### PR TITLE
Adding a test for GalaxyCLI and two methods on which it depends. Tes… 

### DIFF
--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -23,6 +23,12 @@ from ansible.compat.six import PY3
 from ansible.compat.tests import unittest
 
 from nose.plugins.skip import SkipTest
+import ansible
+import os
+import shutil
+import tarfile
+
+from mock import patch
 
 if PY3:
     raise SkipTest('galaxy is not ported to be py3 compatible yet')
@@ -51,3 +57,72 @@ class TestGalaxy(unittest.TestCase):
         display_result = gc._display_role_info(role_info)
         if display_result.find('\t\tgalaxy_tags:') > -1:
             self.fail('Expected galaxy_tags to be indented twice')
+
+    def make_tarfile(self, output_file, source_dir):
+        ''' used for making a tarfile from an artificial role directory for testing installation with a local tar.gz file '''
+        # adding directory into a tar file
+        try:
+            tar = tarfile.open(output_file, "w:gz")
+            tar.add(source_dir, arcname=os.path.basename(source_dir))
+        except AttributeError: # tarfile obj. has no attribute __exit__ prior to python 2.7
+            pass
+        finally:  # ensuring closure of tarfile obj
+            tar.close()
+
+    def create_role(self):
+        ''' creates a "role" directory and a requirements file; used for testing installation '''
+        if os.path.exists('./delete_me'):
+            shutil.rmtree('./delete_me')
+
+        # making the directory for the role
+        os.makedirs('./delete_me')
+        os.makedirs('./delete_me/meta')
+
+        # making main.yml for meta folder
+        fd = open("./delete_me/meta/main.yml", "w")
+        fd.write("---\ngalaxy_info:\n  author: 'shertel'\n  company: Ansible\ndependencies: []")
+        fd.close()
+
+        # making the directory into a tar file
+        self.make_tarfile('./delete_me.tar.gz', './delete_me')
+
+        # removing directory
+        shutil.rmtree('./delete_me')
+
+        # creating requirements.yml for installing the role
+        fd = open("./delete_requirements.yml", "w")
+        fd.write("- 'src': './delete_me.tar.gz'\n  'name': 'delete_me'\n  'path': '/etc/ansible/roles'")
+        fd.close()
+
+    def test_execute_remove(self):
+        ### setup; creating a tar.gz file and installing the role ###
+
+        # creating a tar.gz file for a fake role
+        self.create_role()
+
+        # installing role
+        gc = GalaxyCLI(args=["install"])
+        with patch('sys.argv', ["--offline", "-r", "delete_requirements.yml"]):
+            galaxy_parser = gc.parse()
+        with patch.object(ansible.utils.display.Display, "display") as mock_obj:
+            gc.run()
+
+        ### testing removing the role ###
+        
+        gc.args = ["remove"]
+        with patch('sys.argv', ["-c", "delete_me"]):
+            galaxy_parser = gc.parse()
+        with patch.object(ansible.utils.display.Display, "display") as mock_obj:
+            super(GalaxyCLI, gc).run()
+            gc.api = ansible.galaxy.api.GalaxyAPI(gc.galaxy)
+            completed_task = gc.execute_remove()
+            mock_obj.assert_called_once_with("- successfully removed delete_me")
+            self.assertTrue(completed_task == 0)
+
+        # cleaning up requirements file
+        if os.path.isfile("delete_requirements.yml"):
+            os.remove("delete_requirements.yml")
+
+        # cleaning up tar.gz file
+        if os.path.isfile("./delete_me.tar.gz"):
+            os.remove("./delete_me.tar.gz")

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -126,3 +126,4 @@ class TestGalaxy(unittest.TestCase):
         # cleaning up tar.gz file
         if os.path.isfile("./delete_me.tar.gz"):
             os.remove("./delete_me.tar.gz")
+

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -36,6 +36,55 @@ if PY3:
 from ansible.cli.galaxy import GalaxyCLI
 
 class TestGalaxy(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        '''creating prerequisites for installing a role; setUpClass occurs ONCE whereas setUp occurs with every method tested.'''
+        # class data for easy viewing: role_dir, role_tar, role_name, role_req
+        
+        if os.path.exists("./delete_me"):
+            shutil.rmtree("./delete_me")
+        
+        # creating framework for a role
+        gc = GalaxyCLI(args=["init"])
+        with patch('sys.argv', ["-c", "delete_me"]):
+            gc.parse()
+        gc.run()
+        cls.role_dir = "./delete_me"
+        cls.role_name = "delete_me"
+
+        # creating a tar file name for class data
+        cls.role_tar = './delete_me.tar.gz'
+        cls.makeTar(cls.role_tar, cls.role_dir)
+
+        # creating a temp file with installation requirements
+        cls.role_req = './delete_me_requirements.yml'
+        fd = open(cls.role_req, "w")
+        fd.write("- 'src': '%s'\n  'name': '%s'\n  'path': '/etc/ansible/roles'" % (cls.role_tar, cls.role_name))
+        fd.close()
+
+    @classmethod
+    def makeTar(cls, output_file, source_dir):
+        ''' used for making a tarfile from a role directory '''
+        # adding directory into a tar file
+        try:
+            tar = tarfile.open(output_file, "w:gz")
+            tar.add(source_dir, arcname=os.path.basename(source_dir))
+        except AttributeError: # tarfile obj. has no attribute __exit__ prior to python 2.    7
+                pass
+        finally:  # ensuring closure of tarfile obj
+            tar.close()
+
+    @classmethod
+    def tearDownClass(cls):
+        '''After tests are finished removes things created in setUpClass'''
+        # deleting the temp role directory
+        if os.path.exists(cls.role_dir):
+            shutil.rmtree(cls.role_dir)
+        if os.path.exists(cls.role_req):
+            os.remove(cls.role_req)
+        if os.path.exists(cls.role_tar):
+            os.remove(cls.role_tar)
+
     def setUp(self):
         self.default_args = []
 
@@ -58,51 +107,10 @@ class TestGalaxy(unittest.TestCase):
         if display_result.find('\t\tgalaxy_tags:') > -1:
             self.fail('Expected galaxy_tags to be indented twice')
 
-    def make_tarfile(self, output_file, source_dir):
-        ''' used for making a tarfile from an artificial role directory for testing installation with a local tar.gz file '''
-        # adding directory into a tar file
-        try:
-            tar = tarfile.open(output_file, "w:gz")
-            tar.add(source_dir, arcname=os.path.basename(source_dir))
-        except AttributeError: # tarfile obj. has no attribute __exit__ prior to python 2.7
-            pass
-        finally:  # ensuring closure of tarfile obj
-            tar.close()
-
-    def create_role(self):
-        ''' creates a "role" directory and a requirements file; used for testing installation '''
-        if os.path.exists('./delete_me'):
-            shutil.rmtree('./delete_me')
-
-        # making the directory for the role
-        os.makedirs('./delete_me')
-        os.makedirs('./delete_me/meta')
-
-        # making main.yml for meta folder
-        fd = open("./delete_me/meta/main.yml", "w")
-        fd.write("---\ngalaxy_info:\n  author: 'shertel'\n  company: Ansible\ndependencies: []")
-        fd.close()
-
-        # making the directory into a tar file
-        self.make_tarfile('./delete_me.tar.gz', './delete_me')
-
-        # removing directory
-        shutil.rmtree('./delete_me')
-
-        # creating requirements.yml for installing the role
-        fd = open("./delete_requirements.yml", "w")
-        fd.write("- 'src': './delete_me.tar.gz'\n  'name': 'delete_me'\n  'path': '/etc/ansible/roles'")
-        fd.close()
-
     def test_execute_remove(self):
-        ### setup; creating a tar.gz file and installing the role ###
-
-        # creating a tar.gz file for a fake role
-        self.create_role()
-
         # installing role
         gc = GalaxyCLI(args=["install"])
-        with patch('sys.argv', ["--offline", "-r", "delete_requirements.yml"]):
+        with patch('sys.argv', ["--offline", "-r", self.role_req]):
             galaxy_parser = gc.parse()
         with patch.object(ansible.utils.display.Display, "display") as mock_obj:
             gc.run()
@@ -110,19 +118,12 @@ class TestGalaxy(unittest.TestCase):
         ### testing removing the role ###
         
         gc.args = ["remove"]
-        with patch('sys.argv', ["-c", "delete_me"]):
+        with patch('sys.argv', ["-c", self.role_name]):
             galaxy_parser = gc.parse()
         with patch.object(ansible.utils.display.Display, "display") as mock_obj:
             super(GalaxyCLI, gc).run()
             gc.api = ansible.galaxy.api.GalaxyAPI(gc.galaxy)
             completed_task = gc.execute_remove()
-            mock_obj.assert_called_once_with("- successfully removed delete_me")
+            mock_obj.assert_called_once_with("- successfully removed %s" % self.role_name)
             self.assertTrue(completed_task == 0)
 
-        # cleaning up requirements file
-        if os.path.isfile("delete_requirements.yml"):
-            os.remove("delete_requirements.yml")
-
-        # cleaning up tar.gz file
-        if os.path.isfile("./delete_me.tar.gz"):
-            os.remove("./delete_me.tar.gz")

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -126,4 +126,3 @@ class TestGalaxy(unittest.TestCase):
         # cleaning up tar.gz file
         if os.path.isfile("./delete_me.tar.gz"):
             os.remove("./delete_me.tar.gz")
-


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

This tests the execute_remove method. Testing the execute_remove method relies on having a role installed (otherwise there is nothing to remove). As the tester may not have a role installed this requires a setup and cleanup to test. This setup occurs once by using setUpClass using init to create a role framework and turning the framework (a directory) into a tarball. Installing a role can be done with a local tar.gz file and is more simple for testing than trying to verify internet connection, determine what platform the tester is on, and download an acceptable role.

```
before:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.001s

OK

after:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_execute_remove (cli.test_galaxy.TestGalaxy) ... ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 4 tests in 0.017s

OK
```

…ts execute_remove method.
