### PR TITLE
[WIP] Adding a test for GalaxyCLI. Tests execute_search method.

### DIFF
--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -23,6 +23,12 @@ from ansible.compat.six import PY3
 from ansible.compat.tests import unittest
 
 from nose.plugins.skip import SkipTest
+import ansible
+
+from mock import patch
+
+from ansible.errors import AnsibleError
+from ansible.module_utils.urls import SSLValidationError
 
 if PY3:
     raise SkipTest('galaxy is not ported to be py3 compatible yet')
@@ -51,3 +57,62 @@ class TestGalaxy(unittest.TestCase):
         display_result = gc._display_role_info(role_info)
         if display_result.find('\t\tgalaxy_tags:') > -1:
             self.fail('Expected galaxy_tags to be indented twice')
+
+    def test_execute_search(self):
+        # regardless of internet connection, tests that execute_search is called and calls necessary methods
+        gc = GalaxyCLI(args=["search"])
+
+            ### testing insufficient search query ###
+        with patch('sys.argv', ["-c"]):
+            galaxy_parser = gc.parse()
+            self.assertRaises(AnsibleError, gc.run)
+
+            ### testing search that is successful ###
+        gc.args=["search"]
+        with patch('sys.argv', ["-c", "role"]):
+            galaxy_parser = gc.parse()
+        super(GalaxyCLI, gc).run()
+        gc.api = ansible.galaxy.api.GalaxyAPI(gc.galaxy)
+        # mocking out method that uses the internet
+        with patch.object(ansible.galaxy.api.GalaxyAPI, "search_roles"):
+            # mocking out method that requires data from internet
+            with patch('__builtin__.max', return_value=0):
+                # mocking pager to verify what message the user is given
+                with patch.object(ansible.cli.CLI, "pager") as mock_pager:
+                    completed_task = gc.execute_search()
+                    self.assertTrue(completed_task)
+                    mock_pager.assert_called_with(u'\nFound 1 roles matching your search. Showing first 1000.\n\n Name Description\n ---- -----------')
+
+            ### testing search that gets no results ###
+        gc.args=["search"]
+        with patch('sys.argv', ["-c", "role"]):
+            galaxy_parser = gc.parse()
+        super(GalaxyCLI, gc).run()
+        gc.api = ansible.galaxy.api.GalaxyAPI(gc.galaxy)
+        # mocking out method that uses the internet + return_value that signifies nothing has been found
+        with patch.object(ansible.galaxy.api.GalaxyAPI, "search_roles", return_value={'count': 0}):
+            # mocking display to verify what message the user is given
+            with patch.object(ansible.utils.display.Display, "display") as mock_display:
+                completed_task = gc.execute_search()
+                self.assertTrue(completed_task)
+                mock_display.assert_called_with("No roles match your search.", color='red')
+
+        # This test requires internet connection. Using try/except to ensure internet is working rather than fail tests requiring connection while offline.
+        try:
+            gc = GalaxyCLI(args=["search"])
+
+            ### testing sufficient search ###
+                # searching for 'role' keyword
+            with patch('sys.argv', ["-c", "role"]):
+                galaxy_parser = gc.parse()
+            with patch.object(ansible.cli.CLI, "pager"):  # eliminating display output
+                super(GalaxyCLI, gc).run()
+                gc.api = ansible.galaxy.api.GalaxyAPI(gc.galaxy)
+                completed_task = gc.execute_search()
+                self.assertTrue(completed_task == True)
+
+        except AnsibleError as e:        
+            if "Failed to get data from the API server" in e.message:
+                raise SkipTest(' there is a test case within this method that requires an internet connection and a valid CA certificate installed; this part of the method is skipped when one or both of these requirements are not provided\n ... ok ')
+            else:
+                raise


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

The execute_search method uses internet; to always verify its behavior regardless of the tester's connection, I used mock.patch to ensure the appropriate methods are called (and with the right parameter where applicable). 
In addition, I made the design choice to use a try/except to allow an additional possible test using internet. If try/except is not used and the internet is not working an error is raised that doesn't make note of this possible problem and I feel it could lead to misconstruing the reason for the failed test (there might be nothing wrong with the code at all). Instead of resulting in a failure, if the error raised contains the message 'Failed to get data from the API server' (which is true for the AnsibleError raised when I try to run this test without internet) then a SkipTest will be raised instead with an informative message to the user, explaining why the test was skipped. This is a compromise since this will also occur when there isn't a valid CA certificate installed. This is noted in the helpful SkipTest error message for the tester. 

```
before:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.001s

OK

after:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_execute_search (cli.test_galaxy.TestGalaxy) ... ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 4 tests in 5.383s

OK
```
