### PR TITLE
 Adding a test for GalaxyCLI. Tests execute_login method.

### DIFF
--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -23,6 +23,15 @@ from ansible.compat.six import PY3
 from ansible.compat.tests import unittest
 
 from nose.plugins.skip import SkipTest
+import ansible
+import os
+import getpass
+
+from mock import patch
+
+from ansible.errors import AnsibleError
+from ansible.module_utils.urls import SSLValidationError
+from urllib2 import HTTPError
 
 if PY3:
     raise SkipTest('galaxy is not ported to be py3 compatible yet')
@@ -30,6 +39,23 @@ if PY3:
 from ansible.cli.galaxy import GalaxyCLI
 
 class TestGalaxy(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Prompting the testing to provide credentials will not happen by default and is not required for most tests. This is simply an option to improve the thoroughness of testing.
+        if 'GALAXY_CREDS_PROMPT' in os.environ.keys():
+            try:
+                #authentication may be declined and tests inhibited will be avoided
+                cls.auth = True
+                # using getpass to ensure tester sees message (unlike raw_input)
+                cls.galaxy_username = getpass.getpass("\nPress ENTER to opt out of any of the authentication prompts.\nYour information will not be displayed.\nEnter your Ansible-Galaxy/Github username: ")
+                cls.galaxy_password = getpass.getpass("Enter your Ansible-Galaxy/Github password: ")
+                cls.github_token = getpass.getpass("Enter/Copy + paste Github Personal Access Token to login to Ansible-Galaxy: ")
+                cls.import_repo = getpass.getpass("To test importing a role please provide the name of a valid github repo (containing a role) belonging to the username provided above: ")
+            except getpass.GetPassWarning:
+                cls.auth = False
+        else:
+            cls.auth = False    
+    
     def setUp(self):
         self.default_args = []
 
@@ -51,3 +77,92 @@ class TestGalaxy(unittest.TestCase):
         display_result = gc._display_role_info(role_info)
         if display_result.find('\t\tgalaxy_tags:') > -1:
             self.fail('Expected galaxy_tags to be indented twice')
+
+    @patch.object(ansible.utils.display.Display, "display")  # eliminating messages flushed to screen
+    def test_execute_login(self, mocked_display):
+
+        ### regardless of credentials/internet, tests that execute_login is called and behaves in an expected manner ###
+        gc = GalaxyCLI(args=["login"])
+                
+            # testing when self.options.token is None:
+        with patch('sys.argv', ["-c"]):
+            galaxy_parser = gc.parse()
+        with patch.object(ansible.galaxy.token.GalaxyToken, "__init__", return_value=None) as mocked_GalaxyToken:  # to test token object is created
+            with patch.object(GalaxyCLI, "execute_login", return_value=0) as mocked_login:
+                gc.run()
+                self.assertTrue(mocked_login.call_count, 1)
+                self.assertTrue(mocked_login.return_value==0)
+                self.assertTrue(mocked_GalaxyToken.call_count, 1) 
+
+            # testing when self.options.token is not None
+        with patch('sys.argv', ["-c", "--github-token", "imaginary_token"]):
+            galaxy_parser = gc.parse()
+        with patch.object(ansible.galaxy.token.GalaxyToken, "__init__", return_value=None) as mocked_GalaxyToken:
+            with patch.object(GalaxyCLI, "execute_login", return_value=0) as mocked_login:
+                gc.run()
+                self.assertTrue(mocked_login.call_count, 1)
+                self.assertTrue(mocked_login.return_value==0)
+                self.assertTrue(mocked_GalaxyToken.call_count, 1)
+
+        ### These (optional) tests requires internet connection. Using try/except to ensure internet is working rather than fail tests requiring connection while offline. If connection seems to fail a SkipTest will be raised, informing the tester that internet is required. ###
+        try:
+            # if authentication is provided more thorough tests can verify execute_login's behavior
+            if self.auth:
+
+                # testing login with username and password if possible
+                gc = GalaxyCLI(args=["login"])
+                with patch('sys.argv', ["-c"]):
+                    galaxy_parser = gc.parse()
+                # patches because we only ask tester for authentication once
+                with patch('__builtin__.raw_input', return_value= self.galaxy_username):
+                    with patch('getpass.getpass', return_value=self.galaxy_password):
+                        if not self.galaxy_username or not self.galaxy_password:  # if an empty string for username or password
+                            self.assertRaises(AnsibleError, gc.run)
+                        else:  # if user provided bad credentials "Bad credentials" error will be raised
+                            super(GalaxyCLI, gc).run()
+                            gc.api = ansible.galaxy.api.GalaxyAPI(gc.galaxy)
+                            completed_task = gc.execute_login()
+                            self.assertTrue(completed_task == 0)
+
+                # testing login with token if possible
+                gc = GalaxyCLI(args=["login"])
+                if not self.github_token:
+                    with patch('sys.argv', ["-c", "--github-token"]):
+                        self.assertRaisesRegexp( SystemExit, '2', gc.parse)
+                else:  # if user provided bad credentials this will fail
+                    display = ansible.utils.display.Display()
+                    display.display(u"self.github_token is true. Value is: %s" % self.github_token)
+                    with patch('sys.argv', ["-c", "--github-token", self.github_token]):
+                        galaxy_parser = gc.parse()
+                    super(GalaxyCLI, gc).run()
+                    gc.api = ansible.galaxy.api.GalaxyAPI(gc.galaxy)
+                    completed_task = gc.execute_login()
+                    self.assertTrue(completed_task == 0)
+
+            # if internet is functioning more thorough tests can verify execute_login's behavior 
+            # testing login with insufficient credentials
+            gc = GalaxyCLI(args=["login"])
+            with patch('sys.argv', ["-c"]):
+                galaxy_parser = gc.parse()
+            with patch('__builtin__.raw_input', return_value=None):
+                with patch('getpass.getpass', return_value=None):
+                    self.assertRaises(AnsibleError, gc.run)
+            with patch('__builtin__.raw_input', return_value="invalid_username"):
+                with patch('getpass.getpass', return_value='invalid_password'):
+                    self.assertRaises(AnsibleError, gc.run)
+
+            # testing token login with insufficient token
+            gc = GalaxyCLI(args=["login"])
+            with patch('sys.argv', ["-c", "--github-token", "invalid_token"]):  # with invalid token
+                galaxy_parser = gc.parse()
+            self.assertRaises(HTTPError, gc.run)
+            with patch('sys.argv', ["-c", "--github-token"]):  # without token argument
+                self.assertRaisesRegexp( SystemExit, '2', gc.parse)
+
+        except (SSLValidationError, AnsibleError) as e:
+            if str(e) == "Bad credentials":
+                raise
+            elif "Failed to validate the SSL certificate" in e.message:
+                raise SkipTest(' there is a test case within this method that requires an internet connection and a valid CA certificate installed; this part of the method is skipped when one or both of these requirements are not provided\n ... ok ')
+            else:
+                raise

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -31,12 +31,13 @@ from mock import patch
 
 from ansible.errors import AnsibleError
 from ansible.module_utils.urls import SSLValidationError
-from urllib2 import HTTPError
 
 if PY3:
     raise SkipTest('galaxy is not ported to be py3 compatible yet')
 
 from ansible.cli.galaxy import GalaxyCLI
+
+from urllib2 import HTTPError
 
 class TestGalaxy(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

The execute_login method uses internet; to always verify its behavior regardless of the tester's connection, I used mock.patch to ensure the appropriate methods are called (and with the right parameter where applicable). 
In addition, I made two design choices: to use a try/except to allow an additional possible test using internet, and including setUpClass (see #16631) as a prerequisite to allow for (non-default) authentication. If try/except is not used and the internet is not working an error is raised that doesn't make note of this possible problem and I feel it could lead to misconstruing the reason for the failed test (there might be nothing wrong with the code at all). Instead of resulting in a failure, if the error raised contains the message 'Failed to get data from the API server' (which is true for the AnsibleError raised when I try to run this test without internet) then a SkipTest will be raised instead with an informative message to the user, explaining why the test was skipped. This is a compromise since this will also occur when there isn't a valid CA certificate installed. This is noted in the helpful SkipTest error message for the tester.

```
before:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.001s

OK

after:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_execute_login (cli.test_galaxy.TestGalaxy) ... Usage: -c login [options]

-c: error: --github-token option requires an argument
ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 4 tests in 2.631s

OK
```
