### PR TITLE
Enable color output from integration tests in Docker containers

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -186,12 +186,14 @@ blocks: setup
 	rm -f block_test.out
 	# run the test and check to make sure the right number of completions was logged
 	ansible-playbook -vv -e outputdir=$(TEST_DIR) test_blocks/main.yml | tee block_test.out
-	[ "$$(grep 'TEST COMPLETE' block_test.out | wc -l)" = "$$(egrep '^[0-9]+ plays in' block_test.out | cut -f1 -d' ')" ]
+	sed -r 's/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g' block_test.out >block_test_wo_colors.out
+	[ "$$(grep 'TEST COMPLETE' block_test.out | wc -l)" = "$$(egrep '^[0-9]+ plays in' block_test_wo_colors.out | cut -f1 -d' ')" ]
 	# cleanup the output log again, to make sure the test is clean
-	rm -f block_test.out
+	rm -f block_test.out block_test_wo_colors.out
 	# run test with free strategy and again count the completions
 	ansible-playbook -vv -e outputdir=$(TEST_DIR) test_blocks/main.yml -e test_strategy=free | tee block_test.out
-	[ "$$(grep 'TEST COMPLETE' block_test.out | wc -l)" = "$$(egrep '^[0-9]+ plays in' block_test.out | cut -f1 -d' ')" ]
+	sed -r 's/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]//g' block_test.out >block_test_wo_colors.out
+	[ "$$(grep 'TEST COMPLETE' block_test.out | wc -l)" = "$$(egrep '^[0-9]+ plays in' block_test_wo_colors.out | cut -f1 -d' ')" ]
 
 cloud: amazon rackspace azure
 

--- a/test/utils/run_tests.sh
+++ b/test/utils/run_tests.sh
@@ -30,7 +30,14 @@ else
     fi
     export C_NAME="testAbull_$$_$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)"
     docker pull ansible/ansible:${TARGET}
-    docker run -d --volume="${PWD}:/root/ansible:Z" $LINKS --name "${C_NAME}" --env HTTPTESTER=1 ${TARGET_OPTIONS:=''} ansible/ansible:${TARGET} > /tmp/cid_${TARGET}
+
+    # enable colors if output is going to a terminal
+    COLOR_SETTINGS=""
+    if [ -t 1 ]; then
+	COLOR_SETTINGS="--env TERM=$TERM"
+    fi
+
+    docker run -d --volume="${PWD}:/root/ansible:Z" $LINKS --name "${C_NAME}" $COLOR_SETTINGS --env HTTPTESTER=1 ${TARGET_OPTIONS:=''} ansible/ansible:${TARGET} > /tmp/cid_${TARGET}
     docker exec -ti $(cat /tmp/cid_${TARGET}) /bin/sh -c "export TEST_FLAGS='${TEST_FLAGS:-''}'; cd /root/ansible; . hacking/env-setup; (cd test/integration; LC_ALL=en_US.utf-8 make ${MAKE_TARGET:-})"
     docker kill $(cat /tmp/cid_${TARGET})
 

--- a/test/utils/shippable/integration.sh
+++ b/test/utils/shippable/integration.sh
@@ -67,8 +67,12 @@ if [ "${controller_shared_dir}" ]; then
     cp -a "${SHIPPABLE_BUILD_DIR}" "${controller_shared_dir}"
 fi
 
+# Enabling colored output in Shippable console
+color_settings="--env ANSIBLE_FORCE_COLOR=1"
+
 httptester_id=$(docker run -d "${http_image}")
 container_id=$(docker run -d \
+    ${color_settings} \
     -v "/sys/fs/cgroup:/sys/fs/cgroup:ro" \
     -v "${host_shared_dir}:${test_shared_dir}" \
     --link="${httptester_id}:ansible.http.tests" \

--- a/test/utils/shippable/integration.sh
+++ b/test/utils/shippable/integration.sh
@@ -71,12 +71,9 @@ if [ "${controller_shared_dir}" ]; then
     cp -a "${SHIPPABLE_BUILD_DIR}" "${controller_shared_dir}"
 fi
 
-# Enabling colored output in Shippable console
-color_settings="--env ANSIBLE_FORCE_COLOR=$force_color"
-
 httptester_id=$(docker run -d "${http_image}")
 container_id=$(docker run -d \
-    ${color_settings} \
+    --env "ANSIBLE_FORCE_COLOR=${force_color}" \
     -v "/sys/fs/cgroup:/sys/fs/cgroup:ro" \
     -v "${host_shared_dir}:${test_shared_dir}" \
     --link="${httptester_id}:ansible.http.tests" \

--- a/test/utils/shippable/integration.sh
+++ b/test/utils/shippable/integration.sh
@@ -13,6 +13,10 @@ http_image="${HTTP_IMAGE:-ansible/ansible:httptester}"
 keep_containers="${KEEP_CONTAINERS:-}"
 copy_source="${COPY_SOURCE:-}"
 
+# Force ansible color output by default.
+# To disable color force mode use FORCE_COLOR=0
+force_color="${FORCE_COLOR:-1}"
+
 if [ "${SHIPPABLE_BUILD_DIR:-}" ]; then
     host_shared_dir="/home/shippable/cache/build-${BUILD_NUMBER}"
     controller_shared_dir="/home/shippable/cache/build-${BUILD_NUMBER}"
@@ -68,7 +72,7 @@ if [ "${controller_shared_dir}" ]; then
 fi
 
 # Enabling colored output in Shippable console
-color_settings="--env ANSIBLE_FORCE_COLOR=1"
+color_settings="--env ANSIBLE_FORCE_COLOR=$force_color"
 
 httptester_id=$(docker run -d "${http_image}")
 container_id=$(docker run -d \


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.0.2.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Enable color output from integration tests in Docker containers when then output is attached to the a terminal.  It is much easier to see results of the test this way.
