### PR TITLE
Test service enabled during check run (from bug report)

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -17,6 +17,15 @@ matrix:
     - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1404 PRIVILEGED=true
     - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1604
 
+    - env: TEST=integration TARGET=complex_destructive IMAGE=ansible/ansible:centos6
+    - env: TEST=integration TARGET=complex_destructive IMAGE=ansible/ansible:centos7
+    - env: TEST=integration TARGET=complex_destructive IMAGE=ansible/ansible:fedora-rawhide
+    - env: TEST=integration TARGET=complex_destructive IMAGE=ansible/ansible:fedora23
+    - env: TEST=integration TARGET=complex_destructive IMAGE=ansible/ansible:opensuseleap
+    - env: TEST=integration TARGET=complex_destructive IMAGE=ansible/ansible:ubuntu1204 PRIVILEGED=true
+    - env: TEST=integration TARGET=complex_destructive IMAGE=ansible/ansible:ubuntu1404 PRIVILEGED=true
+    - env: TEST=integration TARGET=complex_destructive IMAGE=ansible/ansible:ubuntu1604
+
     - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:centos6
     - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:centos7
     - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:fedora-rawhide

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -25,7 +25,7 @@ EUID := $(shell id -u -r)
 
 UNAME := $(shell uname | tr '[:upper:]' '[:lower:]')
 
-all: setup other non_destructive destructive
+all: setup other non_destructive destructive complex_destructive
 
 other: test_test_infra parsing test_var_precedence unicode test_templating_settings environment test_connection test_async_conditional includes blocks pull check_mode test_hash test_handlers test_group_by test_vault test_tags test_lookup_paths no_log test_gathering_facts test_binary_modules
 
@@ -123,6 +123,11 @@ test_connection_winrm: setup
 
 destructive: setup
 	ansible-playbook destructive.yml -i $(INVENTORY) -e outputdir=$(TEST_DIR) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
+
+# Complex destructive tests.
+# Every test may required special setup for execution (e.g. run one playbook in normal mode, another in the check mode)
+complex_destructive: setup
+	$(MAKE) -C complex-tests/bug-service-enabled-during-check-run
 
 check_mode: setup
 	ansible-playbook check_mode.yml -i $(INVENTORY) -e outputdir=$(TEST_DIR) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v --check $(TEST_FLAGS)

--- a/test/integration/complex-tests/bug-service-enabled-during-check-run/Makefile
+++ b/test/integration/complex-tests/bug-service-enabled-during-check-run/Makefile
@@ -1,0 +1,5 @@
+AP=ansible-playbook -i inventory
+
+test:
+	$(AP) cleanup-and-copy-service-files.yml
+	$(AP) enabled-test-service.yml  --check

--- a/test/integration/complex-tests/bug-service-enabled-during-check-run/README.md
+++ b/test/integration/complex-tests/bug-service-enabled-during-check-run/README.md
@@ -1,0 +1,13 @@
+This is demonstration of a bug when playbook run in the check mode enables system service.
+
+To demonstrate the issue we do following:
+  - copy dummy service script
+  - copy System V init script `ansible_test`
+  - in the check mode run task `service: name=ansible_test enabled=yes`, this task actually
+    enables service despite the fact that we run playbook in the check mode
+  - in the check mode run task `service: name=ansible_test enabled=yes` again and check whether there are changes or not.  If ansible reports no changes, than the service was enabled the first time and the bug is actually present.  If Ansible does report changes, then there is no bug.
+
+The bug is present on:
+  - Debian 7
+  - Ubuntu 12.04
+  - Ubuntu 14.04

--- a/test/integration/complex-tests/bug-service-enabled-during-check-run/cleanup-and-copy-service-files.yml
+++ b/test/integration/complex-tests/bug-service-enabled-during-check-run/cleanup-and-copy-service-files.yml
@@ -1,0 +1,21 @@
+---
+- hosts: all
+  become: yes
+  tasks:
+
+    - name: cleanup files from the previous run
+      file: path={{item}} state=absent
+      with_items:
+        - /usr/sbin/ansible_test_service
+        - /etc/init.d/ansible_test
+
+    - name: cleanup runlevel links from the previous run
+      command: find /etc -name '[SK]*ansible_test' -delete
+
+    - name: install the test daemon script
+      copy: src=../../roles/test_service/files/ansible_test_service dest=/usr/sbin/ansible_test_service mode=755
+      register: install_result
+
+    - name: install the sysV init file
+      copy: src=../../roles/test_service/files/ansible.sysv dest=/etc/init.d/ansible_test mode=0755
+      register: install_sysv_result

--- a/test/integration/complex-tests/bug-service-enabled-during-check-run/enabled-test-service.yml
+++ b/test/integration/complex-tests/bug-service-enabled-during-check-run/enabled-test-service.yml
@@ -24,4 +24,4 @@
       # On some Docker images there is error 'Could not find the requested service "ansible_test"'.
       # Skipping those images.
       # Also skipping all CentOS because the first attempt not market as "changed".  It's not clear why.
-      when: not ((ansible_distribution == 'CentOS') or (ansible_distribution == 'Fedora') or ((ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare('15.04', '>='))))
+      when: (ansible_distribution == 'Ubuntu' and ansible_distribution_version in ['12.04', '14.04']) or (ansible_distribution == 'Debian' and ansible_distribution_version in ['7'])

--- a/test/integration/complex-tests/bug-service-enabled-during-check-run/enabled-test-service.yml
+++ b/test/integration/complex-tests/bug-service-enabled-during-check-run/enabled-test-service.yml
@@ -2,20 +2,24 @@
 - hosts: all
   become: yes
   tasks:
-    - name: enable service first time
-      service: name=ansible_test enabled=yes
-      register: enabled_res_1
+    - block:
+        - name: enable service first time
+          service: name=ansible_test enabled=yes
+          register: enabled_res_1
 
-    - name: assert that state changed
-      assert:
-        that:
-        - "enabled_res_1.changed == true"
+        - name: assert that state changed
+          assert:
+            that:
+            - "enabled_res_1.changed == true"
 
-    - name: enable service second time
-      service: name=ansible_test enabled=yes
-      register: enabled_res_2
+        - name: enable service second time
+          service: name=ansible_test enabled=yes
+          register: enabled_res_2
 
-    - name: assert that state changed again (in the check mode it should)
-      assert:
-        that:
-        - "enabled_res_2.changed == true"
+        - name: assert that state changed again (in the check mode it should)
+          assert:
+            that:
+            - "enabled_res_2.changed == true"
+        # On some Docker images there is error 'Could not find the requested service "ansible_test"'
+        # Skip those images
+      when: not ((ansible_distribution == 'CentOS' and ansible_distribution_version|version_compare('7', '>=')) or (ansible_distribution == 'Fedora') or ((ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare('15.04', '>='))))

--- a/test/integration/complex-tests/bug-service-enabled-during-check-run/enabled-test-service.yml
+++ b/test/integration/complex-tests/bug-service-enabled-during-check-run/enabled-test-service.yml
@@ -20,6 +20,8 @@
           assert:
             that:
             - "enabled_res_2.changed == true"
-        # On some Docker images there is error 'Could not find the requested service "ansible_test"'
-        # Skip those images
-      when: not ((ansible_distribution == 'CentOS' and ansible_distribution_version|version_compare('7', '>=')) or (ansible_distribution == 'Fedora') or ((ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare('15.04', '>='))))
+
+      # On some Docker images there is error 'Could not find the requested service "ansible_test"'.
+      # Skipping those images.
+      # Also skipping all CentOS because the first attempt not market as "changed".  It's not clear why.
+      when: not ((ansible_distribution == 'CentOS') or (ansible_distribution == 'Fedora') or ((ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare('15.04', '>='))))

--- a/test/integration/complex-tests/bug-service-enabled-during-check-run/enabled-test-service.yml
+++ b/test/integration/complex-tests/bug-service-enabled-during-check-run/enabled-test-service.yml
@@ -1,0 +1,21 @@
+---
+- hosts: all
+  become: yes
+  tasks:
+    - name: enable service first time
+      service: name=ansible_test enabled=yes
+      register: enabled_res_1
+
+    - name: assert that state changed
+      assert:
+        that:
+        - "enabled_res_1.changed == true"
+
+    - name: enable service second time
+      service: name=ansible_test enabled=yes
+      register: enabled_res_2
+
+    - name: assert that state changed again (in the check mode it should)
+      assert:
+        that:
+        - "enabled_res_2.changed == true"

--- a/test/integration/complex-tests/bug-service-enabled-during-check-run/inventory
+++ b/test/integration/complex-tests/bug-service-enabled-during-check-run/inventory
@@ -1,0 +1,1 @@
+localhost ansible_ssh_host=127.0.0.1 ansible_connection=local


### PR DESCRIPTION
##### ISSUE TYPE
- Bug Demonstration Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (bug-service-enabled-during-check-run f6859a426e) last updated 2016/07/09 20:58:44 (GMT +000)
  lib/ansible/modules/core: (detached HEAD db8af4c5af) last updated 2016/07/09 15:54:05 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 618e740d52) last updated 2016/07/09 15:54:05 (GMT +000)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

This pull request demonstrates a bug in the service module.  Integration tests are expected to fail on Debian 7, Ubuntu 12.04, Ubuntu 14.04 until the bug is fixed.
