### PR TITLE
Fix typo on -K/--ask-become-pass option in 'ansible' man page

### DIFF
--- a/docs/man/man1/ansible.1.asciidoc.in
+++ b/docs/man/man1/ansible.1.asciidoc.in
@@ -42,7 +42,7 @@ The 'ARGUMENTS' to pass to the module.
 Use privilege escalation (specific one depends on become_method),
 this does not imply prompting for passwords.
 
-*K*, *--ask-become-pass*::
+*-K*, *--ask-become-pass*::
 
 Ask for privilege escalation password.
 


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
```
##### SUMMARY

The "-" was missing before the "K" in the `ansible` man page. This commit fixes that.
