### PR TITLE
fixed max_fail_percentage trigger condition

### DIFF
--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -157,7 +157,7 @@ class PlaybookExecutor:
                             failed_hosts_count = len(self._tqm._failed_hosts) + len(self._tqm._unreachable_hosts) - \
                                                  (previously_failed + previously_unreachable)
                             if new_play.max_fail_percentage is not None and \
-                               int((new_play.max_fail_percentage)/100.0 * len(batch)) > int((len(batch) - failed_hosts_count) / len(batch) * 100.0):
+                               new_play.max_fail_percentage < float(failed_hosts_count * 100) / len(batch):
                                 break_play = True
                                 break
                             elif len(batch) == failed_hosts_count:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.1.0 (stable-2.1 628a67563f) last updated 2016/07/11 10:04:35 (GMT +300)
  lib/ansible/modules/core: (stable-2.1 665c0f19b1) last updated 2016/07/07 11:07:31 (GMT +300)
  lib/ansible/modules/extras: (stable-2.1 377f911867) last updated 2016/07/06 11:34:09 (GMT +300)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible']

```
##### SUMMARY

The original if condition is as follows:

```
int((new_play.max_fail_percentage)/100.0 * len(batch)) > int((len(batch) - failed_hosts_count) / len(batch) * 100.0):
```

let's assume that we have 2 hosts, one host failed and we have  max_fail_percentage = 1 then the condition looks like that:
int(1/100 \* 2) > int(2 - 1) / 2 *100)
0 > 1/2 \* 100
0 > 50 -> false

Which is not the expected result

As a side note, please note that int(0.9) == 0  

The proposed condition is shorter:

```
new_play.max_fail_percentage < float(failed_hosts_count * 100) / len(batch)
```

Fixes #16666
