### PR TITLE
Adding GalaxyCLI test. Tests execute_info method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Ansible Changes By Release
 - netconf_config
 - openstack
   * os_keystone_service
+  * os_stack
 - rocketchat
 - sensu_subscription
 - smartos

--- a/docsite/rst/playbooks.rst
+++ b/docsite/rst/playbooks.rst
@@ -22,6 +22,7 @@ It is recommended to look at `Example Playbooks <https://github.com/ansible/ansi
    playbooks_roles
    playbooks_variables
    playbooks_filters
+   playbooks_tests
    playbooks_conditionals
    playbooks_loops
    playbooks_blocks

--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -7,6 +7,8 @@ Jinja2 filters
 Filters in Jinja2 are a way of transforming template expressions from one kind of data into another.  Jinja2
 ships with many of these. See `builtin filters`_ in the official Jinja2 template documentation.
 
+Take into account that filters always execute on the Ansible controller, **not** on the task target, as they manipulate local data.
+
 In addition to those, Ansible supplies many more.
 
 .. _filters_for_formatting_data:
@@ -42,37 +44,6 @@ for example::
         register: result
 
       - set_fact: myvar="{{ result.stdout | from_json }}"
-
-.. _filters_used_with_conditionals:
-
-Filters Often Used With Conditionals
-------------------------------------
-
-The following tasks are illustrative of how filters can be used with conditionals::
-
-    tasks:
-
-      - shell: /usr/bin/foo
-        register: result
-        ignore_errors: True
-
-      - debug: msg="it failed"
-        when: result|failed
-
-      # in most cases you'll want a handler, but if you want to do something right now, this is nice
-      - debug: msg="it changed"
-        when: result|changed
-
-      - debug: msg="it succeeded in Ansible >= 2.1"
-        when: result|succeeded
-
-      - debug: msg="it succeeded"
-        when: result|success
-
-      - debug: msg="it was skipped"
-        when: result|skipped
-
-.. note:: From 2.1 You can also use success, failure, change, skip so the grammer matches, for those that want to be strict about it.
 
 .. _forcing_variables_to_be_defined:
 
@@ -170,30 +141,6 @@ To get the symmetric difference of 2 lists (items exclusive to each list)::
 
     {{ list1 | symmetric_difference(list2) }}
 
-.. _version_comparison_filters:
-
-Version Comparison Filters
---------------------------
-
-.. versionadded:: 1.6
-
-To compare a version number, such as checking if the ``ansible_distribution_version``
-version is greater than or equal to '12.04', you can use the ``version_compare`` filter.
-
-The ``version_compare`` filter can also be used to evaluate the ``ansible_distribution_version``::
-
-    {{ ansible_distribution_version | version_compare('12.04', '>=') }}
-
-If ``ansible_distribution_version`` is greater than or equal to 12, this filter will return True, otherwise it will return False.
-
-The ``version_compare`` filter accepts the following operators::
-
-    <, lt, <=, le, >, gt, >=, ge, ==, =, eq, !=, <>, ne
-
-This filter also accepts a 3rd parameter, ``strict`` which defines if strict version parsing should
-be used.  The default is ``False``, and if set as ``True`` will use more strict version parsing::
-
-    {{ sample_version_var | version_compare('1.0', operator='lt', strict=True) }}
 
 .. _random_filter:
 
@@ -244,10 +191,6 @@ Math
 --------------------
 .. versionadded:: 1.9
 
-
-To see if something is actually a number::
-
-    {{ myvar | isnan }}
 
 Get the logarithm (default is e)::
 
@@ -538,20 +481,6 @@ doesn't know it is a boolean value::
 
    - debug: msg=test
      when: some_string_value | bool
-
-To match strings against a regex, use the "match" or "search" filter::
-
-    vars:
-      url: "http://example.com/users/foo/resources/bar"
-
-    tasks:
-        - shell: "msg='matched pattern 1'"
-          when: url | match("http://example.com/users/.*/resources/.*")
-
-        - debug: "msg='matched pattern 2'"
-          when: url | search("/users/.*/resources/.*")
-
-'match' will require a complete match in the string, while 'search' will require a match inside of the string.
 
 .. versionadded:: 1.6
 

--- a/docsite/rst/playbooks_tests.rst
+++ b/docsite/rst/playbooks_tests.rst
@@ -1,0 +1,165 @@
+Jinja2 tests
+============
+
+.. contents:: Topics
+
+
+Tests in Jinja2 are a way of evaluating template expressions and returning True or False.
+Jinja2 ships with many of these. See `builtin tests`_ in the official Jinja2 template documentation.
+Tests are very similar to filters and are used mostly the same way, but they can also be used in list
+processing filters, like C(map()) and C(select()) to choose items in the list.
+
+Like filters, tests always execute on the Ansible controller, **not** on the target of a task, as they test local data.
+
+In addition to those Jinja2 tests, Ansible supplies a few more and users can easily create their own.
+
+.. _testing_strings:
+
+Testing strings
+---------------
+
+To match strings against a substring or a regex, use the "match" or "search" filter::
+
+    vars:
+      url: "http://example.com/users/foo/resources/bar"
+
+    tasks:
+        - shell: "msg='matched pattern 1'"
+          when: url | match("http://example.com/users/.*/resources/.*")
+
+        - debug: "msg='matched pattern 2'"
+          when: url | search("/users/.*/resources/.*")
+
+        - debug: "msg='matched pattern 3'"
+          when: url | search("/users/")
+
+'match' requires a complete match in the string, while 'search' only requires matching a subset of the string.
+
+
+.. _testing_versions:
+
+Version Comparison
+------------------
+
+.. versionadded:: 1.6
+
+To compare a version number, such as checking if the ``ansible_distribution_version``
+version is greater than or equal to '12.04', you can use the ``version_compare`` filter.
+
+The ``version_compare`` filter can also be used to evaluate the ``ansible_distribution_version``::
+
+    {{ ansible_distribution_version | version_compare('12.04', '>=') }}
+
+If ``ansible_distribution_version`` is greater than or equal to 12, this filter returns True, otherwise False.
+
+The ``version_compare`` filter accepts the following operators::
+
+    <, lt, <=, le, >, gt, >=, ge, ==, =, eq, !=, <>, ne
+
+This test also accepts a 3rd parameter, ``strict`` which defines if strict version parsing should
+be used.  The default is ``False``, but this setting as ``True`` uses more strict version parsing::
+
+    {{ sample_version_var | version_compare('1.0', operator='lt', strict=True) }}
+
+
+.. _math_tests:
+
+Group theory tests
+------------------
+
+To see if a list includes or is included by another list, you can use 'issubset' and 'issuperset'::
+
+    vars:
+        a: [1,2,3,4,5]
+        b: [2,3]
+    tasks:
+        - debug: msg="A includes B"
+          when: a|issuperset(b)
+
+        - debug: msg="B is included in A"
+          when: b|issubset(a)
+
+
+.. _path_tests:
+
+Testing paths
+-------------
+
+The following tests can provide information about a path on the controller::
+
+    - debug: msg="path is a directory"
+      when: mypath|isdir
+
+    - debug: msg="path is a file"
+      when: mypath|is_file
+
+    - debug: msg="path is a symlink"
+      when: mypath|is_link
+
+    - debug: msg="path already exists"
+      when: mypath|exists
+
+    - debug: msg="path is {{ (mypath|is_abs)|ternary('absolute','relative')}}"
+
+    - debug: msg="path is the same file as path2"
+      when: mypath|samefile(path2)
+
+    - debug: msg="path is a mount"
+      when: mypath|ismount
+
+
+.. _test_task_results:
+
+Task results
+------------
+
+The following tasks are illustrative of the tests meant to check the status of tasks::
+
+    tasks:
+
+      - shell: /usr/bin/foo
+        register: result
+        ignore_errors: True
+
+      - debug: msg="it failed"
+        when: result|failed
+
+      # in most cases you'll want a handler, but if you want to do something right now, this is nice
+      - debug: msg="it changed"
+        when: result|changed
+
+      - debug: msg="it succeeded in Ansible >= 2.1"
+        when: result|succeeded
+
+      - debug: msg="it succeeded"
+        when: result|success
+
+      - debug: msg="it was skipped"
+        when: result|skipped
+
+.. note:: From 2.1, you can also use success, failure, change, and skip so that the grammar matches, for those who need to be strict about it.
+
+
+
+.. _builtin tests: http://jinja.pocoo.org/docs/templates/#builtin-tests
+
+.. seealso::
+
+   :doc:`playbooks`
+       An introduction to playbooks
+   :doc:`playbooks_conditionals`
+       Conditional statements in playbooks
+   :doc:`playbooks_variables`
+       All about variables
+   :doc:`playbooks_loops`
+       Looping in playbooks
+   :doc:`playbooks_roles`
+       Playbook organization by roles
+   :doc:`playbooks_best_practices`
+       Best practices in playbooks
+   `User Mailing List <http://groups.google.com/group/ansible-devel>`_
+       Have a question?  Stop by the google group!
+   `irc.freenode.net <http://irc.freenode.net>`_
+       #ansible IRC chat channel
+
+

--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -431,9 +431,10 @@ class AnsibleDockerClient(Client):
         images = response
         if tag: 
             lookup = "%s:%s" % (name, tag)
+            images = []
             for image in response:
-                self.log(image, pretty_print=True)
-                if image.get('RepoTags') and lookup in image.get('RepoTags'):
+                tags = image.get('RepoTags')
+                if tags and lookup in tags:
                     images = [image]
                     break
         return images

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -831,18 +831,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             to get back the first existing file found.
         '''
 
-        path_stack = []
-
-        dep_chain =  self._task._block.get_dep_chain()
-        # inside role: add the dependency chain
-        if dep_chain:
-            path_stack.extend(reversed([x._role_path for x in dep_chain]))
-
-
-        task_dir = os.path.dirname(self._task.get_path())
-        # include from diff directory: add it to file path
-        if not task_dir.endswith('tasks') and task_dir != self._loader.get_basedir():
-            path_stack.append(task_dir)
+        path_stack = self._task.get_search_path()
 
         result = self._loader.path_dwim_relative_stack(path_stack, dirname, needle)
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -26,7 +26,6 @@ import itertools
 import json
 import os.path
 import ntpath
-import types
 import pipes
 import glob
 import re
@@ -34,13 +33,11 @@ import crypt
 import hashlib
 import string
 from functools import partial
-import operator as py_operator
 from random import SystemRandom, shuffle
 import uuid
 
 import yaml
 from jinja2.filters import environmentfilter
-from distutils.version import LooseVersion, StrictVersion
 from ansible.compat.six import iteritems, string_types
 
 from ansible import errors
@@ -186,32 +183,6 @@ def ternary(value, true_val, false_val):
         return false_val
 
 
-def version_compare(value, version, operator='eq', strict=False):
-    ''' Perform a version comparison on a value '''
-    op_map = {
-        '==': 'eq', '=':  'eq', 'eq': 'eq',
-        '<':  'lt', 'lt': 'lt',
-        '<=': 'le', 'le': 'le',
-        '>':  'gt', 'gt': 'gt',
-        '>=': 'ge', 'ge': 'ge',
-        '!=': 'ne', '<>': 'ne', 'ne': 'ne'
-    }
-
-    if strict:
-        Version = StrictVersion
-    else:
-        Version = LooseVersion
-
-    if operator in op_map:
-        operator = op_map[operator]
-    else:
-        raise errors.AnsibleFilterError('Invalid operator type')
-
-    try:
-        method = getattr(py_operator, operator)
-        return method(Version(str(value)), Version(str(version)))
-    except Exception as e:
-        raise errors.AnsibleFilterError('Version comparison: %s' % e)
 
 def regex_escape(string):
     '''Escape all regular expressions special characters from STRING.'''
@@ -261,7 +232,6 @@ def get_encrypted_password(password, hashtype='sha512', salt=None):
         'sha512':   '6',
     }
 
-    hastype = hashtype.lower()
     if hashtype in cryptmethod:
         if salt is None:
             r = SystemRandom()
@@ -461,9 +431,6 @@ class FilterModule(object):
             'ternary': ternary,
 
             # list
-            # version comparison
-            'version_compare': version_compare,
-
             # random stuff
             'random': rand,
             'shuffle': randomize_list,

--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -585,7 +585,6 @@ def nthhost(value, query=''):
         return False
 
     try:
-        vsize = ipaddr(v, 'size')
         nth = int(query)
         if value.size > nth:
           return value[nth]

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -70,12 +70,6 @@ def max(a):
     _max = __builtins__.get('max')
     return _max(a);
 
-def isnotanumber(x):
-    try:
-        return math.isnan(x)
-    except TypeError:
-        return False
-
 
 def logarithm(x, base=math.e):
     try:
@@ -136,7 +130,6 @@ class FilterModule(object):
     def filters(self):
         return {
             # general math
-            'isnan': isnotanumber,
             'min' : min,
             'max' : max,
 

--- a/lib/ansible/plugins/lookup/__init__.py
+++ b/lib/ansible/plugins/lookup/__init__.py
@@ -22,6 +22,7 @@ __metaclass__ = type
 from abc import ABCMeta, abstractmethod
 
 from ansible.compat.six import with_metaclass
+from ansible.errors import AnsibleFileNotFound
 
 try:
     from __main__ import display
@@ -101,3 +102,19 @@ class LookupBase(with_metaclass(ABCMeta, object)):
             result_string = to_unicode(result_string)
         """
         pass
+
+    def find_file_in_search_path(self, myvars, subdir, needle):
+        '''
+        Return a file (needle) in the task's expected search path.
+        '''
+
+        if 'ansible_search_path' in myvars:
+            paths = myvars['ansible_search_path']
+        else:
+            paths = self.get_basedir(myvars)
+
+        result = self._loader.path_dwim_relative_stack(paths, subdir, needle)
+        if result is None:
+            raise AnsibleFileNotFound("Unable to find '%s' in expected paths." % needle)
+
+        return result

--- a/lib/ansible/plugins/lookup/csvfile.py
+++ b/lib/ansible/plugins/lookup/csvfile.py
@@ -72,8 +72,6 @@ class LookupModule(LookupBase):
 
     def run(self, terms, variables=None, **kwargs):
 
-        basedir = self.get_basedir(variables)
-
         ret = []
 
         for term in terms:
@@ -100,7 +98,7 @@ class LookupModule(LookupBase):
             if paramvals['delimiter'] == 'TAB':
                 paramvals['delimiter'] = "\t"
 
-            lookupfile = self._loader.path_dwim_relative(basedir, 'files', paramvals['file'])
+            lookupfile = self.find_file_in_search_path(variables, 'files', paramvals['file'])
             var = self.read_csv(lookupfile, key, paramvals['delimiter'], paramvals['encoding'], paramvals['default'], paramvals['col'])
             if var is not None:
                 if type(var) is list:

--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -33,18 +33,11 @@ class LookupModule(LookupBase):
 
         ret = []
 
-        basedir = self.get_basedir(variables)
-
         for term in terms:
             display.debug("File lookup term: %s" % term)
 
-            # Special handling of the file lookup, used primarily when the
-            # lookup is done from a role. If the file isn't found in the
-            # basedir of the current file, use dwim_relative to look in the
-            # role/files/ directory, and finally the playbook directory
-            # itself (which will be relative to the current working dir)
-
-            lookupfile = self._loader.path_dwim_relative(basedir, 'files', term)
+            # Find the file in the expected search path
+            lookupfile = self.find_file_in_search_path(variables, 'files', term)
             display.vvvv("File lookup using %s as file" % lookupfile)
             try:
                 if lookupfile:

--- a/lib/ansible/plugins/lookup/fileglob.py
+++ b/lib/ansible/plugins/lookup/fileglob.py
@@ -26,12 +26,10 @@ class LookupModule(LookupBase):
 
     def run(self, terms, variables=None, **kwargs):
 
-        basedir = self.get_basedir(variables)
-
         ret = []
         for term in terms:
             term_file = os.path.basename(term)
-            dwimmed_path = self._loader.path_dwim_relative(basedir, 'files', os.path.dirname(term))
+            dwimmed_path = self.find_file_in_search_path(variables, 'files', os.path.dirname(term))
             globbed = glob.glob(os.path.join(dwimmed_path, term_file))
             ret.extend(g for g in globbed if os.path.isfile(g))
         return ret

--- a/lib/ansible/plugins/lookup/ini.py
+++ b/lib/ansible/plugins/lookup/ini.py
@@ -107,7 +107,7 @@ class LookupModule(LookupBase):
             except (ValueError, AssertionError) as e:
                 raise AnsibleError(e)
 
-            path = self._loader.path_dwim_relative(basedir, 'files', paramvals['file'])
+            path = self.find_file_in_search_path(variables, 'files', paramvals['file'])
             if paramvals['type'] == "properties":
                 var = self.read_properties(path, key, paramvals['default'], paramvals['re'])
             else:

--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -19,7 +19,6 @@ __metaclass__ = type
 
 import os
 
-from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 from ansible.utils.unicode import to_unicode
@@ -36,26 +35,25 @@ class LookupModule(LookupBase):
     def run(self, terms, variables, **kwargs):
 
         convert_data_p = kwargs.get('convert_data', True)
-        basedir = self.get_basedir(variables)
-
         ret = []
 
         for term in terms:
             display.debug("File lookup term: %s" % term)
 
-            lookupfile = self._loader.path_dwim_relative(basedir, 'templates', term)
+            lookupfile = self.find_file_in_search_path(variables, 'templates', term)
             display.vvvv("File lookup using %s as file" % lookupfile)
-            if lookupfile and os.path.exists(lookupfile):
+            if lookupfile:
                 with open(lookupfile, 'r') as f:
                     template_data = to_unicode(f.read())
 
-                    searchpath = [self._loader._basedir, os.path.dirname(lookupfile)]
-                    if 'role_path' in variables:
-                        if C.DEFAULT_ROLES_PATH:
-                            searchpath[:0] = C.DEFAULT_ROLES_PATH
-                        searchpath.insert(1, variables['role_path'])
-
+                    # set jinja2 internal search path for includes
+                    if 'ansible_search_path' in variables:
+                        searchpath = variables['ansible_search_path']
+                    else:
+                        searchpath = [self._loader._basedir, os.path.dirname(lookupfile)]
                     self._templar.environment.loader.searchpath = searchpath
+
+                    # do the templating
                     res = self._templar.template(template_data, preserve_trailing_newlines=True,convert_data=convert_data_p)
                     ret.append(res)
             else:

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -349,12 +349,15 @@ class StrategyModule(StrategyBase):
 
                 display.debug("checking for any_errors_fatal")
                 failed_hosts = []
+                unreachable_hosts = []
                 for res in results:
                     if res.is_failed():
                         failed_hosts.append(res._host.name)
+                    elif res.is_unreachable():
+                        unreachable_hosts.append(res._host.name)
 
                 # if any_errors_fatal and we had an error, mark all hosts as failed
-                if any_errors_fatal and (len(failed_hosts) > 0 or len(self._tqm._unreachable_hosts.keys()) > 0):
+                if any_errors_fatal and (len(failed_hosts) > 0 or len(unreachable_hosts) > 0):
                     for host in hosts_left:
                         # don't double-mark hosts, or the iterator will potentially
                         # fail them out of the rescue/always states

--- a/lib/ansible/plugins/test/core.py
+++ b/lib/ansible/plugins/test/core.py
@@ -20,6 +20,9 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import re
+import operator as py_operator
+from distutils.version import LooseVersion, StrictVersion
+
 from ansible import errors
 
 def failed(*a, **kw):
@@ -84,6 +87,33 @@ def search(value, pattern='', ignorecase=False, multiline=False):
     ''' Perform a `re.search` returning a boolean '''
     return regex(value, pattern, ignorecase, multiline, 'search')
 
+def version_compare(value, version, operator='eq', strict=False):
+    ''' Perform a version comparison on a value '''
+    op_map = {
+        '==': 'eq', '=':  'eq', 'eq': 'eq',
+        '<':  'lt', 'lt': 'lt',
+        '<=': 'le', 'le': 'le',
+        '>':  'gt', 'gt': 'gt',
+        '>=': 'ge', 'ge': 'ge',
+        '!=': 'ne', '<>': 'ne', 'ne': 'ne'
+    }
+
+    if strict:
+        Version = StrictVersion
+    else:
+        Version = LooseVersion
+
+    if operator in op_map:
+        operator = op_map[operator]
+    else:
+        raise errors.AnsibleFilterError('Invalid operator type')
+
+    try:
+        method = getattr(py_operator, operator)
+        return method(Version(str(value)), Version(str(version)))
+    except Exception as e:
+        raise errors.AnsibleFilterError('Version comparison: %s' % e)
+
 class TestModule(object):
     ''' Ansible core jinja2 tests '''
 
@@ -107,5 +137,8 @@ class TestModule(object):
             'match': match,
             'search': search,
             'regex': regex,
+
+            # version comparison
+            'version_compare': version_compare,
 
         }

--- a/lib/ansible/plugins/test/mathstuff.py
+++ b/lib/ansible/plugins/test/mathstuff.py
@@ -18,11 +18,19 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import math
+
 def issubset(a, b):
     return set(a) <= set(b)
 
 def issuperset(a, b):
     return set(a) >= set(b)
+
+def isnotanumber(x):
+    try:
+        return math.isnan(x)
+    except TypeError:
+        return False
 
 class TestModule:
     ''' Ansible math jinja2 tests '''
@@ -32,4 +40,5 @@ class TestModule:
             # set theory
             'issubset': issubset,
             'issuperset': issuperset,
+            'isnan': isnotanumber,
         }

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -119,14 +119,14 @@ class TestGalaxy(unittest.TestCase):
         ''' testing that execute_info displays information associated with a role '''
         ### testing cases when no role name is given ###
         gc = GalaxyCLI(args=["info"])
-        with patch('sys.argv', ["-c", "-v"]):
+        with patch('sys.argv', ["-c", "--offline", "-v"]):
             galaxy_parser = gc.parse()
         self.assertRaises(AnsibleError, gc.run)
 
         ### testing case when valid role name is given ###
             # installing role
         gc = GalaxyCLI(args=["install"])
-        with patch('sys.argv', ["--offline", "-r", self.role_req]):
+        with patch('sys.argv', ["--offline", "-p", self.role_path, "-r", self.role_req]):
             galaxy_parser = gc.parse()
         gc.run()
 
@@ -136,7 +136,7 @@ class TestGalaxy(unittest.TestCase):
 
             # testing role for info
         gc.args = ["info"]
-        with patch('sys.argv', ["-c", "--offline", self.role_name]):
+        with patch('sys.argv', ["-c", "--offline", "-p", self.role_path, self.role_name]):
             galaxy_parser = gc.parse()
         with patch.object(ansible.cli.CLI, "pager") as mock_obj:
             gc.run()
@@ -144,14 +144,14 @@ class TestGalaxy(unittest.TestCase):
 
             # deleting role
         gc.args = ["remove"]
-        with patch('sys.argv', ["-c", self.role_name]):
+        with patch('sys.argv', ["-c", "-p", self.role_path, self.role_name]):
             galaxy_parser = gc.parse()
         gc.run()
         
         ### testing case when the name of a role not installed is given ###
             # the role is not installed now
         gc = GalaxyCLI(args=["info"])
-        with patch('sys.argv', ["-c", "--offline", "delete_me"]):
+        with patch('sys.argv', ["-c", "--offline", "-p", self.role_path, self.role_name]):
             galaxy_parser = gc.parse()
 
             # this won't accurately reflect the expected outcome until GalaxyCLI.execute_info's FIXME is fixed

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -27,6 +27,7 @@ import ansible
 import os
 import shutil
 import tarfile
+import tempfile
 
 from mock import patch
 
@@ -46,12 +47,16 @@ class TestGalaxy(unittest.TestCase):
         
         # creating framework for a role
         gc = GalaxyCLI(args=["init"])
-        with patch('sys.argv', ["-c", "delete_me"]):
+        with patch('sys.argv', ["-c", "--offline", "delete_me"]):
             gc.parse()
         gc.run()
         cls.role_dir = "./delete_me"
         cls.role_name = "delete_me"
-        cls.role_path = "/etc/ansible/roles"
+
+        # making a temp dir for role installation
+        cls.role_path = os.path.join(tempfile.mkdtemp(), "roles")
+        if not os.path.isdir(cls.role_path):
+            os.makedirs(cls.role_path)
 
         # creating a tar file name for class data
         cls.role_tar = './delete_me.tar.gz'
@@ -85,6 +90,8 @@ class TestGalaxy(unittest.TestCase):
             os.remove(cls.role_req)
         if os.path.exists(cls.role_tar):
             os.remove(cls.role_tar)
+        if os.path.isdir(cls.role_path):
+            shutil.rmtree(cls.role_path)
 
     def setUp(self):
         self.default_args = []
@@ -111,7 +118,7 @@ class TestGalaxy(unittest.TestCase):
     def test_execute_remove(self):
         # installing role
         gc = GalaxyCLI(args=["install"])
-        with patch('sys.argv', ["--offline", "-r", self.role_req]):
+        with patch('sys.argv', ["--offline", "-p", self.role_path, "-r", self.role_req]):
             galaxy_parser = gc.parse()
         gc.run()
         
@@ -120,8 +127,8 @@ class TestGalaxy(unittest.TestCase):
         self.assertTrue(os.path.exists(role_file))
 
         # removing role
-        gc.args = ["remove"]
-        with patch('sys.argv', ["-c", self.role_name]):
+        gc = GalaxyCLI(args=["remove"])
+        with patch('sys.argv', ["-c", "-p", self.role_path, self.role_name]):
             galaxy_parser = gc.parse()
         super(GalaxyCLI, gc).run()
         gc.api = ansible.galaxy.api.GalaxyAPI(gc.galaxy)

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -29,7 +29,7 @@ import shutil
 import tarfile
 
 from mock import patch
-
+from ansible.errors import AnsibleError
 if PY3:
     raise SkipTest('galaxy is not ported to be py3 compatible yet')
 
@@ -107,6 +107,51 @@ class TestGalaxy(unittest.TestCase):
         display_result = gc._display_role_info(role_info)
         if display_result.find('\t\tgalaxy_tags:') > -1:
             self.fail('Expected galaxy_tags to be indented twice')
+
+    def test_execute_info(self):
+        ''' testing that execute_info displays information associated with a role '''
+        ### testing cases when no role name is given ###
+        gc = GalaxyCLI(args=["info"])
+        with patch('sys.argv', ["-c", "-v"]):
+            galaxy_parser = gc.parse()
+        self.assertRaises(AnsibleError, gc.run)
+
+        ### testing case when valid role name is given ###
+            # installing role
+        gc = GalaxyCLI(args=["install"])
+        with patch('sys.argv', ["--offline", "-r", self.role_req]):
+            galaxy_parser = gc.parse()
+        gc.run()
+
+            # data used for testing
+        gr = ansible.galaxy.role.GalaxyRole(gc.galaxy, self.role_name)
+        install_date = gr.install_info['install_date']
+
+            # testing role for info
+        gc.args = ["info"]
+        with patch('sys.argv', ["-c", "--offline", self.role_name]):
+            galaxy_parser = gc.parse()
+        with patch.object(ansible.cli.CLI, "pager") as mock_obj:
+            gc.run()
+            mock_obj.assert_called_once_with(u"\nRole: %s\n\tdescription: \n\tdependencies: []\n\tgalaxy_info:\n\t\tauthor: your name\n\t\tcompany: your company (optional)\n\t\tgalaxy_tags: []\n\t\tlicense: license (GPLv2, CC-BY, etc)\n\t\tmin_ansible_version: 1.2\n\tinstall_date: %s\n\tintalled_version: \n\tpath: ['%s']\n\tscm: None\n\tsrc: %s\n\tversion: " % (self.role_name, install_date, self.role_path, self.role_name))
+
+            # deleting role
+        gc.args = ["remove"]
+        with patch('sys.argv', ["-c", self.role_name]):
+            galaxy_parser = gc.parse()
+        gc.run()
+        
+        ### testing case when the name of a role not installed is given ###
+            # the role is not installed now
+        gc = GalaxyCLI(args=["info"])
+        with patch('sys.argv', ["-c", "--offline", "delete_me"]):
+            galaxy_parser = gc.parse()
+
+            # this won't accurately reflect the expected outcome until GalaxyCLI.execute_info's FIXME is fixed
+        with patch.object(ansible.cli.CLI, "pager") as mock_obj:
+            gc.run()
+            #mock_obj.assert_called_once_with(u'\n- the role delete_me was not found') # FIXME: Uncomment
+
 
     def test_execute_remove(self):
         # installing role

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -231,7 +231,7 @@ class TestActionBase(unittest.TestCase):
             mock_connection.module_implementation_preferences = ('.ps1',)
             (style, shebang, data, path) = action_base._configure_module('stat', mock_task.args)
             self.assertEqual(style, "new")
-            self.assertEqual(shebang, None)
+            self.assertEqual(shebang, u'#!powershell')
 
             # test module not found
             self.assertRaises(AnsibleError, action_base._configure_module, 'badmodule', mock_task.args)

--- a/test/units/plugins/strategies/test_strategy_base.py
+++ b/test/units/plugins/strategies/test_strategy_base.py
@@ -198,6 +198,7 @@ class TestStrategyBase(unittest.TestCase):
         mock_task.ignore_errors = False
 
         mock_handler_task = MagicMock(Handler)
+        mock_handler.name = 'test handler'
         mock_handler_task.action = 'foo'
         mock_handler_task.get_name.return_value = "test handler"
         mock_handler_task.has_triggered.return_value = False

--- a/test/units/plugins/strategies/test_strategy_base.py
+++ b/test/units/plugins/strategies/test_strategy_base.py
@@ -198,7 +198,7 @@ class TestStrategyBase(unittest.TestCase):
         mock_task.ignore_errors = False
 
         mock_handler_task = MagicMock(Handler)
-        mock_handler.name = 'test handler'
+        mock_handler_task.name = 'test handler'
         mock_handler_task.action = 'foo'
         mock_handler_task.get_name.return_value = "test handler"
         mock_handler_task.has_triggered.return_value = False


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

This tests the execute_info method which provides the user with information associated with a role. The execute_info method relies on having an installed role (otherwise there is no info to display). As the tester may not have a role installed this requires a setup and cleanup to test. This test patches the method (pager) that displays the info to the user and checks it is called with the right parameters.

```
before:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
- delete_me was created successfully
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_execute_remove (cli.test_galaxy.TestGalaxy) ... - extracting delete_me to /etc/ansible/roles/delete_me
- delete_me was installed successfully
- successfully removed delete_me
ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 4 tests in 3.972s

OK

after:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
- delete_me was created successfully
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
testing that execute_info displays information associated with a role ... No config file found; using defaults
- extracting delete_me to /etc/ansible/roles/delete_me
- delete_me was installed successfully
[DEPRECATION WARNING]: The comma separated role spec format, use the
yaml/explicit format instead..
This feature will be removed in a future
release. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.
- successfully removed delete_me
ok
test_execute_remove (cli.test_galaxy.TestGalaxy) ... - extracting delete_me to /etc/ansible/roles/delete_me
- delete_me was installed successfully
- successfully removed delete_me
ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 5 tests in 3.061s

OK
```
