### PR TITLE
Fix find_image() not matching on tag

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -431,9 +431,10 @@ class AnsibleDockerClient(Client):
         images = response
         if tag: 
             lookup = "%s:%s" % (name, tag)
+            images = []
             for image in response:
-                self.log(image, pretty_print=True)
-                if image.get('RepoTags') and lookup in image.get('RepoTags'):
+                tags = image.get('RepoTags')
+                if tags and lookup in tags:
                     images = [image]
                     break
         return images


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 16a3f28f6e) last updated 2016/07/11 17:13:08 (GMT -400)
  lib/ansible/modules/core: (detached HEAD db8af4c5af) last updated 2016/07/08 17:30:59 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 482b1a640e) last updated 2016/07/11 17:13:47 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fix [3719](https://github.com/ansible/ansible-modules-core/issues/3719) - docker_image doesn't build an image if another one with the same name already exists, no matter the tag specified.
