### PR TITLE
Update test_galaxy.py

### DIFF
--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -46,7 +46,7 @@ class TestGalaxy(unittest.TestCase):
         
         # creating framework for a role
         gc = GalaxyCLI(args=["init"])
-        with patch('sys.argv', ["-c", "delete_me"]):
+        with patch('sys.argv', ["-c", "--offline", "delete_me"]):
             gc.parse()
         gc.run()
         cls.role_dir = "./delete_me"


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

The execute_init method is online by default. If running tests offline this will fail. Just added --offline flag to fix that glitch.
