### PR TITLE
Add a function to check for killed processes

### DIFF
--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -319,12 +319,12 @@ class TaskQueueManager:
     def has_dead_workers(self):
 
         # [<WorkerProcess(WorkerProcess-2, stopped[SIGKILL])>,
-        # <multiprocessing.queues.Queue object at 0x7f697e31e590>]
+        # <WorkerProcess(WorkerProcess-2, stopped[SIGTERM])>
 
         defunct = False
         for idx,x in enumerate(self._workers):
             if hasattr(x[0], 'exitcode'):
-                if x[0].exitcode == -9:
+                if x[0].exitcode in [-9, -15]:
                     defunct = True
         return defunct
 

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -273,13 +273,6 @@ class TaskQueueManager:
         # and run the play using the strategy and cleanup on way out
         play_return = strategy.run(iterator, play_context)
 
-        '''
-        # check for any sigkills
-        display.debug("checking for any dead workers")
-        workers = self.get_workers()
-        import epdb; epdb.st()
-        '''
-
         # now re-save the hosts that failed from the iterator to our internal list
         for host_name in iterator.get_failed_hosts():
             self._failed_hosts[host_name] = True
@@ -323,7 +316,7 @@ class TaskQueueManager:
     def terminate(self):
         self._terminated = True
 
-    def is_defunct(self):
+    def has_dead_workers(self):
 
         # [<WorkerProcess(WorkerProcess-2, stopped[SIGKILL])>,
         # <multiprocessing.queues.Queue object at 0x7f697e31e590>]

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -455,12 +455,15 @@ class StrategyBase:
         display.debug("waiting for pending results...")
         while self._pending_results > 0 \
             and not self._tqm._terminated \
-            and not self._tqm.is_defunct():
+            and not self._tqm.has_dead_workers():
 
             results = self._process_pending_results(iterator)
             ret_results.extend(results)
             time.sleep(0.005)
         display.debug("no more pending results, returning what we have")
+
+        if self._tqm.has_dead_workers():
+            raise AnsibleError("A worker was found in a SIGKILL state")
 
         return ret_results
 

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -455,12 +455,12 @@ class StrategyBase:
         display.debug("waiting for pending results...")
         while self._pending_results > 0 and not self._tqm._terminated:
 
+            if self._tqm.has_dead_workers():
+                raise AnsibleError("A worker was found in a SIGKILL state")
+
             results = self._process_pending_results(iterator)
             ret_results.extend(results)
             time.sleep(0.005)
-
-            if self._tqm.has_dead_workers():
-                raise AnsibleError("A worker was found in a SIGKILL state")
 
         display.debug("no more pending results, returning what we have")
 

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -456,7 +456,7 @@ class StrategyBase:
         while self._pending_results > 0 and not self._tqm._terminated:
 
             if self._tqm.has_dead_workers():
-                raise AnsibleError("A worker was found in a SIGKILL state")
+                raise AnsibleError("A worker was found in a dead state")
 
             results = self._process_pending_results(iterator)
             ret_results.extend(results)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -453,17 +453,16 @@ class StrategyBase:
         ret_results = []
 
         display.debug("waiting for pending results...")
-        while self._pending_results > 0 \
-            and not self._tqm._terminated \
-            and not self._tqm.has_dead_workers():
+        while self._pending_results > 0 and not self._tqm._terminated:
 
             results = self._process_pending_results(iterator)
             ret_results.extend(results)
             time.sleep(0.005)
-        display.debug("no more pending results, returning what we have")
 
-        if self._tqm.has_dead_workers():
-            raise AnsibleError("A worker was found in a SIGKILL state")
+            if self._tqm.has_dead_workers():
+                raise AnsibleError("A worker was found in a SIGKILL state")
+
+        display.debug("no more pending results, returning what we have")
 
         return ret_results
 

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -453,7 +453,10 @@ class StrategyBase:
         ret_results = []
 
         display.debug("waiting for pending results...")
-        while self._pending_results > 0 and not self._tqm._terminated:
+        while self._pending_results > 0 \
+            and not self._tqm._terminated \
+            and not self._tqm.is_defunct():
+
             results = self._process_pending_results(iterator)
             ret_results.extend(results)
             time.sleep(0.005)

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -159,7 +159,7 @@ class StrategyModule(StrategyBase):
         # iteratate over each task, while there is one left to run
         result     = True
         work_to_do = True
-        while work_to_do and not self._tqm._terminated:
+        while work_to_do and not self._tqm._terminated and not self._tqm.is_defunct():
 
             try:
                 display.debug("getting the remaining hosts for this loop")

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -385,6 +385,10 @@ class StrategyModule(StrategyBase):
                 # most likely an abort, return failed
                 return self._tqm.RUN_UNKNOWN_ERROR
 
+        if self._tqm.is_defunct():
+            display.debug("aborting execution because of defunct workers")
+            return self._tqm.RUN_FAILED_BREAK_PLAY
+
         # run the base class run() method, which executes the cleanup function
         # and runs any outstanding handlers which have been triggered
 

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -384,7 +384,7 @@ class StrategyModule(StrategyBase):
                 display.debug("got IOError/EOFError in task loop: %s" % e)
                 # most likely an abort, return failed
                 return self._tqm.RUN_UNKNOWN_ERROR
- 
+
         # run the base class run() method, which executes the cleanup function
         # and runs any outstanding handlers which have been triggered
 

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -159,7 +159,6 @@ class StrategyModule(StrategyBase):
         # iteratate over each task, while there is one left to run
         result     = True
         work_to_do = True
-        #while work_to_do and not self._tqm._terminated and not self._tqm.has_dead_workers():
         while work_to_do and not self._tqm._terminated:
 
             try:

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -159,7 +159,8 @@ class StrategyModule(StrategyBase):
         # iteratate over each task, while there is one left to run
         result     = True
         work_to_do = True
-        while work_to_do and not self._tqm._terminated and not self._tqm.is_defunct():
+        #while work_to_do and not self._tqm._terminated and not self._tqm.has_dead_workers():
+        while work_to_do and not self._tqm._terminated:
 
             try:
                 display.debug("getting the remaining hosts for this loop")
@@ -384,11 +385,7 @@ class StrategyModule(StrategyBase):
                 display.debug("got IOError/EOFError in task loop: %s" % e)
                 # most likely an abort, return failed
                 return self._tqm.RUN_UNKNOWN_ERROR
-
-        if self._tqm.is_defunct():
-            display.debug("aborting execution because of defunct workers")
-            return self._tqm.RUN_FAILED_BREAK_PLAY
-
+ 
         # run the base class run() method, which executes the cleanup function
         # and runs any outstanding handlers which have been triggered
 

--- a/test/units/plugins/strategies/test_strategy_base.py
+++ b/test/units/plugins/strategies/test_strategy_base.py
@@ -172,7 +172,7 @@ class TestStrategyBase(unittest.TestCase):
                 raise Queue.Empty
             else:
                 return queue_items.pop()
-            
+
         mock_queue = MagicMock()
         mock_queue.empty.side_effect = _queue_empty
         mock_queue.get.side_effect = _queue_get
@@ -238,6 +238,10 @@ class TestStrategyBase(unittest.TestCase):
         strategy_base._variable_manager = mock_var_mgr
         strategy_base._blocked_hosts = dict()
 
+        def _has_dead_workers():
+            return False            
+
+        strategy_base._tqm.has_dead_workers = _has_dead_workers
         results = strategy_base._wait_on_pending_results(iterator=mock_iterator)
         self.assertEqual(len(results), 0)
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
2.2
```
##### SUMMARY

The "terminated" property doesn't catch sigkills, so this adds a function to check for any killed threads and exit early if exists.
