### PR TITLE
Update test_galaxy.py

### DIFF
--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -90,6 +90,8 @@ class TestGalaxy(unittest.TestCase):
             os.remove(cls.role_req)
         if os.path.exists(cls.role_tar):
             os.remove(cls.role_tar)
+        if os.path.isdir(cls.role_path):
+            shutil.rmtree(cls.role_path)
 
     def setUp(self):
         self.default_args = []


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Instead of using os.makedirs using tempfile.mkdtemp. Also changes using same GalaxyCLI instance to instantiating a new one before each action.
