### PR TITLE
Fixing bug in GalaxyCLI test; creates temp dir for role_path instead …

### DIFF
--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -27,6 +27,7 @@ import ansible
 import os
 import shutil
 import tarfile
+import tempfile
 
 from mock import patch
 
@@ -46,12 +47,16 @@ class TestGalaxy(unittest.TestCase):
         
         # creating framework for a role
         gc = GalaxyCLI(args=["init"])
-        with patch('sys.argv', ["-c", "delete_me"]):
+        with patch('sys.argv', ["-c", "--offline", "delete_me"]):
             gc.parse()
         gc.run()
         cls.role_dir = "./delete_me"
         cls.role_name = "delete_me"
-        cls.role_path = "/etc/ansible/roles"
+
+        # making a temp dir for role installation
+        cls.role_path = os.path.join(tempfile.mkdtemp(), "roles")
+        if not os.path.isdir(cls.role_path):
+            os.makedirs(cls.role_path)
 
         # creating a tar file name for class data
         cls.role_tar = './delete_me.tar.gz'
@@ -111,7 +116,7 @@ class TestGalaxy(unittest.TestCase):
     def test_execute_remove(self):
         # installing role
         gc = GalaxyCLI(args=["install"])
-        with patch('sys.argv', ["--offline", "-r", self.role_req]):
+        with patch('sys.argv', ["--offline", "-p", self.role_path, "-r", self.role_req]):
             galaxy_parser = gc.parse()
         gc.run()
         
@@ -120,8 +125,8 @@ class TestGalaxy(unittest.TestCase):
         self.assertTrue(os.path.exists(role_file))
 
         # removing role
-        gc.args = ["remove"]
-        with patch('sys.argv', ["-c", self.role_name]):
+        gc = GalaxyCLI(args=["remove"])
+        with patch('sys.argv', ["-c", "-p", self.role_path, self.role_name]):
             galaxy_parser = gc.parse()
         super(GalaxyCLI, gc).run()
         gc.api = ansible.galaxy.api.GalaxyAPI(gc.galaxy)

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -90,6 +90,8 @@ class TestGalaxy(unittest.TestCase):
             os.remove(cls.role_req)
         if os.path.exists(cls.role_tar):
             os.remove(cls.role_tar)
+        if os.path.isdir(cls.role_path):
+            shutil.rmtree(cls.role_path)
 
     def setUp(self):
         self.default_args = []


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Changing role path from /etc/ansible/roles to a temporary directory.

```
before:

https://gist.github.com/jctanner/359200d3a8db47988c25c1e4a2e2300f

after:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
- delete_me was created successfully
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_execute_remove (cli.test_galaxy.TestGalaxy) ... - extracting delete_me to /var/folders/b2/jz7lnnjj73l_k00lj7ncxn5m0000gn/T/tmpskuQt9/roles/delete_me
- delete_me was installed successfully
- successfully removed delete_me
ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 4 tests in 0.047s

OK
```

…of installing to /etc/ansible/roles
