### PR TITLE
Add intg for apt_repo's mode argument.

### DIFF
--- a/test/integration/roles/test_apt_repository/tasks/mode.yml
+++ b/test/integration/roles/test_apt_repository/tasks/mode.yml
@@ -1,0 +1,111 @@
+---
+
+# These tests are likely slower than they should be, since each
+# invocation of apt_repository seems to end up querying for
+# lots (all?) configured repos.
+
+- set_fact:
+    test_repo_spec: 'deb http://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main'
+    test_repo_path: '/etc/apt/sources.list.d/apt_postgresql_org_pub_repos_apt.list'
+
+- include: 'mode_cleanup.yml'
+
+- name: 'mode specified as yaml literal 0600'
+  apt_repository:
+    repo: "{{ test_repo_spec }}"
+    state: present
+    mode: 0600
+  register: mode_given_results
+
+- name: gather mode_given_as_literal_yaml stat
+  stat: path="{{ test_repo_path }}"
+  register: mode_given_yaml_literal_0600
+
+- name: show mode_given_yaml_literal_0600
+  debug: var=mode_given_yaml_literal_0600
+
+- include: 'mode_cleanup.yml'
+
+- name: assert mode_given_yaml_literal_0600 is correct
+  assert: { that: "mode_given_yaml_literal_0600.stat.mode == '0600'" }
+
+- name: 'no mode specified'
+  apt_repository:
+     repo: "{{ test_repo_spec }}"
+     state: present
+  register: no_mode_results
+
+- name: gather no mode stat
+  stat: path="{{ test_repo_path }}"
+  register: no_mode_stat
+
+- name: show no mode stat
+  debug: var=no_mode_stat
+
+- include: 'mode_cleanup.yml'
+
+- name: assert no_mode_stat is correct
+  assert: { that: "no_mode_stat.stat.mode == '0644'" }
+
+- name: 'mode specified as string 0600'
+  apt_repository:
+     repo: "{{ test_repo_spec }}"
+     state: present
+     mode: "0600"
+  register: mode_given_string_results
+
+- name: gather mode_given_string stat
+  stat: path="{{ test_repo_path }}"
+  register: mode_given_string_stat
+
+- name: show mode_given_string_stat
+  debug: var=mode_given_string_stat
+
+- include: 'mode_cleanup.yml'
+
+- name: 'mode specified as string 600'
+  apt_repository:
+     repo: "{{ test_repo_spec }}"
+     state: present
+     mode: "600"
+  register: mode_given_string_600_results
+
+- name: gather mode_given_600_string stat
+  stat: path="{{ test_repo_path }}"
+  register: mode_given_string_600_stat
+
+- name: show mode_given_string_stat
+  debug: var=mode_given_string_600_stat
+
+- include: 'mode_cleanup.yml'
+
+- name: assert mode is correct
+  assert: { that: "mode_given_string_600_stat.stat.mode == '0600'" }
+
+- name: 'mode specified as yaml literal 600'
+  apt_repository:
+    repo: "{{ test_repo_spec }}"
+    state: present
+    mode: 600
+  register: mode_given_short_results
+
+- name: gather mode_given_yaml_literal_600 stat
+  stat: path="{{ test_repo_path }}"
+  register: mode_given_yaml_literal_600
+
+- name: show mode_given_yaml_literal_600
+  debug: var=mode_given_yaml_literal_600
+
+- include: 'mode_cleanup.yml'
+
+# a literal 600 as the mode will fail currently, in the sense that it
+# doesn't guess and consider 600 and 0600 to be the same, and will instead
+# intepret literal 600 as the decimal 600 (and thereby octal 1130).
+# The literal 0600 can be interpreted as octal correctly. Note that
+# a decimal 644 is octal 420. The default perm is 0644 so a mis intrpretation
+# of 644 was previously resulting in a default file mode of 0420.
+# 'mode: 600' is likely not what a user meant but there isnt enough info
+# to determine that. Note that a string arg of '600' will be intrepeted as 0600.
+# See https://github.com/ansible/ansible/issues/16370
+- name: assert mode_given_yaml_literal_600 is correct
+  assert: { that: "mode_given_yaml_literal_600.stat.mode == '1130'" }

--- a/test/integration/roles/test_apt_repository/tasks/mode_cleanup.yml
+++ b/test/integration/roles/test_apt_repository/tasks/mode_cleanup.yml
@@ -1,0 +1,5 @@
+---
+# tasks to cleanup after creating a repo file, specifically for testing the 'mode' arg
+
+- name: delete existing repo
+  file: path="{{ test_repo_path }}" state=absent

--- a/test/integration/targets/apt_repository/tasks/main.yml
+++ b/test/integration/targets/apt_repository/tasks/main.yml
@@ -18,3 +18,7 @@
 
 - include: 'apt.yml'
   when: ansible_distribution in ('Ubuntu')
+
+- include: 'mode.yml'
+  when: ansible_distribution in ('Ubuntu')
+  tags: [test_apt_repository_mode]


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (add_apt_repository_intg_tests b50b800e0a) last updated 2016/07/12 16:15:29 (GMT -400)
  lib/ansible/modules/core: (detached HEAD db8af4c5af) last updated 2016/07/12 15:32:31 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 482b1a640e) last updated 2016/07/12 15:32:31 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

Adding integration tests for testing the 'mode' arg of the apt_repository module

 related to:
https://github.com/ansible/ansible-modules-core/pull/4072
https://github.com/ansible/ansible/issues/16370
https://github.com/ansible/ansible-modules-core/pull/3991
