### PR TITLE
[WIP] testing execute_import without asking for authentication or requirin…

### DIFF
--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -157,7 +157,7 @@ class TestGalaxy(unittest.TestCase):
                                 ] 
         
         #### testing when gc.options.check_status == False and gc.options.wait == True (the defaults)
-        gc.args = ["import"]
+        gc = GalaxyCLI(args=["import"])
         with patch('sys.argv', ["-c", "username", "repo"]):
             galaxy_parser = gc.parse()
         super(GalaxyCLI, gc).run()
@@ -174,7 +174,7 @@ class TestGalaxy(unittest.TestCase):
                 mocked_get_import_task.assert_called_with(task_id=1)
     
         #### testing when gc.options.check_status == False and gc.options.wait == False; (using --no-wait flag)
-        gc.args = ["import"]
+        gc = GalaxyCLI(args=["import"])
         with patch('sys.argv', ["-c", "--no-wait", "username", "repo"]):
             galaxy_parser = gc.parse()
         super(GalaxyCLI, gc).run()
@@ -191,7 +191,7 @@ class TestGalaxy(unittest.TestCase):
         get_import_task_side_effects = [ create_task_return_val, get_task_return_val ]
         
         #### testing when gc.options.check_status == True; (using --status flag)
-        gc.args = ["import"]
+        gc = GalaxyCLI(args=["import"])
         with patch('sys.argv', ["-c", "--status", "username", "repo"]):
             galaxy_parser = gc.parse()
         super(GalaxyCLI, gc).run()


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Mocked out methods that execute_import calls that access internet or require authentication. Tests that execute_import returns the expected value and that the mocked out methods have been called appropriately.

```
before:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
- delete_me was created successfully
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_execute_remove (cli.test_galaxy.TestGalaxy) ... - extracting delete_me to /var/folders/b2/jz7lnnjj73l_k00lj7ncxn5m0000gn/T/tmpdO_mGy/roles/delete_me
- delete_me was installed successfully
- successfully removed delete_me
ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 4 tests in 0.059s

OK

after:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
- delete_me was created successfully
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_execute_import (cli.test_galaxy.TestGalaxy) ... Successfully submitted import request 1
Successfully submitted import request 1
Role name: test
Repo: username/repo
ok
test_execute_remove (cli.test_galaxy.TestGalaxy) ... - extracting delete_me to /var/folders/b2/jz7lnnjj73l_k00lj7ncxn5m0000gn/T/tmp9apeVQ/roles/delete_me
- delete_me was installed successfully
- successfully removed delete_me
ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 5 tests in 0.060s

OK
```

…g internet
