### PR TITLE
Fix the doctype attribute in man page asciidocs

### DIFF
--- a/docs/man/man1/ansible-doc.1.asciidoc.in
+++ b/docs/man/man1/ansible-doc.1.asciidoc.in
@@ -1,6 +1,6 @@
 ansible-doc(1)
 ==============
-:doctype:manpage
+:doctype:      manpage
 :man source:   Ansible
 :man version:  %VERSION%
 :man manual:   System administration commands

--- a/docs/man/man1/ansible-playbook.1.asciidoc.in
+++ b/docs/man/man1/ansible-playbook.1.asciidoc.in
@@ -1,6 +1,6 @@
 ansible-playbook(1)
 ===================
-:doctype:manpage
+:doctype:      manpage
 :man source:   Ansible
 :man version:  %VERSION%
 :man manual:   System administration commands

--- a/docs/man/man1/ansible-pull.1.asciidoc.in
+++ b/docs/man/man1/ansible-pull.1.asciidoc.in
@@ -1,6 +1,6 @@
 ansible(1)
 =========
-:doctype:manpage
+:doctype:      manpage
 :man source:   Ansible
 :man version:  %VERSION%
 :man manual:   System administration commands

--- a/docs/man/man1/ansible.1.asciidoc.in
+++ b/docs/man/man1/ansible.1.asciidoc.in
@@ -1,6 +1,5 @@
 ansible(1)
 =========
-:doctype:manpage
 :man source:   Ansible
 :man version:  %VERSION%
 :man manual:   System administration commands


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
- Docs Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

ansible 2.2.0 (fix_asciidoc_doctype_attribute 4a05ad7417) last updated 2016/07/13 12:18:50 (GMT -400)
  lib/ansible/modules/core: (detached HEAD db8af4c5af) last updated 2016/07/12 15:32:31 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 482b1a640e) last updated 2016/07/12 15:32:31 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides

```

```
##### SUMMARY

The asciidoc.in sources had an attribute like:

:doctype:manpage

That attribute was not being correctly rendered in a2x
resulting in the 'doctype:manpage' showing up in a spurious
additional AUTHOR section at the end of the generated man pages like:

AUTHOR
       :doctype:manpage

Fix with correct formatting of 'doctype' attribute.
