### PR TITLE
testing GalaxyCLI.run() does what is expected

### DIFF
--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -115,6 +115,20 @@ class TestGalaxy(unittest.TestCase):
         if display_result.find('\t\tgalaxy_tags:') > -1:
             self.fail('Expected galaxy_tags to be indented twice')
 
+    def test_run(self):
+        ''' verifies that the GalaxyCLI object's api is created and that execute() is called. '''
+        gc = GalaxyCLI(args=["install"])
+        with patch('sys.argv', ["-c", "-v", '--ignore-errors', 'imaginary_role']):
+            galaxy_parser = gc.parse()
+        with patch.object(ansible.cli.CLI, "execute", return_value=None) as mock_ex:
+            with patch.object(ansible.cli.CLI, "run", return_value=None) as mock_run:
+                gc.run()
+                
+                # testing
+                self.assertEqual(mock_run.call_count, 1)
+                self.assertTrue(isinstance(gc.api, ansible.galaxy.api.GalaxyAPI))
+                self.assertEqual(mock_ex.call_count, 1)
+
     def test_execute_remove(self):
         # installing role
         gc = GalaxyCLI(args=["install"])


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Tests that GalaxyCLI's run method calls CLI.run, creates a GalaxyAPI instance, and calls CLI.execute. Used mock.patch.object.call_count to check that the methods are called. 

```
before:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
- delete_me was created successfully
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_execute_remove (cli.test_galaxy.TestGalaxy) ... - extracting delete_me to /var/folders/b2/jz7lnnjj73l_k00lj7ncxn5m0000gn/T/tmp1eNe0X/roles/delete_me
- delete_me was installed successfully
- successfully removed delete_me
ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 4 tests in 0.048s

OK

after:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
- delete_me was created successfully
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_execute_remove (cli.test_galaxy.TestGalaxy) ... - extracting delete_me to /var/folders/b2/jz7lnnjj73l_k00lj7ncxn5m0000gn/T/tmpoeWMT5/roles/delete_me
- delete_me was installed successfully
- successfully removed delete_me
ok
test_init (cli.test_galaxy.TestGalaxy) ... ok
verifies that the GalaxyCLI object's api is created and that execute() is called. ... ok

----------------------------------------------------------------------
Ran 5 tests in 0.048s

OK
```
