### PR TITLE
[WIP] testing GalaxyCLI method execute_info without requiring internet con…

### DIFF
--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -31,6 +31,8 @@ import tempfile
 
 from mock import patch
 
+from ansible.errors import AnsibleError
+
 if PY3:
     raise SkipTest('galaxy is not ported to be py3 compatible yet')
 
@@ -114,6 +116,51 @@ class TestGalaxy(unittest.TestCase):
         display_result = gc._display_role_info(role_info)
         if display_result.find('\t\tgalaxy_tags:') > -1:
             self.fail('Expected galaxy_tags to be indented twice')
+
+    def test_execute_info(self):
+        ''' testing that execute_info displays information associated with a role '''
+        ### testing cases when no role name is given ###
+        gc = GalaxyCLI(args=["info"])
+        with patch('sys.argv', ["-c", "--offline", "-v"]):
+            galaxy_parser = gc.parse()
+        self.assertRaises(AnsibleError, gc.run)
+
+        ### testing case when valid role name is given ###
+            # installing role
+        gc = GalaxyCLI(args=["install"])
+        with patch('sys.argv', ["--offline", "-p", self.role_path, "-r", self.role_req]):
+            galaxy_parser = gc.parse()
+        gc.run()
+
+            # data used for testing
+        gr = ansible.galaxy.role.GalaxyRole(gc.galaxy, self.role_name)
+        install_date = gr.install_info['install_date']
+
+            # testing role for info
+        gc.args = ["info"]
+        with patch('sys.argv', ["-c", "--offline", "-p", self.role_path, self.role_name]):
+            galaxy_parser = gc.parse()
+        with patch.object(ansible.cli.CLI, "pager") as mock_obj:
+            gc.run()
+            mock_obj.assert_called_once_with(u"\nRole: %s\n\tdescription: \n\tdependencies: []\n\tgalaxy_info:\n\t\tauthor: your name\n\t\tcompany: your company (optional)\n\t\tgalaxy_tags: []\n\t\tlicense: license (GPLv2, CC-BY, etc)\n\t\tmin_ansible_version: 1.2\n\tinstall_date: %s\n\tintalled_version: \n\tpath: ['%s']\n\tscm: None\n\tsrc: %s\n\tversion: " % (self.role_name, install_date, self.role_path, self.role_name))
+
+            # deleting role
+        gc.args = ["remove"]
+        with patch('sys.argv', ["-c", "-p", self.role_path, self.role_name]):
+            galaxy_parser = gc.parse()
+        gc.run()
+        
+        ### testing case when the name of a role not installed is given ###
+            # the role is not installed now
+        gc = GalaxyCLI(args=["info"])
+        with patch('sys.argv', ["-c", "--offline", "-p", self.role_path, self.role_name]):
+            galaxy_parser = gc.parse()
+
+            # this won't accurately reflect the expected outcome until GalaxyCLI.execute_info's FIXME is fixed
+        with patch.object(ansible.cli.CLI, "pager") as mock_obj:
+            gc.run()
+            #mock_obj.assert_called_once_with(u'\n- the role delete_me was not found') # FIXME: Uncomment
+
 
     def test_execute_remove(self):
         # installing role


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Tests that execute_info displays the correct role information to the user. Mocks the pager method to verify what the user sees.

```
before:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
- delete_me was created successfully
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_execute_remove (cli.test_galaxy.TestGalaxy) ... - extracting delete_me to /var/folders/b2/jz7lnnjj73l_k00lj7ncxn5m0000gn/T/tmpRYmzsq/roles/delete_me
- delete_me was installed successfully
- successfully removed delete_me
ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 4 tests in 0.049s

OK

after:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
- delete_me was created successfully
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
testing that execute_info displays information associated with a role ... No config file found; using defaults
- extracting delete_me to /var/folders/b2/jz7lnnjj73l_k00lj7ncxn5m0000gn/T/tmpQFFqji/roles/delete_me
- delete_me was installed successfully
[DEPRECATION WARNING]: The comma separated role spec format, use the yaml/explicit format
 instead..
This feature will be removed in a future release. Deprecation warnings can be
disabled by setting deprecation_warnings=False in ansible.cfg.
- successfully removed delete_me
ok
test_execute_remove (cli.test_galaxy.TestGalaxy) ... - extracting delete_me to /var/folders/b2/jz7lnnjj73l_k00lj7ncxn5m0000gn/T/tmpQFFqji/roles/delete_me
- delete_me was installed successfully
- successfully removed delete_me
ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 5 tests in 0.091s

OK
```

…nection
