### PR TITLE
ensure localhost is available when using dynamic ec2 inventory

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -475,6 +475,10 @@ class Ec2Inventory(object):
                 self.get_elasticache_clusters_by_region(region)
                 self.get_elasticache_replication_groups_by_region(region)
 
+        # ensure localhost always reachable
+        self.push(self.inventory, 'localhost', 'localhost')
+        self.push(self.inventory, 'localhost', '127.0.0.1')
+
         self.write_to_cache(self.inventory, self.cache_path_cache)
         self.write_to_cache(self.index, self.cache_path_index)
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

My cookbook consists of roles that should run locally (AWS API calls) and roles that run on created EC2 instances. Our use case doesn't allow a strict separation of those roles in two cookbooks. If I'm executing 

```
pre_tasks:
  - meta: refresh_inventory
```

in my cookbook, all following commands do not recognize `hosts: localhost` anymore (output `no hosts matched`).

To fix this problem, localhost should always be present in the dynamic created inventory.
