### PR TITLE
[WIP] Testing GalaxyCLI method execute_search; mocks out internet use

### DIFF
--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -177,7 +177,7 @@ class TestGalaxy(unittest.TestCase):
         search_return_val = {'count':1, 'results':[role]}
         
                 # running method to test #
-        gc.args=["search"]
+        gc = GalaxyCLI(args=["search"])
         with patch('sys.argv', ["-c", "search_example"]):
             galaxy_parser = gc.parse()
         super(GalaxyCLI, gc).run()
@@ -203,7 +203,7 @@ class TestGalaxy(unittest.TestCase):
         search_return_val = {'count':1001, 'results':roles}
 
                 # running method to test #        
-        gc.args=["search"]
+        gc = GalaxyCLI(args=["search"])
         with patch('sys.argv', ["-c", "search_example"]):
             galaxy_parser = gc.parse()
         super(GalaxyCLI, gc).run()

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -29,7 +29,9 @@ import shutil
 import tarfile
 import tempfile
 
-from mock import patch
+from mock import patch, MagicMock
+
+from ansible.errors import AnsibleError
 
 if PY3:
     raise SkipTest('galaxy is not ported to be py3 compatible yet')
@@ -137,3 +139,82 @@ class TestGalaxy(unittest.TestCase):
         # testing role was removed
         self.assertTrue(completed_task == 0)
         self.assertTrue(not os.path.exists(role_file))
+
+    def test_execute_search(self):
+
+        ### testing if no search terms are given
+        gc = GalaxyCLI(args=["search"])
+        with patch('sys.argv', ["-c"]):
+            galaxy_parser = gc.parse()
+        self.assertRaises(AnsibleError, gc.run)
+
+        ### testing if the search term found no results
+                # setup #
+        search_return_val = {'count':0, 'results':[]}
+
+                # running method to test #
+        gc = GalaxyCLI(args=["search"])
+        with patch('sys.argv', ["-c", "search_example"]):
+            galaxy_parser = gc.parse()
+        super(GalaxyCLI, gc).run()
+        gc.api = ansible.galaxy.api.GalaxyAPI(gc.galaxy)
+        with patch.object(ansible.galaxy.api.GalaxyAPI, "search_roles", return_value=search_return_val) as mock_search: # mocks out internet use
+            with patch.object(ansible.utils.display.Display, "display") as mocked_display:  # used for checking correct message
+                completed_task = gc.execute_search()
+
+                # tests #
+                self.assertTrue(completed_task)
+                self.assertEqual(mock_search.call_count, 1)
+                self.assertEqual(mocked_display.call_count, 1)
+                mocked_display.assert_called_once_with('No roles match your search.', color='red')
+
+        ### testing search if there are fewer results than the page size
+                # setup #
+        role = MagicMock()
+        role['username'] = 'username'
+        role['name'] = 'role'
+        role['description'] = "DESCRIPTION"
+        search_return_val = {'count':1, 'results':[role]}
+        
+                # running method to test #
+        gc.args=["search"]
+        with patch('sys.argv', ["-c", "search_example"]):
+            galaxy_parser = gc.parse()
+        super(GalaxyCLI, gc).run()
+        gc.api = ansible.galaxy.api.GalaxyAPI(gc.galaxy)
+        with patch.object(ansible.galaxy.api.GalaxyAPI, "search_roles", return_value=search_return_val) as mock_search:  # mocks out internet use
+            with patch.object(ansible.cli.CLI, "pager") as mock_pager:  # used for checking correct message
+                completed_task = gc.execute_search()
+
+                # tests #
+                self.assertTrue(completed_task)
+                self.assertEqual(mock_search.call_count, 1)
+                self.assertEqual(mock_pager.call_count, 1)
+                mock_pager.assert_called_with(u'\nFound 1 roles matching your search:\n\n Name Description\n ---- -----------\n %s.%s %s' % (role['username'], role['name'], role['description']))
+
+        ### testing search if there are more results than the page size
+                # setup #
+        roles = []
+        role = MagicMock()
+        role['username'] = 'username'
+        role['name'] = 'role'
+        role['description'] = "DESCRIPTION"
+        for i in range(0, 1001): roles.append(role)
+        search_return_val = {'count':1001, 'results':roles}
+
+                # running method to test #        
+        gc.args=["search"]
+        with patch('sys.argv', ["-c", "search_example"]):
+            galaxy_parser = gc.parse()
+        super(GalaxyCLI, gc).run()
+        gc.api = ansible.galaxy.api.GalaxyAPI(gc.galaxy)
+        with patch.object(ansible.galaxy.api.GalaxyAPI, "search_roles", return_value=search_return_val) as mock_search:  # mocks out internet use
+            with patch.object(ansible.cli.CLI, "pager") as mock_pager:  # used for checkitn correct message
+                completed_task = gc.execute_search()
+                
+                # tests #
+                self.assertTrue(completed_task)
+                self.assertEqual(mock_search.call_count, 1)
+                self.assertEqual(mock_pager.call_count, 1)
+                self.assertIn('Found 1001 roles matching your search. Showing first 1000.', str(mock_pager.call_args_list))
+


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

The execute_search method (which this tests) calls a method that uses internet connection. I've mocked this method and its return value out. To test, I verify that execute_search returns the expected value and that mocked out methods are called appropriately.

```
before:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
- delete_me was created successfully
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_execute_remove (cli.test_galaxy.TestGalaxy) ... - extracting delete_me to /var/folders/b2/jz7lnnjj73l_k00lj7ncxn5m0000gn/T/tmpNWm0i_/roles/delete_me
- delete_me was installed successfully
- successfully removed delete_me
ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 4 tests in 0.087s

OK

after:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
- delete_me was created successfully
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_execute_remove (cli.test_galaxy.TestGalaxy) ... - extracting delete_me to /var/folders/b2/jz7lnnjj73l_k00lj7ncxn5m0000gn/T/tmpjWlzus/roles/delete_me
- delete_me was installed successfully
- successfully removed delete_me
ok
test_execute_search (cli.test_galaxy.TestGalaxy) ... ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 5 tests in 0.341s

OK
```
