### PR TITLE
Add integration tests for Docker modules.

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -34,13 +34,14 @@ try:
     from docker import __version__ as docker_version
     from docker.errors import APIError, TLSParameterError, NotFound
     from docker.tls import TLSConfig
-    from docker.constants import DEFAULT_TIMEOUT_SECONDS, DEFAULT_DOCKER_API_VERSION
+    from docker.constants import DEFAULT_TIMEOUT_SECONDS
     from docker.utils.types import Ulimit, LogConfig
     from docker import auth
 except ImportError as exc:
     HAS_DOCKER_ERROR = str(exc)
     HAS_DOCKER_PY = False
 
+DEFAULT_DOCKER_API_VERSION = 'auto'
 DEFAULT_DOCKER_HOST = 'unix://var/run/docker.sock'
 DEFAULT_TLS = False
 DEFAULT_TLS_VERIFY = False
@@ -110,14 +111,14 @@ class DockerBaseClass(object):
         self.debug = False
 
     def log(self, msg, pretty_print=False):
-        pass
-        # if self.debug:
-        #     log_file = open('docker.log', 'a')
-        #     if pretty_print:
-        #         log_file.write(json.dumps(msg, sort_keys=True, indent=4, separators=(',', ': ')))
-        #         log_file.write(u'\n')
-        #     else:
-        #         log_file.write(msg + u'\n')
+        # pass
+        if self.debug:
+            log_file = open('docker.log', 'a')
+            if pretty_print:
+                log_file.write(json.dumps(msg, sort_keys=True, indent=4, separators=(',', ': ')))
+                log_file.write(u'\n')
+            else:
+                log_file.write(msg + u'\n')
 
 
 class AnsibleDockerClient(Client):
@@ -167,14 +168,14 @@ class AnsibleDockerClient(Client):
             self.fail("Error connecting: %s" % exc)
 
     def log(self, msg, pretty_print=False):
-        pass
-        # if self.debug:
-        #     log_file = open('docker.log', 'a')
-        #     if pretty_print:
-        #         log_file.write(json.dumps(msg, sort_keys=True, indent=4, separators=(',', ': ')))
-        #         log_file.write(u'\n')
-        #     else:
-        #         log_file.write(msg + u'\n')
+        # pass
+        if self.debug:
+            log_file = open('docker.log', 'a')
+            if pretty_print:
+                log_file.write(json.dumps(msg, sort_keys=True, indent=4, separators=(',', ': ')))
+                log_file.write(u'\n')
+            else:
+                log_file.write(msg + u'\n')
 
     def fail(self, msg):
         self.module.fail_json(msg=msg)

--- a/shippable.yml
+++ b/shippable.yml
@@ -8,73 +8,77 @@ matrix:
   exclude:
     - env: TEST=none
   include:
-    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:centos6
-    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:centos7
-    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:fedora-rawhide
-    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:fedora23
-    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:opensuseleap
-    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1204 PRIVILEGED=true
-    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1404 PRIVILEGED=true
-    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1604
+#    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:centos6
+#    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:centos7
+#    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:fedora-rawhide
+#    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:fedora23
+#    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:opensuseleap
+#    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1204 PRIVILEGED=true
+#    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1404 PRIVILEGED=true
+#    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1604
+#
+#    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:centos6
+#    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:centos7
+#    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:fedora-rawhide
+#    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:fedora23
+#    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:opensuseleap
+#    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1204
+#    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1404
+#    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1604
+#
+#    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:centos6
+#    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:centos7
+#    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:fedora-rawhide
+#    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:fedora23
+#    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:opensuseleap
+#    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:ubuntu1204
+#    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:ubuntu1404
+#    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:ubuntu1604
 
-    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:centos6
-    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:centos7
-    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:fedora-rawhide
-    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:fedora23
-    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:opensuseleap
-    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1204
-    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1404
-    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1604
+     # Run docker tests
+     - env: TEST=docker TARGET=test_docker IMAGE=ansibletesting/docker-modules:latest
 
-    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:centos6
-    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:centos7
-    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:fedora-rawhide
-    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:fedora23
-    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:opensuseleap
-    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:ubuntu1204
-    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:ubuntu1404
-    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:ubuntu1604
+#    - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py24
+#      python: 2.7
+#    - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py26
+#      python: 2.6
+#    - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py27
+#      python: 2.7
+#    - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py34
+#      python: 3.4
+#    - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py35
+#      python: 3.5
+#
+#    - env: TEST=code-smell INSTALL_DEPS=1
+#      python: 2.7
 
-    - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py24
-      python: 2.7
-    - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py26
-      python: 2.6
-    - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py27
-      python: 2.7
-    - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py34
-      python: 3.4
-    - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py35
-      python: 3.5
-
-    - env: TEST=code-smell INSTALL_DEPS=1
-      python: 2.7
 build:
   pre_ci_boot:
-    options: "--privileged=false --net=bridge"
+    options: "--privileged=false --net=bridge -e SHIPPABLE_HOST_IP=`/sbin/ip route|awk '/default/ { print  $3}'`"
   ci:
     - test/utils/shippable/ci.sh
 
-integrations:
-  notifications:
-    - integrationName: email
-      type: email
-      on_success: never
-      on_failure: never
-      on_start: never
-      on_pull_request: never
-    - integrationName: irc
-      type: irc
-      recipients:
-      - "chat.freenode.net#ansible-notices"
-      on_success: change
-      on_failure: always
-      on_start: never
-      on_pull_request: always
-    - integrationName: slack
-      type: slack
-      recipients:
-      - "#shippable"
-      on_success: change
-      on_failure: always
-      on_start: never
-      on_pull_request: never
+#integrations:
+#  notifications:
+#    - integrationName: email
+#      type: email
+#      on_success: never
+#      on_failure: never
+#      on_start: never
+#      on_pull_request: never
+#    - integrationName: irc
+#      type: irc
+#      recipients:
+#      - "chat.freenode.net#ansible-notices"
+#      on_success: change
+#      on_failure: always
+#      on_start: never
+#      on_pull_request: always
+#    - integrationName: slack
+#      type: slack
+#      recipients:
+#      - "#shippable"
+#      on_success: change
+#      on_failure: always
+#      on_start: never
+#      on_pull_request: never

--- a/shippable.yml
+++ b/shippable.yml
@@ -54,7 +54,7 @@ matrix:
 
 build:
   pre_ci_boot:
-    options: "--privileged=false --net=bridge -e SHIPPABLE_HOST_IP=`/sbin/ip route|awk '/default/ { print  $3}'`"
+    options: "--privileged=false --net=bridge -e SHIPPABLE_HOST_IP=`/sbin/ip route|awk '/default/ { print  $3}'` --add-host=ansibleregistry.com:`/sbin/ip route|awk '/default/{ print $3 }'`"
   ci:
     - test/utils/shippable/ci.sh
 

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -317,3 +317,10 @@ test_async:
 	# Verify that the warning exists by examining debug output.
 	ANSIBLE_DEBUG=1 LC_ALL=bogus ansible-playbook test_async.yml -i localhost, -e ansible_connection=ssh -v $(TEST_FLAGS) \
 	| grep -q 'bash: warning: setlocale: LC_ALL: cannot change locale (bogus)'
+
+test_docker:
+	/bin/rm -rf ./roles/ansible.local-registry; \
+	ansible-galaxy install -p ./roles  ansible.local-registry; \
+	ansible-playbook -i $(INVENTORY) -e @$(VARS_FILE) -v $(TEST_FLAGS) test_docker.yml; \
+	RC=$$? ; \
+	exit $$RC;

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -318,6 +318,11 @@ test_async:
 	ANSIBLE_DEBUG=1 LC_ALL=bogus ansible-playbook test_async.yml -i localhost, -e ansible_connection=ssh -v $(TEST_FLAGS) \
 	| grep -q 'bash: warning: setlocale: LC_ALL: cannot change locale (bogus)'
 
+test_registry:
+	/bin/rm -rf ./roles/ansible.local-registry; \
+	ansible-galaxy install -p ./roles  ansible.local-registry; \
+        ansible-playbook -i inventory.docker -e @$(VARS_FILE) -v $(TEST_FLAGS) test_registry.yml; \
+
 test_docker:
 	/bin/rm -rf ./roles/ansible.local-registry; \
 	ansible-galaxy install -p ./roles  ansible.local-registry; \

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -321,6 +321,6 @@ test_async:
 test_docker:
 	/bin/rm -rf ./roles/ansible.local-registry; \
 	ansible-galaxy install -p ./roles  ansible.local-registry; \
-	ansible-playbook -i $(INVENTORY) -e @$(VARS_FILE) -v $(TEST_FLAGS) test_docker.yml; \
+	ansible-playbook -i inventory.docker -e @$(VARS_FILE) -v $(TEST_FLAGS) test_docker.yml; \
 	RC=$$? ; \
 	exit $$RC;

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -321,7 +321,7 @@ test_async:
 test_registry:
 	/bin/rm -rf ./roles/ansible.local-registry; \
 	ansible-galaxy install -p ./roles  ansible.local-registry; \
-        ansible-playbook -i inventory.docker -e @$(VARS_FILE) -v $(TEST_FLAGS) test_registry.yml; \
+	ansible-playbook -i inventory.docker -e @$(VARS_FILE) -v $(TEST_FLAGS) test_registry.yml; \
 
 test_docker:
 	/bin/rm -rf ./roles/ansible.local-registry; \

--- a/test/integration/integration_config.yml
+++ b/test/integration/integration_config.yml
@@ -3,6 +3,7 @@ win_output_dir: 'C:\ansible_testing'
 output_dir: ~/ansible_testing
 non_root_test_user: ansible
 pip_test_package: epdb
+playbook_debug: no
 
 # variables used in precedence tests, here passed to -e
 etest: 'from -e'

--- a/test/integration/integration_config.yml
+++ b/test/integration/integration_config.yml
@@ -6,7 +6,6 @@ pip_test_package: epdb
 
 # variables for docker modules testing
 playbook_debug: no
-docker_start_registry: yes
 
 # variables used in precedence tests, here passed to -e
 etest: 'from -e'

--- a/test/integration/integration_config.yml
+++ b/test/integration/integration_config.yml
@@ -3,7 +3,10 @@ win_output_dir: 'C:\ansible_testing'
 output_dir: ~/ansible_testing
 non_root_test_user: ansible
 pip_test_package: epdb
+
+# variables for docker modules testing
 playbook_debug: no
+docker_start_registry: yes
 
 # variables used in precedence tests, here passed to -e
 etest: 'from -e'

--- a/test/integration/inventory.docker
+++ b/test/integration/inventory.docker
@@ -1,0 +1,2 @@
+[docker]
+localhost

--- a/test/integration/roles/test_docker_container/defaults/main.yml
+++ b/test/integration/roles/test_docker_container/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+docker_network_name: IntTesting

--- a/test/integration/roles/test_docker_container/files/ubuntu_sshd/Dockerfile
+++ b/test/integration/roles/test_docker_container/files/ubuntu_sshd/Dockerfile
@@ -1,0 +1,20 @@
+# sshd
+#
+# VERSION               0.0.2
+
+FROM ubuntu:14.04
+MAINTAINER Sven Dowideit <SvenDowideit@docker.com>
+
+RUN apt-get update && apt-get install -y openssh-server
+RUN mkdir /var/run/sshd
+RUN echo 'root:screencast' | chpasswd
+RUN sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config
+
+# SSH login fix. Otherwise user is kicked off after login
+RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+
+ENV NOTVISIBLE "in users profile"
+RUN echo "export VISIBLE=now" >> /etc/profile
+
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D"]

--- a/test/integration/roles/test_docker_container/tasks/main.yml
+++ b/test/integration/roles/test_docker_container/tasks/main.yml
@@ -1,0 +1,490 @@
+- name: Remove ubuntu image
+  docker_image:
+    path: "{{ role_path + '/files/ubuntu_sshd' }}" 
+    name: ubuntu_sshd
+    debug: "{{ playbook_debug }}"
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- name: Build container with missing image
+  docker_container:
+    name: ubuntu_running_ssh
+    image: ubuntu_sshd:latest 
+    privileged: yes
+    debug: "{{ playbook_debug }}"
+    restart_policy: "no"
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- name: Start a container 
+  docker_container:
+    name: sleepy 
+    image: ubuntu:14.04
+    debug: "{{ playbook_debug }}"
+    command: sleep infinity
+  register: output
+
+- debug: var=output   
+  when: playbook_debug
+
+- name: Should be running
+  assert:
+    that:
+      - ansible_docker_container.State.Running
+
+- name: Create IntTesting network
+  command: docker network create --subnet 172.1.1.0/24 "{{ docker_network_name }}" 
+  register: output
+  ignore_errors: yes
+
+- name: Create IntTesting2 network
+  command: docker network create --subnet 172.1.10.0/24 "{{ docker_network_name + '2' }}" 
+  register: output
+  ignore_errors: yes
+
+- name: Add existing container to networks
+  docker_container:
+    name: sleepy
+    networks:
+      - name: "{{ docker_network_name }}" 
+        ipv4_address: 172.1.1.18
+      - name: "{{ docker_network_name + '2' }}" 
+        ipv4_address: 172.1.10.20
+    debug: "{{ playbook_debug }}"
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- assert:
+    that:
+      - "ansible_docker_container.NetworkSettings.Networks.{{ docker_network_name }} is defined"
+
+- name: Add existing container to networks, should be idempotent
+  docker_container:
+    name: sleepy
+    networks:
+      - name: "{{ docker_network_name }}" 
+        ipv4_address: 172.1.1.18
+      - name: "{{ docker_network_name + '2' }}" 
+        ipv4_address: 172.1.10.20
+    debug: "{{ playbook_debug }}"
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- assert:
+    that:
+      - not output.changed
+
+- name: Update container network aliases
+  docker_container:
+    name: sleepy
+    networks:
+      - name: "{{ docker_network_name }}"
+        aliases:
+          - sleepyz
+          - zzzz  
+    debug: "{{ playbook_debug }}"
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- assert:
+    that:
+      - "'sleepyz' in ansible_docker_container.NetworkSettings.Networks.{{ docker_network_name }}.Aliases"
+      - "'zzzz' in ansible_docker_container.NetworkSettings.Networks.{{ docker_network_name }}.Aliases"
+
+- name: Update container network aliases, should be idempotent
+  docker_container:
+    name: sleepy
+    networks:
+      - name: "{{ docker_network_name }}"
+        aliases:
+          - sleepyz
+          - zzzz  
+    debug: "{{ playbook_debug }}"
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- assert:
+    that:
+      - not output.changed
+
+- name: Remove container from one network
+  docker_container:
+    name: sleepy
+    networks:
+      - name: "{{ docker_network_name }}"
+    debug: "{{ playbook_debug }}"
+    purge_networks: yes
+  register: output
+
+- assert:
+    that:
+      - "ansible_docker_container.NetworkSettings.Networks.{{ docker_network_name }} is defined"
+      - "ansible_docker_container.NetworkSettings.Networks.{{ docker_network_name + '2' }} is not defined"
+
+- name: Remove container from all networks
+  docker_container:
+    name: sleepy
+    purge_networks: yes
+  register: output
+
+- assert:
+    that:
+      - "ansible_docker_container.NetworkSettings.Networks.{{ docker_network_name }} is not defined"
+      - "ansible_docker_container.NetworkSettings.Networks.{{ docker_network_name + '2' }} is not defined"
+
+- name: Create db container and add to network 
+  docker_container:
+    name: db_test
+    image: "postgres:latest"
+    networks:
+      - name: "{{ docker_network_name }}"
+    debug: "{{ playbook_debug }}" 
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- name: Start a container with networks 
+  docker_container:
+    name: sleepy2
+    image: ubuntu:14.04
+    command: sleep infinity
+    networks:
+      - name: "{{ docker_network_name }}"
+        ipv4_address: "172.1.1.100"
+        aliases:
+          - sleepyzz
+        links:
+          - db_test:db 
+          - sleepy
+      - name: "{{ docker_network_name + '2' }}"
+    debug: "{{ playbook_debug }}"
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- assert:
+    that:
+      - "ansible_docker_container.NetworkSettings.Networks.{{ docker_network_name }} is defined"
+      - "ansible_docker_container.NetworkSettings.Networks.{{ docker_network_name + '2' }} is defined" 
+
+- name: Start a container with networks should be idempotent
+  docker_container:
+    name: sleepy2
+    image: ubuntu:14.04
+    networks:
+      - name: "{{ docker_network_name }}"
+        ipv4_address: "172.1.1.100"
+        aliases:
+          - sleepyzz
+        links:
+          - db_test:db 
+          - sleepy
+      - name: "{{ docker_network_name + '2' }}"
+    debug: "{{ playbook_debug }}"
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- assert:
+    that:
+      - not output.changed
+
+- docker_container:
+    name: db_test
+    purge_networks: yes
+
+- docker_container:
+    name: sleepy2
+    purge_networks: yes 
+  
+- name: Remove IntTesting network
+  command: docker network rm "{{ docker_network_name }}" 
+  ignore_errors: yes
+
+- name: Remove IntTesting network
+  command: docker network rm "{{ docker_network_name + '2' }}" 
+  ignore_errors: yes
+
+- name: Remove containers
+  docker_container:
+    name: "{{ item }}"
+    state: absent
+    force_kill: yes
+  with_items:
+    - sleepy
+    - ubuntu_running_ssh
+    - sleepy2
+    - db_test
+
+- docker_container:
+    name: "{{ item }}" 
+    state: absent
+    force_kill: yes
+  with_items:
+    - sleepy5
+    - sleepy6 
+    - sleepy7
+    - sleepy8
+
+- name: Start container with exposed port range, root bind and command
+  docker_container:
+    name: sleepy5
+    image: ubuntu:14.04 
+    command: sleep infinity
+    expose:
+      - 6000-6100
+    volumes:
+      - "/:/rootfs:ro"
+    state: started 
+    debug: "{{ playbook_debug }}"
+  register: output
+
+- name: Container sleepy5 should build with expected config 
+  assert:
+    that:
+      - ansible_docker_container.State.Running
+      - "ansible_docker_container.HostConfig.Binds[0] == '/:/rootfs:ro'"
+      - "ansible_docker_container.Config.Volumes['/rootfs'] is defined"
+      - "ansible_docker_container.Config.ExposedPorts['6000-6100/tcp'] is defined"
+      - "'sleep' in ansible_docker_container.Config.Cmd"
+      - "'infinity' in ansible_docker_container.Config.Cmd"
+
+- debug: var=output
+  when: playbook_debug 
+
+- name: Stop running container
+  docker_container:
+    name: sleepy5
+    state: stopped
+    force_kill: yes
+    debug: "{{ playbook_debug }}"
+  register: output
+
+- debug: var=output
+  when: playbook_debug 
+
+- name: Existing container should be stopped 
+  assert:
+    that:
+      - not ansible_docker_container.State.Running
+      - ansible_docker_container.State.Status == 'exited'
+
+- name: Create a present container
+  docker_container:
+    name: sleepy6
+    image: ubuntu:14.04 
+    command: sleep infinity 
+    debug: "{{ playbook_debug }}"
+    state: present 
+    force_kill: yes
+  register: output
+      
+- debug: var=output
+  when: playbook_debug
+
+- name: Container should be created and stopped
+  assert:
+    that:
+      - not ansible_docker_container.State.Running
+      - ansible_docker_container.State.Status == 'created'
+
+- name: Start container with published ports and no matching exposed ports 
+  docker_container:
+    image: ubuntu:14.04 
+    name: sleepy7 
+    command: sleep infinity
+    ports: 
+      - 9090:8080
+      - 9443:8443
+    debug: "{{ playbook_debug }}"
+  register: output
+
+- debug: var=output
+  when: playbook_debug 
+
+- name: Exposed ports should automatically include published ports
+  assert:
+    that:
+      - "ansible_docker_container.Config.ExposedPorts['8080/tcp'] is defined"
+      - "ansible_docker_container.Config.ExposedPorts['8443/tcp'] is defined"  
+
+- name: Test sleepy7 idempotency 
+  docker_container:
+    image: ubuntu:14.04
+    name: sleepy7
+    command: sleep infinity
+    ports:
+      - 9090:8080
+      - 9443:8443
+    debug: "{{ playbook_debug }}"
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- name: Automatic exposed ports should be idempotent  
+  assert:
+    that:
+      - not output.changed
+
+- name: Start container with published ports and range of exposed ports 
+  docker_container:
+    image: ubuntu:14.04 
+    name: sleepy8 
+    ports: 
+      - 5090:5090
+      - 4443:4443
+    exposed:
+      - 4000-5090 
+    command: sleep infinity
+    debug: "{{ playbook_debug }}"
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- name: Range of ports should be exposed 
+  assert:
+    that:
+      - ansible_docker_container.State.Running
+      - "ansible_docker_container.Config.ExposedPorts['4000-5090/tcp'] is defined"
+
+- name: Sleepy8 should be idempotent 
+  docker_container:
+    image: ubuntu:14.04
+    name: sleepy8
+    ports:
+      - 5090:5090
+      - 4443:4443
+    exposed:
+      - 4000-5090
+    command: sleep infinity
+    debug: "{{ playbook_debug }}" 
+  register: output   
+
+- debug: var=output
+  when: playbook_debug
+
+- name: Exposed port range should be idempotent 
+  assert:
+    that:
+      - not output.changed
+
+- name: Run detached  
+  docker_container:
+    image: busybox
+    name: waitforme
+    detach: false
+    command: sleep 15
+
+- name: Should be exited 
+  assert:
+    that:
+      - ansible_docker_container.State.Status == 'exited'
+
+- name: Inspect the container
+  command: docker inspect --format='{% raw %}{{.State.Status}}{% endraw %}' waitforme
+  register: output
+
+- name: Should exist
+  assert:
+    that:
+      - output.stdout_lines[0] == 'exited'
+
+- name: Run detached with cleanup 
+  docker_container:
+    image: busybox
+    name: waitforme
+    detach: false
+    cleanup: true
+    command: echo "This works!"
+  register: output
+
+- name: Should contain expected output 
+  assert:
+    that:
+      - "'This works!' in ansible_docker_container.Output"
+
+- name: Inspect the cotnainer, ignoring errors 
+  command: docker inspect waitforme
+  ignore_errors: yes
+  register: output
+
+- name: Should not exist 
+  assert:
+    that:
+      - output.failed
+
+# Test volumes
+- name: Create a container with a host bound volume
+  docker_container:
+    name: mounty1
+    image: ubuntu:14.04
+    command: sleep infinity
+    volumes:
+      - .:/tmp/data
+    debug: "{{ playbook_debug }}"
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- name: Should have a host bound volume  
+  assert:
+    that:
+      - "ansible_docker_container.Mounts | length == 1"
+      - "ansible_docker_container.Mounts[0].Destination == '/tmp/data'"
+
+- name: Create a container with an unbound volume
+  docker_container:
+    name: mounty2
+    image: ubuntu:14.04
+    command: sleep infinity
+    volumes:
+      - /tmp/data
+    debug: "{{ playbook_debug }}"
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- name: Should have an unbound volume.
+  assert:
+    that:
+      - "ansible_docker_container.Mounts | length == 1"
+      - "ansible_docker_container.Config.Volumes['/tmp/data'] == {}"
+
+- name: Create a container bound to named volume
+  docker_container:
+    name: mounty3
+    image: ubuntu:14.04
+    command: sleep infinity
+    volumes:
+      - foo:/tmp/data
+    debug: "{{ playbook_debug }}"
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- name: Should have a named volume. 
+  assert:
+    that:
+      - "ansible_docker_container.Mounts | length == 1"
+      - "ansible_docker_container.Mounts[0].Name == 'foo'" 
+      - "ansible_docker_container.Config.Volumes['/tmp/data'] == {}"

--- a/test/integration/roles/test_docker_container/tasks/test_restart_policy.yml
+++ b/test/integration/roles/test_docker_container/tasks/test_restart_policy.yml
@@ -1,0 +1,43 @@
+
+# Test restart policy
+# Test that env vars containing '=' work
+
+- name: Test restart policy and env vars with multiple equals 
+  docker_container:
+    name: spark01
+    image: ubuntu:14.04 
+    restart_policy: on-failure
+    restart_retries: 5
+    env:
+      SPARK_OPTS: "--driver-java-options=-Xms1024M --driver-java-options=-Xmx4096M --driver-java-options=-Dlog4j.logLevel=info"
+    command: sleep infinity
+  register: output 
+
+- debug: var=output
+  when: playbook_debug
+
+- name: 
+  assert:
+     that:
+       - "ansible_docker_container.Config.Env[0] == 'SPARK_OPTS=--driver-java-options=-Xms1024M --driver-java-options=-Xmx4096M --driver-java-options=-Dlog4j.logLevel=info'"
+       - "ansible_docker_container.HostConfig.RestartPolicy.MaximumRetryCount == 5"
+       - "ansible_docker_container.HostConfig.RestartPolicy.Name == 'on-failure'"
+
+- name: spark01 should be idempotent 
+  docker_container:
+    name: spark01
+    image: ubuntu:14.04
+    restart_policy: on-failure
+    restart_retries: 5
+    env:
+      SPARK_OPTS: "--driver-java-options=-Xms1024M --driver-java-options=-Xmx4096M --driver-java-options=-Dlog4j.logLevel=info"
+    command: sleep infinity
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- name:
+  assert:
+     that:
+       - not output.changed

--- a/test/integration/roles/test_docker_image/defaults/main.yml
+++ b/test/integration/roles/test_docker_image/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+registry_host: localhost
+docker_data_path: "{{ role_path }}/files"
+local_registry_user: testuser
+local_registry_password: testpassword

--- a/test/integration/roles/test_docker_image/files/sinatra/Dockerfile
+++ b/test/integration/roles/test_docker_image/files/sinatra/Dockerfile
@@ -1,0 +1,5 @@
+# taken from https://docs.docker.com/engine/userguide/containers/dockerimages/ 
+FROM ubuntu:14.04
+MAINTAINER Kate Smith <ksmith@example.com>
+RUN apt-get update && apt-get install -y ruby ruby-dev
+RUN gem install sinatra

--- a/test/integration/roles/test_docker_image/tasks/main.yml
+++ b/test/integration/roles/test_docker_image/tasks/main.yml
@@ -1,0 +1,211 @@
+
+- name: Remove my_sinatra.tar
+  file: path=my_sintra.tar state=absent
+
+- name: Remove image sinatra
+  docker_image:
+    state: absent
+    name: mysinatra
+    tag: v1
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- name: Build and archive image
+  docker_image:
+    path: "{{ role_path }}/files/sinatra"
+    name: mysinatra
+    tag: v1
+    archive_path: "{{ docker_data_path }}/my_sinatra.tar"
+    debug: "{{ playbook_debug }}"
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- name: Get sinatra image facts
+  docker_image_facts:
+    name: mysinatra:v1
+    debug: "{{ playbook_debug }}"
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- name: Sinatra image should be present
+  assert:
+    that: output.images | length == 1
+
+- name: Get archive path facts
+  stat: path="{{ docker_data_path }}/my_sinatra.tar"
+  register: output
+
+- name: Archive file should be present
+  assert:
+    that: output.stat.exists
+
+- name: Remove image sinatra
+  docker_image:
+    state: absent
+    name: mysinatra
+    tag: v1
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- name: Get sinatra image facts
+  docker_image_facts:
+    name: mysinatra:v1
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- name: Sinatra image should be absent
+  assert:
+    that: output.images | length == 0
+
+- name: Load image from archive
+  docker_image:
+    name: mysinatra
+    tag: v1
+    load_path: "{{ docker_data_path }}/my_sinatra.tar"
+    debug: "{{ playbook_debug }}"
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- name: Get sinatra image facts
+  docker_image_facts:
+    name: mysinatra:v1
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- name: Sinatra image should be present
+  assert:
+    that: output.images | length == 1
+
+- name: Log into docker hub
+  docker_login:
+    username: "{{ dockerhub_username }}"
+    password: "{{ dockerhub_password }}"
+    email: "{{ dockerhub_email }}"
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- name: Login into local registry
+  docker_login:
+    registry_url: "{{ private_registry_url }}"
+    username: testuser
+    password: testpassword
+    debug: "{{ playbook_debug }}"
+  register: output   
+
+- name: Remove tagged image
+  docker_image:
+    name: "{{ private_registry_url }}/dcoppenhagan/mysinatra"
+    tag: v1
+    debug: "{{ playbook_debug }}"
+    state: absent
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- name: Tag and push sinatra to local registry 
+  docker_image:
+    name: mysinatra
+    tag: v1 
+    repository: "{{ private_registry_url }}/dcoppenhagan/mysinatra"
+    push: yes
+    debug: "{{ playbook_debug }}" 
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- assert:
+    that: "output.image.push_status is defined"
+
+- name: Remove tagged image, if it exists
+  docker_image:
+    name: "{{ private_registry_url }}/chouseknecht/ubuntu"
+    tag: "14.04"
+    debug: "{{ playbook_debug }}"
+    state: absent
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- name: Tag and push an image
+  docker_image:
+    name: ubuntu
+    tag: "14.04"
+    repository: "{{ private_registry_url }}/chouseknecht/ubuntu"
+    push: yes
+    debug: "{{ playbook_debug }}"
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- assert:
+    that: "output.image.push_status is defined"
+  when: output.changed
+
+- name: Image should exist in registry
+  command: "curl --insecure -u {{ local_registry_user }}:{{ local_registry_password }} {{ private_registry_url }}/v2/_catalog"
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- assert:
+    that:
+      - "'chouseknecht' in output.stdout"
+
+- name: Remove local copy of image
+  docker_image:
+    name: "{{ private_registry_url }}/chouseknecht/ubuntu:14.04"
+    state: absent
+
+- name: Check if image exists
+  command: docker inspect "{{ private_registry_url }}/chouseknecht/ubuntu:14.04"
+  ignore_errors: yes
+  register: output
+
+- name: Should not exist
+  assert:
+    that:
+      - output.failed
+
+- name: Should pull image from local registry to create container
+  docker_container:
+    name: sleepy5 
+    image: "{{ private_registry_url }}/chouseknecht/ubuntu:14.04"
+    command: sleep infinity
+    state: started
+    debug: "{{ playbook_debug }}"
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- name: Should be running
+  assert:
+    that:
+      - ansible_docker_container.State.Running
+
+- name: Remove container
+  docker_container:
+    name: sleepy5
+    force_kill: yes
+    state: absent

--- a/test/integration/roles/test_docker_login/tasks/main.yml
+++ b/test/integration/roles/test_docker_login/tasks/main.yml
@@ -1,0 +1,51 @@
+- name: Remove existing config
+  file:
+    path: ~/.docker/config.json
+    state: absent
+
+- name: Should fail on invalid email
+  docker_login:
+    username: "{{ dockerhub_username }}" 
+    password: "{{ dockerhub_password }}" 
+    email: foo
+    debug: "{{ playbook_debug }}"
+  register: output
+  ignore_errors: yes
+
+- debug: var=output
+  when: playbook_debug
+
+- assert:
+    that:
+      - output.failed
+      - "'email' in output.msg"
+
+- name: Should log into Docker hub
+  docker_login:
+    username: "{{ dockerhub_username }}" 
+    password: "{{ dockerhub_password }}" 
+    email: "{{ dockerhub_email }}" 
+    debug: "{{ playbook_debug }}"
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- assert:
+    that:
+      - "'Succeeded' in output.login_result.Status"
+
+- name: Should allow special chars in name
+  docker_login:
+    url: "{{ private_registry_url }}"
+    username: chris+house_knecht
+    password: password123
+    debug: "{{ playbook_debug }}"
+  register: output
+
+- debug: var=output
+  when: playbook_debug
+
+- assert:
+    that:
+      - "'Succeeded' in output.login_result.Status"

--- a/test/integration/roles/test_docker_login/vars/main.yml
+++ b/test/integration/roles/test_docker_login/vars/main.yml
@@ -1,0 +1,4 @@
+---
+dockerhub_username: dcoppenhagan
+dockerhub_password: Apassword123!
+dockerhub_email: dave.coppenhagan@yahoo.com

--- a/test/integration/roles/test_docker_service/defaults/main.yml
+++ b/test/integration/roles/test_docker_service/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+compose_mysql_pswd: wordpress
+compose_mysql_user: wordpress
+compose_mysql_database: wordpress
+docker_host: 127.0.0.1

--- a/test/integration/roles/test_docker_service/files/wordpress/docker-compose.yml
+++ b/test/integration/roles/test_docker_service/files/wordpress/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '2'
+services:
+  db:
+    image: mysql:5.7
+    restart: always
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: wordpress
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+
+  wordpress:
+    depends_on:
+      - db
+    image: wordpress:latest
+    links:
+      - db
+    ports:
+      - "9000:80"
+    restart: always
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_PASSWORD: wordpress

--- a/test/integration/roles/test_docker_service/tasks/main.yml
+++ b/test/integration/roles/test_docker_service/tasks/main.yml
@@ -1,0 +1,85 @@
+# basic tests for docker_service module
+
+- name: Stop the services, if running, using inline compose
+  docker_service:
+    project_name: wordpress
+    definition: "{{ wordpress_project }}"
+    state: absent
+
+- name: Launch compose services using inline compose
+  docker_service:
+    project_name: wordpress
+    definition: "{{ wordpress_project }}"
+
+- command: docker ps --filter name=wordpress_db_1 --format {% raw %}'Status {{ .Status }}'{% endraw %}
+  register: db_status 
+
+- command: docker ps --filter name=wordpress_wordpress_1 --format {% raw %}'Status {{ .Status }}'{% endraw %}
+  register: wordpress_status 
+
+- assert:
+    that: 
+      - "'Status Up' in db_status.stdout_lines[0]" 
+      - "'Status Up' in wordpress_status.stdout_lines[0]" 
+ 
+- name: Stop the service, if running, using filesystem
+  docker_service:
+    project_name: wordpress
+    project_src: "{{ role_path }}/files/wordpress"
+    state: absent
+
+- command: docker ps --filter name=wordpress_db_1 --format {% raw %}'Status {{ .Status }}'{% endraw %}
+  register: db_status 
+
+- command: docker ps --filter name=wordpress_wordpress_1 --format {% raw %}'Status {{ .Status }}'{% endraw %}
+  register: wordpress_status 
+
+- assert:
+    that:
+      - "db_status.stdout_lines | length == 0"
+      - "wordpress_status.stdout_lines | length == 0"
+
+- name: Start the service from filesystem project
+  docker_service:
+    project_name: wordpress
+    project_src: "{{ role_path }}/files/wordpress"
+
+- command: docker ps --filter name=wordpress_db_1 --format {% raw %}'Status {{ .Status }}'{% endraw %}
+  register: db_status 
+
+- command: docker ps --filter name=wordpress_wordpress_1 --format {% raw %}'Status {{ .Status }}'{% endraw %}
+  register: wordpress_status 
+
+- assert:
+    that:
+      - "'Status Up' in db_status.stdout_lines[0]"
+      - "'Status Up' in db_status.stdout_lines[0]"
+
+- command: docker inspect {% raw %}--format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}'{% endraw %} wordpress_db_1
+  register: inspection 
+
+- set_fact:
+    mysqlip: "{{ inspection.stdout_lines[0] }}"
+
+- name: Wait for mysqld to start
+  local_action: wait_for port=3306 host="{{ docker_host }}" timeout=60
+
+- name: Remove dbtest.out
+  file:
+    path: "{{ dbtest_out }}"
+    state: absent
+
+- name: Pause - give the containers a chance to finish starting and connecting
+  pause: seconds=10
+
+- name: Get the database test page
+  get_url:
+    url: "http://{{ docker_host }}:9000/wp-admin/install.php"
+    dest: "{{ dbtest_out }}"
+    force: yes
+
+- set_fact:
+    htmlcontent: "{{ lookup('file', dbtest_out) }}"
+
+- assert:
+    that: "'Continue' in htmlcontent"

--- a/test/integration/roles/test_docker_service/vars/main.yml
+++ b/test/integration/roles/test_docker_service/vars/main.yml
@@ -1,0 +1,26 @@
+---
+dbtest_out: "{{ role_path }}/files/dbtest.out"
+wordpress_project:
+  version: '2'
+  services:
+    db:
+      image: mysql:5.7
+      restart: always
+      environment:
+        MYSQL_ROOT_PASSWORD: "{{ compose_mysql_pswd }}"
+        MYSQL_DATABASE: "{{ compose_mysql_database }}"
+        MYSQL_USER: "{{ compose_mysql_user }}"
+        MYSQL_PASSWORD: "{{ compose_mysql_pswd }}"
+
+    wordpress:
+      depends_on:
+        - db
+      image: wordpress:latest
+      links:
+        - db
+      ports:
+        - "8000:80"
+      restart: always
+      environment:
+        WORDPRESS_DB_HOST: db:3306
+        WORDPRESS_DB_PASSWORD: wordpress

--- a/test/integration/test.yml
+++ b/test/integration/test.yml
@@ -1,0 +1,7 @@
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+    - command: >
+        docker inspect --format="{% raw %}{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}{% endraw %}" registry
+      register: output

--- a/test/integration/test_docker.yml
+++ b/test/integration/test_docker.yml
@@ -13,6 +13,7 @@
           password: testpassword
         - username: chris+house_knecht
           password: password123
+  when: docker_start_registry
 
 - name: Wait for registry 
   hosts: docker
@@ -21,6 +22,7 @@
   tasks: 
     - command: ping -c 3 "{{ registry_common_name }}" 
     - wait_for: host="{{ registry_common_name }}" port="{{ registry_host_port }}"   
+  when: docker_start_registry
     
 - name: Run docker module tests 
   hosts: docker 

--- a/test/integration/test_docker.yml
+++ b/test/integration/test_docker.yml
@@ -57,7 +57,7 @@
 
     - debug: var=output
 
-    - command: cat "{{ docker_data_path }}/auth/htpasswd"
+    - command: cat "/data/auth/htpasswd"
       register: output
 
     - debug: var=output

--- a/test/integration/test_docker.yml
+++ b/test/integration/test_docker.yml
@@ -13,10 +13,6 @@
           password: testpassword
         - username: chris+house_knecht
           password: password123
-      registry_auth_path: /data/auth
-      registry_cert_path: /data/certs
-      registry_host_cert_path: "{{ docker_data_path }}/certs"
-      registry_host_auth_path: "{{ docker_data_path }}/auth"
 
 - name: Wait for registry 
   hosts: docker

--- a/test/integration/test_docker.yml
+++ b/test/integration/test_docker.yml
@@ -52,7 +52,7 @@
     registry_host_port: 5000
     private_registry_url: "https://{{ registry_common_name }}:{{ registry_host_port }}"
   tasks:
-    - command: ping -c 3 "{{ docker_data_path }}"
+    - command: ping -c 3 "{{ registry_common_name }}"
       register: output
 
     - debug: var=output

--- a/test/integration/test_docker.yml
+++ b/test/integration/test_docker.yml
@@ -2,30 +2,11 @@
 #
 # Integration tests for Ansible's Docker modules.
 #
-- name: Check vars
-  hosts: localhost
+- name: Start the registry
+  hosts: docker 
   connection: local
   gather_facts: no
-  vars:
-    docker_data_path: "{{ lookup('env','DOCKER_DATA_PATH') }}"
-    registry_common_name: ansibleregistry.com 
-    registry_host_port: 5000
-    private_registry_url: "https://{{ registry_common_name }}:{{ registry_host_port }}"
-  tasks:
-    - debug: msg="docker_data_path     {{ docker_data_path }}"
-    - debug: msg="private_registry_url {{ private_registry_url }}"      
-
-- name: Run docker module tests 
-  hosts: localhost
-  connection: local
-  gather_facts: no
-  vars:
-    docker_data_path: "{{ lookup('env','DOCKER_DATA_PATH') }}"
-    registry_common_name: ansibleregistry.com 
-    registry_host_port: 5000
-    private_registry_url: "https://{{ registry_common_name }}:{{ registry_host_port }}"
   roles:
-    # Create a secure private registry for use by docker_login and docker_image
     - role: ansible.local-registry
       registry_users:
         - username: testuser
@@ -37,27 +18,21 @@
       registry_host_cert_path: "{{ docker_data_path }}/certs"
       registry_host_auth_path: "{{ docker_data_path }}/auth"
 
-    # - role: test_docker_login
-    # - role: test_docker_image
-    # - role: test_docker_container
-    # - role: test_docker_service
-
-- name: Check htpasswd 
-  hosts: localhost
+- name: Wait for registry 
+  hosts: docker
   connection: local
   gather_facts: no
-  vars:
-    docker_data_path: "{{ lookup('env','DOCKER_DATA_PATH') }}"
-    registry_common_name: ansibleregistry.com 
-    registry_host_port: 5000
-    private_registry_url: "https://{{ registry_common_name }}:{{ registry_host_port }}"
-  tasks:
-    - command: ping -c 3 "{{ registry_common_name }}"
-      register: output
+  tasks: 
+    - command: ping -c 3 "{{ registry_common_name }}" 
+    - wait_for: host="{{ registry_common_name }}" port="{{ registry_host_port }}"   
+    
+- name: Run docker module tests 
+  hosts: docker 
+  connection: local
+  gather_facts: no
+  roles:
+    - role: test_docker_login
+    - role: test_docker_image
+    - role: test_docker_container
+    - role: test_docker_service
 
-    - debug: var=output
-
-    - command: cat "/data/auth/htpasswd"
-      register: output
-
-    - debug: var=output

--- a/test/integration/test_docker.yml
+++ b/test/integration/test_docker.yml
@@ -2,6 +2,19 @@
 #
 # Integration tests for Ansible's Docker modules.
 #
+- name: Check vars
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  vars:
+    docker_data_path: "{{ lookup('env','DOCKER_DATA_PATH') }}"
+    registry_common_name: ansibleregistry.com 
+    registry_host_port: 5000
+    private_registry_url: "https://{{ registry_common_name }}:{{ registry_host_port }}"
+  tasks:
+    - debug: msg="docker_data_path: {{ docker_data_path }}"
+    - debug: msg="private_registry_url: {{ registry_registry_url }}"      
+
 - name: Run docker module tests 
   hosts: localhost
   connection: local

--- a/test/integration/test_docker.yml
+++ b/test/integration/test_docker.yml
@@ -12,8 +12,8 @@
     registry_host_port: 5000
     private_registry_url: "https://{{ registry_common_name }}:{{ registry_host_port }}"
   tasks:
-    - debug: msg="docker_data_path: {{ docker_data_path }}"
-    - debug: msg="private_registry_url: {{ registry_registry_url }}"      
+    - debug: msg="docker_data_path     {{ docker_data_path }}"
+    - debug: msg="private_registry_url {{ private_registry_url }}"      
 
 - name: Run docker module tests 
   hosts: localhost

--- a/test/integration/test_docker.yml
+++ b/test/integration/test_docker.yml
@@ -1,0 +1,30 @@
+# test_docker.yml
+#
+# Integration tests for Ansible's Docker modules.
+#
+- name: Run docker module tests 
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  vars:
+    docker_data_path: "{{ lookup('env','DOCKER_DATA_PATH') }}"
+    registry_common_name: ansibleregistry.com 
+    registry_host_port: 5000
+    private_registry_url: "https://{{ registry_common_name }}:{{ registry_host_port }}"
+  roles:
+    # Create a secure private registry for use by docker_login and docker_image
+    - role: ansible.local-registry
+      registry_users:
+        - username: testuser
+          password: testpassword
+        - username: chris+house_knecht
+          password: password123
+      registry_auth_path: /data/auth
+      registry_cert_path: /data/certs
+      registry_host_cert_path: "{{ docker_data_path }}/certs"
+      registry_host_auth_path: "{{ docker_data_path }}/auth"
+
+    - role: test_docker_login
+    - role: test_docker_image
+    - role: test_docker_container
+    - role: test_docker_service

--- a/test/integration/test_docker.yml
+++ b/test/integration/test_docker.yml
@@ -6,6 +6,8 @@
   hosts: docker 
   connection: local
   gather_facts: no
+  vars:
+    docker_start_registry: "{{ lookup('env','DOCKER_START_REGISTRY') | default(1, true) }}" 
   roles:
     - role: ansible.local-registry
       registry_users:
@@ -13,16 +15,19 @@
           password: testpassword
         - username: chris+house_knecht
           password: password123
-  when: docker_start_registry
+      when: docker_start_registry
 
 - name: Wait for registry 
   hosts: docker
   connection: local
   gather_facts: no
+  vars:
+    docker_start_registry: "{{ lookup('env','DOCKER_START_REGISTRY') | default(1, true) }}" 
   tasks: 
     - command: ping -c 3 "{{ registry_common_name }}" 
+      when: docker_start_registry
     - wait_for: host="{{ registry_common_name }}" port="{{ registry_host_port }}"   
-  when: docker_start_registry
+      when: docker_start_registry
     
 - name: Run docker module tests 
   hosts: docker 

--- a/test/integration/test_docker.yml
+++ b/test/integration/test_docker.yml
@@ -37,7 +37,27 @@
       registry_host_cert_path: "{{ docker_data_path }}/certs"
       registry_host_auth_path: "{{ docker_data_path }}/auth"
 
-    - role: test_docker_login
-    - role: test_docker_image
-    - role: test_docker_container
-    - role: test_docker_service
+    # - role: test_docker_login
+    # - role: test_docker_image
+    # - role: test_docker_container
+    # - role: test_docker_service
+
+- name: Check htpasswd 
+  hosts: localhost
+  connection: local
+  gather_facts: no
+  vars:
+    docker_data_path: "{{ lookup('env','DOCKER_DATA_PATH') }}"
+    registry_common_name: ansibleregistry.com 
+    registry_host_port: 5000
+    private_registry_url: "https://{{ registry_common_name }}:{{ registry_host_port }}"
+  tasks:
+    - command: ping -c 3 "{{ docker_data_path }}"
+      register: output
+
+    - debug: var=output
+
+    - command: cat "{{ docker_data_path }}/auth/htpasswd"
+      register: output
+
+    - debug: var=output

--- a/test/integration/test_registry.yml
+++ b/test/integration/test_registry.yml
@@ -1,0 +1,11 @@
+- name: Start the registry
+  hosts: docker
+  connection: local
+  gather_facts: no
+  roles:
+    - role: ansible.local-registry
+      registry_users:
+        - username: testuser
+          password: testpassword
+        - username: chris+house_knecht
+          password: password123

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -54,8 +54,9 @@ container_id=$(docker run \
                "${image}" /run.sh)
 
 docker inspect registry
-docker exec registry ls -l /ansible
-docker exec regsitry ls -l /data
+docker exec registry ls -l /auth
+docker exec registry ls -l /certs
+docker exec registry cat /auth/htpasswd
 
 show_environment
 cleanup

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -82,7 +82,7 @@ container_id=$(docker run \
 
 docker exec ${container_id} cat /etc/hosts
 docker exec ${container_id} ping -c 3 ansibleregistry.com
-
+docker exec ${container_id} docker login -u testuser -p testpassword -e auser@yahoo.com https://ansibleregistry.com 
 
 docker rm --force registry
 docker ps

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -46,6 +46,8 @@ cat << EOF >${host_shared_dir}/test/integration/group_vars/docker
 ---
 registry_host_cert_path: ${host_shared_dir}/test_data 
 registry_host_auth_path: ${host_shared_dir}/test_data
+registry_auth_path: /data/auth
+registry_cert_path: /data/certs
 registry_common_name: ansibleregistry.com
 registry_host_port: 5000
 private_registry_url: "https://{{ registry_common_name }}:{{ registry_host_port }}"

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -46,8 +46,8 @@ cat << EOF >${host_shared_dir}/test/integration/group_vars/docker
 ---
 registry_host_cert_path: ${host_shared_dir}/test_data 
 registry_host_auth_path: ${host_shared_dir}/test_data
-registry_auth_path: ${host_shared_dir}/test_data 
-registry_cert_path: ${host_shared_dir}/test_data 
+registry_auth_path: /auth
+registry_cert_path: /certs
 registry_common_name: ansibleregistry.com
 registry_host_port: 5000
 private_registry_url: "https://{{ registry_common_name }}:{{ registry_host_port }}"
@@ -56,7 +56,8 @@ EOF
 container_id=$(docker run \
                -v /var/run/docker.sock:/var/run/docker.sock \
                -v ${host_shared_dir}:/ansible \
-               -v ${host_shared_dir}/test_data:/data \
+               -v ${host_shared_dir}/test_data:/certs \
+               -v ${host_shared_dir}/test_data:/auth \
                -e DOCKER_API_VERSION=${docker_api_version} \
                "${image}" /create-registry.sh)
 

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -57,6 +57,7 @@ docker inspect registry
 docker exec registry ls -l /auth
 docker exec registry ls -l /certs
 docker exec registry cat /auth/htpasswd
+docker login -u testuser -p testpassword https://ansibleregistry.com:5000
 
-show_environment
-cleanup
+# show_environment
+# cleanup

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -58,7 +58,7 @@ container_id=$(docker run \
                -v ${host_shared_dir}:/ansible \
                -v ${host_shared_dir}/test_data:/data \
                -e DOCKER_API_VERSION=${docker_api_version} \
-               "${image}" create-registry.sh)
+               "${image}" /create-registry.sh)
 
 registry_ip=$(docker inspect registry --format "{{ .NetworkSettings.IPAddress }}")
 echo "Registry IP: ${registry_ip}"
@@ -73,7 +73,7 @@ container_id=$(docker run \
                -v ${host_shared_dir}/test_data:/data \
                -e DOCKER_API_VERSION=${docker_api_version} \
                --add-host=ansibleregistry.com:${registry_ip} \
-               "${image}" run-tests.sh)
+               "${image}" /run-tests.sh)
 
 
 docker rm --force registry

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -85,9 +85,10 @@ container_id=$(docker run \
 #docker exec ${container_id} docker login -u testuser -p testpassword https://registry:5000/
 
 docker version
-docker exec ${container_id} cat /auth/htpasswd 
-ping -c 3 ansibleregistry.com
-docker login -u testuser -p testpassword -e auser@yahoo.com  https://ansibleregistry.com:5000
+docker exec ${container_id} ls /auth
+
+#ping -c 3 ansibleregistry.com
+#docker login -u testuser -p testpassword -e auser@yahoo.com  https://ansibleregistry.com:5000
 
 docker rm --force ${container_id}
 docker rm --force registry

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -61,7 +61,7 @@ container_id=$(docker run \
                -e DOCKER_API_VERSION=${docker_api_version} \
                "${image}" /create-registry.sh)
 
-registry_ip=$(docker inspect registry --format "{{ .NetworkSettings.IPAddress }}")
+registry_ip=`docker inspect --format "{{ .NetworkSettings.IPAddress }}" registry`
 echo "Registry IP: ${registry_ip}"
 
 cat << EOF >>${host_shared_dir}/test/integration/group_vars/docker

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -86,7 +86,7 @@ container_id=$(docker run \
 
 docker version
 
-docker login -u tesetuser -p testpassword -e auser@yahoo.com  https://ansibleregistry:5000
+docker login -u tesetuser -p testpassword -e auser@yahoo.com  https://ansibleregistry.com:5000
 
 docker rm --force ${container_id}
 docker rm --force registry

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -86,10 +86,7 @@ container_id=$(docker run \
 
 docker version
 
-docker login \
-    -u tesetuser \ 
-    -p testpassword \
-    -e auser@yahoo.com  https://ansibleregistry:5000
+docker login -u tesetuser -p testpassword -e auser@yahoo.com  https://ansibleregistry:5000
 
 docker rm --force ${container_id}
 docker rm --force registry

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -85,7 +85,9 @@ container_id=$(docker run \
 #docker exec ${container_id} docker login -u testuser -p testpassword https://registry:5000/
 
 docker version
-docker exec ${container_id} ls /auth
+docker exec registry ls /auth
+docker exec registry cat /auth/htpasswd
+docker exex registry ls /certs
 
 #ping -c 3 ansibleregistry.com
 #docker login -u testuser -p testpassword -e auser@yahoo.com  https://ansibleregistry.com:5000

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -80,14 +80,14 @@ container_id=$(docker run \
                --link registry \
                "${image}" sleep 60)
 
-#docker exec ${container_id} cat /etc/hosts
-#docker exec ${container_id} ping -c 3 registry 
+docker exec ${container_id} curl https://registry:5000/v2/_catalog  
+
 #docker exec ${container_id} docker login -u testuser -p testpassword https://registry:5000/
 
 docker version
 docker exec registry ls /auth
 docker exec registry cat /auth/htpasswd
-docker exex registry ls /certs
+docker exec registry ls /certs
 
 #ping -c 3 ansibleregistry.com
 #docker login -u testuser -p testpassword -e auser@yahoo.com  https://ansibleregistry.com:5000

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -58,7 +58,7 @@ container_id=$(docker run \
                -v ${host_shared_dir}:/ansible \
                -v ${host_shared_dir}/test_data:/data \
                -e DOCKER_API_VERSION=${docker_api_version} \
-               "${image}" /create-registry.sh)
+               "${image}" create-registry.sh)
 
 registry_ip=$(docker inspect registry --format "{{ .NetworkSettings.IPAddress }}")
 echo "Registry IP: ${registry_ip}"
@@ -73,7 +73,7 @@ container_id=$(docker run \
                -v ${host_shared_dir}/test_data:/data \
                -e DOCKER_API_VERSION=${docker_api_version} \
                --add-host=ansibleregistry.com:${registry_ip} \
-               "${image}" /run-tests.sh)
+               "${image}" run-tests.sh)
 
 
 docker rm --force registry

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -54,7 +54,7 @@ private_registry_url: "https://{{ registry_common_name }}:{{ registry_host_port 
 EOF
 
 cd $source_root
-source ./hacking/env_setup
+source ./hacking/env-setup
 ansible-playbook -i inventory.docker test_registry.yml
 registry_ip=$(docker inspect --format "{{ .NetworkSettings.IPAddress }}")
 echo "Registry IP: ${registry_ip}"

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -51,6 +51,8 @@ registry_host_port: 5000
 private_registry_url: "https://{{ registry_common_name }}:{{ registry_host_port }}"
 EOF
 
+cat ${host_shared_dir}/test/integration/group_vars/docker
+
 container_id=$(docker run \
                -v /var/run/docker.sock:/var/run/docker.sock \
                -v ${host_shared_dir}:/ansible \
@@ -59,3 +61,4 @@ container_id=$(docker run \
                -e DOCKER_API_VERSION=${docker_api_version} \
                --add-host=ansibleregistry.com:${SHIPPABLE_HOST_IP} \
                "${image}" /run.sh)
+

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -1,0 +1,58 @@
+#!/bin/bash -eux
+
+source_root=$(python -c "from os import path; print(path.abspath(path.join(path.dirname('$0'), '../../..')))")
+image=${IMAGE}
+keep_containers=""
+
+function show_environment
+{
+    docker ps
+
+}
+
+function cleanup
+{
+    if [ "${controller_shared_dir}" ]; then
+        rm -rf "${controller_shared_dir}"
+    fi
+
+    if [ "${keep_containers}" == "" ]; then
+        if [ "${container_id}" ]; then
+            docker rm -f "${container_id}"
+        fi
+    fi
+    show_environment
+}
+
+if [ "${SHIPPABLE_BUILD_DIR:-}" ]; then
+    host_shared_dir="/home/shippable/cache/build-${BUILD_NUMBER}"
+    controller_shared_dir="/home/shippable/cache/build-${BUILD_NUMBER}"
+else
+    host_shared_dir="${source_root}"
+    controller_shared_dir=""
+fi
+
+if [ "${controller_shared_dir}" ]; then
+    cp -a "${SHIPPABLE_BUILD_DIR}" "${controller_shared_dir}"
+fi
+
+mkdir -p ${host_shared_dir}/test_data/auth
+mkdir -p ${host_shared_dir}/test_data/certs
+
+show_environment 
+
+docker_api_version=`docker version --format "{{ .Server.APIVersion }}"`
+echo "Setting DOCKER_API_VERSION = ${docker_api_version}"
+echo "Shippable host IP = ${SHIPPABLE_HOST_IP}"
+
+container_id=$(docker run \
+               -v /var/run/docker.sock:/var/run/docker.sock \
+               -v ${host_shared_dir}:/ansible \
+               -v ${host_shared_dir}/test_data:/data \
+               -e DOCKER_DATA_PATH=${host_shared_dir}/test_data \
+               -e DOCKER_API_VERSION=${docker_api_version} \
+               --add-host=ansibleregistry.com:${SHIPPABLE_HOST_IP} \
+               "${image}" /run.sh)
+
+show_environment
+cleanup

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -86,7 +86,10 @@ container_id=$(docker run \
 
 docker version
 
-docker login -u tesetuser -p testpassword -e auser@yahoo.com  https://ansibleregistry:5000
+docker login \
+    -u tesetuser \ 
+    -p testpassword \
+    -e auser@yahoo.com  https://ansibleregistry:5000
 
 docker rm --force ${container_id}
 docker rm --force registry

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -80,7 +80,7 @@ container_id=$(docker run \
                --link registry \
                "${image}" sleep 60)
 
-docker exec ${container_id} curl https://registry:5000/v2/_catalog  
+docker exec ${container_id} curl --insecure --user testuser:testpassword https://registry:5000/v2/_catalog
 
 #docker exec ${container_id} docker login -u testuser -p testpassword https://registry:5000/
 

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -38,9 +38,9 @@ fi
 mkdir -p ${host_shared_dir}/test_data/auth
 mkdir -p ${host_shared_dir}/test_data/certs
 
-show_environment 
+docker ps
 
-export DOCKER_API_VERSION=`docker version --format "{{ .Server.APIVersion }}"`
+docker_api_version=`docker version --format "{{ .Server.APIVersion }}"`
 
 cat << EOF >${host_shared_dir}/test/integration/group_vars/docker 
 ---
@@ -74,3 +74,4 @@ container_id=$(docker run \
                "${image}" /run.sh)
 
 docker rm --force registry
+docker ps

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -40,27 +40,29 @@ mkdir -p ${host_shared_dir}/test_data/certs
 
 show_environment 
 
-docker_api_version=`docker version --format "{{ .Server.APIVersion }}"`
+export DOCKER_API_VERSION=`docker version --format "{{ .Server.APIVersion }}"`
 
 cat << EOF >${host_shared_dir}/test/integration/group_vars/docker 
 ---
 registry_host_cert_path: ${host_shared_dir}/test_data 
 registry_host_auth_path: ${host_shared_dir}/test_data
-registry_auth_path: /data/auth
-registry_cert_path: /data/certs
+registry_auth_path: ${host_shared_dir}/test_data 
+registry_cert_path: ${host_shared_dir}/test_data 
 registry_common_name: ansibleregistry.com
 registry_host_port: 5000
 private_registry_url: "https://{{ registry_common_name }}:{{ registry_host_port }}"
 EOF
 
-cat ${host_shared_dir}/test/integration/group_vars/docker
+source ./hacking/env_setup
+ansible-playbook -i inventory.docker test_registry.yml
+registry_ip=$(docker inspect --format "{{ .NetworkSettings.IPAddress }}")
+echo "Registry IP: ${registry_ip}"
 
 container_id=$(docker run \
                -v /var/run/docker.sock:/var/run/docker.sock \
                -v ${host_shared_dir}:/ansible \
                -v ${host_shared_dir}/test_data:/data \
-               -e DOCKER_DATA_PATH=${host_shared_dir}/test_data \
                -e DOCKER_API_VERSION=${docker_api_version} \
-               --add-host=ansibleregistry.com:${SHIPPABLE_HOST_IP} \
+               --add-host=ansibleregistry.com:${registry_ip} \
                "${image}" /run.sh)
 

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -58,7 +58,7 @@ container_id=$(docker run \
                -v ${host_shared_dir}:/ansible \
                -v ${host_shared_dir}/test_data:/data \
                -e DOCKER_API_VERSION=${docker_api_version} \
-               -w /ansible/test/integration
+               -w /ansible/test/integration \
                "${image}" make test_registry)
 
 registry_ip=$(docker inspect registry --format "{{ .NetworkSettings.IPAddress }}")

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -75,6 +75,7 @@ container_id=$(docker run \
                -v ${host_shared_dir}:/ansible \
                -v ${host_shared_dir}/test_data:/data \
                -e DOCKER_API_VERSION=${docker_api_version} \
+               -e DOCKER_START_REGISTRY=0 \
                --add-host=ansibleregistry.com:${registry_ip} \
                "${image}" /run-tests.sh)
 

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -80,9 +80,13 @@ container_id=$(docker run \
                --link registry \
                "${image}" sleep 60)
 
-docker exec ${container_id} cat /etc/hosts
-docker exec ${container_id} ping -c 3 registry 
-docker exec ${container_id} docker login -u testuser -p testpassword https://registry:5000/
+#docker exec ${container_id} cat /etc/hosts
+#docker exec ${container_id} ping -c 3 registry 
+#docker exec ${container_id} docker login -u testuser -p testpassword https://registry:5000/
+
+docker version
+
+docker login -u tesetuser -p testpassword https://ansibleregistry:5000
 
 docker rm --force ${container_id}
 docker rm --force registry

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -77,12 +77,12 @@ container_id=$(docker run \
                -v ${host_shared_dir}/test_data:/data \
                -e DOCKER_API_VERSION=${docker_api_version} \
                -e DOCKER_START_REGISTRY=0 \
-               --link registry:ansibleregistry.com \
+               --link registry \
                "${image}" sleep 60)
 
 docker exec ${container_id} cat /etc/hosts
-docker exec ${container_id} ping -c 3 ansibleregistry.com
-docker exec ${container_id} docker login -u testuser -p testpassword -e auser@yahoo.com https://ansibleregistry.com:5000 
+docker exec ${container_id} ping -c 3 registry 
+docker exec ${container_id} docker login -u testuser -p testpassword https://registry:5000/
 
 docker rm --force ${container_id}
 docker rm --force registry

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -64,6 +64,10 @@ container_id=$(docker run \
 registry_ip=$(docker inspect registry --format "{{ .NetworkSettings.IPAddress }}")
 echo "Registry IP: ${registry_ip}"
 
+cat << EOF >>${host_shared_dir}/test/integration/group_vars/docker
+docker_start_registry: no
+EOF
+
 container_id=$(docker run \
                -v /var/run/docker.sock:/var/run/docker.sock \
                -v ${host_shared_dir}:/ansible \

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -75,5 +75,6 @@ container_id=$(docker run \
                --add-host=ansibleregistry.com:${registry_ip} \
                "${image}" run.sh)
 
+
 docker rm --force registry
 docker ps

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -53,6 +53,7 @@ registry_host_port: 5000
 private_registry_url: "https://{{ registry_common_name }}:{{ registry_host_port }}"
 EOF
 
+cd $source_root
 source ./hacking/env_setup
 ansible-playbook -i inventory.docker test_registry.yml
 registry_ip=$(docker inspect --format "{{ .NetworkSettings.IPAddress }}")

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -58,7 +58,6 @@ container_id=$(docker run \
                -v ${host_shared_dir}:/ansible \
                -v ${host_shared_dir}/test_data:/data \
                -e DOCKER_API_VERSION=${docker_api_version} \
-               --add-host=ansibleregistry.com:${registry_ip} \
                -w /ansible/test/integration
                "${image}" make test_registry)
 

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -58,7 +58,7 @@ container_id=$(docker run \
                -v ${host_shared_dir}:/ansible \
                -v ${host_shared_dir}/test_data:/data \
                -e DOCKER_API_VERSION=${docker_api_version} \
-               "${image}" create_registry.sh)
+               "${image}" create-registry.sh)
 
 registry_ip=$(docker inspect registry --format "{{ .NetworkSettings.IPAddress }}")
 echo "Registry IP: ${registry_ip}"
@@ -73,7 +73,7 @@ container_id=$(docker run \
                -v ${host_shared_dir}/test_data:/data \
                -e DOCKER_API_VERSION=${docker_api_version} \
                --add-host=ansibleregistry.com:${registry_ip} \
-               "${image}" run.sh)
+               "${image}" run-tests.sh)
 
 
 docker rm --force registry

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -7,7 +7,6 @@ keep_containers=""
 function show_environment
 {
     docker ps
-
 }
 
 function cleanup
@@ -53,6 +52,10 @@ container_id=$(docker run \
                -e DOCKER_API_VERSION=${docker_api_version} \
                --add-host=ansibleregistry.com:${SHIPPABLE_HOST_IP} \
                "${image}" /run.sh)
+
+docker inspect registry
+docker exec registry ls -l /ansible
+docker exec regsitry ls -l /data
 
 show_environment
 cleanup

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -42,8 +42,7 @@ show_environment
 
 docker_api_version=`docker version --format "{{ .Server.APIVersion }}"`
 
-if [ "${SHIPPABLE_BUILD_DIR:-}" ]; then
-     cat << EOF >${source_root}/test/integration/group_vars/docker 
+cat << EOF >${host_shared_dir}/test/integration/group_vars/docker 
 ---
 registry_host_cert_path: ${host_shared_dir}/test_data 
 registry_host_auth_path: ${host_shared_dir}/test_data
@@ -51,7 +50,6 @@ registry_common_name: ansibleregistry.com
 registry_host_port: 5000
 private_registry_url: "https://{{ registry_common_name }}:{{ registry_host_port }}"
 EOF
-fi
 
 container_id=$(docker run \
                -v /var/run/docker.sock:/var/run/docker.sock \

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -61,6 +61,8 @@ container_id=$(docker run \
                -e DOCKER_API_VERSION=${docker_api_version} \
                "${image}" /create-registry.sh)
 
+docker inspect registry 
+
 registry_ip=`docker inspect --format "{{ .NetworkSettings.IPAddress }}" registry`
 echo "Registry IP: ${registry_ip}"
 

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -58,8 +58,7 @@ container_id=$(docker run \
                -v ${host_shared_dir}:/ansible \
                -v ${host_shared_dir}/test_data:/data \
                -e DOCKER_API_VERSION=${docker_api_version} \
-               -w /ansible/test/integration \
-               "${image}" make test_registry)
+               "${image}" create_registry.sh)
 
 registry_ip=$(docker inspect registry --format "{{ .NetworkSettings.IPAddress }}")
 echo "Registry IP: ${registry_ip}"
@@ -74,7 +73,7 @@ container_id=$(docker run \
                -v ${host_shared_dir}/test_data:/data \
                -e DOCKER_API_VERSION=${docker_api_version} \
                --add-host=ansibleregistry.com:${registry_ip} \
-               "${image}" /run.sh)
+               "${image}" run.sh)
 
 docker rm --force registry
 docker ps

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -77,12 +77,13 @@ container_id=$(docker run \
                -v ${host_shared_dir}/test_data:/data \
                -e DOCKER_API_VERSION=${docker_api_version} \
                -e DOCKER_START_REGISTRY=0 \
-               --add-host=ansibleregistry.com:${registry_ip} \
+               --link registry:ansibleregistry.com \
                "${image}" sleep 60)
 
 docker exec ${container_id} cat /etc/hosts
 docker exec ${container_id} ping -c 3 ansibleregistry.com
 docker exec ${container_id} docker login -u testuser -p testpassword -e auser@yahoo.com https://ansibleregistry.com:5000 
 
+docker rm --force ${container_id}
 docker rm --force registry
 docker ps

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -82,7 +82,7 @@ container_id=$(docker run \
 
 docker exec ${container_id} cat /etc/hosts
 docker exec ${container_id} ping -c 3 ansibleregistry.com
-docker exec ${container_id} docker login -u testuser -p testpassword -e auser@yahoo.com https://ansibleregistry.com 
+docker exec ${container_id} docker login -u testuser -p testpassword -e auser@yahoo.com https://ansibleregistry.com:5000 
 
 docker rm --force registry
 docker ps

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -85,8 +85,9 @@ container_id=$(docker run \
 #docker exec ${container_id} docker login -u testuser -p testpassword https://registry:5000/
 
 docker version
-
-docker login -u tesetuser -p testpassword -e auser@yahoo.com  https://ansibleregistry.com:5000
+docker exec ${container_id} cat /auth/htpasswd 
+ping -c 3 ansibleregistry.com
+docker login -u testuser -p testpassword -e auser@yahoo.com  https://ansibleregistry.com:5000
 
 docker rm --force ${container_id}
 docker rm --force registry

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -44,8 +44,8 @@ docker_api_version=`docker version --format "{{ .Server.APIVersion }}"`
 
 cat << EOF >${host_shared_dir}/test/integration/group_vars/docker 
 ---
-registry_host_cert_path: ${host_shared_dir}/test_data 
-registry_host_auth_path: ${host_shared_dir}/test_data
+registry_host_cert_path: ${host_shared_dir}/test_data/certs 
+registry_host_auth_path: ${host_shared_dir}/test_data/auth
 registry_auth_path: /auth
 registry_cert_path: /certs
 registry_common_name: ansibleregistry.com
@@ -56,8 +56,8 @@ EOF
 container_id=$(docker run \
                -v /var/run/docker.sock:/var/run/docker.sock \
                -v ${host_shared_dir}:/ansible \
-               -v ${host_shared_dir}/test_data:/certs \
-               -v ${host_shared_dir}/test_data:/auth \
+               -v ${host_shared_dir}/test_data/certs:/certs \
+               -v ${host_shared_dir}/test_data/auth:/auth \
                -e DOCKER_API_VERSION=${docker_api_version} \
                "${image}" /create-registry.sh)
 

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -48,7 +48,7 @@ registry_host_cert_path: ${host_shared_dir}/test_data/certs
 registry_host_auth_path: ${host_shared_dir}/test_data/auth
 registry_auth_path: /auth
 registry_cert_path: /certs
-registry_common_name: ansibleregistry.com
+registry_common_name: registry
 registry_host_port: 5000
 private_registry_url: "https://{{ registry_common_name }}:{{ registry_host_port }}"
 EOF

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -71,13 +71,17 @@ docker_start_registry: no
 EOF
 
 container_id=$(docker run \
+               -d \
                -v /var/run/docker.sock:/var/run/docker.sock \
                -v ${host_shared_dir}:/ansible \
                -v ${host_shared_dir}/test_data:/data \
                -e DOCKER_API_VERSION=${docker_api_version} \
                -e DOCKER_START_REGISTRY=0 \
                --add-host=ansibleregistry.com:${registry_ip} \
-               "${image}" /run-tests.sh)
+               "${image}" sleep 60)
+
+docker exec ${container_id} cat /etc/hosts
+docker exec ${container_id} ping -c 3 ansibleregistry.com
 
 
 docker rm --force registry

--- a/test/utils/shippable/docker.sh
+++ b/test/utils/shippable/docker.sh
@@ -86,7 +86,7 @@ container_id=$(docker run \
 
 docker version
 
-docker login -u tesetuser -p testpassword https://ansibleregistry:5000
+docker login -u tesetuser -p testpassword -e auser@yahoo.com  https://ansibleregistry:5000
 
 docker rm --force ${container_id}
 docker rm --force registry


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (docker_integration_tests 3ddedb663a) last updated 2016/07/14 16:22:59 (GMT -400)
  lib/ansible/modules/core: (fix_entrypoint a75ee76aa3) last updated 2016/07/13 02:43:12 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 482b1a640e) last updated 2016/07/11 17:13:47 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Adding automated integration tests for docker_container, docker_image, docker_login and docker_service.
