### PR TITLE
Find places where ziploader is used and change them to ansiballz so that people aren't confused when they google for information.

### DIFF
--- a/docsite/rst/roadmap/ROADMAP_2_1.rst
+++ b/docsite/rst/roadmap/ROADMAP_2_1.rst
@@ -49,14 +49,14 @@
      - Openstack (Community maintainers)
      - Google (Google/Community) 
      - Digital Ocean (Community)
-- Ziploader: 
+- Ansiballz (renamed from Ziploader): 
      - Write code to create the zipfile that gets passed across the wire to be run on the remote python  
-     - Port most of the functionality in module\_utils to be usage in ziploader instead
-     - Port a few essential modules to use ziploader instead of module-replacer as proof of concept  
-     - New modules will be able to use ziploader.  Old modules will need to be ported in future releases (Some modules will not need porting but others will)
+     - Port most of the functionality in module\_utils to be usage in ansiballz instead
+     - Port a few essential modules to use ansiballz instead of module-replacer as proof of concept  
+     - New modules will be able to use ansiballz.  Old modules will need to be ported in future releases (Some modules will not need porting but others will)
      - Better testing of modules, caching of modules clientside(Have not yet arrived at an architecture for this that we like), better code sharing between ansible/ansible and modules
-     - ziploader is a helpful building block for: python3 porting(high priority), better code sharing between modules(medium priority)
-     - ziploader is a good idea before: enabling users to have custom module_utils directories
+     - ansiballz is a helpful building block for: python3 porting(high priority), better code sharing between modules(medium priority)
+     - ansiballz is a good idea before: enabling users to have custom module_utils directories
 - Expand module diff support (already in progress in devel)
      - Framework done. Need to add to modules, test etc. 
      - Coordinate with community to update their modules 

--- a/hacking/test-module
+++ b/hacking/test-module
@@ -142,12 +142,12 @@ def boilerplate_module(modfile, args, interpreter, check, destfile):
         task_vars=task_vars
     )
 
-    if module_style == 'new' and 'ZIPLOADER_WRAPPER = True' in module_data:
-        module_style = 'ziploader'
+    if module_style == 'new' and 'ANSIBALLZ_WRAPPER = True' in module_data:
+        module_style = 'ansiballz'
 
     modfile2_path = os.path.expanduser(destfile)
     print("* including generated source, if any, saving to: %s" % modfile2_path)
-    if module_style not in ('ziploader', 'old'):
+    if module_style not in ('ansiballz', 'old'):
         print("* this may offset any line numbers in tracebacks/debuggers!")
     modfile2 = open(modfile2_path, 'w')
     modfile2.write(module_data)
@@ -156,7 +156,7 @@ def boilerplate_module(modfile, args, interpreter, check, destfile):
 
     return (modfile2_path, modname, module_style)
 
-def ziploader_setup(modfile, modname):
+def ansiballz_setup(modfile, modname):
     os.system("chmod +x %s" % modfile)
 
     cmd = subprocess.Popen([modfile, 'explode'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -164,7 +164,7 @@ def ziploader_setup(modfile, modname):
     lines = out.splitlines()
     if len(lines) != 2 or 'Module expanded into' not in lines[0]:
         print("*" * 35)
-        print("INVALID OUTPUT FROM ZIPLOADER MODULE WRAPPER")
+        print("INVALID OUTPUT FROM ANSIBALLZ MODULE WRAPPER")
         print(out)
         sys.exit(1)
     debug_dir = lines[1].strip()
@@ -172,13 +172,13 @@ def ziploader_setup(modfile, modname):
     argsfile = os.path.join(debug_dir, 'args')
     modfile = os.path.join(debug_dir, 'ansible_module_%s.py' % modname)
 
-    print("* ziploader module detected; extracted module source to: %s" % debug_dir)
+    print("* ansiballz module detected; extracted module source to: %s" % debug_dir)
     return modfile, argsfile
 
 def runtest(modfile, argspath, modname, module_style):
     """Test run a module, piping it's output for reporting."""
-    if module_style == 'ziploader':
-        modfile, argspath = ziploader_setup(modfile, modname)
+    if module_style == 'ansiballz':
+        modfile, argspath = ansiballz_setup(modfile, modname)
 
     os.system("chmod +x %s" % modfile)
 
@@ -209,8 +209,8 @@ def runtest(modfile, argspath, modname, module_style):
 def rundebug(debugger, modfile, argspath, modname, module_style):
     """Run interactively with console debugger."""
 
-    if module_style == 'ziploader':
-        modfile, argspath = ziploader_setup(modfile, modname)
+    if module_style == 'ansiballz':
+        modfile, argspath = ansiballz_setup(modfile, modname)
 
     if argspath is not None:
         subprocess.call("%s %s %s" % (debugger, modfile, argspath), shell=True)
@@ -223,7 +223,7 @@ def main():
     (modfile, modname, module_style) = boilerplate_module(options.module_path, options.module_args, options.interpreter, options.check, options.filename)
 
     argspath = None
-    if module_style not in ('new', 'ziploader'):
+    if module_style not in ('new', 'ansiballz'):
         if module_style == 'non_native_want_json':
             argspath = write_argsfile(options.module_args, json=True)
         elif module_style == 'old':

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -61,9 +61,9 @@ _SNIPPET_PATH = os.path.join(os.path.dirname(__file__), '..', 'module_utils')
 
 # ******************************************************************************
 
-ZIPLOADER_TEMPLATE = u'''%(shebang)s
+ANSIBALLZ_TEMPLATE = u'''%(shebang)s
 %(coding)s
-ZIPLOADER_WRAPPER = True # For test-module script to tell this is a ZIPLOADER_WRAPPER
+ANSIBALLZ_WRAPPER = True # For test-module script to tell this is a ANSIBALLZ_WRAPPER
 # This code is part of Ansible, but is an independent component.
 # The code in this particular templatable string, and this templatable string
 # only, is BSD licensed.  Modules which end up using this snippet, which is
@@ -140,7 +140,7 @@ def debug(command, zipped_mod, json_params):
     # The code here normally doesn't run.  It's only used for debugging on the
     # remote machine.
     #
-    # The subcommands in this function make it easier to debug ziploader
+    # The subcommands in this function make it easier to debug ansiballz
     # modules.  Here's the basic steps:
     #
     # Run ansible with the environment variable: ANSIBLE_KEEP_REMOTE_FILES=1 and -vvv
@@ -262,9 +262,9 @@ if __name__ == '__main__':
     # See comments in the debug() method for information on debugging
     #
 
-    ZIPLOADER_PARAMS = %(params)s
+    ANSIBALLZ_PARAMS = %(params)s
     if PY3:
-        ZIPLOADER_PARAMS = ZIPLOADER_PARAMS.encode('utf-8')
+        ANSIBALLZ_PARAMS = ANSIBALLZ_PARAMS.encode('utf-8')
     try:
         # There's a race condition with the controller removing the
         # remote_tmpdir and this module executing under async.  So we cannot
@@ -277,7 +277,7 @@ if __name__ == '__main__':
         modlib.close()
 
         if len(sys.argv) == 2:
-            exitcode = debug(sys.argv[1], zipped_mod, ZIPLOADER_PARAMS)
+            exitcode = debug(sys.argv[1], zipped_mod, ANSIBALLZ_PARAMS)
         else:
             z = zipfile.ZipFile(zipped_mod, mode='r')
             module = os.path.join(temp_path, 'ansible_module_%(ansible_module)s.py')
@@ -297,7 +297,7 @@ if __name__ == '__main__':
             z.writestr('sitecustomize.py', sitecustomize)
             z.close()
 
-            exitcode = invoke_module(module, zipped_mod, ZIPLOADER_PARAMS)
+            exitcode = invoke_module(module, zipped_mod, ANSIBALLZ_PARAMS)
     finally:
         try:
             shutil.rmtree(temp_path)
@@ -320,10 +320,10 @@ def _strip_comments(source):
 if C.DEFAULT_KEEP_REMOTE_FILES:
     # Keep comments when KEEP_REMOTE_FILES is set.  That way users will see
     # the comments with some nice usage instructions
-    ACTIVE_ZIPLOADER_TEMPLATE = ZIPLOADER_TEMPLATE
+    ACTIVE_ANSIBALLZ_TEMPLATE = ANSIBALLZ_TEMPLATE
 else:
-    # ZIPLOADER_TEMPLATE stripped of comments for smaller over the wire size
-    ACTIVE_ZIPLOADER_TEMPLATE = _strip_comments(ZIPLOADER_TEMPLATE)
+    # ANSIBALLZ_TEMPLATE stripped of comments for smaller over the wire size
+    ACTIVE_ANSIBALLZ_TEMPLATE = _strip_comments(ANSIBALLZ_TEMPLATE)
 
 class ModuleDepFinder(ast.NodeVisitor):
     # Caveats:
@@ -526,7 +526,7 @@ def _find_snippet_imports(module_name, module_data, module_path, module_args, ta
     # a separate arguments file needs to be sent over the wire.
     # module_substyle is extra information that's useful internally.  It tells
     # us what we have to look to substitute in the module files and whether
-    # we're using module replacer or ziploader to format the module itself.
+    # we're using module replacer or ansiballz to format the module itself.
     if _is_binary(module_data):
         module_substyle = module_style = 'binary'
     elif REPLACER in module_data:
@@ -566,33 +566,33 @@ def _find_snippet_imports(module_name, module_data, module_path, module_args, ta
             display.warning(u'Bad module compression string specified: %s.  Using ZIP_STORED (no compression)' % module_compression)
             compression_method = zipfile.ZIP_STORED
 
-        lookup_path = os.path.join(C.DEFAULT_LOCAL_TMP, 'ziploader_cache')
+        lookup_path = os.path.join(C.DEFAULT_LOCAL_TMP, 'ansiballz_cache')
         cached_module_filename = os.path.join(lookup_path, "%s-%s" % (module_name, module_compression))
 
         zipdata = None
         # Optimization -- don't lock if the module has already been cached
         if os.path.exists(cached_module_filename):
-            display.debug('ZIPLOADER: using cached module: %s' % cached_module_filename)
+            display.debug('ANSIBALLZ: using cached module: %s' % cached_module_filename)
             zipdata = open(cached_module_filename, 'rb').read()
         else:
             if module_name in strategy.action_write_locks:
-                display.debug('ZIPLOADER: Using lock for %s' % module_name)
+                display.debug('ANSIBALLZ: Using lock for %s' % module_name)
                 lock = strategy.action_write_locks[module_name]
             else:
                 # If the action plugin directly invokes the module (instead of
                 # going through a strategy) then we don't have a cross-process
                 # Lock specifically for this module.  Use the "unexpected
                 # module" lock instead
-                display.debug('ZIPLOADER: Using generic lock for %s' % module_name)
+                display.debug('ANSIBALLZ: Using generic lock for %s' % module_name)
                 lock = strategy.action_write_locks[None]
 
-            display.debug('ZIPLOADER: Acquiring lock')
+            display.debug('ANSIBALLZ: Acquiring lock')
             with lock:
-                display.debug('ZIPLOADER: Lock acquired: %s' % id(lock))
+                display.debug('ANSIBALLZ: Lock acquired: %s' % id(lock))
                 # Check that no other process has created this while we were
                 # waiting for the lock
                 if not os.path.exists(cached_module_filename):
-                    display.debug('ZIPLOADER: Creating module')
+                    display.debug('ANSIBALLZ: Creating module')
                     # Create the module zip data
                     zipoutput = BytesIO()
                     zf = zipfile.ZipFile(zipoutput, mode='w', compression=compression_method)
@@ -613,19 +613,19 @@ def _find_snippet_imports(module_name, module_data, module_path, module_args, ta
                         # Note -- if we have a global function to setup, that would
                         # be a better place to run this
                         os.mkdir(lookup_path)
-                    display.debug('ZIPLOADER: Writing module')
+                    display.debug('ANSIBALLZ: Writing module')
                     with open(cached_module_filename + '-part', 'wb') as f:
                         f.write(zipdata)
 
                     # Rename the file into its final position in the cache so
                     # future users of this module can read it off the
                     # filesystem instead of constructing from scratch.
-                    display.debug('ZIPLOADER: Renaming module')
+                    display.debug('ANSIBALLZ: Renaming module')
                     os.rename(cached_module_filename + '-part', cached_module_filename)
-                    display.debug('ZIPLOADER: Done creating module')
+                    display.debug('ANSIBALLZ: Done creating module')
 
             if zipdata is None:
-                display.debug('ZIPLOADER: Reading module after lock')
+                display.debug('ANSIBALLZ: Reading module after lock')
                 # Another process wrote the file while we were waiting for
                 # the write lock.  Go ahead and read the data from disk
                 # instead of re-creating it.
@@ -649,7 +649,7 @@ def _find_snippet_imports(module_name, module_data, module_path, module_args, ta
             # string
             interpreter = u"'{0}'".format(interpreter)
 
-        output.write(to_bytes(ACTIVE_ZIPLOADER_TEMPLATE % dict(
+        output.write(to_bytes(ACTIVE_ANSIBALLZ_TEMPLATE % dict(
             zipdata=zipdata,
             ansible_module=module_name,
             params=python_repred_params,
@@ -693,7 +693,7 @@ def _find_snippet_imports(module_name, module_data, module_path, module_args, ta
         # these strings could be included in a third-party module but
         # officially they were included in the 'basic' snippet for new-style
         # python modules (which has been replaced with something else in
-        # ziploader) If we remove them from jsonargs-style module replacer
+        # ansiballz) If we remove them from jsonargs-style module replacer
         # then we can remove them everywhere.
         python_repred_args = to_bytes(repr(module_args_json))
         module_data = module_data.replace(REPLACER_VERSION, to_bytes(repr(__version__)))

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2031,7 +2031,7 @@ class AnsibleModule(object):
         # If using ansible or ansible-playbook with a remote system ...
         #   /tmp/ansible_vmweLQ/ansible_modlib.zip/ansible/module_utils/basic.py
 
-        # Clean out python paths set by ziploader
+        # Clean out python paths set by ansiballz
         if 'PYTHONPATH' in os.environ:
             pypaths = os.environ['PYTHONPATH'].split(':')
             pypaths = [x for x in pypaths \

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -40,7 +40,7 @@ except ImportError:
     import configparser
 from ansible.module_utils.basic import get_all_subclasses
 
-# py2 vs py3; replace with six via ziploader
+# py2 vs py3; replace with six via ansiballz
 try:
     # python2
     from StringIO import StringIO

--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -21,7 +21,7 @@ import socket
 
 from ansible.module_utils.basic import get_exception
 
-# py2 vs py3; replace with six via ziploader
+# py2 vs py3; replace with six via ansiballz
 try:
     from StringIO import StringIO
 except ImportError:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request
##### ANSIBLE VERSION

```
devel
```
##### SUMMARY

Left ziploader in a few places in the code and documentation.  Rename those so that people know to google Ansiballz, not ziploader for more information.
