### PR TITLE
fixes for service module interaction with systemd

### DIFF
--- a/lib/ansible/plugins/action/service.py
+++ b/lib/ansible/plugins/action/service.py
@@ -25,6 +25,10 @@ class ActionModule(ActionBase):
 
     TRANSFERS_FILES = False
 
+    UNUSED_PARAMS = {
+        'systemd': ['pattern', 'runlevels', 'sleep', 'arguments'],
+    }
+
     def run(self, tmp=None, task_vars=None):
         ''' handler for package operations '''
         if task_vars is None:
@@ -58,6 +62,12 @@ class ActionModule(ActionBase):
             # for backwards compatibility
             if 'state' in new_module_args and new_module_args['state'] == 'running':
                 new_module_args['state'] = 'started'
+
+            if module in self.UNUSED_PARAMS:
+                for unused in self.UNUSED_PARAMS[module]:
+                    if unused in new_module_args:
+                        del new_module_args[unused]
+                        self._display.warning('Ignoring "%s" as it is not used in "%s"' % (unused, module))
 
             self._display.vvvv("Running %s" % module)
             result.update(self._execute_module(module_name=module, module_args=new_module_args, task_vars=task_vars))


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
2.2
```
##### SUMMARY

now systemd will run even if service module is inovked with parameters that it does not support
these will be removed before invoking systemd and issue a warning.

this facility will work for any new service modules.

fixes #16694
fixes https://github.com/ansible/ansible-modules-core/issues/3897
