### PR TITLE
Fix exceptions thrown from cryptography import

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -30,6 +30,12 @@ from hashlib import sha256
 from binascii import hexlify
 from binascii import unhexlify
 
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
 # Note: Only used for loading obsolete VaultAES files.  All files are written
 # using the newer VaultAES256 which does not require md5
 from hashlib import md5
@@ -71,10 +77,9 @@ try:
 except ImportError:
     pass
 except Exception as e:
-    if e.__module__ == 'pkg_resources' and e.__class__.__name__ == 'DistributionNotFound':
-        pass
-    else:
-        raise
+    display.warning("Optional dependency 'cryptography' raised an exception, falling back to 'Crypto'")
+    import traceback
+    traceback.print_exc()
 
 from ansible.compat.six import PY3
 from ansible.utils.unicode import to_unicode, to_bytes


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fix exceptions thrown from cryptography import
(see my reasoning below)

<!-- Paste verbatim command output below, e.g. before and after your change -->

**To reproduce:**

```
pip install setuptools==3.3 (anything less than 11.3 which is cryptography's requirement)
pip install ansible=2.1.0.0 (or latest)
ansible --version
```

**Before:**

```
$ ansible --version
ERROR! Unexpected Exception: (setuptools 3.3 (/usr/lib/python2.7/dist-packages), Requirement.parse('setuptools>=11.3'))
the full traceback was:

Traceback (most recent call last):
  File "/usr/local/bin/ansible", line 81, in <module>
    from ansible.cli.adhoc import AdHocCLI as mycli
  File "/usr/local/lib/python2.7/dist-packages/ansible/cli/adhoc.py", line 28, in <module>
    from ansible.executor.task_queue_manager import TaskQueueManager
  File "/usr/local/lib/python2.7/dist-packages/ansible/executor/task_queue_manager.py", line 28, in <module>
    from ansible.executor.play_iterator import PlayIterator
  File "/usr/local/lib/python2.7/dist-packages/ansible/executor/play_iterator.py", line 29, in <module>
    from ansible.playbook.block import Block
  File "/usr/local/lib/python2.7/dist-packages/ansible/playbook/__init__.py", line 25, in <module>
    from ansible.playbook.play import Play
  File "/usr/local/lib/python2.7/dist-packages/ansible/playbook/play.py", line 27, in <module>
    from ansible.playbook.base import Base
  File "/usr/local/lib/python2.7/dist-packages/ansible/playbook/base.py", line 35, in <module>
    from ansible.parsing.dataloader import DataLoader
  File "/usr/local/lib/python2.7/dist-packages/ansible/parsing/dataloader.py", line 33, in <module>
    from ansible.parsing.vault import VaultLib
  File "/usr/local/lib/python2.7/dist-packages/ansible/parsing/vault/__init__.py", line 67, in <module>
    from cryptography.hazmat.primitives.hashes import SHA256 as c_SHA256
  File "/usr/local/lib/python2.7/dist-packages/cryptography/hazmat/primitives/hashes.py", line 15, in <module>
    from cryptography.hazmat.backends.interfaces import HashBackend
  File "/usr/local/lib/python2.7/dist-packages/cryptography/hazmat/backends/__init__.py", line 7, in <module>
    import pkg_resources
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources.py", line 2720, in <module>
    parse_requirements(__requires__), Environment()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources.py", line 592, in resolve
    raise VersionConflict(dist,req) # XXX put more info here
VersionConflict: (setuptools 3.3 (/usr/lib/python2.7/dist-packages), Requirement.parse('setuptools>=11.3'))
```

**After:**

```
ansible --version
ansible 2.2.0
  config file = 
  configured module search path = Default w/o overrides
```

A simple import of cryptography can throw several types of errors. For example, if `setuptools` is less than cryptography's minimum requirement of 11.3, then this import of cryptography will throw a `VersionConflict` here.  Ansible places no restrictions on `setuptools`, so a valid install of ansible throws an exception because of an optional dependency. Ansible is making assumptions about the environment.
