### PR TITLE
Get role vars with the dependency chain

### DIFF
--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -334,7 +334,7 @@ class VariableManager:
         # vars (which will look at parent blocks/task includes)
         if task:
             if task._role:
-                all_vars = combine_vars(all_vars, task._role.get_vars(include_params=False))
+                all_vars = combine_vars(all_vars, task._role.get_vars(task._block._dep_chain, include_params=False))
             all_vars = combine_vars(all_vars, task.get_vars())
 
         # next, we merge in the vars cache (include vars) and nonpersistent


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### SUMMARY

This fixes issue #16729 introduced by commit 3ced6d3e.

The role vars need to respect the dependency chain, so I added the missing parameter to `get_vars` (and I added a unit test for this).
