### PR TITLE
let chdir support relative path in more modules

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2084,23 +2084,20 @@ class AnsibleModule(object):
             stderr=subprocess.PIPE,
         )
 
-        if cwd and os.path.isdir(cwd):
-            kwargs['cwd'] = cwd
-
         # store the pwd
         prev_dir = os.getcwd()
 
         # make sure we're in the right working directory
         if cwd and os.path.isdir(cwd):
+            cwd = os.path.abspath(os.path.expanduser(cwd))
+            kwargs['cwd'] = cwd
             try:
-                abs_cwd = os.path.abspath(os.path.expanduser(cwd))
-                os.chdir(abs_cwd)
+                os.chdir(cwd)
             except (OSError, IOError):
                 e = get_exception()
-                self.fail_json(rc=e.errno, msg="Could not open %s, %s" % (abs_cwd, str(e)))
+                self.fail_json(rc=e.errno, msg="Could not open %s, %s" % (cwd, str(e)))
 
         try:
-
             if self._debug:
                 if isinstance(args, list):
                     running = ' '.join(args)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1965,7 +1965,7 @@ class AnsibleModule(object):
         :kw path_prefix: If given, additional path to find the command in.
             This adds to the PATH environment vairable so helper commands in
             the same directory can also be found
-        :kw cwd: iIf given, working directory to run the command inside
+        :kw cwd: If given, working directory to run the command inside
         :kw use_unsafe_shell: See `args` parameter.  Default False
         :kw prompt_regex: Regex string (not a compiled regex) which can be
             used to detect prompts in the stdout which would otherwise cause
@@ -2093,10 +2093,11 @@ class AnsibleModule(object):
         # make sure we're in the right working directory
         if cwd and os.path.isdir(cwd):
             try:
-                os.chdir(cwd)
+                abs_cwd = os.path.abspath(os.path.expanduser(cwd))
+                os.chdir(abs_cwd)
             except (OSError, IOError):
                 e = get_exception()
-                self.fail_json(rc=e.errno, msg="Could not open %s, %s" % (cwd, str(e)))
+                self.fail_json(rc=e.errno, msg="Could not open %s, %s" % (abs_cwd, str(e)))
 
         try:
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Many Ansible modules supports an arg called `chdir`, but it has slightly different behaviour in different modules.

Here are some examples (this is a non-exhaustive list):

`chdir` supports relative path in following modules:
- command
- shell

`chdir` doesn't support relative path in following modules:
- pip
- make

What makes it worse is that, this behaviour is not documented anywhere and always causes confusion.

With the following `playbook.yml`

``` yaml

---
- name: test pip install chdir
  hosts: localhost
  connection: local
  gather_facts: no

  tasks:
    - name: create pip_test dir
      file:
        path: pip_test
        state: directory

    - name: create setup.cfg for no prefix
      copy:
        dest: pip_test/setup.cfg # workaround for 'pip install -t .' on osx
        content: |
          [install]
          prefix=

    - name: install pip
      pip:
        name: bottle
        extra_args: '-t .' # install in current dir to see if chdir works
        chdir: pip_test
```

Run it in Ansible 2.1.0.0, it will fail

```
$ ansible-playbook playbook.yml
 [WARNING]: Host file not found: /usr/local/etc/ansible/hosts

 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [test pip install chdir] **************************************************

TASK [create pip_test dir] *****************************************************
ok: [localhost]

TASK [create setup.cfg for no prefix] ******************************************
ok: [localhost]

TASK [install pip] *************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "cmd": "/usr/local/bin/pip install -t . bottle", "failed": true, "msg": "[Errno 2] No such file or directory: 'pip_test'", "rc": 2}

NO MORE HOSTS LEFT *************************************************************
    to retry, use: --limit @playbook.retry

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=1
```

Run it with this PR applied, it will succeed

```
$ ansible-playbook playbook.yml
 [WARNING]: Host file not found: /etc/ansible/hosts

 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [test pip install chdir] **************************************************

TASK [create pip_test dir] *****************************************************
ok: [localhost]

TASK [create setup.cfg for no prefix] ******************************************
ok: [localhost]

TASK [install pip] *************************************************************
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=1    unreachable=0    failed=0
```
