### PR TITLE
Testing that service not enabled during check run

### DIFF
--- a/test/integration/roles/test_service/files/ansible.systemd
+++ b/test/integration/roles/test_service/files/ansible.systemd
@@ -5,3 +5,6 @@ Description=Ansible Test Service
 ExecStart=/usr/sbin/ansible_test_service "Test\nthat newlines in scripts\nwork"
 ExecReload=/bin/true
 Type=forking
+
+[Install]
+WantedBy=multi-user.target

--- a/test/integration/roles/test_service/tasks/main.yml
+++ b/test/integration/roles/test_service/tasks/main.yml
@@ -38,6 +38,7 @@
 - name: find the service with a pattern
   service: name=ansible_test pattern="ansible_test_ser*" state=started
   register: start2_result
+  # don't enable this check yet on systems with systemd because of https://github.com/ansible/ansible/issues/16694
   when: service_type != "systemd"
 
 - name: assert that the service was started via the pattern
@@ -50,17 +51,16 @@
 - name: restart the ansible test service
   service: name=ansible_test state=restarted
   register: restart_result
-  when: service_type != "systemd"
 
 - name: assert that the service was restarted
   assert:
     that:
     - "restart_result.state == 'started'"
-  when: service_type != "systemd"
 
 - name: restart the ansible test service with a sleep
   service: name=ansible_test state=restarted sleep=2
   register: restart_sleep_result
+  # don't enable this check yet on systems with systemd because of https://github.com/ansible/ansible/issues/16694
   when: service_type != "systemd"
 
 - name: assert that the service was restarted with a sleep
@@ -72,6 +72,8 @@
 - name: reload the ansible test service
   service: name=ansible_test state=reloaded
   register: reload_result
+  # don't do this on systems with systemd because it triggers error:
+  #   Unable to reload service ansible_test: ansible_test.service is not active, cannot reload.
   when: service_type != "systemd"
 
 - name: assert that the service was reloaded
@@ -92,13 +94,11 @@
 - name: disable the ansible test service
   service: name=ansible_test enabled=no
   register: disable_result
-  when: service_type != "systemd"
 
 - name: assert that the service was disabled
   assert:
     that:
     - "disable_result.enabled == false"
-  when: service_type != "systemd"
 
 - name: try to enable a broken service
   service: name=ansible_broken_test enabled=yes

--- a/test/integration/roles/test_service/tasks/main.yml
+++ b/test/integration/roles/test_service/tasks/main.yml
@@ -10,12 +10,24 @@
     - "install_result.state == 'file'"
     - "install_result.mode == '0755'"
 
-- include: 'sysv_setup.yml'
+# determine init system is in use
+- name: detect sysv init system
+  set_fact: service_type=sysv
   when: ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and (ansible_distribution_version|version_compare('6', '>=') and ansible_distribution_version|version_compare('7', '<'))
-- include: 'systemd_setup.yml'
-  when: (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and (ansible_distribution_version|version_compare('7', '>=') and ansible_distribution_version|version_compare('8', '<'))) or ansible_distribution == 'Fedora' or (ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare('15.04', '>=')) or (ansible_distribution == 'Debian' and ansible_distribution_version|version_compare('8', '>=')) or ansible_os_family == 'Suse'
-- include: 'upstart_setup.yml'
+- name: detect systemd init system
+  set_fact: service_type=systemd
+  when: (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and (ansible_distribution_version|version_compare('7', '>=') and ansible_distribution_version|version_compare('8', '<'))) or ansible_distribution == 'Fedora' or (ansible_distribution == 'Ubuntu' and     ble_distribution_version|version_compare('15.04', '>=')) or (ansible_distribution == 'Debian' and ansible_distribution_version|version_compare('8', '>=')) or ansible_os_family == 'Suse'
+- name: detect upstart init system
+  set_fact: service_type=upstart
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare('15.04', '<')
+
+# setup test service script
+- include: 'sysv_setup.yml'
+  when: service_type == "sysv"
+- include: 'systemd_setup.yml'
+  when: service_type == "systemd"
+- include: 'upstart_setup.yml'
+  when: service_type == "upstart"
 
 - name: enable the ansible test service
   service: name=ansible_test enabled=yes
@@ -120,9 +132,10 @@
     - "remove_result.path == '/usr/sbin/ansible_test_service'"
     - "remove_result.state == 'absent'"
 
+# cleaning up changes made by this playbook
 - include: 'sysv_cleanup.yml'
-  when: ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux']
+  when: service_type == "sysv"
 - include: 'systemd_cleanup.yml'
-  when: ansible_distribution == 'Fedora'
+  when: service_type == "systemd"
 - include: 'upstart_cleanup.yml'
-  when: ansible_distribution == 'Ubuntu'
+  when: service_type == "upstart"

--- a/test/integration/roles/test_service/tasks/main.yml
+++ b/test/integration/roles/test_service/tasks/main.yml
@@ -29,14 +29,28 @@
 - include: 'upstart_setup.yml'
   when: service_type == "upstart"
 
+- name: disable the ansible test service
+  service: name=ansible_test enabled=no
+
+- name: (check mode run) enable the ansible test service
+  service: name=ansible_test enabled=yes
+  register: enable_in_check_mode_result
+  check_mode: yes
+
+- name: assert that changes reported for check mode run
+  assert:
+    that:
+    - "enable_in_check_mode_result.changed == true"
+
 - name: enable the ansible test service
   service: name=ansible_test enabled=yes
   register: enable_result
 
-- name: assert that the service was enabled
+- name: assert that the service was enabled and changes reported
   assert:
     that:
     - "enable_result.enabled == true"
+    - "enable_result.changed == true"
 
 - name: start the ansible test service
   service: name=ansible_test state=started

--- a/test/integration/roles/test_service/tasks/main.yml
+++ b/test/integration/roles/test_service/tasks/main.yml
@@ -16,7 +16,7 @@
   when: ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and (ansible_distribution_version|version_compare('6', '>=') and ansible_distribution_version|version_compare('7', '<'))
 - name: detect systemd init system
   set_fact: service_type=systemd
-  when: (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and (ansible_distribution_version|version_compare('7', '>=') and ansible_distribution_version|version_compare('8', '<'))) or ansible_distribution == 'Fedora' or (ansible_distribution == 'Ubuntu' and     ble_distribution_version|version_compare('15.04', '>=')) or (ansible_distribution == 'Debian' and ansible_distribution_version|version_compare('8', '>=')) or ansible_os_family == 'Suse'
+  when: (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and (ansible_distribution_version|version_compare('7', '>=') and ansible_distribution_version|version_compare('8', '<'))) or ansible_distribution == 'Fedora' or (ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare('15.04', '>=')) or (ansible_distribution == 'Debian' and ansible_distribution_version|version_compare('8', '>=')) or ansible_os_family == 'Suse'
 - name: detect upstart init system
   set_fact: service_type=upstart
   when: ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare('15.04', '<')

--- a/test/integration/roles/test_service/tasks/systemd_setup.yml
+++ b/test/integration/roles/test_service/tasks/systemd_setup.yml
@@ -15,7 +15,6 @@
     - "install_systemd_result.dest == '/etc/systemd/system/ansible_test.service'"
     - "install_systemd_result.state == 'file'"
     - "install_systemd_result.mode == '0644'"
-    - "install_systemd_result.checksum == 'ca4b413fdf3cb2002f51893b9e42d2e449ec5afb'"
+    - "install_systemd_result.checksum == '6b5f2b9318524a387c77c550cef4dd411a471acf'"
     - "install_broken_systemd_result.dest == '/etc/systemd/system/ansible_test_broken.service'"
     - "install_broken_systemd_result.state == 'link'"
-

--- a/test/integration/roles/test_service/tasks/systemd_setup.yml
+++ b/test/integration/roles/test_service/tasks/systemd_setup.yml
@@ -1,6 +1,3 @@
-- name: set service_type fact
-  set_fact: service_type=systemd
-
 - name: install the systemd unit file
   copy: src=ansible.systemd dest=/etc/systemd/system/ansible_test.service
   register: install_systemd_result

--- a/test/integration/roles/test_service/tasks/sysv_setup.yml
+++ b/test/integration/roles/test_service/tasks/sysv_setup.yml
@@ -1,6 +1,3 @@
-- name: set service_type fact
-  set_fact: service_type=sysv
-
 - name: install the sysV init file
   copy: src=ansible.sysv dest=/etc/init.d/ansible_test mode=0755
   register: install_sysv_result

--- a/test/integration/roles/test_service/tasks/upstart_setup.yml
+++ b/test/integration/roles/test_service/tasks/upstart_setup.yml
@@ -1,6 +1,3 @@
-- name: set service_type fact
-  set_fact: service_type=upstart
-
 - name: install the upstart init file
   copy: src=ansible.upstart dest=/etc/init/ansible_test.conf mode=0644
   register: install_upstart_result


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (detached HEAD 134d70e7b9) last updated 2016/07/17 12:09:48 (GMT +300)
  lib/ansible/modules/core: (detached HEAD 7de287237f) last updated 2016/07/17 01:09:14 (GMT +300)
  lib/ansible/modules/extras: (detached HEAD 68ca157f3b) last updated 2016/07/16 20:29:35 (GMT +300)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

This pull request adds a complex destructive test that checks that a system service is not enabled when a playbook is run in the check (dry) mode.  This tests that issue https://github.com/ansible/ansible-modules-core/issues/4146 is fixed.

This is improved version of the previous pull request https://github.com/ansible/ansible/pull/16664
