### PR TITLE
synchronize: fix for rsync protocol support

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -32,6 +32,9 @@ class ActionModule(ActionBase):
     def _get_absolute_path(self, path):
         original_path = path
 
+        if path.startswith('rsync://'):
+            return path
+
         if self._task._role is not None:
             path = self._loader.path_dwim_relative(self._task._role._role_path, 'files', path)
         else:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.1.0.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

I've requested this feature in ansible/ansible#12197 and it's merged
but after I update ansible to 2.1, this feature is not working as I expected.
here's patch for fix this issue.
sorry for inconvenient

work with ansible/ansible-modules-core#4211

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```
