### PR TITLE
Fix typo in lib/ansible/parsing/__init__.py

### DIFF
--- a/lib/ansible/parsing/__init__.py
+++ b/lib/ansible/parsing/__init__.py
@@ -1,4 +1,4 @@
-# (c) 2015, Toshio Kuratomi <tkuratomi@ansbile.com>
+# (c) 2015, Toshio Kuratomi <tkuratomi@ansible.com>
 #
 # This file is part of Ansible
 #


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible --version
ansible 2.1.0.0
```
##### SUMMARY

I found a typo. check file changes to got it.
