### PR TITLE
Change line 172 to reflect lower Python version

### DIFF
--- a/docsite/rst/intro_windows.rst
+++ b/docsite/rst/intro_windows.rst
@@ -169,7 +169,7 @@ In group_vars/windows.yml, define the following inventory variables::
     ansible_password: SecretPasswordGoesHere
     ansible_port: 5986
     ansible_connection: winrm
-    # The following is necessary for Python 2.7.9+ when using default WinRM self-signed certificates:
+    # The following is necessary for Python 2.7.5+ when using default WinRM self-signed certificates:
     ansible_winrm_server_cert_validation: ignore
 
 Attention for the older style variables (``ansible_ssh_*``): ansible_ssh_password doesn't exist, should be ansible_ssh_pass.


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Current documentation states ansible_winrm_server_cert_validation: ignore is required for Python 2.7.9+. Confirmed with Python 2.7.5 this is required as well.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
[root@vxprt-ansible group_vars]# ansible --version
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
[root@vxprt-ansible group_vars]# python -V
Python 2.7.5
[root@vxprt-ansible group_vars]# cat dc.yml
ansible_user: administrator@xxxxx
ansible_password: xxxxx
ansible_port: 5986
ansible_connection: winrm
[root@vxprt-ansible group_vars]# ansible dc -m win_ping
vxprt-dc01.vxprt.local | UNREACHABLE! => {
    "changed": false,
    "msg": "kerberos: __init__() got an unexpected keyword argument 'hostname_override', ssl: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:765)",
    "unreachable": true
}
[root@vxprt-ansible group_vars]# vi dc.yml
[root@vxprt-ansible group_vars]# cat dc.yml
ansible_user: administrator@xxxxx
ansible_password: xxxxx
ansible_port: 5986
ansible_connection: winrm
ansible_winrm_server_cert_validation: ignore
[root@vxprt-ansible group_vars]# ansible dc -m win_ping
vxprt-dc01.vxprt.local | SUCCESS => {
    "changed": false,
    "ping": "pong"
}
[root@vxprt-ansible group_vars]#

```

Confirmed Python 2.7.5 requires ansible_winrm_server_cert_validation: ignore for self signed certificates
