### PR TITLE
task_result _check_key should handle empty results

### DIFF
--- a/lib/ansible/executor/task_result.py
+++ b/lib/ansible/executor/task_result.py
@@ -62,7 +62,7 @@ class TaskResult:
         return self._check_key('unreachable')
 
     def _check_key(self, key):
-        if 'results' in self._result and self._task.loop:
+        if self._result.get('results', []) and self._task.loop:
             flag = False
             for res in self._result.get('results', []):
                 if isinstance(res, dict):

--- a/test/integration/roles/test_yum/tasks/yum.yml
+++ b/test/integration/roles/test_yum/tasks/yum.yml
@@ -185,3 +185,15 @@
 
 - name: uninstall sos and sharutils
   yum: name=sos,sharutils state=removed
+
+- name: install non-existent rpm 
+  yum: name="{{ item }}"
+  with_items:
+  - does-not-exist
+  register: non_existent_rpm
+  ignore_errors: True
+
+- name: check non-existent rpm install failed
+  assert:
+    that:
+    - non_existent_rpm|failed


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 73d29c5dea) last updated 2016/07/20 14:19:09 (GMT +1000)
  lib/ansible/modules/core: (detached HEAD 7de287237f) last updated 2016/07/20 13:59:30 (GMT +1000)
  lib/ansible/modules/extras: (detached HEAD 68ca157f3b) last updated 2016/07/20 13:59:30 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

When a task result has an empty results list, the
list should be ignored when determining the results
of `_check_key`. Here the empty list is treated the
same as a non-existent list.

This fixes a bug that manifests itself with squashed
items - namely the task result contains the correct
value for the key, but an empty results list. The
empty results list was treated as zero failures
when deciding which handler to call - so the task
show as a success in the output, but is deemed to
have failed when deciding whether to continue.

This also demonstrates a mismatch between task
result processing and play iteration.

A test is also added for this case, but it would not
have caught the bug - because the bug is really in
the display, and not the success/failure of the
task (visually the test is more accurate).

Fixes ansible/ansible-modules-core#4214
