### PR TITLE
Add pvs output to hardware facts

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1367,6 +1367,17 @@ class LinuxHardware(Hardware):
             uptime_seconds_string = uptime_file_content.split(' ')[0]
             self.facts['uptime_seconds'] = int(float(uptime_seconds_string))
 
+    def _find_mapper_device_name(self, dm_device):
+        dm_prefix = '/dev/dm-'
+        mapper_device = dm_device
+        if dm_device.startswith(dm_prefix):
+            dmsetup_cmd = self.module.get_bin_path('dmsetup', True)
+            mapper_prefix = '/dev/mapper/'
+            rc, dm_name, err = self.module.run_command("%s info -C --noheadings -o name %s" % (dmsetup_cmd, dm_device))
+            if rc == 0:
+                mapper_device = mapper_prefix + dm_name.rstrip()
+        return mapper_device
+
     def get_lvm_facts(self):
         """ Get LVM Facts if running as root and lvm utils are available """
 
@@ -1395,7 +1406,20 @@ class LinuxHardware(Hardware):
                     items = lv_line.split()
                     lvs[items[0]] = {'size_g': items[3], 'vg': items[1]}
 
-            self.facts['lvm'] = {'lvs': lvs, 'vgs': vgs}
+
+            pvs_path = self.module.get_bin_path('pvs')
+            #pvs fields: PV VG #Fmt #Attr PSize PFree
+            pvs = {}
+            if pvs_path:
+                rc, pv_lines, err = self.module.run_command( '%s %s' % (pvs_path, lvm_util_options))
+                for pv_line in pv_lines.splitlines():
+                    items = pv_line.split()
+                    pvs[self._find_mapper_device_name(items[0])] = {
+                        'size_g': items[4],
+                        'free_g': items[5],
+                        'vg': items[1]}
+
+            self.facts['lvm'] = {'lvs': lvs, 'vgs': vgs, 'pvs': pvs}
 
 
 class SunOSHardware(Hardware):


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 5ac65b8864) last updated 2016/07/20 17:56:51 (GMT +300)
  lib/ansible/modules/core: (detached HEAD 7de287237f) last updated 2016/07/18 18:57:38 (GMT +300)
  lib/ansible/modules/extras: (detached HEAD 68ca157f3b) last updated 2016/07/18 18:57:53 (GMT +300)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Hardware facts do provide information about vgs and lvs LVM entities. Any information about underlying physical volumes isn't reported at all.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
$ ansible all -m setup -a 'filter=ansible_lvm'
before:
192.168.100.1 | SUCCESS => {
    "ansible_facts": {
        "ansible_lvm": {
            "lvs": {
                "homme": {
                    "size_g": "340.00", 
                    "vg": "vg_r007"
                }, 
                "lvol0": {
                    "size_g": "1.00", 
                    "vg": "vg_r007"
                }, 
                "lvol1": {
                    "size_g": "1.00", 
                    "vg": "vg_r007"
                }, 
                "rooot": {
                    "size_g": "100.00", 
                    "vg": "vg_r007"
                }
            }, 
            "vgs": {
                "vg_r007": {
                    "free_g": "23.57", 
                    "num_lvs": "4", 
                    "num_pvs": "1", 
                    "size_g": "465.57"
                }
            }
        }
    }, 
    "changed": false
}
after:
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_lvm": {
            "lvs": {
                "homme": {
                    "size_g": "340.00", 
                    "vg": "vg_r007"
                }, 
                "lvol0": {
                    "size_g": "1.00", 
                    "vg": "vg_r007"
                }, 
                "lvol1": {
                    "size_g": "1.00", 
                    "vg": "vg_r007"
                }, 
                "rooot": {
                    "size_g": "100.00", 
                    "vg": "vg_r007"
                }
            }, 
            "pvs": {
                "/dev/sda2": {
                    "free_g": "23.57", 
                    "size_g": "465.57", 
                    "vg": "vg_r007"
                }
            }, 
            "vgs": {
                "vg_r007": {
                    "free_g": "23.57", 
                    "num_lvs": "4", 
                    "num_pvs": "1", 
                    "size_g": "465.57"
                }
            }
        }
    }, 
    "changed": false
}


```

This change adds the information about physical volume to hardware
facts.
