### PR TITLE
Update fail behavior for with_items (#16597)

### DIFF
--- a/lib/ansible/executor/task_result.py
+++ b/lib/ansible/executor/task_result.py
@@ -64,9 +64,18 @@ class TaskResult:
     def _check_key(self, key):
         if 'results' in self._result and self._task.loop:
             flag = False
+            found = False
             for res in self._result.get('results', []):
                 if isinstance(res, dict):
+                    if key in res:
+                        found = True
                     flag |= res.get(key, False)
-            return flag
+            if found:
+                return flag
+            else:
+                if key in self._result:
+                    return self._result.get(key, False)
+                else:
+                    return flag
         else:
             return self._result.get(key, False)


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Check the status of each `with_item` of a task and fails if any item fails. Fixes #16597 implementing the patch proposed by @jctanner [here](https://github.com/ansible/ansible/issues/16597#issuecomment-231398989).

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

Task: (php56 should be php56u - that's what should cause failure)

```
- name: Install Prerequisites
  yum: name={{ item }} state=present
  with_items:
    - php56
    - php56u-mysql
```

Before: 

```
TASK [Install Prerequisites] ****************************************
ok: [testhost] => (item=[u'php56', u'php56u-mysql'])
```

After:

```
TASK [Install Prerequisites] ****************************************
failed: [testhost] => (item=[u'php56', u'php56u-mysql']) => {"changed": false, "failed": true, "item": ["php56", "uphp56u-mysql"], ,"msg": "No package matching 'php56' found available, installed or updated", "rc": 0, "results": []}
```
