### PR TITLE
Make returning results after loading vars optional

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -718,13 +718,13 @@ class Inventory(object):
             self._vars_per_host = {}
             self._vars_per_group = {}
 
-    def get_host_vars(self, host, new_pb_basedir=False):
+    def get_host_vars(self, host, new_pb_basedir=False, return_results=False):
         """ Read host_vars/ files """
-        return self._get_hostgroup_vars(host=host, group=None, new_pb_basedir=new_pb_basedir)
+        return self._get_hostgroup_vars(host=host, group=None, new_pb_basedir=new_pb_basedir, return_results=return_results)
 
-    def get_group_vars(self, group, new_pb_basedir=False):
+    def get_group_vars(self, group, new_pb_basedir=False, return_results=False):
         """ Read group_vars/ files """
-        return self._get_hostgroup_vars(host=None, group=group, new_pb_basedir=new_pb_basedir)
+        return self._get_hostgroup_vars(host=None, group=group, new_pb_basedir=new_pb_basedir, return_results=return_results)
 
     def _find_group_vars_files(self, basedir):
         """ Find group_vars/ files """
@@ -746,7 +746,7 @@ class Inventory(object):
             found_vars = set(os.listdir(to_unicode(path)))
         return found_vars
 
-    def _get_hostgroup_vars(self, host=None, group=None, new_pb_basedir=False):
+    def _get_hostgroup_vars(self, host=None, group=None, new_pb_basedir=False, return_results=False):
         """
         Loads variables from group_vars/<groupname> and host_vars/<hostname> in directories parallel
         to the inventory base directory or in the same directory as the playbook.  Variables in the playbook
@@ -785,11 +785,15 @@ class Inventory(object):
             if host is None and any(map(lambda ext: group.name + ext in self._group_vars_files, C.YAML_FILENAME_EXTENSIONS)):
                 # load vars in dir/group_vars/name_of_group
                 base_path = to_unicode(os.path.abspath(os.path.join(to_bytes(basedir), b"group_vars/" + to_bytes(group.name))), errors='strict')
-                self._variable_manager.add_group_vars_file(base_path, self._loader)
+                host_results = self._variable_manager.add_group_vars_file(base_path, self._loader)
+                if return_results:
+                    results = combine_vars(results, host_results)
             elif group is None and any(map(lambda ext: host.name + ext in self._host_vars_files, C.YAML_FILENAME_EXTENSIONS)):
                 # same for hostvars in dir/host_vars/name_of_host
                 base_path = to_unicode(os.path.abspath(os.path.join(to_bytes(basedir), b"host_vars/" + to_bytes(host.name))), errors='strict')
-                self._variable_manager.add_host_vars_file(base_path, self._loader)
+                group_results = self._variable_manager.add_host_vars_file(base_path, self._loader)
+                if return_results:
+                    results = combine_vars(results, group_results)
 
         # all done, results is a dictionary of variables for this particular host.
         return results


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Commit 0ba9a6a removed an expensive merge operation that is normally not required.  However, there is no public method of VariableManager to read the set of variables an inventory defines that apply just to that group or host.  This use case is required for a plugin used by our team.

As calculating the results is an expensive operation and is normally not required, I have defaulted the behaviour to not generate the result.  This makes the default behaviour the same as after 0ba9a6a, but allows for the previous behaviour to be used if required.
