### PR TITLE
OpenStack inventory caching multiple environments

### DIFF
--- a/contrib/inventory/openstack.py
+++ b/contrib/inventory/openstack.py
@@ -176,6 +176,19 @@ def is_cache_stale(cache_file, cache_expiration_time, refresh=False):
     return True
 
 
+def get_cache_name():
+    cloud = os.getenv('OS_CLOUD')
+    if not cloud:
+        project_name = (os.getenv('OS_PROJECT_NAME') or
+                        os.getenv('OS_TENANT_NAME') or
+                        os.getenv('OS_PROJECT_ID') or
+                        os.getenv('OS_TENANT_ID') or
+                        'ansible')
+        region = (os.getenv('OS_REGION_NAME') or 'inventory')
+        cloud = project_name + '-' + region.lower()
+    return cloud + ".cache"
+
+
 def get_cache_settings():
     config = os_client_config.config.OpenStackConfig(
         config_files=os_client_config.config.CONFIG_FILES + CONFIG_FILES)
@@ -184,7 +197,7 @@ def get_cache_settings():
     cache_path = config.get_cache_path()
     if not os.path.exists(cache_path):
         os.makedirs(cache_path)
-    cache_file = os.path.join(cache_path, 'ansible-inventory.cache')
+    cache_file = os.path.join(cache_path, get_cache_name())
     return (cache_file, cache_expiration_time)
 
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

The current OpenStack dynamic inventory script cache does not distinguish between 
what environment you are running against.  If you change your environment to point to
a mew environment, you may get the cache from the previous environment.  In order to
avoid this, you currently need to run _opentsack.py --list --refresh_ manually.  This change
will make that unncessary since it will generate the cache file name based on the
environment settings.

Before:

```
$ OS_REGION_NAME=NCE
$ ./openstack.py --list 
{
  "_meta": {
    "hostvars": {}
  }
}
$ OS_REGION_NAME=NCW
$ ./openstack.py --list 
{
  "_meta": {
    "hostvars": {}
  }
}
$ 
```

After:

```
$ OS_REGION_NAME=NCE
$ ./openstack.py --list 
{
  "_meta": {
    "hostvars": {}
  }
}
$ OS_REGION_NAME=NCW
$ ./openstack.py --list 
{
  "NCW": [
    "b24c2797-bae4-4173-8084-1e780b831fc5"
  ], 
  "NCW_nova": [
    "b24c2797-bae4-4173-8084-1e780b831fc5"
  ], 
  "_meta": {
    "hostvars": {
      "b24c2797-bae4-4173-8084-1e780b831fc5": {
        "ansible_ssh_host": "", 
        "openstack": {
          "HUMAN_ID": true, 
          "NAME_ATTR": "name", 
          "OS-DCF:diskConfig": "AUTO", 
          "OS-EXT-AZ:availability_zone": "nova", 
          "OS-EXT-STS:power_state": 1, 
          "OS-EXT-STS:task_state": null, 
          "OS-EXT-STS:vm_state": "active", 
          "OS-SRV-USG:launched_at": "2016-07-21T17:17:34.000000", 
          "OS-SRV-USG:terminated_at": null, 
          "accessIPv4": "", 
          "accessIPv6": "", 
          "addresses": {
            "default-network": [
              {
                "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:c3:c2:de", 
                "OS-EXT-IPS:type": "fixed", 
                "addr": "192.168.0.10", 
                "version": 4
              }
            ]
          }, 
          "az": "nova", 
          "cloud": "envvars", 
          "config_drive": "True", 
          "created": "2016-07-21T17:17:22Z", 
          "flavor": {
            "id": "4025", 
            "name": "m4.1CPU.512MB"
          }, 
          "hostId": "9643e78eb22eed49620b221c6aa339d65fc603d3f448d1edfe111991", 
          "human_id": "templeofthedog", 
          "id": "b24c2797-bae4-4173-8084-1e780b831fc5", 
          "image": {
            "id": "4fd703ce-c2f5-43ac-88e7-85f8f9835a3f", 
            "name": "Ubuntu-Server-14.04"
          }, 
          "interface_ip": "", 
          "key_name": "sandbox", 
          "metadata": {}, 
          "name": "templeofthedog", 
          "networks": {
            "default-network": [
              "192.168.0.10"
            ]
          }, 
          "os-extended-volumes:volumes_attached": [], 
          "private_v4": "192.168.0.10", 
          "progress": 0, 
          "public_v4": "", 
          "public_v6": "", 
          "region": "NCW", 
          "request_ids": [], 
          "security_groups": [
            {
              "description": "Default security group", 
              "id": "4780efc6-21e3-4da1-826f-6666dac2d33f", 
              "name": "default", 
              "security_group_rules": [
                {
                  "direction": "ingress", 
                  "ethertype": "IPv4", 
                  "id": "09c3051d-5ad4-4ede-aa98-444665afc4f3", 
                  "port_range_max": 22, 
                  "port_range_min": 22, 
                  "protocol": "tcp", 
                  "remote_ip_prefix": "0.0.0.0/0", 
                  "security_group_id": "4780efc6-21e3-4da1-826f-6666dac2d33f"
                }
              ]
            }
          ], 
          "status": "ACTIVE", 
          "tenant_id": "5291d1d7647b46e599b8229c8d8645c6", 
          "updated": "2016-07-21T17:17:35Z", 
          "user_id": "7e0a48766ba8453c9759624d24d5e01e", 
          "volumes": [], 
          "x_openstack_request_ids": []
        }
      }
    }
  }, 
  "envvars": [
    "b24c2797-bae4-4173-8084-1e780b831fc5"
  ], 
  "envvars_NCW": [
    "b24c2797-bae4-4173-8084-1e780b831fc5"
  ], 
  "envvars_NCW_nova": [
    "b24c2797-bae4-4173-8084-1e780b831fc5"
  ], 
  "flavor-m4.1CPU.512MB": [
    "b24c2797-bae4-4173-8084-1e780b831fc5"
  ], 
  "image-Ubuntu-Server-14.04": [
    "b24c2797-bae4-4173-8084-1e780b831fc5"
  ], 
  "instance-b24c2797-bae4-4173-8084-1e780b831fc5": [
    "b24c2797-bae4-4173-8084-1e780b831fc5"
  ], 
  "nova": [
    "b24c2797-bae4-4173-8084-1e780b831fc5"
  ], 
  "templeofthedog": [
    "b24c2797-bae4-4173-8084-1e780b831fc5"
  ]
}
$
```
