### PR TITLE
Testing GalaxyCLI.parse() with refactoring per ryansb's suggestions

### DIFF
--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -35,7 +35,6 @@ import ansible
 from ansible.errors import AnsibleError, AnsibleOptionsError
 
 from nose.plugins.skip import SkipTest
-import ansible
 
 if PY3:
     raise SkipTest('galaxy is not ported to be py3 compatible yet')


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Adds a new test for GalaxyCLI. Tests cases when no actions are provided, when invalid actions are provided, and when each valid action is provided. When parser() runs successfully the method returns True, creates a SortedOptParser instance, a Galaxy instance, and update certain class data. The test verifies this.

```
before:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
- delete_me was created successfully
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_execute_remove (cli.test_galaxy.TestGalaxy) ... - extracting delete_me to /var/folders/b2/jz7lnnjj73l_k00lj7ncxn5m0000gn/T/tmp0nd_5z/roles/delete_me
- delete_me was installed successfully
- successfully removed delete_me
ok
tests that GalaxyCLI exits with the error specified unless the --ignore-errors flag is used ... ok
test_init (cli.test_galaxy.TestGalaxy) ... ok

----------------------------------------------------------------------
Ran 5 tests in 3.027s

OK

after:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
- delete_me was created successfully
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_execute_remove (cli.test_galaxy.TestGalaxy) ... - extracting delete_me to /var/folders/b2/jz7lnnjj73l_k00lj7ncxn5m0000gn/T/tmpi631Na/roles/delete_me
- delete_me was installed successfully
- successfully removed delete_me
ok
tests that GalaxyCLI exits with the error specified unless the --ignore-errors flag is used ... ok
test_init (cli.test_galaxy.TestGalaxy) ... ok
systematically testing that the expected options parser is created ... ok

----------------------------------------------------------------------
Ran 6 tests in 3.337s

OK
```
