### PR TITLE
changed missing file error to warning for lookups

### DIFF
--- a/lib/ansible/plugins/lookup/__init__.py
+++ b/lib/ansible/plugins/lookup/__init__.py
@@ -22,7 +22,6 @@ __metaclass__ = type
 from abc import ABCMeta, abstractmethod
 
 from ansible.compat.six import with_metaclass
-from ansible.errors import AnsibleFileNotFound
 
 try:
     from __main__ import display
@@ -115,6 +114,6 @@ class LookupBase(with_metaclass(ABCMeta, object)):
 
         result = self._loader.path_dwim_relative_stack(paths, subdir, needle)
         if result is None:
-            raise AnsibleFileNotFound("Unable to find '%s' in expected paths." % needle)
+            self._display.warning("Unable to find '%s' in expected paths." % needle)
 
         return result

--- a/lib/ansible/plugins/lookup/fileglob.py
+++ b/lib/ansible/plugins/lookup/fileglob.py
@@ -32,10 +32,7 @@ class LookupModule(LookupBase):
         ret = []
         for term in terms:
             term_file = os.path.basename(term)
-            try:
-                dwimmed_path = self.find_file_in_search_path(variables, 'files', os.path.dirname(term))
-            except AnsibleFileNotFound:
-                dwimmed_path = None
+            dwimmed_path = self.find_file_in_search_path(variables, 'files', os.path.dirname(term))
             if dwimmed_path:
                 globbed = glob.glob(to_bytes(os.path.join(dwimmed_path, term_file), errors='surrogate_or_strict'))
                 ret.extend(to_text(g, errors='surrogate_or_strict') for g in globbed if os.path.isfile(g))

--- a/lib/ansible/plugins/lookup/first_found.py
+++ b/lib/ansible/plugins/lookup/first_found.py
@@ -181,11 +181,9 @@ class LookupModule(LookupBase):
              # get subdir if set by task executor, default to files otherwise
             subdir = getattr(self, '_subdir', 'files')
             path = None
-            try:
-                path = self.find_file_in_search_path(variables, subdir, fn)
+            path = self.find_file_in_search_path(variables, subdir, fn)
+            if path is not None:
                 return [path]
-            except AnsibleFileNotFound:
-                continue
         else:
             if skip:
                 return []


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.2
```
##### SUMMARY

This should reestablish the old behavior skipping loops instead of creating errors.

fixes #16801    
