### PR TITLE
Adding a test for the GalaxyCLI.init() method. \n\nThe test creates a temporary directory in which to create the role framework. The execute_init method creates a directory and files (a framework) for a role. My test checks the initial creation of the framework, tests what happens if the directory already exists with and without the force flag, and then removes the temporary directory. 

### DIFF
--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -21,14 +21,11 @@ __metaclass__ = type
 
 import os
 import shutil
-<<<<<<< HEAD
-=======
 
 from mock import patch
 
 from ansible.errors import AnsibleError
 from ansible.module_utils.urls import SSLValidationError
->>>>>>> ed4c277... setting framework up in a temporary directory and cleaning up code a little
 import tarfile
 import tempfile
 
@@ -42,11 +39,6 @@ from mock import patch, call
 import ansible
 from ansible.errors import AnsibleError, AnsibleOptionsError
 
-<<<<<<< HEAD
-from nose.plugins.skip import SkipTest
-
-=======
->>>>>>> ed4c277... setting framework up in a temporary directory and cleaning up code a little
 if PY3:
     raise SkipTest('galaxy is not ported to be py3 compatible yet')
 
@@ -131,8 +123,6 @@ class TestGalaxy(unittest.TestCase):
         if display_result.find('\n\tgalaxy_info:') == -1:
             self.fail('Expected galaxy_info to be indented once')
 
-<<<<<<< HEAD
-=======
     def test_execute_init(self):
         ''' verifies that execute_init created a skeleton framework of a role that complies with the galaxy metadata format '''
         # testing that an error is raised if no role name is given
@@ -178,7 +168,6 @@ class TestGalaxy(unittest.TestCase):
         # removing the temporary dir and files we created
         shutil.rmtree(role_path)
 
->>>>>>> ed4c277... setting framework up in a temporary directory and cleaning up code a little
     def test_execute_remove(self):
         # installing role
         gc = GalaxyCLI(args=["install"])
@@ -325,7 +314,3 @@ class TestGalaxy(unittest.TestCase):
         self.assertTrue(gc.options.verbosity==0)
         self.assertTrue(gc.options.remove_id==None)
         self.assertTrue(gc.options.setup_list==False)
-<<<<<<< HEAD
-=======
-
->>>>>>> ed4c277... setting framework up in a temporary directory and cleaning up code a little

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -21,6 +21,14 @@ __metaclass__ = type
 
 import os
 import shutil
+<<<<<<< HEAD
+=======
+
+from mock import patch
+
+from ansible.errors import AnsibleError
+from ansible.module_utils.urls import SSLValidationError
+>>>>>>> ed4c277... setting framework up in a temporary directory and cleaning up code a little
 import tarfile
 import tempfile
 
@@ -34,8 +42,11 @@ from mock import patch, call
 import ansible
 from ansible.errors import AnsibleError, AnsibleOptionsError
 
+<<<<<<< HEAD
 from nose.plugins.skip import SkipTest
 
+=======
+>>>>>>> ed4c277... setting framework up in a temporary directory and cleaning up code a little
 if PY3:
     raise SkipTest('galaxy is not ported to be py3 compatible yet')
 
@@ -120,6 +131,54 @@ class TestGalaxy(unittest.TestCase):
         if display_result.find('\n\tgalaxy_info:') == -1:
             self.fail('Expected galaxy_info to be indented once')
 
+<<<<<<< HEAD
+=======
+    def test_execute_init(self):
+        ''' verifies that execute_init created a skeleton framework of a role that complies with the galaxy metadata format '''
+        # testing that an error is raised if no role name is given
+        gc = GalaxyCLI(args=["init"])
+        with patch('sys.argv', ["-c"]):
+            galaxy_parser = gc.parse()
+        self.assertRaises(AnsibleError, gc.execute_init)
+
+        # setup - temp dir to create framework for role
+        role_path = os.path.join(tempfile.mkdtemp(), "roles")
+        
+        gc = GalaxyCLI(args=["init"])
+        with patch('sys.argv', ["-c", "--offline", "-p", role_path, "delete_me"]):
+            galaxy_parser = gc.parse()
+        with patch.object(ansible.utils.display.Display, "display") as mock_display:  # used to test that it was called with the expected message
+            gc.run()
+            self.assertTrue(mock_display.called_once_with("- delete_me was created successfully"))
+
+        # verifying that framework was created
+        for path in ['./delete_me', './delete_me/README.md', './delete_me/files', './delete_me/templates', './delete_me/handlers/main.yml', './delete_me/tasks/main.yml', './delete_me/vars/main.yml', './delete_me/tests/inventory', './delete_me/tests/test.yml', './delete_me/meta/main.yml']:
+            created_path = os.path.join(role_path, path)
+            self.assertTrue(os.path.exists(created_path))
+
+        # testing for case when the directory and files are in existence already
+        gc = GalaxyCLI(args=["init"])
+        with patch('sys.argv', ["-c", "--offline", "-p", role_path, "delete_me"]):
+            galaxy_parser = gc.parse()
+        self.assertRaises(AnsibleError, gc.run)
+
+        # testing for case when the directory and files are in existence already while using the option: --force
+        gc = GalaxyCLI(args=["init"])
+        with patch('sys.argv', ["-c", "--offline", "-p", role_path, "delete_me", "--force"]):
+            galaxy_parser = gc.parse()
+        with patch.object(ansible.utils.display.Display, "display") as mock_display:  # used to test that it was called with the expected message
+            gc.run()
+            self.assertTrue(mock_display.called_once_with("- delete_me was created successfully"))
+
+        # testing framework is as expected
+        for path in ['./delete_me', './delete_me/README.md', './delete_me/files', './delete_me/templates', './delete_me/handlers/main.yml', './delete_me/tasks/main.yml', './delete_me/vars/main.yml', './delete_me/tests/inventory', './delete_me/tests/test.yml', './delete_me/meta/main.yml']:
+            created_path = os.path.join(role_path, path)
+            self.assertTrue(os.path.exists(created_path))
+
+        # removing the temporary dir and files we created
+        shutil.rmtree(role_path)
+
+>>>>>>> ed4c277... setting framework up in a temporary directory and cleaning up code a little
     def test_execute_remove(self):
         # installing role
         gc = GalaxyCLI(args=["install"])
@@ -266,3 +325,7 @@ class TestGalaxy(unittest.TestCase):
         self.assertTrue(gc.options.verbosity==0)
         self.assertTrue(gc.options.remove_id==None)
         self.assertTrue(gc.options.setup_list==False)
+<<<<<<< HEAD
+=======
+
+>>>>>>> ed4c277... setting framework up in a temporary directory and cleaning up code a little


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

The test creates a temporary directory in which to create the role framework. The execute_init method creates a directory and files (a framework) for a role. My test checks the initial creation of the framework, tests what happens if the directory already exists with and without the force flag, and then removes the temporary directory. 

```
before:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
- delete_me was created successfully
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
test_execute_remove (cli.test_galaxy.TestGalaxy) ... - extracting delete_me to /var/folders/b2/jz7lnnjj73l_k00lj7ncxn5m0000gn/T/tmp98eVnn/roles/delete_me
- delete_me was installed successfully
- successfully removed delete_me
ok
tests that GalaxyCLI exits with the error specified unless the --ignore-errors flag is used ... ok
test_init (cli.test_galaxy.TestGalaxy) ... ok
systematically testing that the expected options parser is created ... ok

----------------------------------------------------------------------
Ran 6 tests in 2.889s

OK

after:

shertel-OSX:ansible shertel$ PYTHONPATH=./lib nosetests -d -w test/units -v -s cli.test_galaxy
- delete_me was created successfully
test_display_galaxy_info (cli.test_galaxy.TestGalaxy) ... ok
test_display_min (cli.test_galaxy.TestGalaxy) ... ok
verifies that execute_init created a skeleton framework of a role that complies with the galaxy metadata format ... ok
test_execute_remove (cli.test_galaxy.TestGalaxy) ... - extracting delete_me to /var/folders/b2/jz7lnnjj73l_k00lj7ncxn5m0000gn/T/tmpBMXqY5/roles/delete_me
- delete_me was installed successfully
- successfully removed delete_me
ok
tests that GalaxyCLI exits with the error specified unless the --ignore-errors flag is used ... ok
test_init (cli.test_galaxy.TestGalaxy) ... ok
systematically testing that the expected options parser is created ... ok

----------------------------------------------------------------------
Ran 7 tests in 3.858s

OK
```
