### PR TITLE
'feature' to disable modules that fail adhoc

### DIFF
--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -155,6 +155,9 @@ class AdHocCLI(CLI):
                 err = err + ' (did you mean to run ansible-playbook?)'
             raise AnsibleOptionsError(err)
 
+        if self.options.module_name in C.NON_ADHOC_MODULES:
+            raise AnsibleOptionsError("This module (%s) is not compatible with the adhoc CLI" % self.options.module_name)
+
         # dynamically load any plugins from the playbook directory
         for name, obj in get_all_plugin_loaders():
             if obj.subdir:

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -247,6 +247,7 @@ CACHE_PLUGIN                   = get_config(p, DEFAULTS, 'fact_caching', 'ANSIBL
 CACHE_PLUGIN_CONNECTION        = get_config(p, DEFAULTS, 'fact_caching_connection', 'ANSIBLE_CACHE_PLUGIN_CONNECTION', None)
 CACHE_PLUGIN_PREFIX            = get_config(p, DEFAULTS, 'fact_caching_prefix', 'ANSIBLE_CACHE_PLUGIN_PREFIX', 'ansible_facts')
 CACHE_PLUGIN_TIMEOUT           = get_config(p, DEFAULTS, 'fact_caching_timeout', 'ANSIBLE_CACHE_PLUGIN_TIMEOUT', 24 * 60 * 60, integer=True)
+NON_ADHOC_MODULES              = get_config(p, DEFAULTS, 'non_adhoc_modules', 'ANSIBLE_NON_ADHOC_MODULES', ['include', 'include_role', 'include_vars'], islist=True)
 
 # Display
 ANSIBLE_FORCE_COLOR            = get_config(p, DEFAULTS, 'force_color', 'ANSIBLE_FORCE_COLOR', None, boolean=True)


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.2
```
##### SUMMARY

allows adhoc to give 'nice' message when someone attempts to use an incompatible module

fixes #16821
