### PR TITLE
Fixing remote docker issues

### DIFF
--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -4,6 +4,7 @@
 # (c) 2014, Lorin Hochstein
 # (c) 2015, Leendert Brouwer
 # (c) 2015, Toshio Kuratomi <tkuratomi@ansible.com>
+# (c) 2016, Gian Perrone
 #
 # Maintainer: Leendert Brouwer (https://github.com/objectified)
 #

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -124,7 +124,7 @@ class Connection(ConnectionBase):
             if match:
                 return self._sanitize_version(match.group(1))
             else:
-                raise subprocess.CalledProcessError(p.returncode)
+                raise subprocess.CalledProcessError(p.returncode, cmd)
 
         for line in cmd_output.split('\n'):
             if line.startswith('Server version:'):  # old docker versions
@@ -133,8 +133,8 @@ class Connection(ConnectionBase):
         # no result yet, must be newer Docker version
         cmd += ['--format', "'{{.Server.Version}}'"]
 
-        p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-        cmd_output = p.communicate()[0]
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        cmd_output, cmd_error = p.communicate()
 
         return self._sanitize_version(cmd_output)
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel b435ab17ed) last updated 2016/07/26 00:59:22 (GMT +200)
  lib/ansible/modules/core: (detached HEAD d64060ace0) last updated 2016/07/25 22:27:29 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD bef9a1c14f) last updated 2016/07/25 22:27:32 (GMT +200)
  config file = /cygdrive/d/ownCloud/ownCloud/Ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

This fixes two things in the docker connection plugin.
1. docker_extra_args were previously ignored by some commands including the version check for newer versions which made connecting to newer remote hosts impossible.
2. When connecting to a remote host with a newer client version, docker return an error. This is easily fixed by setting the DOCKER_API_VERSION environment variable to the server version.

It is debatable whether b) is a bugfix, a feature or a workaround (why doesn't docker do this itself?) but it is definitely enabling the use case of a current docker client with a "stable" (as in Debian) docker host.

I'd like to further enhance the remote feature enabling simpler syntax than docker_extra_args for it, but that will be a different pull request.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
