### PR TITLE
Indent JSON output on verbose

### DIFF
--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -89,7 +89,7 @@ class CallbackBase:
         if result.get('_ansible_no_log', False):
             return json.dumps(dict(censored="the output has been hidden due to the fact that 'no_log: true' was specified for this result"))
 
-        if not indent and (result.get('_ansible_verbose_always') or self._display.verbosity > 2):
+        if not indent and (result.get('_ansible_verbose_always') or self._display.verbosity > 0):
             indent = 4
 
         # All result keys stating with _ansible_ are internal, so remove them from the result before we output anything.


### PR DESCRIPTION
As discussed on the [Improving default output thread](https://groups.google.com/forum/#!topic/ansible-devel/pyJGj1dXZ-c), this PR enables output indentation with only -v.
