### PR TITLE
Debug output callback

### DIFF
--- a/lib/ansible/plugins/callback/debug.py
+++ b/lib/ansible/plugins/callback/debug.py
@@ -14,6 +14,8 @@ class CallbackModule(CallbackModule_default):  # pylint: disable=too-few-public-
 
     def _dump_results(self, result):
         '''Return the text to output for a result.'''
+
+        # Enable JSON identation
         result['_ansible_verbose_always'] = True
 
         save = {}

--- a/lib/ansible/plugins/callback/debug.py
+++ b/lib/ansible/plugins/callback/debug.py
@@ -1,19 +1,7 @@
-import codecs
-import imp
-import os
-
-# For some reason this would cause ImportError
-# import ansible.plugins.callback.default as DEFAULT_MODULE
-# So, please forgive the horror you are about to witness, but it is necessary
-ANSIBLE_PATH = imp.find_module('ansible')[1]
-DEFAULT_PATH = os.path.join(ANSIBLE_PATH, 'plugins/callback/default.py')
-DEFAULT_MODULE = imp.load_source(
-    'ansible.plugins.callback.default',
-    DEFAULT_PATH
-)
+from ansible.plugins.callback.default import CallbackModule as CallbackModule_default
 
 
-class CallbackModule(DEFAULT_MODULE.CallbackModule):  # pylint: disable=too-few-public-methods,no-init
+class CallbackModule(CallbackModule_default):  # pylint: disable=too-few-public-methods,no-init
     '''
     Override for the default callback module.
 
@@ -33,7 +21,7 @@ class CallbackModule(DEFAULT_MODULE.CallbackModule):  # pylint: disable=too-few-
             if key in result:
                 save[key] = result.pop(key)
 
-        output = DEFAULT_MODULE.CallbackModule._dump_results(self, result)
+        output = CallbackModule_default._dump_results(self, result)
 
         for key in ['stdout', 'stderr', 'msg']:
             if key in save and save[key]:

--- a/lib/ansible/plugins/callback/debug.py
+++ b/lib/ansible/plugins/callback/debug.py
@@ -1,0 +1,45 @@
+import codecs
+import imp
+import os
+
+# For some reason this would cause ImportError
+# import ansible.plugins.callback.default as DEFAULT_MODULE
+# So, please forgive the horror you are about to witness, but it is necessary
+ANSIBLE_PATH = imp.find_module('ansible')[1]
+DEFAULT_PATH = os.path.join(ANSIBLE_PATH, 'plugins/callback/default.py')
+DEFAULT_MODULE = imp.load_source(
+    'ansible.plugins.callback.default',
+    DEFAULT_PATH
+)
+
+
+class CallbackModule(DEFAULT_MODULE.CallbackModule):  # pylint: disable=too-few-public-methods,no-init
+    '''
+    Override for the default callback module.
+
+    Render std err/out outside of the rest of the result which it prints with
+    indentation.
+    '''
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'stdout'
+    CALLBACK_NAME = 'debug'
+
+    def _dump_results(self, result):
+        '''Return the text to output for a result.'''
+        result['_ansible_verbose_always'] = True
+
+        save = {}
+        for key in ['stdout', 'stdout_lines', 'stderr', 'stderr_lines', 'msg']:
+            if key in result:
+                save[key] = result.pop(key)
+
+        output = DEFAULT_MODULE.CallbackModule._dump_results(self, result)
+
+        for key in ['stdout', 'stderr', 'msg']:
+            if key in save and save[key]:
+                output += '\n\n%s:\n\n%s\n' % (key.upper(), save[key])
+
+        for key, value in save.items():
+            result[key] = value
+
+        return output


### PR DESCRIPTION
As discussed on the [Improving default output thread](https://groups.google.com/forum/#!topic/ansible-devel/pyJGj1dXZ-c), this PR makes multiline output readable with -v.
