### PR TITLE
Strip group names of whitespaces, so we can use space after comma in openstack's groups metadata field.

### DIFF
--- a/contrib/inventory/openstack.py
+++ b/contrib/inventory/openstack.py
@@ -86,7 +86,7 @@ def get_groups_from_server(server_vars, namegroup=True):
 
     for extra_group in metadata.get('groups', '').split(','):
         if extra_group:
-            groups.append(extra_group)
+            groups.append(extra_group.strip())
 
     groups.append('instance-%s' % server_vars['id'])
     if namegroup:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.0.2.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

strip() is non destructive on normal strings, and in this case it will allow to separate group names in openstack metadata by comma and space ", ". This is more elegant and easier to read. Without this, openstack.py will create a group names with leading space.
