### PR TITLE
raise AnsibleError in hashi_vault lookup plugin when hvac module is missing

### DIFF
--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -45,7 +45,7 @@ class HashiVault:
         try:
             import hvac
         except ImportError:
-            AnsibleError("Please pip install hvac to use this module")
+            raise AnsibleError("Please pip install hvac to use this module")
 
         self.url = kwargs.get('url', ANSIBLE_HASHI_VAULT_ADDR)
             


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides                                                           
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Raises caught exception when hvac is not installed.

Play:

```
- hosts: localhost
  tasks:
  - debug: msg="{{ lookup('hashi_vault', 'secret=secret/hello token=<token> url=http://127.0.0.1:8200')}}"
```

Before:

```
TASK [debug] *******************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: UnboundLocalError: local variable 'hvac' referenced before assignment
fatal: [localhost]: FAILED! => {"failed": true, "msg": "Unexpected failure during module execution.", "stdout": ""}
```

After:

```
TASK [debug] *******************************************************************
fatal: [localhost]: FAILED! => {"failed": true, "msg": "Please pip install hvac to use this module"}
```
