### PR TITLE
Fix import of gce/gcdns without a libcloud module

### DIFF
--- a/lib/ansible/module_utils/gcdns.py
+++ b/lib/ansible/module_utils/gcdns.py
@@ -40,11 +40,12 @@ except ImportError:
 USER_AGENT_PRODUCT = "Ansible-gcdns"
 USER_AGENT_VERSION = "v1"
 
-def gcdns_connect(module, provider=Provider.GOOGLE):
+def gcdns_connect(module, provider=None):
     """Return a GCP connection for Google Cloud DNS."""
     if not HAS_LIBCLOUD_BASE:
         module.fail_json(msg='libcloud must be installed to use this module')
 
+    provider = provider or Provider.GOOGLE
     return gcp_connect(module, provider, get_driver, USER_AGENT_PRODUCT, USER_AGENT_VERSION)
 
 def unexpected_error_msg(error):

--- a/lib/ansible/module_utils/gce.py
+++ b/lib/ansible/module_utils/gce.py
@@ -40,10 +40,11 @@ except ImportError:
 USER_AGENT_PRODUCT = "Ansible-gce"
 USER_AGENT_VERSION = "v1"
 
-def gce_connect(module, provider=Provider.GCE):
+def gce_connect(module, provider=None):
     """Return a GCP connection for Google Compute Engine."""
     if not HAS_LIBCLOUD_BASE:
         module.fail_json(msg='libcloud must be installed to use this module')
+    provider = provider or Provider.GCE
 
     return gcp_connect(module, provider, get_driver, USER_AGENT_PRODUCT, USER_AGENT_VERSION)
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (gce_module_utils fa1d55f683) last updated 2016/07/29 13:42:08 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 24db4de245) last updated 2016/07/27 15:10:26 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD db979dde74) last updated 2016/07/27 15:10:26 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

If the libcloud module is not available, a direct import of the gce and gcdns module
will fail. For ex:

```
[fedora-23:ansible (devel % u=)]$ python /home/adrian/src/ansible/lib/ansible/module_utils/gce.py
Traceback (most recent call last):
  File "/home/adrian/src/ansible/lib/ansible/module_utils/gce.py", line 43, in <module>
    def gce_connect(module, provider=Provider.GCE):
NameError: name 'Provider' is not defined
```

That's not common usage, but it does affect tools like automated api generation tools that attempt to import a module.

The module level function defs for gcdns_connect() and
gce_connect() provide a default arg for 'provider' that
references into the libcloud module. If the libcloud
modules were not installed, the gce/gcdns python modules
would throw ImportError.

Let the provider arg default to None and if not provided,
set it to the default libcloud.compute.types.Provider.*
value if the modules are installed.
