### PR TITLE
Download files from S3 to improve reliability.

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -315,18 +315,21 @@ no_log: setup
 	[ "$$(ansible-playbook no_log_local.yml -i $(INVENTORY) -e outputdir=$(TEST_DIR) -vvvvv | awk --source 'BEGIN { logme = 0; nolog = 0; } /LOG_ME/ { logme += 1;} /DO_NOT_LOG/ { nolog += 1;} END { printf "%d/%d", logme, nolog; }')" = "26/0" ]
 
 test_binary_modules:
-	mytmpdir=$(MYTMPDIR); \
-	ls -al $$mytmpdir; \
-	curl https://storage.googleapis.com/golang/go1.6.2.$(UNAME)-amd64.tar.gz | tar -xz -C $$mytmpdir; \
-	[ $$? != 0 ] && wget -qO- https://storage.googleapis.com/golang/go1.6.2.$(UNAME)-amd64.tar.gz | tar -xz -C $$mytmpdir; \
-	ls -al $$mytmpdir; \
-	cd library; \
-	GOROOT=$$mytmpdir/go GOOS=linux GOARCH=amd64 $$mytmpdir/go/bin/go build -o helloworld_linux helloworld.go; \
-	GOROOT=$$mytmpdir/go GOOS=windows GOARCH=amd64 $$mytmpdir/go/bin/go build -o helloworld_win32nt.exe helloworld.go; \
-	GOROOT=$$mytmpdir/go GOOS=darwin GOARCH=amd64 $$mytmpdir/go/bin/go build -o helloworld_darwin helloworld.go; \
-	cd ..; \
-	rm -rf $$mytmpdir; \
+	ANSIBLE_HOST_KEY_CHECKING=false ansible-playbook download_binary_modules.yml -i $(INVENTORY) -v $(TEST_FLAGS)
 	ANSIBLE_HOST_KEY_CHECKING=false ansible-playbook test_binary_modules.yml -i $(INVENTORY) -v $(TEST_FLAGS)
+
+binary_modules:
+	# Compiled versions of these binary modules are available at the url below.
+	# This avoids a dependency on go and keeps the binaries out of our git repository.
+	# https://ansible-ci-files.s3.amazonaws.com/test/integration/roles/test_binary_modules/
+	cd library; \
+	GOOS=linux   GOARCH=amd64 go build -o helloworld_linux       helloworld.go; \
+	GOOS=windows GOARCH=amd64 go build -o helloworld_win32nt.exe helloworld.go; \
+	GOOS=darwin  GOARCH=amd64 go build -o helloworld_darwin      helloworld.go; \
+	GOOS=freebsd GOARCH=amd64 go build -o helloworld_freebsd     helloworld.go
+
+clean_binary_modules:
+	rm library/helloworld_*
 
 test_async:
 	# Verify that extra data before module JSON output during async call is ignored.

--- a/test/integration/download_binary_modules.yml
+++ b/test/integration/download_binary_modules.yml
@@ -1,0 +1,10 @@
+- hosts: all
+  tasks:
+    - debug: var=ansible_system
+
+    - name: download binary module
+      tags: test_binary_modules
+      get_url:
+        url: "https://ansible-ci-files.s3.amazonaws.com/test/integration/roles/test_binary_modules/helloworld_{{ ansible_system|lower }}"
+        dest: "{{ playbook_dir }}/library/helloworld_{{ ansible_system|lower }}"
+        mode: 0755

--- a/test/integration/roles/test_win_msi/defaults/main.yml
+++ b/test/integration/roles/test_win_msi/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-msi_url: http://downloads.sourceforge.net/project/sevenzip/7-Zip/9.22/7z922-x64.msi
+msi_url: https://ansible-ci-files.s3.amazonaws.com/test/integration/roles/test_win_msi/7z922-x64.msi
 msi_download_path: "C:\\Program Files\\7z922-x64.msi"
 msi_install_path: "C:\\Program Files\\7-Zip"
 msi_product_code: "{23170F69-40C1-2702-0922-000001000000}"


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (ansible-ci-files a2cac4b4f0) last updated 2016/07/31 08:13:10 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 24db4de245) last updated 2016/07/28 11:12:27 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD db979dde74) last updated 2016/07/28 11:12:27 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Binary module tests now download pre-compiled binaries from S3
instead of downloading go and compiling the modules.

Files downloaded form SourceForge are now downloaded from S3.
