### PR TITLE
Fix the security rules name duplication of azure_rm_common.

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -532,12 +532,12 @@ class AzureRMModuleBase(object):
                 ]
                 parameters.location = location
             else:
-                # for windows add inbound RDP rules
+                # for windows add inbound RDP and WinRM rules
                 parameters.security_rules = [
                     SecurityRule('Tcp', '*', '*', 'Allow', 'Inbound', description='Allow RDP port 3389',
                                  source_port_range='*', destination_port_range='3389', priority=100, name='RDP01'),
-                    SecurityRule('Tcp', '*', '*', 'Allow', 'Inbound', description='Allow RDP port 5986',
-                                 source_port_range='*', destination_port_range='5986', priority=101, name='RDP01'),
+                    SecurityRule('Tcp', '*', '*', 'Allow', 'Inbound', description='Allow WinRM HTTPS port 5986',
+                                 source_port_range='*', destination_port_range='5986', priority=101, name='WinRM01'),
                 ]
         else:
             # Open custom ports


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 6dc148d82c) last updated 2016/08/01 17:41:49 (GMT +900)
  lib/ansible/modules/core: (detached HEAD 24db4de245) last updated 2016/08/01 17:17:02 (GMT +900)
  lib/ansible/modules/extras: (detached HEAD db979dde74) last updated 2016/08/01 17:17:03 (GMT +900)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

In azure_rm_common, the name of security rules of windows are duplicated.
As the port 5986 is not for RPD but for WinRM HTTPS connection actually, I renamed the name and the description of the port 5986 security rule.
