### PR TITLE
correct ini variable name

### DIFF
--- a/contrib/inventory/vmware_inventory.ini
+++ b/contrib/inventory/vmware_inventory.ini
@@ -21,7 +21,7 @@ password=vmware
 
 # Specify the directory used for storing the inventory cache.  If not defined,
 # caching will be disabled.
-#cache_dir = ~/.cache/ansible
+#cache_path = ~/.cache/ansible
 
 
 # Max object level refers to the level of recursion the script will delve into


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
- New Module Pull Request
- Bugfix Pull Request
- Docs Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```

cache_path is used to calculate cache_dir , the script doesn't actually read cache_dir from this file.

This makes the setting work (otherwise it always uses the default).
