### PR TITLE
introduce fine-grained control of yaml parser warnings

### DIFF
--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -63,10 +63,12 @@ class DataLoader():
         ds = dl.load_from_file('/path/to/file')
     '''
 
-    def __init__(self):
+    def __init__(self, fatal_warnings=None, ignore_warnings=None):
         self._basedir = '.'
         self._FILE_CACHE = dict()
         self._tempfiles = set()
+        self._fatal_warnings=fatal_warnings
+        self._ignore_warnings=ignore_warnings
 
         # initialize the vault stuff with an empty password
         self.set_vault_password(None)
@@ -149,7 +151,9 @@ class DataLoader():
     def _safe_load(self, stream, file_name=None):
         ''' Implements yaml.safe_load(), except using our custom loader class. '''
 
-        loader = AnsibleLoader(stream, file_name)
+        loader = AnsibleLoader(stream, file_name,
+                               fatal_warnings=self._fatal_warnings,
+                               ignore_warnings=self._ignore_warnings)
         try:
             return loader.get_single_data()
         finally:

--- a/lib/ansible/parsing/yaml/loader.py
+++ b/lib/ansible/parsing/yaml/loader.py
@@ -31,9 +31,11 @@ from ansible.parsing.yaml.constructor import AnsibleConstructor
 
 if HAVE_PYYAML_C:
     class AnsibleLoader(CParser, AnsibleConstructor, Resolver):
-        def __init__(self, stream, file_name=None):
+        def __init__(self, stream, file_name=None, fatal_warnings=None, ignore_warnings=None):
             CParser.__init__(self, stream)
-            AnsibleConstructor.__init__(self, file_name=file_name)
+            AnsibleConstructor.__init__(self, file_name=file_name,
+                                        fatal_warnings=fatal_warnings,
+                                        ignore_warnings=ignore_warnings)
             Resolver.__init__(self)
 else:
     from yaml.composer import Composer
@@ -42,10 +44,12 @@ else:
     from yaml.parser import Parser
 
     class AnsibleLoader(Reader, Scanner, Parser, Composer, AnsibleConstructor, Resolver):
-        def __init__(self, stream, file_name=None):
+        def __init__(self, stream, file_name=None, fatal_warnings=None):
             Reader.__init__(self, stream)
             Scanner.__init__(self)
             Parser.__init__(self)
             Composer.__init__(self)
-            AnsibleConstructor.__init__(self, file_name=file_name)
+            AnsibleConstructor.__init__(self, file_name=file_name,
+                                        fatal_warnings=fatal_warnings,
+                                        ignore_warnings=ignore_warnings)
             Resolver.__init__(self)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (bug/16903 1155eb740c) last updated 2016/08/01 14:25:00 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 24db4de245) last updated 2016/08/01 12:00:49 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD db979dde74) last updated 2016/08/01 12:00:50 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

This patch addresses both #16903 and #13603 by introducing a mechanism
for fine-grained control over warnings in
`ansible.parsing.yaml.constructor.AnsibleConstructor`.  We introduce
two new parameters:
- `fatal_warnings`: named warnings in this list will raise an
  exception instead of emitting a warning message.
- `ignore_warnings`: named warnings in this list will be ignored.

The constructor code currently recognizes one named warning,
`duplicate-key`, which is generated when the parser encounters a
duplicate key in a YAML mapping.

This patches _does not_ change the default behavior, because while the
following is clearly an error...

```
- host: myhost
  tasks:
    - debug:
        msg: this is a task

  host: yourhost
  tasks:
    - debug:
        msg: oops
```

...there are other situations in which people intentionally use
duplicate keys to override values set via YAML anchors, as in #13603.

This patch explicitly does not include a user interface for setting
these options; it is expected that initially they will be used by
third-party tools that call the ansible modules directly.

Fixes: #16903
Fixes: #13603
