### PR TITLE
Add remote CI support for modules.

### DIFF
--- a/test/utils/shippable/remote.sh
+++ b/test/utils/shippable/remote.sh
@@ -131,6 +131,7 @@ test_remote() {
 cat <<EOF
 env \
 REPOSITORY_URL='${REPOSITORY_URL:-}' \
+REPO_NAME='${REPO_NAME:-}' \
 PULL_REQUEST='${PULL_REQUEST:-}' \
 BRANCH='${BRANCH:-}' \
 COMMIT='${COMMIT:-}' \


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (remote-ci-modules 6b3f62c1ef) last updated 2016/08/01 15:14:11 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 24db4de245) last updated 2016/07/28 11:12:27 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD db979dde74) last updated 2016/07/28 11:12:27 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

This will allow module PRs on Shippable to run tests on remote instances, such as FreeBSD.
