### PR TITLE
Add binary module tests to Windows CI.

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -176,7 +176,7 @@ test_delegate_to: setup
 # Targets should be balanced to have similar run times.
 ci_win: ci_win1 ci_win2 ci_win3
 ci_win1: test_win_group1
-ci_win2: test_win_group2
+ci_win2: test_win_group2 test_binary_modules_winrm
 ci_win3: test_win_group3 test_connection_winrm
 
 test_winrm: test_win_group1 test_win_group2 test_win_group3
@@ -315,6 +315,9 @@ test_lookup_paths: setup
 no_log: setup
 	# This test expects 7 loggable vars and 0 non loggable ones, if either mismatches it fails, run the ansible-playbook command to debug
 	[ "$$(ansible-playbook no_log_local.yml -i $(INVENTORY) -e outputdir=$(TEST_DIR) -vvvvv | awk --source 'BEGIN { logme = 0; nolog = 0; } /LOG_ME/ { logme += 1;} /DO_NOT_LOG/ { nolog += 1;} END { printf "%d/%d", logme, nolog; }')" = "26/0" ]
+
+test_binary_modules_winrm: INVENTORY = inventory.winrm
+test_binary_modules_winrm: test_binary_modules
 
 test_binary_modules:
 	ANSIBLE_HOST_KEY_CHECKING=false ansible-playbook download_binary_modules.yml -i $(INVENTORY) -v $(TEST_FLAGS)

--- a/test/integration/download_binary_modules.yml
+++ b/test/integration/download_binary_modules.yml
@@ -1,10 +1,21 @@
-- hosts: all
+- hosts: testhost_binary_modules
   tasks:
     - debug: var=ansible_system
 
+    - name: set module filename (POSIX)
+      set_fact:
+        module_filename: "helloworld_{{ ansible_system | lower }}"
+      when: ansible_system != 'Win32NT'
+
+    - name: set module filename (Win32NT)
+      set_fact:
+        module_filename: "helloworld_{{ ansible_system | lower }}.exe"
+      when: ansible_system == 'Win32NT'
+
     - name: download binary module
       tags: test_binary_modules
-      get_url:
-        url: "https://ansible-ci-files.s3.amazonaws.com/test/integration/roles/test_binary_modules/helloworld_{{ ansible_system|lower }}"
-        dest: "{{ playbook_dir }}/library/helloworld_{{ ansible_system|lower }}"
+      local_action:
+        module: get_url
+        url: "https://ansible-ci-files.s3.amazonaws.com/test/integration/roles/test_binary_modules/{{ module_filename }}"
+        dest: "{{ playbook_dir }}/library/{{ module_filename }}"
         mode: 0755

--- a/test/integration/inventory
+++ b/test/integration/inventory
@@ -7,6 +7,8 @@ testhost4 ansible_ssh_host=127.0.0.4
 # For testing fact gathering
 facthost[0:8] ansible_host=1270.0.0.1 ansible_connection=local
 
+[binary_modules]
+testhost_binary_modules ansible_host=127.0.0.1 ansible_connection=local
 
 # the following inline declarations are accompanied
 # by (preferred) group_vars/ and host_vars/ variables

--- a/test/integration/inventory.winrm.template
+++ b/test/integration/inventory.winrm.template
@@ -1,7 +1,8 @@
-[windows]
-server
+[windows_hosts]
+windows
+testhost_binary_modules
 
-[windows:vars]
+[windows_hosts:vars]
 ansible_connection=winrm
 ansible_host=@ansible_host
 ansible_user=@ansible_user

--- a/test/integration/test_binary_modules.yml
+++ b/test/integration/test_binary_modules.yml
@@ -1,4 +1,4 @@
-- hosts: all
+- hosts: testhost_binary_modules
   roles:
     - role: test_binary_modules
       tags:


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (binary-module-tests 0ce582d1b2) last updated 2016/08/01 20:51:44 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 24db4de245) last updated 2016/07/28 11:12:27 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD db979dde74) last updated 2016/07/28 11:12:27 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Binary module tests, using a go binary module, are now run on Shippable when testing Windows.

This PR also fixes various issues with binary module tests:
- Tests are only run on a single host, either local or remote, depending on the platform.
- Binary module downloads from S3 are always done locally.
