### PR TITLE
Increase async time limit on tests to 10 seconds.

### DIFF
--- a/test/integration/roles/test_binary_modules/tasks/main.yml
+++ b/test/integration/roles/test_binary_modules/tasks/main.yml
@@ -28,7 +28,7 @@
 
 - name: Async Hello, World!
   action: "helloworld_{{ ansible_system|lower }}"
-  async: 1
+  async: 10
   poll: 1
   when: ansible_system != 'Win32NT'
   register: async_hello_world
@@ -42,7 +42,7 @@
   action: "helloworld_{{ ansible_system|lower }}"
   args:
     name: Ansible
-  async: 1
+  async: 10
   poll: 1
   when: ansible_system != 'Win32NT'
   register: async_hello_ansible

--- a/test/integration/test_async.yml
+++ b/test/integration/test_async.yml
@@ -4,7 +4,7 @@
   # make sure non-JSON data before module output is ignored
   - name: async ping with invalid locale via ssh
     ping:
-    async: 3
+    async: 10
     poll: 1
     register: result
   - debug: var=result


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (async-wait 82e6ac566e) last updated 2016/08/02 11:12:02 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 24db4de245) last updated 2016/07/28 11:12:27 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD db979dde74) last updated 2016/07/28 11:12:27 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Increase the async time limit to 10 seconds for integration tests with a lower timeout. This should reduce the occurrence of intermittent CI failures due to async tests having short time limits.
