### PR TITLE
Use file list, not recursion, in _fixup_perms.

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -373,28 +373,28 @@ class ActionBase(with_metaclass(ABCMeta, object)):
 
         return remote_paths
 
-    def _remote_chmod(self, paths, mode):
+    def _remote_chmod(self, paths, mode, sudoable=False):
         '''
         Issue a remote chmod command
         '''
         cmd = self._connection._shell.chmod(paths, mode)
-        res = self._low_level_execute_command(cmd, sudoable=False)
+        res = self._low_level_execute_command(cmd, sudoable=sudoable)
         return res
 
-    def _remote_chown(self, paths, user):
+    def _remote_chown(self, paths, user, sudoable=False):
         '''
         Issue a remote chown command
         '''
         cmd = self._connection._shell.chown(paths, user)
-        res = self._low_level_execute_command(cmd, sudoable=False)
+        res = self._low_level_execute_command(cmd, sudoable=sudoable)
         return res
 
-    def _remote_set_user_facl(self, paths, user, mode):
+    def _remote_set_user_facl(self, paths, user, mode, sudoable=False):
         '''
         Issue a remote call to setfacl
         '''
         cmd = self._connection._shell.set_user_facl(paths, user, mode)
-        res = self._low_level_execute_command(cmd, sudoable=False)
+        res = self._low_level_execute_command(cmd, sudoable=sudoable)
         return res
 
     def _execute_remote_stat(self, path, all_vars, follow, tmp=None):

--- a/lib/ansible/plugins/action/assemble.py
+++ b/lib/ansible/plugins/action/assemble.py
@@ -159,7 +159,7 @@ class ActionModule(ActionBase):
             xfered = self._transfer_file(path, remote_path)
 
             # fix file permissions when the copy is done as a different user
-            self._fixup_perms([tmp, remote_path], remote_user)
+            self._fixup_perms((tmp, remote_path), remote_user)
 
             new_module_args.update( dict( src=xfered,))
 

--- a/lib/ansible/plugins/action/assemble.py
+++ b/lib/ansible/plugins/action/assemble.py
@@ -159,7 +159,7 @@ class ActionModule(ActionBase):
             xfered = self._transfer_file(path, remote_path)
 
             # fix file permissions when the copy is done as a different user
-            self._fixup_perms(tmp, remote_user, recursive=True)
+            self._fixup_perms([tmp, remote_path], remote_user)
 
             new_module_args.update( dict( src=xfered,))
 

--- a/lib/ansible/plugins/action/async.py
+++ b/lib/ansible/plugins/action/async.py
@@ -73,17 +73,7 @@ class ActionModule(ActionBase):
                 args_data += '%s="%s" ' % (k, pipes.quote(to_unicode(v)))
             argsfile = self._transfer_data(self._connection._shell.join_path(tmp, 'arguments'), args_data)
 
-        self._fixup_perms(tmp, remote_user, execute=True, recursive=True)
-        # Only the following two files need to be executable but we'd have to
-        # make three remote calls if we wanted to just set them executable.
-        # There's not really a problem with marking too many of the temp files
-        # executable so we go ahead and mark them all as executable in the
-        # line above (the line above is needed in any case [although
-        # execute=False is okay if we uncomment the lines below] so that all
-        # the files are readable in case the remote_user and become_user are
-        # different and both unprivileged)
-        #self._fixup_perms(remote_module_path, remote_user, execute=True, recursive=False)
-        #self._fixup_perms(async_module_path, remote_user, execute=True, recursive=False)
+        self._fixup_perms([tmp, remote_module_path, async_module_path, argsfile], remote_user, execute=True)
 
         async_limit = self._task.async
         async_jid   = str(random.randint(0, 999999999999))

--- a/lib/ansible/plugins/action/async.py
+++ b/lib/ansible/plugins/action/async.py
@@ -73,8 +73,13 @@ class ActionModule(ActionBase):
                 args_data += '%s="%s" ' % (k, pipes.quote(to_unicode(v)))
             argsfile = self._transfer_data(self._connection._shell.join_path(tmp, 'arguments'), args_data)
 
+        remote_paths = tmp, remote_module_path, async_module_path
+
         # argsfile doesn't need to be executable, but this saves an extra call to the remote host
-        self._fixup_perms([tmp, remote_module_path, async_module_path, argsfile], remote_user, execute=True)
+        if argsfile:
+            remote_paths += argsfile,
+
+        self._fixup_perms(remote_paths, remote_user, execute=True)
 
         async_limit = self._task.async
         async_jid   = str(random.randint(0, 999999999999))

--- a/lib/ansible/plugins/action/async.py
+++ b/lib/ansible/plugins/action/async.py
@@ -73,6 +73,7 @@ class ActionModule(ActionBase):
                 args_data += '%s="%s" ' % (k, pipes.quote(to_unicode(v)))
             argsfile = self._transfer_data(self._connection._shell.join_path(tmp, 'arguments'), args_data)
 
+        # argsfile doesn't need to be executable, but this saves an extra call to the remote host
         self._fixup_perms([tmp, remote_module_path, async_module_path, argsfile], remote_user, execute=True)
 
         async_limit = self._task.async

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -213,8 +213,10 @@ class ActionModule(ActionBase):
                 # Define a remote directory that we will copy the file to.
                 tmp_src = self._connection._shell.join_path(tmp, 'source')
 
+                remote_path = None
+
                 if not raw:
-                    self._transfer_file(source_full, tmp_src)
+                    remote_path = self._transfer_file(source_full, tmp_src)
                 else:
                     self._transfer_file(source_full, dest_file)
 
@@ -223,7 +225,7 @@ class ActionModule(ActionBase):
                 self._loader.cleanup_tmp_file(source_full)
 
                 # fix file permissions when the copy is done as a different user
-                self._fixup_perms(tmp, remote_user, recursive=True)
+                self._fixup_perms([tmp, remote_path], remote_user)
 
                 if raw:
                     # Continue to next iteration if raw is defined.

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -225,7 +225,8 @@ class ActionModule(ActionBase):
                 self._loader.cleanup_tmp_file(source_full)
 
                 # fix file permissions when the copy is done as a different user
-                self._fixup_perms([tmp, remote_path], remote_user)
+                if remote_path:
+                    self._fixup_perms((tmp, remote_path), remote_user)
 
                 if raw:
                     # Continue to next iteration if raw is defined.

--- a/lib/ansible/plugins/action/patch.py
+++ b/lib/ansible/plugins/action/patch.py
@@ -63,7 +63,7 @@ class ActionModule(ActionBase):
         tmp_src = self._connection._shell.join_path(tmp, os.path.basename(src))
         self._transfer_file(src, tmp_src)
 
-        self._fixup_perms([tmp, tmp_src], remote_user)
+        self._fixup_perms((tmp, tmp_src), remote_user)
 
         new_module_args = self._task.args.copy()
         new_module_args.update(

--- a/lib/ansible/plugins/action/patch.py
+++ b/lib/ansible/plugins/action/patch.py
@@ -63,7 +63,7 @@ class ActionModule(ActionBase):
         tmp_src = self._connection._shell.join_path(tmp, os.path.basename(src))
         self._transfer_file(src, tmp_src)
 
-        self._fixup_perms(tmp, remote_user, recursive=True)
+        self._fixup_perms([tmp, tmp_src], remote_user)
 
         new_module_args = self._task.args.copy()
         new_module_args.update(

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -81,7 +81,7 @@ class ActionModule(ActionBase):
         self._transfer_file(source, tmp_src)
 
         # set file permissions, more permissive when the copy is done as a different user
-        self._fixup_perms([tmp, tmp_src], remote_user, execute=True)
+        self._fixup_perms((tmp, tmp_src), remote_user, execute=True)
 
         # add preparation steps to one ssh roundtrip executing the script
         env_string = self._compute_environment_string()

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -81,7 +81,7 @@ class ActionModule(ActionBase):
         self._transfer_file(source, tmp_src)
 
         # set file permissions, more permissive when the copy is done as a different user
-        self._fixup_perms(tmp, remote_user, execute=True, recursive=True)
+        self._fixup_perms([tmp, tmp_src], remote_user, execute=True)
 
         # add preparation steps to one ssh roundtrip executing the script
         env_string = self._compute_environment_string()

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -166,7 +166,7 @@ class ActionModule(ActionBase):
                 xfered = self._transfer_data(self._connection._shell.join_path(tmp, 'source'), resultant)
 
                 # fix file permissions when the copy is done as a different user
-                self._fixup_perms([tmp, xfered], remote_user)
+                self._fixup_perms((tmp, xfered), remote_user)
 
                 # run the copy module
                 new_module_args.update(

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -166,7 +166,7 @@ class ActionModule(ActionBase):
                 xfered = self._transfer_data(self._connection._shell.join_path(tmp, 'source'), resultant)
 
                 # fix file permissions when the copy is done as a different user
-                self._fixup_perms(tmp, remote_user, recursive=True)
+                self._fixup_perms([tmp, xfered], remote_user)
 
                 # run the copy module
                 new_module_args.update(

--- a/lib/ansible/plugins/action/unarchive.py
+++ b/lib/ansible/plugins/action/unarchive.py
@@ -97,7 +97,7 @@ class ActionModule(ActionBase):
 
         if copy:
             # fix file permissions when the copy is done as a different user
-            self._fixup_perms([tmp, tmp_src], remote_user)
+            self._fixup_perms((tmp, tmp_src), remote_user)
             # Build temporary module_args.
             new_module_args = self._task.args.copy()
             new_module_args.update(

--- a/lib/ansible/plugins/action/unarchive.py
+++ b/lib/ansible/plugins/action/unarchive.py
@@ -97,7 +97,7 @@ class ActionModule(ActionBase):
 
         if copy:
             # fix file permissions when the copy is done as a different user
-            self._fixup_perms(tmp, remote_user, recursive=True)
+            self._fixup_perms([tmp, tmp_src], remote_user)
             # Build temporary module_args.
             new_module_args = self._task.args.copy()
             new_module_args.update(

--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -57,45 +57,22 @@ class ShellBase(object):
     def path_has_trailing_slash(self, path):
         return path.endswith('/')
 
-    def chmod(self, mode, path, recursive=True):
-        path = pipes.quote(path)
-        cmd = ['chmod']
-
-        if recursive:
-            cmd.append('-R') # many chmods require -R before file list
-
-        cmd.extend([mode, path])
+    def chmod(self, paths, mode):
+        cmd = ['chmod', mode] + paths
+        cmd = [pipes.quote(c) for c in cmd]
 
         return ' '.join(cmd)
 
-    def chown(self, path, user, group=None, recursive=True):
-        path = pipes.quote(path)
-        user = pipes.quote(user)
-
-        cmd = ['chown']
-
-        if recursive:
-            cmd.append('-R') # many chowns require -R before file list
-
-        if group is None:
-            cmd.extend([user, path])
-        else:
-            group = pipes.quote(group)
-            cmd.extend(['%s:%s' % (user, group), path])
+    def chown(self, paths, user):
+        cmd = ['chown', user] + paths
+        cmd = [pipes.quote(c) for c in cmd]
 
         return ' '.join(cmd)
 
-    def set_user_facl(self, path, user, mode, recursive=True):
+    def set_user_facl(self, paths, user, mode):
         """Only sets acls for users as that's really all we need"""
-        path = pipes.quote(path)
-        mode = pipes.quote(mode)
-        user = pipes.quote(user)
-
-        cmd = ['setfacl', '-m', 'u:%s:%s' % (user, mode)]
-        if recursive:
-            cmd = ['find', path, '-exec'] + cmd + ["'{}'", "'+'"]
-        else:
-            cmd.append(path)
+        cmd = ['setfacl', '-m', 'u:%s:%s' % (user, mode)] + paths
+        cmd = [pipes.quote(c) for c in cmd]
 
         return ' '.join(cmd)
 

--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -58,20 +58,23 @@ class ShellBase(object):
         return path.endswith('/')
 
     def chmod(self, paths, mode):
-        cmd = ['chmod', mode] + paths
+        cmd = ['chmod', mode]
+        cmd.extend(paths)
         cmd = [pipes.quote(c) for c in cmd]
 
         return ' '.join(cmd)
 
     def chown(self, paths, user):
-        cmd = ['chown', user] + paths
+        cmd = ['chown', user]
+        cmd.extend(paths)
         cmd = [pipes.quote(c) for c in cmd]
 
         return ' '.join(cmd)
 
     def set_user_facl(self, paths, user, mode):
         """Only sets acls for users as that's really all we need"""
-        cmd = ['setfacl', '-m', 'u:%s:%s' % (user, mode)] + paths
+        cmd = ['setfacl', '-m', 'u:%s:%s' % (user, mode)]
+        cmd.extend(paths)
         cmd = [pipes.quote(c) for c in cmd]
 
         return ' '.join(cmd)

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -68,13 +68,13 @@ class ShellModule(object):
         path = self._unquote(path)
         return path.endswith('/') or path.endswith('\\')
 
-    def chmod(self, mode, path, recursive=True):
+    def chmod(self, paths, mode):
         raise NotImplementedError('chmod is not implemented for Powershell')
 
-    def chown(self, path, user, group=None, recursive=True):
+    def chown(self, paths, user):
         raise NotImplementedError('chown is not implemented for Powershell')
 
-    def set_user_facl(self, path, user, mode, recursive=True):
+    def set_user_facl(self, paths, user, mode):
         raise NotImplementedError('set_user_facl is not implemented for Powershell')
 
     def remove(self, path, recurse=False):

--- a/test/utils/shippable/remote-integration.sh
+++ b/test/utils/shippable/remote-integration.sh
@@ -15,7 +15,7 @@ test_flags="${TEST_FLAGS:-}"
 force_color="${FORCE_COLOR:-1}"
 
 # FIXME: these tests fail
-skip_tags='test_copy,test_template,test_unarchive,test_command_shell,test_sudo,test_become,test_service,test_postgresql,test_mysql_db,test_mysql_user,test_mysql_variables,test_uri,test_get_url'
+skip_tags='test_copy,test_template,test_unarchive,test_command_shell,test_service,test_postgresql,test_mysql_db,test_mysql_user,test_mysql_variables,test_uri,test_get_url'
 
 cd ~/
 


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (setfacl-pipe f20bea6c5f) last updated 2016/08/02 15:15:18 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 24db4de245) last updated 2016/07/28 11:12:27 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD db979dde74) last updated 2016/07/28 11:12:27 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Calling setfacl on FreeBSD using find -exec always returns 0, even on failure.

Instead of recursively updating permissions and file ownership in _fixup_perms, we now update them explicitly for each uploaded file.

This means _fixup_perms now passes a list of paths to the following commands instead of a single path on which to operate recursively:
- setfacl
- chown
- chmod

Tests for FreeBSD which pass as a result of this fix have been enabled as well.
