### PR TITLE
EC2 inventory: Destination variables can now be lists

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -43,6 +43,10 @@ destination_variable = public_dns_name
 # WARNING: - instances that are in the private vpc, _without_ public ip address
 # will not be listed in the inventory until You set:
 # vpc_destination_variable = private_ip_address
+# If you want to list instances in a public subnet with their public IP
+# addresses and instances in a private subnet with their private IP addresses,
+# you need to set:
+# vpc_destination_variable = ip_address,private_ip_address
 vpc_destination_variable = ip_address
 
 # The following two settings allow flexible ansible host naming based on a


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (features/ec2-destination-variable-list 6d1edd7011) last updated 2016/08/03 11:11:51 (GMT +900)
  lib/ansible/modules/core: (detached HEAD 24db4de245) last updated 2016/08/03 11:26:05 (GMT +900)
  lib/ansible/modules/extras: (detached HEAD db979dde74) last updated 2016/08/03 11:26:31 (GMT +900)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

This PR introduces several changes to the EC2 dynamic inventory script.
###### Modularity

Make the EC2 inventory script more modular by moving the generation of the json outside of the constructor, and moving the `print` into its own function.

Moreover, the script will generate and print the inventory only if executed directly.
It allows to be imported by another script to generate the json. Then the script will be able to modify the generated json.

``` python
from ec2 import Ec2Inventory

inventory = Ec2Inventory()
json = inventory.generate_data()
...
```
###### Destination variables as lists

The `destination_variable` and `vpc_destination_variable` variables now accept several values separated by comma.

It allows to define `vpc_destination_variable = ip_address,private_ip_address`, the inventory will then contain the servers in the public subnets with their public IP addresses (ssh gateway, bastion, ...) and the servers in the private subnets with their private IP addresses.

The inventory can be used as it, you just need to edit your `.ssh/config` to use the gateway to access the servers in the private subnets.
