### PR TITLE
docs_fragments: Correct spelling mistakes, fix formatting

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/asa.py
+++ b/lib/ansible/utils/module_docs_fragments/asa.py
@@ -31,24 +31,24 @@ options:
     required: true
   port:
     description:
-      - Specifies the port to use when buiding the connection to the remote
+      - Specifies the port to use when building the connection to the remote
         device.  The port value will default to the well known SSH port
         of 22
     required: false
     default: 22
   username:
     description:
-      - Configures the usename to use to authenticate the connection to
+      - Configures the username to use to authenticate the connection to
         the remote device.  The value of I(username) is used to authenticate
         the SSH session. If the value is not specified in the task, the
-        value of environment variable ANSIBLE_NET_USERNAME will be used instead.
+        value of environment variable C(ANSIBLE_NET_USERNAME) will be used instead.
     required: false
   password:
     description:
       - Specifies the password to use to authenticate the connection to
         the remote device.   The value of I(password) is used to authenticate
         the SSH session. If the value is not specified in the task, the
-        value of environment variable ANSIBLE_NET_PASSWORD will be used instead.
+        value of environment variable C(ANSIBLE_NET_PASSWORD) will be used instead.
     required: false
     default: null
   ssh_keyfile:
@@ -56,16 +56,16 @@ options:
       - Specifies the SSH key to use to authenticate the connection to
         the remote device.   The value of I(ssh_keyfile) is the path to the
         key used to authenticate the SSH session. If the value is not specified
-        in the task, the value of environment variable ANSIBLE_NET_SSH_KEYFILE
+        in the task, the value of environment variable C(ANSIBLE_NET_SSH_KEYFILE)
         will be used instead.
     required: false
   authorize:
     description:
-      - Instructs the module to enter priviledged mode on the remote device
+      - Instructs the module to enter privileged mode on the remote device
         before sending any commands.  If not specified, the device will
-        attempt to excecute all commands in non-priviledged mode. If the value
+        attempt to execute all commands in non-privileged mode. If the value
         is not specified in the task, the value of environment variable
-        ANSIBLE_NET_AUTHORIZE will be used instead.
+        C(ANSIBLE_NET_AUTHORIZE) will be used instead.
     required: false
     default: no
     choices: ['yes', 'no']
@@ -74,7 +74,7 @@ options:
       - Specifies the password to use if required to enter privileged mode
         on the remote device.  If I(authorize) is false, then this argument
         does nothing. If the value is not specified in the task, the value of
-        environment variable ANSIBLE_NET_AUTH_PASS will be used instead.
+        environment variable C(ANSIBLE_NET_AUTH_PASS) will be used instead.
     required: false
     default: none
   timeout:
@@ -85,7 +85,7 @@ options:
     default: 10
   provider:
     description:
-      - Convience method that allows all M(ios) arguments to be passed as
+      - Convenience method that allows all I(ios) arguments to be passed as
         a dict object.  All constraints (required, choices, etc) must be
         met either by individual arguments or values in this dict.
     required: false
@@ -93,12 +93,12 @@ options:
   show_command:
     description:
       - Specifies which command will be used to get the current configuration.
-        By default the 'show running-config' command will be used, this command
-        masks some passwords. For example ike passwords for VPN. If you need to
-        match against masked passwords use 'more system:running-config'.
-        Note that the 'more system:running-config' only works in the system
+        By default the C(show running-config) command will be used, this command
+        masks some passwords. For example passwords for VPN. If you need to
+        match against masked passwords use C(more system:running-config).
+        Note that the C(more system:running-config) only works in the system
         context if you are running the ASA in multiple context mode.
-        before sending any commands.  If not specified, the device will
+        before sending any commands.
     required: false
     default: show running-config
     choices: ['show running-config', 'more system:running-config']

--- a/lib/ansible/utils/module_docs_fragments/azure_tags.py
+++ b/lib/ansible/utils/module_docs_fragments/azure_tags.py
@@ -32,7 +32,7 @@ options:
         default: null
     append_tags:
         description:
-            - Use to control if tags field is cannonical or just appends to existing tags. When cannonical, any tags not found in the tags parameter will be removed from the object's metadata.
+            - Use to control if tags field is canonical or just appends to existing tags. When canonical, any tags not found in the tags parameter will be removed from the object's metadata.
         default: True
         required: false
     '''

--- a/lib/ansible/utils/module_docs_fragments/eos.py
+++ b/lib/ansible/utils/module_docs_fragments/eos.py
@@ -30,26 +30,26 @@ options:
     required: true
   port:
     description:
-      - Specifies the port to use when buiding the connection to the remote
+      - Specifies the port to use when building the connection to the remote
         device.  This value applies to either I(cli) or I(eapi).  The port
-        value will default to the approriate transport common port if
+        value will default to the appropriate transport common port if
         none is provided in the task.  (cli=22, http=80, https=443).
     required: false
     default: 0 (use common port)
   username:
     description:
-      - Configures the usename to use to authenticate the connection to
+      - Configures the username to use to authenticate the connection to
         the remote device.  The value of I(username) is used to authenticate
         either the CLI login or the eAPI authentication depending on which
         transport is used. If the value is not specified in the task, the
-        value of environment variable ANSIBLE_NET_USERNAME will be used instead.
+        value of environment variable C(ANSIBLE_NET_USERNAME) will be used instead.
     required: false
   password:
     description:
       - Specifies the password to use to authenticate the connection to
         the remote device.  This is a common argument used for either I(cli)
         or I(eapi) transports. If the value is not specified in the task, the
-        value of environment variable ANSIBLE_NET_PASSWORD will be used instead.
+        value of environment variable C(ANSIBLE_NET_PASSWORD) will be used instead.
     required: false
     default: null
   ssh_keyfile:
@@ -57,15 +57,15 @@ options:
       - Specifies the SSH keyfile to use to authenticate the connection to
         the remote device.  This argument is only used for I(cli) transports.
         If the value is not specified in the task, the value of environment
-        variable ANSIBLE_NET_SSH_KEYFILE will be used instead.
+        variable C(ANSIBLE_NET_SSH_KEYFILE) will be used instead.
     required: false
   authorize:
     description:
-      - Instructs the module to enter priviledged mode on the remote device
+      - Instructs the module to enter privileged mode on the remote device
         before sending any commands.  If not specified, the device will
-        attempt to excecute all commands in non-priviledged mode. If the value
+        attempt to execute all commands in non-privileged mode. If the value
         is not specified in the task, the value of environment variable
-        ANSIBLE_NET_AUTHORIZE will be used instead.
+        C(ANSIBLE_NET_AUTHORIZE) will be used instead.
     required: false
     default: no
     choices: ['yes', 'no']
@@ -74,27 +74,29 @@ options:
       - Specifies the password to use if required to enter privileged mode
         on the remote device.  If I(authorize) is false, then this argument
         does nothing. If the value is not specified in the task, the value of
-        environment variable ANSIBLE_NET_AUTH_PASS will be used instead.
+        environment variable C(ANSIBLE_NET_AUTH_PASS) will be used instead.
     required: false
     default: none
   transport:
     description:
       - Configures the transport connection to use when connecting to the
-        remote device.  The transport argument supports connectivity to the
-        device over cli (ssh) or eapi.
+        remote device.
     required: true
+    choices:
+        - eapi
+        - cli
     default: cli
   use_ssl:
     description:
       - Configures the I(transport) to use SSL if set to true only when the
-        I(transport) argument is configured as eapi.  If the transport
-        argument is not eapi, this value is ignored
+        C(transport=eapi).  If the transport
+        argument is not eapi, this value is ignored.
     required: false
     default: yes
     choices: ['yes', 'no']
   provider:
     description:
-      - Convience method that allows all M(eos) arguments to be passed as
+      - Convenience method that allows all I(eos) arguments to be passed as
         a dict object.  All constraints (required, choices, etc) must be
         met either by individual arguments or values in this dict.
     required: false

--- a/lib/ansible/utils/module_docs_fragments/ios.py
+++ b/lib/ansible/utils/module_docs_fragments/ios.py
@@ -88,33 +88,4 @@ options:
         met either by individual arguments or values in this dict.
     required: false
     default: null
-  force:
-    description:
-      - The force argument instructs the module to not consider the
-        current devices running-config.  When set to true, this will
-        cause the module to push the contents of I(src) into the device
-        without first checking if already configured.
-    required: false
-    default: false
-    choices: ['yes', 'no']
-  running_config:
-    description:
-      - The module, by default, will connect to the remote device and
-        retrieve the current running-config to use as a base for comparing
-        against the contents of source.  There are times when it is not
-        desirable to have the task get the current running-config for
-        every task in a playbook.  The I(config) argument allows the
-        implementer to pass in the configuruation to use as the base
-        config for comparision.
-    required: false
-    default: null
-    aliases: ['config']
-  save_config:
-    description:
-      - Specifies the current C(running-config) should be saved to
-        non-volatile memory so that configuration changes are
-        persistent if the device is restarted.
-    required: false
-    default: null
-    aliases: ['save']
 """

--- a/lib/ansible/utils/module_docs_fragments/ios.py
+++ b/lib/ansible/utils/module_docs_fragments/ios.py
@@ -30,14 +30,13 @@ options:
     required: true
   port:
     description:
-      - Specifies the port to use when buiding the connection to the remote
-        device.  The port value will default to the well known SSH port
-        of 22
+      - Specifies the port to use when buiding the connection to the remote.
+        device.
     required: false
     default: 22
   username:
     description:
-      - Configures the usename to use to authenticate the connection to
+      - Configures the username to use to authenticate the connection to
         the remote device.  The value of I(username) is used to authenticate
         the SSH session. If the value is not specified in the task, the
         value of environment variable ANSIBLE_NET_USERNAME will be used instead.
@@ -60,9 +59,9 @@ options:
     required: false
   authorize:
     description:
-      - Instructs the module to enter priviledged mode on the remote device
+      - Instructs the module to enter privileged mode on the remote device
         before sending any commands.  If not specified, the device will
-        attempt to excecute all commands in non-priviledged mode. If the value
+        attempt to execute all commands in non-privileged mode. If the value
         is not specified in the task, the value of environment variable
         ANSIBLE_NET_AUTHORIZE will be used instead.
     required: false
@@ -89,4 +88,33 @@ options:
         met either by individual arguments or values in this dict.
     required: false
     default: null
+  force:
+    description:
+      - The force argument instructs the module to not consider the
+        current devices running-config.  When set to true, this will
+        cause the module to push the contents of I(src) into the device
+        without first checking if already configured.
+    required: false
+    default: false
+    choices: ['yes', 'no']
+  running_config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source.  There are times when it is not
+        desirable to have the task get the current running-config for
+        every task in a playbook.  The I(config) argument allows the
+        implementer to pass in the configuruation to use as the base
+        config for comparision.
+    required: false
+    default: null
+    aliases: ['config']
+  save_config:
+    description:
+      - Specifies the current C(running-config) should be saved to
+        non-volatile memory so that configuration changes are
+        persistent if the device is restarted.
+    required: false
+    default: null
+    aliases: ['save']
 """

--- a/lib/ansible/utils/module_docs_fragments/iosxr.py
+++ b/lib/ansible/utils/module_docs_fragments/iosxr.py
@@ -30,24 +30,23 @@ options:
     required: true
   port:
     description:
-      - Specifies the port to use when buiding the connection to the remote
-        device.  The port value will default to the well known SSH port
-        of 22
+      - Specifies the port to use when building the connection to the remote
+        device.
     required: false
     default: 22
   username:
     description:
-      - Configures the usename to use to authenticate the connection to
+      - Configures the username to use to authenticate the connection to
         the remote device.  The value of I(username) is used to authenticate
         the SSH session. If the value is not specified in the task, the
-        value of environment variable ANSIBLE_NET_USERNAME will be used instead.
+        value of environment variable C(ANSIBLE_NET_USERNAME) will be used instead.
     required: false
   password:
     description:
       - Specifies the password to use to authenticate the connection to
         the remote device.   The value of I(password) is used to authenticate
         the SSH session. If the value is not specified in the task, the
-        value of environment variable ANSIBLE_NET_PASSWORD will be used instead.
+        value of environment variable C(ANSIBLE_NET_PASSWORD) will be used instead.
     required: false
     default: null
   ssh_keyfile:
@@ -55,12 +54,12 @@ options:
       - Specifies the SSH key to use to authenticate the connection to
         the remote device.   The value of I(ssh_keyfile) is the path to the
         key used to authenticate the SSH session. If the value is not specified
-        in the task, the value of environment variable ANSIBLE_NET_SSH_KEYFILE
+        in the task, the value of environment variable C(ANSIBLE_NET_SSH_KEYFILE)
         will be used instead.
     required: false
   provider:
     description:
-      - Convience method that allows all M(iosxr) arguments to be passed as
+      - Convenience method that allows all I(iosxr) arguments to be passed as
         a dict object.  All constraints (required, choices, etc) must be
         met either by individual arguments or values in this dict.
     required: false

--- a/lib/ansible/utils/module_docs_fragments/junos.py
+++ b/lib/ansible/utils/module_docs_fragments/junos.py
@@ -31,6 +31,8 @@ options:
   port:
     description:
       - Specifies the port to use when building the connection to the remote
+        device.  The port value will default to the well known SSH port
+        of 22 (for C(transport=cli)) or port 830 (for C(transport=netconf))
         device.
     required: false
     default: 22

--- a/lib/ansible/utils/module_docs_fragments/junos.py
+++ b/lib/ansible/utils/module_docs_fragments/junos.py
@@ -30,14 +30,13 @@ options:
     required: true
   port:
     description:
-      - Specifies the port to use when buiding the connection to the remote
-        device.  The port value will default to the well known SSH port
-        of 22 (for C(transport=cli)) or port 830 (for C(transport=netconf))
+      - Specifies the port to use when building the connection to the remote
+        device.
     required: false
     default: 22
   username:
     description:
-      - Configures the usename to use to authenticate the connection to
+      - Configures the username to use to authenticate the connection to
         the remote device.  The value of I(username) is used to authenticate
         the SSH session. If the value is not specified in the task, the
         value of environment variable ANSIBLE_NET_USERNAME will be used instead.
@@ -60,7 +59,7 @@ options:
     required: false
   provider:
     description:
-      - Convience method that allows all M(ios) arguments to be passed as
+      - Convenience method that allows all I(ios) arguments to be passed as
         a dict object.  All constraints (required, choices, etc) must be
         met either by individual arguments or values in this dict.
     required: false

--- a/lib/ansible/utils/module_docs_fragments/nxos.py
+++ b/lib/ansible/utils/module_docs_fragments/nxos.py
@@ -30,26 +30,26 @@ options:
     required: true
   port:
     description:
-      - Specifies the port to use when buiding the connection to the remote
+      - Specifies the port to use when building the connection to the remote
         device.  This value applies to either I(cli) or I(nxapi).  The port
-        value will default to the approriate transport common port if
+        value will default to the appropriate transport common port if
         none is provided in the task.  (cli=22, http=80, https=443).
     required: false
     default: 0 (use common port)
   username:
     description:
-      - Configures the usename to use to authenticate the connection to
+      - Configures the username to use to authenticate the connection to
         the remote device.  The value of I(username) is used to authenticate
         either the CLI login or the nxapi authentication depending on which
         transport is used. If the value is not specified in the task, the
-        value of environment variable ANSIBLE_NET_USERNAME will be used instead.
+        value of environment variable C(ANSIBLE_NET_USERNAME) will be used instead.
     required: false
   password:
     description:
       - Specifies the password to use to authenticate the connection to
         the remote device.  This is a common argument used for either I(cli)
         or I(nxapi) transports. If the value is not specified in the task, the
-        value of environment variable ANSIBLE_NET_PASSWORD will be used instead.
+        value of environment variable C(ANSIBLE_NET_PASSWORD) will be used instead.
     required: false
     default: null
   ssh_keyfile:
@@ -57,7 +57,7 @@ options:
       - Specifies the SSH key to use to authenticate the connection to
         the remote device.  This argument is only used for the I(cli)
         transport. If the value is not specified in the task, the
-        value of environment variable ANSIBLE_NET_SSH_KEYFILE will be used instead.
+        value of environment variable C(ANSIBLE_NET_SSH_KEYFILE) will be used instead.
     required: false
   transport:
     description:
@@ -69,14 +69,13 @@ options:
   use_ssl:
     description:
       - Configures the I(transport) to use SSL if set to true only when the
-        I(transport) argument is configured as nxapi.  If the transport
-        argument is not nxapi, this value is ignored
+        C(transport=nxapi), otherwise this value is ignored.
     required: false
     default: no
     choices: ['yes', 'no']
   provider:
     description:
-      - Convience method that allows all M(nxos) arguments to be passed as
+      - Convenience method that allows all I(nxos) arguments to be passed as
         a dict object.  All constraints (required, choices, etc) must be
         met either by individual arguments or values in this dict.
     required: false

--- a/lib/ansible/utils/module_docs_fragments/openswitch.py
+++ b/lib/ansible/utils/module_docs_fragments/openswitch.py
@@ -31,21 +31,21 @@ options:
     required: true
   port:
     description:
-      - Specifies the port to use when buiding the connection to the remote
-        device.  This value applies to either I(cli) or I().  The port
-        value will default to the approriate transport common port if
+      - Specifies the port to use when building the connection to the remote
+        device.  This value applies to either I(cli) or I(rest).  The port
+        value will default to the appropriate transport common port if
         none is provided in the task.  (cli=22, http=80, https=443).  Note
         this argument does not affect the SSH transport.
     required: false
     default: 0 (use common port)
   username:
     description:
-      - Configures the usename to use to authenticate the connection to
+      - Configures the username to use to authenticate the connection to
         the remote device.  The value of I(username) is used to authenticate
         either the CLI login or the eAPI authentication depending on which
         transport is used. Note this argument does not affect the SSH
         transport. If the value is not specified in the task, the value of
-        environment variable ANSIBLE_NET_USERNAME will be used instead.
+        environment variable C(ANSIBLE_NET_USERNAME) will be used instead.
     required: false
   password:
     description:
@@ -53,7 +53,7 @@ options:
         the remote device.  This is a common argument used for either I(cli)
         or I(rest) transports.  Note this argument does not affect the SSH
         transport. If the value is not specified in the task, the value of
-        environment variable ANSIBLE_NET_PASSWORD will be used instead.
+        environment variable C(ANSIBLE_NET_PASSWORD) will be used instead.
     required: false
     default: null
   ssh_keyfile:
@@ -61,7 +61,7 @@ options:
       - Specifies the SSH key to use to authenticate the connection to
         the remote device.  This argument is only used for the I(cli)
         transports. If the value is not specified in the task, the value of
-        environment variable ANSIBLE_NET_SSH_KEYFILE will be used instead.
+        environment variable C(ANSIBLE_NET_SSH_KEYFILE) will be used instead.
     required: false
   transport:
     description:
@@ -75,13 +75,13 @@ options:
     description:
       - Configures the I(transport) to use SSL if set to true only when the
         I(transport) argument is configured as rest.  If the transport
-        argument is not rest, this value is ignored
+        argument is not I(rest), this value is ignored.
     required: false
     default: yes
     choices: ['yes', 'no']
   provider:
     description:
-      - Convience method that allows all M(openswitch) arguments to be passed as
+      - Convenience method that allows all I(openswitch) arguments to be passed as
         a dict object.  All constraints (required, choices, etc) must be
         met either by individual arguments or values in this dict.
     required: false

--- a/lib/ansible/utils/module_docs_fragments/vyos.py
+++ b/lib/ansible/utils/module_docs_fragments/vyos.py
@@ -30,24 +30,23 @@ options:
     required: true
   port:
     description:
-      - Specifies the port to use when buiding the connection to the remote
-        device.  The port value will default to the well known SSH port
-        of 22
+      - Specifies the port to use when building the connection to the remote
+        device.
     required: false
     default: 22
   username:
     description:
-      - Configures the usename to use to authenticate the connection to
+      - Configures the username to use to authenticate the connection to
         the remote device.  The value of I(username) is used to authenticate
         the SSH session. If the value is not specified in the task, the
-        value of environment variable ANSIBLE_NET_USERNAME will be used instead.
+        value of environment variable C(ANSIBLE_NET_USERNAME) will be used instead.
     required: false
   password:
     description:
       - Specifies the password to use to authenticate the connection to
         the remote device.   The value of I(password) is used to authenticate
         the SSH session. If the value is not specified in the task, the
-        value of environment variable ANSIBLE_NET_PASSWORD will be used instead.
+        value of environment variable C(ANSIBLE_NET_PASSWORD) will be used instead.
     required: false
     default: null
   ssh_keyfile:
@@ -55,7 +54,7 @@ options:
       - Specifies the SSH key to use to authenticate the connection to
         the remote device.   The value of I(ssh_keyfile) is the path to the
         key used to authenticate the SSH session. If the value is not specified
-        in the task, the value of environment variable ANSIBLE_NET_SSH_KEYFILE
+        in the task, the value of environment variable C(ANSIBLE_NET_SSH_KEYFILE)
         will be used instead.
     required: false
   timeout:
@@ -66,7 +65,7 @@ options:
     default: 10
   provider:
     description:
-      - Convience method that allows all M(vyos) arguments to be passed as
+      - Convenience method that allows all I(vyos) arguments to be passed as
         a dict object.  All constraints (required, choices, etc) must be
         met either by individual arguments or values in this dict.
     required: false


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### ANSIBLE VERSION

devel
##### SUMMARY

Fix various spelling mistakes/typos
Use consistent formatting
Document `choices`

In the `Convenience method that allows all I(iosxr) arguments to be passed as` section iosxr isn't a name of a module, so use `I(iosxr)` rather than `M(iosxr)`.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/16930)

<!-- Reviewable:end -->
