### PR TITLE
Set example ansible.cfg *includes_static options to default value

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -67,8 +67,8 @@
 # default. As of 2.0, includes are dynamic by default. Setting these
 # values to True will make includes behave more like they did in the
 # 1.x versions.
-#task_includes_static = True
-#handler_includes_static = True
+#task_includes_static = False
+#handler_includes_static = False
 
 # change this for alternative sudo implementations
 #sudo_exe = sudo


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file = /Users/jtravis/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

It is less confusing for the options in an example config file to contain default values and let the comments describe valid alternatives.
