### PR TITLE
Add ansible adhoc commandline ssh prompt support for the new feature …

### DIFF
--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -71,6 +71,9 @@ class AdHocCLI(CLI):
         self.parser.add_option('-m', '--module-name', dest='module_name',
             help="module name to execute (default=%s)" % C.DEFAULT_MODULE_NAME,
             default=C.DEFAULT_MODULE_NAME)
+        self.parser.add_option("--ssh-prompt", dest="ssh_prompt",
+            help="ssh connection prompt string (default=%s)" % C.DEFAULT_SSH_PROMPT,
+            default=C.DEFAULT_SSH_PROMPT, metavar="SSH_PROMPT")
 
         self.options, self.args = self.parser.parse_args(self.args[1:])
 

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -161,6 +161,7 @@ DEFAULT_TIMEOUT           = get_config(p, DEFAULTS, 'timeout',          'ANSIBLE
 DEFAULT_POLL_INTERVAL     = get_config(p, DEFAULTS, 'poll_interval',    'ANSIBLE_POLL_INTERVAL',    15, integer=True)
 DEFAULT_REMOTE_USER       = get_config(p, DEFAULTS, 'remote_user',      'ANSIBLE_REMOTE_USER',      None)
 DEFAULT_ASK_PASS          = get_config(p, DEFAULTS, 'ask_pass',  'ANSIBLE_ASK_PASS',    False, boolean=True)
+DEFAULT_SSH_PROMPT        = get_config(p, DEFAULTS, 'ssh_prompt', 'ANSIBLE_SSH_PROMPT', 'assword')
 DEFAULT_PRIVATE_KEY_FILE  = get_config(p, DEFAULTS, 'private_key_file', 'ANSIBLE_PRIVATE_KEY_FILE', None, ispath=True)
 DEFAULT_REMOTE_PORT       = get_config(p, DEFAULTS, 'remote_port',      'ANSIBLE_REMOTE_PORT',      None, integer=True)
 DEFAULT_ASK_VAULT_PASS    = get_config(p, DEFAULTS, 'ask_vault_pass',    'ANSIBLE_ASK_VAULT_PASS',    False, boolean=True)

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -161,6 +161,7 @@ class PlayContext(Base):
     _shell            = FieldAttribute(isa='string')
     _ssh_args         = FieldAttribute(isa='string', default=C.ANSIBLE_SSH_ARGS)
     _ssh_common_args  = FieldAttribute(isa='string')
+    _ssh_prompt       = FieldAttribute(isa='string')
     _sftp_extra_args  = FieldAttribute(isa='string')
     _scp_extra_args   = FieldAttribute(isa='string')
     _ssh_extra_args   = FieldAttribute(isa='string')
@@ -268,7 +269,7 @@ class PlayContext(Base):
         self.check_mode = boolean(options.check)
 
         # get ssh options FIXME: make these common to all connections
-        for flag in ['ssh_common_args', 'docker_extra_args', 'sftp_extra_args', 'scp_extra_args', 'ssh_extra_args']:
+        for flag in ['ssh_common_args', 'docker_extra_args', 'sftp_extra_args', 'scp_extra_args', 'ssh_extra_args', 'ssh_prompt']:
             setattr(self, flag, getattr(options,flag, ''))
 
         # general flags (should we move out?)

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -127,7 +127,11 @@ class Connection(ConnectionBase):
                 raise AnsibleError("to use the 'ssh' connection type with passwords, you must install the sshpass program")
 
             self.sshpass_pipe = os.pipe()
-            self._command += ['sshpass', '-d{0}'.format(self.sshpass_pipe[0])]
+            if self._play_context.ssh_prompt == "assword":
+                self._command += ['sshpass', '-d{0}'.format(self.sshpass_pipe[0])]
+            else:
+                self._command += ['sshpass', '-P',self._play_context.ssh_prompt,'-d{0}'.format(self.sshpass_pipe[0])]
+            display.vvvvv('SSH: building command (' + ')('.join(self._command))
 
         self._command += [binary]
 
@@ -232,7 +236,7 @@ class Connection(ConnectionBase):
 
         if other_args:
             self._command += other_args
-
+        display.vvvvv('SSH: built command (' + ')('.join(self._command))
         return self._command
 
     def _send_initial_data(self, fh, in_data):


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (ssh_prompt 8ca3c61703) last updated 2016/08/03 22:34:10 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 24db4de245) last updated 2016/07/30 12:01:14 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD db979dde74) last updated 2016/07/30 12:01:30 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

When use ansible  -k option to specify a ssh connection password, there was no option to specify the ssh prompt and therefore ansible will hang when the remote server is using prompt other than P'assword.
Luckily sshpass v1.06 released on June 30 2016 added the support to specify the ssh prompt via -P command line parameter. With this, I added the ansible adhoc command line support with --ssh-prompt=SSH_PROMPT.
Simply don't use this new parameter if your sshpass is not updated to v1.06 yet, it will work too.

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
ansible 192.168.0.98 -u root -k --ssh-prompt=asscode -vvvvv  -a 'ls'
<192.168.0.98> SSH: found only ControlPersist; added ControlPath: (-o)(ControlPath=/home/jli/.ansible/cp/ansible-ssh-%h-%p-%r)
SSH: built command (sshpass)(-P)(asscode)(-d12)(ssh)(-vvv)(-C)(-o)(ControlMaster=auto)(-o)(ControlPersist=60s)(-o)(User=root)(-o)(ConnectTimeout=10)(-o)(ControlPath=/home/jli/.ansible/cp/ansible-ssh-%h-%p-%r)(-tt)(192.168.0.98)(/bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1470280236.73-177731019044694/command.py; rm -rf "/root/.ansible/tmp/ansible-tmp-1470280236.73-177731019044694/" > /dev/null 2>&1 && sleep 0'
<192.168.0.98> SSH: EXEC sshpass -P asscode -d12 ssh -vvv -C -o ControlMaster=auto -o ControlPersist=60s -o User=root -o ConnectTimeout=10 -o ControlPath=/home/jli/.ansible/cp/ansible-ssh-%h-%p-%r -tt 192.168.0.98 '/bin/sh -c '"'"'/usr/bin/python /root/.ansible/tmp/ansible-tmp-1470280236.73-177731019044694/command.py; rm -rf "/root/.ansible/tmp/ansible-tmp-1470280236.73-177731019044694/" > /dev/null 2>&1 && sleep 0'"'"''
192.168.0.98 | SUCCESS | rc=0 >>
```

…of sshpass(1.06+),

so we can specify --ssh-prompt SSH_PROMPT for the scenario like RSA Secure ID, freebsd etc etc
