### PR TITLE
add transparent vault use to other plugins

### DIFF
--- a/lib/ansible/plugins/action/assemble.py
+++ b/lib/ansible/plugins/action/assemble.py
@@ -48,7 +48,8 @@ class ActionModule(ActionBase):
             fragment = "%s/%s" % (src_path, f)
             if not os.path.isfile(fragment) or (ignore_hidden and os.path.basename(fragment).startswith('.')):
                 continue
-            fragment_content = file(fragment).read()
+
+            fragment_content = file(self._loader.get_real_file(fragment)).read()
 
             # always put a newline between fragments if the previous fragment didn't end with a newline.
             if add_newline:

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -72,7 +72,7 @@ class ActionModule(ActionBase):
         args   = ' '.join(parts[1:])
 
         try:
-            source = self._find_needle('files', source)
+            source = self._loader.get_real_file(self._find_needle('files', source))
         except AnsibleError as e:
             return dict(failed=True, msg=to_str(e))
 

--- a/lib/ansible/plugins/action/unarchive.py
+++ b/lib/ansible/plugins/action/unarchive.py
@@ -68,7 +68,7 @@ class ActionModule(ActionBase):
 
         if copy:
             try:
-                source = self._find_needle('files', source)
+                source = self._loader.get_real_file(self._find_needle('files', source))
             except AnsibleError as e:
                 result['failed'] = True
                 result['msg'] = to_str(e)


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.2
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Added 'transparent vault' use to assemble, script and unarchive (copy already had it).
