### PR TITLE
Allow multiple newline delimited passwords in the vault password

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -113,7 +113,6 @@ class VaultLib:
             for _password in password.split('\n'):
                 b_password = to_bytes(_password, errors='strict', encoding='utf-8')
                 passwords.append(b_password)
-        passwords = [x.strip() for x in passwords if x.strip()]
         return passwords
 
     def is_encrypted(self, data):

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -113,6 +113,7 @@ class VaultLib:
             for _password in password.split('\n'):
                 b_password = to_bytes(_password, errors='strict', encoding='utf-8')
                 passwords.append(b_password)
+        passwords = [x.strip() for x in passwords if x.strip()]
         return passwords
 
     def is_encrypted(self, data):


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

```
2.2
```
##### SUMMARY

If the vault password contains newlines, split it and iterate through the list to attempt decryption.
