### PR TITLE
Ensure task retries default is set

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -431,9 +431,7 @@ class TaskExecutor:
         # Read some values from the task, so that we can modify them if need be
         if self._task.until:
             retries = self._task.retries + 1
-            if retries is None:
-                retries = 3
-            elif retries <= 0:
+            if retries <= 0:
                 retries = 1
         else:
             retries = 1

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -86,7 +86,7 @@ class Task(Base, Conditional, Taggable, Become):
     _notify               = FieldAttribute(isa='list')
     _poll                 = FieldAttribute(isa='int')
     _register             = FieldAttribute(isa='string')
-    _retries              = FieldAttribute(isa='int')
+    _retries              = FieldAttribute(isa='int', default=3)
     _until                = FieldAttribute(isa='list', default=[])
 
     def __init__(self, block=None, role=None, task_include=None):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (retries-none b0b2da7a74) last updated 2016/08/04 14:57:53 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 24db4de245) last updated 2016/08/04 12:28:17 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD db979dde74) last updated 2016/08/04 12:28:19 (GMT -700)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Retry evaluation logic changed in 2.1.1.0 to fix an off-by-one bug.  However, that introduced a type-related bug because of an interaction with an unset default value for the `retries` field of a task object.  Instead of assigning a default value to `retries` at evaluation/execution time, I set the default in the `FieldAttribute` instantiation.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
$ cat default-retries.yml
- name: sample until loop
  hosts: localhost
  connection: local
  gather_facts: false
  vars:
    success_on_zero_based_attempt: 1
    retry_count: 1

  tasks:
  - name: clean up explicit state file
    file: path=/tmp/explicit-retries.count state=absent
  - name: explicit retries
    shell: "a=$(wc -l /tmp/explicit-retries.count 2>/dev/null || echo 0); [ $(echo $a | awk '{ print $1; }') -eq {{ success_on_zero_based_attempt }} ] && exit 0 || { echo 1 >>/tmp/explicit-retries.count; exit 1; }"
    until: res.rc == 0
    retries: "{{ retry_count }}"
    register: res

  - name: clean up default state file
    file: path=/tmp/default-retries.count state=absent
  - name: default retries
    shell: "a=$(wc -l /tmp/default-retries.count 2>/dev/null || echo 0); [ $(echo $a | awk '{ print $1; }') -eq {{ success_on_zero_based_attempt }} ] && exit 0 || { echo 1 >>/tmp/default-retries.count; exit 1; }"
    until: res.rc == 0
    register: res



$ # BEFORE THE BUGFIX
$ ansible-playbook -i 'localhost,' default-retries.yml -vvv
No config file found; using defaults

PLAYBOOK: default-retries.yml **************************************************
1 plays in default-retries.yml

PLAY [sample until loop] *******************************************************

TASK [clean up explicit state file] ********************************************
task path: /Users/foo/src/exp/ansible-retries/default-retries.yml:10
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: foo
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1470348597.18-277837667962261 `" && echo ansible-tmp-1470348597.18-277837667962261="` echo $HOME/.ansible/tmp/ansible-tmp-1470348597.18-277837667962261 `" ) && sleep 0'
<localhost> PUT /var/folders/kt/9hmqw7md0tlgk8rdmv5yqd20b962kz/T/tmpGs9w1j TO /Users/foo/.ansible/tmp/ansible-tmp-1470348597.18-277837667962261/file
<localhost> EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /Users/foo/.ansible/tmp/ansible-tmp-1470348597.18-277837667962261/file; rm -rf "/Users/foo/.ansible/tmp/ansible-tmp-1470348597.18-277837667962261/" > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {"changed": true, "diff": {"after": {"path": "/tmp/explicit-retries.count", "state": "absent"}, "before": {"path": "/tmp/explicit-retries.count", "state": "file"}}, "invocation": {"module_args": {"backup": null, "content": null, "delimiter": null, "diff_peek": null, "directory_mode": null, "follow": false, "force": false, "group": null, "mode": null, "original_basename": null, "owner": null, "path": "/tmp/explicit-retries.count", "recurse": false, "regexp": null, "remote_src": null, "selevel": null, "serole": null, "setype": null, "seuser": null, "src": null, "state": "absent", "validate": null}, "module_name": "file"}, "path": "/tmp/explicit-retries.count", "state": "absent"}

TASK [explicit retries] ********************************************************
task path: /Users/foo/src/exp/ansible-retries/default-retries.yml:12
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: foo
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1470348597.54-262253652451421 `" && echo ansible-tmp-1470348597.54-262253652451421="` echo $HOME/.ansible/tmp/ansible-tmp-1470348597.54-262253652451421 `" ) && sleep 0'
<localhost> PUT /var/folders/kt/9hmqw7md0tlgk8rdmv5yqd20b962kz/T/tmpth65cr TO /Users/foo/.ansible/tmp/ansible-tmp-1470348597.54-262253652451421/command
<localhost> EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /Users/foo/.ansible/tmp/ansible-tmp-1470348597.54-262253652451421/command; rm -rf "/Users/foo/.ansible/tmp/ansible-tmp-1470348597.54-262253652451421/" > /dev/null 2>&1 && sleep 0'
FAILED - RETRYING: TASK: explicit retries (1 retries left).Result was: {"attempts": 1, "changed": true, "cmd": "a=$(wc -l /tmp/explicit-retries.count 2>/dev/null || echo 0); [ $(echo $a | awk '{ print $1; }') -eq 1 ] && exit 0 || { echo 1 >>/tmp/explicit-retries.count; exit 1; }", "delta": "0:00:00.015225", "end": "2016-08-04 15:09:57.761655", "failed": true, "invocation": {"module_args": {"_raw_params": "a=$(wc -l /tmp/explicit-retries.count 2>/dev/null || echo 0); [ $(echo $a | awk '{ print $1; }') -eq 1 ] && exit 0 || { echo 1 >>/tmp/explicit-retries.count; exit 1; }", "_uses_shell": true, "chdir": null, "creates": null, "executable": null, "removes": null, "warn": true}, "module_name": "command"}, "rc": 1, "retries": 2, "start": "2016-08-04 15:09:57.746430", "stderr": "", "stdout": "", "stdout_lines": [], "warnings": []}
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1470348602.78-152205879724485 `" && echo ansible-tmp-1470348602.78-152205879724485="` echo $HOME/.ansible/tmp/ansible-tmp-1470348602.78-152205879724485 `" ) && sleep 0'
<localhost> PUT /var/folders/kt/9hmqw7md0tlgk8rdmv5yqd20b962kz/T/tmprsz8BE TO /Users/foo/.ansible/tmp/ansible-tmp-1470348602.78-152205879724485/command
<localhost> EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /Users/foo/.ansible/tmp/ansible-tmp-1470348602.78-152205879724485/command; rm -rf "/Users/foo/.ansible/tmp/ansible-tmp-1470348602.78-152205879724485/" > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {"changed": true, "cmd": "a=$(wc -l /tmp/explicit-retries.count 2>/dev/null || echo 0); [ $(echo $a | awk '{ print $1; }') -eq 1 ] && exit 0 || { echo 1 >>/tmp/explicit-retries.count; exit 1; }", "delta": "0:00:00.014957", "end": "2016-08-04 15:10:03.010913", "invocation": {"module_args": {"_raw_params": "a=$(wc -l /tmp/explicit-retries.count 2>/dev/null || echo 0); [ $(echo $a | awk '{ print $1; }') -eq 1 ] && exit 0 || { echo 1 >>/tmp/explicit-retries.count; exit 1; }", "_uses_shell": true, "chdir": null, "creates": null, "executable": null, "removes": null, "warn": true}, "module_name": "command"}, "rc": 0, "start": "2016-08-04 15:10:02.995956", "stderr": "", "stdout": "", "stdout_lines": [], "warnings": []}

TASK [clean up default state file] *********************************************
task path: /Users/foo/src/exp/ansible-retries/default-retries.yml:18
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: foo
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1470348603.08-260066647027455 `" && echo ansible-tmp-1470348603.08-260066647027455="` echo $HOME/.ansible/tmp/ansible-tmp-1470348603.08-260066647027455 `" ) && sleep 0'
<localhost> PUT /var/folders/kt/9hmqw7md0tlgk8rdmv5yqd20b962kz/T/tmp7SRzyn TO /Users/foo/.ansible/tmp/ansible-tmp-1470348603.08-260066647027455/file
<localhost> EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /Users/foo/.ansible/tmp/ansible-tmp-1470348603.08-260066647027455/file; rm -rf "/Users/foo/.ansible/tmp/ansible-tmp-1470348603.08-260066647027455/" > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {"changed": true, "diff": {"after": {"path": "/tmp/default-retries.count", "state": "absent"}, "before": {"path": "/tmp/default-retries.count", "state": "file"}}, "invocation": {"module_args": {"backup": null, "content": null, "delimiter": null, "diff_peek": null, "directory_mode": null, "follow": false, "force": false, "group": null, "mode": null, "original_basename": null, "owner": null, "path": "/tmp/default-retries.count", "recurse": false, "regexp": null, "remote_src": null, "selevel": null, "serole": null, "setype": null, "seuser": null, "src": null, "state": "absent", "validate": null}, "module_name": "file"}, "path": "/tmp/default-retries.count", "state": "absent"}

TASK [default retries] *********************************************************
task path: /Users/foo/src/exp/ansible-retries/default-retries.yml:20
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/Users/foo/venvs/cma-prod/lib/python2.7/site-packages/ansible/executor/task_executor.py", line 124, in run
    res = self._execute()
  File "/Users/foo/venvs/cma-prod/lib/python2.7/site-packages/ansible/executor/task_executor.py", line 427, in _execute
    retries = self._task.retries + 1
TypeError: unsupported operand type(s) for +: 'NoneType' and 'int'

fatal: [localhost]: FAILED! => {"failed": true, "msg": "Unexpected failure during module execution.", "stdout": ""}

NO MORE HOSTS LEFT *************************************************************
 [WARNING]: Could not create retry file 'default-retries.retry'.         [Errno 2] No such file or directory: ''


PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=3    unreachable=0    failed=1




$ # AFTER THE BUGFIX
$ ansible-playbook -i 'localhost,' default-retries.yml -vvv
No config file found; using defaults

PLAYBOOK: default-retries.yml **************************************************
1 plays in default-retries.yml

PLAY [sample until loop] *******************************************************

TASK [clean up explicit state file] ********************************************
task path: /Users/foo/src/exp/ansible-retries/default-retries.yml:10
Using module file /Users/foo/src/ansible/lib/ansible/modules/core/files/file.py
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: foo
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1470348810.61-265856793553636 `" && echo ansible-tmp-1470348810.61-265856793553636="` echo $HOME/.ansible/tmp/ansible-tmp-1470348810.61-265856793553636 `" ) && sleep 0'
<localhost> PUT /var/folders/kt/9hmqw7md0tlgk8rdmv5yqd20b962kz/T/tmpYaLqYG TO /Users/foo/.ansible/tmp/ansible-tmp-1470348810.61-265856793553636/file.py
<localhost> EXEC /bin/sh -c 'chmod -R u+x /Users/foo/.ansible/tmp/ansible-tmp-1470348810.61-265856793553636/ && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/python /Users/foo/.ansible/tmp/ansible-tmp-1470348810.61-265856793553636/file.py; rm -rf "/Users/foo/.ansible/tmp/ansible-tmp-1470348810.61-265856793553636/" > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true,
    "diff": {
        "after": {
            "path": "/tmp/explicit-retries.count",
            "state": "absent"
        },
        "before": {
            "path": "/tmp/explicit-retries.count",
            "state": "file"
        }
    },
    "invocation": {
        "module_args": {
            "backup": null,
            "content": null,
            "delimiter": null,
            "diff_peek": null,
            "directory_mode": null,
            "follow": false,
            "force": false,
            "group": null,
            "mode": null,
            "original_basename": null,
            "owner": null,
            "path": "/tmp/explicit-retries.count",
            "recurse": false,
            "regexp": null,
            "remote_src": null,
            "selevel": null,
            "serole": null,
            "setype": null,
            "seuser": null,
            "src": null,
            "state": "absent",
            "validate": null
        },
        "module_name": "file"
    },
    "path": "/tmp/explicit-retries.count",
    "state": "absent"
}

TASK [explicit retries] ********************************************************
task path: /Users/foo/src/exp/ansible-retries/default-retries.yml:12
Using module file /Users/foo/src/ansible/lib/ansible/modules/core/commands/command.py
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: foo
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1470348811.0-123631091690030 `" && echo ansible-tmp-1470348811.0-123631091690030="` echo $HOME/.ansible/tmp/ansible-tmp-1470348811.0-123631091690030 `" ) && sleep 0'
<localhost> PUT /var/folders/kt/9hmqw7md0tlgk8rdmv5yqd20b962kz/T/tmp0Z42Bv TO /Users/foo/.ansible/tmp/ansible-tmp-1470348811.0-123631091690030/command.py
<localhost> EXEC /bin/sh -c 'chmod -R u+x /Users/foo/.ansible/tmp/ansible-tmp-1470348811.0-123631091690030/ && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/python /Users/foo/.ansible/tmp/ansible-tmp-1470348811.0-123631091690030/command.py; rm -rf "/Users/foo/.ansible/tmp/ansible-tmp-1470348811.0-123631091690030/" > /dev/null 2>&1 && sleep 0'
FAILED - RETRYING: TASK: explicit retries (1 retries left).Result was: {
    "attempts": 1,
    "changed": true,
    "cmd": "a=$(wc -l /tmp/explicit-retries.count 2>/dev/null || echo 0); [ $(echo $a | awk '{ print $1; }') -eq 1 ] && exit 0 || { echo 1 >>/tmp/explicit-retries.count; exit 1; }",
    "delta": "0:00:00.014706",
    "end": "2016-08-04 15:13:31.247463",
    "failed": true,
    "invocation": {
        "module_args": {
            "_raw_params": "a=$(wc -l /tmp/explicit-retries.count 2>/dev/null || echo 0); [ $(echo $a | awk '{ print $1; }') -eq 1 ] && exit 0 || { echo 1 >>/tmp/explicit-retries.count; exit 1; }",
            "_uses_shell": true,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "warn": true
        },
        "module_name": "command"
    },
    "rc": 1,
    "retries": 2,
    "start": "2016-08-04 15:13:31.232757",
    "stderr": "",
    "stdout": "",
    "stdout_lines": [],
    "warnings": []
}
Using module file /Users/foo/src/ansible/lib/ansible/modules/core/commands/command.py
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1470348816.27-175350007884935 `" && echo ansible-tmp-1470348816.27-175350007884935="` echo $HOME/.ansible/tmp/ansible-tmp-1470348816.27-175350007884935 `" ) && sleep 0'
<localhost> PUT /var/folders/kt/9hmqw7md0tlgk8rdmv5yqd20b962kz/T/tmpr03I9R TO /Users/foo/.ansible/tmp/ansible-tmp-1470348816.27-175350007884935/command.py
<localhost> EXEC /bin/sh -c 'chmod -R u+x /Users/foo/.ansible/tmp/ansible-tmp-1470348816.27-175350007884935/ && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/python /Users/foo/.ansible/tmp/ansible-tmp-1470348816.27-175350007884935/command.py; rm -rf "/Users/foo/.ansible/tmp/ansible-tmp-1470348816.27-175350007884935/" > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true,
    "cmd": "a=$(wc -l /tmp/explicit-retries.count 2>/dev/null || echo 0); [ $(echo $a | awk '{ print $1; }') -eq 1 ] && exit 0 || { echo 1 >>/tmp/explicit-retries.count; exit 1; }",
    "delta": "0:00:00.014348",
    "end": "2016-08-04 15:13:36.513813",
    "invocation": {
        "module_args": {
            "_raw_params": "a=$(wc -l /tmp/explicit-retries.count 2>/dev/null || echo 0); [ $(echo $a | awk '{ print $1; }') -eq 1 ] && exit 0 || { echo 1 >>/tmp/explicit-retries.count; exit 1; }",
            "_uses_shell": true,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "warn": true
        },
        "module_name": "command"
    },
    "rc": 0,
    "start": "2016-08-04 15:13:36.499465",
    "stderr": "",
    "stdout": "",
    "stdout_lines": [],
    "warnings": []
}

TASK [clean up default state file] *********************************************
task path: /Users/foo/src/exp/ansible-retries/default-retries.yml:18
Using module file /Users/foo/src/ansible/lib/ansible/modules/core/files/file.py
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: foo
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1470348816.58-133365416031679 `" && echo ansible-tmp-1470348816.58-133365416031679="` echo $HOME/.ansible/tmp/ansible-tmp-1470348816.58-133365416031679 `" ) && sleep 0'
<localhost> PUT /var/folders/kt/9hmqw7md0tlgk8rdmv5yqd20b962kz/T/tmp8G0cy7 TO /Users/foo/.ansible/tmp/ansible-tmp-1470348816.58-133365416031679/file.py
<localhost> EXEC /bin/sh -c 'chmod -R u+x /Users/foo/.ansible/tmp/ansible-tmp-1470348816.58-133365416031679/ && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/python /Users/foo/.ansible/tmp/ansible-tmp-1470348816.58-133365416031679/file.py; rm -rf "/Users/foo/.ansible/tmp/ansible-tmp-1470348816.58-133365416031679/" > /dev/null 2>&1 && sleep 0'
ok: [localhost] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "backup": null,
            "content": null,
            "delimiter": null,
            "diff_peek": null,
            "directory_mode": null,
            "follow": false,
            "force": false,
            "group": null,
            "mode": null,
            "original_basename": null,
            "owner": null,
            "path": "/tmp/default-retries.count",
            "recurse": false,
            "regexp": null,
            "remote_src": null,
            "selevel": null,
            "serole": null,
            "setype": null,
            "seuser": null,
            "src": null,
            "state": "absent",
            "validate": null
        },
        "module_name": "file"
    },
    "path": "/tmp/default-retries.count",
    "state": "absent"
}

TASK [default retries] *********************************************************
task path: /Users/foo/src/exp/ansible-retries/default-retries.yml:20
Using module file /Users/foo/src/ansible/lib/ansible/modules/core/commands/command.py
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: foo
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1470348816.88-256773295269671 `" && echo ansible-tmp-1470348816.88-256773295269671="` echo $HOME/.ansible/tmp/ansible-tmp-1470348816.88-256773295269671 `" ) && sleep 0'
<localhost> PUT /var/folders/kt/9hmqw7md0tlgk8rdmv5yqd20b962kz/T/tmpWHMmVA TO /Users/foo/.ansible/tmp/ansible-tmp-1470348816.88-256773295269671/command.py
<localhost> EXEC /bin/sh -c 'chmod -R u+x /Users/foo/.ansible/tmp/ansible-tmp-1470348816.88-256773295269671/ && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/python /Users/foo/.ansible/tmp/ansible-tmp-1470348816.88-256773295269671/command.py; rm -rf "/Users/foo/.ansible/tmp/ansible-tmp-1470348816.88-256773295269671/" > /dev/null 2>&1 && sleep 0'
FAILED - RETRYING: TASK: default retries (3 retries left).Result was: {
    "attempts": 1,
    "changed": true,
    "cmd": "a=$(wc -l /tmp/default-retries.count 2>/dev/null || echo 0); [ $(echo $a | awk '{ print $1; }') -eq 1 ] && exit 0 || { echo 1 >>/tmp/default-retries.count; exit 1; }",
    "delta": "0:00:00.014909",
    "end": "2016-08-04 15:13:37.118351",
    "failed": true,
    "invocation": {
        "module_args": {
            "_raw_params": "a=$(wc -l /tmp/default-retries.count 2>/dev/null || echo 0); [ $(echo $a | awk '{ print $1; }') -eq 1 ] && exit 0 || { echo 1 >>/tmp/default-retries.count; exit 1; }",
            "_uses_shell": true,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "warn": true
        },
        "module_name": "command"
    },
    "rc": 1,
    "retries": 4,
    "start": "2016-08-04 15:13:37.103442",
    "stderr": "",
    "stdout": "",
    "stdout_lines": [],
    "warnings": []
}
Using module file /Users/foo/src/ansible/lib/ansible/modules/core/commands/command.py
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1470348822.14-25685810878690 `" && echo ansible-tmp-1470348822.14-25685810878690="` echo $HOME/.ansible/tmp/ansible-tmp-1470348822.14-25685810878690 `" ) && sleep 0'
<localhost> PUT /var/folders/kt/9hmqw7md0tlgk8rdmv5yqd20b962kz/T/tmp0UqQq8 TO /Users/foo/.ansible/tmp/ansible-tmp-1470348822.14-25685810878690/command.py
<localhost> EXEC /bin/sh -c 'chmod -R u+x /Users/foo/.ansible/tmp/ansible-tmp-1470348822.14-25685810878690/ && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/python /Users/foo/.ansible/tmp/ansible-tmp-1470348822.14-25685810878690/command.py; rm -rf "/Users/foo/.ansible/tmp/ansible-tmp-1470348822.14-25685810878690/" > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true,
    "cmd": "a=$(wc -l /tmp/default-retries.count 2>/dev/null || echo 0); [ $(echo $a | awk '{ print $1; }') -eq 1 ] && exit 0 || { echo 1 >>/tmp/default-retries.count; exit 1; }",
    "delta": "0:00:00.013857",
    "end": "2016-08-04 15:13:42.380540",
    "invocation": {
        "module_args": {
            "_raw_params": "a=$(wc -l /tmp/default-retries.count 2>/dev/null || echo 0); [ $(echo $a | awk '{ print $1; }') -eq 1 ] && exit 0 || { echo 1 >>/tmp/default-retries.count; exit 1; }",
            "_uses_shell": true,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "warn": true
        },
        "module_name": "command"
    },
    "rc": 0,
    "start": "2016-08-04 15:13:42.366683",
    "stderr": "",
    "stdout": "",
    "stdout_lines": [],
    "warnings": []
}

PLAY RECAP *********************************************************************
localhost                  : ok=4    changed=3    unreachable=0    failed=0

```

Fixes #16868.
