### PR TITLE
* Fix race in creating temp directories pre-fork

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -28,6 +28,7 @@ from ansible.compat.six.moves import configparser
 
 from ansible.parsing.quoting import unquote
 from ansible.errors import AnsibleOptionsError
+from ansible.utils.path import makedirs_safe
 
 BOOL_TRUE = frozenset([ "true", "t", "y", "1", "yes", "on" ])
 
@@ -77,7 +78,7 @@ def get_config(p, section, key, env_var, default, boolean=False, integer=False, 
         elif istmppath:
             value = shell_expand(value)
             if not os.path.exists(value):
-                os.makedirs(value, 0o700)
+                makedirs_safe(value, 0o700)
             prefix = 'ansible-local-%s' % os.getpid()
             value = tempfile.mkdtemp(prefix=prefix, dir=value)
         elif ispathlist:

--- a/lib/ansible/utils/path.py
+++ b/lib/ansible/utils/path.py
@@ -31,7 +31,7 @@ def unfrackpath(path):
     example:
     '$HOME/../../var/mail' becomes '/var/spool/mail'
     '''
-    return os.path.normpath(os.path.realpath(os.path.expandvars(os.path.expanduser(to_bytes(path, errors='strict')))))
+    return os.path.normpath(os.path.realpath(os.path.expanduser(os.path.expandvars(to_bytes(path, errors='strict')))))
 
 def makedirs_safe(path, mode=None):
     '''Safe way to create dirs in muliprocess/thread environments'''


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

```
devel and 2.1
```
##### SUMMARY
- Fix race in creating temp directories pre-fork
  - These can still race when multiple ansible processes are created at
    the same time.
- Reverse order of expanduser and expandvars in unfrakpath(). So that
  tildes in environment variables will be handled.
