### PR TITLE
Add partition uuid to facts for Linux.

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1326,6 +1326,7 @@ class LinuxHardware(Hardware):
                     if not part['sectorsize']:
                         part['sectorsize'] = get_file_content(part_sysdir + "/queue/hw_sector_size",512)
                     part['size'] = self.module.pretty_bytes((float(part['sectors']) * float(part['sectorsize'])))
+                    part['uuid'] = get_partition_uuid(partname)
                     self.get_holders(part, part_sysdir)
 
                     d['partitions'][partname] = part
@@ -3222,6 +3223,19 @@ def get_uname_version(module):
     rc, out, err = module.run_command(['uname', '-v'])
     if rc == 0:
         return out
+    return None
+
+def get_partition_uuid(partname):
+    try:
+        uuids = os.listdir("/dev/disk/by-uuid")
+    except OSError:
+        return
+
+    for uuid in uuids:
+        dev = os.path.realpath("/dev/disk/by-uuid/" + uuid)
+        if dev == ("/dev/" + partname):
+            return uuid
+
     return None
 
 def get_file_lines(path):


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Introduce uuid to partitions under ansible_devices facts,
should allow for easier ways to automate filesystem creation and updating/modifying fstab.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Works by looking for partition name in /dev/disk/by-uuid
