### PR TITLE
Removed run_once from alias of any error fatal

### DIFF
--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -230,7 +230,7 @@ class StrategyModule(StrategyBase):
 
                         run_once = templar.template(task.run_once) or action and getattr(action, 'BYPASS_HOST_LOOP', False)
 
-                        if (task.any_errors_fatal or run_once) and not task.ignore_errors:
+                        if (task.any_errors_fatal) and not task.ignore_errors:
                             any_errors_fatal = True
 
                         if not callback_sent:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (fix_runonce_rescue 1273431b27) last updated 2016/08/08 10:41:29 (GMT -700)
  lib/ansible/modules/core: (detached HEAD c0d373f258) last updated 2016/08/08 07:57:28 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 33716b1837) last updated 2016/08/08 07:57:30 (GMT -700)
  config file = /home/aaron/workspace/vagrant/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

In the linear strategy the flag run_once was synonymous with any_error_fatal for error checking.  This caused plays to abort before running any rescue or always blocks.  By remove this the play executes as expected, and the error handling is handled by the executor. This is a fix for #16937

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
BEFORE:
ansible-playbook bug_blocks.yml

PLAY [all] *********************************************************************

TASK [debug] *******************************************************************
ok: [node1] => {
    "msg": "I execute normally"
}
ok: [node2] => {
    "msg": "I execute normally"
}
ok: [node3] => {
    "msg": "I execute normally"
}
ok: [test] => {
    "msg": "I execute normally"
}

TASK [command] *****************************************************************
fatal: [node1]: FAILED! => {"changed": true, "cmd": ["/bin/false"], "delta": "0:00:00.001322", "end": "2016-08-08 17:47:50.284766", "failed": true, "rc": 1, "start": "2016-08-08 17:47:50.283444", "stderr": "", "stdout": "", "stdout_lines": [], "warnings": []}

NO MORE HOSTS LEFT *************************************************************
    to retry, use: --limit @bug_blocks.retry

PLAY RECAP *********************************************************************
node1                      : ok=1    changed=0    unreachable=0    failed=0   
node2                      : ok=1    changed=0    unreachable=0    failed=0   
node3                      : ok=1    changed=0    unreachable=0    failed=0   
test                       : ok=1    changed=0    unreachable=0    failed=0   



AFTER:
PLAY [all] *********************************************************************

TASK [debug] *******************************************************************
ok: [node1] => {
    "msg": "I execute normally"
}
ok: [node2] => {
    "msg": "I execute normally"
}
ok: [node3] => {
    "msg": "I execute normally"
}
ok: [test] => {
    "msg": "I execute normally"
}

TASK [command] *****************************************************************
fatal: [node1]: FAILED! => {"changed": true, "cmd": ["/bin/false"], "delta": "0:00:00.001327", "end": "2016-08-08 17:48:23.093575", "failed": true, "rc": 1, "start": "2016-08-08 17:48:23.092248", "stderr": "", "stdout": "", "stdout_lines": [], "warnings": []}

TASK [debug] *******************************************************************
ok: [node1] => {
    "msg": "I caught an error"
}
ok: [node2] => {
    "msg": "I caught an error"
}
ok: [node3] => {
    "msg": "I caught an error"
}
ok: [test] => {
    "msg": "I caught an error"
}

TASK [command] *****************************************************************
fatal: [node1]: FAILED! => {"changed": true, "cmd": ["/bin/false"], "delta": "0:00:00.001300", "end": "2016-08-08 17:48:23.388586", "failed": true, "rc": 1, "start": "2016-08-08 17:48:23.387286", "stderr": "", "stdout": "", "stdout_lines": [], "warnings": []}
fatal: [node2]: FAILED! => {"changed": true, "cmd": ["/bin/false"], "delta": "0:00:00.001387", "end": "2016-08-08 17:48:23.896836", "failed": true, "rc": 1, "start": "2016-08-08 17:48:23.895449", "stderr": "", "stdout": "", "stdout_lines": [], "warnings": []}
fatal: [node3]: FAILED! => {"changed": true, "cmd": ["/bin/false"], "delta": "0:00:00.001336", "end": "2016-08-08 17:48:23.841399", "failed": true, "rc": 1, "start": "2016-08-08 17:48:23.840063", "stderr": "", "stdout": "", "stdout_lines": [], "warnings": []}
fatal: [test]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh.", "unreachable": true}

TASK [debug] *******************************************************************
ok: [node1] => {
    "msg": "this always executes"
}
ok: [node2] => {
    "msg": "this always executes"
}
ok: [node3] => {
    "msg": "this always executes"
}

NO MORE HOSTS LEFT *************************************************************
    to retry, use: --limit @bug_blocks.retry

PLAY RECAP *********************************************************************
node1                      : ok=3    changed=0    unreachable=0    failed=1   
node2                      : ok=3    changed=0    unreachable=0    failed=1   
node3                      : ok=3    changed=0    unreachable=0    failed=1   
test                       : ok=2    changed=0    unreachable=1    failed=0   



cat bug_block.yml
- hosts: all
  gather_facts: false
  #strategy: debug
  tasks:
  - block:
      - debug: msg='I execute normally'
      - command: /bin/false
        run_once: true
      - debug: msg='I never execute, cause ERROR!'
    rescue:
      - debug: msg='I caught an error'
      - command: /bin/false
      - debug: msg='I also never execute :-('
    always:
      - debug: msg="this always executes"
```
