### PR TITLE
Remove FreeBSD interpreter test hacks.

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -49,21 +49,21 @@ includes: setup
 pull:	pull_run pull_no_127 pull_limit_inventory
 
 pull_run:
-	ansible-pull -d $(MYTMPDIR) -U https://github.com/ansible-test-robinro/pull-integration-test.git | grep MAGICKEYWORD; \
+	ansible-pull -d $(MYTMPDIR) -U https://github.com/ansible-test-robinro/pull-integration-test.git $(TEST_FLAGS) | grep MAGICKEYWORD; \
     RC=$$? ; \
 	rm -rf $(MYTMPDIR); \
     exit $$RC
 
 # test for https://github.com/ansible/ansible/issues/13681
 pull_no_127:
-	ansible-pull -d $(MYTMPDIR) -U https://github.com/ansible-test-robinro/pull-integration-test.git | grep -v 127\.0\.0\.1; \
+	ansible-pull -d $(MYTMPDIR) -U https://github.com/ansible-test-robinro/pull-integration-test.git $(TEST_FLAGS) | grep -v 127\.0\.0\.1; \
     RC=$$? ; \
 	rm -rf $(MYTMPDIR); \
     exit $$RC
 
 # test for https://github.com/ansible/ansible/issues/13688
 pull_limit_inventory:
-	ansible-pull -d $(MYTMPDIR) -U https://github.com/ansible-test-robinro/pull-integration-test.git; \
+	ansible-pull -d $(MYTMPDIR) -U https://github.com/ansible-test-robinro/pull-integration-test.git $(TEST_FLAGS); \
     RC=$$? ; \
 	rm -rf $(MYTMPDIR); \
     exit $$RC

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -314,7 +314,7 @@ test_lookup_paths: setup
 
 no_log: setup
 	# This test expects 7 loggable vars and 0 non loggable ones, if either mismatches it fails, run the ansible-playbook command to debug
-	[ "$$(ansible-playbook no_log_local.yml -i $(INVENTORY) -e outputdir=$(TEST_DIR) -vvvvv | awk --source 'BEGIN { logme = 0; nolog = 0; } /LOG_ME/ { logme += 1;} /DO_NOT_LOG/ { nolog += 1;} END { printf "%d/%d", logme, nolog; }')" = "26/0" ]
+	[ "$$(ansible-playbook no_log_local.yml -i $(INVENTORY) -e outputdir=$(TEST_DIR) $(TEST_FLAGS) -vvvvv | awk --source 'BEGIN { logme = 0; nolog = 0; } /LOG_ME/ { logme += 1;} /DO_NOT_LOG/ { nolog += 1;} END { printf "%d/%d", logme, nolog; }')" = "26/0" ]
 
 test_binary_modules_winrm: INVENTORY = inventory.winrm
 test_binary_modules_winrm: test_binary_modules

--- a/test/utils/shippable/remote-integration.sh
+++ b/test/utils/shippable/remote-integration.sh
@@ -62,11 +62,6 @@ if [ ! -f /usr/local/bin/sha1sum ]; then
     ln -s /usr/local/bin/shasum /usr/local/bin/sha1sum
 fi
 
-# FIXME: async doesn't work with ansible_python_interpreter, see: https://github.com/ansible/ansible/issues/14101
-if [ ! -f /usr/bin/python ]; then
-    ln -s /usr/local/bin/python /usr/bin/python
-fi
-
 # Tests assume loopback addresses other than 127.0.0.1 will work.
 # Add aliases for loopback addresses used by tests.
 


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### ANSIBLE VERSION

```
ansible 2.2.0 (freebsd-tests 5b2f390014) last updated 2016/08/08 12:25:29 (GMT -700)
  lib/ansible/modules/core: (detached HEAD c0d373f258) last updated 2016/08/05 11:41:13 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 33716b1837) last updated 2016/08/05 17:19:53 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Remove FreeBSD interpreter test hacks.
