### PR TITLE
Fix docstring for GenericBsdIfconfogNetwork.

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2306,6 +2306,7 @@ class LinuxNetwork(Network):
                     features[key.strip().replace('-','_')] = value.strip()
         return features
 
+
 class GenericBsdIfconfigNetwork(Network):
     """
     This is a generic BSD subclass of Network using the ifconfig command.
@@ -2313,9 +2314,6 @@ class GenericBsdIfconfigNetwork(Network):
     - interfaces (a list of interface names)
     - interface_<name> dictionary of ipv4, ipv6, and mac address information.
     - all_ipv4_addresses and all_ipv6_addresses: lists of all configured addresses.
-    It currently does not define
-    - default_ipv4 and default_ipv6
-    - type, mtu and network on interfaces
     """
     platform = 'Generic_BSD_Ifconfig'
 
@@ -2430,7 +2428,7 @@ class GenericBsdIfconfigNetwork(Network):
         current_if['flags']  = self.get_options(words[1])
         current_if['macaddress'] = 'unknown'    # will be overwritten later
 
-        if len(words) >= 5 : # Newer FreeBSD versions
+        if len(words) >= 5 :  # Newer FreeBSD versions
             current_if['metric'] = words[3]
             current_if['mtu'] = words[5]
         else:
@@ -2527,6 +2525,7 @@ class GenericBsdIfconfigNetwork(Network):
         if len(ifinfo[ip_type]) > 0:
             for item in ifinfo[ip_type][0].keys():
                 defaults[item] = ifinfo[ip_type][0][item]
+
 
 class HPUXNetwork(Network):
     """


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (bsd_facts_docs 89b98a6c15) last updated 2016/08/08 18:07:08 (GMT -400)
  lib/ansible/modules/core: (detached HEAD c0d373f258) last updated 2016/08/08 12:43:31 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 33716b1837) last updated 2016/08/08 12:43:31 (GMT -400)
  config file = /home/adrian/ansible-setup/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

Remove a blurb in the docstring about bsd network facts that is usually
wrong now with current versions.

default_ipv4/default_ipv6 and type/mtu/network
were listed as not defined, but they are usually
defined now.
