### PR TITLE
Increase `local version` for unofficial rpms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ ifeq ($(OFFICIAL),yes)
         DEBUILD_OPTS += -k$(DEBSIGN_KEYID)
     endif
 else
-    DEB_RELEASE = 0.git$(DATE)$(GITINFO)
+    DEB_RELEASE = 100.git$(DATE)$(GITINFO)
     # Do not sign unofficial builds
     DEBUILD_OPTS += -uc -us
     DPUT_OPTS += -u
@@ -83,7 +83,7 @@ RPMSPEC = $(RPMSPECDIR)/ansible.spec
 RPMDIST = $(shell rpm --eval '%{?dist}')
 RPMRELEASE = $(RELEASE)
 ifneq ($(OFFICIAL),yes)
-    RPMRELEASE = 0.git$(DATE)$(GITINFO)
+    RPMRELEASE = 100.git$(DATE)$(GITINFO)
 endif
 RPMNVR = "$(NAME)-$(VERSION)-$(RPMRELEASE)$(RPMDIST)"
 


### PR DESCRIPTION
##### ISSUE TYPE
- Other: Workaround to enable Tower team to test Ansible unofficial RPMs
##### COMPONENT NAME

ansible Makefile
##### ANSIBLE VERSION

All versions (see details below - would need this cherry-picked to `stable-1.9` and `stable-2.1`)
##### SUMMARY

The Tower team setup nightly installs so that Tower would run against nightly builds of Ansible from `stable-1.9` and `stable-2.1`. This week, we found that - due to the versioning of nightly and official releases - the official ansible packages are getting installed instead of the nightlies.

Here's what we're seeing:
- Goal: Install nightly ansible package
- Fresh instance has both epel and ansible nightly repo enabled. (epel _must_ be enabled when trying to install ansible in order to pull in dependencies)
- Attempt to install ansible (or ansible1.9)
- yum sees (a) version `1.9.6-0.git201607010348.el6` on ansible nightly repo and (b) `1.9.6-2.el6.1` on epel. The version numbers - `1.9.6` - are the same, but the local versions - `0` and `2`, respectively, are different. The epel version (`2`) is greater, so yum installs the package from epel.

The local version appears to be set in Ansible's `Makefile`. It looks like the localversion for unofficial rpms will always be `0.git...`. So, if the official version is anything above 0, the unofficial package won't be installed. This PR increases the local version to 100, so that when the ansible nightly repo is enabled, yum will favor the nightly package.

Another option does come to mind - if the version number on `stable-1.9` and `stable-2.1` were consistently bumped after each release (to whatever the next release number will be), then the nightly packages would have a higher version than the released packages.
