### PR TITLE
Fix classes that select a subclass based on platform

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -961,6 +961,12 @@ class Hardware(Facts):
     platform = 'Generic'
 
     def __new__(cls, *arguments, **keyword):
+        # When Hardware is created, it chooses a subclass to create instead.
+        # This check prevents the subclass from then trying to find a subclass
+        # and create that.
+        if cls is not Hardware:
+            return super(Hardware, cls).__new__(cls)
+
         subclass = cls
         for sc in get_all_subclasses(Hardware):
             if sc.platform == platform.system():
@@ -2052,6 +2058,12 @@ class Network(Facts):
                    '80' : 'organization' }
 
     def __new__(cls, *arguments, **keyword):
+        # When Network is created, it chooses a subclass to create instead.
+        # This check prevents the subclass from then trying to find a subclass
+        # and create that.
+        if cls is not Network:
+            return super(Network, cls).__new__(cls)
+
         subclass = cls
         for sc in get_all_subclasses(Network):
             if sc.platform == platform.system():
@@ -2836,6 +2848,12 @@ class Virtual(Facts):
     """
 
     def __new__(cls, *arguments, **keyword):
+        # When Virtual is created, it chooses a subclass to create instead.
+        # This check prevents the subclass from then trying to find a subclass
+        # and create that.
+        if cls is not Virtual:
+            return super(Virtual, cls).__new__(cls)
+
         subclass = cls
         for sc in get_all_subclasses(Virtual):
             if sc.platform == platform.system():


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ansible/module_utils/facts.py
##### ANSIBLE VERSION

```
devel
```
##### SUMMARY

When unittesting this we found that the platform selecting class
hierarchies weren't working in all cases.  If the subclass was directly
created (ie: LinuxHardware()), then it would use its inherited **new**()
to try to create itself.  The inherited **new** would look for
subclasses and end up calling its own **new**() again.  This would
recurse endlessly.  The new code detects when we want to find a subclass
to create (when the base class is used, ie: Hardware()) vs when to
create the class itself (when the subclass is used, ie:
LinuxHardware()).
