### PR TITLE
CloudRetry/AWSRetry backoff decorator with unit tests

### DIFF
--- a/lib/ansible/module_utils/cloud.py
+++ b/lib/ansible/module_utils/cloud.py
@@ -1,0 +1,105 @@
+#
+# (c) 2016 Allen Sanabria, <asanabria@linuxdynasty.org>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+"""
+This module adds shared support for generic cloud modules
+
+In order to use this module, include it as part of a custom
+module as shown below.
+
+from ansible.module_utils.cloud import *
+
+The 'cloud' module provides the following common argument specs:
+
+    * CloudRetry Class
+        - The base class to be used by other cloud providers, in order to
+          provide a backoff/retry decorator based on status codes.
+
+        - Example using the AWSRetry class which inherits from CloudRetry.
+          @AWSRetry.retry(tries=20, delay=2, backoff=2)
+          get_ec2_security_group_ids_from_names()
+
+"""
+from functools import wraps
+import syslog
+import time
+
+
+class CloudRetry(object):
+    """ CloudRetry can be used by any cloud provider, in order to implement a
+        backoff algorithm/retry effect based on Status Code from Exceptions.
+    """
+    # This is the base class of the exception.
+    # AWS Example botocore.exceptions.ClientError
+    base_class = None
+
+    @staticmethod
+    def status_code_from_exception(error):
+        """ Return the status code from the exception object
+        Args:
+            error (object): The exception itself.
+        """
+        pass
+
+    @staticmethod
+    def found(response_code):
+        """ Return True if the Response Code to retry on was found.
+        Args:
+            response_code (str): This is the Response Code that is being matched against.
+        """
+        pass
+
+    @classmethod
+    def retry(cls, tries=10, delay=3, backoff=2):
+        """ Retry calling the Cloud decorated function using an exponential backoff.
+        Kwargs:
+            tries (int): Number of times to try (not retry) before giving up
+                default=10
+            delay (int): Initial delay between retries in seconds
+                default=3
+            backoff (int): backoff multiplier e.g. value of 2 will double the delay each retry
+                default=2
+
+        """
+        def deco(f):
+            @wraps(f)
+            def retry(*args, **kwargs):
+                max_tries, max_delay = tries, delay
+                while max_tries > 1:
+                    try:
+                        return f(*args, **kwargs)
+                    except Exception as e:
+                        if isinstance(e, cls.base_class):
+                            response_code = cls.status_code_from_exception(e)
+                            if cls.found(response_code):
+                                msg = "{0}: Retrying in {1} seconds...".format(str(e), max_delay)
+                                syslog.syslog(syslog.LOG_INFO, msg)
+                                time.sleep(max_delay)
+                                max_tries -= 1
+                                max_delay *= backoff
+                            else:
+                                # Return original exception if exception is not a ClientError
+                                raise e
+                        else:
+                            # Return original exception if exception is not a ClientError
+                            raise e
+                return f(*args, **kwargs)
+
+            return retry  # true decorator
+
+        return deco

--- a/lib/ansible/module_utils/cloud.py
+++ b/lib/ansible/module_utils/cloud.py
@@ -39,7 +39,7 @@ from functools import wraps
 import syslog
 import time
 
-from pycompat24 import get_exception
+from ansible.module_utils.pycompat24 import get_exception
 
 
 class CloudRetry(object):

--- a/lib/ansible/module_utils/cloud.py
+++ b/lib/ansible/module_utils/cloud.py
@@ -67,7 +67,7 @@ class CloudRetry(object):
         pass
 
     @classmethod
-    def backoff(cls, tries=10, delay=3, backoff=2):
+    def backoff(cls, tries=10, delay=3, backoff=1.1):
         """ Retry calling the Cloud decorated function using an exponential backoff.
         Kwargs:
             tries (int): Number of times to try (not retry) before giving up

--- a/lib/ansible/module_utils/cloud.py
+++ b/lib/ansible/module_utils/cloud.py
@@ -67,7 +67,7 @@ class CloudRetry(object):
         pass
 
     @classmethod
-    def retry(cls, tries=10, delay=3, backoff=2):
+    def backoff(cls, tries=10, delay=3, backoff=2):
         """ Retry calling the Cloud decorated function using an exponential backoff.
         Kwargs:
             tries (int): Number of times to try (not retry) before giving up

--- a/lib/ansible/module_utils/cloud.py
+++ b/lib/ansible/module_utils/cloud.py
@@ -39,6 +39,8 @@ from functools import wraps
 import syslog
 import time
 
+from pycompat24 import get_exception
+
 
 class CloudRetry(object):
     """ CloudRetry can be used by any cloud provider, in order to implement a
@@ -83,7 +85,8 @@ class CloudRetry(object):
                 while max_tries > 1:
                     try:
                         return f(*args, **kwargs)
-                    except Exception as e:
+                    except Exception:
+                        e = get_exception()
                         if isinstance(e, cls.base_class):
                             response_code = cls.status_code_from_exception(e)
                             if cls.found(response_code):

--- a/lib/ansible/module_utils/cloud.py
+++ b/lib/ansible/module_utils/cloud.py
@@ -24,9 +24,9 @@ module as shown below.
 
 from ansible.module_utils.cloud import *
 
-The 'cloud' module provides the following common argument specs:
+The 'cloud' module provides the following common classes:
 
-    * CloudRetry Class
+    * CloudRetry
         - The base class to be used by other cloud providers, in order to
           provide a backoff/retry decorator based on status codes.
 
@@ -78,7 +78,7 @@ class CloudRetry(object):
         """
         def deco(f):
             @wraps(f)
-            def retry(*args, **kwargs):
+            def retry_func(*args, **kwargs):
                 max_tries, max_delay = tries, delay
                 while max_tries > 1:
                     try:
@@ -100,6 +100,6 @@ class CloudRetry(object):
                             raise e
                 return f(*args, **kwargs)
 
-            return retry  # true decorator
+            return retry_func  # true decorator
 
         return deco

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -27,9 +27,10 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import re
 from time import sleep
 
-from cloud import CloudRetry
+from ansible.module_utils.cloud import CloudRetry
 
 try:
     import boto

--- a/test/units/module_utils/ec2/test_aws.py
+++ b/test/units/module_utils/ec2/test_aws.py
@@ -59,8 +59,11 @@ class RetryTestCase(unittest.TestCase):
             self.counter += 1
             raise botocore.exceptions.ClientError(err_msg, 'toooo fast!!')
 
-        with self.assertRaises(botocore.exceptions.ClientError):
+        #with self.assertRaises(botocore.exceptions.ClientError):
+        try:
             fail()
+        except Exception as e:
+            self.assertEqual(e.response['Error']['Code'], 'RequestLimitExceeded')
         self.assertEqual(self.counter, 4)
 
     def test_unexpected_exception_does_not_retry(self):
@@ -72,8 +75,11 @@ class RetryTestCase(unittest.TestCase):
             self.counter += 1
             raise botocore.exceptions.ClientError(err_msg, 'unexpected error')
 
-        with self.assertRaises(botocore.exceptions.ClientError):
+        #with self.assertRaises(botocore.exceptions.ClientError):
+        try:
             raise_unexpected_error()
+        except Exception as e:
+            self.assertEqual(e.response['Error']['Code'], 'AuthFailure')
 
         self.assertEqual(self.counter, 1)
 

--- a/test/units/module_utils/ec2/test_aws.py
+++ b/test/units/module_utils/ec2/test_aws.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+# (c) 2015, Allen Sanabria <asanabria@linuxdynasty.org>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+import botocore
+
+from ansible.module_utils.ec2 import aws_retry
+
+class RetryTestCase(unittest.TestCase):
+
+    def test_no_failures(self):
+        self.counter = 0
+
+        @aws_retry(tries=2, delay=0.1)
+        def no_failures():
+            self.counter += 1
+
+        r = no_failures()
+        self.assertEqual(self.counter, 1)
+
+    def test_retry_once(self):
+        self.counter = 0
+	err_msg = {'Error': {'Code': 'InstanceId.NotFound'}}
+
+        @aws_retry(tries=2, delay=0.1)
+        def retry_once():
+            self.counter += 1
+            if self.counter < 2:
+                raise botocore.exceptions.ClientError(err_msg, 'Could not find you')
+            else:
+                return 'success'
+
+        r = retry_once()
+        self.assertEqual(r, 'success')
+        self.assertEqual(self.counter, 2)
+
+    def test_reached_limit(self):
+        self.counter = 0
+	err_msg = {'Error': {'Code': 'RequestLimitExceeded'}}
+
+        @aws_retry(tries=4, delay=0.1)
+        def fail():
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_msg, 'toooo fast!!')
+
+        with self.assertRaises(botocore.exceptions.ClientError):
+            fail()
+        self.assertEqual(self.counter, 4)
+
+    def test_unexpected_exception_does_not_retry(self):
+        self.counter = 0
+	err_msg = {'Error': {'Code': 'AuthFailure'}}
+
+        @aws_retry(tries=4, delay=0.1)
+        def raise_unexpected_error():
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_msg, 'unexpected error')
+
+        with self.assertRaises(botocore.exceptions.ClientError):
+            raise_unexpected_error()
+
+        self.assertEqual(self.counter, 1)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/units/module_utils/ec2/test_aws.py
+++ b/test/units/module_utils/ec2/test_aws.py
@@ -19,14 +19,14 @@
 import unittest
 import botocore
 
-from ansible.module_utils.ec2 import aws_retry
+from ansible.module_utils.ec2 import AWSRetry
 
 class RetryTestCase(unittest.TestCase):
 
     def test_no_failures(self):
         self.counter = 0
 
-        @aws_retry(tries=2, delay=0.1)
+        @AWSRetry.retry(tries=2, delay=0.1)
         def no_failures():
             self.counter += 1
 
@@ -37,7 +37,7 @@ class RetryTestCase(unittest.TestCase):
         self.counter = 0
 	err_msg = {'Error': {'Code': 'InstanceId.NotFound'}}
 
-        @aws_retry(tries=2, delay=0.1)
+        @AWSRetry.retry(tries=2, delay=0.1)
         def retry_once():
             self.counter += 1
             if self.counter < 2:
@@ -53,7 +53,7 @@ class RetryTestCase(unittest.TestCase):
         self.counter = 0
 	err_msg = {'Error': {'Code': 'RequestLimitExceeded'}}
 
-        @aws_retry(tries=4, delay=0.1)
+        @AWSRetry.retry(tries=4, delay=0.1)
         def fail():
             self.counter += 1
             raise botocore.exceptions.ClientError(err_msg, 'toooo fast!!')
@@ -66,7 +66,7 @@ class RetryTestCase(unittest.TestCase):
         self.counter = 0
 	err_msg = {'Error': {'Code': 'AuthFailure'}}
 
-        @aws_retry(tries=4, delay=0.1)
+        @AWSRetry.retry(tries=4, delay=0.1)
         def raise_unexpected_error():
             self.counter += 1
             raise botocore.exceptions.ClientError(err_msg, 'unexpected error')

--- a/test/units/module_utils/ec2/test_aws.py
+++ b/test/units/module_utils/ec2/test_aws.py
@@ -18,6 +18,7 @@
 
 import unittest
 import botocore
+import boto3
 
 from ansible.module_utils.ec2 import AWSRetry
 
@@ -35,7 +36,7 @@ class RetryTestCase(unittest.TestCase):
 
     def test_retry_once(self):
         self.counter = 0
-	err_msg = {'Error': {'Code': 'InstanceId.NotFound'}}
+        err_msg = {'Error': {'Code': 'InstanceId.NotFound'}}
 
         @AWSRetry.retry(tries=2, delay=0.1)
         def retry_once():
@@ -51,7 +52,7 @@ class RetryTestCase(unittest.TestCase):
 
     def test_reached_limit(self):
         self.counter = 0
-	err_msg = {'Error': {'Code': 'RequestLimitExceeded'}}
+        err_msg = {'Error': {'Code': 'RequestLimitExceeded'}}
 
         @AWSRetry.retry(tries=4, delay=0.1)
         def fail():
@@ -64,7 +65,7 @@ class RetryTestCase(unittest.TestCase):
 
     def test_unexpected_exception_does_not_retry(self):
         self.counter = 0
-	err_msg = {'Error': {'Code': 'AuthFailure'}}
+        err_msg = {'Error': {'Code': 'AuthFailure'}}
 
         @AWSRetry.retry(tries=4, delay=0.1)
         def raise_unexpected_error():

--- a/test/units/module_utils/ec2/test_aws.py
+++ b/test/units/module_utils/ec2/test_aws.py
@@ -27,7 +27,7 @@ class RetryTestCase(unittest.TestCase):
     def test_no_failures(self):
         self.counter = 0
 
-        @AWSRetry.retry(tries=2, delay=0.1)
+        @AWSRetry.backoff(tries=2, delay=0.1)
         def no_failures():
             self.counter += 1
 
@@ -38,7 +38,7 @@ class RetryTestCase(unittest.TestCase):
         self.counter = 0
         err_msg = {'Error': {'Code': 'InstanceId.NotFound'}}
 
-        @AWSRetry.retry(tries=2, delay=0.1)
+        @AWSRetry.backoff(tries=2, delay=0.1)
         def retry_once():
             self.counter += 1
             if self.counter < 2:
@@ -54,7 +54,7 @@ class RetryTestCase(unittest.TestCase):
         self.counter = 0
         err_msg = {'Error': {'Code': 'RequestLimitExceeded'}}
 
-        @AWSRetry.retry(tries=4, delay=0.1)
+        @AWSRetry.backoff(tries=4, delay=0.1)
         def fail():
             self.counter += 1
             raise botocore.exceptions.ClientError(err_msg, 'toooo fast!!')
@@ -70,7 +70,7 @@ class RetryTestCase(unittest.TestCase):
         self.counter = 0
         err_msg = {'Error': {'Code': 'AuthFailure'}}
 
-        @AWSRetry.retry(tries=4, delay=0.1)
+        @AWSRetry.backoff(tries=4, delay=0.1)
         def raise_unexpected_error():
             self.counter += 1
             raise botocore.exceptions.ClientError(err_msg, 'unexpected error')

--- a/test/utils/shippable/sanity-requirements.txt
+++ b/test/utils/shippable/sanity-requirements.txt
@@ -2,5 +2,3 @@ tox
 pyyaml
 jinja2
 setuptools
-botocore
-boto3

--- a/test/utils/shippable/sanity-requirements.txt
+++ b/test/utils/shippable/sanity-requirements.txt
@@ -2,3 +2,5 @@ tox
 pyyaml
 jinja2
 setuptools
+botocore
+boto3

--- a/test/utils/shippable/sanity.sh
+++ b/test/utils/shippable/sanity.sh
@@ -12,7 +12,7 @@ if [ "${TOXENV}" = 'py24' ]; then
     fi
 
     python2.4 -V
-    python2.4 -m compileall -fq -x 'module_utils/(a10|rax|openstack|ec2|gce|lxd|docker_common|azure_rm_common|vca|vmware|gcp|gcdns).py' lib/ansible/module_utils
+    python2.4 -m compileall -fq -x 'module_utils/(a10|rax|openstack|cloud|ec2|gce|docker_common|azure_rm_common|vca|vmware|gcp|gcdns).py' lib/ansible/module_utils
 else
     if [ "${install_deps}" != "" ]; then
         pip install -r "${source_root}/test/utils/shippable/sanity-requirements.txt" --upgrade

--- a/test/utils/shippable/sanity.sh
+++ b/test/utils/shippable/sanity.sh
@@ -12,7 +12,7 @@ if [ "${TOXENV}" = 'py24' ]; then
     fi
 
     python2.4 -V
-    python2.4 -m compileall -fq -x 'module_utils/(a10|rax|openstack|cloud|ec2|gce|docker_common|azure_rm_common|vca|vmware|gcp|gcdns).py' lib/ansible/module_utils
+    python2.4 -m compileall -fq -x 'module_utils/(a10|rax|openstack|cloud|ec2|gce|lxd|docker_common|azure_rm_common|vca|vmware|gcp|gcdns).py' lib/ansible/module_utils
 else
     if [ "${install_deps}" != "" ]; then
         pip install -r "${source_root}/test/utils/shippable/sanity-requirements.txt" --upgrade

--- a/test/utils/tox/requirements-py3.txt
+++ b/test/utils/tox/requirements-py3.txt
@@ -11,3 +11,5 @@ unittest2
 redis
 python3-memcached
 python-systemd
+botocore
+boto3

--- a/test/utils/tox/requirements.txt
+++ b/test/utils/tox/requirements.txt
@@ -12,3 +12,5 @@ redis
 python-memcached
 python-systemd
 pycrypto
+botocore
+boto3


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

CloudRetry Base class inside of module_utils/cloud.py
AWSRetry decorator inside of module_utils/ec2.py
##### ANSIBLE VERSION

```
ansible 2.1.1.0
```
##### SUMMARY

The CloudRetry class can be implemented by any other cloud provider, that wants to implement a basic backoff algorithm in a decorator.

AWSRetry class overwrites 2 methods.
- status_code_from_exception (Parses the exception for the exact string)
- found (Iterates over a list of exceptions to match against.

AWSRetry.backoff() decorator can be applied to any function that is making an aws boto/boto3 call.
It will only retry on the following Exceptions.
This list of failures is based on this [API Reference](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html).
- RequestLimitExceeded
- Unavailable
- ServiceUnavailable
- InternalFailure
- InternalError
- "\w+.NotFound" (Eventual Consistency) 

The CloudRetry.backoff decorator takes on the following kwargs.
- tries (number of times to try) default=10
- delay (initial delay between retries in seconds) default=3
- backoff (This is the multiplier, that will double on each retry) default=2

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/17039)

<!-- Reviewable:end -->
