### PR TITLE
Try to avoid module-related tickets in the core Ansible project

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,13 @@
-<!--- Verify first that your issue/request is not already reported in GitHub -->
+<!---
+Please do not report issues/requests related to Ansible modules here !!
+
+Report them to the appropriate modules-core or modules-extras project:
+  - https://github.com/ansible/ansible-modules-core/issues
+  - https://github.com/ansible/ansible-modules-extras/issues
+
+Also verify first that your issue/request is not already reported in GitHub
+-->
+
 
 ##### ISSUE TYPE
 <!--- Pick one below and delete the rest: -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -16,7 +16,7 @@ Also verify first that your issue/request is not already reported in GitHub
  - Documentation Report
 
 ##### COMPONENT NAME
-<!--- Name of the plugin/module/task -->
+<!--- Name of the plugin/task/feature -->
 
 ##### ANSIBLE VERSION
 <!--- Paste verbatim output from “ansible --version” between quotes below -->


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Since most users still report module-related problems in the Ansible core GitHub project, I added a warning at the top of the template.

Maybe it could help if the various projects would have more specific names ?
- ansible/ansible  ->  ansible/main (or something even better ?)
- ansible/ansible-modules-core  ->  ansible/modules-core
- ansible/ansible-modules-extras  ->  ansible/modules-extras

I am sure someone can come up with perfect, yet short names ;-)
