### PR TITLE
Add missing version_added

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/ios.py
+++ b/lib/ansible/utils/module_docs_fragments/ios.py
@@ -97,6 +97,7 @@ options:
         without first checking if already configured.
     required: false
     default: false
+    version_added: "2.2"
     choices: ['yes', 'no']
   running_config:
     description:
@@ -109,6 +110,7 @@ options:
         config for comparision.
     required: false
     default: null
+    version_added: "2.2"
     aliases: ['config']
   save_config:
     description:
@@ -117,5 +119,6 @@ options:
         persistent if the device is restarted.
     required: false
     default: null
+    version_added: "2.2"
     aliases: ['save']
 """


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

ios_*
##### ANSIBLE VERSION

devel
##### SUMMARY

A number of new arguments were added in
https://github.com/ansible/ansible/commit/637bbdadfa6cc73c7bca4e30836b120f617cee0a#diff-60710cdc60751ecd19968b01b98283a0
but missed `version_added`

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/17050)

<!-- Reviewable:end -->
