### PR TITLE
adding use_floatingip arg to openstack inventory script to allow sett…

### DIFF
--- a/contrib/inventory/openstack.py
+++ b/contrib/inventory/openstack.py
@@ -4,6 +4,7 @@
 # Copyright (c) 2013, Jesse Keating <jesse.keating@rackspace.com>
 # Copyright (c) 2015, Hewlett-Packard Development Company, L.P.
 # Copyright (c) 2016, Rackspace Australia
+# Copyright (c) 2016, Hugh Ma <hugh.ma@flextronics.com>
 #
 # This module is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/contrib/inventory/openstack.yml
+++ b/contrib/inventory/openstack.yml
@@ -30,3 +30,4 @@ ansible:
   use_hostnames: True
   expand_hostvars: False
   fail_on_errors: True
+  use_floatingip: False


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

Openstack Inventory Script
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

The current OpenStack dynamic inventory script does not appear to have a way to force the usage of assigning instances' floating ip as the ansible_ssh_host address. It only takes whatever the _public_v4_ key in the server object is and uses that. This change will allow the user to specify an inventory variable to ensure the usage of a floating ip if it exists. It also does it in a manner which will allow future similar implementations with other parts of hostvars. 

<!-- Paste verbatim command output below, e.g. before and after your change -->

Before:

```
"CiiiVM8": {
        "ansible_ssh_host": "192.168.111.21",
        "openstack": {
          "HUMAN_ID": true,
          "NAME_ATTR": "name",
          "OS-DCF:diskConfig": "MANUAL",
          "OS-EXT-AZ:availability_zone": "nova",
          "OS-EXT-SRV-ATTR:host": "node-9.domain.tld",
          "OS-EXT-SRV-ATTR:hypervisor_hostname": "node-9.domain.tld",
          "OS-EXT-SRV-ATTR:instance_name": "instance-00000088",
          "OS-EXT-STS:power_state": 1,
          "OS-EXT-STS:task_state": null,
          "OS-EXT-STS:vm_state": "active",
          "OS-SRV-USG:launched_at": "2016-08-03T17:06:33.000000",
          "OS-SRV-USG:terminated_at": null,
          "accessIPv4": "192.168.111.21",
          "accessIPv6": "",
          "addresses": {
            "admin_internal_net": [
              {
                "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:95:85:60",
                "OS-EXT-IPS:type": "fixed",
                "addr": "192.168.111.21",
                "version": 4
              },
              {
                "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:95:85:60",
                "OS-EXT-IPS:type": "floating",
                "addr": "10.118.124.61",
                "version": 4
              }
            ]
          },
          "az": "nova",
          "cloud": "rack2f9",
          "config_drive": "True",
          "created": "2016-08-03T17:06:23Z",
          "flavor": {
            "id": "2"
          },
          "hostId": "67d3e9cc79a089b49291836f223b3d91108d9cd49e9992392b0e10ac",
          "human_id": "ciiivm8",
          "id": "97bc0f6f-5c24-4206-8a51-fa197f7d343d",
          "image": {
            "id": "058a5139-ed77-47c9-a031-a9b8bed6c5dc"
          },
          "interface_ip": "192.168.111.21",
          "key_name": "hught",
          "metadata": {
            "group": "client",
            "hostname": "CiiiVM8"
          },
          "name": "CiiiVM8",
          "networks": {
            "admin_internal_net": [
              "192.168.111.21",
              "10.118.124.61"
            ]
          },
          "os-extended-volumes:volumes_attached": [],
          "private_v4": "",
          "progress": 0,
          "public_v4": "192.168.111.21",
          "public_v6": "",
          "region": "",
          "request_ids": [],
          "security_groups": [
            {
              "name": "automata"
            }
          ],
          "status": "ACTIVE",
          "tenant_id": "870adc072e3240ec9733740eea5c2473",
          "updated": "2016-08-03T17:06:34Z",
          "user_id": "3c6d9ba4a20a4255aa5fd6b137ad5fcd",
          "volumes": [],
          "x_openstack_request_ids": []
        }
      },
```

After:

```
"CiiiVM8": {
        "ansible_ssh_host": "10.118.124.61",
        "openstack": {
          "HUMAN_ID": true,
          "NAME_ATTR": "name",
          "OS-DCF:diskConfig": "MANUAL",
          "OS-EXT-AZ:availability_zone": "nova",
          "OS-EXT-SRV-ATTR:host": "node-9.domain.tld",
          "OS-EXT-SRV-ATTR:hypervisor_hostname": "node-9.domain.tld",
          "OS-EXT-SRV-ATTR:instance_name": "instance-00000088",
          "OS-EXT-STS:power_state": 1,
          "OS-EXT-STS:task_state": null,
          "OS-EXT-STS:vm_state": "active",
          "OS-SRV-USG:launched_at": "2016-08-03T17:06:33.000000",
          "OS-SRV-USG:terminated_at": null,
          "accessIPv4": "192.168.111.21",
          "accessIPv6": "",
          "addresses": {
            "admin_internal_net": [
              {
                "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:95:85:60",
                "OS-EXT-IPS:type": "fixed",
                "addr": "192.168.111.21",
                "version": 4
              },
              {
                "OS-EXT-IPS-MAC:mac_addr": "fa:16:3e:95:85:60",
                "OS-EXT-IPS:type": "floating",
                "addr": "10.118.124.61",
                "version": 4
              }
            ]
          },
          "az": "nova",
          "cloud": "rack2f9",
          "config_drive": "True",
          "created": "2016-08-03T17:06:23Z",
          "flavor": {
            "id": "2"
          },
          "hostId": "67d3e9cc79a089b49291836f223b3d91108d9cd49e9992392b0e10ac",
          "human_id": "ciiivm8",
          "id": "97bc0f6f-5c24-4206-8a51-fa197f7d343d",
          "image": {
            "id": "058a5139-ed77-47c9-a031-a9b8bed6c5dc"
          },
          "interface_ip": "192.168.111.21",
          "key_name": "hught",
          "metadata": {
            "group": "client",
            "hostname": "CiiiVM8"
          },
          "name": "CiiiVM8",
          "networks": {
            "admin_internal_net": [
              "192.168.111.21",
              "10.118.124.61"
            ]
          },
          "os-extended-volumes:volumes_attached": [],
          "private_v4": "",
          "progress": 0,
          "public_v4": "192.168.111.21",
          "public_v6": "",
          "region": "",
          "request_ids": [],
          "security_groups": [
            {
              "name": "automata"
            }
          ],
          "status": "ACTIVE",
          "tenant_id": "870adc072e3240ec9733740eea5c2473",
          "updated": "2016-08-03T17:06:34Z",
          "user_id": "3c6d9ba4a20a4255aa5fd6b137ad5fcd",
          "volumes": [],
          "x_openstack_request_ids": []
        }
      },
```

…ing ansible_ssh_host with floating ip instead of the private
