### PR TITLE
Restore previous behavior of with_fileglob ignoring missing files

### DIFF
--- a/lib/ansible/plugins/lookup/fileglob.py
+++ b/lib/ansible/plugins/lookup/fileglob.py
@@ -21,6 +21,7 @@ import os
 import glob
 
 from ansible.plugins.lookup import LookupBase
+from ansible.errors import AnsibleFileNotFound
 
 class LookupModule(LookupBase):
 
@@ -29,7 +30,11 @@ class LookupModule(LookupBase):
         ret = []
         for term in terms:
             term_file = os.path.basename(term)
-            dwimmed_path = self.find_file_in_search_path(variables, 'files', os.path.dirname(term))
-            globbed = glob.glob(os.path.join(dwimmed_path, term_file))
-            ret.extend(g for g in globbed if os.path.isfile(g))
+            try:
+                dwimmed_path = self.find_file_in_search_path(variables, 'files', os.path.dirname(term))
+            except AnsibleFileNotFound:
+                dwimmed_path = None
+            if dwimmed_path:
+                globbed = glob.glob(os.path.join(dwimmed_path, term_file))
+                ret.extend(g for g in globbed if os.path.isfile(g))
         return ret


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

fileglob lookup
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.2
```
##### SUMMARY

Fixes #16801
