### PR TITLE
tweak hacking/env-setup to work under ash

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -16,9 +16,9 @@ if [ -n "$BASH_SOURCE" ] ; then
     HACKING_DIR=$(dirname "$BASH_SOURCE")
 elif [ $(basename -- "$0") = "env-setup" ]; then
     HACKING_DIR=$(dirname "$0")
-# Works with ksh93 but not pdksh
+# Works with ksh93 but not pdksh, have to eval to keep ash happy...
 elif [ -n "$KSH_VERSION" ] && echo $KSH_VERSION | grep -qv '^@(#)PD KSH'; then
-    HACKING_DIR=$(dirname "${.sh.file}")
+    eval "HACKING_DIR=\$(dirname \"\${.sh.file}\")"
 else
     HACKING_DIR="$PWD/hacking"
 fi


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

hacking/env-setup
##### SUMMARY

ash's parser barfs on ksh shell vars even when they're not being exec'd; wrapped that in an eval to keep it happy...
