### PR TITLE
Include last message from module on retry failure

### DIFF
--- a/docsite/rst/playbooks_loops.rst
+++ b/docsite/rst/playbooks_loops.rst
@@ -238,7 +238,8 @@ Sometimes you would want to retry a task until a certain condition is met.  Here
 The above example run the shell module recursively till the module's result has "all systems go" in its stdout or the task has
 been retried for 5 times with a delay of 10 seconds. The default value for "retries" is 3 and "delay" is 5.
 
-The task returns the results returned by the last task run. The results of individual retries can be viewed by -vv option.
+The task returns the results returned by the last task run, including the last 'msg' saved as 'last_msg'.
+The results of individual retries can be viewed by -vv option.
 The registered variable will also have a new key "attempts" which will have the number of the retries for the task.
 
 .. _with_first_found:

--- a/lib/ansible/runner/__init__.py
+++ b/lib/ansible/runner/__init__.py
@@ -1063,6 +1063,7 @@ class Runner(object):
                     if utils.check_conditional(cond, self.basedir, inject, fail_on_undefined=self.error_on_undefined_vars):
                         break
                 if result.result['attempts'] == retries and not utils.check_conditional(cond, self.basedir, inject, fail_on_undefined=self.error_on_undefined_vars):
+                    result.result['last_msg'] = result.result['msg']
                     result.result['failed'] = True
                     result.result['msg'] = "Task failed as maximum retries was encountered"
             else:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

runner
##### ANSIBLE VERSION

```
ansible 1.9.6
  configured module search path = None
```
##### SUMMARY

Preserve the last "msg" from the module executed when failure results
in the retry limit exceeded. This fixes the code to work as documented
where it is currently stated 'The task returns the results returned by
the last task run', but in reality this is incorrect as 'msg' is
overridden, thus hiding part of the result from the last run.

When using `retry` and `until`, upon max attempts being reached,
ansible will replace the 'msg' value returned from the executed module
with a simple message of:

  Task failed as maximum retries was encountered

This hides any messages returned from the module leaving the user non
the wiser as to the underlying cause. While it may be possible to
increase the verbosity to see each execution, for larger playbooks this
causes so much info to be printed, that it becomes problematic viewing
results from such output.

Inline with expectations based on the documentation, this change
preserves the last message returned by the module to be included in
what is displayed to the user using 'last_msg'.

It uses 'last_msg' to avoid unintentional regressions where users are expecting to only see the message:

> msg: Task failed as maximum retries was encountered

Fixes: #17059

Example playbook

```
- hosts: localhost
  connection: local
  gather_facts: False
  tasks:
    - pip:
        name: pip wheel virtualenv
        virtualenv: ~/tmp/test-virtualenv
        state: present
        extra_args: >
          --upgrade
          --timeout 30
          --invalid-arg
      register: _test_retries_virtualenv_result
      until: _test_retries_virtualenv_result|success
      retries: 3
      delay: 1
```

Before:

```
PLAY [localhost] ************************************************************** 

TASK: [pip ] ****************************************************************** 
failed: [localhost] => {"attempts": 3, "cmd": "/home/<user>/tmp/test-virtualenv/bin/pip install --upgrade 
--timeout 30 --invalid-arg\n pip wheel virtualenv", "failed": true}
msg: Task failed as maximum retries was encountered

FATAL: all hosts have already failed -- aborting

PLAY RECAP ******************************************************************** 
pip  -------------------------------------------------------------------- 4.21s
-------------------------------------------------------------------------------
Total: ------------------------------------------------------------------ 4.24s
           to retry, use: --limit @/home/<user>/test-virtualenv.retry

localhost                  : ok=0    changed=0    unreachable=0    failed=1
```

After:

```
PLAY [localhost] ************************************************************** 

TASK: [pip ] ****************************************************************** 
failed: [localhost] => {"attempts": 3, "cmd": "/home/<user>/tmp/test-virtualenv/bin/pip install --upgrade 
--timeout 30 --invalid-arg\n pip wheel virtualenv", "failed": true, "last_msg": "\n:stderr: \nUsage:   \n  
pip install [options] <requirement specifier> [package-index-options] ...\n  pip install [options] -r 
<requirements file> [package-index-options] ...\n  pip install [options] [-e] <vcs project url> ...\n  pip 
install [options] [-e] <local project path> ...\n  pip install [options] <archive url/path> ...\n\nno such 
option: --invalid-arg\n"}
msg: Task failed as maximum retries was encountered

FATAL: all hosts have already failed -- aborting

PLAY RECAP ******************************************************************** 
pip  -------------------------------------------------------------------- 4.22s
-------------------------------------------------------------------------------
Total: ------------------------------------------------------------------ 4.28s
           to retry, use: --limit @/home/<user>/test-virtualenv.retry

localhost                  : ok=0    changed=0    unreachable=0    failed=1
```
