### PR TITLE
Revert to the default behavior of combining/returning group/hostvars

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -185,6 +185,8 @@ DEFAULT_LOG_PATH          = get_config(p, DEFAULTS, 'log_path',           'ANSIB
 DEFAULT_FORCE_HANDLERS    = get_config(p, DEFAULTS, 'force_handlers', 'ANSIBLE_FORCE_HANDLERS', False, boolean=True)
 DEFAULT_INVENTORY_IGNORE  = get_config(p, DEFAULTS, 'inventory_ignore_extensions', 'ANSIBLE_INVENTORY_IGNORE', ["~", ".orig", ".bak", ".ini", ".cfg", ".retry", ".pyc", ".pyo"], islist=True)
 DEFAULT_VAR_COMPRESSION_LEVEL = get_config(p, DEFAULTS, 'var_compression_level', 'ANSIBLE_VAR_COMPRESSION_LEVEL', 0, integer=True)
+DEFAULT_GROUP_VAR_COMBINE = get_config(p, DEFAULTS, 'group_var_combine', 'ANSIBLE_GROUP_VAR_COMBINE', True, boolean=True)
+DEFAULT_HOST_VAR_COMBINE  = get_config(p, DEFAULTS, 'host_var_combine', 'ANSIBLE_HOST_VAR_COMBINE', True, boolean=True)
 
 # static includes
 DEFAULT_TASK_INCLUDES_STATIC    = get_config(p, DEFAULTS, 'task_includes_static', 'ANSIBLE_TASK_INCLUDES_STATIC', False, boolean=True)

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -740,11 +740,11 @@ class Inventory(object):
             self._vars_per_host = {}
             self._vars_per_group = {}
 
-    def get_host_vars(self, host, new_pb_basedir=False, return_results=False):
+    def get_host_vars(self, host, new_pb_basedir=False, return_results=C.DEFAULT_HOST_VAR_COMBINE):
         """ Read host_vars/ files """
         return self._get_hostgroup_vars(host=host, group=None, new_pb_basedir=new_pb_basedir, return_results=return_results)
 
-    def get_group_vars(self, group, new_pb_basedir=False, return_results=False):
+    def get_group_vars(self, group, new_pb_basedir=False, return_results=C.DEFAULT_GROUP_VAR_COMBINE):
         """ Read group_vars/ files """
         return self._get_hostgroup_vars(host=None, group=group, new_pb_basedir=new_pb_basedir, return_results=return_results)
 
@@ -768,7 +768,7 @@ class Inventory(object):
             found_vars = set(os.listdir(to_unicode(path)))
         return found_vars
 
-    def _get_hostgroup_vars(self, host=None, group=None, new_pb_basedir=False, return_results=False):
+    def _get_hostgroup_vars(self, host=None, group=None, new_pb_basedir=False, return_results=C.DEFAULT_HOST_VAR_COMBINE):
         """
         Loads variables from group_vars/<groupname> and host_vars/<hostname> in directories parallel
         to the inventory base directory or in the same directory as the playbook.  Variables in the playbook


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

`ansible.inventory.Inventory` group and host var combining
##### ANSIBLE VERSION

```
ansible 2.2.0 (var_combine_fix 50b789b950) last updated 2016/08/12 11:26:36 (GMT -500)
  lib/ansible/modules/core: (detached HEAD a216ef210b) last updated 2016/08/11 19:17:25 (GMT -500)
  lib/ansible/modules/extras: (detached HEAD 39153ea154) last updated 2016/08/11 19:17:53 (GMT -500)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY
#16779 changes the internal API to prevent host and group vars being combined and returned by the `Inventory` class.   This greatly affects `vars_plugins` functionality by not setting combined host and group vars on their respective `Host` and `Group` objects.   Because of this, vars plugins no longer have access to these vars and can no longer change them from the context of a plugin.  Additionally, the inventory object passed to the vars plugin has itself not been changed due to order of operations, there is no access to current vars, compounding the problem presented by this #16779.

This new behavior has broken some of my team's prod vars plugins. I feel that this kind of internal API change perhaps is better suited for a major (or even minor) release.  

This PR reverts the default behavior to its previous default of combining vars, with the option of changing the behavior to prevent the "expensive" combine operation via configuration.

Please consider cherry-picking this change to the 2.x stable release to remediate the changed behavior.
