### PR TITLE
Fix named include handler (#15915)

### DIFF
--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -192,6 +192,10 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                             return []
                         elif not isinstance(data, list):
                             raise AnsibleError("included task files must contain a list of tasks", obj=data)
+                        else:
+                            if t.name:
+                                for mapping in data:
+                                    mapping['name'] = t.name
 
                         # since we can't send callbacks here, we display a message directly in
                         # the same fashion used by the on_include callback. We also do it here,

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -193,7 +193,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                         elif not isinstance(data, list):
                             raise AnsibleError("included task files must contain a list of tasks", obj=data)
                         else:
-                            if t.name:
+                            if isinstance(t, HandlerTaskInclude) and t.name:
                                 for mapping in data:
                                     mapping['name'] = t.name
 

--- a/test/integration/roles/test_includes/handlers/main.yml
+++ b/test/integration/roles/test_includes/handlers/main.yml
@@ -1,2 +1,4 @@
 - include: more_handlers.yml
 
+- name: named_include_handler
+  include: more_handlers.yml

--- a/test/integration/roles/test_includes/tasks/main.yml
+++ b/test/integration/roles/test_includes/tasks/main.yml
@@ -80,5 +80,5 @@
     # both these via a handler include
     - included_handler
     - verify_handler
-
+    - named_include_handler
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

playbook/helpers.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

and

```
ansible 2.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

This fixes #15915, which is that static named includes as handlers don't work.
I have added a failing test as the [first commit](fac59ef86140a29f8bf6b4d421d4345adfe2ac2e).
This is because the name of the include is ignored when the included tasks are loaded.
Instead I am adding the name (given to the included task) to each named include task.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

before: 

```
TASK [test_includes : test handlers with includes] *****************************
ERROR! The requested handler 'named_include_handler' was not found in any of the known handlers
make: *** [includes] Error 1
```

after

```
RUNNING HANDLER [test_includes : named_include_handler] ************************
ok: [testhost]
```
