### PR TITLE
Fix issue with proxy setting leaving temp files

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -631,6 +631,13 @@ class SSLValidationHandler(urllib2.BaseHandler):
         use_proxy = self.detect_no_proxy(req.get_full_url())
 
         if not use_proxy:
+            try:
+                # cleanup the temp file created, don't worry
+                # if it fails for some reason
+                os.remove(tmp_ca_cert_path)
+            except:
+                pass
+            
             # ignore proxy settings for this host request
             return req
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

module_utils/urls.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
```
##### SUMMARY

For sites that use a proxy server, often a no_proxy environment variable is used in Linux. This can be used to exclude local hosts from having to use the proxy. In our case, we have a local proxy and often connect via HTTPS to a Splunk server for Ansible playbooks. We found that Ansible was leaving a bunch of temp files around when connecting to this server. We discovered that urls.py was not removing the temp files when it discovered that the no_proxy variable was set to the current URL.

This small patch fixes that issue by removing the temp file.
