### PR TITLE
Update junos docs fragment to note the default port for transport=netconf

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/junos.py
+++ b/lib/ansible/utils/module_docs_fragments/junos.py
@@ -32,7 +32,7 @@ options:
     description:
       - Specifies the port to use when buiding the connection to the remote
         device.  The port value will default to the well known SSH port
-        of 22
+        of 22 (for C(transport=cli)) or port 830 (for C(transport=netconf))
     required: false
     default: 22
   username:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

junos_command (and related modules)
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
```
##### SUMMARY

The `junos` docs snippet shows that the default value for the `port` parameter is `22`. However, this is only true with `transport=cli`, which is only valid for the `junos_netconf` module. Otherwise, the default port is `830` with `transport=netconf`.
