### PR TITLE
Note that to_nice_yaml(indent=X) was new in 2.2

### DIFF
--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -27,7 +27,7 @@ For human readable output, you can use::
     {{ some_variable | to_nice_json }}
     {{ some_variable | to_nice_yaml }}
 
-It's also possible to change the indentation of both::
+It's also possible to change the indentation of both (new in version 2.2)::
 
     {{ some_variable | to_nice_json(indent=2) }}
     {{ some_variable | to_nice_yaml(indent=8) }}


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

to_nice_yaml filter
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

N/A
##### SUMMARY

The ability to pass indent parameter to to_nice_yaml was introduced in 2.2, but this is not noted in the docs.
