### PR TITLE
implement module params deprecation warnings

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -710,8 +710,11 @@ class AnsibleModule(object):
         self.no_log_values = set()
         # Use the argspec to determine which args are no_log
         for arg_name, arg_opts in self.argument_spec.items():
-            if arg_opts.get('deprecated', False) and arg_name in self.params:
-                self._deprecated_param_warnings.append("Param '%s' is deprecated. See the module docs for more information" % arg_name)
+            if arg_opts.get('deprecated_version') is not None and arg_name in self.params:
+                self._deprecated_param_warnings.append({
+                    'msg': "Param '%s' is deprecated. See the module docs for more information" % arg_name,
+                    'version': arg_opts.get('deprecated_version'),
+                })
 
             if arg_opts.get('no_log', False):
                 # Find the value for the no_log'd param
@@ -1896,6 +1899,7 @@ class AnsibleModule(object):
             elif not isinstance(kwargs['deprecation_warnings'], list):
                 kwargs['deprecation_warnings'] = [kwargs['deprecation_warnings']]
             kwargs['deprecation_warnings'].extend(self._deprecated_param_warnings)
+            del self._deprecated_param_warnings
         return kwargs
 
     def exit_json(self, **kwargs):

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -101,6 +101,9 @@ class CallbackBase:
         if C.COMMAND_WARNINGS and 'warnings' in res and res['warnings']:
             for warning in res['warnings']:
                 self._display.warning(warning)
+        if 'deprecation_warnings' in res and res['deprecation_warnings']:
+            for warning in res['deprecation_warnings']:
+                self._display.deprecated(msg=warning)
 
     def _get_diff(self, difflist):
 

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -103,7 +103,8 @@ class CallbackBase:
                 self._display.warning(warning)
         if 'deprecation_warnings' in res and res['deprecation_warnings']:
             for warning in res['deprecation_warnings']:
-                self._display.deprecated(msg=warning)
+                self._display.deprecated(msg=warning.get('msg',''), version=warning.get('version'))
+            del res['deprecation_warnings']
 
     def _get_diff(self, difflist):
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

module_utils
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.3
```
##### SUMMARY

implemented a simple way to deprecate a module param by adding `deprecated_version=2.4` 

Test module
~~~python
#!/usr/bin/python

from ansible.module_utils.basic import *
def main():
    module = AnsibleModule(dict(
        foo=dict(deprecated_version=2.4),
        )
    )
    module.exit_json(msg="ok")

if __name__ == '__main__':
    main()
~~~

output:
~~~
 $ ansible-playbook test.yml
 [WARNING]: Host file not found: /etc/ansible/hosts

 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [localhost] ******************************************************************************************************************************************************************************************************************************

TASK [foobar] *********************************************************************************************************************************************************************************************************************************
ok: [localhost]
[DEPRECATION WARNING]: Param 'foo' is deprecated. See the module docs for more information.
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

PLAY RECAP ************************************************************************************************************************************************************************************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0   
~~~