### PR TITLE
force deletion of .pyc files

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -57,10 +57,10 @@ fi
 	cd "$ANSIBLE_HOME"
 	if [ "$verbosity" = silent ] ; then
 	    gen_egg_info > /dev/null 2>&1
-            find . -type f -name "*.pyc" -exec rm {} \; > /dev/null 2>&1
+            find . -type f -name "*.pyc" -exec rm -f {} \; > /dev/null 2>&1
 	else
 	    gen_egg_info
-            find . -type f -name "*.pyc" -exec rm {} \;
+            find . -type f -name "*.pyc" -exec rm -f {} \;
 	fi
 	cd "$current_dir"
 )


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

hacking/env-setup
##### ANSIBLE VERSION

```
ansible 2.2.0 (rm-dash-f-pyc-files 0d71b33f12) last updated 2016/08/16 16:18:14 (GMT -400)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras:  not found - use git submodule update --init lib/ansible/modules/extras
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

hacking/env-setup removes .pyc files, but if you sometimes run Ansible as root and sometimes run as non-root users, you'll end up with .pyc files created as root, which the non-root users can't remove. That's actually fine, but a plain 'rm' asks prompts the non-root if they really want to remove the files. Adding a '-f' causes it to silently fail to remove the files.

(This is substantially similar to https://github.com/ansible/ansible/commit/4a206cdde9e648b00bf89ad9408a1984969379f1, which fixed an earlier instance of this problem.)
