### PR TITLE
Update the ec2.py inventory script to set ansible_host as well as ansible_ssh_host

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -999,7 +999,7 @@ class Ec2Inventory(object):
         self.push(self.inventory, 'ec2', hostname)
 
         self.inventory["_meta"]["hostvars"][hostname] = self.get_host_info_dict_from_instance(instance)
-        self.inventory["_meta"]["hostvars"][hostname]['ansible_ssh_host'] = dest
+        self.inventory["_meta"]["hostvars"][hostname]['ansible_host'] = dest
 
     def add_rds_instance(self, instance, region):
         ''' Adds an RDS instance to the inventory and index, as long as it is
@@ -1096,7 +1096,7 @@ class Ec2Inventory(object):
         self.push(self.inventory, 'rds', hostname)
 
         self.inventory["_meta"]["hostvars"][hostname] = self.get_host_info_dict_from_instance(instance)
-        self.inventory["_meta"]["hostvars"][hostname]['ansible_ssh_host'] = dest
+        self.inventory["_meta"]["hostvars"][hostname]['ansible_host'] = dest
 
     def add_elasticache_cluster(self, cluster, region):
         ''' Adds an ElastiCache cluster to the inventory and index, as long as


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

contrib/inventory/ec2.py
##### ANSIBLE VERSION

```
ansible 2.2.0 (inventory-ec2-py-ansible-host 118d7957b4) last updated 2016/08/16 21:17:54 (GMT -400)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras:  not found - use git submodule update --init lib/ansible/modules/extras
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

contrib/inventory/ec2.py sets ansible_ssh_host, but http://docs.ansible.com/ansible/intro_inventory.html#hosts-and-groups says

> Ansible 2.0 has deprecated the "ssh" from ansible_ssh_user, ansible_ssh_host, and ansible_ssh_port to become ansible_user, ansible_host, and ansible_port.

Since the ansible_ssh_\* variables aren't removed, just deprecated, this commit simply adds ansible_host to the variables set by ec2.py.

May address some (but probably not all) of #15286.
