### PR TITLE
Added Dell Networking Modules to the Roadmap

### DIFF
--- a/docsite/rst/roadmap/ROADMAP_2_2.rst
+++ b/docsite/rst/roadmap/ROADMAP_2_2.rst
@@ -84,6 +84,7 @@ Target: September 2016
   - Quagga modules 
   - Bird modules (stretch)
   - GoBGP modules (stretch)
+  - Support for Dell Networking operating systems (OS9, OS6, OS10)
 
 - **Implement ‘role revamp’ proposal to give users more control on role/task execution (Brian) **
 


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

ansible-modules-core/network/dell
##### ANSIBLE VERSION

2.2
##### SUMMARY

 Support for Dell Networking operating systems (OS9, OS6, OS10)
