### PR TITLE
Relative ansible cfg lookup

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -107,16 +107,30 @@ def load_config_file():
 
     p = configparser.ConfigParser()
 
+    path_list = []
+
+    # Get config file location from ENV
     path0 = os.getenv("ANSIBLE_CONFIG", None)
     if path0 is not None:
         path0 = os.path.expanduser(path0)
         if os.path.isdir(path0):
             path0 += "/ansible.cfg"
-    path1 = os.getcwd() + "/ansible.cfg"
-    path2 = os.path.expanduser("~/.ansible.cfg")
-    path3 = "/etc/ansible/ansible.cfg"
+    path_list.append(path0)
 
-    for path in [path0, path1, path2, path3]:
+    # Get config file location from CWD
+    # FIXME: Needs deprecation? See: https://github.com/ansible/ansible/issues/11175#issuecomment-109386699
+    path1 = os.getcwd() + "/ansible.cfg"
+    path_list.append(path1)
+
+    # Get config for HOME
+    path2 = os.path.expanduser("~/.ansible.cfg")
+    path_list.append(path2)
+
+    # Get config from /etc/ansible
+    path3 = "/etc/ansible/ansible.cfg"
+    path_list.append(path3)
+
+    for path in path_list:
         if path is not None and os.path.exists(path):
             try:
                 p.read(path)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request #11175 
##### COMPONENT NAME

constants.py / locating config
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 30268f6bd0) last updated 2016/08/16 09:26:05 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 45c1ae0ac1) last updated 2016/08/16 09:27:13 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD a6b34973a8) last updated 2016/08/16 09:27:30 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes #11175 allowing to traverse from playbook file location towards the root in order to find ansible.cfg
