### PR TITLE
actions/unarchive: fix unarchive from remote url

### DIFF
--- a/lib/ansible/plugins/action/unarchive.py
+++ b/lib/ansible/plugins/action/unarchive.py
@@ -38,8 +38,19 @@ class ActionModule(ActionBase):
 
         source  = self._task.args.get('src', None)
         dest    = self._task.args.get('dest', None)
-        copy    = boolean(self._task.args.get('copy', True))
+        remote_src = boolean(self._task.args.get('remote_src', False))
         creates = self._task.args.get('creates', None)
+
+        # "copy" is deprecated in favor of "remote_src".
+        if 'copy' in self._task.args:
+            # They are mutually exclusive.
+            if 'remote_src' in self._task.args:
+                result['failed'] = True
+                result['msg'] = "parameters are mutually exclusive: ('copy', 'remote_src')"
+                return result
+            # We will take the information from copy and store it in
+            # the remote_src var to use later in this file.
+            remote_src = not boolean(self._task.args.get('copy'))
 
         if source is None or dest is None:
             result['failed'] = True
@@ -66,7 +77,7 @@ class ActionModule(ActionBase):
         dest = self._remote_expand_user(dest) # CCTODO: Fix path for Windows hosts.
         source = os.path.expanduser(source)
 
-        if copy:
+        if not remote_src:
             try:
                 source = self._loader.get_real_file(self._find_needle('files', source))
             except AnsibleError as e:
@@ -87,7 +98,7 @@ class ActionModule(ActionBase):
             self._remove_tmp_path(tmp)
             return result
 
-        if copy:
+        if not remote_src:
             # transfer the file to a remote tmp location
             tmp_src = self._connection._shell.join_path(tmp, 'source')
             self._transfer_file(source, tmp_src)
@@ -95,7 +106,7 @@ class ActionModule(ActionBase):
         # handle diff mode client side
         # handle check mode client side
 
-        if copy:
+        if not remote_src:
             # fix file permissions when the copy is done as a different user
             self._fixup_perms((tmp, tmp_src), remote_user)
             # Build temporary module_args.

--- a/test/integration/roles/test_unarchive/tasks/main.yml
+++ b/test/integration/roles/test_unarchive/tasks/main.yml
@@ -299,7 +299,7 @@
     src: "test-unarchive-nonascii-くらとみ.tar.gz"
     dest: "{{ output_dir }}/test-unarchive-nonascii-くらとみ-tar-gz"
     mode: "u+rwX,go+rX"
-    remote_src: yes
+    remote_src: no
   register: nonascii_result0
 
 - name: Check that file is really there


### PR DESCRIPTION
Currently unarchive from remote url does not work because the core
unarchive module was updated to support 'remote_src' [1], but the
unarchive action plugin was not updated for this. This causes failures
because the action plugin assumes it needs to copy a file to the
remote server, but in the case of downloading a file from a remote
url a local file does not exist, so an error occurs when the file is
not found.

[1] https://github.com/ansible/ansible-modules-core/commit/467516e
