### PR TITLE
[DOC FIX] Time Limited Background Operations topic styles

### DIFF
--- a/docsite/rst/intro_adhoc.rst
+++ b/docsite/rst/intro_adhoc.rst
@@ -224,9 +224,9 @@ Time Limited Background Operations
 ``````````````````````````````````
 
 Long running operations can be run in the background, and it is possible to
-check their status later. For example, to execute ``long_running_operation`
+check their status later. For example, to execute ``long_running_operation``
 asynchronously in the background, with a timeout of 3600 seconds (``-B``), 
-and without polling (-P)::
+and without polling (``-P``)::
 
     $ ansible all -B 3600 -P 0 -a "/usr/bin/long_running_operation --do-stuff"
 


### PR DESCRIPTION
The docs styles are leaking on page , **"Time Limited Background Operations"** by not closing the "coding" part on the right place
