### PR TITLE
become_method: Add support for ksu

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -552,6 +552,10 @@ class PlayContext(Base):
 
                 becomecmd = '%s -u %s %s' % (exe, self.become_user, command)
 
+            elif self.become_method == 'ksu':
+                becomecmd = 'ksu %s -q -e %s' % (self.become_user, command)
+                self.become_pass = None
+
             else:
                 raise AnsibleError("Privilege escalation method not found: %s" % self.become_method)
 

--- a/test/units/playbook/test_play_context.py
+++ b/test/units/playbook/test_play_context.py
@@ -132,6 +132,7 @@ class TestPlayContext(unittest.TestCase):
         doas_exe    = 'doas'
         doas_flags  = ' -n  -u foo '
         dzdo_exe   = 'dzdo'
+        ksu_exe     = 'ksu'
 
         cmd = play_context.make_become_cmd(cmd=default_cmd, executable=default_exe)
         self.assertEqual(cmd, default_cmd)
@@ -170,6 +171,10 @@ class TestPlayContext(unittest.TestCase):
         play_context.become_method = 'dzdo'
         cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")
         self.assertEqual(cmd, """%s -u %s %s -c 'echo %s; %s'""" % (dzdo_exe, play_context.become_user, default_exe, play_context.success_key, default_cmd))
+
+        play_context.become_method = 'ksu'
+        cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")
+        self.assertEqual(cmd, """%s -q -e %s -c 'echo %s; %s'""" & (ksu_exe, play_context.become_user, default_exe, play_context.success_key, default_cmd))
 
 class TestTaskAndVariableOverrride(unittest.TestCase):
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

playbook/play_context.py
##### ANSIBLE VERSION

git devel commit 677a34a191b7e5cde815ce36737fcada222f20c4
##### SUMMARY

On kerberized systems using ksu will simplify privilege escalation.

The requirements for ksu to work is that the calling user have
a valid kerberos ticket, that the remote system supports GSSAPI
authentication where the kerberos ticket is forwarded and that
the target user have a .k5login file with the kerberos principal
of the user calling ksu listed.  With this in place, no password
will be needed.
