### PR TITLE
action plugin net_config will now remove any private result key

### DIFF
--- a/lib/ansible/plugins/action/net_config.py
+++ b/lib/ansible/plugins/action/net_config.py
@@ -20,12 +20,15 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
+import re
 import time
 import glob
 import urlparse
 
 from ansible.plugins.action import ActionBase
 from ansible.utils.unicode import to_unicode
+
+PRIVATE_KEYS_RE = re.compile('__.+__')
 
 class ActionModule(ActionBase):
 
@@ -41,16 +44,24 @@ class ActionModule(ActionBase):
             except ValueError as exc:
                 return dict(failed=True, msg=exc.message)
 
-        result.update(self._execute_module(module_name=self._task.action,
+        action = self._task.action
+
+        result.update(self._execute_module(module_name=action,
             module_args=self._task.args, task_vars=task_vars))
 
-        if self._task.args.get('backup_config') and result.get('__backup__'):
+        if self._task.args.get('backup') and result.get('__backup__'):
             # User requested backup and no error occurred in module.
             # NOTE: If there is a parameter error, _backup key may not be in results.
-            self._write_backup(task_vars['inventory_hostname'], result['__backup__'])
+            filepath = self._write_backup(task_vars['inventory_hostname'],
+                                          result['__backup__'])
+            result['backup_path'] = filepath
 
-        if '__backup__' in result:
-            del result['__backup__']
+
+        # strip out any keys that have two leading and two trailing
+        # underscore characters
+        for key in result.keys():
+            if PRIVATE_KEYS_RE.match(key):
+                del result[key]
 
         return result
 
@@ -69,6 +80,7 @@ class ActionModule(ActionBase):
         tstamp = time.strftime("%Y-%m-%d@%H:%M:%S", time.localtime(time.time()))
         filename = '%s/%s_config.%s' % (backup_path, host, tstamp)
         open(filename, 'w').write(contents)
+        return filename
 
     def _handle_template(self):
         src = self._task.args.get('src')


### PR DESCRIPTION
This update will now remove any keys from results that are created using
the private names.  Private names are identified as double underscore (__)
on either side of the key name
