### PR TITLE
Make _to_filesystem_str return a string on py3

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -790,6 +790,8 @@ class AnsibleModule(object):
         '''
         if isinstance(path, unicode):
             path = path.encode("utf-8")
+        if isinstance(path, bytes):
+            path = path.decode("utf-8")
         return path
 
     # If selinux fails to find a default, return an array of None

--- a/test/units/module_utils/test_basic.py
+++ b/test/units/module_utils/test_basic.py
@@ -588,8 +588,8 @@ class TestModuleUtilsBasic(ModuleTestCase):
             argument_spec = dict(),
         )
 
-        self.assertEqual(am._to_filesystem_str(u'foo'), b'foo')
-        self.assertEqual(am._to_filesystem_str(u'föö'), b'f\xc3\xb6\xc3\xb6')
+        self.assertEqual(am._to_filesystem_str(u'foo'), 'foo')
+        self.assertEqual(am._to_filesystem_str(u'föö'), u'f\xf6\xf6')
 
     def test_module_utils_basic_ansible_module_user_and_group(self):
         from ansible.module_utils import basic
@@ -653,7 +653,7 @@ class TestModuleUtilsBasic(ModuleTestCase):
         with patch.dict('sys.modules', {'selinux': basic.selinux}):
             with patch('selinux.lsetfilecon', return_value=0) as m:
                 self.assertEqual(am.set_context_if_different('/path/to/file', ['foo_u', 'foo_r', 'foo_t', 's0'], False), True)
-                m.assert_called_with(b'/path/to/file', 'foo_u:foo_r:foo_t:s0')
+                m.assert_called_with('/path/to/file', 'foo_u:foo_r:foo_t:s0')
                 m.reset_mock()
                 am.check_mode = True
                 self.assertEqual(am.set_context_if_different('/path/to/file', ['foo_u', 'foo_r', 'foo_t', 's0'], False), True)
@@ -670,7 +670,7 @@ class TestModuleUtilsBasic(ModuleTestCase):
             
             with patch('selinux.lsetfilecon', return_value=0) as m:
                 self.assertEqual(am.set_context_if_different('/path/to/file', ['foo_u', 'foo_r', 'foo_t', 's0'], False), True)
-                m.assert_called_with(b'/path/to/file', 'sp_u:sp_r:sp_t:s0')
+                m.assert_called_with('/path/to/file', 'sp_u:sp_r:sp_t:s0')
 
         delattr(basic, 'selinux')
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ansible
##### SUMMARY

On python 3, this return a bytes object, so this fail
with the following traceback:

```
Traceback (most recent call last):
  File \"/tmp/ansible_rs2o3x04/ansible_module_authorized_key.py\", line 499, in <module>
    main()
  File \"/tmp/ansible_rs2o3x04/ansible_module_authorized_key.py\", line 493, in main
    results = enforce_state(module, module.params)
  File \"/tmp/ansible_rs2o3x04/ansible_module_authorized_key.py\", line 468, in enforce_state
    writekeys(module, keyfile(module, user, do_write, path, manage_dir), existing_keys)
  File \"/tmp/ansible_rs2o3x04/ansible_module_authorized_key.py\", line 371, in writekeys
    module.atomic_move(tmp_path, filename)
  File \"/tmp/ansible_rs2o3x04/ansible_modlib.zip/ansible/module_utils/basic.py\", line 1905, in atomic_move
  File \"/tmp/ansible_rs2o3x04/ansible_modlib.zip/ansible/module_utils/basic.py\", line 816, in selinux_context
TypeError: in method 'lgetfilecon_raw', argument 1 of type 'char const *'
```
