### PR TITLE
[ansible-doc cmd]  Declare 'choices' and 'default' as empty strings.

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -280,6 +280,7 @@ class DocCLI(CLI):
             else:
                 text.append(textwrap.fill(CLI.tty_ify(opt['description']), limit, initial_indent=opt_indent, subsequent_indent=opt_indent))
 
+            choices, default = '', ''
             if 'choices' in opt:
                 choices = "(Choices: " + ", ".join(str(i) for i in opt['choices']) + ")"
             if 'default' in opt or not required:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

ansible/ansible
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (ansible-doc 4173919af7) last updated 2016/08/19 17:21:03 (GMT +000)
  lib/ansible/modules/core: (detached HEAD 91a839f1e3) last updated 2016/08/19 17:11:10 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 1aeb9f8a8c) last updated 2016/08/19 17:11:12 (GMT +000)
  config file = /home/supertom/.ansible.cfg
  configured module search path = Default w/o overrides

ansible-doc 2.2.0 (ansible-doc 4173919af7) last updated 2016/08/19 17:21:03 (GMT +000)
  lib/ansible/modules/core: (detached HEAD 91a839f1e3) last updated 2016/08/19 17:11:10 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 1aeb9f8a8c) last updated 2016/08/19 17:11:12 (GMT +000)
  config file = /home/supertom/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

When running ansible-doc from devel, I receive an UnboundLocalError if 'choices' is not set for an option.

```
ansible-doc gce
Traceback (most recent call last):
  File "/home/supertom/virts/ansible-doc/code/ansible/lib/ansible/cli/doc.py", line 130, in run
    text += self.get_man_text(doc)
  File "/home/supertom/virts/ansible-doc/code/ansible/lib/ansible/cli/doc.py", line 287, in get_man_text
    text.append(textwrap.fill(CLI.tty_ify(choices + default), limit, initial_indent=opt_indent, subsequent_indent=opt_indent))
UnboundLocalError: local variable 'choices' referenced before assignment

```

This declares the variables so they can be concatenated correctly.

It also has the added side-benefit of not printing "Choices" text for options that don't have choices.  See this snippet for the ec2 module as an example:
## Before change:

```
ansible-doc ec2
- exact_count
        An integer value which indicates how many instances that match the 'count_tag' parameter should be running. Instances are either
        created or terminated based on this value.
        (Choices: yes, no)[Default: None]
```
## After change

```
ansible-doc ec2
- exact_count
        An integer value which indicates how many instances that match the 'count_tag' parameter should be running. Instances are either
        created or terminated based on this value.
        [Default: None]
```
