### PR TITLE
Enable some basic.py tests on python3

### DIFF
--- a/test/units/module_utils/basic/test_heuristic_log_sanitize.py
+++ b/test/units/module_utils/basic/test_heuristic_log_sanitize.py
@@ -85,7 +85,6 @@ class TestHeuristicLogSanitize(unittest.TestCase):
         self.assertTrue(ssh_output.endswith("}"))
         self.assertIn(":********@foo.com/data'", ssh_output)
 
-    @unittest.skipIf(sys.version_info[0] >= 3, "Python 3 is not supported on targets (yet)")
     def test_hides_parameter_secrets(self):
         output = heuristic_log_sanitize('token="secret", user="person", token_entry="test=secret"', frozenset(['secret']))
         self.assertNotIn('secret', output)

--- a/test/units/module_utils/basic/test_no_log.py
+++ b/test/units/module_utils/basic/test_no_log.py
@@ -50,7 +50,6 @@ class TestReturnValues(unittest.TestCase):
             ('Toshio くらとみ', frozenset(['Toshio くらとみ'])),
         )
 
-    @unittest.skipIf(sys.version_info[0] >= 3, "Python 3 is not supported on targets (yet)")
     def test_return_values(self):
         for data, expected in self.dataset:
             self.assertEquals(frozenset(return_values(data)), expected)
@@ -103,12 +102,10 @@ class TestRemoveValues(unittest.TestCase):
             (u'Toshio くらとみ', frozenset(['くらとみ']), u'Toshio ********'),
             )
 
-    @unittest.skipIf(sys.version_info[0] >= 3, "Python 3 is not supported on targets (yet)")
     def test_no_removal(self):
         for value, no_log_strings in self.dataset_no_remove:
             self.assertEquals(remove_values(value, no_log_strings), value)
 
-    @unittest.skipIf(sys.version_info[0] >= 3, "Python 3 is not supported on targets (yet)")
     def test_strings_to_remove(self):
         for value, no_log_strings, expected in self.dataset_remove:
             self.assertEquals(remove_values(value, no_log_strings), expected)

--- a/test/units/modules/core/test_apt.py
+++ b/test/units/modules/core/test_apt.py
@@ -16,7 +16,6 @@ except:
         pass
 
 
-@unittest.skipIf(sys.version_info[0] >= 3, "Python 3 is not supported on targets (yet)")
 class AptExpandPkgspecTestCase(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

tests of basic.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
devel
```
##### SUMMARY

The recent cleanup of module_utils/basic.py to use six included normalizing uses of basestring for python3 and python2.   This made it possible for a few functions to run successfully under python3.  We can now enable unittests for those functions.
