### PR TITLE
Update command for generating password

### DIFF
--- a/docsite/rst/faq.rst
+++ b/docsite/rst/faq.rst
@@ -264,7 +264,7 @@ How do I generate crypted passwords for the user module?
 
 The mkpasswd utility that is available on most Linux systems is a great option::
 
-    mkpasswd --method=SHA-512
+    mkpasswd --method=sha-512
 
 If this utility is not installed on your system (e.g. you are using OS X) then you can still easily
 generate these passwords using Python. First, ensure that the `Passlib <https://code.google.com/p/passlib/>`_


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

/docsite/rst/faq.rst
##### SUMMARY

When using `mkpasswd`, the option to generate a password is `--method=sha-512` instead of `--method=SHA-512` which produces a hash not found error
