### PR TITLE
fix setup module on Fedora Core 5 (#17175)

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -444,7 +444,7 @@ class Facts(object):
             self.facts['selinux']['status'] = 'enabled'
             try:
                 self.facts['selinux']['policyvers'] = selinux.security_policyvers()
-            except OSError:
+            except (AttributeError,OSError):
                 self.facts['selinux']['policyvers'] = 'unknown'
             try:
                 (rc, configmode) = selinux.selinux_getenforcemode()
@@ -452,12 +452,12 @@ class Facts(object):
                     self.facts['selinux']['config_mode'] = Facts.SELINUX_MODE_DICT.get(configmode, 'unknown')
                 else:
                     self.facts['selinux']['config_mode'] = 'unknown'
-            except OSError:
+            except (AttributeError,OSError):
                 self.facts['selinux']['config_mode'] = 'unknown'
             try:
                 mode = selinux.security_getenforce()
                 self.facts['selinux']['mode'] = Facts.SELINUX_MODE_DICT.get(mode, 'unknown')
-            except OSError:
+            except (AttributeError,OSError):
                 self.facts['selinux']['mode'] = 'unknown'
             try:
                 (rc, policytype) = selinux.selinux_getpolicytype()
@@ -465,7 +465,7 @@ class Facts(object):
                     self.facts['selinux']['type'] = policytype
                 else:
                     self.facts['selinux']['type'] = 'unknown'
-            except OSError:
+            except (AttributeError,OSError):
                 self.facts['selinux']['type'] = 'unknown'
 
     def get_caps_facts(self):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

setup module
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 321d2e8cee) last updated 2016/08/22 11:48:55 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 24db4de245) last updated 2016/08/01 15:26:29 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD db979dde74) last updated 2016/08/01 15:26:35 (GMT +200)
  config file = /home/yann/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### OS / ENVIRONMENT

Managed node running Fedora Core 5
##### SUMMARY

setup module fails in get_selinux_facts on Fedora Core 5 with error : "AttributeError: 'module' object has no attribute 'selinux_getpolicytype."
