### PR TITLE
Add RHEV host detection support

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -3119,7 +3119,20 @@ class LinuxVirtual(Virtual):
                 modules.append(data[0])
 
             if 'kvm' in modules:
-                self.facts['virtualization_type'] = 'kvm'
+                
+                # Build a list of process-names (to detect vdsm running on RHEV)
+                proc_list = []
+                for f in glob.glob('/proc/[0-9]*/comm'):
+                    try:
+                        proc_list.append(open(f).read().rstrip())
+                    except:
+                        pass
+                
+                # Check whether this is a RHEV hypervisor
+                if 'vdsm' in proc_list and os.path.isdir('/rhev/'):
+                    self.facts['virtualization_type'] = 'rhev'
+                else:
+                    self.facts['virtualization_type'] = 'kvm'
                 self.facts['virtualization_role'] = 'host'
                 return
 

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -3119,18 +3119,20 @@ class LinuxVirtual(Virtual):
                 modules.append(data[0])
 
             if 'kvm' in modules:
-                
-                # Build a list of process-names (to detect vdsm running on RHEV)
-                proc_list = []
-                for f in glob.glob('/proc/[0-9]*/comm'):
-                    try:
-                        proc_list.append(open(f).read().rstrip())
-                    except:
-                        pass
-                
-                # Check whether this is a RHEV hypervisor
-                if 'vdsm' in proc_list and os.path.isdir('/rhev/'):
-                    self.facts['virtualization_type'] = 'rhev'
+
+                if os.path.isdir('/rhev/'):
+
+                    # Check whether this is a RHEV hypervisor (is vdsm running ?)
+                    for f in glob.glob('/proc/[0-9]*/comm'):
+                        try:
+                            if open(f).read().rstrip() == 'vdsm':
+                                self.facts['virtualization_type'] = 'RHEV'
+                                break
+                        except:
+                            pass
+                    else:
+                        self.facts['virtualization_type'] = 'kvm'
+
                 else:
                     self.facts['virtualization_type'] = 'kvm'
                 self.facts['virtualization_role'] = 'host'


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

facts
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

This adds RHEV host detection support based on a running 'vdsm' process and the existence of _/rhev/_ (which are both part of the vdsm RPM package in a RHEV installation). Without this change, a RHEV host would be reported as a kvm host (which is also true, but often not specific enough).

This closes #17058
