### PR TITLE
New filter: crc32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,10 @@ Ansible Changes By Release
   * All functionality from *_template network modules have been combined into *_config module
   * Network *_command modules not longer allow configuration mode statements
 
+
+####New Filters:
+* crc32
+
 ####New Modules:
 - apache2_mod_proxy
 - asa

--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -248,6 +248,10 @@ To get the md5 hash of a string::
 
     {{ 'test1'|hash('md5') }}
 
+To get the crc32 hash of a string::
+
+    {{ 'test'|crc32('crc32') }}
+
 Get a string checksum::
 
     {{ 'test2'|checksum }}

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -50,7 +50,7 @@ from ansible.compat.six import iteritems, string_types
 from ansible.compat.six.moves import reduce
 from ansible.module_utils._text import to_text
 from ansible.parsing.yaml.dumper import AnsibleDumper
-from ansible.utils.hashing import md5s, checksum_s
+from ansible.utils.hashing import md5s, checksum_s, crc32_s
 from ansible.utils.unicode import unicode_wrap
 from ansible.utils.vars import merge_hash
 from ansible.vars.hostvars import HostVars
@@ -470,9 +470,11 @@ class FilterModule(object):
             'quote': quote,
 
             # hash filters
+            # crc32 digest of string
+            'crc32': crc32_s,
             # md5 hex digest of string
             'md5': md5s,
-            # sha1 hex digeset of string
+            # sha1 hex digest of string
             'sha1': checksum_s,
             # checksum of string as used by ansible for checksuming files
             'checksum': checksum_s,

--- a/lib/ansible/utils/hashing.py
+++ b/lib/ansible/utils/hashing.py
@@ -20,6 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
+import binascii
 
 # Note, sha1 is the only hash algorithm compatible with python2.4 and with
 # FIPS-140 mode (as of 11-2014)
@@ -95,3 +96,6 @@ def md5(filename):
     if not _md5:
         raise ValueError('MD5 not available.  Possibly running in FIPS mode')
     return secure_hash(filename, _md5)
+
+def crc32_s(data):
+    return binascii.crc32(data) & 0xffffffff

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -110,3 +110,7 @@
     that:
       - "users | json_query('[*].hosts[].host') == ['host_a', 'host_b', 'host_c', 'host_d']"
 
+- name: Test crc32 filter
+  assert:
+    that:
+      - "'ansible_crc32_test_string' | crc32 == 2593132251"


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

filter: add crc32 filtering
##### ANSIBLE VERSION

```
Commit ID 321d2e8ceea50bba386376c5f81e6ed8b60511cb
```
##### SUMMARY

This charge add a new useful filter crc32 which parse strings to generate crc32 output. This is useful with databases id or whenever you need to do a very lightweight comparison
