### PR TITLE
Add documentation on YAML floating-point values

### DIFF
--- a/docsite/rst/YAMLSyntax.rst
+++ b/docsite/rst/YAMLSyntax.rst
@@ -143,6 +143,14 @@ In these cases just use quotes::
     other_string: "False"
 
 
+YAML converts certain strings into floating-point values, such as the string
+`1.0`. If you need to specify a version number (in a requirements.yml file, for
+example), you will need to quote the value if it looks like a floating-point
+value::
+
+  version: "1.0"
+
+
 .. seealso::
 
    :doc:`playbooks`

--- a/docsite/rst/galaxy.rst
+++ b/docsite/rst/galaxy.rst
@@ -129,7 +129,7 @@ And here's an example showing some specific version downloads from multiple sour
    # from GitLab or other git-based scm   
     - src: git@gitlab.company.com:mygroup/ansible-base.git
       scm: git
-      version: 0.1.0
+      version: "0.1"  # quoted, so YAML doesn't parse this as a floating-point value
 
 As you can see in the above, there are a large amount of controls available
 to customize where roles can be pulled from, and what to save roles as. 


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME
- docsite/rst/YAMLSyntax.rst
- docsite/rst/galaxy.rst
##### SUMMARY

When specifying ansible roles to be downloaded by ansible-galaxy in a `requirements.yml` file, you can specify a tag, if the ansible role is a git repository:

```
- src: git@gitlab.company.com:mygroup/ansible-base.git
   scm: git
   version: 0.1.0
```

Certain values of `version` (e.g. `1.0`) get parsed into floating-point values by YAML, which causes an error. To help people diagnose this issue, I have added some documentation to the YAML gotchas section and to the galaxy documentation itself.
