### PR TITLE
Fix tmpfile misspelled as tmplfile

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -493,7 +493,7 @@ class VaultFile(object):
     # VaultFile a context manager instead (implement __enter__ and __exit__)
     def __del__(self):
         self.filehandle.close()
-        os.unlink(self.tmplfile)
+        os.unlink(self.tmpfile)
 
     def is_encrypted(self):
         peak = self.filehandle.readline()


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

vault
##### ANSIBLE VERSION

devel and stable-2.1
##### SUMMARY

```
Exception AttributeError: "'VaultFile' object has no attribute 'tmplfile'" in <bound method VaultFile.__del__ of <ansible.parsing.vault.VaultFile object at 0x10203b910>> ignored
```

Reported by shaps on IRC.
