### PR TITLE
Fix errors when using -vvvv with python 3

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -457,6 +457,8 @@ def heuristic_log_sanitize(data, no_log_values=None):
     # prev_begin: where in the overall string to start a search for
     #   a passwd
     # sep_search_end: where in the string to end a search for the sep
+    data = to_native(data)
+
     output = []
     begin = len(data)
     prev_begin = begin


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

setup
##### SUMMARY

```
Traceback (most recent call last):
  File "/tmp/ansible_tpehdgt7/ansible_module_setup.py", line 134, in <module>
    main()
  File "/tmp/ansible_tpehdgt7/ansible_module_setup.py", line 124, in main
    supports_check_mode = True,
  File "/tmp/ansible_tpehdgt7/ansible_modlib.zip/ansible/module_utils/basic.py", line 696, in __init__
  File "/tmp/ansible_tpehdgt7/ansible_modlib.zip/ansible/module_utils/basic.py", line 1670, in _log_invocation
  File "/tmp/ansible_tpehdgt7/ansible_modlib.zip/ansible/module_utils/basic.py", line 469, in heuristic_log_sanitize
TypeError: 'str' does not support the buffer interface
```
