### PR TITLE
Fix trivial ImportErrors when trying to use with_fileglob

### DIFF
--- a/lib/ansible/plugins/lookup/__init__.py
+++ b/lib/ansible/plugins/lookup/__init__.py
@@ -98,7 +98,7 @@ class LookupBase(with_metaclass(ABCMeta, object)):
         must be converted into python's unicode type as the strings will be run
         through jinja2 which has this requirement.  You can use::
 
-            from ansible.module_utils.unicode import to_unicode
+            from ansible.utils.unicode import to_unicode
             result_string = to_unicode(result_string)
         """
         pass

--- a/lib/ansible/plugins/lookup/fileglob.py
+++ b/lib/ansible/plugins/lookup/fileglob.py
@@ -22,7 +22,7 @@ import glob
 
 from ansible.plugins.lookup import LookupBase
 from ansible.errors import AnsibleFileNotFound
-from ansible.utils.unicode import to_bytes
+from ansible.utils.unicode import to_bytes, to_unicode
 
 class LookupModule(LookupBase):
 

--- a/lib/ansible/plugins/lookup/fileglob.py
+++ b/lib/ansible/plugins/lookup/fileglob.py
@@ -22,7 +22,7 @@ import glob
 
 from ansible.plugins.lookup import LookupBase
 from ansible.errors import AnsibleFileNotFound
-from ansible.module_utils.unicode import to_bytes
+from ansible.utils.unicode import to_bytes
 
 class LookupModule(LookupBase):
 


### PR DESCRIPTION
I had a task that did

```
- name: apache configs
  copy: dest=/etc/apache2/sites-available/ src=apache/{{ item }}
  with_items:
    - "{{ fridge_site_configs }}"
  notify: reload apache
  tags: apache
```

where `fridge_site_configs` was defined as `"{{ fridge_site_config_files|map('basename')|list }}"`, where `fridge_site_config_files` was defined as `"{{ lookup('fileglob', 'apache/*.conf').split(',')|sort }}"`, and this would produce the following error with

```
ansible 2.2.0 (fix-import-error-unicode 73caff58e8) last updated 2016/08/23 09:24:10 (GMT +300)
  lib/ansible/modules/core: (devel 91a839f1e3) last updated 2016/08/18 20:46:51 (GMT +300)
  lib/ansible/modules/extras: (detached HEAD 1aeb9f8a8c) last updated 2016/08/23 09:03:03 (GMT +300)
  config file = /home/mg/src/deployments/provisioning/ansible.cfg
  configured module search path = Default w/o overrides
```

```
TASK [fridge : apache configs] *************************************************
task path: /home/mg/src/deployments/provisioning/roles/fridge/tasks/websites.yml:54
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/home/mg/src/ansible/lib/ansible/executor/task_executor.py", line 89, in run
    items = self._get_loop_items()
  File "/home/mg/src/ansible/lib/ansible/executor/task_executor.py", line 187, in _get_loop_items
    loop_terms = listify_lookup_plugin_terms(terms=self._task.loop_args, templar=templar, loader=self._loader, fail_on_undefined=True, convert_bare=True)
  File "/home/mg/src/ansible/lib/ansible/utils/listify.py", line 37, in listify_lookup_plugin_terms
    terms = templar.template(terms, fail_on_undefined=fail_on_undefined)
  File "/home/mg/src/ansible/lib/ansible/template/__init__.py", line 351, in template
    return [self.template(v, preserve_trailing_newlines=preserve_trailing_newlines, fail_on_undefined=fail_on_undefined, overrides=overrides) for v in variable]
  File "/home/mg/src/ansible/lib/ansible/template/__init__.py", line 330, in template
    result = self._do_template(variable, preserve_trailing_newlines=preserve_trailing_newlines, escape_backslashes=escape_backslashes, fail_on_undefined=fail_on_undefined, overrides=overrides)
  File "/home/mg/src/ansible/lib/ansible/template/__init__.py", line 494, in _do_template
    res = j2_concat(rf)
  File "<template>", line 6, in root
  File "/usr/lib/python2.7/dist-packages/jinja2/runtime.py", line 156, in resolve
    return self.parent[key]
  File "/home/mg/src/ansible/lib/ansible/template/vars.py", line 91, in __getitem__
    raise type(e)(to_unicode(variable) + ': ' + e.message)
ImportError: {{ fridge_site_config_files|map('basename')|list }}: {{ lookup('fileglob', 'apache/*.conf').split(',')|sort }}: No module named unicode

fatal: [trusty]: FAILED! => {
    "failed": true, 
    "msg": "Unexpected failure during module execution.", 
    "stdout": ""
}
```

I found and fixed the wrong module path (commit 1 in this PR) and got a new error:

```
TASK [fridge : apache configs] *************************************************
task path: /home/mg/src/deployments/provisioning/roles/fridge/tasks/websites.yml:54
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/home/mg/src/ansible/lib/ansible/executor/task_executor.py", line 89, in run
    items = self._get_loop_items()
  File "/home/mg/src/ansible/lib/ansible/executor/task_executor.py", line 187, in _get_loop_items
    loop_terms = listify_lookup_plugin_terms(terms=self._task.loop_args, templar=templar, loader=self._loader, fail_on_undefined=True, convert_bare=True)
  File "/home/mg/src/ansible/lib/ansible/utils/listify.py", line 37, in listify_lookup_plugin_terms
    terms = templar.template(terms, fail_on_undefined=fail_on_undefined)
  File "/home/mg/src/ansible/lib/ansible/template/__init__.py", line 351, in template
    return [self.template(v, preserve_trailing_newlines=preserve_trailing_newlines, fail_on_undefined=fail_on_undefined, overrides=overrides) for v in variable]
  File "/home/mg/src/ansible/lib/ansible/template/__init__.py", line 330, in template
    result = self._do_template(variable, preserve_trailing_newlines=preserve_trailing_newlines, escape_backslashes=escape_backslashes, fail_on_undefined=fail_on_undefined, overrides=overrides)
  File "/home/mg/src/ansible/lib/ansible/template/__init__.py", line 494, in _do_template
    res = j2_concat(rf)
  File "<template>", line 6, in root
  File "/usr/lib/python2.7/dist-packages/jinja2/runtime.py", line 156, in resolve
    return self.parent[key]
  File "/home/mg/src/ansible/lib/ansible/template/vars.py", line 91, in __getitem__
    raise type(e)(to_unicode(variable) + ': ' + e.message)
NameError: {{ fridge_site_config_files|map('basename')|list }}: {{ lookup('fileglob', 'apache/*.conf').split(',')|sort }}: global name 'to_unicode' is not defined

fatal: [trusty]: FAILED! => {
    "failed": true, 
    "msg": "Unexpected failure during module execution.", 
    "stdout": ""
}
```

So I fixed that one too, and now my test playbook runs fine.
