### PR TITLE
New action plugin that will include a vars dir.

### DIFF
--- a/lib/ansible/plugins/action/include_vars_dir.py
+++ b/lib/ansible/plugins/action/include_vars_dir.py
@@ -1,0 +1,209 @@
+# (c) 2016, Allen Sanabria <asanabria@linuxdynasty.org>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from os import path, walk
+import re
+
+from ansible.errors import AnsibleError
+from ansible.plugins.action import ActionBase
+
+
+class ActionModule(ActionBase):
+
+    TRANSFERS_FILES = False
+
+    def _set_args(self):
+        """ Set instance variables based on the arguments that were passed
+        """
+        IGNORE_FILES = ['.*.md', '.*.py', '.*.pyc']
+        VALID_ARGUMENTS = [
+            'name', 'dir', 'depth', 'files_matching', 'ignore_files'
+        ]
+        for arg in self._task.args:
+            if arg not in VALID_ARGUMENTS:
+                return {
+                    'failed': True,
+                    'message': '{0} is not a valid option in debug'.format(arg)
+                }
+        self.return_results_as_name = self._task.args.get('name', None)
+        self.source_dir = self._task.args.get('dir')
+        self.depth = self._task.args.get('depth', 0)
+        self.files_matching = self._task.args.get('files_matching', None)
+        if self.files_matching:
+            self.matcher = re.compile(r'{0}'.format(self.files_matching))
+        else:
+            self.matcher = None
+        self.ignore_files = self._task.args.get('ignore_files', list())
+        if isinstance(self.ignore_files, str):
+            self.ignore_files = self.ignore_files.split()
+        elif isinstance(self.ignore_files, dict):
+            return {
+                'failed': True,
+                'message': '{0} must be a list'.format(self.ignore_files)
+            }
+        self.ignore_files.extend(IGNORE_FILES)
+
+        if not self.source_dir:
+            err_msg = '{0}{1}{2}{3}'.format(
+                'No directory was found for the included vars. ',
+                'Use `- include_vars_dir: <dirname>` or the `dir:` option ',
+                'to specify the vars dirname.',
+                self._task._ds
+            )
+            raise AnsibleError(err_msg)
+
+    def run(self, tmp=None, task_vars=None):
+        """ Load yml files recursively from a directory.
+        """
+        if not task_vars:
+            task_vars = dict()
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        self.show_content = True
+        self._set_args()
+        self._set_root_dir()
+        results = dict()
+        if path.exists(self.source_dir):
+            for root_dir, filenames in self._traverse_dir_depth():
+                failed, err_msg, updated_results = (
+                    self._load_files(root_dir, filenames)
+                )
+                if not failed:
+                    results.update(updated_results)
+                else:
+                    result['failed'] = failed
+                    result['message'] = err_msg
+                    break
+
+            if self.return_results_as_name:
+                scope = dict()
+                scope[self.return_results_as_name] = results
+                results = scope
+
+            result['ansible_facts'] = results
+            result['_ansible_no_log'] = not self.show_content
+        else:
+            result['failed'] = True
+            result['message'] = (
+                '{0} directory does not exist'.format(self.source_dir)
+            )
+
+        return result
+
+    def _set_root_dir(self):
+        results = dict()
+        if self._task._role:
+            if self.source_dir == 'vars':
+                path_to_use = (
+                    path.join(self._task._role._role_path, self.source_dir)
+                )
+                if path.exists(path_to_use):
+                    self.source_dir = path_to_test
+            else:
+                path_to_use = (
+                    path.join(
+                        self._task._role._role_path, 'vars', self.source_dir
+                    )
+                )
+                self.source_dir = path_to_use
+        else:
+            self.source_dir = (
+                path.join(
+                    "/".join(self._task._ds._data_source.split('/')[:-1]),
+                    self.source_dir
+                )
+            )
+
+    def _traverse_dir_depth(self):
+        """ Recursively iterate over a directory and sort the files in
+            alphabetical order. Do not iterate pass the set depth.
+            The default depth is unlimited.
+        """
+        current_depth = 0
+        sorted_walk = list(walk(self.source_dir))
+        sorted_walk.sort(key=lambda x: x[0])
+        for current_root, current_dir, current_files in sorted_walk:
+            current_depth += 1
+            if current_depth <= self.depth or self.depth == 0:
+                current_files.sort()
+                yield (current_root, current_files)
+            else:
+                break
+
+    def _ignore_file(self, filename):
+        """ Return True if a file matches the list of ignore_files.
+        Args:
+            filename (str): The filename that is being matched against.
+
+        Returns:
+            Boolean
+        """
+        for file_type in self.ignore_files:
+            try:
+                if re.search(r'{0}$'.format(file_type), filename):
+                    return True
+            except Exception:
+                err_msg = 'Invalid regular expression: {0}'.format(file_type)
+                raise AnsibleError(err_msg)
+        return False
+
+    def _load_files(self, root_dir, var_files):
+        """ Load the found yml files and update/overwrite the dictionary.
+        Args:
+            root_dir (str): The base directory of the list of files that is being passed.
+            var_files: (list): List of files to iterate over and load into a dictionary.
+
+        Returns:
+            Tuple (bool, str, dict)
+        """
+        results = dict()
+        failed = False
+        err_msg = ''
+        for filename in var_files:
+            stop_iter = False
+            # Never include main.yml from a role, as that is the default included by the role
+            if self._task._role:
+                if filename == 'main.yml':
+                    stop_iter = True
+                    continue
+
+            filepath = path.join(root_dir, filename)
+            if self.files_matching:
+                if not self.matcher.search(filename):
+                    stop_iter = True
+
+            if not stop_iter and not failed:
+                if path.exists(filepath) and not self._ignore_file(filename):
+                    data, show_content = (
+                        self._loader._get_file_contents(filepath)
+                    )
+                    loaded_data = self._loader.load(data, show_content)
+                    self.show_content = show_content
+                    if not loaded_data:
+                        data = dict()
+                    if not isinstance(loaded_data, dict):
+                        failed = True
+                        err_msg = (
+                            '{0} must be stored as a dictionary/hash'
+                            .format(filepath)
+                        )
+                    else:
+                        results.update(loaded_data)
+        return failed, err_msg, results

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -405,7 +405,6 @@ class StrategyBase:
                                             # and if none were found, then we raise an error
                                             if not found:
                                                 raise AnsibleError("The requested handler '%s' was found in neither the main handlers list nor the listening handlers list" % handler_name)
- 
 
                         if 'add_host' in result_item:
                             # this task added a new host (add_host module)
@@ -423,7 +422,7 @@ class StrategyBase:
 
                             item = result_item.get(loop_var, None)
 
-                            if original_task.action == 'include_vars':
+                            if original_task.action == 'include_vars' or original_task.action == 'include_vars_dir':
                                 for (var_name, var_value) in iteritems(result_item['ansible_facts']):
                                     # find the host we're actually refering too here, which may
                                     # be a host that is not really in inventory at all

--- a/test/units/plugins/action/fixtures/vars/all/all.yml
+++ b/test/units/plugins/action/fixtures/vars/all/all.yml
@@ -1,0 +1,3 @@
+---
+testing: 123
+base_dir: all

--- a/test/units/plugins/action/fixtures/vars/environments/development/all.yml
+++ b/test/units/plugins/action/fixtures/vars/environments/development/all.yml
@@ -1,0 +1,3 @@
+---
+testing: 789
+base_dir: 'environments/development'

--- a/test/units/plugins/action/fixtures/vars/environments/development/services/webapp.yml
+++ b/test/units/plugins/action/fixtures/vars/environments/development/services/webapp.yml
@@ -1,0 +1,4 @@
+---
+testing: 101112
+base_dir: 'development/services'
+webapp_containers: 20

--- a/test/units/plugins/action/fixtures/vars/services/webapp.yml
+++ b/test/units/plugins/action/fixtures/vars/services/webapp.yml
@@ -1,0 +1,4 @@
+---
+testing: 456
+base_dir: services
+webapp_containers: 10

--- a/test/units/plugins/action/test_include_vars_dir.py
+++ b/test/units/plugins/action/test_include_vars_dir.py
@@ -1,0 +1,171 @@
+# (c) 2016, Allen Sanabria <asanabria@linuxdynasty.org>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import MagicMock
+
+from ansible.playbook.play_context import PlayContext
+from ansible.parsing.dataloader import DataLoader
+from ansible.plugins.action.include_vars_dir import ActionModule
+
+
+class TestIncludeVarsDirPlugin(unittest.TestCase):
+
+    def test_return_name_fact(self):
+        mock_task = MagicMock()
+        mock_task.action = "include_vars_dir"
+        base_path = (
+            os.path.realpath(os.path.dirname(os.path.realpath(__file__)))
+        )
+        vars_dir = os.path.join(base_path, "fixtures/vars")
+        mock_task.args = dict(dir=vars_dir, name='foobar')
+        mock_connection = MagicMock()
+        play_context = PlayContext()
+        mock_task.async = None
+        loader = DataLoader()
+        action_base = (
+            ActionModule(
+                mock_task, mock_connection, play_context, loader, None, None
+            )
+        )
+        action_base._task._role = None
+        results = action_base.run()
+        self.assertTrue('foobar' in results['ansible_facts'])
+        self.assertEqual(results['ansible_facts']['foobar']['testing'], 456)
+
+    def test_correct_load_order(self):
+        mock_task = MagicMock()
+        mock_task.action = "include_vars_dir"
+        base_path = (
+            os.path.realpath(os.path.dirname(os.path.realpath(__file__)))
+        )
+        vars_dir = os.path.join(base_path, "fixtures/vars")
+        mock_task.args = dict(dir=vars_dir)
+        mock_connection = MagicMock()
+        play_context = PlayContext()
+        mock_task.async = None
+        loader = DataLoader()
+        action_base = (
+            ActionModule(
+                mock_task, mock_connection, play_context, loader, None, None
+            )
+        )
+        action_base._task._role = None
+        results = action_base.run()
+        self.assertEqual(results['ansible_facts']['testing'], 456)
+
+    def test_matching(self):
+        mock_task = MagicMock()
+        mock_task.action = "include_vars_dir"
+        base_path = (
+            os.path.realpath(os.path.dirname(os.path.realpath(__file__)))
+        )
+        vars_dir = os.path.join(base_path, "fixtures/vars")
+        mock_task.args = dict(dir=vars_dir, files_matching='webapp.yml')
+        mock_connection = MagicMock()
+        play_context = PlayContext()
+        mock_task.async = None
+        loader = DataLoader()
+        action_base = (
+            ActionModule(
+                mock_task, mock_connection, play_context, loader, None, None
+            )
+        )
+        action_base._task._role = None
+        results = action_base.run()
+        self.assertEqual(results['ansible_facts']['webapp_containers'], 10)
+        self.assertEqual(results['ansible_facts']['base_dir'], 'services')
+        self.assertEqual(results['ansible_facts']['testing'], 456)
+
+    def test_ignore_files(self):
+        mock_task = MagicMock()
+        mock_task.action = "include_vars_dir"
+        base_path = (
+            os.path.realpath(os.path.dirname(os.path.realpath(__file__)))
+        )
+        vars_dir = os.path.join(base_path, "fixtures/vars")
+        mock_task.args = dict(dir=vars_dir, ignore_files='webapp.yml')
+        mock_connection = MagicMock()
+        play_context = PlayContext()
+        mock_task.async = None
+        loader = DataLoader()
+        action_base = (
+            ActionModule(
+                mock_task, mock_connection, play_context, loader, None, None
+            )
+        )
+        action_base._task._role = None
+        results = action_base.run()
+        self.assertEqual(
+            results['ansible_facts']['base_dir'], 'environments/development'
+        )
+        self.assertEqual(results['ansible_facts']['testing'], 789)
+
+    def test_depth(self):
+        mock_task = MagicMock()
+        mock_task.action = "include_vars_dir"
+        base_path = (
+            os.path.realpath(os.path.dirname(os.path.realpath(__file__)))
+        )
+        vars_dir = (
+            os.path.join(base_path, "fixtures/vars/environments/development")
+        )
+        mock_task.args = dict(dir=vars_dir, depth=1)
+        mock_connection = MagicMock()
+        play_context = PlayContext()
+        mock_task.async = None
+        loader = DataLoader()
+        action_base = (
+            ActionModule(
+                mock_task, mock_connection, play_context, loader, None, None
+            )
+        )
+        action_base._task._role = None
+        results = action_base.run()
+        self.assertEqual(results['ansible_facts']['testing'], 789)
+        self.assertEqual(
+            results['ansible_facts']['base_dir'], 'environments/development'
+        )
+
+    def test_fail_dir_does_not_exist(self):
+        mock_task = MagicMock()
+        mock_task.action = "include_vars_dir"
+        base_path = (
+            os.path.realpath(os.path.dirname(os.path.realpath(__file__)))
+        )
+        vars_dir = os.path.join(base_path, "vars")
+        mock_task.args = dict(dir=vars_dir)
+        mock_connection = MagicMock()
+        play_context = PlayContext()
+        mock_task.async = None
+        loader = DataLoader()
+        action_base = (
+            ActionModule(
+                mock_task, mock_connection, play_context, loader, None, None
+            )
+        )
+        action_base._task._role = None
+        results = action_base.run()
+        self.assertEqual(results['failed'], True)
+
+
+def main():
+    unittest.main()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### ISSUE TYPE
- New Module Pull Request
##### COMPONENT NAME

include_vars_dir
##### ANSIBLE VERSION

```
ansible 2.1.1.0
```
##### SUMMARY

New action plugin that will include a vars dir.
This plugin allows you to include an entire directory and its nested directories of variable files.
Features..
- Ignore by default *.md, *.py, and *.pyc
- Ignore any list of files.
- Only include files nested by depth (default=unlimited)
- Match only files matching (valid regex)
- Sort files alphabetically and load in that order.
- Sort directories alphabetically and load in that order.

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
    - name: include all yml files in vars/all and all nested directories
      include_vars_dir:
        dir: 'vars/all'

    - name: include all yml files in vars/all and all nested directories and save the output in test.
      include_vars_dir:
        dir: 'vars/all'
        name: test

    - name: include all yml files in vars/services
      include_vars_dir:
        dir: 'vars/services'
        depth: 1

    - name: include only bastion.yml files
      include_vars_dir:
        dir: 'vars'
        files_matching: 'bastion.yml'

    - name: include only all yml files exception bastion.yml
      include_vars_dir:
        dir: 'vars'
        ignore_files: 'bastion.yml'
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/17195)

<!-- Reviewable:end -->
