### PR TITLE
Add some missing imports from last night's py3 fixes

### DIFF
--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -292,7 +292,7 @@ class DataLoader():
 
         result = None
         if not source:
-           display.warning('Invalid request to find a file that matches an empty string or "null" value')
+            display.warning('Invalid request to find a file that matches an empty string or "null" value')
         elif source.startswith('~') or source.startswith(os.path.sep):
             # path is absolute, no relative needed, check existence and return source
             test_path = unfrackpath(b_source)

--- a/lib/ansible/plugins/lookup/ini.py
+++ b/lib/ansible/plugins/lookup/ini.py
@@ -30,6 +30,7 @@ except ImportError:
 
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
+from ansible.utils.unicode import to_bytes
 
 
 def _parse_params(term):

--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -21,7 +21,7 @@ import os
 
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
-from ansible.utils.unicode import to_unicode
+from ansible.utils.unicode import to_unicode, to_bytes
 
 try:
     from __main__ import display


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

dataloader.py, lookup/{ini.py,template.py}
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
devel
```
##### SUMMARY

A few of the py3 text vs string fixes from last night didn't include the imports of helper functions they needed.  This commit fixes those.
