### PR TITLE
Local variable *choices* referenced before assignment

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -280,6 +280,7 @@ class DocCLI(CLI):
             else:
                 text.append(textwrap.fill(CLI.tty_ify(opt['description']), limit, initial_indent=opt_indent, subsequent_indent=opt_indent))
 
+            choices = ''
             if 'choices' in opt:
                 choices = "(Choices: " + ", ".join(str(i) for i in opt['choices']) + ")"
             if 'default' in opt or not required:


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

lib/cli/doc.py 
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel a695e18615) last updated 2016/08/23 16:03:55 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 45c1ae0ac1) last updated 2016/08/17 15:40:47 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD a6b34973a8) last updated 2016/08/17 15:40:48 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Simple fix to make things work again. Defaults _choices_ var to an empty string.
