### PR TITLE
Fix "Text file busy" exception in atomic_move (#9526)

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1876,55 +1876,59 @@ class AnsibleModule(object):
                 dest_dir = os.path.dirname(dest)
                 dest_file = os.path.basename(dest)
                 try:
-                    tmp_dest = tempfile.NamedTemporaryFile(
+                    tmp_dest_fd, tmp_dest_name = tempfile.mkstemp(
                         prefix=".ansible_tmp", dir=dest_dir, suffix=dest_file)
                 except (OSError, IOError):
                     e = get_exception()
                     self.fail_json(msg='The destination directory (%s) is not writable by the current user. Error was: %s' % (dest_dir, e))
 
-                try: # leaves tmp file behind when sudo and  not root
-                    if switched_user and os.getuid() != 0:
-                        # cleanup will happen by 'rm' of tempdir
-                        # copy2 will preserve some metadata
-                        shutil.copy2(src, tmp_dest.name)
-                    else:
-                        shutil.move(src, tmp_dest.name)
-                    if self.selinux_enabled():
-                        self.set_context_if_different(
-                            tmp_dest.name, context, False)
+                try:
                     try:
-                        tmp_stat = os.stat(tmp_dest.name)
-                        if dest_stat and (tmp_stat.st_uid != dest_stat.st_uid or tmp_stat.st_gid != dest_stat.st_gid):
-                            os.chown(tmp_dest.name, dest_stat.st_uid, dest_stat.st_gid)
-                    except OSError:
-                        e = get_exception()
-                        if e.errno != errno.EPERM:
-                            raise
-                    os.rename(tmp_dest.name, dest)
-                except (shutil.Error, OSError, IOError):
-                    e = get_exception()
-                    # sadly there are some situations where we cannot ensure atomicity, but only if
-                    # the user insists and we get the appropriate error we update the file unsafely
-                    if unsafe_writes and e.errno == errno.EBUSY:
-                        #TODO: issue warning that this is an unsafe operation, but doing it cause user insists
+                        # close tmp file handle before file operations to prevent text file busy errors on vboxfs synced folders (windows host)
+                        os.close(tmp_dest_fd)
+                        # leaves tmp file behind when sudo and  not root
+                        if switched_user and os.getuid() != 0:
+                            # cleanup will happen by 'rm' of tempdir
+                            # copy2 will preserve some metadata
+                            shutil.copy2(src, tmp_dest_name)
+                        else:
+                            shutil.move(src, tmp_dest_name)
+                        if self.selinux_enabled():
+                            self.set_context_if_different(
+                                tmp_dest_name, context, False)
                         try:
-                            try:
-                                out_dest = open(dest, 'wb')
-                                in_src = open(src, 'rb')
-                                shutil.copyfileobj(in_src, out_dest)
-                            finally: # assuring closed files in 2.4 compatible way
-                                if out_dest:
-                                    out_dest.close()
-                                if in_src:
-                                    in_src.close()
-                        except (shutil.Error, OSError, IOError):
+                            tmp_stat = os.stat(tmp_dest_name)
+                            if dest_stat and (tmp_stat.st_uid != dest_stat.st_uid or tmp_stat.st_gid != dest_stat.st_gid):
+                                os.chown(tmp_dest_name, dest_stat.st_uid, dest_stat.st_gid)
+                        except OSError:
                             e = get_exception()
-                            self.fail_json(msg='Could not write data to file (%s) from (%s): %s' % (dest, src, e))
+                            if e.errno != errno.EPERM:
+                                raise
+                        os.rename(tmp_dest_name, dest)
+                    except (shutil.Error, OSError, IOError):
+                        e = get_exception()
+                        # sadly there are some situations where we cannot ensure atomicity, but only if
+                        # the user insists and we get the appropriate error we update the file unsafely
+                        if unsafe_writes and e.errno == errno.EBUSY:
+                            #TODO: issue warning that this is an unsafe operation, but doing it cause user insists
+                            try:
+                                try:
+                                    out_dest = open(dest, 'wb')
+                                    in_src = open(src, 'rb')
+                                    shutil.copyfileobj(in_src, out_dest)
+                                finally: # assuring closed files in 2.4 compatible way
+                                    if out_dest:
+                                        out_dest.close()
+                                    if in_src:
+                                        in_src.close()
+                            except (shutil.Error, OSError, IOError):
+                                e = get_exception()
+                                self.fail_json(msg='Could not write data to file (%s) from (%s): %s' % (dest, src, e))
 
-                    else:
-                        self.fail_json(msg='Could not replace file: %s to %s: %s' % (src, dest, e))
-
-                    self.cleanup(tmp_dest.name)
+                        else:
+                            self.fail_json(msg='Could not replace file: %s to %s: %s' % (src, dest, e))
+                finally:
+                    self.cleanup(tmp_dest_name)
 
         if creating:
             # make sure the file has the correct permissions


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

module_utils
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (fix_textfilebusy f659e54a35) last updated 2016/08/23 22:59:01 (GMT +000)
  lib/ansible/modules/core: (detached HEAD 368ca738fa) last updated 2016/08/23 21:57:28 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 0749ce6faa) last updated 2016/08/23 21:57:36 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

tempfile.NamedTemporaryFile keeps a file handle causing os.rename() to fail with windows based vboxfs: [Errno 26] Text file busy. Changed NamedTemporaryFile to mkstemp() and added a finally block to unlink the temp file in each and every case.
