### PR TITLE
Document when clause list of conditions

### DIFF
--- a/docsite/rst/playbooks_conditionals.rst
+++ b/docsite/rst/playbooks_conditionals.rst
@@ -38,6 +38,15 @@ You can also use parentheses to group conditions::
         when: (ansible_distribution == "CentOS" and ansible_distribution_major_version == "6") or
               (ansible_distribution == "Debian" and ansible_distribution_major_version == "7")
 
+Multiple conditions that all need to be true (a logical 'and') can also be specified as a list::
+
+    tasks:
+      - name: "shut down CentOS 6 systems"
+        command: /sbin/shutdown -t now
+        when:
+          - ansible_distribution == "CentOS"
+          - ansible_distribution_major_version == "6"
+
 A number of Jinja2 "filters" can also be used in when statements, some of which are unique
 and provided by Ansible.  Suppose we want to ignore the error of one statement and then
 decide to do something conditionally based on success or failure::


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

Conditional blocks.
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

N/A
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```

The 'when' clause supports a list of conditions, applying a logical 'and' to the conditions (i.e. requiring all of them to be true).

This can be useful for legibility sometimes, allowing distinct conditions to be listed on separate lines.
