### PR TITLE
Enable Python 3 CI for Ubuntu 16.04 on Shippable.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -43,6 +43,8 @@ matrix:
     - env: TEST=integration TARGET=other IMAGE=ansible/ansible:ubuntu1404
     - env: TEST=integration TARGET=other IMAGE=ansible/ansible:ubuntu1604
 
+    - env: TEST=integration TARGET=all IMAGE=ansible/ansible:ubuntu1604py3 PYTHON3=1
+
     - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py24
       python: 2.7
     - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py26


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### COMPONENT NAME

N/A
##### ANSIBLE VERSION

N/A
##### SUMMARY

Enable Python 3 CI for Ubuntu 16.04 on Shippable.
