### PR TITLE
Fix get_distribution for Alpine Linux

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -216,7 +216,7 @@ def get_distribution():
     ''' return the distribution name '''
     if platform.system() == 'Linux':
         try:
-            supported_dists = platform._supported_dists + ('arch',)
+            supported_dists = platform._supported_dists + ('arch','alpine')
             distribution = platform.linux_distribution(supported_dists=supported_dists)[0].capitalize()
             if not distribution and os.path.isfile('/etc/system-release'):
                 distribution = platform.linux_distribution(supported_dists=['system'])[0].capitalize()


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

basic module
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 300d6482d1) last updated 2016/08/24 18:51:18 (GMT +200)
  lib/ansible/modules/core: (devel 2f26352e49) last updated 2016/08/24 18:45:43 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD db979dde74) last updated 2016/08/01 15:26:35 (GMT +200)
```
##### SUMMARY

To override a generic class that is subclassed based on platform, the subclass must define platform and distribution.

The load_platform_subclass() calls the get_platform() and get_distribution() methods to detect the platform and the distribution.

On Alpine Linux, get_distribution() method returns None and it is not possible to have different implementations based on detected platform.

Here is the python code of get_distribution() executed on an Alpine Linux host.

```
>>> import platform
>>> supported_dists = platform._supported_dists + ('arch',)
>>> print platform.linux_distribution(supported_dists=supported_dists)[0].capitalize()

```

The same code with this patch applied.

```
>>> import platform
>>> supported_dists = platform._supported_dists + ('arch','alpine')
>>> print platform.linux_distribution(supported_dists=supported_dists)[0].capitalize()
Alpine
```
