### PR TITLE
The former match for a section header included hosts that began with a range

### DIFF
--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -124,7 +124,7 @@ class InventoryParser(object):
                     del pending_declarations[groupname]
 
                 continue
-            elif line.startswith('['):
+            elif line.startswith('[') and line.endswith(']'):
                 self._raise_error("Invalid section entry: '%s'. Please make sure that there are no spaces" % line + \
                                   "in the section entry, and that there are no other invalid characters")
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

 lib/ansible/inventory/ini.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```

```
##### SUMMARY

Checking that the line ends with "]" narrows that window somewhat,

Fixes #15331
