### PR TITLE
xrange and izip_longest aren't available in vanilla python3

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -218,7 +218,7 @@ class DocCLI(CLI):
         text.append("- name: %s" % (desc))
         text.append("  action: %s" % (doc['module']))
         pad = 31
-        subdent = ''.join([" " for a in xrange(pad)])
+        subdent = " " * pad
         limit = display.columns - pad
 
         for o in sorted(doc['options'].keys()):

--- a/lib/ansible/module_utils/netcfg.py
+++ b/lib/ansible/module_utils/netcfg.py
@@ -26,14 +26,14 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+import itertools
 import re
-import time
-import itertools
 import shlex
-import itertools
+import time
 
 from ansible.module_utils.basic import BOOLEANS_TRUE, BOOLEANS_FALSE
 from ansible.module_utils.six import string_types
+from ansible.module_utils.six.moves import zip_longest
 
 DEFAULT_COMMENT_TOKENS = ['#', '!', '/*', '*/']
 
@@ -98,7 +98,7 @@ def ignore_line(text, tokens=None):
 def get_next(iterable):
     item, next_item = itertools.tee(iterable, 2)
     next_item = itertools.islice(next_item, 1, None)
-    return itertools.izip_longest(item, next_item)
+    return zip_longest(item, next_item)
 
 def parse(lines, indent, comment_tokens=None):
     toplevel = re.compile(r'\S')

--- a/lib/ansible/plugins/lookup/sequence.py
+++ b/lib/ansible/plugins/lookup/sequence.py
@@ -19,6 +19,7 @@ __metaclass__ = type
 
 from re import compile as re_compile, IGNORECASE
 
+from ansible.compat.six.moves import xrange
 from ansible.errors import AnsibleError
 from ansible.parsing.splitter import parse_kv
 from ansible.plugins.lookup import LookupBase

--- a/test/integration/roles/setup_ec2/tasks/main.yml
+++ b/test/integration/roles/setup_ec2/tasks/main.yml
@@ -17,7 +17,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 - name: generate random string
-  command: python -c "import string,random; print ''.join(random.choice(string.ascii_lowercase) for _ in xrange(8));"
+  command: python -c "import string,random; print ''.join(random.choice(string.ascii_lowercase) for _ in range(8));"
   register: random_string
   tags:
     - prepare


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

Various controller-side files
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
devel
```
##### SUMMARY

Fixes for these are either rewriting to get rid of the need for the
functions or using six.moves to get equivalent functions for both
python2 and python3
