### PR TITLE
Add OpenBSD virtualization facts.

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -3169,7 +3169,9 @@ class OpenBSDVirtual(Virtual):
         return self.facts
 
     def get_virtual_facts(self):
-        rc, out, err = self.module.run_command("/usr/sbin/sysctl -n hw.product")
+        sysctl_path = self.module.get_bin_path('sysctl')
+
+        rc, out, err = self.module.run_command("%s -n hw.product" % sysctl_path)
         if rc != 0:
             self.facts['virtualization_type'] = ''
             self.facts['virtualization_role'] = ''
@@ -3193,7 +3195,7 @@ class OpenBSDVirtual(Virtual):
             self.facts['virtualization_role'] = 'guest'
         else:
             # Try harder and see if hw.vendor has anything we could use.
-            rc, out, err = self.module.run_command("/usr/sbin/sysctl -n hw.vendor")
+            rc, out, err = self.module.run_command("%s -n hw.vendor" % sysctl_path)
             if rc != 0:
                 self.facts['virtualization_type'] = ''
                 self.facts['virtualization_role'] = ''

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -3169,43 +3169,48 @@ class OpenBSDVirtual(Virtual):
         return self.facts
 
     def get_virtual_facts(self):
-        sysctl_path = self.module.get_bin_path('sysctl', required=True)
+        sysctl_path = self.module.get_bin_path('sysctl')
 
-        rc, out, err = self.module.run_command("%s -n hw.product" % sysctl_path)
-        if rc != 0:
-            self.facts['virtualization_type'] = ''
-            self.facts['virtualization_role'] = ''
-        elif re.match('(KVM|Bochs|SmartDC).*', out):
-            self.facts['virtualization_type'] = 'kvm'
-            self.facts['virtualization_role'] = 'guest'
-        elif re.match('.*VMware.*', out):
-            self.facts['virtualization_type'] = 'VMware'
-            self.facts['virtualization_role'] = 'guest'
-        elif out.rstrip() == 'VirtualBox':
-            self.facts['virtualization_type'] = 'virtualbox'
-            self.facts['virtualization_role'] = 'guest'
-        elif out.rstrip() == 'HVM domU':
-            self.facts['virtualization_type'] = 'xen'
-            self.facts['virtualization_role'] = 'guest'
-        elif out.rstrip() == 'Parallels':
-            self.facts['virtualization_type'] = 'parallels'
-            self.facts['virtualization_role'] = 'guest'
-        elif out.rstrip() == 'RHEV Hypervisor':
-            self.facts['virtualization_type'] = 'RHEV'
-            self.facts['virtualization_role'] = 'guest'
-        else:
-            # Try harder and see if hw.vendor has anything we could use.
-            rc, out, err = self.module.run_command("%s -n hw.vendor" % sysctl_path)
+        if sysctl_path:
+            rc, out, err = self.module.run_command("%s -n hw.product" % sysctl_path)
             if rc != 0:
                 self.facts['virtualization_type'] = ''
                 self.facts['virtualization_role'] = ''
-            elif out.rstrip() == 'QEMU':
+            elif re.match('(KVM|Bochs|SmartDC).*', out):
                 self.facts['virtualization_type'] = 'kvm'
                 self.facts['virtualization_role'] = 'guest'
+            elif re.match('.*VMware.*', out):
+                self.facts['virtualization_type'] = 'VMware'
+                self.facts['virtualization_role'] = 'guest'
+            elif out.rstrip() == 'VirtualBox':
+                self.facts['virtualization_type'] = 'virtualbox'
+                self.facts['virtualization_role'] = 'guest'
+            elif out.rstrip() == 'HVM domU':
+                self.facts['virtualization_type'] = 'xen'
+                self.facts['virtualization_role'] = 'guest'
+            elif out.rstrip() == 'Parallels':
+                self.facts['virtualization_type'] = 'parallels'
+                self.facts['virtualization_role'] = 'guest'
+            elif out.rstrip() == 'RHEV Hypervisor':
+                self.facts['virtualization_type'] = 'RHEV'
+                self.facts['virtualization_role'] = 'guest'
             else:
-                # Set empty values if we find no match at all.
-                self.facts['virtualization_type'] = ''
-                self.facts['virtualization_role'] = ''
+                # Try harder and see if hw.vendor has anything we could use.
+                rc, out, err = self.module.run_command("%s -n hw.vendor" % sysctl_path)
+                if rc != 0:
+                    self.facts['virtualization_type'] = ''
+                    self.facts['virtualization_role'] = ''
+                elif out.rstrip() == 'QEMU':
+                    self.facts['virtualization_type'] = 'kvm'
+                    self.facts['virtualization_role'] = 'guest'
+                else:
+                    # Set empty values if we find no match at all.
+                    self.facts['virtualization_type'] = ''
+                    self.facts['virtualization_role'] = ''
+        else:
+            # Set empty values if we find no sysctl binary.
+            self.facts['virtualization_type'] = ''
+            self.facts['virtualization_role'] = ''
 
 
 class HPUXVirtual(Virtual):

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -3171,44 +3171,35 @@ class OpenBSDVirtual(Virtual):
     def get_virtual_facts(self):
         rc, out, err = self.module.run_command("/usr/sbin/sysctl -n hw.product")
         if rc != 0:
-          self.facts['virtualization_type'] = ''
-          self.facts['virtualization_role'] = ''
-          return
+            self.facts['virtualization_type'] = ''
+            self.facts['virtualization_role'] = ''
         elif re.match('(KVM|Bochs|SmartDC).*', out):
-          self.facts['virtualization_type'] = 'kvm'
-          self.facts['virtualization_role'] = 'guest'
-          return
+            self.facts['virtualization_type'] = 'kvm'
+            self.facts['virtualization_role'] = 'guest'
         elif re.match('.*VMware.*', out):
-          self.facts['virtualization_type'] = 'VMware'
-          self.facts['virtualization_role'] = 'guest'
-          return
+            self.facts['virtualization_type'] = 'VMware'
+            self.facts['virtualization_role'] = 'guest'
         elif out.rstrip() == 'VirtualBox':
-          self.facts['virtualization_type'] = 'virtualbox'
-          self.facts['virtualization_role'] = 'guest'
-          return
+            self.facts['virtualization_type'] = 'virtualbox'
+            self.facts['virtualization_role'] = 'guest'
         elif out.rstrip() == 'HVM domU':
-          self.facts['virtualization_type'] = 'xen'
-          self.facts['virtualization_role'] = 'guest'
-          return
+            self.facts['virtualization_type'] = 'xen'
+            self.facts['virtualization_role'] = 'guest'
         elif out.rstrip() == 'Parallels':
-          self.facts['virtualization_type'] = 'parallels'
-          self.facts['virtualization_role'] = 'guest'
-          return
+            self.facts['virtualization_type'] = 'parallels'
+            self.facts['virtualization_role'] = 'guest'
         elif out.rstrip() == 'RHEV Hypervisor':
-          self.facts['virtualization_type'] = 'RHEV'
-          self.facts['virtualization_role'] = 'guest'
-          return
-
-        # Try harder and see if hw.vendor has anything we could use.
-        rc, out, err = self.module.run_command("/usr/sbin/sysctl -n hw.vendor")
-        if rc != 0:
-          self.facts['virtualization_type'] = ''
-          self.facts['virtualization_role'] = ''
-          return
-        elif out.rstrip() == 'QEMU':
-          self.facts['virtualization_type'] = 'kvm'
-          self.facts['virtualization_role'] = 'guest'
-          return
+            self.facts['virtualization_type'] = 'RHEV'
+            self.facts['virtualization_role'] = 'guest'
+        else:
+            # Try harder and see if hw.vendor has anything we could use.
+            rc, out, err = self.module.run_command("/usr/sbin/sysctl -n hw.vendor")
+            if rc != 0:
+                self.facts['virtualization_type'] = ''
+                self.facts['virtualization_role'] = ''
+            elif out.rstrip() == 'QEMU':
+                self.facts['virtualization_type'] = 'kvm'
+                self.facts['virtualization_role'] = 'guest'
 
 
 class HPUXVirtual(Virtual):

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -3169,7 +3169,7 @@ class OpenBSDVirtual(Virtual):
         return self.facts
 
     def get_virtual_facts(self):
-        sysctl_path = self.module.get_bin_path('sysctl')
+        sysctl_path = self.module.get_bin_path('sysctl', required=True)
 
         rc, out, err = self.module.run_command("%s -n hw.product" % sysctl_path)
         if rc != 0:

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -3200,6 +3200,10 @@ class OpenBSDVirtual(Virtual):
             elif out.rstrip() == 'QEMU':
                 self.facts['virtualization_type'] = 'kvm'
                 self.facts['virtualization_role'] = 'guest'
+            else:
+                # Set empty values if we find no match at all.
+                self.facts['virtualization_type'] = ''
+                self.facts['virtualization_role'] = ''
 
 
 class HPUXVirtual(Virtual):

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -3169,8 +3169,47 @@ class OpenBSDVirtual(Virtual):
         return self.facts
 
     def get_virtual_facts(self):
-        self.facts['virtualization_type'] = ''
-        self.facts['virtualization_role'] = ''
+        rc, out, err = self.module.run_command("/usr/sbin/sysctl -n hw.product")
+        if rc != 0:
+          self.facts['virtualization_type'] = ''
+          self.facts['virtualization_role'] = ''
+          return
+        elif re.match('(KVM|Bochs|SmartDC).*', out):
+          self.facts['virtualization_type'] = 'kvm'
+          self.facts['virtualization_role'] = 'guest'
+          return
+        elif re.match('.*VMware.*', out):
+          self.facts['virtualization_type'] = 'VMware'
+          self.facts['virtualization_role'] = 'guest'
+          return
+        elif out.rstrip() == 'VirtualBox':
+          self.facts['virtualization_type'] = 'virtualbox'
+          self.facts['virtualization_role'] = 'guest'
+          return
+        elif out.rstrip() == 'HVM domU':
+          self.facts['virtualization_type'] = 'xen'
+          self.facts['virtualization_role'] = 'guest'
+          return
+        elif out.rstrip() == 'Parallels':
+          self.facts['virtualization_type'] = 'parallels'
+          self.facts['virtualization_role'] = 'guest'
+          return
+        elif out.rstrip() == 'RHEV Hypervisor':
+          self.facts['virtualization_type'] = 'RHEV'
+          self.facts['virtualization_role'] = 'guest'
+          return
+
+        # Try harder and see if hw.vendor has anything we could use.
+        rc, out, err = self.module.run_command("/usr/sbin/sysctl -n hw.vendor")
+        if rc != 0:
+          self.facts['virtualization_type'] = ''
+          self.facts['virtualization_role'] = ''
+          return
+        elif out.rstrip() == 'QEMU':
+          self.facts['virtualization_type'] = 'kvm'
+          self.facts['virtualization_role'] = 'guest'
+          return
+
 
 class HPUXVirtual(Virtual):
     """


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

facts
##### ANSIBLE VERSION

```
ansible 2.2.0 (openbsd_vm_facts df66dc4acc) last updated 2016/08/24 18:15:04 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 2f26352e49) last updated 2016/08/24 18:02:24 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 65eba72ee6) last updated 2016/08/24 18:02:24 (GMT +200)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Add OpenBSD virtualization facts.

<!-- Paste verbatim command output below, e.g. before and after your change -->

Before:

```
$ ansible -i hosts -u root 192.168.1.60 -m setup | grep ansible_virtual 
        "ansible_virtualization_role": "", 
        "ansible_virtualization_type": "", 

```

After:

```
$ ansible -i hosts -u root 192.168.1.60 -m setup | grep ansible_virtual
        "ansible_virtualization_role": "guest", 
        "ansible_virtualization_type": "virtualbox", 
```

Patch written by @jasperla.

Tested by various people on:
- virtualbox
- vmware esx(i) + fusion
- kvm (smartos + plain linux + a random cloud provider)

This patch is already present in the OpenBSD port of ansible.
