### PR TITLE
Fix file and copy modules on py3 and enable tests.

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1197,7 +1197,7 @@ class AnsibleModule(object):
             kwargs['owner'] = user
             kwargs['group'] = group
             st = os.lstat(path)
-            kwargs['mode']  = oct(stat.S_IMODE(st[stat.ST_MODE]))
+            kwargs['mode'] = '0%03o' % stat.S_IMODE(st[stat.ST_MODE])
             # secontext not yet supported
             if os.path.islink(path):
                 kwargs['state'] = 'link'

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -113,7 +113,7 @@ class ActionModule(ActionBase):
             # Walk the directory and append the file tuples to source_files.
             for base_path, sub_folders, files in os.walk(to_bytes(source)):
                 for file in files:
-                    full_path = os.path.join(base_path, file)
+                    full_path = to_unicode(os.path.join(base_path, file), errors='strict')
                     rel_path = full_path[sz:]
                     if rel_path.startswith('/'):
                         rel_path = rel_path[1:]

--- a/test/utils/shippable/python3-test-tag-blacklist.txt
+++ b/test/utils/shippable/python3-test-tag-blacklist.txt
@@ -3,8 +3,6 @@ test_apt
 test_assemble
 test_async
 test_authorized_key
-test_copy
-test_file
 test_filters
 test_gem
 test_get_url


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME
- module_utils/basic.py
- action/copy.py
##### ANSIBLE VERSION

```
ansible 2.2.0 (py3-fix e7b7b40e48) last updated 2016/08/24 22:56:14 (GMT -700)
  lib/ansible/modules/core: (detached HEAD cbd9e07f19) last updated 2016/08/24 12:30:28 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD beaa0c6c22) last updated 2016/08/24 12:30:28 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY
- Fix octal formatting of file mode in module response on py3.
- Convert file path to unicode in copy action.
- Enable file and copy module tests for py3 now that they pass.
