### PR TITLE
initial add of shared modules for supporting Nokia SROS devices

### DIFF
--- a/lib/ansible/module_utils/netcfg.py
+++ b/lib/ansible/module_utils/netcfg.py
@@ -75,8 +75,7 @@ class ConfigLine(object):
 
     @property
     def line(self):
-        line = ['set']
-        line.extend([p.text for p in self.parents])
+        line = [p.text for p in self.parents]
         line.append(self.text)
         return ' '.join(line)
 
@@ -84,8 +83,7 @@ class ConfigLine(object):
         return self.raw
 
     def __eq__(self, other):
-        if self.text == other.text:
-            return self.parents == other.parents
+        return self.line == other.line
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -183,7 +181,13 @@ class NetworkConfig(object):
         return dumps(self.expand_line(self.items))
 
     def load(self, contents):
-        self._config = parse(contents, indent=self.indent)
+        # Going to start adding device profiles post 2.2
+        tokens = list(DEFAULT_COMMENT_TOKENS)
+        if self._device_os == 'sros':
+            tokens.append('echo')
+            self._config = parse(contents, indent=4, comment_tokens=tokens)
+        else:
+            self._config = parse(contents, indent=self.indent)
 
     def load_from_file(self, filename):
         self.load(open(filename).read())

--- a/lib/ansible/module_utils/sros.py
+++ b/lib/ansible/module_utils/sros.py
@@ -1,0 +1,90 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Copyright (c) 2016 Peter Sprygada, <psprygada@ansible.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright
+#    notice,
+#      this list of conditions and the following disclaimer in the
+#      documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+import re
+
+from ansible.module_utils.network import NetworkModule, NetworkError
+from ansible.module_utils.network import register_transport, to_list
+from ansible.module_utils.shell import CliBase
+from ansible.module_utils.netcli import Command
+
+
+class Cli(CliBase):
+
+    NET_PASSWD_RE = re.compile(r"[\r\n]?password: $", re.I)
+
+    CLI_PROMPTS_RE = [
+        re.compile(r"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
+        re.compile(r"\[\w+\@[\w\-\.]+(?: [^\]])\] ?[>#\$] ?$")
+    ]
+
+    CLI_ERRORS_RE = [
+        re.compile(r"% ?Error"),
+        re.compile(r"% ?Bad secret"),
+        re.compile(r"invalid input", re.I),
+        re.compile(r"(?:incomplete|ambiguous) command", re.I),
+        re.compile(r"connection timed out", re.I),
+        re.compile(r"[^\r\n]+ not found", re.I),
+        re.compile(r"'[^']' +returned error code: ?\d+"),
+    ]
+
+    def connect(self, params, **kwargs):
+        super(Cli, self).connect(params, kickstart=False, **kwargs)
+        self.shell.send('environment no more')
+        self._connected = True
+
+    ### implementation of netcli.Cli ###
+
+    def run_commands(self, commands, **kwargs):
+        return self.execute(to_list(commands))
+
+    ### implementation of netcfg.Config ###
+
+    def configure(self, commands, **kwargs):
+        cmds = to_list(commands)
+        responses = self.execute(cmds)
+        self.execute(['exit all'])
+        return responses
+
+    def get_config(self, detail=False, **kwargs):
+        cmd = 'admin display-config'
+        if detail:
+            cmd += ' detail'
+        return self.execute(cmd)[0]
+
+    def load_config(self, commands, **kwargs):
+        return self.configure(commands)
+
+    def save_config(self):
+        self.execute(['admin save'])
+
+Cli = register_transport('cli', default=True)(Cli)
+
+

--- a/lib/ansible/plugins/action/sros_config.py
+++ b/lib/ansible/plugins/action/sros_config.py
@@ -1,0 +1,28 @@
+#
+# Copyright 2016 Peter Sprygada <psprygada@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+from ansible.plugins.action.net_config import ActionModule as NetActionModule
+
+class ActionModule(NetActionModule, ActionBase):
+    pass
+
+

--- a/lib/ansible/utils/module_docs_fragments/sros.py
+++ b/lib/ansible/utils/module_docs_fragments/sros.py
@@ -1,0 +1,75 @@
+#
+# (c) 2015, Peter Sprygada <psprygada@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class ModuleDocFragment(object):
+
+    # Standard files documentation fragment
+    DOCUMENTATION = """
+options:
+  host:
+    description:
+      - Specifies the DNS host name or address for connecting to the remote
+        device over the specified transport.  The value of host is used as
+        the destination address for the transport.
+    required: true
+  port:
+    description:
+      - Specifies the port to use when building the connection to the remote
+        device.  The port value will default to the well known SSH port
+        of 22
+    required: false
+    default: 22
+  username:
+    description:
+      - Configures the username to use to authenticate the connection to
+        the remote device.  The value of I(username) is used to authenticate
+        the SSH session. If the value is not specified in the task, the
+        value of environment variable ANSIBLE_NET_USERNAME will be used instead.
+    required: false
+  password:
+    description:
+      - Specifies the password to use to authenticate the connection to
+        the remote device.   The value of I(password) is used to authenticate
+        the SSH session. If the value is not specified in the task, the
+        value of environment variable ANSIBLE_NET_PASSWORD will be used instead.
+    required: false
+    default: null
+  ssh_keyfile:
+    description:
+      - Specifies the SSH key to use to authenticate the connection to
+        the remote device.   The value of I(ssh_keyfile) is the path to the
+        key used to authenticate the SSH session. If the value is not specified
+        in the task, the value of environment variable ANSIBLE_NET_SSH_KEYFILE
+        will be used instead.
+    required: false
+  timeout:
+    description:
+      - Specifies idle timeout for the connection. Useful if the console
+        freezes before continuing. For example when saving configurations.
+    required: false
+    default: 10
+  provider:
+    description:
+      - Convenience argument that allows connection arguments to be passed as
+        a dict object.  These include C(host), C(port), C(username), C(password),
+        C(ssh_keyfile), and C(timeout). All constraints (required, choices,
+        etc) must be met either by individual arguments or values in this dict.
+    required: false
+    default: null
+"""


### PR DESCRIPTION
This adds a cli transport, netcfg, and netcli implementations for working
with devices running Nokia SROS.  There is also an update to netcfg
to support the sros config file format.
