### PR TITLE
Implement Jinja2 filters for basic arithmetic (add, subtract, multiply, divide, modulo)

### DIFF
--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -212,31 +212,31 @@ Square root, or the 5th::
 
 Note that jinja2 already provides some like abs() and round().
 
-Since version 2.2 Ansible also includes some basic arithmetic filters. They are useful only in advanced cases (like a map() call). Normally, you can use the standard arithmetic operators (+, -, *, /, %).
+Starting from version 2.2 Ansible also includes some basic arithmetic filters. They are useful only in advanced cases (like a map() call). Normally, you can use the standard arithmetic operators (+, -, *, /, %).
 
 Add a number::
 
-    # only useful in a map() call, otehrwise use '+'
+    # only useful in a map() call, otherwise use '+'
     {{ list_of_numbers | map('add', 2) | list }}
 
 Subtract a number::
 
-    # only useful in a map() call, otehrwise use '-'
+    # only useful in a map() call, otherwise use '-'
     {{ list_of_numbers | map('subtract', 2) | list }}
 
 Multiply by a number::
 
-    # only useful in a map() call, otehrwise use '*'
-    {{ list_of_numbers | map('multiply' ,2) | list }}
+    # only useful in a map() call, otherwise use '*'
+    {{ list_of_numbers | map('multiply', 2) | list }}
 
 Divide by a number::
 
-    # only useful in a map() call, otehrwise use '/'
+    # only useful in a map() call, otherwise use '/'
     {{ list_of_numbers | map('divide', 2) | list }}
 
 Modulo operation::
 
-    # only useful in a map() call, otehrwise use '%'
+    # only useful in a map() call, otherwise use '%'
     {{ list_of_numbers | map('modulo', 7) | list }}
 
 .. _ipaddr_filter:

--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -217,27 +217,27 @@ Since version 2.2 Ansible also includes some basic arithmetic filters. They are 
 Add a number::
 
     # only useful in a map() call, otehrwise use '+'
-    {{ myvar | map('add', 2) }}
+    {{ mylist | map('add', 2) | list }}
 
 Subtract a number::
 
     # only useful in a map() call, otehrwise use '-'
-    {{ myvar | map('subtract', 2) }}
+    {{ mylist | map('subtract', 2) | list }}
 
 Multiply by a number::
 
     # only useful in a map() call, otehrwise use '*'
-    {{ myvar | map('multiply' ,2) }}
+    {{ mylist | map('multiply' ,2) | list }}
 
 Divide by a number::
 
     # only useful in a map() call, otehrwise use '/'
-    {{ myvar | map('divide', 2) }}
+    {{ mylist | map('divide', 2) | list }}
 
 Modulo operation::
 
     # only useful in a map() call, otehrwise use '%'
-    {{ myvar | map('modulo', 7) }}
+    {{ mylist | map('modulo', 7) | list }}
 
 .. _ipaddr_filter:
 

--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -210,6 +210,26 @@ Square root, or the 5th::
     {{ myvar | root }}
     {{ myvar | root(5) }}
 
+Add a number (since version 2.X)::
+
+    {{ myvar | add(2) }}
+
+Subtract a number (since version 2.X)::
+
+    {{ myvar | subtract(2) }}
+
+Multiply by a number (since version 2.X)::
+
+    {{ myvar | multiply(2) }}
+
+Divide by a number (since version 2.X)::
+
+    {{ myvar | divide(2) }}
+
+Modulo operation (from version 2.X)::
+
+    {{ myvar | modulo(7) }}
+
 Note that jinja2 already provides some like abs() and round().
 
 .. _ipaddr_filter:

--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -210,23 +210,23 @@ Square root, or the 5th::
     {{ myvar | root }}
     {{ myvar | root(5) }}
 
-Add a number (since version 2.X)::
+Add a number (since version 2.2)::
 
     {{ myvar | add(2) }}
 
-Subtract a number (since version 2.X)::
+Subtract a number (since version 2.2)::
 
     {{ myvar | subtract(2) }}
 
-Multiply by a number (since version 2.X)::
+Multiply by a number (since version 2.2)::
 
     {{ myvar | multiply(2) }}
 
-Divide by a number (since version 2.X)::
+Divide by a number (since version 2.2)::
 
     {{ myvar | divide(2) }}
 
-Modulo operation (from version 2.X)::
+Modulo operation (from version 2.2)::
 
     {{ myvar | modulo(7) }}
 

--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -217,27 +217,27 @@ Since version 2.2 Ansible also includes some basic arithmetic filters. They are 
 Add a number::
 
     # only useful in a map() call, otehrwise use '+'
-    {{ mylist | map('add', 2) | list }}
+    {{ list_of_numbers | map('add', 2) | list }}
 
 Subtract a number::
 
     # only useful in a map() call, otehrwise use '-'
-    {{ mylist | map('subtract', 2) | list }}
+    {{ list_of_numbers | map('subtract', 2) | list }}
 
 Multiply by a number::
 
     # only useful in a map() call, otehrwise use '*'
-    {{ mylist | map('multiply' ,2) | list }}
+    {{ list_of_numbers | map('multiply' ,2) | list }}
 
 Divide by a number::
 
     # only useful in a map() call, otehrwise use '/'
-    {{ mylist | map('divide', 2) | list }}
+    {{ list_of_numbers | map('divide', 2) | list }}
 
 Modulo operation::
 
     # only useful in a map() call, otehrwise use '%'
-    {{ mylist | map('modulo', 7) | list }}
+    {{ list_of_numbers | map('modulo', 7) | list }}
 
 .. _ipaddr_filter:
 

--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -210,27 +210,34 @@ Square root, or the 5th::
     {{ myvar | root }}
     {{ myvar | root(5) }}
 
-Add a number (since version 2.2)::
-
-    {{ myvar | add(2) }}
-
-Subtract a number (since version 2.2)::
-
-    {{ myvar | subtract(2) }}
-
-Multiply by a number (since version 2.2)::
-
-    {{ myvar | multiply(2) }}
-
-Divide by a number (since version 2.2)::
-
-    {{ myvar | divide(2) }}
-
-Modulo operation (from version 2.2)::
-
-    {{ myvar | modulo(7) }}
-
 Note that jinja2 already provides some like abs() and round().
+
+Since version 2.2 Ansible also includes some basic arithmetic filters. They are useful only in advanced cases (like a map() call). Normally, you can use the standard arithmetic operators (+, -, *, /, %).
+
+Add a number::
+
+    # only useful in a map() call, otehrwise use '+'
+    {{ myvar | map('add', 2) }}
+
+Subtract a number::
+
+    # only useful in a map() call, otehrwise use '-'
+    {{ myvar | map('subtract', 2) }}
+
+Multiply by a number::
+
+    # only useful in a map() call, otehrwise use '*'
+    {{ myvar | map('multiply' ,2) }}
+
+Divide by a number::
+
+    # only useful in a map() call, otehrwise use '/'
+    {{ myvar | map('divide', 2) }}
+
+Modulo operation::
+
+    # only useful in a map() call, otehrwise use '%'
+    {{ myvar | map('modulo', 7) }}
 
 .. _ipaddr_filter:
 

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -71,6 +71,35 @@ def max(a):
     _max = __builtins__.get('max')
     return _max(a);
 
+def add(x, y):
+    try:
+        return (x + y)
+    except TypeError as e:
+        raise errors.AnsibleFilterError('add() can only be used on numbers: %s' % str(e))
+
+def subtract(x, y):
+    try:
+        return (x - y)
+    except TypeError as e:
+        raise errors.AnsibleFilterError('subtract() can only be used on numbers: %s' % str(e))
+
+def multiply(x, y):
+    try:
+        return (x * y)
+    except TypeError as e:
+        raise errors.AnsibleFilterError('multiply() can only be used on numbers: %s' % str(e))
+
+def divide(x, y):
+    try:
+        return (x / y)
+    except TypeError as e:
+        raise errors.AnsibleFilterError('divide() can only be used on numbers: %s' % str(e))
+
+def modulo(x, y):
+    try:
+        return (x % y)
+    except TypeError as e:
+        raise errors.AnsibleFilterError('modulo() can only be used on numbers: %s' % str(e))
 
 def logarithm(x, base=math.e):
     try:
@@ -121,6 +150,13 @@ class FilterModule(object):
             # general math
             'min' : min,
             'max' : max,
+
+            # basic arithmetic
+            'add':      add,
+            'subtract': subtract,
+            'multiply': multiply,
+            'divide':   divide,
+            'modulo':   modulo,
 
             # exponents and logarithms
             'log': logarithm,


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

Jinja2 math filter
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 35a3653dfc) last updated 2016/08/25 23:10:15 (GMT +200)
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Implement `add`, `subtract`, `multiply`, `divide` and `modulo` operations as Jinja filters and updated the relevant documentation.

The original feature request for this PR is #17205
