### PR TITLE
Correctly infer task results

### DIFF
--- a/lib/ansible/executor/task_result.py
+++ b/lib/ansible/executor/task_result.py
@@ -62,11 +62,8 @@ class TaskResult:
         return self._check_key('unreachable')
 
     def _check_key(self, key):
-        if self._result.get('results', []):
+        if 'results' in self._result:
             flag = False
-            for res in self._result.get('results', []):
-                if isinstance(res, dict):
-                    flag |= res.get(key, False)
-            return flag
-        else:
-            return self._result.get(key, False)
+            if any([isinstance(res, dict) and key in res and res[key] for res in self._result['results']]):
+                return True
+        return self._result.get(key, False)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

task_result
##### ANSIBLE VERSION

```

```
##### SUMMARY

The results field in a task result is not necessarily a list of dicts containing `failed` and `changed` keys, but can just be a list of strings (e.g. the results from the yum module). In that case, the results list is not useful for calculating `changed` or `failed`, at which point `_check_key` should fail back to the `changed` or `failed` key in the task result itself 

e.g. the result from yum looks a little like:

```
self._result = { 'failed': true,
                 'results': ['a already installed',
                             'b already installed',
                             'could not install c'] }
```

and the result should be the `failed` key, and not the fact that none of the results contained a `failed` key.

The side effect prior to this change is that tasks are displayed as if they succeed, and then the playbook fails (i.e. the runner_v2_on_ok handler is called, and then the playbook stops)

Fixes #17208
