### PR TITLE
Fix fetch idempotence

### DIFF
--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -64,7 +64,8 @@ class ActionModule(ActionBase):
         remote_checksum = None
         if not self._play_context.become:
             # calculate checksum for the remote file, don't bother if using become as slurp will be used
-            remote_checksum = self._remote_checksum(source, all_vars=task_vars)
+            # Force remote_checksum to follow symlinks because fetch always follows symlinks
+            remote_checksum = self._remote_checksum(source, all_vars=task_vars, follow=True)
 
         # use slurp if permissions are lacking or privilege escalation is needed
         remote_data = None


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

lib/ansible/plugins/action/fetch.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
devel and stable-2.1
```
##### SUMMARY

Fetch always follows symlinks when downloading so it needs to always
follow symlinks when getting the checksum of the file as well.
