### PR TITLE
Fix for run_command on py3 and enable lineinfile test on py3

### DIFF
--- a/test/utils/shippable/python3-test-tag-blacklist.txt
+++ b/test/utils/shippable/python3-test-tag-blacklist.txt
@@ -9,7 +9,6 @@ test_get_url
 test_git
 test_hg
 test_iterators
-test_lineinfile
 test_lookups
 test_mysql_db
 test_mysql_user


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

module_utils/basic.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
devel
```
##### SUMMARY
- run_command needed a bit of tweaking to its string handling of
  arguments.
- The run_command change fixes the last bit of lineinfile so we can
  enable its tests
