### PR TITLE
Fix wrong error class

### DIFF
--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -191,7 +191,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                         if data is None:
                             return []
                         elif not isinstance(data, list):
-                            raise AnsibleError("included task files must contain a list of tasks", obj=data)
+                            raise AnsibleParserError("included task files must contain a list of tasks", obj=data)
 
                         # since we can't send callbacks here, we display a message directly in
                         # the same fashion used by the on_include callback. We also do it here,


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### SUMMARY

AnsibleError is not imported in that file, and since that's
a parsing time issue, better raise AnsibleParserError like the
rest of the file.

Issue signaled on irc by gordon`
