### PR TITLE
fixes iosxr configure method to commit the changes

### DIFF
--- a/lib/ansible/module_utils/iosxr.py
+++ b/lib/ansible/module_utils/iosxr.py
@@ -69,7 +69,10 @@ class Cli(CliBase):
 
     def configure(self, commands, **kwargs):
         cmds = ['configure terminal']
+        if commands[-1] == 'end':
+            commands.pop()
         cmds.extend(to_list(commands))
+        cmds.extend(['commit', 'end'])
         responses = self.execute(cmds)
         return responses[1:]
 


### PR DESCRIPTION
The iosxr configure method did not send the commit command to active the
changes after pushed to the remote device.  This change address that problem
