### PR TITLE
Python3 fixes and porting

### DIFF
--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -254,7 +254,7 @@ class ConnectionBase(with_metaclass(ABCMeta, object)):
             b_prompt = to_bytes(self._play_context.prompt)
             return b_output.startswith(b_prompt)
         else:
-            return self._play_context.prompt(output)
+            return self._play_context.prompt(b_output)
 
     def check_incorrect_password(self, b_output):
         b_incorrect_password = to_bytes(gettext.dgettext(self._play_context.become_method, C.BECOME_ERROR_STRINGS[self._play_context.become_method]))

--- a/test/units/module_utils/basic/test_set_mode_if_different.py
+++ b/test/units/module_utils/basic/test_set_mode_if_different.py
@@ -68,7 +68,7 @@ def _check_mode_changed_to_0660(self, mode):
     with patch('os.lstat', side_effect=[self.mock_stat1, self.mock_stat2, self.mock_stat2]) as m_lstat:
         with patch('os.lchmod', return_value=None, create=True) as m_lchmod:
             self.assertEqual(self.am.set_mode_if_different('/path/to/file', mode, False), True)
-            m_lchmod.assert_called_with('/path/to/file', 0o660)
+            m_lchmod.assert_called_with(b'/path/to/file', 0o660)
 
 def _check_mode_unchanged_when_already_0660(self, mode):
     # Note: This is for checking that all the different ways of specifying

--- a/test/units/module_utils/test_basic.py
+++ b/test/units/module_utils/test_basic.py
@@ -804,8 +804,8 @@ class TestModuleUtilsBasic(ModuleTestCase):
         _os_chown.reset_mock()
         am.set_context_if_different.reset_mock()
         am.atomic_move('/path/to/src', '/path/to/dest')
-        _os_rename.assert_called_with('/path/to/src', '/path/to/dest')
-        self.assertEqual(_os_chmod.call_args_list, [call('/path/to/dest', basic.DEFAULT_PERM & ~18)])
+        _os_rename.assert_called_with(b'/path/to/src', b'/path/to/dest')
+        self.assertEqual(_os_chmod.call_args_list, [call(b'/path/to/dest', basic.DEFAULT_PERM & ~18)])
 
         # same as above, except selinux_enabled
         _os_path_exists.side_effect = [False, False]
@@ -822,8 +822,8 @@ class TestModuleUtilsBasic(ModuleTestCase):
         am.set_context_if_different.reset_mock()
         am.selinux_default_context.reset_mock()
         am.atomic_move('/path/to/src', '/path/to/dest')
-        _os_rename.assert_called_with('/path/to/src', '/path/to/dest')
-        self.assertEqual(_os_chmod.call_args_list, [call('/path/to/dest', basic.DEFAULT_PERM & ~18)])
+        _os_rename.assert_called_with(b'/path/to/src', b'/path/to/dest')
+        self.assertEqual(_os_chmod.call_args_list, [call(b'/path/to/dest', basic.DEFAULT_PERM & ~18)])
         self.assertEqual(am.selinux_default_context.call_args_list, [call('/path/to/dest')])
         self.assertEqual(am.set_context_if_different.call_args_list, [call('/path/to/dest', mock_context, False)])
 
@@ -846,7 +846,7 @@ class TestModuleUtilsBasic(ModuleTestCase):
         _os_chown.reset_mock()
         am.set_context_if_different.reset_mock()
         am.atomic_move('/path/to/src', '/path/to/dest')
-        _os_rename.assert_called_with('/path/to/src', '/path/to/dest')
+        _os_rename.assert_called_with(b'/path/to/src', b'/path/to/dest')
 
         # dest missing, selinux enabled
         _os_path_exists.side_effect = [True, True]
@@ -868,7 +868,7 @@ class TestModuleUtilsBasic(ModuleTestCase):
         am.set_context_if_different.reset_mock()
         am.selinux_default_context.reset_mock()
         am.atomic_move('/path/to/src', '/path/to/dest')
-        _os_rename.assert_called_with('/path/to/src', '/path/to/dest')
+        _os_rename.assert_called_with(b'/path/to/src', b'/path/to/dest')
         self.assertEqual(am.selinux_context.call_args_list, [call('/path/to/dest')])
         self.assertEqual(am.set_context_if_different.call_args_list, [call('/path/to/dest', mock_context, False)])
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

Various, connections and module_utils/basic.py
##### ANSIBLE VERSION

```
devel
```
##### SUMMARY
- Fix to_native call in selinux_context and selinux_default_context to
  use the error handler correctly.
- Port set_mode_if_different to work on python3
- Port atomic_move to work on python3
- Fix check_password_prompt variable which wasn't renamed properly
