### PR TITLE
Simple documentation typo fix, 'iIf' to 'If'

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2028,7 +2028,7 @@ class AnsibleModule(object):
         :kw path_prefix: If given, additional path to find the command in.
             This adds to the PATH environment vairable so helper commands in
             the same directory can also be found
-        :kw cwd: iIf given, working directory to run the command inside
+        :kw cwd: If given, working directory to run the command inside
         :kw use_unsafe_shell: See `args` parameter.  Default False
         :kw prompt_regex: Regex string (not a compiled regex) which can be
             used to detect prompts in the stdout which would otherwise cause


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

lib/ansible/module_utils/basic.py
##### ANSIBLE VERSION

```
ansible 2.2.0 (typo-fix 15f10ab4bc) last updated 2016/08/26 22:52:31 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 6eab2b3d40) last updated 2016/08/26 22:41:59 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 628ee6864d) last updated 2016/08/26 22:41:59 (GMT -400)
```
##### SUMMARY

Simple typo fix in the help string of `run_command`
