### PR TITLE
catches timeout error when connecting to remote host in shell

### DIFF
--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -106,6 +106,11 @@ class Shell(object):
             raise ShellError("unable to resolve host name")
         except AuthenticationException:
             raise ShellError('Unable to authenticate to remote device')
+        except socket.error:
+            exc = get_exception()
+            if exc.errno == 60:
+                raise ShellError('timeout trying to connect to host')
+            raise
 
         if self.kickstart:
             self.shell.sendall("\n")


### PR DESCRIPTION
This will now catch a timeout error when shell attempts to open the
connection to the remove device and gracefully raise it as a ShellError
