### PR TITLE
Fix indexed_items.py to run on python3

### DIFF
--- a/lib/ansible/plugins/lookup/indexed_items.py
+++ b/lib/ansible/plugins/lookup/indexed_items.py
@@ -31,5 +31,5 @@ class LookupModule(LookupBase):
             raise AnsibleError("with_indexed_items expects a list")
 
         items = self._flatten(terms)
-        return zip(range(len(items)), items)
+        return list(zip(range(len(items)), items))
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### SUMMARY

On python3, zip is a iterator so we need
to explicitly create the list from that.
