### PR TITLE
Support for specifying item label in a loop

### DIFF
--- a/lib/ansible/playbook/loop_control.py
+++ b/lib/ansible/playbook/loop_control.py
@@ -29,6 +29,7 @@ from ansible.playbook.base import Base
 class LoopControl(Base):
 
     _loop_var = FieldAttribute(isa='str')
+    _label    = FieldAttribute(isa='str')
 
     def __init__(self):
         super(LoopControl, self).__init__()

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -174,6 +174,8 @@ class CallbackBase:
     def _get_item(self, result):
         if result.get('_ansible_no_log', False):
             item = "(censored due to no_log)"
+        elif result.get('_ansible_item_label', False):
+            item = result.get('_ansible_item_label')
         else:
             item = result.get('item', None)
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

Loop control
##### ANSIBLE VERSION

```
ansible 2.2.0 (loop_control_item_label faf35aa209) last updated 2016/08/29 18:41:15 (GMT -600)
  lib/ansible/modules/core: (detached HEAD 5310bab12f) last updated 2016/08/29 18:32:12 (GMT -600)
  lib/ansible/modules/extras: (detached HEAD 2ef4a34eee) last updated 2016/08/29 18:32:16 (GMT -600)
```
##### SUMMARY

This commit adds support for specifying the label for each item in a loop. This allows you to override the default of displaying the entire content of `item`, which is...verbose when looping over a complex structure.

Test playbook:

```

---
- hosts: localhost
  gather_facts: no
  vars:
    my_var:
      - name: foo
      - name: bar
      - name: baz
  tasks:
    - debug: var=item
      with_items: "{{ my_var }}"
      loop_control:
        label: "{{ item.name }}"
```

Result:

```
TASK [debug] *******************************************************************
ok: [localhost] => (item=foo) => {
    "item": {
        "name": "foo"
    }
}
ok: [localhost] => (item=bar) => {
    "item": {
        "name": "bar"
    }
}
ok: [localhost] => (item=baz) => {
    "item": {
        "name": "baz"
    }
}
```
