### PR TITLE
Ignore difference on whitespace

### DIFF
--- a/test/integration/roles/test_filters/tasks/main.yml
+++ b/test/integration/roles/test_filters/tasks/main.yml
@@ -52,7 +52,7 @@
   copy: src=foo.txt dest={{output_dir}}/foo.txt
 
 - name: compare templated file to known good
-  shell: diff {{output_dir}}/foo.templated {{output_dir}}/foo.txt
+  shell: diff -w {{output_dir}}/foo.templated {{output_dir}}/foo.txt
   register: diff_result
 
 - name: verify templated file matches known good

--- a/test/integration/roles/test_template/tasks/main.yml
+++ b/test/integration/roles/test_template/tasks/main.yml
@@ -50,7 +50,7 @@
   copy: src=foo.txt dest={{output_dir}}/foo.txt
 
 - name: compare templated file to known good
-  shell: diff {{output_dir}}/foo.templated {{output_dir}}/foo.txt
+  shell: diff -w {{output_dir}}/foo.templated {{output_dir}}/foo.txt
   register: diff_result
 
 - name: verify templated file matches known good


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

test
##### SUMMARY

While trying to fix the test suite on python3, I noticed
this test fail due to to_json adding more whitespace in
python3 than in python2. So -w should ignored those
differences.
