### PR TITLE
Reduce no longer exist in python3, so we have to use six

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -46,6 +46,7 @@ from ansible.utils.hashing import md5s, checksum_s
 from ansible.utils.unicode import unicode_wrap, to_unicode
 from ansible.utils.vars import merge_hash
 from ansible.vars.hostvars import HostVars
+from ansible.compat.six.moves import reduce
 
 try:
     import passlib.hash


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

filter
