### PR TITLE
Running the test with a locale other than English make that test fail

### DIFF
--- a/test/integration/roles/test_git/tasks/main.yml
+++ b/test/integration/roles/test_git/tasks/main.yml
@@ -421,6 +421,8 @@
   register: remote_url
   args:
     chdir: '{{ checkout_dir }}'
+  environment:
+    LC_ALL: C
 
 - assert:
     that: 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

tests
##### SUMMARY

While tests are supposed to be run in docker, people might still
want to use them on their own boxes.

In my case, I found out because git started to be translated in french on Fedora 24.
