### PR TITLE
Add support for become_flags on the task level

### DIFF
--- a/docsite/rst/become.rst
+++ b/docsite/rst/become.rst
@@ -31,6 +31,9 @@ become_user
 become_method
     (at play or task level) overrides the default method set in ansible.cfg, set to `sudo`/`su`/`pbrun`/`pfexec`/`doas`/`dzdo`
 
+become_flags
+    (at play or task level) permit to use specific flags for the tasks or role. One common use is to change user to nobody when the shell is set to no login
+
 For example, to manage a system service (which requires ``root`` privileges) when connected as a non-``root`` user (this takes advantage of the fact that the default value of ``become_user`` is ``root``)::
 
     - name: Ensure the httpd service is running
@@ -45,6 +48,15 @@ To run a command as the ``apache`` user::
       command: somecommand
       become: true
       become_user: apache
+
+To do something as the ``nobody`` user when the shell is nologin::
+
+    - name: Run a command as nobody
+      command: somecommand
+      become: true
+      become_method: su
+      become_user: nobody
+      become_flags: '-s /bin/sh'
 
 Connection variables
 --------------------

--- a/lib/ansible/playbook/become.py
+++ b/lib/ansible/playbook/become.py
@@ -35,6 +35,7 @@ class Become:
     _become              = FieldAttribute(isa='bool')
     _become_method       = FieldAttribute(isa='string')
     _become_user         = FieldAttribute(isa='string')
+    _become_flags        = FieldAttribute(isa='string')
 
     def __init__(self):
         return super(Become, self).__init__()

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -122,6 +122,7 @@ TASK_ATTRIBUTE_OVERRIDES = (
     'become_user',
     'become_pass',
     'become_method',
+    'become_flags',
     'connection',
     'docker_extra_args',
     'delegate_to',


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

become
##### SUMMARY

Working on the test suite, I tried to replace a call to sudo to a
call to su, and found out that I can't change user to 'nobody'
without changing the option become_flags in ansible.cfg

As this would be dependent on the user and the task, it make more sense
to push the setting there.
