### PR TITLE
Improved caching for urls

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -846,13 +846,14 @@ def open_url(url, data=None, headers=None, method=None, use_proxy=True,
     # with sites that block the default urllib agent string
     request.add_header('User-agent', http_agent)
 
-    # if we're ok with getting a 304, set the timestamp in the
-    # header, otherwise make sure we don't get a cached copy
-    if last_mod_time and not force:
+    # Cache control
+    # Either we directly force a cache refresh
+    if force:
+        request.add_header('cache-control', 'no-cache')
+    # or we do it if the original is more recent than our copy
+    elif last_mod_time:
         tstamp = last_mod_time.strftime('%a, %d %b %Y %H:%M:%S +0000')
         request.add_header('If-Modified-Since', tstamp)
-    else:
-        request.add_header('cache-control', 'no-cache')
 
     # user defined headers now, which may override things we've set above
     if headers:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

lib/ansible/module_utils/urls.py
##### ANSIBLE VERSION

```
ansible 2.2.0 (get_url-cache-improvement f7d0698bda) last updated 2016/08/30 11:54:22 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 5310bab12f) last updated 2016/08/30 11:14:57 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 2ef4a34eee) last updated 2016/08/30 11:15:02 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

With this change `get_url` can now make use of a proxy even when the file does not yet exist on the target system. This is important especially when you want to mass deploy and use a cache to relieve your internet connection.

Fixes ansible/ansible-modules-core#2966

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```
- When there is no file at the destination yet, we have no modification time for the `If-Modified-Since`-Header. In this case trust the cache to make the right decision to either serve a cached version or to refresh from origin. This should help with mass-deployment scenarios where you want to use a local cache to relieve your uplink.
- If you don't trust the cache to make the right decision you can still force it to refresh by providing the `force: yes` option.
