### PR TITLE
fixes issue with converting commands to an iterable was not being done

### DIFF
--- a/lib/ansible/module_utils/netcli.py
+++ b/lib/ansible/module_utils/netcli.py
@@ -65,7 +65,7 @@ class Cli(object):
 
     def __call__(self, commands, output=None):
         objects = list()
-        for cmd in commands:
+        for cmd in to_list(commands):
             objects.append(self.to_command(cmd, output))
         return self.connection.run_commands(objects)
 


### PR DESCRIPTION
This fix will now force the commands arg in **call** to be a list of
objects which otherwise would cause netcli not process the stack

This should fix the issue reported in ansible/ansible-modules-core#4419
