### PR TITLE
Disable yum test on python 3

### DIFF
--- a/test/integration/destructive.yml
+++ b/test/integration/destructive.yml
@@ -10,7 +10,7 @@
     # to a different hash or allows us to not check md5
     - { role: test_pip, tags: test_pip, when: ansible_fips != True }
     - { role: test_gem, tags: test_gem }
-    - { role: test_yum, tags: test_yum }
+    - { role: test_yum, tags: test_yum, when: ansible_python.version.major == '2' }
     - { role: test_apt, tags: test_apt }
     - { role: test_apt_repository, tags: [test_apt_repository, test_apt_key] }
     - { role: test_postgresql, tags: [test_postgresql, test_postgresql_db, test_postgresql_privs, test_postgresql_user] }


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

test
##### SUMMARY

Since yum is not gonna be running on python3 ever, we have to filter it.
