### PR TITLE
Fix paramiko as connection via API, exception encountered: TypeError: sequence item 0

### DIFF
--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -148,7 +148,7 @@ class Connection(ConnectionBase):
             getattr(self._play_context, 'ssh_args', ''),
         ]
         if ssh_args is not None:
-            args = self._split_ssh_args(' '.join(ssh_args))
+            args = self._split_ssh_args(' '.join(filter(None,ssh_args)))
             for i, arg in enumerate(args):
                 if arg.lower() == 'proxycommand':
                     # _split_ssh_args split ProxyCommand from the command itself


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

connection/paramiko_ssh.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

```
While using paramiko as connection type, exception occurs:
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
File "/usr/lib/python2.7/site-packages/ansible/executor/task_executor.py", line 124, in run
res = self.execute()
File "/usr/lib/python2.7/site-packages/ansible/executor/task_executor.py", line 448, in execute
result = self._handler.run(task_vars=variables)
File "/usr/lib/python2.7/site-packages/ansible/plugins/action/normal.py", line 33, in run
results = merge_hash(results, self._execute_module(tmp=tmp, task_vars=task_vars))
File "/usr/lib/python2.7/site-packages/ansible/plugins/action/__init.py", line 591, in execute_module
tmp = self.make_tmp_path(remote_user)
File "/usr/lib/python2.7/site-packages/ansible/plugins/action/__init.py", line 218, in make_tmp_path
result = self.low_level_execute_command(cmd, sudoable=False)
File "/usr/lib/python2.7/site-packages/ansible/plugins/action/__init.py", line 718, in low_level_execute_command
rc, stdout, stderr = self.connection.exec_command(cmd, in_data=in_data, sudoable=sudoable)
File "/usr/lib/python2.7/site-packages/ansible/plugins/connection/paramiko_ssh.py", line 253, in exec_command
super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
File "/usr/lib/python2.7/site-packages/ansible/plugins/connection/__init.py", line 51, in wrapped
self._connect()
File "/usr/lib/python2.7/site-packages/ansible/plugins/connection/paramiko_ssh.py", line 139, in _connect
self.ssh = SSH_CONNECTION_CACHE[cache_key] = self._connect_uncached()
File "/usr/lib/python2.7/site-packages/ansible/plugins/connection/paramiko_ssh.py", line 212, in _connect_uncached
sock_kwarg = self._parse_proxy_command(port)
File "/usr/lib/python2.7/site-packages/ansible/plugins/connection/paramiko_ssh.py", line 153, in _parse_proxy_command
args = self._split_ssh_args(' '.join(ssh_args))
TypeError: sequence item 0: expected string, NoneType found
```

fixes #17330
