### PR TITLE
Mention how to load a specific inventory file

### DIFF
--- a/docsite/rst/intro_inventory.rst
+++ b/docsite/rst/intro_inventory.rst
@@ -8,7 +8,8 @@ Inventory
 Ansible works against multiple systems in your infrastructure at the
 same time.  It does this by selecting portions of systems listed in
 Ansible's inventory file, which defaults to being saved in
-the location ``/etc/ansible/hosts``.
+the location ``/etc/ansible/hosts``. You can specify a different inventory file using the
+``-i <path>`` option on the command line.
 
 Not only is this inventory configurable, but you can also use
 multiple inventory files at the same time (explained below) and also


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

I had to do a silly amount of searching and reading man pages before I found this vital info - it really should be mentioned on this page!
