### PR TITLE
Add test for checking pip package in check mode

### DIFF
--- a/test/integration/roles/test_pip/tasks/main.yml
+++ b/test/integration/roles/test_pip/tasks/main.yml
@@ -116,3 +116,19 @@
   assert:
     that:
       - "not url_installed.changed"
+
+
+# Test pip package in check mode doesn't always report changed.
+
+- name: check for pip package
+  pip: name=pip virtualenv={{ output_dir }}/pipenv state=present
+
+- name: check for pip package in check_mode
+  pip: name=pip virtualenv={{ output_dir }}/pipenv state=present
+  check_mode: True
+  register: pip_check_mode
+
+- name: make sure pip in check_mode doesn't report changed
+  assert:
+    that:
+      - "not pip_check_mode.changed"


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

Pip
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (add-pip-test c28741035d) last updated 2016/09/01 08:12:12 (GMT -400)
  lib/ansible/modules/core: (issue-3060 30c0e9dcc2) last updated 2016/09/01 07:47:15 (GMT -400)
  lib/ansible/modules/extras: (devel e8a5442345) last updated 2016/09/01 07:59:52 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

This adds a test for [pull request 4644](https://github.com/ansible/ansible-modules-core/pull/4644). It should only be merged if that pull request is merged as well.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
