### PR TITLE
typo fix for variable ANSIBLE_ETCD_VERSION

### DIFF
--- a/lib/ansible/plugins/lookup/etcd.py
+++ b/lib/ansible/plugins/lookup/etcd.py
@@ -34,7 +34,7 @@ if os.getenv('ANSIBLE_ETCD_URL') is not None:
 
 ANSIBLE_ETCD_VERSION = 'v1'
 if os.getenv('ANSIBLE_ETCD_VERSION') is not None:
-    ANSIBLE_ETCD_URL = os.environ['ANSIBLE_ETCD_VERSION']
+    ANSIBLE_ETCD_VERSION = os.environ['ANSIBLE_ETCD_VERSION']
 
 class Etcd:
     def __init__(self, url=ANSIBLE_ETCD_URL, version=ANSIBLE_ETCD_VERSION,


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

plugins/lookup/etcd.py
##### ANSIBLE VERSION

ansible-devel
##### SUMMARY

Typo was introduced instead of putting the ETCD_VERSION into ANSIBLE_ETCD_VERSION it was overwriting the ANSIBLE_ETCD_URL. Therefor as soon as you exported the ETCD_VERSION the etcd lookup stopped working. 
