### PR TITLE
Pass '_' to async_wrapper for no argsfile.

### DIFF
--- a/lib/ansible/plugins/action/async.py
+++ b/lib/ansible/plugins/action/async.py
@@ -89,6 +89,9 @@ class ActionModule(ActionBase):
         async_cmd = [env_string, async_module_path, async_jid, async_limit, remote_module_path]
         if argsfile:
             async_cmd.append(argsfile)
+        else:
+            # maintain a fixed number of positional parameters for async_wrapper
+            async_cmd.append('_')
         async_cmd = " ".join([to_unicode(x) for x in async_cmd])
         result.update(self._low_level_execute_command(cmd=async_cmd))
 


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### COMPONENT NAME

async
##### ANSIBLE VERSION

```
ansible 2.2.0 (async-argsfile a02463ec2f) last updated 2016/09/02 18:10:42 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 269c06a4c9) last updated 2016/09/02 17:13:34 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD ab7391ff14) last updated 2016/09/02 17:13:34 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

This provides compatibility with changes made to the async_wrapper module.
