### PR TITLE
Use ansible_python for interpreter in test_uri.

### DIFF
--- a/test/integration/roles/test_uri/tasks/main.yml
+++ b/test/integration/roles/test_uri/tasks/main.yml
@@ -41,12 +41,8 @@
     src: "testserver.py"
     dest: "{{ output_dir }}/testserver.py"
 
-- name: verify that python2 is installed so this test can continue
-  shell: which python2
-  register: py2
-
 - name: start SimpleHTTPServer
-  shell: cd {{ files_dir }} && {{ py2.stdout }} {{ output_dir}}/testserver.py {{ http_port }}
+  shell: cd {{ files_dir }} && {{ ansible_python.executable }} {{ output_dir}}/testserver.py {{ http_port }}
   async: 60 # this test set takes ~15 seconds to run
   poll: 0
 


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

Integration Tests
##### ANSIBLE VERSION

```
ansible 2.2.0 (test-uri-fix 7cde69a679) last updated 2016/09/03 00:00:31 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 982c4557d2) last updated 2016/09/02 19:17:04 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD ab7391ff14) last updated 2016/09/02 13:52:23 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

To support systems with only python 3, use `ansible_python.executable` as the interpreter to run testserver.py for test_uri.
