### PR TITLE
Added option to change ssh executable path

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -277,6 +277,7 @@ ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'AN
 ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', "%(directory)s/ansible-ssh-%%h-%%p-%%r")
 ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', False, boolean=True)
 ANSIBLE_SSH_RETRIES            = get_config(p, 'ssh_connection', 'retries', 'ANSIBLE_SSH_RETRIES', 0, integer=True)
+ANSIBLE_SSH_EXECUTABLE         = get_config(p, 'ssh_connection', 'ssh_executable', 'ANSIBLE_SSH_EXECUTABLE', 'ssh')
 PARAMIKO_RECORD_HOST_KEYS      = get_config(p, 'paramiko_connection', 'record_host_keys', 'ANSIBLE_PARAMIKO_RECORD_HOST_KEYS', True, boolean=True)
 PARAMIKO_PROXY_COMMAND         = get_config(p, 'paramiko_connection', 'proxy_command', 'ANSIBLE_PARAMIKO_PROXY_COMMAND', None)
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -20,7 +20,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import base64
-import json
 import subprocess
 import sys
 import time
@@ -239,7 +238,7 @@ class TaskExecutor:
         label = None
         loop_pause = 0
         if self._task.loop_control:
-            # the value may be 'None', so we still need to default it back to 'item' 
+            # the value may be 'None', so we still need to default it back to 'item'
             loop_var = self._task.loop_control.loop_var or 'item'
             label = self._task.loop_control.label or ('{{' + loop_var + '}}')
             loop_pause = self._task.loop_control.pause or 0
@@ -664,7 +663,8 @@ class TaskExecutor:
             else:
                 # see if SSH can support ControlPersist if not use paramiko
                 try:
-                    cmd = subprocess.Popen(['ssh','-o','ControlPersist'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                    ssh_executable = C.ANSIBLE_SSH_EXECUTABLE
+                    cmd = subprocess.Popen([ssh_executable, '-o', 'ControlPersist'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                     (out, err) = cmd.communicate()
                     err = to_unicode(err)
                     if u"Bad configuration option" in err or u"Usage:" in err:

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -144,7 +144,7 @@ class Connection(ConnectionBase):
 
         if self._play_context.verbosity > 3:
             self._command += ['-vvv']
-        elif binary == 'ssh':
+        elif binary == C.ANSIBLE_SSH_EXECUTABLE:
             # Older versions of ssh (e.g. in RHEL 6) don't accept sftp -q.
             self._command += ['-q']
 
@@ -568,10 +568,12 @@ class Connection(ConnectionBase):
         # python interactive-mode but the modules are not compatible with the
         # interactive-mode ("unexpected indent" mainly because of empty lines)
 
+        ssh_executable = C.ANSIBLE_SSH_EXECUTABLE
+
         if not in_data and sudoable:
-            args = ('ssh', '-tt', self.host, cmd)
+            args = (ssh_executable, '-tt', self.host, cmd)
         else:
-            args = ('ssh', self.host, cmd)
+            args = (ssh_executable, self.host, cmd)
 
         cmd = self._build_command(*args)
         (returncode, stdout, stderr) = self._run(cmd, in_data, sudoable=sudoable)
@@ -682,7 +684,8 @@ class Connection(ConnectionBase):
         # TODO: reenable once winrm issues are fixed
         # temporarily disabled as we are forced to currently close connections after every task because of winrm
         # if self._connected and self._persistent:
-        #     cmd = self._build_command('ssh', '-O', 'stop', self.host)
+        #     ssh_executable = C.ANSIBLE_SSH_EXECUTABLE
+        #     cmd = self._build_command(ssh_executable, '-O', 'stop', self.host)
         #
         #     cmd = map(to_bytes, cmd)
         #     p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME
- SSH connection plugin
- (C)onstants
- TaskExecutor
##### SUMMARY

I happened to have two versions of the SSH binary installed in different locations. The ssh connection plugin and the TaskExecutor have hardcoded `ssh` which will default to using the first binary available in `$PATH`. 
Having the ssh binary path as a parameter allows the user to use a binary installed in a different location than the default ( or the one that has precedence in `$PATH` ). 

The parameter `ANSIBLE_SSH_EXECUTABLE` added in `constants.py` is used in ssh connection plugin when building the command.

`task_executor.py` has been updated to use the parameter when testing if ssh supports `ControlPersist`

**Using custom path**

``` shell
$ ANSIBLE_SSH_EXECUTABLE=/usr/bin/ssh ansible -vvvvi /tmp/hosts all -m ping
No config file found; using defaults
Loading callback plugin minimal of type stdout, v2.0 from /home/vagrant/sync/lib/ansible/plugins/callback/__init__.pyc
Using module file /home/vagrant/sync/lib/ansible/modules/core/system/ping.py
<localhost> ESTABLISH SSH CONNECTION FOR USER: None
<localhost> SSH: EXEC /usr/bin/ssh -vvv -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r localhost '/bin/sh -c '"'"'( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1472831820.75-149289026678631 `" && echo ansible-tmp-1472831820.75-149289026678631="` echo $HOME/.ansible/tmp/ansible-tmp-1472831820.75-149289026678631 `" ) && sleep 0'"'"''
<localhost> PUT /tmp/tmpMiamHu TO /root/.ansible/tmp/ansible-tmp-1472831820.75-149289026678631/ping.py
<localhost> SSH: EXEC sftp -b - -vvv -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r '[localhost]'
<localhost> ESTABLISH SSH CONNECTION FOR USER: None
<localhost> SSH: EXEC /usr/bin/ssh -vvv -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r localhost '/bin/sh -c '"'"'chmod u+x /root/.ansible/tmp/ansible-tmp-1472831820.75-149289026678631/ /root/.ansible/tmp/ansible-tmp-1472831820.75-149289026678631/ping.py && sleep 0'"'"''
<localhost> ESTABLISH SSH CONNECTION FOR USER: None
<localhost> SSH: EXEC /usr/bin/ssh -vvv -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r -tt localhost '/bin/sh -c '"'"'/usr/bin/python /root/.ansible/tmp/ansible-tmp-1472831820.75-149289026678631/ping.py; rm -rf "/root/.ansible/tmp/ansible-tmp-1472831820.75-149289026678631/" > /dev/null 2>&1 && sleep 0'"'"''
localhost | SUCCESS => {
    "changed": false,
    "invocation": {
        "module_args": {
            "data": null
        },
        "module_name": "ping"
    },
    "ping": "pong"
}

```

**Default behaviour** 

``` shell
$ ansible -vvvvi /tmp/hosts all -m ping
No config file found; using defaults
Loading callback plugin minimal of type stdout, v2.0 from /home/vagrant/sync/lib/ansible/plugins/callback/__init__.pyc
Using module file /home/vagrant/sync/lib/ansible/modules/core/system/ping.py
<localhost> ESTABLISH SSH CONNECTION FOR USER: None
<localhost> SSH: EXEC ssh -vvv -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r localhost '/bin/sh -c '"'"'( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1472831827.31-256337880160962 `" && echo ansible-tmp-1472831827.31-256337880160962="` echo $HOME/.ansible/tmp/ansible-tmp-1472831827.31-256337880160962 `" ) && sleep 0'"'"''
<localhost> PUT /tmp/tmpSLVe7D TO /root/.ansible/tmp/ansible-tmp-1472831827.31-256337880160962/ping.py
<localhost> SSH: EXEC sftp -b - -vvv -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r '[localhost]'
<localhost> ESTABLISH SSH CONNECTION FOR USER: None
<localhost> SSH: EXEC ssh -vvv -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r localhost '/bin/sh -c '"'"'chmod u+x /root/.ansible/tmp/ansible-tmp-1472831827.31-256337880160962/ /root/.ansible/tmp/ansible-tmp-1472831827.31-256337880160962/ping.py && sleep 0'"'"''
<localhost> ESTABLISH SSH CONNECTION FOR USER: None
<localhost> SSH: EXEC ssh -vvv -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r -tt localhost '/bin/sh -c '"'"'/usr/bin/python /root/.ansible/tmp/ansible-tmp-1472831827.31-256337880160962/ping.py; rm -rf "/root/.ansible/tmp/ansible-tmp-1472831827.31-256337880160962/" > /dev/null 2>&1 && sleep 0'"'"''
localhost | SUCCESS => {
    "changed": false,
    "invocation": {
        "module_args": {
            "data": null
        },
        "module_name": "ping"
    },
    "ping": "pong"
}
```
