### PR TITLE
add very basic tests of win_package, based on existing win_msi tests.

### DIFF
--- a/test/integration/roles/test_win_package/defaults/main.yml
+++ b/test/integration/roles/test_win_package/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+
+msi_url: https://ansible-ci-files.s3.amazonaws.com/test/integration/roles/test_win_msi/7z922-x64.msi
+msi_download_path: "C:\\Program Files\\7z922-x64.msi"
+msi_install_path: "C:\\Program Files\\7-Zip"
+msi_product_code: "{23170F69-40C1-2702-0922-000001000000}"

--- a/test/integration/roles/test_win_package/tasks/main.yml
+++ b/test/integration/roles/test_win_package/tasks/main.yml
@@ -27,7 +27,6 @@
     path: "{{msi_download_path}}"
     product_id: "{{msi_product_code}}"
     state: absent
-#  ignore_errors: true
 
 - name: install msi
   win_package:
@@ -42,7 +41,7 @@
       - "not win_package_install_result|failed"
       - "win_package_install_result|changed"
 
-- name: install msi again with argument
+- name: install msi again (check for no change)
   win_package:
     path: "{{msi_download_path}}"
     product_id: "{{msi_product_code}}"
@@ -50,7 +49,6 @@
   register: win_package_install_again_result
 
 - name: check win_package install again result
-#  ignore_errors: true
   assert: 
     that:
       - "not win_package_install_again_result|failed"
@@ -68,3 +66,16 @@
     that:
       - "not win_package_uninstall_result|failed"
       - "win_package_uninstall_result|changed"
+
+- name: uninstall msi again (check for no change)
+  win_package:
+    path: "{{msi_download_path}}"
+    product_id: "{{msi_product_code}}"
+    state: absent
+  register: win_package_uninstall_again_result
+
+- name: check win_package uninstall result
+  assert: 
+    that:
+      - "not win_package_uninstall_result|failed"
+      - "not win_package_uninstall_again_result|changed"

--- a/test/integration/roles/test_win_package/tasks/main.yml
+++ b/test/integration/roles/test_win_package/tasks/main.yml
@@ -1,0 +1,70 @@
+# test code for the win_package module
+# (c) 2014, Chris Church <chris@ninemoreminutes.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- name: use win_get_url module to download msi
+  win_get_url:
+    url: "{{msi_url}}"
+    dest: "{{msi_download_path}}"
+  register: win_get_url_result
+
+- name: make sure msi is uninstalled
+  win_package:
+    path: "{{msi_download_path}}"
+    product_id: "{{msi_product_code}}"
+    state: absent
+#  ignore_errors: true
+
+- name: install msi
+  win_package:
+    path: "{{msi_download_path}}"
+    product_id: "{{msi_product_code}}"
+    state: present
+  register: win_package_install_result
+
+- name: check win_package install result
+  assert:
+    that:
+      - "not win_package_install_result|failed"
+      - "win_package_install_result|changed"
+
+- name: install msi again with argument
+  win_package:
+    path: "{{msi_download_path}}"
+    product_id: "{{msi_product_code}}"
+    state: present
+  register: win_package_install_again_result
+
+- name: check win_package install again result
+#  ignore_errors: true
+  assert: 
+    that:
+      - "not win_package_install_again_result|failed"
+      - "not win_package_install_again_result|changed"
+
+- name: uninstall msi
+  win_package:
+    path: "{{msi_download_path}}"
+    product_id: "{{msi_product_code}}"
+    state: absent
+  register: win_package_uninstall_result
+
+- name: check win_package uninstall result
+  assert: 
+    that:
+      - "not win_package_uninstall_result|failed"
+      - "win_package_uninstall_result|changed"

--- a/test/integration/test_win_group2.yml
+++ b/test/integration/test_win_group2.yml
@@ -9,3 +9,4 @@
     - { role: test_win_stat, tags: test_win_stat }
     - { role: test_win_get_url, tags: test_win_get_url }
     - { role: test_win_msi, tags: test_win_msi }
+    - { role: test_win_package, tags: test_win_package }


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

win_package
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (test_win_package 519815f223) last updated 2016/09/04 06:53:46 (GMT +100)
  lib/ansible/modules/core: (detached HEAD 6eab2b3d40) last updated 2016/08/28 10:52:27 (GMT +100)
  lib/ansible/modules/extras: (detached HEAD 628ee6864d) last updated 2016/09/04 06:24:26 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

As discussed at modules review a few weeks ago, win_msi is going to be deprecated, so this pr adds some basic tests for win_package, which will be the prefered way of installing msi (and .exe packaged windows installers) in future.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Doesn't fix a specific issue, but there's plenty of examples of people struggling with win_msi on the ansible project google group.

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
before is not applicable (new tests)

after:
export TEST_FLAGS='-i /etc/ansible/hosts -t test_win_package -l 12'
time make test_win_group2
rm -rf ~/ansible_testing
mkdir -p ~/ansible_testing
ansible-playbook test_win_group2.yml -i inventory.winrm -e outputdir=~/ansible_testing -e @integration_config.yml  -v -i /etc/ansible/hosts -t test_win_package -l 12
Using /etc/ansible/ansible.cfg as config file

PLAY [windows] *****************************************************************

TASK [test_win_package : use win_get_url module to download msi] ***************
changed: [WIN-12] => {"changed": true, "win_get_url": {"dest": "C:\\Program Files\\7z922-x64.msi", "url": "https://ansible-ci-files.s3.amazonaws.com/test/integration/roles/test_win_msi/7z922-x64.msi"}}

TASK [test_win_package : make sure msi is uninstalled] *************************
 [WARNING]: SyntaxError in safe_eval() on expr:
{23170F69-40C1-2702-0922-000001000000} (invalid syntax (<unknown>, line 1))

ok: [WIN-12] => {"changed": false, "name": "C:\\Program Files\\7z922-x64.msi"}

TASK [test_win_package : install msi] ******************************************
 [WARNING]: SyntaxError in safe_eval() on expr:
{23170F69-40C1-2702-0922-000001000000} (invalid syntax (<unknown>, line 1))

changed: [WIN-12] => {"changed": true, "name": "C:\\Program Files\\7z922-x64.msi"}

TASK [test_win_package : check win_package install result] *********************
ok: [WIN-12] => {"changed": false, "msg": "all assertions passed"}

TASK [test_win_package : install msi again with argument] **********************
 [WARNING]: SyntaxError in safe_eval() on expr:
{23170F69-40C1-2702-0922-000001000000} (invalid syntax (<unknown>, line 1))

ok: [WIN-12] => {"changed": false, "name": "C:\\Program Files\\7z922-x64.msi"}

TASK [test_win_package : check win_package install again result] ***************
ok: [WIN-12] => {"changed": false, "msg": "all assertions passed"}

TASK [test_win_package : uninstall msi] ****************************************
 [WARNING]: SyntaxError in safe_eval() on expr:
{23170F69-40C1-2702-0922-000001000000} (invalid syntax (<unknown>, line 1))

changed: [WIN-12] => {"changed": true, "name": "C:\\Program Files\\7z922-x64.msi"}

TASK [test_win_package : check win_package uninstall result] *******************
ok: [WIN-12] => {"changed": false, "msg": "all assertions passed"}

PLAY RECAP *********************************************************************
WIN-12                     : ok=8    changed=3    unreachable=0    failed=0   


real    0m15.097s
user    0m2.436s
sys 0m0.328s

```
