### PR TITLE
Add public_ip option to linode dynamic inventory

### DIFF
--- a/contrib/inventory/linode.ini
+++ b/contrib/inventory/linode.ini
@@ -15,4 +15,4 @@ cache_path = /tmp
 cache_max_age = 300
 
 # If set to true use the hosts public ip in the dictionary instead of the label
-use_public_ip = true
+use_public_ip = false

--- a/contrib/inventory/linode.ini
+++ b/contrib/inventory/linode.ini
@@ -13,3 +13,6 @@ cache_path = /tmp
 # The number of seconds a cache file is considered valid. After this many
 # seconds, a new API call will be made, and the cache file will be updated.
 cache_max_age = 300
+
+# If set to true use the hosts public ip in the dictionary instead of the label
+use_public_ip = true

--- a/contrib/inventory/linode.py
+++ b/contrib/inventory/linode.py
@@ -15,9 +15,13 @@ installed and has a valid config at ~/.chube. If not, run:
 
 For more details, see: https://github.com/exosite/chube
 
-NOTE: This script also assumes that the Linodes in your account all have
+NOTE: By default, this script also assumes that the Linodes in your account all have
 labels that correspond to hostnames that are in your resolver search path.
 Your resolver search path resides in /etc/hosts.
+Optionally, if you would like to use the hosts public IP instead of it's label use
+the following setting in linode.ini:
+
+    use_public_ip = true
 
 When run against a specific host, this script returns the following variables:
 
@@ -161,6 +165,7 @@ class LinodeInventory(object):
         self.cache_path_cache = cache_path + "/ansible-linode.cache"
         self.cache_path_index = cache_path + "/ansible-linode.index"
         self.cache_max_age = config.getint('linode', 'cache_max_age')
+        self.use_public_ip = config.getboolean('linode', 'use_public_ip')
 
     def parse_cli_args(self):
         """Command line argument processing"""
@@ -212,8 +217,10 @@ class LinodeInventory(object):
 
     def add_node(self, node):
         """Adds an node to the inventory and index."""
-
-        dest = node.label
+        if self.use_public_ip:
+            dest = self.get_node_public_ip(node)
+        else:
+            dest = node.label
 
         # Add to index
         self.index[dest] = node.api_id
@@ -226,6 +233,10 @@ class LinodeInventory(object):
 
         # Inventory: Group by dipslay group
         self.push(self.inventory, node.display_group, dest)
+
+    def get_node_public_ip(self, node):
+        """Returns a the public IP address of the node"""
+        return [addr.address for addr in node.ipaddresses if addr.is_public][0]
 
     def get_host_info(self):
         """Get variables about a specific host."""
@@ -272,7 +283,7 @@ class LinodeInventory(object):
             node_vars[direct_attr] = getattr(node, direct_attr)
 
         node_vars["datacenter_city"] = self.get_datacenter_city(node)
-        node_vars["public_ip"] = [addr.address for addr in node.ipaddresses if addr.is_public][0]
+        node_vars["public_ip"] = self.get_node_public_ip(node)
 
         # Set the SSH host information, so these inventory items can be used if
         # their labels aren't FQDNs


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

linode dynamic inventory
##### ANSIBLE VERSION

```
ansible 2.1.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Currently the linode dynamic inventory in contrib/inventory/linode.py assumes that your linode labels match a resolvable hostname.  This patch adds the option to use the linodes public IP instead of the linode label.   This is convenient for linode users who have many linodes that don't have labels set that match hostnames, but public IPs will always be resolvable no matter what the linode label is set to. 

This patch does not change default behavior but just adds an additional config parameter in linode.ini called `use_public_ip` that is set to false by default.  Setting it to true changes the output to public IP instead of label.  See the below output. 

<!-- Paste verbatim command output below, e.g. before and after your change -->
### Before

```
{
  "2196623": [
    "node-dallas-1"
  ], 
  "dallas": [
    "node-dallas-1", 
  ], 
  "nodes-dallas": [
    "node-dallas-1"
  ]
}
```
### After with use_public_ip = true

```
{
  "2196623": [
    "45.33.11.123"
  ], 
  "dallas": [
    "45.33.11.123", 
  ], 
  "nodes-dallas": [
    "45.33.11.123"
  ]
}
```
