### PR TITLE
Explicitly convert input to from_yaml to str. This fixes #17397

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -193,6 +193,11 @@ def regex_escape(string):
     '''Escape all regular expressions special characters from STRING.'''
     return re.escape(string)
 
+def from_yaml(data):
+    if isinstance(data, string_types):
+        return yaml.safe_load(data)
+    return data
+
 @environmentfilter
 def rand(environment, end, start=None, step=None):
     r = SystemRandom()
@@ -396,7 +401,7 @@ class FilterModule(object):
             # yaml
             'to_yaml': to_yaml,
             'to_nice_yaml': to_nice_yaml,
-            'from_yaml': yaml.safe_load,
+            'from_yaml': from_yaml,
 
             #date
             'to_datetime': to_datetime,


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

from_yaml filter
##### SUMMARY

Explicitly convert input to from_yaml to str. This avoids type-related errors, e.g. when using a template that evaluates to an empty list. Fixes  #17397
