### PR TITLE
Fix list separator typo

### DIFF
--- a/docsite/rst/intro_patterns.rst
+++ b/docsite/rst/intro_patterns.rst
@@ -98,7 +98,7 @@ And if you want to read the list of hosts from a file, prefix the file name with
 Easy enough.  See :doc:`intro_adhoc` and then :doc:`playbooks` for how to apply this knowledge.
 
 .. note:: With the exception of version 1.9, you can use ',' instead of ':' as a host list separator. The ',' is prefered specially when dealing with ranges and ipv6.
-.. note:: As of 2.0 the ';' is deprecated as a host list separator.
+.. note:: As of 2.0 the ':' is deprecated as a host list separator.
 
 .. seealso::
 


### PR DESCRIPTION
##### ISSUE TYPE

 Docs Pull Request
##### COMPONENT NAME

http://docs.ansible.com/ansible/intro_patterns.html
##### ANSIBLE VERSION

Not relevant.
##### SUMMARY

The ':' (colon) had turned into a ';' (semicolon).
