### PR TITLE
fixes issue #13981: unsafe_writes block appeared too late in the atom…

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1941,7 +1941,24 @@ class AnsibleModule(object):
             os.rename(b_src, b_dest)
         except (IOError, OSError):
             e = get_exception()
-            if e.errno not in [errno.EPERM, errno.EXDEV, errno.EACCES, errno.ETXTBSY]:
+            # sadly there are some situations where we cannot ensure atomicity, but only if
+            # the user insists and we get the appropriate error we update the file unsafely
+            if unsafe_writes and e.errno == errno.EBUSY:
+                #TODO: issue warning that this is an unsafe operation, but doing it cause user insists
+                try:
+                    try:
+                        out_dest = open(b_dest, 'wb')
+                        in_src = open(b_src, 'rb')
+                        shutil.copyfileobj(in_src, out_dest)
+                    finally: # assuring closed files in 2.4 compatible way
+                        if out_dest:
+                            out_dest.close()
+                        if in_src:
+                            in_src.close()
+                except (shutil.Error, OSError, IOError):
+                    e = get_exception()
+                    self.fail_json(msg='Could not write data to file (%s) from (%s): %s' % (dest, src, e))
+            elif e.errno not in [errno.EPERM, errno.EXDEV, errno.EACCES, errno.ETXTBSY]:
                 # only try workarounds for errno 18 (cross device), 1 (not permitted),  13 (permission denied)
                 # and 26 (text file busy) which happens on vagrant synced folders and other 'exotic' non posix file systems
                 self.fail_json(msg='Could not replace file: %s to %s: %s' % (src, dest, e))
@@ -1986,26 +2003,7 @@ class AnsibleModule(object):
                         os.rename(b_tmp_dest_name, b_dest)
                     except (shutil.Error, OSError, IOError):
                         e = get_exception()
-                        # sadly there are some situations where we cannot ensure atomicity, but only if
-                        # the user insists and we get the appropriate error we update the file unsafely
-                        if unsafe_writes and e.errno == errno.EBUSY:
-                            #TODO: issue warning that this is an unsafe operation, but doing it cause user insists
-                            try:
-                                try:
-                                    out_dest = open(b_dest, 'wb')
-                                    in_src = open(b_src, 'rb')
-                                    shutil.copyfileobj(in_src, out_dest)
-                                finally: # assuring closed files in 2.4 compatible way
-                                    if out_dest:
-                                        out_dest.close()
-                                    if in_src:
-                                        in_src.close()
-                            except (shutil.Error, OSError, IOError):
-                                e = get_exception()
-                                self.fail_json(msg='Could not write data to file (%s) from (%s): %s' % (dest, src, e))
-
-                        else:
-                            self.fail_json(msg='Could not replace file: %s to %s: %s' % (src, dest, e))
+			self.fail_json(msg='Could not replace file: %s to %s: %s' % (src, dest, e))
                 finally:
                     self.cleanup(b_tmp_dest_name)
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
- New Module Pull Request
- Bugfix Pull Request
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```

…ic_move

workflow. This led to errno.EBUSY to not be managed in the context of
issue #!#981
