### PR TITLE
Fix galaxy import command for 2.1

### DIFF
--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -127,6 +127,7 @@ class GalaxyAPI(object):
         data = json.load(resp)
         return data
 
+    @g_connect
     def create_import_task(self, github_user, github_repo, reference=None):
         """
         Post an import request


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ansible-galaxy
##### ANSIBLE VERSION

```
ansible 2.1.1.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

The g_connect decorator is required on create_import_task or else
self.baseurl is None. This is fixed in devel already.

```
mordred@camelot:~/src/openstack-infra/shade$ ansible-galaxy -vvvv import openstack-infra ansible-role-puppet
No config file found; using defaults
Opened /home/mordred/.ansible_galaxy
Initial connection to galaxy_server: https://galaxy.ansible.com
Base API: https://galaxy.ansible.com/api/v1
None/imports/
ERROR! Unexpected Exception: unknown url type: None/imports/
the full traceback was:

Traceback (most recent call last):
  File "/home/mordred/.local/bin/ansible-galaxy", line 92, in <module>
    exit_code = cli.run()
  File "/home/mordred/.local/lib/python2.7/site-packages/ansible/cli/galaxy.py", line 133, in run
    self.execute()
  File "/home/mordred/.local/lib/python2.7/site-packages/ansible/cli/__init__.py", line 103, in execute
    fn()
  File "/home/mordred/.local/lib/python2.7/site-packages/ansible/cli/galaxy.py", line 577, in execute_import
    task = self.api.create_import_task(github_user, github_repo, reference=self.options.reference)
  File "/home/mordred/.local/lib/python2.7/site-packages/ansible/galaxy/api.py", line 140, in create_import_task
    data = self.__call_galaxy(url, args=args)
  File "/home/mordred/.local/lib/python2.7/site-packages/ansible/galaxy/api.py", line 56, in wrapped
    return method(self, *args, **kwargs)
  File "/home/mordred/.local/lib/python2.7/site-packages/ansible/galaxy/api.py", line 92, in __call_galaxy
    resp = open_url(url, data=args, validate_certs=self._validate_certs, headers=headers, method=method)
  File "/home/mordred/.local/lib/python2.7/site-packages/ansible/module_utils/urls.py", line 839, in open_url
    r = urllib2.urlopen(*urlopen_args)
  File "/usr/lib/python2.7/urllib2.py", line 154, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python2.7/urllib2.py", line 421, in open
    protocol = req.get_type()
  File "/usr/lib/python2.7/urllib2.py", line 283, in get_type
    raise ValueError, "unknown url type: %s" % self.__original
ValueError: unknown url type: None/imports/

# apply patch

mordred@camelot:~/src/openstack-infra/shade$ ansible-galaxy -vvvv import openstack-infra ansible-role-puppet
No config file found; using defaults
Opened /home/mordred/.ansible_galaxy
Initial connection to galaxy_server: https://galaxy.ansible.com
Base API: https://galaxy.ansible.com/api/v1
https://galaxy.ansible.com/api/v1/imports/
Successfully submitted import request 25420
https://galaxy.ansible.com/api/v1/imports/?id=25420
Starting import 25420: role_name=ansible-role-puppet repo=openstack-infra/ansible-role-puppet ref=
Retrieving Github repo openstack-infra/ansible-role-puppet
https://galaxy.ansible.com/api/v1/imports/?id=25420
https://galaxy.ansible.com/api/v1/imports/?id=25420
https://galaxy.ansible.com/api/v1/imports/?id=25420
https://galaxy.ansible.com/api/v1/imports/?id=25420
https://galaxy.ansible.com/api/v1/imports/?id=25420
https://galaxy.ansible.com/api/v1/imports/?id=25420
https://galaxy.ansible.com/api/v1/imports/?id=25420
Accessing branch: master
Parsing and validating meta/main.yml
No issue tracker defined. Enable issue tracker in repo settings or define galaxy_info.issue_tracker_url in meta/main.yml.
https://galaxy.ansible.com/api/v1/imports/?id=25420
Parsing galaxy_tags
Found galaxy_info.categories. Update meta/main.yml to use galaxy_info.galaxy_tags.
Parsing platforms
Adding dependencies
Parsing and validating README
Adding repo tags as role versions
Import completed
Status SUCCESS : warnings=2 errors=0
```
