### PR TITLE
Allow setting alternate_role_name for galaxy CLI

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -79,6 +79,7 @@ class GalaxyCLI(CLI):
             self.parser.set_usage("usage: %prog import [options] github_user github_repo")
             self.parser.add_option('--no-wait', dest='wait', action='store_false', default=True, help='Don\'t wait for import results.')
             self.parser.add_option('--branch', dest='reference', help='The name of a branch to import. Defaults to the repository\'s default branch (usually master)')
+            self.parser.add_option('--role-name', dest='role_name', help='The name the role should have, if different than the repo name')
             self.parser.add_option('--status', dest='check_status', action='store_true', default=False, help='Check the status of the most recent import request for given github_user/github_repo.')
         elif self.action == "info":
             self.parser.set_usage("usage: %prog info [options] role_name[,version]")
@@ -585,7 +586,7 @@ class GalaxyCLI(CLI):
             task = self.api.get_import_task(github_user=github_user, github_repo=github_repo)
         else:
             # Submit an import request
-            task = self.api.create_import_task(github_user, github_repo, reference=self.options.reference)
+            task = self.api.create_import_task(github_user, github_repo, reference=self.options.reference, role_name=self.options.role_name)
 
             if len(task) > 1:
                 # found multiple roles associated with github_user/github_repo

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -139,17 +139,21 @@ class GalaxyAPI(object):
         return data
 
     @g_connect
-    def create_import_task(self, github_user, github_repo, reference=None):
+    def create_import_task(self, github_user, github_repo, reference=None, role_name=None):
         """
         Post an import request
         """
         url = '%s/imports/' % self.baseurl
-        args = urlencode({
+        args = {
             "github_user": github_user,
             "github_repo": github_repo,
             "github_reference": reference if reference else ""
-        })
-        data = self.__call_galaxy(url, args=args)
+        }
+        if role_name:
+            args['alternate_role_name'] = role_name
+        elif github_repo.startswith('ansible-role'):
+            args['alternate_role_name'] = github_repo[len('ansible-role')+1:]
+        data = self.__call_galaxy(url, args=urlencode(args))
         if data.get('results', None):
             return data['results']
         return data


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

ansible-galaxy
##### ANSIBLE VERSION

ansible 2.1.1.0
  config file = 
  configured module search path = Default w/o overrides
##### SUMMARY

When using the ansible-galaxy CLI to import roles, it's not possible to
specify an alternate_role_name, even though the REST API seems to allow
such a thing (at least on investigation of the interactions the web app
makes) That makes importing things like:
openstack/openstack-ansible-os_cloudkitty wind up with roles named
"openstack-ansible-os_cloudkitty" instead of "os_cloudkitty".

Also, the web ui is smart and imports
"openstack-infra/ansible-role-puppet" as openstack-infra.puppet ... but
the CLI imports it as openstack-infra.ansible-role-puppet. Add that
filtering as well.

I used this patch to import:

https://galaxy.ansible.com/openstack-infra/good-puppet/

```
mordred@camelot:~/src/ansible$ testgalaxy/bin/ansible-galaxy import --role-name=good-puppet openstack-infra ansible-role-puppet
Successfully submitted import request 25436
Starting import 25436: role_name=good-puppet repo=openstack-infra/ansible-role-puppet ref=
Retrieving Github repo openstack-infra/ansible-role-puppet
Accessing branch: master
Parsing and validating meta/main.yml
Setting role name to good-puppet
No issue tracker defined. Enable issue tracker in repo settings or define galaxy_info.issue_tracker_url in meta/main.yml.
Parsing galaxy_tags
Found galaxy_info.categories. Update meta/main.yml to use galaxy_info.galaxy_tags.
Parsing platforms
Adding dependencies
Parsing and validating README
Adding repo tags as role versions
Import completed
Status SUCCESS : warnings=2 errors=0
```
