### PR TITLE
allow 'nonpersistent facts' for other action plugins

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -236,6 +236,7 @@ DEFAULT_BECOME_ASK_PASS   = get_config(p, 'privilege_escalation', 'become_ask_pa
 # In the future we should probably generalize this even further
 # (mapping of param: squash field)
 DEFAULT_SQUASH_ACTIONS         = get_config(p, DEFAULTS, 'squash_actions',     'ANSIBLE_SQUASH_ACTIONS', "apk, apt, dnf, package, pacman, pkgng, yum, zypper", islist=True)
+DEFAULT_FACTS_ACTIONS          = get_config(p, DEFAULTS, 'facts_actions',      'ANSIBLE_FACTS_ACTIONS', "set_fact", islist=True)
 # paths
 DEFAULT_ACTION_PLUGIN_PATH     = get_config(p, DEFAULTS, 'action_plugins',     'ANSIBLE_ACTION_PLUGINS', '~/.ansible/plugins/action:/usr/share/ansible/plugins/action', ispathlist=True)
 DEFAULT_CACHE_PLUGIN_PATH      = get_config(p, DEFAULTS, 'cache_plugins',      'ANSIBLE_CACHE_PLUGINS', '~/.ansible/plugins/cache:/usr/share/ansible/plugins/cache', ispathlist=True)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -367,7 +367,7 @@ class StrategyBase:
                                     host_list = [original_host]
 
                                 for target_host in host_list:
-                                    if original_task.action == 'set_fact':
+                                    if original_task.action in C.DEFAULT_FACTS_ACTIONS:
                                         self._variable_manager.set_nonpersistent_facts(target_host, result_item['ansible_facts'].copy())
                                     else:
                                         self._variable_manager.set_host_facts(target_host, result_item['ansible_facts'].copy())


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

`ansible.plugins.strategy.StrategyBase`
`ansible.constants`
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel cfc0753e83) last updated 2016/09/06 20:51:24 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 982c4557d2) last updated 2016/09/06 20:09:40 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 06bd2a5ce2) last updated 2016/09/06 20:09:40 (GMT +200)
```
##### SUMMARY

Facts setting actions are not able to overwrite existing facts unless the
strategy plugin invokes `VariableManager.set_nonpersistent_facts`. This used
to be the case explicitly for the `set_fact` action plugin.

This change introduces the constant `ansible.constants.DEFAULT_FACTS_ACTIONS`
for flexible configuration of those kind of action plugins. Its default value
is just `set_fact`, so there should not be any broken dependencies.

```
# Assume 'my_set_fact' is just a copy of the 'set_fact' action plugin/module.
- hosts: localhost
  vars:
    foo: "spam"
  tasks:
    - my_set_fact: foo="egg"
    - debug: msg="{{ foo }}"

# before:
ok: [localhost] => {
    "msg": "spam"
}

# after: with ANSIBLE_FACTS_ACTIONS="set_fact, my_set_fact"
ok: [localhost] => {
    "msg": "egg"
}
```
