### PR TITLE
Allow for no prefix in the comment filter

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -336,8 +336,14 @@ def comment(text, style='plain', **kw):
     str_beginning = ''
     if p['beginning']:
         str_beginning = "%s%s" % (p['beginning'], p['newline'])
-    str_prefix = str(
-        "%s%s" % (p['prefix'], p['newline'])) * int(p['prefix_count'])
+    str_prefix = ''
+    if p['prefix']:
+        if p['prefix'] != p['newline']:
+            str_prefix = str(
+                "%s%s" % (p['prefix'], p['newline'])) * int(p['prefix_count'])
+        else:
+            str_prefix = str(
+                "%s" % (p['newline'])) * int(p['prefix_count'])
     str_text = ("%s%s" % (
         p['decoration'],
         # Prepend each line of the text with the decorator


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

The `comment` filter.
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

At the moment, when the `comment` filter is used with `prefix=''` (empty `prefix`), it creates an empty line above the comment. In most cases it's a good behaviour to leave an empty line between sections in the configuration files with comments, however in certain corner cases, like a top of the file, it is annoying and impossible to override either directly in the `comment` parameters, or through Jinja.

This PR changes the behaviour of the

```
{{ "string" | comment(prefix='') }}
```

parameter. Instead of leaving an empty line, nothing  will be prepended to the output. To use the old behaviour, set the parameter as

```
{{ "string" | comment(prefix='\n') }}
```

This will add an empty line before the comment.

This change will affect existing templates that use the `prefix=''` parameter, however an alternative is provided. The change brings the `prefix=` parameter in line with the `beginning=` parameter which works in a similar way, therefore I think it's the correct course of action.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
