### PR TITLE
Move uses of to_bytes, to_text, to_native to use the module_utils version

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -43,7 +43,7 @@ from multiprocessing import Lock
 import ansible.constants as C
 from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
 from ansible.utils.display import Display
-from ansible.utils.unicode import to_unicode
+from ansible.module_utils._text import to_text
 
 
 ########################################
@@ -97,10 +97,10 @@ if __name__ == '__main__':
 
     except AnsibleOptionsError as e:
         cli.parser.print_help()
-        display.error(to_unicode(e), wrap_text=False)
+        display.error(to_text(e), wrap_text=False)
         exit_code = 5
     except AnsibleParserError as e:
-        display.error(to_unicode(e), wrap_text=False)
+        display.error(to_text(e), wrap_text=False)
         exit_code = 4
 # TQM takes care of these, but leaving comment to reserve the exit codes
 #    except AnsibleHostUnreachable as e:
@@ -110,16 +110,16 @@ if __name__ == '__main__':
 #        display.error(str(e))
 #        exit_code = 2
     except AnsibleError as e:
-        display.error(to_unicode(e), wrap_text=False)
+        display.error(to_text(e), wrap_text=False)
         exit_code = 1
     except KeyboardInterrupt:
         display.error("User interrupted execution")
         exit_code = 99
     except Exception as e:
         have_cli_options = cli is not None and cli.options is not None
-        display.error("Unexpected Exception: %s" % to_unicode(e), wrap_text=False)
+        display.error("Unexpected Exception: %s" % to_text(e), wrap_text=False)
         if not have_cli_options or have_cli_options and cli.options.verbosity > 2:
-            display.display(u"the full traceback was:\n\n%s" % to_unicode(traceback.format_exc()))
+            display.display(u"the full traceback was:\n\n%s" % to_text(traceback.format_exc()))
         else:
             display.display("to see the full traceback, use -vvv")
         exit_code = 250

--- a/docsite/rst/developing_modules_python3.rst
+++ b/docsite/rst/developing_modules_python3.rst
@@ -215,6 +215,28 @@ Python3.  We'll need to gather experience to see if this is going to work out
 well for modules as well or if we should give the module_utils API explicit
 switches so that modules can choose to operate with text type all of the time.
 
+Helpers
+~~~~~~~
+
+For converting between bytes, text, and native strings we have three helper
+functions.  These are :func:`ansible.module_utils._text.to_bytes`,
+:func:`ansible.module_utils._text.to_native`, and
+:func:`ansible.module_utils._text.to_text`.  These are similar to using
+``bytes.decode()`` and ``unicode.encode()`` with a few differences.
+
+* By default they try very hard not to traceback.
+* The default encoding is "utf-8"
+* There are two error strategies that don't correspond one-to-one with
+  a python codec error handler.  These are ``surrogate_or_strict`` and
+  ``surrogate_or_replace``.  ``surrogate_or_strict`` will use the ``surrogateescape``
+  error handler if available (mostly on python3) or strict if not.  It is most
+  appropriate to use when dealing with something that needs to round trip its
+  value like file paths database keys, etc.  Without ``surrogateescape`` the best
+  thing these values can do is generate a traceback that our code can catch
+  and decide how to show an error message.  ``surrogate_or_replace`` is for
+  when a value is going to be displayed to the user.  If the
+  ``surrogateescape`` error handler is not present, it will replace
+  undecodable byte sequences with a replacement character.
 
 ================================
 Porting Core Ansible to Python 3

--- a/hacking/module_formatter.py
+++ b/hacking/module_formatter.py
@@ -19,6 +19,7 @@
 #
 
 from __future__ import print_function
+__metaclass__ = type
 
 import os
 import glob
@@ -34,10 +35,10 @@ from collections import defaultdict
 from jinja2 import Environment, FileSystemLoader
 from six import iteritems
 
+from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_bytes
 from ansible.utils import module_docs
 from ansible.utils.vars import merge_hash
-from ansible.utils.unicode import to_bytes
-from ansible.errors import AnsibleError
 
 #####################################################################################
 # constants and paths

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -33,7 +33,7 @@ import subprocess
 from ansible.release import __version__
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleOptionsError
-from ansible.utils.unicode import to_bytes, to_unicode
+from ansible.module_utils._text import to_bytes, to_text
 
 try:
     from __main__ import display
@@ -109,7 +109,7 @@ class CLI(object):
 
         if self.options.verbosity > 0:
             if C.CONFIG_FILE:
-                display.display(u"Using %s as config file" % to_unicode(C.CONFIG_FILE))
+                display.display(u"Using %s as config file" % to_text(C.CONFIG_FILE))
             else:
                 display.display(u"No config file found; using defaults")
 

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -27,13 +27,13 @@ from ansible.cli import CLI
 from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.inventory import Inventory
+from ansible.module_utils._text import to_text
 from ansible.parsing.dataloader import DataLoader
 from ansible.parsing.splitter import parse_kv
 from ansible.playbook.play import Play
 from ansible.plugins import get_all_plugin_loaders
 from ansible.utils.vars import load_extra_vars
 from ansible.utils.vars import load_options_vars
-from ansible.utils.unicode import to_unicode
 from ansible.vars import VariableManager
 
 try:
@@ -99,7 +99,7 @@ class AdHocCLI(CLI):
         super(AdHocCLI, self).run()
 
         # only thing left should be host pattern
-        pattern = to_unicode(self.args[0], errors='strict')
+        pattern = to_text(self.args[0], errors='surrogate_or_strict')
 
         # ignore connection password cause we are local
         if self.options.connection == "local":
@@ -169,7 +169,7 @@ class AdHocCLI(CLI):
         play_ds = self._play_ds(pattern, self.options.seconds, self.options.poll_interval)
         play = Play().load(play_ds, variable_manager=variable_manager, loader=loader)
 
-        if self.callback: 
+        if self.callback:
             cb = self.callback
         elif self.options.one_line:
             cb = 'oneline'

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -39,18 +39,16 @@ import sys
 from ansible import constants as C
 from ansible.cli import CLI
 from ansible.errors import AnsibleError
-
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.inventory import Inventory
+from ansible.module_utils._text import to_native, to_text
 from ansible.parsing.dataloader import DataLoader
 from ansible.parsing.splitter import parse_kv
 from ansible.playbook.play import Play
-from ansible.vars import VariableManager
+from ansible.plugins import module_loader
 from ansible.utils import module_docs
 from ansible.utils.color import stringc
-from ansible.utils.unicode import to_unicode, to_str
-from ansible.plugins import module_loader
-
+from ansible.vars import VariableManager
 
 try:
     from __main__ import display
@@ -152,11 +150,11 @@ class ConsoleCLI(CLI, cmd.Cmd):
                     continue
                 elif module.startswith('_'):
                     fullpath = '/'.join([path,module])
-                    if os.path.islink(fullpath): # avoids aliases
+                    if os.path.islink(fullpath):  # avoids aliases
                         continue
                     module = module.replace('_', '', 1)
 
-                module = os.path.splitext(module)[0] # removes the extension
+                module = os.path.splitext(module)[0]  # removes the extension
                 yield module
 
     def default(self, arg, forceshell=False):
@@ -192,11 +190,11 @@ class ConsoleCLI(CLI, cmd.Cmd):
             )
             play = Play().load(play_ds, variable_manager=self.variable_manager, loader=self.loader)
         except Exception as e:
-            display.error(u"Unable to build command: %s" % to_unicode(e))
+            display.error(u"Unable to build command: %s" % to_text(e))
             return False
 
         try:
-            cb = 'minimal' #FIXME: make callbacks configurable
+            cb = 'minimal'  # FIXME: make callbacks configurable
             # now create a task queue manager to execute the play
             self._tqm = None
             try:
@@ -225,8 +223,8 @@ class ConsoleCLI(CLI, cmd.Cmd):
             display.error('User interrupted execution')
             return False
         except Exception as e:
-            display.error(to_unicode(e))
-            #FIXME: add traceback in very very verbose mode
+            display.error(to_text(e))
+            # FIXME: add traceback in very very verbose mode
             return False
 
     def emptyline(self):
@@ -379,7 +377,7 @@ class ConsoleCLI(CLI, cmd.Cmd):
         else:
             completions = [x.name for x in self.inventory.list_hosts(self.options.cwd)]
 
-        return [to_str(s)[offs:] for s in completions if to_str(s).startswith(to_str(mline))]
+        return [to_native(s)[offs:] for s in completions if to_native(s).startswith(to_native(mline))]
 
     def completedefault(self, text, line, begidx, endidx):
         if line.split()[0] in self.modules:
@@ -393,7 +391,6 @@ class ConsoleCLI(CLI, cmd.Cmd):
         in_path = module_loader.find_plugin(module_name)
         oc, a, _ = module_docs.get_docstring(in_path)
         return oc['options'].keys()
-
 
     def run(self):
 
@@ -409,7 +406,6 @@ class ConsoleCLI(CLI, cmd.Cmd):
         else:
             self.pattern = self.args[0]
         self.options.cwd = self.pattern
-
 
         # dynamically add modules as commands
         self.modules = self.list_modules()
@@ -465,4 +461,3 @@ class ConsoleCLI(CLI, cmd.Cmd):
         atexit.register(readline.write_history_file, histfile)
         self.set_prompt()
         self.cmdloop()
-

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -26,7 +26,7 @@ from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.parsing.dataloader import DataLoader
 from ansible.parsing.vault import VaultEditor
 from ansible.cli import CLI
-from ansible.utils.unicode import to_unicode
+from ansible.module_utils._text import to_text
 
 try:
     from __main__ import display
@@ -163,7 +163,7 @@ class VaultCLI(CLI):
             # unicode here because we are displaying it and therefore can make
             # the decision that the display doesn't have to be precisely what
             # the input was (leave that to decrypt instead)
-            self.pager(to_unicode(self.editor.plaintext(f)))
+            self.pager(ansible.module_utils._text.to_text(self.editor.plaintext(f)))
 
     def execute_rekey(self):
         for f in self.args:

--- a/lib/ansible/errors/__init__.py
+++ b/lib/ansible/errors/__init__.py
@@ -25,8 +25,7 @@ from ansible.errors.yaml_strings import ( YAML_POSITION_DETAILS,
         YAML_COMMON_UNQUOTED_COLON_ERROR,
         YAML_COMMON_PARTIALLY_QUOTED_LINE_ERROR,
         YAML_COMMON_UNBALANCED_QUOTES_ERROR )
-
-from ansible.utils.unicode import to_unicode, to_str
+from ansible.module_utils._text import to_native, to_text
 
 
 class AnsibleError(Exception):
@@ -54,11 +53,11 @@ class AnsibleError(Exception):
         if obj and isinstance(obj, AnsibleBaseYAMLObject):
             extended_error = self._get_extended_error()
             if extended_error and not suppress_extended_error:
-                self.message = '%s\n\n%s' % (to_str(message), to_str(extended_error))
+                self.message = '%s\n\n%s' % (to_native(message), to_native(extended_error))
             else:
-                self.message = '%s' % to_str(message)
+                self.message = '%s' % to_native(message)
         else:
-            self.message = '%s' % to_str(message)
+            self.message = '%s' % to_native(message)
 
     def __str__(self):
         return self.message
@@ -104,8 +103,8 @@ class AnsibleError(Exception):
             error_message += YAML_POSITION_DETAILS % (src_file, line_number, col_number)
             if src_file not in ('<string>', '<unicode>') and self._show_content:
                 (target_line, prev_line) = self._get_error_lines_from_file(src_file, line_number - 1)
-                target_line = to_unicode(target_line)
-                prev_line = to_unicode(prev_line)
+                target_line = to_text(target_line)
+                prev_line = to_text(prev_line)
                 if target_line:
                     stripped_line = target_line.replace(" ","")
                     arrow_line    = (" " * (col_number-1)) + "^ here"

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -21,15 +21,13 @@ __metaclass__ = type
 
 import os
 
-from ansible.compat.six import string_types
-
 from ansible import constants as C
 from ansible.executor.task_queue_manager import TaskQueueManager
+from ansible.module_utils._text import to_native, to_text
 from ansible.playbook import Playbook
 from ansible.template import Templar
 from ansible.utils.helpers import pct_to_int
 from ansible.utils.path import makedirs_safe
-from ansible.utils.unicode import to_unicode, to_str
 
 try:
     from __main__ import display
@@ -74,7 +72,7 @@ class PlaybookExecutor:
                 pb = Playbook.load(playbook_path, variable_manager=self._variable_manager, loader=self._loader)
                 self._inventory.set_playbook_basedir(os.path.realpath(os.path.dirname(playbook_path)))
 
-                if self._tqm is None: # we are doing a listing
+                if self._tqm is None:  # we are doing a listing
                     entry = {'playbook': playbook_path}
                     entry['plays'] = []
                 else:
@@ -84,7 +82,7 @@ class PlaybookExecutor:
 
                 i = 1
                 plays = pb.get_plays()
-                display.vv(u'%d plays in %s' % (len(plays), to_unicode(playbook_path)))
+                display.vv(u'%d plays in %s' % (len(plays), to_text(playbook_path)))
 
                 for play in plays:
                     if play._included_path is not None:
@@ -110,7 +108,7 @@ class PlaybookExecutor:
                                 if self._tqm:
                                     self._tqm.send_callback('v2_playbook_on_vars_prompt', vname, private, prompt, encrypt, confirm, salt_size, salt, default)
                                     play.vars[vname] = display.do_var_prompt(vname, private, prompt, encrypt, confirm, salt_size, salt, default)
-                                else: # we are either in --list-<option> or syntax check
+                                else:  # we are either in --list-<option> or syntax check
                                     play.vars[vname] = default
 
                     # Create a temporary copy of the play here, so we can run post_validate
@@ -156,7 +154,7 @@ class PlaybookExecutor:
                             # conditions are met, we break out, otherwise we only break out if the entire
                             # batch failed
                             failed_hosts_count = len(self._tqm._failed_hosts) + len(self._tqm._unreachable_hosts) - \
-                                                 (previously_failed + previously_unreachable)
+                                (previously_failed + previously_unreachable)
 
                             if len(batch) == failed_hosts_count:
                                 break_play = True
@@ -173,10 +171,10 @@ class PlaybookExecutor:
                         if break_play:
                             break
 
-                    i = i + 1 # per play
+                    i = i + 1  # per play
 
                 if entry:
-                    entrylist.append(entry) # per playbook
+                    entrylist.append(entry)  # per playbook
 
                 # send the stats callback for this playbook
                 if self._tqm is not None:
@@ -276,7 +274,7 @@ class PlaybookExecutor:
                 for x in replay_hosts:
                     fd.write("%s\n" % x)
         except Exception as e:
-            display.warning("Could not create retry file '%s'.\n\t%s" % (retry_path, to_str(e)))
+            display.warning("Could not create retry file '%s'.\n\t%s" % (retry_path, to_native(e)))
             return False
 
         return True

--- a/lib/ansible/executor/process/worker.py
+++ b/lib/ansible/executor/process/worker.py
@@ -19,16 +19,10 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.compat.six.moves import queue
-
-import json
 import multiprocessing
 import os
-import signal
 import sys
-import time
 import traceback
-import zlib
 
 from jinja2.exceptions import TemplateNotFound
 
@@ -40,13 +34,10 @@ try:
 except ImportError:
     HAS_ATFORK=False
 
-from ansible.errors import AnsibleError, AnsibleConnectionFailure
+from ansible.errors import AnsibleConnectionFailure
 from ansible.executor.task_executor import TaskExecutor
 from ansible.executor.task_result import TaskResult
-from ansible.playbook.handler import Handler
-from ansible.playbook.task import Task
-from ansible.vars.unsafe_proxy import AnsibleJSONUnsafeDecoder
-from ansible.utils.unicode import to_unicode
+from ansible.module_utils._text import to_text
 
 try:
     from __main__ import display
@@ -144,11 +135,11 @@ class WorkerProcess(multiprocessing.Process):
                 try:
                     self._host.vars = dict()
                     self._host.groups = []
-                    task_result = TaskResult(self._host.name, self._task._uuid, dict(failed=True, exception=to_unicode(traceback.format_exc()), stdout=''))
+                    task_result = TaskResult(self._host.name, self._task._uuid, dict(failed=True, exception=to_text(traceback.format_exc()), stdout=''))
                     self._rslt_q.put(task_result, block=False)
                 except:
-                    display.debug(u"WORKER EXCEPTION: %s" % to_unicode(e))
-                    display.debug(u"WORKER TRACEBACK: %s" % to_unicode(traceback.format_exc()))
+                    display.debug(u"WORKER EXCEPTION: %s" % to_text(e))
+                    display.debug(u"WORKER TRACEBACK: %s" % to_text(traceback.format_exc()))
 
         display.debug("WORKER PROCESS EXITING")
 

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -28,21 +28,20 @@ import time
 from collections import deque
 
 from ansible import constants as C
+from ansible.compat.six import string_types
 from ansible.errors import AnsibleError
 from ansible.executor import action_write_locks
 from ansible.executor.play_iterator import PlayIterator
 from ansible.executor.process.worker import WorkerProcess
 from ansible.executor.stats import AggregateStats
-from ansible.module_utils.facts import Facts
+from ansible.module_utils._text import to_text
 from ansible.playbook.block import Block
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins import action_loader, callback_loader, connection_loader, filter_loader, lookup_loader, module_loader, strategy_loader, test_loader
-from ansible.template import Templar
-from ansible.vars.hostvars import HostVars
 from ansible.plugins.callback import CallbackBase
+from ansible.template import Templar
 from ansible.utils.helpers import pct_to_int
-from ansible.utils.unicode import to_unicode
-from ansible.compat.six import string_types
+from ansible.vars.hostvars import HostVars
 
 try:
     from __main__ import display
@@ -288,7 +287,8 @@ class TaskQueueManager:
                     stdout_callback_loaded = True
                 elif callback_name == 'tree' and self._run_tree:
                     pass
-                elif not self._run_additional_callbacks or (callback_needs_whitelist and (C.DEFAULT_CALLBACK_WHITELIST is None or callback_name not in C.DEFAULT_CALLBACK_WHITELIST)):
+                elif not self._run_additional_callbacks or (callback_needs_whitelist and (
+                        C.DEFAULT_CALLBACK_WHITELIST is None or callback_name not in C.DEFAULT_CALLBACK_WHITELIST)):
                     continue
 
             self._callback_plugins.append(callback_plugin())
@@ -336,8 +336,8 @@ class TaskQueueManager:
                 serial_items = [serial_items]
             max_serial = max([pct_to_int(x, num_hosts) for x in serial_items])
 
-        contenders =  [self._options.forks, max_serial, num_hosts]
-        contenders =  [v for v in contenders if v is not None and v > 0]
+        contenders = [self._options.forks, max_serial, num_hosts]
+        contenders = [v for v in contenders if v is not None and v > 0]
         self._initialize_processes(min(contenders))
 
         play_context = PlayContext(new_play, self._options, self.passwords, self._connection_lockfile.fileno())
@@ -446,7 +446,7 @@ class TaskQueueManager:
             # try to find v2 method, fallback to v1 method, ignore callback if no method found
             methods = []
             for possible in [method_name, 'v2_on_any']:
-                gotit =  getattr(callback_plugin, possible, None)
+                gotit = getattr(callback_plugin, possible, None)
                 if gotit is None:
                     gotit = getattr(callback_plugin, possible.replace('v2_',''), None)
                 if gotit is not None:
@@ -468,8 +468,8 @@ class TaskQueueManager:
                     else:
                         method(*args, **kwargs)
                 except Exception as e:
-                    #TODO: add config toggle to make this fatal or not?
-                    display.warning(u"Failure using method (%s) in callback plugin (%s): %s" % (to_unicode(method_name), to_unicode(callback_plugin), to_unicode(e)))
+                    # TODO: add config toggle to make this fatal or not?
+                    display.warning(u"Failure using method (%s) in callback plugin (%s): %s" % (to_text(method_name), to_text(callback_plugin), to_text(e)))
                     from traceback import format_tb
                     from sys import exc_info
                     display.debug('Callback Exception: \n' + ' '.join(format_tb(exc_info()[2])))

--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -28,12 +28,12 @@ import json
 
 import ansible.constants as C
 from ansible.compat.six import string_types
-from ansible.compat.six.moves.urllib.parse import quote as urlquote, urlencode
 from ansible.compat.six.moves.urllib.error import HTTPError
+from ansible.compat.six.moves.urllib.parse import quote as urlquote, urlencode
 from ansible.errors import AnsibleError
-from ansible.module_utils.urls import open_url
 from ansible.galaxy.token import GalaxyToken
-from ansible.utils.unicode import to_str
+from ansible.module_utils._text import to_native
+from ansible.module_utils.urls import open_url
 
 try:
     from __main__ import display
@@ -115,12 +115,12 @@ class GalaxyAPI(object):
         try:
             return_data = open_url(url, validate_certs=self._validate_certs)
         except Exception as e:
-            raise AnsibleError("Failed to get data from the API server (%s): %s " % (url, to_str(e)))
+            raise AnsibleError("Failed to get data from the API server (%s): %s " % (url, to_native(e)))
 
         try:
             data = json.load(return_data)
         except Exception as e:
-            raise AnsibleError("Could not process data from the API server (%s): %s " % (url, to_str(e)))
+            raise AnsibleError("Could not process data from the API server (%s): %s " % (url, to_native(e)))
 
         if 'current_version' not in data:
             raise AnsibleError("missing required 'current_version' from server response (%s)" % url)

--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -28,9 +28,10 @@ from ansible.inventory.host import Host
 from ansible.inventory.group import Group
 from ansible.inventory.expand_hosts import detect_range
 from ansible.inventory.expand_hosts import expand_hostname_range
+from ansible.module_utils._text import to_text
 from ansible.parsing.utils.addresses import parse_address
 from ansible.utils.shlex import shlex_split
-from ansible.utils.unicode import to_unicode
+
 
 class InventoryParser(object):
     """
@@ -56,7 +57,7 @@ class InventoryParser(object):
             (data, private) = loader._get_file_contents(filename)
         else:
             with open(filename) as fh:
-                data = to_unicode(fh.read())
+                data = to_text(fh.read())
         data = data.split('\n')
 
         self._parse(data)
@@ -125,7 +126,7 @@ class InventoryParser(object):
 
                 continue
             elif line.startswith('[') and line.endswith(']'):
-                self._raise_error("Invalid section entry: '%s'. Please make sure that there are no spaces" % line + \
+                self._raise_error("Invalid section entry: '%s'. Please make sure that there are no spaces" % line +
                                   "in the section entry, and that there are no other invalid characters")
 
             # It's not a section, so the current state tells us what kind of
@@ -187,7 +188,6 @@ class InventoryParser(object):
         for group in self.groups.values():
             if group.depth == 0 and group.name not in ('all', 'ungrouped'):
                 self.groups['all'].add_child_group(group)
-
 
     def _parse_group_name(self, line):
         '''
@@ -323,7 +323,7 @@ class InventoryParser(object):
             except SyntaxError:
                 # Is this a hash with an equals at the end?
                 pass
-        return to_unicode(v, nonstring='passthru', errors='strict')
+        return to_text(v, nonstring='passthru', errors='surrogate_or_strict')
 
     def get_host_variables(self, host):
         return {}

--- a/lib/ansible/inventory/script.py
+++ b/lib/ansible/inventory/script.py
@@ -31,7 +31,7 @@ from ansible.errors import AnsibleError
 from ansible.inventory.host import Host
 from ansible.inventory.group import Group
 from ansible.module_utils.basic import json_dict_bytes_to_unicode
-from ansible.utils.unicode import to_str, to_unicode
+from ansible.module_utils._text import to_native, to_text
 
 
 class InventoryScript:
@@ -61,9 +61,9 @@ class InventoryScript:
         # make sure script output is unicode so that json loader will output
         # unicode strings itself
         try:
-            self.data = to_unicode(stdout, errors="strict")
+            self.data = to_text(stdout, errors="strict")
         except Exception as e:
-            raise AnsibleError("inventory data from {0} contained characters that cannot be interpreted as UTF-8: {1}".format(to_str(self.filename), to_str(e)))
+            raise AnsibleError("inventory data from {0} contained characters that cannot be interpreted as UTF-8: {1}".format(to_native(self.filename), to_native(e)))
 
         # see comment about _meta below
         self.host_vars_from_top = None
@@ -78,11 +78,11 @@ class InventoryScript:
             self.raw = self._loader.load(self.data)
         except Exception as e:
             sys.stderr.write(err + "\n")
-            raise AnsibleError("failed to parse executable inventory script results from {0}: {1}".format(to_str(self.filename), to_str(e)))
+            raise AnsibleError("failed to parse executable inventory script results from {0}: {1}".format(to_native(self.filename), to_native(e)))
 
         if not isinstance(self.raw, Mapping):
             sys.stderr.write(err + "\n")
-            raise AnsibleError("failed to parse executable inventory script results from {0}: data needs to be formatted as a json dict".format(to_str(self.filename)))
+            raise AnsibleError("failed to parse executable inventory script results from {0}: data needs to be formatted as a json dict".format(to_native(self.filename)))
 
         group = None
         for (group_name, data) in self.raw.items():
@@ -152,7 +152,7 @@ class InventoryScript:
             try:
                 got = self.host_vars_from_top.get(host.name, {})
             except AttributeError as e:
-                raise AnsibleError("Improperly formated host information for %s: %s" % (host.name,to_str(e)))
+                raise AnsibleError("Improperly formated host information for %s: %s" % (host.name,to_native(e)))
             return got
 
         cmd = [self.filename, "--host", host.name]

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -805,7 +805,7 @@ class AnsibleModule(object):
         if not HAVE_SELINUX or not self.selinux_enabled():
             return context
         try:
-            ret = selinux.matchpathcon(to_native(path, errors='strict'), mode)
+            ret = selinux.matchpathcon(to_native(path, errors='surrogate_or_strict'), mode)
         except OSError:
             return context
         if ret[0] == -1:
@@ -820,7 +820,7 @@ class AnsibleModule(object):
         if not HAVE_SELINUX or not self.selinux_enabled():
             return context
         try:
-            ret = selinux.lgetfilecon_raw(to_native(path, errors='strict'))
+            ret = selinux.lgetfilecon_raw(to_native(path, errors='surrogate_or_strict'))
         except OSError:
             e = get_exception()
             if e.errno == errno.ENOENT:
@@ -2121,10 +2121,10 @@ class AnsibleModule(object):
         to_clean_args = args
         if PY2:
             if isinstance(args, text_type):
-                to_clean_args = args.encode('utf-8')
+                to_clean_args = to_bytes(args)
         else:
             if isinstance(args, binary_type):
-                to_clean_args = args.decode('utf-8', errors='replace')
+                to_clean_args = to_text(args)
         if isinstance(args, (text_type, binary_type)):
             to_clean_args = shlex.split(to_clean_args)
 
@@ -2193,11 +2193,7 @@ class AnsibleModule(object):
                 if not binary_data:
                     data += '\n'
                 if isinstance(data, text_type):
-                    if PY3:
-                        errors = 'surrogateescape'
-                    else:
-                        errors = 'strict'
-                    data = data.encode('utf-8', errors=errors)
+                    data = to_bytes(data)
                 cmd.stdin.write(data)
                 cmd.stdin.close()
 

--- a/lib/ansible/parsing/splitter.py
+++ b/lib/ansible/parsing/splitter.py
@@ -23,7 +23,9 @@ import re
 import codecs
 
 from ansible.errors import AnsibleParserError
+from ansible.module_utils._text import to_text
 from ansible.parsing.quoting import unquote
+
 
 # Decode escapes adapted from rspeer's answer here:
 # http://stackoverflow.com/questions/4020539/process-escape-sequences-in-a-string-in-python
@@ -36,11 +38,13 @@ _ESCAPE_SEQUENCE_RE = re.compile(r'''
     | \\[\\'"abfnrtv]  # Single-character escapes
     )'''.format(_HEXCHAR*8, _HEXCHAR*4, _HEXCHAR*2), re.UNICODE | re.VERBOSE)
 
+
 def _decode_escapes(s):
     def decode_match(match):
         return codecs.decode(match.group(0), 'unicode-escape')
 
     return _ESCAPE_SEQUENCE_RE.sub(decode_match, s)
+
 
 def parse_kv(args, check_raw=False):
     '''
@@ -50,9 +54,7 @@ def parse_kv(args, check_raw=False):
     they will simply be ignored.
     '''
 
-    ### FIXME: args should already be a unicode string
-    from ansible.utils.unicode import to_unicode
-    args = to_unicode(args, nonstring='passthru')
+    args = to_text(args, nonstring='passthru')
 
     options = {}
     if args is not None:
@@ -60,7 +62,7 @@ def parse_kv(args, check_raw=False):
             vargs = split_args(args)
         except ValueError as ve:
             if 'no closing quotation' in str(ve).lower():
-                raise AnsibleParsingError("error parsing argument string, try quoting the entire line.")
+                raise AnsibleParserError("error parsing argument string, try quoting the entire line.")
             else:
                 raise
 
@@ -99,6 +101,7 @@ def parse_kv(args, check_raw=False):
 
     return options
 
+
 def _get_quote_state(token, quote_char):
     '''
     the goal of this block is to determine if the quoted string
@@ -118,6 +121,7 @@ def _get_quote_state(token, quote_char):
                 quote_char = cur_char
     return quote_char
 
+
 def _count_jinja2_blocks(token, cur_depth, open_token, close_token):
     '''
     this function counts the number of opening/closing blocks for a
@@ -131,6 +135,7 @@ def _count_jinja2_blocks(token, cur_depth, open_token, close_token):
         if cur_depth < 0:
             cur_depth = 0
     return cur_depth
+
 
 def split_args(args):
     '''
@@ -166,9 +171,9 @@ def split_args(args):
 
     quote_char = None
     inside_quotes = False
-    print_depth   = 0 # used to count nested jinja2 {{ }} blocks
-    block_depth   = 0 # used to count nested jinja2 {% %} blocks
-    comment_depth = 0 # used to count nested jinja2 {# #} blocks
+    print_depth   = 0  # used to count nested jinja2 {{ }} blocks
+    block_depth   = 0  # used to count nested jinja2 {% %} blocks
+    comment_depth = 0  # used to count nested jinja2 {# #} blocks
 
     # now we loop over each split chunk, coalescing tokens if the white space
     # split occurred within quotes or a jinja2 block of some kind

--- a/lib/ansible/parsing/yaml/constructor.py
+++ b/lib/ansible/parsing/yaml/constructor.py
@@ -22,12 +22,11 @@ __metaclass__ = type
 from yaml.constructor import Constructor, ConstructorError
 from yaml.nodes import MappingNode
 
+from ansible.module_utils._text import to_bytes
+from ansible.parsing.vault import VaultLib
 from ansible.parsing.yaml.objects import AnsibleMapping, AnsibleSequence, AnsibleUnicode
 from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
-
 from ansible.vars.unsafe_proxy import wrap_var
-from ansible.parsing.vault import VaultLib
-from ansible.utils.unicode import to_bytes
 
 try:
     from __main__ import display
@@ -74,7 +73,8 @@ class AnsibleConstructor(Constructor):
                         "found unacceptable key (%s)" % exc, key_node.start_mark)
 
             if key in mapping:
-                display.warning(u'While constructing a mapping from {1}, line {2}, column {3}, found a duplicate dict key ({0}).  Using last defined value only.'.format(key, *mapping.ansible_pos))
+                display.warning(u'While constructing a mapping from {1}, line {2}, column {3}, found a duplicate dict key ({0}).'
+                u' Using last defined value only.'.format(key, *mapping.ansible_pos))
 
             value = self.construct_object(value_node, deep=deep)
             mapping[key] = value

--- a/lib/ansible/parsing/yaml/objects.py
+++ b/lib/ansible/parsing/yaml/objects.py
@@ -22,8 +22,7 @@ __metaclass__ = type
 import yaml
 
 from ansible.compat.six import text_type
-from ansible.errors import AnsibleError
-from ansible.utils.unicode import to_bytes
+from ansible.module_utils._text import to_bytes
 
 
 class AnsibleBaseYAMLObject(object):

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -19,25 +19,22 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import collections
 import itertools
 import operator
 import uuid
 
-from copy import copy as shallowcopy, deepcopy
+from copy import copy as shallowcopy
 from functools import partial
-from inspect import getmembers
-
-from ansible.compat.six import iteritems, string_types, with_metaclass
 
 from jinja2.exceptions import UndefinedError
 
+from ansible.compat.six import iteritems, string_types, with_metaclass
 from ansible.errors import AnsibleParserError, AnsibleUndefinedVariable
-from ansible.parsing.dataloader import DataLoader
+from ansible.module_utils._text import to_text
 from ansible.playbook.attribute import Attribute, FieldAttribute
+from ansible.parsing.dataloader import DataLoader
 from ansible.utils.boolean import boolean
 from ansible.utils.vars import combine_vars, isidentifier
-from ansible.utils.unicode import to_unicode
 
 try:
     from __main__ import display
@@ -52,6 +49,7 @@ def _generic_g(prop_name, self):
     except KeyError:
         raise AttributeError("'%s' object has no attribute '%s'" % (self.__class__.__name__, prop_name))
 
+
 def _generic_g_method(prop_name, self):
     try:
         if self._squashed:
@@ -60,6 +58,7 @@ def _generic_g_method(prop_name, self):
         return getattr(self, method)()
     except KeyError:
         raise AttributeError("'%s' object has no attribute '%s'" % (self.__class__.__name__, prop_name))
+
 
 def _generic_g_parent(prop_name, self):
     try:
@@ -74,11 +73,14 @@ def _generic_g_parent(prop_name, self):
 
     return value
 
+
 def _generic_s(prop_name, self, value):
     self._attributes[prop_name] = value
 
+
 def _generic_d(prop_name, self):
     del self._attributes[prop_name]
+
 
 class BaseMeta(type):
 
@@ -141,6 +143,7 @@ class BaseMeta(type):
         _process_parents(parents, dct)
 
         return super(BaseMeta, cls).__new__(cls, name, parents, dct)
+
 
 class Base(with_metaclass(BaseMeta, object)):
 
@@ -376,7 +379,7 @@ class Base(with_metaclass(BaseMeta, object)):
                 # and make sure the attribute is of the type it should be
                 if value is not None:
                     if attribute.isa == 'string':
-                        value = to_unicode(value)
+                        value = to_text(value)
                     elif attribute.isa == 'int':
                         value = int(value)
                     elif attribute.isa == 'float':
@@ -395,8 +398,8 @@ class Base(with_metaclass(BaseMeta, object)):
                         elif not isinstance(value, list):
                             if isinstance(value, string_types) and attribute.isa == 'barelist':
                                 display.deprecated(
-                                    "Using comma separated values for a list has been deprecated. " \
-                                    "You should instead use the correct YAML syntax for lists. " \
+                                    "Using comma separated values for a list has been deprecated. "
+                                    "You should instead use the correct YAML syntax for lists. "
                                 )
                                 value = value.split(',')
                             else:
@@ -532,4 +535,3 @@ class Base(with_metaclass(BaseMeta, object)):
         setattr(self, '_uuid', data.get('uuid'))
         self._finalized = data.get('finalized', False)
         self._squashed = data.get('squashed', False)
-

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -22,12 +22,10 @@ __metaclass__ = type
 import os
 
 from ansible.compat.six import iteritems, string_types
-
 from ansible.errors import AnsibleError, AnsibleParserError
-
+from ansible.module_utils._text import to_native
 from ansible.parsing.mod_args import ModuleArgsParser
 from ansible.parsing.yaml.objects import AnsibleBaseYAMLObject, AnsibleMapping, AnsibleUnicode
-
 from ansible.plugins import lookup_loader
 from ansible.playbook.attribute import FieldAttribute
 from ansible.playbook.base import Base
@@ -38,7 +36,6 @@ from ansible.playbook.loop_control import LoopControl
 from ansible.playbook.role import Role
 from ansible.playbook.taggable import Taggable
 
-from ansible.utils.unicode import to_str
 
 try:
     from __main__ import display
@@ -182,7 +179,7 @@ class Task(Base, Conditional, Taggable, Become):
         try:
             (action, args, delegate_to) = args_parser.parse()
         except AnsibleParserError as e:
-            raise AnsibleParserError(to_str(e), obj=ds)
+            raise AnsibleParserError(to_native(e), obj=ds)
 
         # the command/shell/script modules used to support the `cmd` arg,
         # which corresponds to what we now call _raw_params, so move that
@@ -232,11 +229,11 @@ class Task(Base, Conditional, Taggable, Become):
 
     def _load_loop_control(self, attr, ds):
         if not isinstance(ds, dict):
-           raise AnsibleParserError(
-               "the `loop_control` value must be specified as a dictionary and cannot " \
-               "be a variable itself (though it can contain variables)",
-               obj=ds,
-           )
+            raise AnsibleParserError(
+                "the `loop_control` value must be specified as a dictionary and cannot "
+                "be a variable itself (though it can contain variables)",
+                obj=ds,
+            )
 
         return LoopControl.load(data=ds, variable_manager=self._variable_manager, loader=self._loader)
 
@@ -267,18 +264,18 @@ class Task(Base, Conditional, Taggable, Become):
             return dict()
 
         elif isinstance(value, list):
-            if  len(value) == 1:
+            if len(value) == 1:
                 return templar.template(value[0], convert_bare=True)
             else:
                 env = []
                 for env_item in value:
                     if isinstance(env_item, (string_types, AnsibleUnicode)) and env_item in templar._available_variables.keys():
-                        env[env_item] =  templar.template(env_item, convert_bare=True)
+                        env[env_item] = templar.template(env_item, convert_bare=True)
         elif isinstance(value, dict):
             env = dict()
             for env_item in value:
                 if isinstance(env_item, (string_types, AnsibleUnicode)) and env_item in templar._available_variables.keys():
-                    env[env_item] =  templar.template(value[env_item], convert_bare=True)
+                    env[env_item] = templar.template(value[env_item], convert_bare=True)
 
         # at this point it should be a simple string
         return templar.template(value, convert_bare=True)
@@ -436,7 +433,7 @@ class Task(Base, Conditional, Taggable, Become):
         '''
         path_stack = []
 
-        dep_chain =  self.get_dep_chain()
+        dep_chain = self.get_dep_chain()
         # inside role: add the dependency chain from current to dependant
         if dep_chain:
             path_stack.extend(reversed([x._role_path for x in dep_chain]))
@@ -452,4 +449,3 @@ class Task(Base, Conditional, Taggable, Become):
         if self._parent:
             return self._parent.all_parents_static()
         return True
-

--- a/lib/ansible/plugins/action/assemble.py
+++ b/lib/ansible/plugins/action/assemble.py
@@ -24,10 +24,10 @@ import tempfile
 import re
 
 from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_native, to_text
 from ansible.plugins.action import ActionBase
 from ansible.utils.boolean import boolean
 from ansible.utils.hashing import checksum_s
-from ansible.utils.unicode import to_str, to_unicode
 
 
 class ActionModule(ActionBase):
@@ -42,7 +42,7 @@ class ActionModule(ActionBase):
         delimit_me = False
         add_newline = False
 
-        for f in (to_unicode(p, errors='strict') for p in sorted(os.listdir(src_path))):
+        for f in (to_text(p, errors='surrogate_or_strict') for p in sorted(os.listdir(src_path))):
             if compiled_regexp and not compiled_regexp.search(f):
                 continue
             fragment = u"%s/%s" % (src_path, f)
@@ -114,7 +114,7 @@ class ActionModule(ActionBase):
                 src = self._find_needle('files', src)
             except AnsibleError as e:
                 result['failed'] = True
-                result['msg'] = to_str(e)
+                result['msg'] = to_native(e)
                 return result
 
         if not os.path.isdir(src):

--- a/lib/ansible/plugins/action/async.py
+++ b/lib/ansible/plugins/action/async.py
@@ -22,9 +22,10 @@ import pipes
 import random
 
 from ansible import constants as C
-from ansible.plugins.action import ActionBase
 from ansible.compat.six import iteritems
-from ansible.utils.unicode import to_unicode
+from ansible.module_utils._text import to_text
+from ansible.plugins.action import ActionBase
+
 
 class ActionModule(ActionBase):
 
@@ -76,7 +77,7 @@ class ActionModule(ActionBase):
         elif module_style == 'old':
             args_data = ""
             for k, v in iteritems(module_args):
-                args_data += '%s="%s" ' % (k, pipes.quote(to_unicode(v)))
+                args_data += '%s="%s" ' % (k, pipes.quote(to_text(v)))
             argsfile = self._transfer_data(self._connection._shell.join_path(tmp, 'arguments'), args_data)
 
         remote_paths = tmp, remote_module_path, remote_async_module_path
@@ -100,7 +101,7 @@ class ActionModule(ActionBase):
         if not self._should_remove_tmp_path(tmp):
             async_cmd.append("-preserve_tmp")
 
-        async_cmd = " ".join([to_unicode(x) for x in async_cmd])
+        async_cmd = " ".join(to_text(x) for x in async_cmd)
         result.update(self._low_level_execute_command(cmd=async_cmd))
 
         result['changed'] = True

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -24,10 +24,10 @@ import os
 import tempfile
 
 from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.plugins.action import ActionBase
 from ansible.utils.boolean import boolean
 from ansible.utils.hashing import checksum
-from ansible.utils.unicode import to_bytes, to_str, to_unicode
 
 
 class ActionModule(ActionBase):
@@ -81,7 +81,7 @@ class ActionModule(ActionBase):
                 source = content_tempfile
             except Exception as err:
                 result['failed'] = True
-                result['msg'] = "could not write content temp file: %s" % to_str(err)
+                result['msg'] = "could not write content temp file: %s" % to_native(err)
                 return result
 
         # if we have first_available_file in our vars
@@ -91,19 +91,19 @@ class ActionModule(ActionBase):
         elif remote_src:
             result.update(self._execute_module(module_name='copy', module_args=self._task.args, task_vars=task_vars, delete_remote_tmp=False))
             return result
-        else: # find in expected paths
+        else:  # find in expected paths
             try:
                 source = self._find_needle('files', source)
             except AnsibleError as e:
                 result['failed'] = True
-                result['msg'] = to_unicode(e)
+                result['msg'] = to_text(e)
                 return result
 
         # A list of source file tuples (full_path, relative_path) which will try to copy to the destination
         source_files = []
 
         # If source is a directory populate our list else source is a file and translate it to a tuple.
-        if os.path.isdir(to_bytes(source, errors='strict')):
+        if os.path.isdir(to_bytes(source, errors='surrogate_or_strict')):
             # Get the amount of spaces to remove to get the relative path.
             if source_trailing_slash:
                 sz = len(source)
@@ -113,7 +113,7 @@ class ActionModule(ActionBase):
             # Walk the directory and append the file tuples to source_files.
             for base_path, sub_folders, files in os.walk(to_bytes(source)):
                 for file in files:
-                    full_path = to_unicode(os.path.join(base_path, file), errors='strict')
+                    full_path = to_text(os.path.join(base_path, file), errors='surrogate_or_strict')
                     rel_path = full_path[sz:]
                     if rel_path.startswith('/'):
                         rel_path = rel_path[1:]
@@ -247,7 +247,9 @@ class ActionModule(ActionBase):
                 if 'content' in new_module_args:
                     del new_module_args['content']
 
-                module_return = self._execute_module(module_name='copy', module_args=new_module_args, task_vars=task_vars, tmp=tmp, delete_remote_tmp=delete_remote_tmp)
+                module_return = self._execute_module(module_name='copy',
+                        module_args=new_module_args, task_vars=task_vars,
+                        tmp=tmp, delete_remote_tmp=delete_remote_tmp)
                 module_executed = True
 
             else:
@@ -272,7 +274,9 @@ class ActionModule(ActionBase):
                 )
 
                 # Execute the file module.
-                module_return = self._execute_module(module_name='file', module_args=new_module_args, task_vars=task_vars, tmp=tmp, delete_remote_tmp=delete_remote_tmp)
+                module_return = self._execute_module(module_name='file',
+                        module_args=new_module_args, task_vars=task_vars,
+                        tmp=tmp, delete_remote_tmp=delete_remote_tmp)
                 module_executed = True
 
             if not module_return.get('checksum'):

--- a/lib/ansible/plugins/action/debug.py
+++ b/lib/ansible/plugins/action/debug.py
@@ -20,8 +20,8 @@ __metaclass__ = type
 
 from ansible.compat.six import string_types
 from ansible.errors import AnsibleUndefinedVariable
+from ansible.module_utils._text import to_text
 from ansible.plugins.action import ActionBase
-from ansible.utils.unicode import to_unicode
 
 
 class ActionModule(ActionBase):
@@ -66,7 +66,7 @@ class ActionModule(ActionBase):
 
                 if isinstance(self._task.args['var'], (list, dict)):
                     # If var is a list or dict, use the type as key to display
-                    result[to_unicode(type(self._task.args['var']))] = results
+                    result[to_text(type(self._task.args['var']))] = results
                 else:
                     result[self._task.args['var']] = results
             else:

--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -21,11 +21,11 @@ import os
 import base64
 
 from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_bytes
 from ansible.plugins.action import ActionBase
 from ansible.utils.boolean import boolean
 from ansible.utils.hashing import checksum, checksum_s, md5, secure_hash
 from ansible.utils.path import makedirs_safe
-from ansible.utils.unicode import to_bytes
 
 
 class ActionModule(ActionBase):
@@ -160,7 +160,7 @@ class ActionModule(ActionBase):
                 self._connection.fetch_file(source, dest)
             else:
                 try:
-                    f = open(to_bytes(dest, errors='strict'), 'w')
+                    f = open(to_bytes(dest, errors='surrogate_or_strict'), 'wb')
                     f.write(remote_data)
                     f.close()
                 except (IOError, OSError) as e:

--- a/lib/ansible/plugins/action/include_vars.py
+++ b/lib/ansible/plugins/action/include_vars.py
@@ -22,8 +22,8 @@ from os import path, walk
 import re
 
 from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_native
 from ansible.plugins.action import ActionBase
-from ansible.utils.unicode import to_str
 
 
 class ActionModule(ActionBase):
@@ -137,7 +137,7 @@ class ActionModule(ActionBase):
                     results.update(updated_results)
 
             except AnsibleError as e:
-                err_msg = to_str(e)
+                err_msg = to_native(e)
                 raise AnsibleError(err_msg)
 
         if self.return_results_as_name:

--- a/lib/ansible/plugins/action/net_config.py
+++ b/lib/ansible/plugins/action/net_config.py
@@ -26,9 +26,11 @@ import glob
 import urlparse
 
 from ansible.plugins.action import ActionBase
-from ansible.utils.unicode import to_unicode
+from ansible.module_utils._text import to_text
+
 
 PRIVATE_KEYS_RE = re.compile('__.+__')
+
 
 class ActionModule(ActionBase):
 
@@ -55,7 +57,6 @@ class ActionModule(ActionBase):
             filepath = self._write_backup(task_vars['inventory_hostname'],
                                           result['__backup__'])
             result['backup_path'] = filepath
-
 
         # strip out any keys that have two leading and two trailing
         # underscore characters
@@ -98,7 +99,7 @@ class ActionModule(ActionBase):
 
         try:
             with open(source, 'r') as f:
-                template_data = to_unicode(f.read())
+                template_data = to_text(f.read())
         except IOError:
             return dict(failed=True, msg='unable to load src file')
 
@@ -114,5 +115,3 @@ class ActionModule(ActionBase):
         searchpath.append(os.path.dirname(source))
         self._templar.environment.loader.searchpath = searchpath
         self._task.args['src'] = self._templar.template(template_data)
-
-

--- a/lib/ansible/plugins/action/net_template.py
+++ b/lib/ansible/plugins/action/net_template.py
@@ -19,17 +19,17 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import sys
 import os
 import time
 import glob
 import urlparse
 
+from ansible.module_utils._text import to_text
 from ansible.plugins.action import ActionBase
-from ansible.utils.boolean import boolean
-from ansible.utils.unicode import to_unicode
+
 
 BOOLEANS = ('true', 'false', 'yes', 'no')
+
 
 class ActionModule(ActionBase):
 
@@ -92,7 +92,7 @@ class ActionModule(ActionBase):
 
         try:
             with open(source, 'r') as f:
-                template_data = to_unicode(f.read())
+                template_data = to_text(f.read())
         except IOError:
             return dict(failed=True, msg='unable to load src file')
 
@@ -108,5 +108,3 @@ class ActionModule(ActionBase):
         searchpath.append(os.path.dirname(source))
         self._templar.environment.loader.searchpath = searchpath
         self._task.args['src'] = self._templar.template(template_data)
-
-

--- a/lib/ansible/plugins/action/patch.py
+++ b/lib/ansible/plugins/action/patch.py
@@ -20,10 +20,10 @@ __metaclass__ = type
 
 import os
 
+from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_native
 from ansible.plugins.action import ActionBase
 from ansible.utils.boolean import boolean
-from ansible.errors import AnsibleError
-from ansible.utils.unicode import to_str
 
 
 class ActionModule(ActionBase):
@@ -52,7 +52,7 @@ class ActionModule(ActionBase):
             src = self._find_needle('files', src)
         except AnsibleError as e:
             result['failed'] = True
-            result['msg'] = to_str(e)
+            result['msg'] = to_native(e)
             return result
 
         # create the remote tmp dir if needed, and put the source file there

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -19,14 +19,13 @@ __metaclass__ = type
 
 import os
 
-from ansible.plugins.action import ActionBase
 from ansible.errors import AnsibleError
-from ansible.utils.unicode import to_str
+from ansible.module_utils._text import to_native
+from ansible.plugins.action import ActionBase
 
 
 class ActionModule(ActionBase):
     TRANSFERS_FILES = True
-
 
     def run(self, tmp=None, task_vars=None):
         ''' handler for file transfer operations '''
@@ -74,7 +73,7 @@ class ActionModule(ActionBase):
         try:
             source = self._loader.get_real_file(self._find_needle('files', source))
         except AnsibleError as e:
-            return dict(failed=True, msg=to_str(e))
+            return dict(failed=True, msg=to_native(e))
 
         # transfer the file to a remote tmp location
         tmp_src = self._connection._shell.join_path(tmp, os.path.basename(source))

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -23,12 +23,11 @@ import pwd
 import time
 
 from ansible import constants as C
+from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.plugins.action import ActionBase
 from ansible.utils.hashing import checksum_s
 from ansible.utils.boolean import boolean
-from ansible.utils.unicode import to_bytes, to_unicode, to_str
-from ansible.errors import AnsibleError
-
 
 
 class ActionModule(ActionBase):
@@ -78,7 +77,7 @@ class ActionModule(ActionBase):
                 source = self._find_needle('templates', source)
             except AnsibleError as e:
                 result['failed'] = True
-                result['msg'] = to_str(e)
+                result['msg'] = to_native(e)
 
         if 'failed' in result:
             return result
@@ -96,7 +95,7 @@ class ActionModule(ActionBase):
         b_source = to_bytes(source)
         try:
             with open(b_source, 'r') as f:
-                template_data = to_unicode(f.read())
+                template_data = to_text(f.read())
 
             try:
                 template_uid = pwd.getpwuid(os.stat(b_source).st_uid).pw_name
@@ -163,7 +162,7 @@ class ActionModule(ActionBase):
             if self._play_context.diff:
                 diff = self._get_diff_data(dest, resultant, task_vars, source_file=False)
 
-            if not self._play_context.check_mode: # do actual work thorugh copy
+            if not self._play_context.check_mode:  # do actual work through copy
                 xfered = self._transfer_data(self._connection._shell.join_path(tmp, 'source'), resultant)
 
                 # fix file permissions when the copy is done as a different user
@@ -176,7 +175,7 @@ class ActionModule(ActionBase):
                        dest=dest,
                        original_basename=os.path.basename(source),
                        follow=True,
-                    ),
+                   ),
                 )
                 result.update(self._execute_module(module_name='copy', module_args=new_module_args, task_vars=task_vars, tmp=tmp, delete_remote_tmp=False))
 

--- a/lib/ansible/plugins/action/unarchive.py
+++ b/lib/ansible/plugins/action/unarchive.py
@@ -20,10 +20,11 @@ __metaclass__ = type
 
 import os
 
+from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_native
 from ansible.plugins.action import ActionBase
 from ansible.utils.boolean import boolean
-from ansible.errors import AnsibleError
-from ansible.utils.unicode import to_str
+
 
 class ActionModule(ActionBase):
 
@@ -82,7 +83,7 @@ class ActionModule(ActionBase):
                 source = self._loader.get_real_file(self._find_needle('files', source))
             except AnsibleError as e:
                 result['failed'] = True
-                result['msg'] = to_str(e)
+                result['msg'] = to_native(e)
                 self._remove_tmp_path(tmp)
                 return result
 

--- a/lib/ansible/plugins/action/win_reboot.py
+++ b/lib/ansible/plugins/action/win_reboot.py
@@ -19,16 +19,12 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.plugins.action import ActionBase
-from ansible.utils.boolean import boolean
-from ansible.utils.unicode import to_unicode
-from ansible.errors import AnsibleUndefinedVariable
-
 import socket
 import time
-import traceback
 
 from datetime import datetime, timedelta
+
+from ansible.plugins.action import ActionBase
 
 try:
     from __main__ import display
@@ -36,8 +32,10 @@ except ImportError:
     from ansible.utils.display import Display
     display = Display()
 
+
 class TimedOutException(Exception):
     pass
+
 
 class ActionModule(ActionBase):
     TRANSFERS_FILES = False
@@ -50,7 +48,7 @@ class ActionModule(ActionBase):
 
     def do_until_success_or_timeout(self, what, timeout_sec, what_desc, fail_sleep_sec=1):
         max_end_time = datetime.utcnow() + timedelta(seconds=timeout_sec)
-        
+
         while datetime.utcnow() < max_end_time:
             try:
                 what()
@@ -82,7 +80,7 @@ class ActionModule(ActionBase):
         winrm_port = self._connection._winrm_port
 
         result = super(ActionModule, self).run(tmp, task_vars)
-        
+
         # initiate reboot
         (rc, stdout, stderr) = self._connection.exec_command("shutdown /r /t %d" % pre_reboot_delay_sec)
 
@@ -92,7 +90,7 @@ class ActionModule(ActionBase):
             result['msg'] = "Shutdown command failed, error text was %s" % stderr
             return result
 
-        def raise_if_port_open(): 
+        def raise_if_port_open():
             try:
                 sock = socket.create_connection((winrm_host, winrm_port), connect_timeout_sec)
                 sock.close()
@@ -137,4 +135,3 @@ class ActionModule(ActionBase):
             result['msg'] = toex.message
 
         return result
-

--- a/lib/ansible/plugins/cache/jsonfile.py
+++ b/lib/ansible/plugins/cache/jsonfile.py
@@ -31,9 +31,9 @@ except ImportError:
 
 from ansible import constants as C
 from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_bytes
 from ansible.parsing.utils.jsonify import jsonify
 from ansible.plugins.cache.base import BaseCacheModule
-from ansible.utils.unicode import to_bytes
 
 try:
     from __main__ import display

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -24,12 +24,10 @@ import difflib
 import warnings
 from copy import deepcopy
 
-from ansible.compat.six import string_types
-
 from ansible import constants as C
-from ansible.vars import strip_internal_keys
+from ansible.module_utils._text import to_text
 from ansible.utils.color import stringc
-from ansible.utils.unicode import to_unicode
+from ansible.vars import strip_internal_keys
 
 try:
     from __main__ import display as global_display
@@ -37,13 +35,14 @@ except ImportError:
     from ansible.utils.display import Display
     global_display = Display()
 
-__all__ = ["CallbackBase"]
-
 try:
     from __main__ import cli
 except ImportError:
-    # using API w/o cli 
+    # using API w/o cli
     cli = False
+
+__all__ = ["CallbackBase"]
+
 
 class CallbackBase:
 
@@ -146,8 +145,8 @@ class CallbackBase:
                             after_header = "after: %s" % diff['after_header']
                         else:
                             after_header = 'after'
-                        differ = difflib.unified_diff(to_unicode(diff['before']).splitlines(True),
-                                                      to_unicode(diff['after']).splitlines(True),
+                        differ = difflib.unified_diff(to_text(diff['before']).splitlines(True),
+                                                      to_text(diff['after']).splitlines(True),
                                                       fromfile=before_header,
                                                       tofile=after_header,
                                                       fromfiledate='',
@@ -166,7 +165,7 @@ class CallbackBase:
                         if has_diff:
                             ret.append('\n')
                     if 'prepared' in diff:
-                        ret.append(to_unicode(diff['prepared']))
+                        ret.append(to_text(diff['prepared']))
             except UnicodeDecodeError:
                 ret.append(">> the files are different, but the diff library cannot compare unicode strings\n\n")
         return u''.join(ret)
@@ -362,4 +361,3 @@ class CallbackBase:
 
     def v2_runner_retry(self, result):
         pass
-

--- a/lib/ansible/plugins/callback/junit.py
+++ b/lib/ansible/plugins/callback/junit.py
@@ -21,8 +21,8 @@ __metaclass__ = type
 import os
 import time
 
+from ansible.module_utils._text import to_bytes
 from ansible.plugins.callback import CallbackBase
-from ansible.utils.unicode import to_bytes
 
 try:
     from junit_xml import TestSuite, TestCase
@@ -39,6 +39,7 @@ except ImportError:
         HAS_ORDERED_DICT = True
     except ImportError:
         HAS_ORDERED_DICT = False
+
 
 class CallbackModule(CallbackBase):
     """
@@ -181,7 +182,7 @@ class CallbackModule(CallbackBase):
         output_file = os.path.join(self._output_dir, '%s-%s.xml' % (self._playbook_name, time.time()))
 
         with open(output_file, 'wb') as xml:
-            xml.write(to_bytes(report, errors='strict'))
+            xml.write(to_bytes(report, errors='surrogate_or_strict'))
 
     def v2_playbook_on_start(self, playbook):
         self._playbook_path = playbook._file_name

--- a/lib/ansible/plugins/callback/log_plays.py
+++ b/lib/ansible/plugins/callback/log_plays.py
@@ -23,8 +23,9 @@ import os
 import time
 import json
 
-from ansible.utils.unicode import to_bytes
+from ansible.module_utils._text import to_bytes
 from ansible.plugins.callback import CallbackBase
+
 
 # NOTE: in Ansible 1.2 or later general logging is available without
 # this plugin, just set ANSIBLE_LOG_PATH as an environment variable

--- a/lib/ansible/plugins/callback/mail.py
+++ b/lib/ansible/plugins/callback/mail.py
@@ -25,8 +25,9 @@ import smtplib
 import json
 
 from ansible.compat.six import string_types
-from ansible.utils.unicode import to_bytes
+from ansible.module_utils._text import to_bytes
 from ansible.plugins.callback import CallbackBase
+
 
 def mail(subject='Ansible error mail', sender=None, to=None, cc=None, bcc=None, body=None, smtphost=None):
 
@@ -84,7 +85,7 @@ class CallbackModule(CallbackBase):
         if ignore_errors:
             return
         sender = '"Ansible: %s" <root>' % host
-        attach =  res._task.action
+        attach = res._task.action
         if 'invocation' in res._result:
             attach = "%s:  %s" % (res._result['invocation']['module_name'], json.dumps(res._result['invocation']['module_args']))
 

--- a/lib/ansible/plugins/callback/tree.py
+++ b/lib/ansible/plugins/callback/tree.py
@@ -20,10 +20,10 @@ __metaclass__ = type
 
 import os
 
+from ansible.constants import TREE_DIR
+from ansible.module_utils._text import to_bytes
 from ansible.plugins.callback import CallbackBase
 from ansible.utils.path import makedirs_safe
-from ansible.utils.unicode import to_bytes
-from ansible.constants import TREE_DIR
 
 
 class CallbackModule(CallbackBase):
@@ -68,4 +68,3 @@ class CallbackModule(CallbackBase):
 
     def v2_runner_on_unreachable(self, result):
         self.result_to_tree(result)
-

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -1,4 +1,3 @@
-
 # (c) 2015 Toshio Kuratomi <tkuratomi@ansible.com>
 #
 # This file is part of Ansible
@@ -32,8 +31,9 @@ from ansible.compat.six import with_metaclass
 from ansible import constants as C
 from ansible.compat.six import string_types
 from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_bytes, to_text
 from ansible.plugins import shell_loader
-from ansible.utils.unicode import to_bytes, to_unicode
+
 
 try:
     from __main__ import display
@@ -138,9 +138,9 @@ class ConnectionBase(with_metaclass(ABCMeta, object)):
             # exception, it merely mangles the output:
             # >>> shlex.split(u't e')
             # ['t\x00\x00\x00', '\x00\x00\x00e\x00\x00\x00']
-            return [to_unicode(x.strip()) for x in shlex.split(to_bytes(argstring)) if x.strip()]
+            return [to_text(x.strip()) for x in shlex.split(to_bytes(argstring)) if x.strip()]
         except AttributeError:
-            return [to_unicode(x.strip()) for x in shlex.split(argstring) if x.strip()]
+            return [to_text(x.strip()) for x in shlex.split(argstring) if x.strip()]
 
     @abstractproperty
     def transport(self):

--- a/lib/ansible/plugins/connection/accelerate.py
+++ b/lib/ansible/plugins/connection/accelerate.py
@@ -27,10 +27,11 @@ import time
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleFileNotFound, AnsibleConnectionFailure
+from ansible.module_utils._text import to_bytes
 from ansible.parsing.utils.jsonify import jsonify
 from ansible.plugins.connection import ConnectionBase
 from ansible.utils.encrypt import key_for_hostname, keyczar_encrypt, keyczar_decrypt
-from ansible.utils.unicode import to_bytes
+
 
 try:
     from __main__ import display
@@ -211,7 +212,7 @@ class Connection(ConnectionBase):
         ''' transfer a file from local to remote '''
         display.vvv("PUT %s TO %s" % (in_path, out_path), host=self._play_context.remote_addr)
 
-        in_path = to_bytes(in_path, errors='strict')
+        in_path = to_bytes(in_path, errors='surrogate_or_strict')
 
         if not os.path.exists(in_path):
             raise AnsibleFileNotFound("file or module does not exist: %s" % in_path)
@@ -265,7 +266,7 @@ class Connection(ConnectionBase):
         if self.send_data(data):
             raise AnsibleError("failed to initiate the file fetch with %s" % self._play_context.remote_addr)
 
-        fh = open(to_bytes(out_path, errors='strict'), "w")
+        fh = open(to_bytes(out_path, errors='surrogate_or_strict'), "w")
         try:
             bytes = 0
             while True:

--- a/lib/ansible/plugins/connection/chroot.py
+++ b/lib/ansible/plugins/connection/chroot.py
@@ -28,9 +28,10 @@ import traceback
 
 from ansible import constants as C
 from ansible.errors import AnsibleError
-from ansible.plugins.connection import ConnectionBase, BUFSIZE
 from ansible.module_utils.basic import is_executable
-from ansible.utils.unicode import to_bytes
+from ansible.module_utils._text import to_bytes
+from ansible.plugins.connection import ConnectionBase, BUFSIZE
+
 
 try:
     from __main__ import display
@@ -93,7 +94,7 @@ class Connection(ConnectionBase):
         local_cmd = [self.chroot_cmd, self.chroot, executable, '-c', cmd]
 
         display.vvv("EXEC %s" % (local_cmd), host=self.chroot)
-        local_cmd = [to_bytes(i, errors='strict') for i in local_cmd]
+        local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
         p = subprocess.Popen(local_cmd, shell=False, stdin=stdin,
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -129,7 +130,7 @@ class Connection(ConnectionBase):
 
         out_path = pipes.quote(self._prefix_login_path(out_path))
         try:
-            with open(to_bytes(in_path, errors='strict'), 'rb') as in_file:
+            with open(to_bytes(in_path, errors='surrogate_or_strict'), 'rb') as in_file:
                 try:
                     p = self._buffered_exec_command('dd of=%s bs=%s' % (out_path, BUFSIZE), stdin=in_file)
                 except OSError:
@@ -155,7 +156,7 @@ class Connection(ConnectionBase):
         except OSError:
             raise AnsibleError("chroot connection requires dd command in the chroot")
 
-        with open(to_bytes(out_path, errors='strict'), 'wb+') as out_file:
+        with open(to_bytes(out_path, errors='surrogate_or_strict'), 'wb+') as out_file:
             try:
                 chunk = p.stdout.read(BUFSIZE)
                 while chunk:

--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -35,8 +35,9 @@ from distutils.version import LooseVersion
 
 import ansible.constants as C
 from ansible.errors import AnsibleError, AnsibleFileNotFound
+from ansible.module_utils._text import to_bytes
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
-from ansible.utils.unicode import to_bytes
+
 
 try:
     from __main__ import display
@@ -196,7 +197,7 @@ class Connection(ConnectionBase):
         local_cmd = self._build_exec_cmd([self._play_context.executable, '-c', cmd])
 
         display.vvv("EXEC %s" % (local_cmd,), host=self._play_context.remote_addr)
-        local_cmd = [to_bytes(i, errors='strict') for i in local_cmd]
+        local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
         p = subprocess.Popen(local_cmd, shell=False, stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -223,7 +224,7 @@ class Connection(ConnectionBase):
         display.vvv("PUT %s TO %s" % (in_path, out_path), host=self._play_context.remote_addr)
 
         out_path = self._prefix_login_path(out_path)
-        if not os.path.exists(to_bytes(in_path, errors='strict')):
+        if not os.path.exists(to_bytes(in_path, errors='surrogate_or_strict')):
             raise AnsibleFileNotFound(
                 "file or module does not exist: %s" % in_path)
 
@@ -233,8 +234,8 @@ class Connection(ConnectionBase):
         # Although docker version 1.8 and later provide support, the
         # owner and group of the files are always set to root
         args = self._build_exec_cmd([self._play_context.executable, "-c", "dd of=%s bs=%s" % (out_path, BUFSIZE)])
-        args = [to_bytes(i, errors='strict') for i in args]
-        with open(to_bytes(in_path, errors='strict'), 'rb') as in_file:
+        args = [to_bytes(i, errors='surrogate_or_strict') for i in args]
+        with open(to_bytes(in_path, errors='surrogate_or_strict'), 'rb') as in_file:
             try:
                 p = subprocess.Popen(args, stdin=in_file,
                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -256,7 +257,7 @@ class Connection(ConnectionBase):
         out_dir = os.path.dirname(out_path)
 
         args = [self.docker_cmd, "cp", "%s:%s" % (self._play_context.remote_addr, in_path), out_dir]
-        args = [to_bytes(i, errors='strict') for i in args]
+        args = [to_bytes(i, errors='surrogate_or_strict') for i in args]
 
         p = subprocess.Popen(args, stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/lib/ansible/plugins/connection/jail.py
+++ b/lib/ansible/plugins/connection/jail.py
@@ -27,10 +27,9 @@ import pipes
 import subprocess
 import traceback
 
-from ansible import constants as C
 from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_bytes
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
-from ansible.utils.unicode import to_bytes
 
 try:
     from __main__ import display
@@ -117,7 +116,7 @@ class Connection(ConnectionBase):
         local_cmd += [self.jail, self._play_context.executable, '-c', set_env + cmd]
 
         display.vvv("EXEC %s" % (local_cmd,), host=self.jail)
-        local_cmd = [to_bytes(i, errors='strict') for i in local_cmd]
+        local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
         p = subprocess.Popen(local_cmd, shell=False, stdin=stdin,
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -153,7 +152,7 @@ class Connection(ConnectionBase):
 
         out_path = pipes.quote(self._prefix_login_path(out_path))
         try:
-            with open(to_bytes(in_path, errors='strict'), 'rb') as in_file:
+            with open(to_bytes(in_path, errors='surrogate_or_strict'), 'rb') as in_file:
                 try:
                     p = self._buffered_exec_command('dd of=%s bs=%s' % (out_path, BUFSIZE), stdin=in_file)
                 except OSError:
@@ -179,7 +178,7 @@ class Connection(ConnectionBase):
         except OSError:
             raise AnsibleError("jail connection requires dd command in the jail")
 
-        with open(to_bytes(out_path, errors='strict'), 'wb+') as out_file:
+        with open(to_bytes(out_path, errors='surrogate_or_strict'), 'wb+') as out_file:
             try:
                 chunk = p.stdout.read(BUFSIZE)
                 while chunk:

--- a/lib/ansible/plugins/connection/libvirt_lxc.py
+++ b/lib/ansible/plugins/connection/libvirt_lxc.py
@@ -29,8 +29,9 @@ import traceback
 
 from ansible import constants as C
 from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_bytes
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
-from ansible.utils.unicode import to_bytes
+
 
 try:
     from __main__ import display
@@ -94,7 +95,7 @@ class Connection(ConnectionBase):
         local_cmd += [self.lxc, '--', executable, '-c', cmd]
 
         display.vvv("EXEC %s" % (local_cmd,), host=self.lxc)
-        local_cmd = [to_bytes(i, errors='strict') for i in local_cmd]
+        local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
         p = subprocess.Popen(local_cmd, shell=False, stdin=stdin,
                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -130,7 +131,7 @@ class Connection(ConnectionBase):
 
         out_path = pipes.quote(self._prefix_login_path(out_path))
         try:
-            with open(to_bytes(in_path, errors='strict'), 'rb') as in_file:
+            with open(to_bytes(in_path, errors='surrogate_or_strict'), 'rb') as in_file:
                 try:
                     p = self._buffered_exec_command('dd of=%s bs=%s' % (out_path, BUFSIZE), stdin=in_file)
                 except OSError:
@@ -156,7 +157,7 @@ class Connection(ConnectionBase):
         except OSError:
             raise AnsibleError("chroot connection requires dd command in the chroot")
 
-        with open(to_bytes(out_path, errors='strict'), 'wb+') as out_file:
+        with open(to_bytes(out_path, errors='surrogate_or_strict'), 'wb+') as out_file:
             try:
                 chunk = p.stdout.read(BUFSIZE)
                 while chunk:

--- a/lib/ansible/plugins/connection/local.py
+++ b/lib/ansible/plugins/connection/local.py
@@ -30,8 +30,9 @@ from ansible.compat.six import text_type, binary_type
 import ansible.constants as C
 
 from ansible.errors import AnsibleError, AnsibleFileNotFound
+from ansible.module_utils._text import to_bytes, to_native
 from ansible.plugins.connection import ConnectionBase
-from ansible.utils.unicode import to_bytes, to_str
+
 
 try:
     from __main__ import display
@@ -122,14 +123,14 @@ class Connection(ConnectionBase):
         super(Connection, self).put_file(in_path, out_path)
 
         display.vvv(u"PUT {0} TO {1}".format(in_path, out_path), host=self._play_context.remote_addr)
-        if not os.path.exists(to_bytes(in_path, errors='strict')):
-            raise AnsibleFileNotFound("file or module does not exist: {0}".format(to_str(in_path)))
+        if not os.path.exists(to_bytes(in_path, errors='surrogate_or_strict')):
+            raise AnsibleFileNotFound("file or module does not exist: {0}".format(to_native(in_path)))
         try:
-            shutil.copyfile(to_bytes(in_path, errors='strict'), to_bytes(out_path, errors='strict'))
+            shutil.copyfile(to_bytes(in_path, errors='surrogate_or_strict'), to_bytes(out_path, errors='surrogate_or_strict'))
         except shutil.Error:
-            raise AnsibleError("failed to copy: {0} and {1} are the same".format(to_str(in_path), to_str(out_path)))
+            raise AnsibleError("failed to copy: {0} and {1} are the same".format(to_native(in_path), to_native(out_path)))
         except IOError as e:
-            raise AnsibleError("failed to transfer file to {0}: {1}".format(to_str(out_path), to_str(e)))
+            raise AnsibleError("failed to transfer file to {0}: {1}".format(to_native(out_path), to_native(e)))
 
     def fetch_file(self, in_path, out_path):
         ''' fetch a file from local to local -- for copatibility '''

--- a/lib/ansible/plugins/connection/lxc.py
+++ b/lib/ansible/plugins/connection/lxc.py
@@ -24,10 +24,6 @@ import traceback
 import select
 import fcntl
 import errno
-from ansible import errors
-from ansible import constants as C
-from ansible.plugins.connection import ConnectionBase
-from ansible.utils.unicode import to_bytes
 
 HAS_LIBLXC = False
 try:
@@ -35,6 +31,12 @@ try:
     HAS_LIBLXC = True
 except ImportError:
     pass
+
+from ansible import constants as C
+from ansible import errors
+from ansible.module_utils._text import to_bytes
+from ansible.plugins.connection import ConnectionBase
+
 
 class Connection(ConnectionBase):
     ''' Local lxc based connections '''
@@ -102,8 +104,8 @@ class Connection(ConnectionBase):
         ''' run a command on the chroot '''
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
 
-        executable = to_bytes(self._play_context.executable, errors='strict')
-        local_cmd = [executable, '-c', to_bytes(cmd, errors='strict')]
+        executable = to_bytes(self._play_context.executable, errors='surrogate_or_strict')
+        local_cmd = [executable, '-c', to_bytes(cmd, errors='surrogate_or_strict')]
 
         read_stdout, write_stdout = None, None
         read_stderr, write_stderr = None, None
@@ -154,8 +156,8 @@ class Connection(ConnectionBase):
         ''' transfer a file from local to lxc '''
         super(Connection, self).put_file(in_path, out_path)
         self._display.vvv("PUT %s TO %s" % (in_path, out_path), host=self.container_name)
-        in_path = to_bytes(in_path, errors='strict')
-        out_path = to_bytes(out_path, errors='strict')
+        in_path = to_bytes(in_path, errors='surrogate_or_strict')
+        out_path = to_bytes(out_path, errors='surrogate_or_strict')
 
         if not os.path.exists(in_path):
             msg = "file or module does not exist: %s" % in_path
@@ -182,8 +184,8 @@ class Connection(ConnectionBase):
         ''' fetch a file from lxc to local '''
         super(Connection, self).fetch_file(in_path, out_path)
         self._display.vvv("FETCH %s TO %s" % (in_path, out_path), host=self.container_name)
-        in_path = to_bytes(in_path, errors='strict')
-        out_path = to_bytes(out_path, errors='strict')
+        in_path = to_bytes(in_path, errors='surrogate_or_strict')
+        out_path = to_bytes(out_path, errors='surrogate_or_strict')
 
         try:
             dst_file = open(out_path, "wb")

--- a/lib/ansible/plugins/connection/lxd.py
+++ b/lib/ansible/plugins/connection/lxd.py
@@ -23,8 +23,8 @@ from distutils.spawn import find_executable
 from subprocess import call, Popen, PIPE
 
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
+from ansible.module_utils._text import to_bytes, to_text
 from ansible.plugins.connection import ConnectionBase
-from ansible.utils.unicode import to_bytes, to_unicode
 
 
 class Connection(ConnectionBase):
@@ -61,14 +61,14 @@ class Connection(ConnectionBase):
 
         local_cmd = [self._lxc_cmd, "exec", self._host, "--", self._play_context.executable, "-c", cmd]
 
-        local_cmd = [to_bytes(i, errors='strict') for i in local_cmd]
-        in_data = to_bytes(in_data, errors='strict', nonstring='passthru')
+        local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
+        in_data = to_bytes(in_data, errors='surrogate_or_strict', nonstring='passthru')
 
         process = Popen(local_cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
         stdout, stderr = process.communicate(in_data)
 
-        stdout = to_unicode(stdout)
-        stderr = to_unicode(stderr)
+        stdout = to_text(stdout)
+        stderr = to_text(stderr)
 
         if stderr == "error: Container is not running.\n":
             raise AnsibleConnectionFailure("container not running: %s" % self._host)
@@ -84,12 +84,12 @@ class Connection(ConnectionBase):
 
         self._display.vvv(u"PUT {0} TO {1}".format(in_path, out_path), host=self._host)
 
-        if not os.path.isfile(to_bytes(in_path, errors='strict')):
+        if not os.path.isfile(to_bytes(in_path, errors='surrogate_or_strict')):
             raise AnsibleFileNotFound("input path is not a file: %s" % in_path)
 
         local_cmd = [self._lxc_cmd, "file", "push", in_path, self._host + "/" + out_path]
 
-        local_cmd = [to_bytes(i, errors='strict') for i in local_cmd]
+        local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
 
         call(local_cmd)
 
@@ -101,7 +101,7 @@ class Connection(ConnectionBase):
 
         local_cmd = [self._lxc_cmd, "file", "pull", self._host + "/" + in_path, out_path]
 
-        local_cmd = [to_bytes(i, errors='strict') for i in local_cmd]
+        local_cmd = [to_bytes(i, errors='surrogate_or_strict') for i in local_cmd]
 
         call(local_cmd)
 

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -44,13 +44,14 @@ from ansible.compat.six.moves import input
 from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNotFound
 from ansible.plugins.connection import ConnectionBase
 from ansible.utils.path import makedirs_safe
-from ansible.utils.unicode import to_bytes
+from ansible.module_utils._text import to_bytes
 
 try:
     from __main__ import display
 except ImportError:
     from ansible.utils.display import Display
     display = Display()
+
 
 AUTHENTICITY_MSG="""
 paramiko: The authenticity of host '%s' can't be established.
@@ -273,7 +274,7 @@ class Connection(ConnectionBase):
 
         display.vvv("EXEC %s" % cmd, host=self._play_context.remote_addr)
 
-        cmd = to_bytes(cmd, errors='strict')
+        cmd = to_bytes(cmd, errors='surrogate_or_strict')
 
         no_prompt_out = b''
         no_prompt_err = b''
@@ -330,7 +331,7 @@ class Connection(ConnectionBase):
 
         display.vvv("PUT %s TO %s" % (in_path, out_path), host=self._play_context.remote_addr)
 
-        if not os.path.exists(to_bytes(in_path, errors='strict')):
+        if not os.path.exists(to_bytes(in_path, errors='surrogate_or_strict')):
             raise AnsibleFileNotFound("file or module does not exist: %s" % in_path)
 
         try:
@@ -339,7 +340,7 @@ class Connection(ConnectionBase):
             raise AnsibleError("failed to open a SFTP connection (%s)" % e)
 
         try:
-            self.sftp.put(to_bytes(in_path, errors='strict'), to_bytes(out_path, errors='strict'))
+            self.sftp.put(to_bytes(in_path, errors='surrogate_or_strict'), to_bytes(out_path, errors='surrogate_or_strict'))
         except IOError:
             raise AnsibleError("failed to transfer file to %s" % out_path)
 
@@ -365,7 +366,7 @@ class Connection(ConnectionBase):
             raise AnsibleError("failed to open a SFTP connection (%s)", e)
 
         try:
-            self.sftp.get(to_bytes(in_path, errors='strict'), to_bytes(out_path, errors='strict'))
+            self.sftp.get(to_bytes(in_path, errors='surrogate_or_strict'), to_bytes(out_path, errors='surrogate_or_strict'))
         except IOError:
             raise AnsibleError("failed to transfer file from %s" % in_path)
 

--- a/lib/ansible/plugins/connection/zone.py
+++ b/lib/ansible/plugins/connection/zone.py
@@ -31,7 +31,8 @@ import traceback
 from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
-from ansible.utils.unicode import to_bytes
+from ansible.module_utils._text import to_bytes
+
 
 try:
     from __main__ import display

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -19,7 +19,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-
 import sys
 import base64
 import itertools
@@ -39,21 +38,22 @@ import uuid
 
 import yaml
 from jinja2.filters import environmentfilter
-from ansible.compat.six import iteritems, string_types
-
-from ansible import errors
-from ansible.parsing.yaml.dumper import AnsibleDumper
-from ansible.utils.hashing import md5s, checksum_s
-from ansible.utils.unicode import unicode_wrap, to_unicode
-from ansible.utils.vars import merge_hash
-from ansible.vars.hostvars import HostVars
-from ansible.compat.six.moves import reduce
 
 try:
     import passlib.hash
     HAS_PASSLIB = True
 except:
     HAS_PASSLIB = False
+
+from ansible import errors
+from ansible.compat.six import iteritems, string_types
+from ansible.compat.six.moves import reduce
+from ansible.module_utils._text import to_text
+from ansible.parsing.yaml.dumper import AnsibleDumper
+from ansible.utils.hashing import md5s, checksum_s
+from ansible.utils.unicode import unicode_wrap
+from ansible.utils.vars import merge_hash
+from ansible.vars.hostvars import HostVars
 
 
 UUID_NAMESPACE_ANSIBLE = uuid.UUID('361E6D51-FAEC-444A-9079-341386DA8E2E')
@@ -72,12 +72,12 @@ class AnsibleJSONEncoder(json.JSONEncoder):
 def to_yaml(a, *args, **kw):
     '''Make verbose, human readable yaml'''
     transformed = yaml.dump(a, Dumper=AnsibleDumper, allow_unicode=True, **kw)
-    return to_unicode(transformed)
+    return to_text(transformed)
 
 def to_nice_yaml(a, indent=4, *args, **kw):
     '''Make verbose, human readable yaml'''
     transformed = yaml.dump(a, Dumper=AnsibleDumper, indent=indent, allow_unicode=True, default_flow_style=False, **kw)
-    return to_unicode(transformed)
+    return to_text(transformed)
 
 def to_json(a, *args, **kw):
     ''' Convert the value to JSON '''
@@ -132,7 +132,7 @@ def fileglob(pathname):
 def regex_replace(value='', pattern='', replacement='', ignorecase=False):
     ''' Perform a `re.sub` returning a string '''
 
-    value = to_unicode(value, errors='strict', nonstring='simplerepr')
+    value = to_text(value, errors='surrogate_or_strict', nonstring='simplerepr')
 
     if ignorecase:
         flags = re.I

--- a/lib/ansible/plugins/lookup/__init__.py
+++ b/lib/ansible/plugins/lookup/__init__.py
@@ -98,8 +98,8 @@ class LookupBase(with_metaclass(ABCMeta, object)):
         must be converted into python's unicode type as the strings will be run
         through jinja2 which has this requirement.  You can use::
 
-            from ansible.utils.unicode import to_unicode
-            result_string = to_unicode(result_string)
+            from ansible.module_utils._text import to_text
+            result_string = to_text(result_string)
         """
         pass
 

--- a/lib/ansible/plugins/lookup/csvfile.py
+++ b/lib/ansible/plugins/lookup/csvfile.py
@@ -22,7 +22,8 @@ import csv
 
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
-from ansible.utils.unicode import to_bytes, to_str, to_unicode
+from ansible.module_utils._text import to_bytes, to_native, to_text
+
 
 class CSVRecoder:
     """
@@ -49,7 +50,7 @@ class CSVReader:
 
     def next(self):
         row = self.reader.next()
-        return [to_unicode(s) for s in row]
+        return [to_text(s) for s in row]
 
     def __iter__(self):
         return self
@@ -66,7 +67,7 @@ class LookupModule(LookupBase):
                 if row[0] == key:
                     return row[int(col)]
         except Exception as e:
-            raise AnsibleError("csvfile: %s" % to_str(e))
+            raise AnsibleError("csvfile: %s" % to_native(e))
 
         return dflt
 

--- a/lib/ansible/plugins/lookup/fileglob.py
+++ b/lib/ansible/plugins/lookup/fileglob.py
@@ -22,7 +22,8 @@ import glob
 
 from ansible.plugins.lookup import LookupBase
 from ansible.errors import AnsibleFileNotFound
-from ansible.utils.unicode import to_bytes, to_unicode
+from ansible.module_utils._text import to_bytes, to_text
+
 
 class LookupModule(LookupBase):
 
@@ -36,6 +37,6 @@ class LookupModule(LookupBase):
             except AnsibleFileNotFound:
                 dwimmed_path = None
             if dwimmed_path:
-                globbed = glob.glob(to_bytes(os.path.join(dwimmed_path, term_file), errors='strict'))
-                ret.extend(to_unicode(g, errors='strict') for g in globbed if os.path.isfile(g))
+                globbed = glob.glob(to_bytes(os.path.join(dwimmed_path, term_file), errors='surrogate_or_strict'))
+                ret.extend(to_text(g, errors='surrogate_or_strict') for g in globbed if os.path.isfile(g))
         return ret

--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -22,18 +22,17 @@ import pwd
 import grp
 import stat
 
-from ansible.plugins.lookup import LookupBase
-from ansible.utils.unicode import to_str
-
-from __main__ import display
-warning = display.warning
-
 HAVE_SELINUX=False
 try:
     import selinux
     HAVE_SELINUX=True
 except ImportError:
     pass
+
+from ansible.plugins.lookup import LookupBase
+from ansible.module_utils._text import to_native
+
+from __main__ import display
 
 
 # If selinux fails to find a default, return an array of None
@@ -43,7 +42,7 @@ def selinux_context(path):
         try:
             # note: the selinux module uses byte strings on python2 and text
             # strings on python3
-            ret = selinux.lgetfilecon_raw(to_str(path))
+            ret = selinux.lgetfilecon_raw(to_native(path))
         except OSError:
             return context
         if ret[0] != -1:
@@ -60,7 +59,7 @@ def file_props(root, path):
     try:
         st = os.lstat(abspath)
     except OSError as e:
-        warning('filetree: Error using stat() on path %s (%s)' % (abspath, e))
+        display.warning('filetree: Error using stat() on path %s (%s)' % (abspath, e))
         return None
 
     ret = dict(root=root, path=path)
@@ -74,7 +73,7 @@ def file_props(root, path):
         ret['state'] = 'file'
         ret['src'] = abspath
     else:
-        warning('filetree: Error file type of %s is not supported' % abspath)
+        display.warning('filetree: Error file type of %s is not supported' % abspath)
         return None
 
     ret['uid'] = st.st_uid

--- a/lib/ansible/plugins/lookup/ini.py
+++ b/lib/ansible/plugins/lookup/ini.py
@@ -30,7 +30,7 @@ except ImportError:
 
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
-from ansible.utils.unicode import to_bytes
+from ansible.module_utils._text import to_bytes, to_text
 
 
 def _parse_params(term):
@@ -59,13 +59,15 @@ class LookupModule(LookupBase):
 
     def read_properties(self, filename, key, dflt, is_regexp):
         config = StringIO()
-        config.write(u'[java_properties]\n' + open(to_bytes(filename, errors='strict')).read())
+        current_cfg_file = open(to_bytes(filename, errors='surrogate_or_strict'), 'rb')
+
+        config.write(u'[java_properties]\n' + to_text(current_cfg_file.read(), errors='surrogate_or_strict'))
         config.seek(0, os.SEEK_SET)
         self.cp.readfp(config)
         return self.get_value(key, 'java_properties', dflt, is_regexp)
 
     def read_ini(self, filename, key, section, dflt, is_regexp):
-        self.cp.readfp(open(to_bytes(filename, errors='strict')))
+        self.cp.readfp(open(to_bytes(filename, errors='surrogate_or_strict')))
         return self.get_value(key, section, dflt, is_regexp)
 
     def get_value(self, key, section, dflt, is_regexp):

--- a/lib/ansible/plugins/lookup/shelvefile.py
+++ b/lib/ansible/plugins/lookup/shelvefile.py
@@ -21,10 +21,10 @@ import shelve
 
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
-from ansible.utils.unicode import to_bytes, to_unicode
+from ansible.module_utils._text import to_bytes, to_text
+
 
 class LookupModule(LookupBase):
-
 
     def read_shelve(self, shelve_filename, key):
         """
@@ -66,7 +66,7 @@ class LookupModule(LookupBase):
                 if res is None:
                     raise AnsibleError("Key %s not found in shelve file %s" % (key, file))
                 # Convert the value read to string
-                ret.append(to_unicode(res))
+                ret.append(to_text(res))
                 break
             else:
                 raise AnsibleError("Could not locate shelve file in lookup: %s" % file)

--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -21,7 +21,7 @@ import os
 
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
-from ansible.utils.unicode import to_unicode, to_bytes
+from ansible.module_utils._text import to_bytes, to_text
 
 try:
     from __main__ import display
@@ -43,8 +43,8 @@ class LookupModule(LookupBase):
             lookupfile = self.find_file_in_search_path(variables, 'templates', term)
             display.vvvv("File lookup using %s as file" % lookupfile)
             if lookupfile:
-                with open(to_bytes(lookupfile, errors='strict'), 'r') as f:
-                    template_data = to_unicode(f.read())
+                with open(to_bytes(lookupfile, errors='surrogate_or_strict'), 'rb') as f:
+                    template_data = to_text(f.read(), errors='surrogate_or_strict')
 
                     # set jinja2 internal search path for includes
                     if 'ansible_search_path' in variables:

--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -18,11 +18,11 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 
-from ansible.errors import AnsibleError
-from ansible.plugins.lookup import LookupBase
-from ansible.module_utils.urls import open_url, ConnectionError, SSLValidationError
-from ansible.utils.unicode import to_unicode
 from ansible.compat.six.moves.urllib.error import HTTPError, URLError
+from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_text
+from ansible.module_utils.urls import open_url, ConnectionError, SSLValidationError
+from ansible.plugins.lookup import LookupBase
 
 try:
     from __main__ import display
@@ -52,5 +52,5 @@ class LookupModule(LookupBase):
                 raise AnsibleError("Error connecting to %s: %s" % (term, str(e)))
 
             for line in response.read().splitlines():
-                ret.append(to_unicode(line))
+                ret.append(to_text(line))
         return ret

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -26,7 +26,8 @@ from ansible.playbook.included_file import IncludedFile
 from ansible.plugins import action_loader
 from ansible.plugins.strategy import StrategyBase
 from ansible.template import Templar
-from ansible.utils.unicode import to_unicode
+from ansible.module_utils._text import to_text
+
 
 try:
     from __main__ import display
@@ -66,8 +67,7 @@ class StrategyModule(StrategyBase):
                 break
 
             work_to_do = False        # assume we have no more work to do
-            starting_host = last_host # save current position so we know when we've
-                                      # looped back around and need to break
+            starting_host = last_host # save current position so we know when we've looped back around and need to break
 
             # try and find an unblocked host with a task to run
             host_results = []
@@ -109,7 +109,7 @@ class StrategyModule(StrategyBase):
                         display.debug("done getting variables")
 
                         try:
-                            task.name = to_unicode(templar.template(task.name, fail_on_undefined=False), nonstring='empty')
+                            task.name = to_text(templar.template(task.name, fail_on_undefined=False), nonstring='empty')
                             display.debug("done templating")
                         except:
                             # just ignore any errors during task name templating,
@@ -120,10 +120,10 @@ class StrategyModule(StrategyBase):
                         run_once = templar.template(task.run_once) or action and getattr(action, 'BYPASS_HOST_LOOP', False)
                         if run_once:
                             if action and getattr(action, 'BYPASS_HOST_LOOP', False):
-                                raise AnsibleError("The '%s' module bypasses the host loop, which is currently not supported in the free strategy " \
+                                raise AnsibleError("The '%s' module bypasses the host loop, which is currently not supported in the free strategy "
                                                    "and would instead execute for every host in the inventory list." % task.action, obj=task._ds)
                             else:
-                                display.warning("Using run_once with the free strategy is not currently supported. This task will still be " \
+                                display.warning("Using run_once with the free strategy is not currently supported. This task will still be "
                                                 "executed for every host in the inventory list.")
 
                         # check to see if this task should be skipped, due to it being a member of a
@@ -143,7 +143,8 @@ class StrategyModule(StrategyBase):
                             # handle step if needed, skip meta actions as they are used internally
                             if not self._step or self._take_step(task, host_name):
                                 if task.any_errors_fatal:
-                                    display.warning("Using any_errors_fatal with the free strategy is not supported, as tasks are executed independently on each host")
+                                    display.warning("Using any_errors_fatal with the free strategy is not supported,"
+                                            " as tasks are executed independently on each host")
                                 self._tqm.send_callback('v2_playbook_on_task_start', task, is_conditional=False)
                                 self._queue_task(host, task, task_vars, play_context)
                                 del task_vars

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -29,7 +29,8 @@ from ansible.playbook.task import Task
 from ansible.plugins import action_loader
 from ansible.plugins.strategy import StrategyBase
 from ansible.template import Templar
-from ansible.utils.unicode import to_unicode
+from ansible.module_utils._text import to_text
+
 
 try:
     from __main__ import display
@@ -243,7 +244,7 @@ class StrategyModule(StrategyBase):
                             saved_name = task.name
                             display.debug("done copying, going to template now")
                             try:
-                                task.name = to_unicode(templar.template(task.name, fail_on_undefined=False), nonstring='empty')
+                                task.name = to_text(templar.template(task.name, fail_on_undefined=False), nonstring='empty')
                                 display.debug("done templating")
                             except:
                                 # just ignore any errors during task name templating,
@@ -368,7 +369,7 @@ class StrategyModule(StrategyBase):
                             for host in included_file._hosts:
                                 self._tqm._failed_hosts[host.name] = True
                                 iterator.mark_host_failed(host)
-                            display.error(to_unicode(e), wrap_text=False)
+                            display.error(to_text(e), wrap_text=False)
                             include_failure = True
                             continue
 

--- a/lib/ansible/template/vars.py
+++ b/lib/ansible/template/vars.py
@@ -21,7 +21,8 @@ __metaclass__ = type
 
 from ansible.compat.six import iteritems
 from jinja2.utils import missing
-from ansible.utils.unicode import to_unicode
+from ansible.module_utils._text import to_native
+
 
 __all__ = ['AnsibleJ2Vars']
 
@@ -88,7 +89,7 @@ class AnsibleJ2Vars:
             try:
                 value = self._templar.template(variable)
             except Exception as e:
-                raise type(e)(to_unicode(variable) + ': ' + e.message)
+                raise type(e)(to_native(variable) + ': ' + e.message)
             return value
 
     def add_locals(self, locals):
@@ -99,4 +100,3 @@ class AnsibleJ2Vars:
         if locals is None:
             return self
         return AnsibleJ2Vars(self._templar, self._globals, locals=locals, *self._extras)
-

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -35,7 +35,8 @@ from termios import TIOCGWINSZ
 from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.utils.color import stringc
-from ansible.utils.unicode import to_bytes, to_unicode
+from ansible.module_utils._text import to_bytes, to_text
+
 
 try:
     # Python 2
@@ -43,7 +44,6 @@ try:
 except NameError:
     # Python 3, we already have raw_input
     pass
-
 
 
 logger = None
@@ -105,7 +105,7 @@ class Display:
         """ Display a message to the user
 
         Note: msg *must* be a unicode string to prevent UnicodeError tracebacks.
-        """ 
+        """
 
         # FIXME: this needs to be implemented
         #msg = utils.sanitize_output(msg)
@@ -124,7 +124,7 @@ class Display:
                 # Convert back to text string on python3
                 # We first convert to a byte string so that we get rid of
                 # characters that are invalid in the user's locale
-                msg2 = to_unicode(msg2, self._output_encoding(stderr=stderr))
+                msg2 = to_text(msg2, self._output_encoding(stderr=stderr))
 
             if not stderr:
                 fileobj = sys.stdout
@@ -149,7 +149,7 @@ class Display:
                 # Convert back to text string on python3
                 # We first convert to a byte string so that we get rid of
                 # characters that are invalid in the user's locale
-                msg2 = to_unicode(msg2, self._output_encoding(stderr=stderr))
+                msg2 = to_text(msg2, self._output_encoding(stderr=stderr))
 
             if color == C.COLOR_ERROR:
                 logger.error(msg2)
@@ -279,7 +279,7 @@ class Display:
         if sys.version_info >= (3,):
             # Convert back into text on python3.  We do this double conversion
             # to get rid of characters that are illegal in the user's locale
-            prompt_string = to_unicode(prompt_string)
+            prompt_string = to_text(prompt_string)
 
         if private:
             return getpass.getpass(msg)
@@ -323,7 +323,7 @@ class Display:
             result = do_encrypt(result, encrypt, salt_size, salt)
 
         # handle utf-8 chars
-        result = to_unicode(result, errors='strict')
+        result = to_text(result, errors='surrogate_or_strict')
         return result
 
     @staticmethod

--- a/lib/ansible/utils/hashing.py
+++ b/lib/ansible/utils/hashing.py
@@ -39,14 +39,14 @@ except ImportError:
         _md5 = None
 
 from ansible.errors import AnsibleError
-from ansible.utils.unicode import to_bytes
+from ansible.module_utils._text import to_bytes
 
 
 def secure_hash_s(data, hash_func=sha1):
     ''' Return a secure hash hex digest of data. '''
 
     digest = hash_func()
-    data = to_bytes(data, errors='strict')
+    data = to_bytes(data, errors='surrogate_or_strict')
     digest.update(data)
     return digest.hexdigest()
 
@@ -54,12 +54,12 @@ def secure_hash_s(data, hash_func=sha1):
 def secure_hash(filename, hash_func=sha1):
     ''' Return a secure hash hex digest of local file, None if file is not present or a directory. '''
 
-    if not os.path.exists(to_bytes(filename, errors='strict')) or os.path.isdir(to_bytes(filename, errors='strict')):
+    if not os.path.exists(to_bytes(filename, errors='surrogate_or_strict')) or os.path.isdir(to_bytes(filename, errors='strict')):
         return None
     digest = hash_func()
     blocksize = 64 * 1024
     try:
-        infile = open(to_bytes(filename, errors='strict'), 'rb')
+        infile = open(to_bytes(filename, errors='surrogate_or_strict'), 'rb')
         block = infile.read(blocksize)
         while block:
             digest.update(block)

--- a/lib/ansible/utils/path.py
+++ b/lib/ansible/utils/path.py
@@ -20,10 +20,11 @@ __metaclass__ = type
 import os
 from errno import EEXIST
 from ansible.errors import AnsibleError
-from ansible.utils.unicode import to_bytes, to_str, to_unicode
-from ansible.compat.six import PY2
+from ansible.module_utils._text import to_bytes, to_native, to_text
+
 
 __all__ = ['unfrackpath', 'makedirs_safe']
+
 
 def unfrackpath(path):
     '''
@@ -40,10 +41,9 @@ def unfrackpath(path):
     example::
         '$HOME/../../var/mail' becomes '/var/spool/mail'
     '''
-    canonical_path = os.path.normpath(os.path.realpath(os.path.expanduser(os.path.expandvars(to_bytes(path, errors='strict')))))
-    if PY2:
-        return to_unicode(canonical_path, errors='strict')
-    return to_unicode(canonical_path, errors='surrogateescape')
+    canonical_path = os.path.normpath(os.path.realpath(os.path.expanduser(os.path.expandvars(to_bytes(path, errors='surrogate_or_strict')))))
+    return to_text(canonical_path, errors='surrogate_or_strict')
+
 
 def makedirs_safe(path, mode=None):
     '''Safe way to create dirs in muliprocess/thread environments.
@@ -64,4 +64,4 @@ def makedirs_safe(path, mode=None):
                 os.makedirs(b_rpath)
         except OSError as e:
             if e.errno != EEXIST:
-                raise AnsibleError("Unable to create local directories(%s): %s" % (to_str(rpath), to_str(e)))
+                raise AnsibleError("Unable to create local directories(%s): %s" % (to_native(rpath), to_native(e)))

--- a/lib/ansible/utils/shlex.py
+++ b/lib/ansible/utils/shlex.py
@@ -21,8 +21,7 @@ __metaclass__ = type
 
 import shlex
 from ansible.compat.six import PY3
-
-from ansible.utils.unicode import to_bytes, to_unicode
+from ansible.module_utils._text import to_bytes, to_text
 
 
 if PY3:
@@ -31,5 +30,5 @@ if PY3:
 else:
     # shlex.split() wants bytes (i.e. ``str``) input on Python 2
     def shlex_split(s, comments=False, posix=True):
-        return map(to_unicode, shlex.split(to_bytes(s), comments, posix))
+        return map(to_text, shlex.split(to_bytes(s), comments, posix))
     shlex_split.__doc__ = shlex.split.__doc__

--- a/lib/ansible/utils/unicode.py
+++ b/lib/ansible/utils/unicode.py
@@ -19,264 +19,48 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.compat.six import string_types, text_type, binary_type, PY3
+from ansible.module_utils._text import to_bytes as _to_bytes, to_text, to_native
 
-# to_bytes and to_unicode were written by Toshio Kuratomi for the
-# python-kitchen library https://pypi.python.org/pypi/kitchen
-# They are licensed in kitchen under the terms of the GPLv2+
-# They were copied and modified for use in ansible by Toshio in Jan 2015
-# (simply removing the deprecated features)
-
-#: Aliases for the utf-8 codec
-_UTF8_ALIASES = frozenset(('utf-8', 'UTF-8', 'utf8', 'UTF8', 'utf_8', 'UTF_8',
-    'utf', 'UTF', 'u8', 'U8'))
-#: Aliases for the latin-1 codec
-_LATIN1_ALIASES = frozenset(('latin-1', 'LATIN-1', 'latin1', 'LATIN1',
-    'latin', 'LATIN', 'l1', 'L1', 'cp819', 'CP819', '8859', 'iso8859-1',
-    'ISO8859-1', 'iso-8859-1', 'ISO-8859-1'))
-
-# EXCEPTION_CONVERTERS is defined below due to using to_unicode
-
-def to_unicode(obj, encoding='utf-8', errors='replace', nonstring=None):
-    '''Convert an object into a :class:`unicode` string
-
-    :arg obj: Object to convert to a :class:`unicode` string.  This should
-        normally be a byte :class:`str`
-    :kwarg encoding: What encoding to try converting the byte :class:`str` as.
-        Defaults to :term:`utf-8`
-    :kwarg errors: If errors are found while decoding, perform this action.
-        Defaults to ``replace`` which replaces the invalid bytes with
-        a character that means the bytes were unable to be decoded.  Other
-        values are the same as the error handling schemes in the `codec base
-        classes
-        <http://docs.python.org/library/codecs.html#codec-base-classes>`_.
-        For instance ``strict`` which raises an exception and ``ignore`` which
-        simply omits the non-decodable characters.
-    :kwarg nonstring: How to treat nonstring values.  Possible values are:
-
-        :simplerepr: Attempt to call the object's "simple representation"
-            method and return that value.  Python-2.3+ has two methods that
-            try to return a simple representation: :meth:`object.__unicode__`
-            and :meth:`object.__str__`.  We first try to get a usable value
-            from :meth:`object.__unicode__`.  If that fails we try the same
-            with :meth:`object.__str__`.
-        :empty: Return an empty :class:`unicode` string
-        :strict: Raise a :exc:`TypeError`
-        :passthru: Return the object unchanged
-        :repr: Attempt to return a :class:`unicode` string of the repr of the
-            object
-
-        Default is ``simplerepr``
-
-    :raises TypeError: if :attr:`nonstring` is ``strict`` and
-        a non-:class:`basestring` object is passed in or if :attr:`nonstring`
-        is set to an unknown value
-    :raises UnicodeDecodeError: if :attr:`errors` is ``strict`` and
-        :attr:`obj` is not decodable using the given encoding
-    :returns: :class:`unicode` string or the original object depending on the
-        value of :attr:`nonstring`.
-
-    Usually this should be used on a byte :class:`str` but it can take both
-    byte :class:`str` and :class:`unicode` strings intelligently.  Nonstring
-    objects are handled in different ways depending on the setting of the
-    :attr:`nonstring` parameter.
-
-    The default values of this function are set so as to always return
-    a :class:`unicode` string and never raise an error when converting from
-    a byte :class:`str` to a :class:`unicode` string.  However, when you do
-    not pass validly encoded text (or a nonstring object), you may end up with
-    output that you don't expect.  Be sure you understand the requirements of
-    your data, not just ignore errors by passing it through this function.
-    '''
-    # Could use isbasestring/isunicode here but we want this code to be as
-    # fast as possible
-    if isinstance(obj, text_type):
-        return obj
-    if isinstance(obj, binary_type):
-        if encoding in _UTF8_ALIASES:
-            return text_type(obj, 'utf-8', errors)
-        if encoding in _LATIN1_ALIASES:
-            return text_type(obj, 'latin-1', errors)
-        return obj.decode(encoding, errors)
-
-    if not nonstring:
-        nonstring = 'simplerepr'
-    if nonstring == 'empty':
-        return u''
-    elif nonstring == 'passthru':
-        return obj
-    elif nonstring == 'simplerepr':
-        try:
-            simple = obj.__unicode__()
-        except (AttributeError, UnicodeError):
-            simple = None
-        if not simple:
-            try:
-                simple = text_type(obj)
-            except UnicodeError:
-                try:
-                    simple = obj.__str__()
-                except (UnicodeError, AttributeError):
-                    simple = u''
-        if isinstance(simple, binary_type):
-            return text_type(simple, encoding, errors)
-        return simple
-    elif nonstring in ('repr', 'strict'):
-        obj_repr = repr(obj)
-        if isinstance(obj_repr, binary_type):
-            obj_repr = text_type(obj_repr, encoding, errors)
-        if nonstring == 'repr':
-            return obj_repr
-        raise TypeError('to_unicode was given "%(obj)s" which is neither'
-            ' a byte string (str) or a unicode string' %
-            {'obj': obj_repr.encode(encoding, 'replace')})
-
-    raise TypeError('nonstring value, %(param)s, is not set to a valid'
-        ' action' % {'param': nonstring})
-
-def to_bytes(obj, encoding='utf-8', errors='replace', nonstring=None):
-    '''Convert an object into a byte :class:`str`
-
-    :arg obj: Object to convert to a byte :class:`str`.  This should normally
-        be a :class:`unicode` string.
-    :kwarg encoding: Encoding to use to convert the :class:`unicode` string
-        into a byte :class:`str`.  Defaults to :term:`utf-8`.
-    :kwarg errors: If errors are found while encoding, perform this action.
-        Defaults to ``replace`` which replaces the invalid bytes with
-        a character that means the bytes were unable to be encoded.  Other
-        values are the same as the error handling schemes in the `codec base
-        classes
-        <http://docs.python.org/library/codecs.html#codec-base-classes>`_.
-        For instance ``strict`` which raises an exception and ``ignore`` which
-        simply omits the non-encodable characters.
-    :kwarg nonstring: How to treat nonstring values.  Possible values are:
-
-        :simplerepr: Attempt to call the object's "simple representation"
-            method and return that value.  Python-2.3+ has two methods that
-            try to return a simple representation: :meth:`object.__unicode__`
-            and :meth:`object.__str__`.  We first try to get a usable value
-            from :meth:`object.__str__`.  If that fails we try the same
-            with :meth:`object.__unicode__`.
-        :empty: Return an empty byte :class:`str`
-        :strict: Raise a :exc:`TypeError`
-        :passthru: Return the object unchanged
-        :repr: Attempt to return a byte :class:`str` of the :func:`repr` of the
-            object
-
-        Default is ``simplerepr``.
-
-    :raises TypeError: if :attr:`nonstring` is ``strict`` and
-        a non-:class:`basestring` object is passed in or if :attr:`nonstring`
-        is set to an unknown value.
-    :raises UnicodeEncodeError: if :attr:`errors` is ``strict`` and all of the
-        bytes of :attr:`obj` are unable to be encoded using :attr:`encoding`.
-    :returns: byte :class:`str` or the original object depending on the value
-        of :attr:`nonstring`.
-
-    .. warning::
-
-        If you pass a byte :class:`str` into this function the byte
-        :class:`str` is returned unmodified.  It is **not** re-encoded with
-        the specified :attr:`encoding`.  The easiest way to achieve that is::
-
-            to_bytes(to_unicode(text), encoding='utf-8')
-
-        The initial :func:`to_unicode` call will ensure text is
-        a :class:`unicode` string.  Then, :func:`to_bytes` will turn that into
-        a byte :class:`str` with the specified encoding.
-
-    Usually, this should be used on a :class:`unicode` string but it can take
-    either a byte :class:`str` or a :class:`unicode` string intelligently.
-    Nonstring objects are handled in different ways depending on the setting
-    of the :attr:`nonstring` parameter.
-
-    The default values of this function are set so as to always return a byte
-    :class:`str` and never raise an error when converting from unicode to
-    bytes.  However, when you do not pass an encoding that can validly encode
-    the object (or a non-string object), you may end up with output that you
-    don't expect.  Be sure you understand the requirements of your data, not
-    just ignore errors by passing it through this function.
-    '''
-    # Could use isbasestring, isbytestring here but we want this to be as fast
-    # as possible
-    if isinstance(obj, binary_type):
-        return obj
-    if isinstance(obj, text_type):
-        return obj.encode(encoding, errors)
-    if not nonstring:
-        nonstring = 'simplerepr'
-
-    if nonstring == 'empty':
-        return b''
-    elif nonstring == 'passthru':
-        return obj
-    elif nonstring == 'simplerepr':
-        try:
-            simple = str(obj)
-        except UnicodeError:
-            try:
-                simple = obj.__str__()
-            except (AttributeError, UnicodeError):
-                simple = None
-        if not simple:
-            try:
-                simple = obj.__unicode__()
-            except (AttributeError, UnicodeError):
-                simple = b''
-        if isinstance(simple, text_type):
-            simple = simple.encode(encoding, 'replace')
-        return simple
-    elif nonstring in ('repr', 'strict'):
-        try:
-            obj_repr = obj.__repr__()
-        except (AttributeError, UnicodeError):
-            obj_repr = b''
-        if isinstance(obj_repr, text_type):
-            obj_repr =  obj_repr.encode(encoding, errors)
-        else:
-            obj_repr = binary_type(obj_repr)
-        if nonstring == 'repr':
-            return obj_repr
-        raise TypeError('to_bytes was given "%(obj)s" which is neither'
-            ' a unicode string or a byte string (str)' % {'obj': obj_repr})
-
-    raise TypeError('nonstring value, %(param)s, is not set to a valid'
-        ' action' % {'param': nonstring})
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
 
 
-# force the return value of a function to be unicode.  Use with partial to
-# ensure that a filter will return unicode values.
+__all__ = ('to_bytes', 'to_unicode', 'to_str', 'unicode_wrap')
+
+
+###
+### Backwards compat
+###
+
+def to_bytes(*args, **kwargs):
+    display.deprecated(u'ansible.utils.unicode.to_bytes is deprecated.  Use ansible.module_utils._text.to_bytes instead', version=u'2.4')
+    if 'errors' not in kwargs:
+        kwargs['errors'] = 'replace'
+    return _to_bytes(*args, **kwargs)
+
+
+def to_unicode(*args, **kwargs):
+    display.deprecated(u'ansible.utils.unicode.to_unicode is deprecated.  Use ansible.module_utils._text.to_text instead', version=u'2.4')
+    if 'errors' not in kwargs:
+        kwargs['errors'] = 'replace'
+    return to_text(*args, **kwargs)
+
+
+def to_str(*args, **kwargs):
+    display.deprecated(u'ansible.utils.unicode.to_str is deprecated.  Use ansible.module_utils._text.to_native instead', version=u'2.4')
+    if 'errors' not in kwargs:
+        kwargs['errors'] = 'replace'
+    return to_native(*args, **kwargs)
+
+### End Backwards compat
+
+
 def unicode_wrap(func, *args, **kwargs):
-    return to_unicode(func(*args, **kwargs), nonstring='passthru')
+    """If a function returns a string, force it to be a text string.
 
-
-# Alias for converting to native strings.
-# Native strings are the default string type for the particular version of
-# python.  The objects are called "str" in both py2 and py3 but they mean
-# different things.  In py2, it's a byte string like in C.  In py3 it's an
-# abstract text type (like py2's unicode type).
-#
-# Use this when raising exceptions and wanting to get the string
-# representation of an object for the exception message.  For example:
-#
-# try:
-#    do_something()
-# except Exception as e:
-#    raise AnsibleError(to_str(e))
-#
-# Note that this is because python's exception handling expects native strings
-# and doe the wrong thing if given the other sort of string (in py2, if given
-# unicode strings, it could traceback or omit the message.  in py3, if given
-# byte strings it prints their repr (so the message ends up as b'message').
-#
-# If you use ansible's API instead of re-raising an exception, use to_unicode
-# instead:
-#
-# try:
-#     do_something()
-# except Exception as e:
-#     display.warn(to_unicode(e))
-if PY3:
-    to_str = to_unicode
-else:
-    to_str = to_bytes
+    Use with partial to ensure that filter plugins will return text values.
+    """
+    return to_text(func(*args, **kwargs), nonstring='passthru')

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -28,7 +28,7 @@ from ansible.compat.six import iteritems, string_types
 from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.parsing.splitter import parse_kv
-from ansible.utils.unicode import to_unicode, to_str
+from ansible.module_utils._text import to_native, to_text
 
 
 def _validate_mutable_mappings(a, b):
@@ -49,10 +49,11 @@ def _validate_mutable_mappings(a, b):
             try:
                 myvars.append(dumps(x))
             except:
-                myvars.append(to_str(x))
+                myvars.append(to_native(x))
         raise AnsibleError("failed to combine variables, expected dicts but got a '{0}' and a '{1}': \n{2}\n{3}".format(
             a.__class__.__name__, b.__class__.__name__, myvars[0], myvars[1])
         )
+
 
 def combine_vars(a, b):
     """
@@ -67,6 +68,7 @@ def combine_vars(a, b):
         result = a.copy()
         result.update(b)
         return result
+
 
 def merge_hash(a, b):
     """
@@ -95,10 +97,11 @@ def merge_hash(a, b):
 
     return result
 
+
 def load_extra_vars(loader, options):
     extra_vars = {}
     for extra_vars_opt in options.extra_vars:
-        extra_vars_opt = to_unicode(extra_vars_opt, errors='strict')
+        extra_vars_opt = to_text(extra_vars_opt, errors='surrogate_or_strict')
         if extra_vars_opt.startswith(u"@"):
             # Argument is a YAML file (JSON is a subset of YAML)
             data = loader.load_from_file(extra_vars_opt[1:])
@@ -111,12 +114,14 @@ def load_extra_vars(loader, options):
         extra_vars = combine_vars(extra_vars, data)
     return extra_vars
 
+
 def load_options_vars(options):
     options_vars = {}
     # For now only return check mode, but we can easily return more
     # options if we need variables for them
     options_vars['ansible_check_mode'] = options.check
     return options_vars
+
 
 def isidentifier(ident):
     """
@@ -148,4 +153,3 @@ def isidentifier(ident):
         return False
 
     return True
-

--- a/lib/ansible/vars/unsafe_proxy.py
+++ b/lib/ansible/vars/unsafe_proxy.py
@@ -54,17 +54,20 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import json
-
-from ansible.utils.unicode import to_unicode
 from ansible.compat.six import string_types, text_type
+from ansible.module_utils._text import to_text
+
 
 __all__ = ['UnsafeProxy', 'AnsibleUnsafe', 'AnsibleJSONUnsafeEncoder', 'AnsibleJSONUnsafeDecoder', 'wrap_var']
+
 
 class AnsibleUnsafe(object):
     __UNSAFE__ = True
 
+
 class AnsibleUnsafeText(text_type, AnsibleUnsafe):
     pass
+
 
 class UnsafeProxy(object):
     def __new__(cls, obj, *args, **kwargs):
@@ -73,9 +76,10 @@ class UnsafeProxy(object):
         # we're given but we may want to take it out for testing and sanitize
         # our input instead.
         if isinstance(obj, string_types):
-            obj = to_unicode(obj, errors='strict')
+            obj = to_text(obj, errors='surrogate_or_strict')
             return AnsibleUnsafeText(obj)
         return obj
+
 
 class AnsibleJSONUnsafeEncoder(json.JSONEncoder):
     def encode(self, obj):
@@ -84,6 +88,7 @@ class AnsibleJSONUnsafeEncoder(json.JSONEncoder):
         else:
             return super(AnsibleJSONUnsafeEncoder, self).encode(obj)
 
+
 class AnsibleJSONUnsafeDecoder(json.JSONDecoder):
     def decode(self, obj):
         value = super(AnsibleJSONUnsafeDecoder, self).decode(obj)
@@ -91,6 +96,7 @@ class AnsibleJSONUnsafeDecoder(json.JSONDecoder):
             return UnsafeProxy(value.get('value', ''))
         else:
             return value
+
 
 def _wrap_dict(v):
     for k in v.keys():
@@ -115,4 +121,3 @@ def wrap_var(v):
         if v is not None and not isinstance(v, AnsibleUnsafe):
             v = UnsafeProxy(v)
     return v
-

--- a/test/units/mock/procenv.py
+++ b/test/units/mock/procenv.py
@@ -27,7 +27,8 @@ from contextlib import contextmanager
 from io import BytesIO, StringIO
 from ansible.compat.six import PY3
 from ansible.compat.tests import unittest
-from ansible.utils.unicode import to_bytes
+from ansible.module_utils._text import to_bytes
+
 
 @contextmanager
 def swap_stdin_and_argv(stdin_data='', argv_data=tuple()):
@@ -48,6 +49,7 @@ def swap_stdin_and_argv(stdin_data='', argv_data=tuple()):
     sys.stdin = real_stdin
     sys.argv = real_argv
 
+
 @contextmanager
 def swap_stdout():
     """
@@ -61,6 +63,7 @@ def swap_stdout():
     sys.stdout = fake_stream
     yield fake_stream
     sys.stdout = old_stdout
+
 
 class ModuleTestCase(unittest.TestCase):
     def setUp(self, module_args=None):

--- a/test/units/parsing/vault/test_vault.py
+++ b/test/units/parsing/vault/test_vault.py
@@ -30,11 +30,12 @@ from binascii import hexlify
 from nose.plugins.skip import SkipTest
 
 from ansible.compat.tests import unittest
-from ansible.utils.unicode import to_bytes, to_unicode
 
 from ansible import errors
 from ansible.parsing.vault import VaultLib
 from ansible.parsing import vault
+from ansible.module_utils._text import to_bytes
+
 
 # Counter import fails for 2.0.1, requires >= 2.6.1 from pip
 try:

--- a/test/units/parsing/yaml/test_loader.py
+++ b/test/units/parsing/yaml/test_loader.py
@@ -32,7 +32,6 @@ from ansible.parsing.yaml.loader import AnsibleLoader
 from ansible.parsing import vault
 from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
 from ansible.parsing.yaml.dumper import AnsibleDumper
-from ansible.utils.unicode import to_bytes
 
 from units.mock.yaml_helper import YamlTestUtils
 
@@ -41,6 +40,7 @@ try:
 except ImportError:
     from yaml.parser import ParserError
 
+
 class NameStringIO(StringIO):
     """In py2.6, StringIO doesn't let you set name because a baseclass has it
     as readonly property"""
@@ -48,6 +48,7 @@ class NameStringIO(StringIO):
 
     def __init__(self, *args, **kwargs):
         super(NameStringIO, self).__init__(*args, **kwargs)
+
 
 class TestAnsibleLoaderBasic(unittest.TestCase):
 
@@ -282,6 +283,7 @@ class TestAnsibleLoaderVault(unittest.TestCase, YamlTestUtils):
         self.assertEquals(vault_string, plaintext_var)
         self.assertFalse(plaintext_var != vault_string)
         self.assertFalse(vault_string != plaintext_var)
+
 
 class TestAnsibleLoaderPlay(unittest.TestCase):
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

Various
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
devel
```
##### SUMMARY

We couldn't copy to_unicode, to_bytes, to_str into module_utils because
of licensing so we had to make new versions.  Once created, we had two sets of functions that did
the same things but had different implementations.  To remedy that, this
change removes the ansible.utils.unicode versions of those functions.
