### PR TITLE
removes unneeded code from netcli

### DIFF
--- a/lib/ansible/module_utils/netcli.py
+++ b/lib/ansible/module_utils/netcli.py
@@ -73,9 +73,6 @@ class Cli(object):
         output = output or self.default_output
         if isinstance(command, Command):
             return command
-        elif isinstance(command, dict):
-            output = cmd.get('output') or output
-            cmd = cmd['command']
         if isinstance(prompt, string_types):
             prompt = re.compile(re.escape(prompt))
         return Command(command, output, prompt=prompt, response=response, **kwargs)


### PR DESCRIPTION
Some old remnants of code from the refactor of netcli was left over as
reported in #17408.  This commit removes the old code as it isn't need
and in fact wasnt doing anything
