### PR TITLE
fixes issue when piping commands through json with output not specifed

### DIFF
--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -283,4 +283,6 @@ def prepare_commands(commands):
     for cmd in to_list(commands):
         if cmd.output == 'json':
             cmd.command_string = jsonify(cmd)
+        if cmd.command.endswith('| json'):
+            cmd.output = 'json'
         yield cmd


### PR DESCRIPTION
There is an issue when piping cli commands through json but the output
is specified as either text or the output is none and the transport is
cli.  The results would not be loaded properly for conditional
evaluation.  This is similar to #17422
