### PR TITLE
Show only reference title in modules

### DIFF
--- a/docsite/rst/intro_adhoc.rst
+++ b/docsite/rst/intro_adhoc.rst
@@ -94,12 +94,12 @@ specify that all of the time.  We'll use ``-m`` in later examples to
 run some other :doc:`modules`.
 
 .. note::
-   The :ref:`command` module does not
+   The :ref:`command <command>` module does not
    support shell variables and things like piping.  If we want to execute a module using a
    shell, use the 'shell' module instead. Read more about the differences on the :doc:`modules`
    page.
 
-Using the :ref:`shell` module looks like this::
+Using the :ref:`shell <shell>` module looks like this::
 
     $ ansible raleigh -m shell -a 'echo $TERM'
 


### PR DESCRIPTION
##### ISSUE TYPE

Docs Pull Request
##### COMPONENT NAME

http://docs.ansible.com/ansible/intro_adhoc.html
##### ANSIBLE VERSION

Not relevant
##### SUMMARY

The :ref: in the page is being expanded to include the description of the module. It makes the sentence hard to read.

Not exactly familiar with rst syntax, but according to http://www.sphinx-doc.org/en/stable/markup/inline.html#ref-role a label can be specified.
