### PR TITLE
Fix NameError on 'ansible-vault view'

### DIFF
--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -163,7 +163,7 @@ class VaultCLI(CLI):
             # unicode here because we are displaying it and therefore can make
             # the decision that the display doesn't have to be precisely what
             # the input was (leave that to decrypt instead)
-            self.pager(ansible.module_utils._text.to_text(self.editor.plaintext(f)))
+            self.pager(to_text(self.editor.plaintext(f)))
 
     def execute_rekey(self):
         for f in self.args:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

lib/ansible/cli/vauly.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```ansible 2.2.0 (devel 8c43750a3e) last updated 2016/09/07 10:40:18 (GMT -400)
  lib/ansible/modules/core: (detached HEAD db38f0c876) last updated 2016/09/07 10:40:23 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 8bfdcfcab2) last updated 2016/09/07 10:40:23 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
Fix NameError on 'ansible-vault view'

4ed88512e45112f9670560ac3f01707a40a7f5c5 had a import error in lib/ansible/cli/vault.py

```
