### PR TITLE
Remove bashism

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -479,7 +479,7 @@ class CLI(object):
                 display.display(text)
             else:
                 self.pager_pipe(text, os.environ['PAGER'])
-        elif subprocess.call('(less --version) &> /dev/null', shell = True) == 0:
+        elif subprocess.call('(less --version) > /dev/null 2>&1', shell = True) == 0:
             self.pager_pipe(text, 'less')
         else:
             display.display(text)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cli
##### ANSIBLE VERSION

```
ansible 2.1.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Remove bashism. Now it will work in any shell.
