### PR TITLE
minor fix in eos shared module returning diff

### DIFF
--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -91,6 +91,7 @@ class EosConfigMixin(object):
             self.abort_config(session)
             diff = None
             raise
+
         return diff
 
     def save_config(self):
@@ -103,8 +104,11 @@ class EosConfigMixin(object):
 
         if isinstance(self, Eapi):
             response = self.execute(commands, output='text')
+            response[-2] = response[-2].get('output').strip()
         else:
             response = self.execute(commands)
+
+
 
         return response[-2]
 


### PR DESCRIPTION
The diff returned from eos when the transport was set to eapi was as
a dict but is expected to be a str.  This change extracts the diff string
from the dict object and returns it.  The behavior is now consistent
between cli and eapi transports.
