### PR TITLE
Write notices during playbook run to stderr.

### DIFF
--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -193,7 +193,7 @@ class PlaybookExecutor:
                             (retry_name, _) = os.path.splitext(os.path.basename(playbook_path))
                             filename = os.path.join(basedir, "%s.retry" % retry_name)
                             if self._generate_retry_inventory(filename, retries):
-                                display.display("\tto retry, use: --limit @%s\n" % filename)
+                                display.notice("\tto retry, use: --limit @%s\n" % filename)
 
                     self._tqm.send_callback('v2_playbook_on_stats', self._tqm._stats)
 

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -93,7 +93,7 @@ class Playbook:
                 if pb is not None:
                     self._entries.extend(pb._entries)
                 else:
-                    display.display("skipping playbook include '%s' due to conditional test failure" % entry.get('include', entry), color=C.COLOR_SKIP)
+                    display.notice("skipping playbook include '%s' due to conditional test failure" % entry.get('include', entry), color=C.COLOR_SKIP)
             else:
                 entry_obj = Play.load(entry, variable_manager=variable_manager, loader=self._loader)
                 self._entries.append(entry_obj)

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -197,7 +197,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                         # the same fashion used by the on_include callback. We also do it here,
                         # because the recursive nature of helper methods means we may be loading
                         # nested includes, and we want the include order printed correctly
-                        display.display("statically included: %s" % include_file, color=C.COLOR_SKIP)
+                        display.notice("statically included: %s" % include_file, color=C.COLOR_SKIP)
                     except AnsibleFileNotFound:
                         if t.static or \
                            C.DEFAULT_TASK_INCLUDES_STATIC or \

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -101,6 +101,14 @@ class Display:
                 # MacPorts path for cowsay
                 self.cowsay = "/opt/local/bin/cowsay"
 
+    def notice(self, msg, color=None):
+        """ Display a message to the user on stderr
+
+        Note: msg *must* be a unicode string to prevent UnicodeError tracebacks.
+        """
+
+        self.display(msg, color=color, stderr=True)
+
     def display(self, msg, color=None, stderr=False, screen_only=False, log_only=False):
         """ Display a message to the user
 


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

N/A
##### ANSIBLE VERSION

```
ansible 2.2.0 (stderr-messages 964bee9cfc) last updated 2016/09/07 12:34:40 (GMT -700)
  lib/ansible/modules/core: (detached HEAD db38f0c876) last updated 2016/09/07 09:03:55 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 8bfdcfcab2) last updated 2016/09/07 09:03:55 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Write notices during playbook run to stderr.
This avoids mixing notices with callback output.

Resolves #17122
