### PR TITLE
Don't use the shell to catch output, catch output in python. Fixes #17137

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -479,10 +479,13 @@ class CLI(object):
                 display.display(text)
             else:
                 self.pager_pipe(text, os.environ['PAGER'])
-        elif subprocess.call('(less --version) &> /dev/null', shell = True) == 0:
-            self.pager_pipe(text, 'less')
         else:
-            display.display(text)
+            p = subprocess.Popen('less --version', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            p.communicate()
+            if p.returncode == 0:
+                self.pager_pipe(text, 'less')
+            else:
+                display.display(text)
 
     @staticmethod
     def pager_pipe(text, cmd):


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

ansible-vault
##### ANSIBLE VERSION

```
v2
```
##### SUMMARY

Instead of trying to capture the output of `less --version` in the shell, let `subprocess` capture it. This likely wasn't done before, as `subprocess.call` recommends not using `PIPE`, however we can follow the recommendation and use `Popen` instead of `call`.
