### PR TITLE
Make ssh_executable available as ansible_ssh_* variable

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -53,6 +53,7 @@ MAGIC_VARIABLE_MAPPING = dict(
    remote_addr      = ('ansible_ssh_host', 'ansible_host'),
    remote_user      = ('ansible_ssh_user', 'ansible_user'),
    port             = ('ansible_ssh_port', 'ansible_port'),
+   ssh_executable   = ('ansible_ssh_executable',),
    accelerate_port  = ('ansible_accelerate_port',),
    password         = ('ansible_ssh_pass', 'ansible_password'),
    private_key_file = ('ansible_ssh_private_key_file', 'ansible_private_key_file'),
@@ -139,6 +140,7 @@ RESET_VARS = (
     'ansible_ssh_user',
     'ansible_ssh_private_key_file',
     'ansible_ssh_pipelining',
+    'ansible_ssh_executable',
     'ansible_user',
     'ansible_host',
     'ansible_port',
@@ -165,6 +167,7 @@ class PlayContext(Base):
     _sftp_extra_args  = FieldAttribute(isa='string')
     _scp_extra_args   = FieldAttribute(isa='string')
     _ssh_extra_args   = FieldAttribute(isa='string')
+    _ssh_executable   = FieldAttribute(isa='string', default=C.ANSIBLE_SSH_EXECUTABLE)
     _connection_lockfd= FieldAttribute(isa='int')
     _pipelining       = FieldAttribute(isa='bool', default=C.ANSIBLE_SSH_PIPELINING)
     _accelerate       = FieldAttribute(isa='bool', default=False)

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -144,7 +144,7 @@ class Connection(ConnectionBase):
 
         if self._play_context.verbosity > 3:
             self._command += ['-vvv']
-        elif binary == C.ANSIBLE_SSH_EXECUTABLE:
+        elif binary == self._play_context.ssh_executable:
             # Older versions of ssh (e.g. in RHEL 6) don't accept sftp -q.
             self._command += ['-q']
 
@@ -563,12 +563,13 @@ class Connection(ConnectionBase):
 
         display.vvv(u"ESTABLISH SSH CONNECTION FOR USER: {0}".format(self._play_context.remote_user), host=self._play_context.remote_addr)
 
+
         # we can only use tty when we are not pipelining the modules. piping
         # data into /usr/bin/python inside a tty automatically invokes the
         # python interactive-mode but the modules are not compatible with the
         # interactive-mode ("unexpected indent" mainly because of empty lines)
 
-        ssh_executable = C.ANSIBLE_SSH_EXECUTABLE
+        ssh_executable = self._play_context.ssh_executable
 
         if not in_data and sudoable:
             args = (ssh_executable, '-tt', self.host, cmd)
@@ -684,7 +685,7 @@ class Connection(ConnectionBase):
         # TODO: reenable once winrm issues are fixed
         # temporarily disabled as we are forced to currently close connections after every task because of winrm
         # if self._connected and self._persistent:
-        #     ssh_executable = C.ANSIBLE_SSH_EXECUTABLE
+        #     ssh_executable = self._play_context.ssh_executable
         #     cmd = self._build_command(ssh_executable, '-O', 'stop', self.host)
         #
         #     cmd = map(to_bytes, cmd)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME
- ssh connection plugin
##### SUMMARY

This will make `ANSIBLE_SSH_EXECUTABLE` available as `ansible_ssh_executable` variable that can be set as any other ansible_ssh_*. 

<!-- Paste verbatim command output below, e.g. before and after your change -->

``` shell
# playbook.yml
- hosts: all
  tasks: []

# Output
<localhost> SSH: EXEC **ssh** -vvv -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r localhost '/bin/sh -c '"'"'( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1473281435.92-199313159730947 `" && echo ansible-tmp-1473281435.92-199313159730947="` echo $HOME/.ansible/tmp/ansible-tmp-1473281435.92-199313159730947 `" ) && sleep 0'"'"''
```

``` shell
# playbook.yml
- hosts: all
  vars:
        - ansible_ssh_executable: "/usr/bin/ssh"
  tasks: []

# Output
<localhost> SSH: EXEC **/usr/bin/ssh** -vvv -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r localhost '/bin/sh -c '"'"'( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1473281568.01-3395576390216 `" && echo ansible-tmp-1473281568.01-3395576390216="` echo $HOME/.ansible/tmp/ansible-tmp-1473281568.01-3395576390216 `" ) && sleep 0'"'"''
```
