### PR TITLE
Pass the absolute path to dirname when assigning basedir

### DIFF
--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -186,7 +186,7 @@ class PlaybookExecutor:
                             if C.RETRY_FILES_SAVE_PATH:
                                 basedir = C.shell_expand(C.RETRY_FILES_SAVE_PATH)
                             elif playbook_path:
-                                basedir = os.path.dirname(playbook_path)
+                                basedir = os.path.dirname(os.path.realpath(playbook_path))
                             else:
                                 basedir = '~/'
 

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -186,7 +186,7 @@ class PlaybookExecutor:
                             if C.RETRY_FILES_SAVE_PATH:
                                 basedir = C.shell_expand(C.RETRY_FILES_SAVE_PATH)
                             elif playbook_path:
-                                basedir = os.path.dirname(os.path.realpath(playbook_path))
+                                basedir = os.path.dirname(os.path.abspath(playbook_path))
                             else:
                                 basedir = '~/'
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

`PlaybookExecutor`
##### ANSIBLE VERSION

```
ansible 2.1.1.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

As reported in #17456 ansible-playbook fails to create a retry file. This happens when a playbook is called without passing a path ( `ansible-playbook test.yml` ). 
The basedir created with `os.path.dirname(playbook_path` will return `''` which will, cause `os.path.basename` to return `''` ending with an empty string as filename. 
This will cause  the error later in `_generate_retry_inventory` to write the file as the `retry_path` filename will be empty. 

```
PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [command] *****************************************************************
fatal: [localhost]: FAILED! => {"changed": true, "cmd": ["false"], "delta": "0:00:00.001884", "end": "2016-09-08 10:20:40.023480", "failed": true, "rc": 1, "start": "2016-09-08 10:20:40.021596", "stderr": "", "stdout": "", "stdout_lines": [], "warnings": []}

NO MORE HOSTS LEFT *************************************************************
 [WARNING]: Could not create retry file 'test.retry'.         [Errno 2] No such file or directory: ''


PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1
```

```
PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [command] *****************************************************************
fatal: [localhost]: FAILED! => {"changed": true, "cmd": ["false"], "delta": "0:00:00.002157", "end": "2016-09-08 10:21:38.494251", "failed": true, "rc": 1, "start": "2016-09-08 10:21:38.492094", "stderr": "", "stdout": "", "stdout_lines": [], "warnings": []}

NO MORE HOSTS LEFT *************************************************************
/root/test.retry
        to retry, use: --limit @/root/test.retry

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1
```

Fixes #17456
