### PR TITLE
Re-fix the per-item diff output

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -199,6 +199,9 @@ class StrategyBase:
                     elif task_result.is_skipped():
                         self._tqm.send_callback('v2_runner_item_on_skipped', task_result)
                     else:
+                        if 'diff' in task_result._result:
+                            if self._diff:
+                                self._tqm.send_callback('v2_on_file_diff', task_result)
                         self._tqm.send_callback('v2_runner_item_on_ok', task_result)
                     continue
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (refix-diff-for-task-items 534ae73265) last updated 2016/09/08 12:33:33 (GMT +200)
  lib/ansible/modules/core: (devel 1d48b47cad) last updated 2016/09/01 09:55:33 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 2ef4a34eee) last updated 2016/08/31 16:07:04 (GMT +200)
  config file = /home/towolf/src/ansible/users/tobias.wolf/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

**Re-fix the per-item diff output**

which got lost in recent big 'performance improvements' merge by @jimi-c.

I had made a previous PR to fix this, then @bcoca had committed an
improved fix. Now it's lost again.

cf: d2b3b2c03e2934b126f5701e5f6e25821e2dbe35 (lost here)
cf:  25e9b5788bb2c43743a06f877f34c2336d19338b (previous fix)

Earlier PR #14849
Earlier issue #14843

Please note that jimi-c broke this last time as well ... seeing a
pattern here.
