### PR TITLE
Re-fix diff display in the `actionable` stdout callback

### DIFF
--- a/lib/ansible/plugins/callback/actionable.py
+++ b/lib/ansible/plugins/callback/actionable.py
@@ -32,6 +32,7 @@ class CallbackModule(CallbackModule_default):
         self.super_ref.__init__()
         self.last_task = None
         self.shown_title = False
+        self.diff = False
 
     def v2_playbook_on_handler_task_start(self, task):
         self.super_ref.v2_playbook_on_handler_task_start(task)
@@ -40,6 +41,7 @@ class CallbackModule(CallbackModule_default):
     def v2_playbook_on_task_start(self, task, is_conditional):
         self.last_task = task
         self.shown_title = False
+        self.diff = False
 
     def display_task_banner(self):
         if not self.shown_title:
@@ -53,6 +55,8 @@ class CallbackModule(CallbackModule_default):
     def v2_runner_on_ok(self, result):
         if result._result.get('changed', False):
             self.display_task_banner()
+            if self.diff:
+                self.super_ref.v2_on_file_diff(result)
             self.super_ref.v2_runner_on_ok(result)
 
     def v2_runner_on_unreachable(self, result):
@@ -68,6 +72,8 @@ class CallbackModule(CallbackModule_default):
     def v2_runner_item_on_ok(self, result):
         if result._result.get('changed', False):
             self.display_task_banner()
+            if self.diff:
+                self.super_ref.v2_on_file_diff(result)
             self.super_ref.v2_runner_item_on_ok(result)
 
     def v2_runner_item_on_skipped(self, result):
@@ -77,3 +83,5 @@ class CallbackModule(CallbackModule_default):
         self.display_task_banner()
         self.super_ref.v2_runner_item_on_failed(result)
 
+    def v2_on_file_diff(self, result):
+        self.diff = True

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -145,13 +145,7 @@ class CallbackModule(CallbackBase):
         self._display.banner(msg)
 
     def v2_on_file_diff(self, result):
-        if result._task.loop and 'results' in result._result:
-            for res in result._result['results']:
-                if 'diff' in res and res['diff'] and res.get('changed', False):
-                    diff = self._get_diff(res['diff'])
-                    if diff:
-                        self._display.display(diff)
-        elif 'diff' in result._result and result._result['diff'] and result._result.get('changed', False):
+        if 'diff' in result._result and result._result['diff'] and result._result.get('changed', False):
             diff = self._get_diff(result._result['diff'])
             if diff:
                 self._display.display(diff)


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (temp e6deae7abf) last updated 2016/09/08 15:05:15 (GMT +200)
  lib/ansible/modules/core: (devel 1d48b47cad) last updated 2016/09/01 09:55:33 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 2ef4a34eee) last updated 2016/08/31 16:07:04 (GMT +200)
  config file = /home/towolf/src/ansible/users/tobias.wolf/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

**Regarding the actionable plugin**

The diff was displayed before the TASK banner for for itemized and
unitemized tasks:
1. diff
2. banner
3. item_on_ok

I removed the loopwise handling of diff in the default callback and
handle the on_file_diff callback in the actionable callback plugin itself.

Now all diff display correctly.

This PR requires the previous PR #17458

Please review the logic for this.
