### PR TITLE
Support late evaluation, suppress warnings on SyntaxError

### DIFF
--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -137,9 +137,8 @@ def safe_eval(expr, locals={}, include_exceptions=False):
         else:
             return result
     except SyntaxError as e:
-        display.warning('SyntaxError in safe_eval() on expr: %s (%s)' % (expr, e))
         # special handling for syntax errors, we just return
-        # the expression string back as-is
+        # the expression string back as-is to support late evaluation
         if include_exceptions:
             return (expr, None)
         return expr


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

safe_eval
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

v2.2
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

See #14304 comments (https://github.com/ansible/ansible/pull/14304#issuecomment-245453209) for more information.
