### PR TITLE
Improve unit testing of 'password' lookup

### DIFF
--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -138,7 +138,7 @@ def _gen_candidate_chars(characters):
     chars = u''.join(chars).replace(u'"', u'').replace(u"'", u'')
     return chars
 
-def _create_password_file(b_path):
+def _create_password_file_dir(b_path):
     b_pathdir = os.path.dirname(b_path)
 
     try:
@@ -177,7 +177,7 @@ def _format_content(password, salt, encrypt):
 
     return u'%s salt=%s' % (password, salt)
 
-def _read_or_create_password_file(b_path):
+def _read_or_create_password_file_dir(b_path):
     salt = None
     plaintext_password = None
     content = None
@@ -186,7 +186,7 @@ def _read_or_create_password_file(b_path):
         b_file_content = _read_password_file(b_path)
         content, plaintext_password, salt = _parse_password(b_file_content)
     else:
-        _create_password_file(b_path)
+        _create_password_file_dir(b_path)
 
     return content, plaintext_password, salt
 
@@ -216,7 +216,7 @@ class LookupModule(LookupBase):
             b_path = to_bytes(path, errors='surrogate_or_strict')
 
             # get password or create it if file doesn't exist
-            content, plaintext_password, salt = _read_or_create_password_file(b_path)
+            content, plaintext_password, salt = _read_or_create_password_file_dir(b_path)
             content, plaintext_password, salt = _update_content(plaintext_password, salt, params)
 
             # save it

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -31,6 +31,7 @@ from ansible.plugins.lookup import LookupBase
 from ansible.parsing.splitter import parse_kv
 from ansible.utils.encrypt import do_encrypt
 from ansible.utils.path import makedirs_safe
+from ansible.compat.six import text_type
 
 from ansible.module_utils._text import to_bytes, to_native, to_text
 
@@ -98,7 +99,7 @@ def _random_password(length=DEFAULT_LENGTH, chars=C.DEFAULT_PASSWORD_CHARS):
     # Asserts would be perfect for this if they were disabled by default.
     # Alas, in python, they're active by default; only turned off if
     # python is run with optimization.
-    # assert isinstance(chars, text_type)
+    assert isinstance(chars, text_type)
     random_generator = random.SystemRandom()
 
     password = []

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -139,6 +139,8 @@ def _create_password_file(b_path):
     except OSError as e:
         raise AnsibleError("cannot create the path for the password lookup: %s (error was %s)" % (b_pathdir, str(e)))
 
+    return open(b_path)
+
 def _read_password_file(b_path):
     content = open(b_path).read().rstrip()
 

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -132,7 +132,7 @@ def _gen_candidate_chars(characters):
     for chars_spec in characters:
         chars.append(to_text(getattr(string, to_native(chars_spec), chars_spec),
                             errors='surrogate_or_strict'))
-    chars = u''.join(to_text(c) for c in chars).replace(u'"', u'').replace(u"'", u'')
+    chars = u''.join(chars).replace(u'"', u'').replace(u"'", u'')
     return chars
 
 

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -114,6 +114,20 @@ def _random_salt():
     return _random_password(length=8, chars=salt_chars)
 
 def _gen_candidate_chars(characters):
+    '''Generate a string containing all valid chars as defined by char spec in arg 'characters'
+
+    The input here is a list of character specs. The character specs are shorthand
+    names for sets of characters like 'digits', 'ascii_letters', or 'punctuation'.
+
+    The values of each char spec can be:
+        - a name of an attribute in the 'strings' module ('digits' for example). The
+        value of the attribute will be added to the candidate chars return value.
+        - a string of characters. If the string isn't an attribute in 'string' module, the
+        string will be directly added to the candidate chars.
+
+    characters=['digits', '?|'] will match string.digits and add all ascii digits, and '?|'
+    will add those chars directly. Return will be the string '0123456789?|'
+    '''
     chars = []
     for chars_spec in characters:
         chars.append(to_text(getattr(string, to_native(chars_spec), chars_spec),

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -85,7 +85,7 @@ def _parse_parameters(term):
 
     return relpath, params
 
-def _random_password(length=DEFAULT_LENGTH, chars=C.DEFAULT_PASSWORD_CHARS):
+def _random_password(length=DEFAULT_LENGTH, chars=None):
     '''
     Return a random password string of length containing only chars.
     NOTE: this was moved from the old ansible utils code, as nothing
@@ -99,6 +99,7 @@ def _random_password(length=DEFAULT_LENGTH, chars=C.DEFAULT_PASSWORD_CHARS):
     # Asserts would be perfect for this if they were disabled by default.
     # Alas, in python, they're active by default; only turned off if
     # python is run with optimization.
+    chars = chars or to_text(C.DEFAULT_PASSWORD_CHARS)
     assert isinstance(chars, text_type)
     random_generator = random.SystemRandom()
 

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -37,9 +37,6 @@ from ansible.module_utils._text import to_bytes, to_native, to_text
 DEFAULT_LENGTH = 20
 VALID_PARAMS = frozenset(('length', 'encrypt', 'chars'))
 
-
-# ALIKINS
-
 def _parse_parameters(term):
     # Hacky parsing of params
     # See https://github.com/ansible/ansible-modules-core/issues/1968#issuecomment-136842156

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -149,21 +149,22 @@ def _create_password_file_dir(b_path):
         raise AnsibleError(msg)
 
 def _read_password_file(b_path):
-    content = open(b_path, 'rb').read().rstrip()
-    return content
+    b_content = open(b_path, 'rb').read().rstrip()
+    return to_text(b_content, errors='surrogate_or_strict')
 
-def _parse_password(b_content):
-    content = to_text(b_content, errors='surrogate_or_strict')
+def _parse_password(content):
+    '''parse 'content' (text_type) into content, password, and salt'''
     password = content
     salt = None
 
+    salt_slug = ' salt='
     try:
-        sep = content.rindex(' salt=')
+        sep = content.rindex(salt_slug)
     except ValueError:
         # No salt
         pass
     else:
-        salt = password[sep + len(' salt='):]
+        salt = password[sep + len(salt_slug):]
         password = content[:sep]
 
     return content, password, salt
@@ -185,8 +186,8 @@ def _read_or_create_password_file_dir(b_path):
     content = None
 
     if os.path.exists(b_path):
-        b_file_content = _read_password_file(b_path)
-        content, plaintext_password, salt = _parse_password(b_file_content)
+        file_content = _read_password_file(b_path)
+        content, plaintext_password, salt = _parse_password(file_content)
     else:
         _create_password_file_dir(b_path)
 

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -117,7 +117,7 @@ def _random_salt():
     salt_chars = to_text(ascii_letters + digits + './', errors='surrogate_or_strict')
     return _random_password(length=8, chars=salt_chars)
 
-def _new_gen_candidate_chars(characters):
+def _gen_candidate_chars(characters):
     chars = []
     for chars_spec in characters:
         chars.append(to_text(getattr(string, to_native(chars_spec), chars_spec),
@@ -125,21 +125,9 @@ def _new_gen_candidate_chars(characters):
     chars = u''.join(to_text(c) for c in chars).replace(u'"', u'').replace(u"'", u'')
     return chars
 
-def _gen_candidate_chars(chars):
-    candidate_chars_list = []
-    for c in chars:
-        try:
-            defaults = getattr(string, c, c)
-        except UnicodeError:
-            defaults = c
-        candidate_chars_list.append(defaults)
-    candidate_chars = "".join(candidate_chars_list)
-    candidate_chars.replace('"', '')
-    candidate_chars.replace("'", '')
-    return candidate_chars
 
 def _gen_password(length, chars):
-    chars = _new_gen_candidate_chars(chars)
+    chars = _gen_candidate_chars(chars)
     password = ''.join(random.choice(chars) for _ in range(length))
     return password
 

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -105,8 +105,7 @@ def _random_password(length=DEFAULT_LENGTH, chars=C.DEFAULT_PASSWORD_CHARS):
     password = []
     while len(password) < length:
         new_char = random_generator.choice(chars)
-        if new_char in chars:
-            password.append(new_char)
+        password.append(new_char)
 
     return u''.join(password)
 

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -144,7 +144,9 @@ def _create_password_file_dir(b_path):
     try:
         makedirs_safe(b_pathdir, mode=0o700)
     except OSError as e:
-        raise AnsibleError("cannot create the path for the password lookup: %s (error was %s)" % (b_pathdir, str(e)))
+        msg = "cannot create the path for the password lookup: %s (error was %s)" % \
+            (to_native(b_pathdir), to_native(e))
+        raise AnsibleError(msg)
 
 def _read_password_file(b_path):
     content = open(b_path, 'rb').read().rstrip()

--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -172,7 +172,8 @@ def _parse_password(content):
 def _write_password_file(b_path, content):
     with open(b_path, 'wb') as f:
         os.chmod(b_path, 0o600)
-        f.write(content)
+        b_content = to_bytes(content, errors='surrogate_or_strict') + b'\n'
+        f.write(b_content)
 
 def _format_content(password, salt, encrypt):
     if not encrypt:
@@ -223,8 +224,7 @@ class LookupModule(LookupBase):
             content, plaintext_password, salt = _update_content(plaintext_password, salt, params)
 
             # save it
-            b_content = to_bytes(content, errors='surrogate_or_strict') + b'\n'
-            _write_password_file(b_path, b_content)
+            _write_password_file(b_path, content)
 
             if params['encrypt']:
                 b_password = do_encrypt(plaintext_password, params['encrypt'],

--- a/test/units/plugins/lookup/test_password.py
+++ b/test/units/plugins/lookup/test_password.py
@@ -20,158 +20,268 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from units.mock.loader import DictDataLoader
 from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import patch
+
 from ansible.compat.six import text_type
 
+from ansible.errors import AnsibleError
+from ansible.plugins import PluginLoader
 from ansible.plugins.lookup import password
+
+from ansible.module_utils._text import to_bytes
 
 DEFAULT_CHARS = sorted([u'ascii_letters', u'digits', u".,:-_"])
 DEFAULT_CANDIDATE_CHARS = u'.,:-_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
 
-class TestPasswordLookup(unittest.TestCase):
+# Currently there isn't a new-style
+old_style_params_data = (
+    # Simple case
+    dict(term=u'/path/to/file',
+         filename=u'/path/to/file',
+         params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
+         candidate_chars=DEFAULT_CANDIDATE_CHARS,
+         ),
 
-    # Currently there isn't a new-style
-    old_style_params_data = (
-        # Simple case
-        dict(term=u'/path/to/file',
-             filename=u'/path/to/file',
-             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
-             candidate_chars=DEFAULT_CANDIDATE_CHARS,
-             ),
+    # Special characters in path
+    dict(term=u'/path/with/embedded spaces and/file',
+         filename=u'/path/with/embedded spaces and/file',
+         params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
+         candidate_chars=DEFAULT_CANDIDATE_CHARS,
+         ),
+    dict(term=u'/path/with/equals/cn=com.ansible',
+         filename=u'/path/with/equals/cn=com.ansible',
+         params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
+         candidate_chars=DEFAULT_CANDIDATE_CHARS,
+         ),
+    dict(term=u'/path/with/unicode/くらとみ/file',
+         filename=u'/path/with/unicode/くらとみ/file',
+         params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
+         candidate_chars=DEFAULT_CANDIDATE_CHARS,
+         ),
+    # Mix several special chars
+    dict(term=u'/path/with/utf 8 and spaces/くらとみ/file',
+         filename=u'/path/with/utf 8 and spaces/くらとみ/file',
+         params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
+         candidate_chars=DEFAULT_CANDIDATE_CHARS,
+         ),
+    dict(term=u'/path/with/encoding=unicode/くらとみ/file',
+         filename=u'/path/with/encoding=unicode/くらとみ/file',
+         params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
+         candidate_chars=DEFAULT_CANDIDATE_CHARS,
+         ),
+    dict(term=u'/path/with/encoding=unicode/くらとみ/and spaces file',
+         filename=u'/path/with/encoding=unicode/くらとみ/and spaces file',
+         params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
+         candidate_chars=DEFAULT_CANDIDATE_CHARS,
+         ),
 
-        # Special characters in path
-        dict(term=u'/path/with/embedded spaces and/file',
-             filename=u'/path/with/embedded spaces and/file',
-             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
-             candidate_chars=DEFAULT_CANDIDATE_CHARS,
-             ),
-        dict(term=u'/path/with/equals/cn=com.ansible',
-             filename=u'/path/with/equals/cn=com.ansible',
-             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
-             candidate_chars=DEFAULT_CANDIDATE_CHARS,
-             ),
-        dict(term=u'/path/with/unicode/くらとみ/file',
-             filename=u'/path/with/unicode/くらとみ/file',
-             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
-             candidate_chars=DEFAULT_CANDIDATE_CHARS,
-             ),
-        # Mix several special chars
-        dict(term=u'/path/with/utf 8 and spaces/くらとみ/file',
-             filename=u'/path/with/utf 8 and spaces/くらとみ/file',
-             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
-             candidate_chars=DEFAULT_CANDIDATE_CHARS,
-             ),
-        dict(term=u'/path/with/encoding=unicode/くらとみ/file',
-             filename=u'/path/with/encoding=unicode/くらとみ/file',
-             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
-             candidate_chars=DEFAULT_CANDIDATE_CHARS,
-             ),
-        dict(term=u'/path/with/encoding=unicode/くらとみ/and spaces file',
-             filename=u'/path/with/encoding=unicode/くらとみ/and spaces file',
-             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
-             candidate_chars=DEFAULT_CANDIDATE_CHARS,
-             ),
+    # Simple parameters
+    dict(term=u'/path/to/file length=42',
+         filename=u'/path/to/file',
+         params=dict(length=42, encrypt=None, chars=DEFAULT_CHARS),
+         candidate_chars=DEFAULT_CANDIDATE_CHARS,
+         ),
+    dict(term=u'/path/to/file encrypt=pbkdf2_sha256',
+         filename=u'/path/to/file',
+         params=dict(length=password.DEFAULT_LENGTH, encrypt='pbkdf2_sha256', chars=DEFAULT_CHARS),
+         candidate_chars=DEFAULT_CANDIDATE_CHARS,
+         ),
+    dict(term=u'/path/to/file chars=abcdefghijklmnop',
+        filename=u'/path/to/file',
+        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'abcdefghijklmnop']),
+        candidate_chars=u'abcdefghijklmnop',
+         ),
+    dict(term=u'/path/to/file chars=digits,abc,def',
+        filename=u'/path/to/file',
+        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'abc', u'def'])),
+        candidate_chars=u'abcdef0123456789',
+         ),
 
-        # Simple parameters
-        dict(term=u'/path/to/file length=42',
-             filename=u'/path/to/file',
-             params=dict(length=42, encrypt=None, chars=DEFAULT_CHARS),
-             candidate_chars=DEFAULT_CANDIDATE_CHARS,
-             ),
-        dict(term=u'/path/to/file encrypt=pbkdf2_sha256',
-             filename=u'/path/to/file',
-             params=dict(length=password.DEFAULT_LENGTH, encrypt='pbkdf2_sha256', chars=DEFAULT_CHARS),
-             candidate_chars=DEFAULT_CANDIDATE_CHARS,
-             ),
-        dict(term=u'/path/to/file chars=abcdefghijklmnop',
-             filename=u'/path/to/file',
-             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'abcdefghijklmnop']),
-             candidate_chars=u'abcdefghijklmnop',
-             ),
-        dict(term=u'/path/to/file chars=digits,abc,def',
-             filename=u'/path/to/file',
-             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'abc', u'def'])),
-             candidate_chars=u'abcdef0123456789',
-             ),
+    # Including comma in chars
+    dict(term=u'/path/to/file chars=abcdefghijklmnop,,digits',
+         filename=u'/path/to/file',
+         params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'abcdefghijklmnop', u',', u'digits'])),
+         candidate_chars = u',abcdefghijklmnop0123456789',
+         ),
+    dict(term=u'/path/to/file chars=,,',
+         filename=u'/path/to/file',
+         params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u',']),
+         candidate_chars=u',',
+         ),
 
-        # Including comma in chars
-        dict(term=u'/path/to/file chars=abcdefghijklmnop,,digits',
-             filename=u'/path/to/file',
-             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'abcdefghijklmnop', u',', u'digits'])),
-             candidate_chars = u',abcdefghijklmnop0123456789',
-             ),
-        dict(term=u'/path/to/file chars=,,',
-             filename=u'/path/to/file',
-             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u',']),
-             candidate_chars=u',',
-             ),
+    # Including = in chars
+    dict(term=u'/path/to/file chars=digits,=,,',
+         filename=u'/path/to/file',
+         params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'=', u','])),
+         candidate_chars=u',=0123456789',
+         ),
+    dict(term=u'/path/to/file chars=digits,abc=def',
+         filename=u'/path/to/file',
+         params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'abc=def'])),
+         candidate_chars=u'abc=def0123456789',
+         ),
 
-        # Including = in chars
-        dict(term=u'/path/to/file chars=digits,=,,',
-             filename=u'/path/to/file',
-             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'=', u','])),
-             candidate_chars=u',=0123456789',
-             ),
-        dict(term=u'/path/to/file chars=digits,abc=def',
-             filename=u'/path/to/file',
-             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'abc=def'])),
-             candidate_chars=u'abc=def0123456789',
-             ),
+    # Including unicode in chars
+    dict(term=u'/path/to/file chars=digits,くらとみ,,',
+         filename=u'/path/to/file',
+         params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'くらとみ', u','])),
+         candidate_chars=u',0123456789くらとみ',
+         ),
+    # Including only unicode in chars
+    dict(term=u'/path/to/file chars=くらとみ',
+         filename=u'/path/to/file',
+         params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'くらとみ'])),
+         candidate_chars=u'くらとみ',
+         ),
 
-        # Including unicode in chars
-        dict(term=u'/path/to/file chars=digits,くらとみ,,',
-             filename=u'/path/to/file',
-             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'くらとみ', u','])),
-             candidate_chars=u',0123456789くらとみ',
-             ),
-        # Including only unicode in chars
-        dict(term=u'/path/to/file chars=くらとみ',
-             filename=u'/path/to/file',
-             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'くらとみ'])),
-             candidate_chars=u'くらとみ',
-             ),
+    # Include ':' in path
+    dict(term=u'/path/to/file_with:colon chars=ascii_letters,digits',
+         filename=u'/path/to/file_with:colon',
+         params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'ascii_letters', u'digits'])),
+         candidate_chars=u'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+         ),
 
-        # Include ':' in path
-        dict(term=u'/path/to/file_with:colon chars=ascii_letters,digits',
-             filename=u'/path/to/file_with:colon',
-             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'ascii_letters', u'digits'])),
-             candidate_chars=u'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
-             ),
+    # Including special chars in both path and chars
+    # Special characters in path
+    dict(term=u'/path/with/embedded spaces and/file chars=abc=def',
+         filename=u'/path/with/embedded spaces and/file',
+         params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'abc=def']),
+         candidate_chars=u'abc=def',
+         ),
+    dict(term=u'/path/with/equals/cn=com.ansible chars=abc=def',
+         filename=u'/path/with/equals/cn=com.ansible',
+         params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'abc=def']),
+         candidate_chars=u'abc=def',
+         ),
+    dict(term=u'/path/with/unicode/くらとみ/file chars=くらとみ',
+         filename=u'/path/with/unicode/くらとみ/file',
+         params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'くらとみ']),
+         candidate_chars=u'くらとみ',
+         ),
+)
 
-        # Including special chars in both path and chars
-        # Special characters in path
-        dict(term=u'/path/with/embedded spaces and/file chars=abc=def',
-             filename=u'/path/with/embedded spaces and/file',
-             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'abc=def']),
-             candidate_chars=u'abc=def',
-             ),
-        dict(term=u'/path/with/equals/cn=com.ansible chars=abc=def',
-             filename=u'/path/with/equals/cn=com.ansible',
-             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'abc=def']),
-             candidate_chars=u'abc=def',
-             ),
-        dict(term=u'/path/with/unicode/くらとみ/file chars=くらとみ',
-             filename=u'/path/with/unicode/くらとみ/file',
-             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'くらとみ']),
-             candidate_chars=u'くらとみ',
-             ),
-        )
 
-    def setUp(self):
-        pass
+class TestLookupModule(unittest.TestCase):
+    @patch.object(PluginLoader, '_get_paths')
+    @patch('ansible.plugins.lookup.password._create_password_file')
+    @patch('ansible.plugins.lookup.password._write_password_file')
+    def test(self, mock_get_paths, mock_create_pf, mock_write_file):
+        mock_get_paths.return_value = ['/path/one', '/path/two', '/path/three']
+        fake_loader = DictDataLoader({'/path/to/somewhere':'sdfsdf'})
+        password_lookup = password.LookupModule(loader=fake_loader)
+        results = password_lookup.run([u'/path/to/somewhere'],
+                                  None)
 
-    def tearDown(self):
-        pass
+        # FIXME: assert something useful
+        for result in results:
+            self.assertIsInstance(result, text_type)
 
-    def test_parse_parameters(self):
-        for testcase in self.old_style_params_data:
+    @patch.object(PluginLoader, '_get_paths')
+    @patch('ansible.plugins.lookup.password._create_password_file')
+    @patch('ansible.plugins.lookup.password._write_password_file')
+    def test_encrypt(self, mock_get_paths, mock_create_pf, mock_write_file):
+        mock_get_paths.return_value = ['/path/one', '/path/two', '/path/three']
+        fake_loader = DictDataLoader({'/path/to/somewhere':'sdfsdf'})
+        password_lookup = password.LookupModule(loader=fake_loader)
+        results = password_lookup.run([u'/path/to/somewhere encrypt=pbkdf2_sha256'],
+                                      None)
+
+        # FIXME: assert something useful
+        for result in results:
+            self.assertIsInstance(result, text_type)
+
+    @patch.object(PluginLoader, '_get_paths')
+    @patch('ansible.plugins.lookup.password._create_password_file')
+    @patch('ansible.plugins.lookup.password._write_password_file')
+    def test_only_a(self, mock_get_paths, mock_create_pf, mock_write_file):
+        mock_get_paths.return_value = ['/path/one', '/path/two', '/path/three']
+        fake_loader = DictDataLoader({'/path/to/somewhere':'sdfsdf'})
+        password_lookup = password.LookupModule(loader=fake_loader)
+        results = password_lookup.run([u'/path/to/somewhere chars=a'],
+                                  None)
+        for result in results:
+            for char in result:
+                self.assertEqual(char, u'a')
+
+
+class TestParsePassword(unittest.TestCase):
+    def test_empty_password_file(self):
+        content, plaintext_password, salt = password._parse_password(b'')
+        self.assertEquals(content, u'')
+
+    def test(self):
+        expected_content = u'12345678'
+        b_file_content = to_bytes(expected_content, errors='surrogate_or_strict')
+        content, plaintext_password, salt = password._parse_password(b_file_content)
+        self.assertEquals(content, expected_content)
+        self.assertEquals(plaintext_password, expected_content)
+
+    def test_with_salt(self):
+        expected_content = u'12345678 salt=87654321'
+        b_file_content = to_bytes(expected_content, errors='surrogate_or_strict')
+        content, plaintext_password, salt = password._parse_password(b_file_content)
+        self.assertEquals(content, expected_content)
+        self.assertEquals(salt, u'87654321')
+
+
+class TestUpdateContent(unittest.TestCase):
+    default_params = {'length': 20,
+                      'chars': DEFAULT_CHARS,
+                      'encrypt': None}
+
+    # FIXME: could use better asserts here
+    def _assert_type(self, content, pw, salt):
+        self.assertIsInstance(content, text_type)
+        self.assertIsInstance(salt, text_type)
+        self.assertIsInstance(pw, text_type)
+
+    def test(self):
+        content, pw, salt = password._update_content(u'123456', None, self.default_params)
+        self._assert_type(content, pw, salt)
+        self.assertEqual(content, u'123456')
+
+    def test_none(self):
+        content, pw, salt = password._update_content(None, None, self.default_params)
+        self._assert_type(content, pw, salt)
+
+    def test_no_salt(self):
+        content, pw, salt = password._update_content(u'12345', None, self.default_params)
+        self._assert_type(content, pw, salt)
+        self.assertEqual(content, u'12345')
+
+    def test_no_password(self):
+        content, pw, salt = password._update_content(None, u'12345678', self.default_params)
+        self._assert_type(content, pw, salt)
+
+
+class TestParseParamaters(unittest.TestCase):
+    def test(self):
+        for testcase in old_style_params_data:
             filename, params = password._parse_parameters(testcase['term'])
             params['chars'].sort()
             self.assertEqual(filename, testcase['filename'])
             self.assertEqual(params, testcase['params'])
 
+    def test_unrecognized_value(self):
+        testcase = dict(term=u'/path/to/file chars=くらとみi  sdfsdf',
+                        filename=u'/path/to/file',
+                        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'くらとみ']),
+                        candidate_chars=u'くらとみ')
+        self.assertRaises(AnsibleError, password._parse_parameters, testcase['term'])
+
+    def test_invalid_params(self):
+        testcase = dict(term=u'/path/to/file chars=くらとみi  somethign_invalid=123',
+                        filename=u'/path/to/file',
+                        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'くらとみ']),
+                        candidate_chars=u'くらとみ')
+        self.assertRaises(AnsibleError, password._parse_parameters, testcase['term'])
+
+
+class TestGenPassword(unittest.TestCase):
     def test_gen_password(self):
-        for testcase in self.old_style_params_data:
+        for testcase in old_style_params_data:
             params = testcase['params']
             candidate_chars = testcase['candidate_chars']
             password_string = password._gen_password(length=params['length'],
@@ -186,6 +296,8 @@ class TestPasswordLookup(unittest.TestCase):
                               msg='%s not found in %s from chars spect %s' %
                               (char, candidate_chars, params['chars']))
 
+
+class TestGenCandidateChars(unittest.TestCase):
     def _assert_gen_candidate_chars(self, testcase):
         expected_candidate_chars = testcase['candidate_chars']
         params = testcase['params']
@@ -194,7 +306,7 @@ class TestPasswordLookup(unittest.TestCase):
         self.assertEquals(res, expected_candidate_chars)
 
     def test_gen_candidate_chars(self):
-        for testcase in self.old_style_params_data:
+        for testcase in old_style_params_data:
             self._assert_gen_candidate_chars(testcase)
 
 
@@ -240,3 +352,17 @@ class TestRandomSalt(unittest.TestCase):
         self.assertEquals(len(res), 8)
         for res_char in res:
             self.assertIn(res_char, expected_salt_candidate_chars)
+
+
+class TestFormatContent(unittest.TestCase):
+    def test_no_encrypt(self):
+        res = password._format_content(password=u'hunter42',
+                                       salt=u'87654321',
+                                       encrypt=None)
+        self.assertEqual(res, u'hunter42')
+
+    def test_encrypt(self):
+        res = password._format_content(password=u'hunter42',
+                                       salt=u'87654321',
+                                       encrypt='pbkdf2_sha256')
+        self.assertNotEqual(res, u'hunter42')

--- a/test/units/plugins/lookup/test_password.py
+++ b/test/units/plugins/lookup/test_password.py
@@ -133,10 +133,10 @@ class TestPasswordLookup(unittest.TestCase):
                 ),
 
             # zero length
-            dict(term=u'/path/to/zero_length chars=ascii_letters,digits length=0',
-                 filename=u'/path/to/zero_length',
-                params=dict(length=0, encrypt=None, chars=sorted([u'ascii_letters', u'digits']))
-                ),
+            #dict(term=u'/path/to/zero_length chars=ascii_letters,digits length=0',
+            #     filename=u'/path/to/zero_length',
+            #    params=dict(length=0, encrypt=None, chars=sorted([u'ascii_letters', u'digits']))
+            #    ),
 
             )
 
@@ -157,7 +157,9 @@ class TestPasswordLookup(unittest.TestCase):
         for testcase in self.old_style_params_data:
             params = testcase['params']
             # password_lookup = password.LookupModule()
-            candidate_chars = password._gen_candidate_chars(params['chars'])
+#            print(params)
+#            print()
+            candidate_chars = password._new_gen_candidate_chars(params['chars'])
             password_string = password._gen_password(length=params['length'],
                                                     chars=params['chars'])
             self.assertEquals(len(password_string),

--- a/test/units/plugins/lookup/test_password.py
+++ b/test/units/plugins/lookup/test_password.py
@@ -25,120 +25,136 @@ from ansible.compat.tests import unittest
 from ansible.plugins.lookup import password
 
 DEFAULT_CHARS = sorted([u'ascii_letters', u'digits', u".,:-_"])
+DEFAULT_CANDIDATE_CHARS = u'.,:-_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
 
 class TestPasswordLookup(unittest.TestCase):
 
     # Currently there isn't a new-style
     old_style_params_data = (
-            # Simple case
-            dict(term=u'/path/to/file',
-                filename=u'/path/to/file',
-                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS)
-                ),
+        # Simple case
+        dict(term=u'/path/to/file',
+             filename=u'/path/to/file',
+             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
+             candidate_chars=DEFAULT_CANDIDATE_CHARS,
+             ),
 
-            # Special characters in path
-            dict(term=u'/path/with/embedded spaces and/file',
-                filename=u'/path/with/embedded spaces and/file',
-                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS)
-                ),
-            dict(term=u'/path/with/equals/cn=com.ansible',
-                filename=u'/path/with/equals/cn=com.ansible',
-                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS)
-                ),
-            dict(term=u'/path/with/unicode/くらとみ/file',
-                filename=u'/path/with/unicode/くらとみ/file',
-                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS)
-                ),
-            # Mix several special chars
-            dict(term=u'/path/with/utf 8 and spaces/くらとみ/file',
-                filename=u'/path/with/utf 8 and spaces/くらとみ/file',
-                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS)
-                ),
-            dict(term=u'/path/with/encoding=unicode/くらとみ/file',
-                filename=u'/path/with/encoding=unicode/くらとみ/file',
-                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS)
-                ),
-            dict(term=u'/path/with/encoding=unicode/くらとみ/and spaces file',
-                filename=u'/path/with/encoding=unicode/くらとみ/and spaces file',
-                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS)
-                ),
+        # Special characters in path
+        dict(term=u'/path/with/embedded spaces and/file',
+             filename=u'/path/with/embedded spaces and/file',
+             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
+             candidate_chars=DEFAULT_CANDIDATE_CHARS,
+             ),
+        dict(term=u'/path/with/equals/cn=com.ansible',
+             filename=u'/path/with/equals/cn=com.ansible',
+             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
+             candidate_chars=DEFAULT_CANDIDATE_CHARS,
+             ),
+        dict(term=u'/path/with/unicode/くらとみ/file',
+             filename=u'/path/with/unicode/くらとみ/file',
+             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
+             candidate_chars=DEFAULT_CANDIDATE_CHARS,
+             ),
+        # Mix several special chars
+        dict(term=u'/path/with/utf 8 and spaces/くらとみ/file',
+             filename=u'/path/with/utf 8 and spaces/くらとみ/file',
+             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
+             candidate_chars=DEFAULT_CANDIDATE_CHARS,
+             ),
+        dict(term=u'/path/with/encoding=unicode/くらとみ/file',
+             filename=u'/path/with/encoding=unicode/くらとみ/file',
+             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
+             candidate_chars=DEFAULT_CANDIDATE_CHARS,
+             ),
+        dict(term=u'/path/with/encoding=unicode/くらとみ/and spaces file',
+             filename=u'/path/with/encoding=unicode/くらとみ/and spaces file',
+             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
+             candidate_chars=DEFAULT_CANDIDATE_CHARS,
+             ),
 
-            # Simple parameters
-            dict(term=u'/path/to/file length=42',
-                filename=u'/path/to/file',
-                params=dict(length=42, encrypt=None, chars=DEFAULT_CHARS)
-                ),
-            dict(term=u'/path/to/file encrypt=pbkdf2_sha256',
-                filename=u'/path/to/file',
-                params=dict(length=password.DEFAULT_LENGTH, encrypt='pbkdf2_sha256', chars=DEFAULT_CHARS)
-                ),
-            dict(term=u'/path/to/file chars=abcdefghijklmnop',
-                filename=u'/path/to/file',
-                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'abcdefghijklmnop'])
-                ),
-            dict(term=u'/path/to/file chars=digits,abc,def',
-                filename=u'/path/to/file',
-                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'abc', u'def']))
-                ),
-            # Including comma in chars
-            dict(term=u'/path/to/file chars=abcdefghijklmnop,,digits',
-                filename=u'/path/to/file',
-                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'abcdefghijklmnop', u',', u'digits']))
-                ),
-            dict(term=u'/path/to/file chars=,,',
-                filename=u'/path/to/file',
-                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u','])
-                ),
+        # Simple parameters
+        dict(term=u'/path/to/file length=42',
+             filename=u'/path/to/file',
+             params=dict(length=42, encrypt=None, chars=DEFAULT_CHARS),
+             candidate_chars=DEFAULT_CANDIDATE_CHARS,
+             ),
+        dict(term=u'/path/to/file encrypt=pbkdf2_sha256',
+             filename=u'/path/to/file',
+             params=dict(length=password.DEFAULT_LENGTH, encrypt='pbkdf2_sha256', chars=DEFAULT_CHARS),
+             candidate_chars=DEFAULT_CANDIDATE_CHARS,
+             ),
+        dict(term=u'/path/to/file chars=abcdefghijklmnop',
+             filename=u'/path/to/file',
+             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'abcdefghijklmnop']),
+             candidate_chars=u'abcdefghijklmnop',
+             ),
+        dict(term=u'/path/to/file chars=digits,abc,def',
+             filename=u'/path/to/file',
+             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'abc', u'def'])),
+             candidate_chars=u'abcdef0123456789',
+             ),
 
-            # Including = in chars
-            dict(term=u'/path/to/file chars=digits,=,,',
-                filename=u'/path/to/file',
-                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'=', u',']))
-                ),
-            dict(term=u'/path/to/file chars=digits,abc=def',
-                filename=u'/path/to/file',
-                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'abc=def']))
-                ),
+        # Including comma in chars
+        dict(term=u'/path/to/file chars=abcdefghijklmnop,,digits',
+             filename=u'/path/to/file',
+             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'abcdefghijklmnop', u',', u'digits'])),
+             candidate_chars = u',abcdefghijklmnop0123456789',
+             ),
+        dict(term=u'/path/to/file chars=,,',
+             filename=u'/path/to/file',
+             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u',']),
+             candidate_chars=u',',
+             ),
 
-            # Including unicode in chars
-            dict(term=u'/path/to/file chars=digits,くらとみ,,',
-                filename=u'/path/to/file',
-                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'くらとみ', u',']))
-                ),
-            # Including only unicode in chars
-            dict(term=u'/path/to/file chars=くらとみ',
-                filename=u'/path/to/file',
-                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'くらとみ']))
-                ),
+        # Including = in chars
+        dict(term=u'/path/to/file chars=digits,=,,',
+             filename=u'/path/to/file',
+             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'=', u','])),
+             candidate_chars=u',=0123456789',
+             ),
+        dict(term=u'/path/to/file chars=digits,abc=def',
+             filename=u'/path/to/file',
+             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'abc=def'])),
+             candidate_chars=u'abc=def0123456789',
+             ),
 
-            # Include ':' in path
-            dict(term=u'/path/to/file_with:colon chars=ascii_letters,digits',
-                 filename=u'/path/to/file_with:colon',
-                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'ascii_letters', u'digits']))
-                ),
+        # Including unicode in chars
+        dict(term=u'/path/to/file chars=digits,くらとみ,,',
+             filename=u'/path/to/file',
+             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'くらとみ', u','])),
+             candidate_chars=u',0123456789くらとみ',
+             ),
+        # Including only unicode in chars
+        dict(term=u'/path/to/file chars=くらとみ',
+             filename=u'/path/to/file',
+             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'くらとみ'])),
+             candidate_chars=u'くらとみ',
+             ),
 
-            # Including special chars in both path and chars
-            # Special characters in path
-            dict(term=u'/path/with/embedded spaces and/file chars=abc=def',
-                filename=u'/path/with/embedded spaces and/file',
-                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'abc=def'])
-                ),
-            dict(term=u'/path/with/equals/cn=com.ansible chars=abc=def',
-                filename=u'/path/with/equals/cn=com.ansible',
-                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'abc=def'])
-                ),
-            dict(term=u'/path/with/unicode/くらとみ/file chars=くらとみ',
-                filename=u'/path/with/unicode/くらとみ/file',
-                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'くらとみ'])
-                ),
+        # Include ':' in path
+        dict(term=u'/path/to/file_with:colon chars=ascii_letters,digits',
+             filename=u'/path/to/file_with:colon',
+             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'ascii_letters', u'digits'])),
+             candidate_chars=u'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+             ),
 
-            # zero length
-            #dict(term=u'/path/to/zero_length chars=ascii_letters,digits length=0',
-            #     filename=u'/path/to/zero_length',
-            #    params=dict(length=0, encrypt=None, chars=sorted([u'ascii_letters', u'digits']))
-            #    ),
-
-            )
+        # Including special chars in both path and chars
+        # Special characters in path
+        dict(term=u'/path/with/embedded spaces and/file chars=abc=def',
+             filename=u'/path/with/embedded spaces and/file',
+             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'abc=def']),
+             candidate_chars=u'abc=def',
+             ),
+        dict(term=u'/path/with/equals/cn=com.ansible chars=abc=def',
+             filename=u'/path/with/equals/cn=com.ansible',
+             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'abc=def']),
+             candidate_chars=u'abc=def',
+             ),
+        dict(term=u'/path/with/unicode/くらとみ/file chars=くらとみ',
+             filename=u'/path/with/unicode/くらとみ/file',
+             params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'くらとみ']),
+             candidate_chars=u'くらとみ',
+             ),
+        )
 
     def setUp(self):
         pass
@@ -156,12 +172,9 @@ class TestPasswordLookup(unittest.TestCase):
     def test_gen_password(self):
         for testcase in self.old_style_params_data:
             params = testcase['params']
-            # password_lookup = password.LookupModule()
-#            print(params)
-#            print()
-            candidate_chars = password._new_gen_candidate_chars(params['chars'])
+            candidate_chars = testcase['candidate_chars']
             password_string = password._gen_password(length=params['length'],
-                                                    chars=params['chars'])
+                                                     chars=params['chars'])
             self.assertEquals(len(password_string),
                               params['length'],
                               msg='generated password=%s has length (%s) instead of expected length (%s)' %
@@ -171,3 +184,14 @@ class TestPasswordLookup(unittest.TestCase):
                 self.assertIn(char, candidate_chars,
                               msg='%s not found in %s from chars spect %s' %
                               (char, candidate_chars, params['chars']))
+
+    def _assert_gen_candidate_chars(self, testcase):
+        expected_candidate_chars = testcase['candidate_chars']
+        params = testcase['params']
+        chars_spec = params['chars']
+        res = password._gen_candidate_chars(chars_spec)
+        self.assertEquals(res, expected_candidate_chars)
+
+    def test_gen_candidate_chars(self):
+        for testcase in self.old_style_params_data:
+            self._assert_gen_candidate_chars(testcase)

--- a/test/units/plugins/lookup/test_password.py
+++ b/test/units/plugins/lookup/test_password.py
@@ -29,8 +29,6 @@ from ansible.compat.six import text_type
 from ansible.errors import AnsibleError
 from ansible.plugins import PluginLoader
 
-from ansible.module_utils._text import to_bytes
-
 from ansible.plugins.lookup import password
 
 DEFAULT_CHARS = sorted([u'ascii_letters', u'digits', u".,:-_"])
@@ -209,20 +207,20 @@ class TestLookupModule(unittest.TestCase):
 
 class TestParsePassword(unittest.TestCase):
     def test_empty_password_file(self):
-        content, plaintext_password, salt = password._parse_password(b'')
+        content, plaintext_password, salt = password._parse_password('')
         self.assertEquals(content, u'')
 
     def test(self):
         expected_content = u'12345678'
-        b_file_content = to_bytes(expected_content, errors='surrogate_or_strict')
-        content, plaintext_password, salt = password._parse_password(b_file_content)
+        file_content = expected_content
+        content, plaintext_password, salt = password._parse_password(file_content)
         self.assertEquals(content, expected_content)
         self.assertEquals(plaintext_password, expected_content)
 
     def test_with_salt(self):
         expected_content = u'12345678 salt=87654321'
-        b_file_content = to_bytes(expected_content, errors='surrogate_or_strict')
-        content, plaintext_password, salt = password._parse_password(b_file_content)
+        file_content = expected_content
+        content, plaintext_password, salt = password._parse_password(file_content)
         self.assertEquals(content, expected_content)
         self.assertEquals(salt, u'87654321')
 

--- a/test/units/plugins/lookup/test_password.py
+++ b/test/units/plugins/lookup/test_password.py
@@ -166,7 +166,7 @@ old_style_params_data = (
 
 class TestLookupModule(unittest.TestCase):
     @patch.object(PluginLoader, '_get_paths')
-    @patch('ansible.plugins.lookup.password._create_password_file')
+    @patch('ansible.plugins.lookup.password._create_password_file_dir')
     @patch('ansible.plugins.lookup.password._write_password_file')
     def test(self, mock_get_paths, mock_create_pf, mock_write_file):
         mock_get_paths.return_value = ['/path/one', '/path/two', '/path/three']
@@ -180,7 +180,7 @@ class TestLookupModule(unittest.TestCase):
             self.assertIsInstance(result, text_type)
 
     @patch.object(PluginLoader, '_get_paths')
-    @patch('ansible.plugins.lookup.password._create_password_file')
+    @patch('ansible.plugins.lookup.password._create_password_file_dir')
     @patch('ansible.plugins.lookup.password._write_password_file')
     def test_encrypt(self, mock_get_paths, mock_create_pf, mock_write_file):
         mock_get_paths.return_value = ['/path/one', '/path/two', '/path/three']
@@ -194,7 +194,7 @@ class TestLookupModule(unittest.TestCase):
             self.assertIsInstance(result, text_type)
 
     @patch.object(PluginLoader, '_get_paths')
-    @patch('ansible.plugins.lookup.password._create_password_file')
+    @patch('ansible.plugins.lookup.password._create_password_file_dir')
     @patch('ansible.plugins.lookup.password._write_password_file')
     def test_only_a(self, mock_get_paths, mock_create_pf, mock_write_file):
         mock_get_paths.return_value = ['/path/one', '/path/two', '/path/three']

--- a/test/units/plugins/lookup/test_password.py
+++ b/test/units/plugins/lookup/test_password.py
@@ -280,24 +280,6 @@ class TestParseParamaters(unittest.TestCase):
         self.assertRaises(AnsibleError, password._parse_parameters, testcase['term'])
 
 
-class TestGenPassword(unittest.TestCase):
-    def test_gen_password(self):
-        for testcase in old_style_params_data:
-            params = testcase['params']
-            candidate_chars = testcase['candidate_chars']
-            password_string = password._gen_password(length=params['length'],
-                                                     chars=params['chars'])
-            self.assertEquals(len(password_string),
-                              params['length'],
-                              msg='generated password=%s has length (%s) instead of expected length (%s)' %
-                              (password_string, len(password_string), params['length']))
-
-            for char in password_string:
-                self.assertIn(char, candidate_chars,
-                              msg='%s not found in %s from chars spect %s' %
-                              (char, candidate_chars, params['chars']))
-
-
 class TestGenCandidateChars(unittest.TestCase):
     def _assert_gen_candidate_chars(self, testcase):
         expected_candidate_chars = testcase['candidate_chars']
@@ -344,6 +326,23 @@ class TestRandomPassword(unittest.TestCase):
         res = password._random_password(length=11, chars=u'くらとみ')
         self._assert_valid_chars(res, u'くらとみ')
         self.assertEquals(len(res), 11)
+
+    def test_gen_password(self):
+        for testcase in old_style_params_data:
+            params = testcase['params']
+            candidate_chars = testcase['candidate_chars']
+            params_chars_spec = password._gen_candidate_chars(params['chars'])
+            password_string = password._random_password(length=params['length'],
+                                                        chars=params_chars_spec)
+            self.assertEquals(len(password_string),
+                              params['length'],
+                              msg='generated password=%s has length (%s) instead of expected length (%s)' %
+                              (password_string, len(password_string), params['length']))
+
+            for char in password_string:
+                self.assertIn(char, candidate_chars,
+                              msg='%s not found in %s from chars spect %s' %
+                              (char, candidate_chars, params['chars']))
 
 
 class TestRandomSalt(unittest.TestCase):

--- a/test/units/plugins/lookup/test_password.py
+++ b/test/units/plugins/lookup/test_password.py
@@ -28,9 +28,10 @@ from ansible.compat.six import text_type
 
 from ansible.errors import AnsibleError
 from ansible.plugins import PluginLoader
-from ansible.plugins.lookup import password
 
 from ansible.module_utils._text import to_bytes
+
+from ansible.plugins.lookup import password
 
 DEFAULT_CHARS = sorted([u'ascii_letters', u'digits', u".,:-_"])
 DEFAULT_CANDIDATE_CHARS = u'.,:-_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'

--- a/test/units/plugins/lookup/test_password.py
+++ b/test/units/plugins/lookup/test_password.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 
 from ansible.compat.tests import unittest
 
-from ansible.plugins.lookup.password import LookupModule, _parse_parameters, DEFAULT_LENGTH
+from ansible.plugins.lookup import password
 
 DEFAULT_CHARS = sorted([u'ascii_letters', u'digits', u".,:-_"])
 
@@ -33,34 +33,34 @@ class TestPasswordLookup(unittest.TestCase):
             # Simple case
             dict(term=u'/path/to/file',
                 filename=u'/path/to/file',
-                params=dict(length=DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS)
+                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS)
                 ),
 
             # Special characters in path
             dict(term=u'/path/with/embedded spaces and/file',
                 filename=u'/path/with/embedded spaces and/file',
-                params=dict(length=DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS)
+                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS)
                 ),
             dict(term=u'/path/with/equals/cn=com.ansible',
                 filename=u'/path/with/equals/cn=com.ansible',
-                params=dict(length=DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS)
+                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS)
                 ),
             dict(term=u'/path/with/unicode/くらとみ/file',
                 filename=u'/path/with/unicode/くらとみ/file',
-                params=dict(length=DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS)
+                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS)
                 ),
             # Mix several special chars
             dict(term=u'/path/with/utf 8 and spaces/くらとみ/file',
                 filename=u'/path/with/utf 8 and spaces/くらとみ/file',
-                params=dict(length=DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS)
+                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS)
                 ),
             dict(term=u'/path/with/encoding=unicode/くらとみ/file',
                 filename=u'/path/with/encoding=unicode/くらとみ/file',
-                params=dict(length=DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS)
+                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS)
                 ),
             dict(term=u'/path/with/encoding=unicode/くらとみ/and spaces file',
                 filename=u'/path/with/encoding=unicode/くらとみ/and spaces file',
-                params=dict(length=DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS)
+                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS)
                 ),
 
             # Simple parameters
@@ -70,66 +70,66 @@ class TestPasswordLookup(unittest.TestCase):
                 ),
             dict(term=u'/path/to/file encrypt=pbkdf2_sha256',
                 filename=u'/path/to/file',
-                params=dict(length=DEFAULT_LENGTH, encrypt='pbkdf2_sha256', chars=DEFAULT_CHARS)
+                params=dict(length=password.DEFAULT_LENGTH, encrypt='pbkdf2_sha256', chars=DEFAULT_CHARS)
                 ),
             dict(term=u'/path/to/file chars=abcdefghijklmnop',
                 filename=u'/path/to/file',
-                params=dict(length=DEFAULT_LENGTH, encrypt=None, chars=[u'abcdefghijklmnop'])
+                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'abcdefghijklmnop'])
                 ),
             dict(term=u'/path/to/file chars=digits,abc,def',
                 filename=u'/path/to/file',
-                params=dict(length=DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'abc', u'def']))
+                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'abc', u'def']))
                 ),
             # Including comma in chars
             dict(term=u'/path/to/file chars=abcdefghijklmnop,,digits',
                 filename=u'/path/to/file',
-                params=dict(length=DEFAULT_LENGTH, encrypt=None, chars=sorted([u'abcdefghijklmnop', u',', u'digits']))
+                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'abcdefghijklmnop', u',', u'digits']))
                 ),
             dict(term=u'/path/to/file chars=,,',
                 filename=u'/path/to/file',
-                params=dict(length=DEFAULT_LENGTH, encrypt=None, chars=[u','])
+                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u','])
                 ),
 
             # Including = in chars
             dict(term=u'/path/to/file chars=digits,=,,',
                 filename=u'/path/to/file',
-                params=dict(length=DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'=', u',']))
+                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'=', u',']))
                 ),
             dict(term=u'/path/to/file chars=digits,abc=def',
                 filename=u'/path/to/file',
-                params=dict(length=DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'abc=def']))
+                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'abc=def']))
                 ),
 
             # Including unicode in chars
             dict(term=u'/path/to/file chars=digits,くらとみ,,',
                 filename=u'/path/to/file',
-                params=dict(length=DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'くらとみ', u',']))
+                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'くらとみ', u',']))
                 ),
             # Including only unicode in chars
             dict(term=u'/path/to/file chars=くらとみ',
                 filename=u'/path/to/file',
-                params=dict(length=DEFAULT_LENGTH, encrypt=None, chars=sorted([u'くらとみ']))
+                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'くらとみ']))
                 ),
 
             # Include ':' in path
             dict(term=u'/path/to/file_with:colon chars=ascii_letters,digits',
                  filename=u'/path/to/file_with:colon',
-                params=dict(length=DEFAULT_LENGTH, encrypt=None, chars=sorted([u'ascii_letters', u'digits']))
+                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'ascii_letters', u'digits']))
                 ),
 
             # Including special chars in both path and chars
             # Special characters in path
             dict(term=u'/path/with/embedded spaces and/file chars=abc=def',
                 filename=u'/path/with/embedded spaces and/file',
-                params=dict(length=DEFAULT_LENGTH, encrypt=None, chars=[u'abc=def'])
+                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'abc=def'])
                 ),
             dict(term=u'/path/with/equals/cn=com.ansible chars=abc=def',
                 filename=u'/path/with/equals/cn=com.ansible',
-                params=dict(length=DEFAULT_LENGTH, encrypt=None, chars=[u'abc=def'])
+                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'abc=def'])
                 ),
             dict(term=u'/path/with/unicode/くらとみ/file chars=くらとみ',
                 filename=u'/path/with/unicode/くらとみ/file',
-                params=dict(length=DEFAULT_LENGTH, encrypt=None, chars=[u'くらとみ'])
+                params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'くらとみ'])
                 ),
 
             # zero length
@@ -148,24 +148,24 @@ class TestPasswordLookup(unittest.TestCase):
 
     def test_parse_parameters(self):
         for testcase in self.old_style_params_data:
-            filename, params = _parse_parameters(testcase['term'])
+            filename, params = password._parse_parameters(testcase['term'])
             params['chars'].sort()
             self.assertEqual(filename, testcase['filename'])
             self.assertEqual(params, testcase['params'])
 
     def test_gen_password(self):
         for testcase in self.old_style_params_data:
-            filename, params = _parse_parameters(testcase['term'])
-            password_lookup = LookupModule()
-            candidate_chars = password_lookup.gen_candidate_chars(params['chars'])
-            password = password_lookup.gen_password(length=params['length'],
+            params = testcase['params']
+            # password_lookup = password.LookupModule()
+            candidate_chars = password._gen_candidate_chars(params['chars'])
+            password_string = password._gen_password(length=params['length'],
                                                     chars=params['chars'])
-            self.assertEquals(len(password),
+            self.assertEquals(len(password_string),
                               params['length'],
                               msg='generated password=%s has length (%s) instead of expected length (%s)' %
-                              (password, len(password), params['length']))
+                              (password_string, len(password_string), params['length']))
 
-            for char in password:
+            for char in password_string:
                 self.assertIn(char, candidate_chars,
                               msg='%s not found in %s from chars spect %s' %
                               (char, candidate_chars, params['chars']))


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

lib/ansible/plugins/lookup/password.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (password_lookup ab5bd4a9eb) last updated 2016/09/08 14:30:44 (GMT -400)
  lib/ansible/modules/core: (detached HEAD db38f0c876) last updated 2016/09/07 12:50:14 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 8bfdcfcab2) last updated 2016/09/07 12:50:14 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

Was attempting to reproduce https://github.com/ansible/ansible/issues/17461 with
unit tests, and these were changes to make the module a little easier to test. ( Note
this doesn't fix https://github.com/ansible/ansible/issues/17461)

The tests showed some UnicodeErrors for the
cases where the 'chars' param include unicode,
causing the 'getattr(string, c, c)' to fail.
So the candidate char generation code try/excepts
UnicodeErrors there now.

Some refactoring of the password.py module to make
it easier to test, and some new tests that cover more
of the password and salt generation.
