### PR TITLE
fixes issue with netcfg not working with match=line and path

### DIFF
--- a/lib/ansible/module_utils/netcfg.py
+++ b/lib/ansible/module_utils/netcfg.py
@@ -306,7 +306,7 @@ class NetworkConfig(object):
 
     def difference(self, other, path=None, match='line', replace='line'):
         try:
-            if path:
+            if path and match != 'line':
                 try:
                     other = other.get_section_objects(path)
                 except ValueError:


### PR DESCRIPTION
The difference() method now checks this condition and doesn't filter
the path when match=line
