### PR TITLE
Add `docker_friendly` flag to role meta data.

### DIFF
--- a/lib/ansible/galaxy/data/metadata_template.j2
+++ b/lib/ansible/galaxy/data/metadata_template.j2
@@ -18,6 +18,9 @@ galaxy_info:
 
   min_ansible_version: {{ min_ansible_version }}
 
+  # Has this role been tested to work with the Docker connection plugin?
+  docker_friendly: no
+
   # Optionally specify the branch Galaxy will use when accessing the GitHub
   # repo for this role. During role install, if no tags are available,
   # Galaxy will use this branch. During import Galaxy will access files on


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### COMPONENT NAME

galaxy
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 194e49bd43) last updated 2016/09/08 18:19:41 (GMT -400)
  lib/ansible/modules/core: (detached HEAD db38f0c876) last updated 2016/09/08 18:19:03 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 8bfdcfcab2) last updated 2016/09/08 18:19:03 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Add a way to indicate whether a role is expected to work via the Docker connection plugin.

See [ansible/ansible-container #220](https://github.com/ansible/ansible-container/issues/220)
