### PR TITLE
Enable more tests that pass on python 3.

### DIFF
--- a/test/utils/shippable/python3-test-tag-blacklist.txt
+++ b/test/utils/shippable/python3-test-tag-blacklist.txt
@@ -7,11 +7,7 @@ test_gem
 test_git
 test_hg
 test_lookups
-test_mysql_db
-test_mysql_user
-test_mysql_variables
 test_pip
-test_postgresql
 test_service
 test_subversion
 test_synchronize

--- a/test/utils/shippable/python3-test-tag-blacklist.txt
+++ b/test/utils/shippable/python3-test-tag-blacklist.txt
@@ -1,5 +1,6 @@
 test_apache2_module
 test_apt
+test_apt_repository
 test_assemble
 test_authorized_key
 test_filters


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

Integration Tests
##### ANSIBLE VERSION

```
ansible 2.2.0 (py3-tests 2bd0d7dc5a) last updated 2016/09/08 16:15:30 (GMT -700)
  lib/ansible/modules/core: (detached HEAD db38f0c876) last updated 2016/09/08 10:37:13 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 8bfdcfcab2) last updated 2016/09/08 10:37:13 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Enable more tests that pass on python 3.

NOTE: Requires an updated ubuntu1604py3 docker image with `python3-apt` installed.
