### PR TITLE
Add python 3 support to test_apt_repository.

### DIFF
--- a/test/integration/roles/test_apt_repository/tasks/apt.yml
+++ b/test/integration/roles/test_apt_repository/tasks/apt.yml
@@ -6,16 +6,29 @@
     test_ppa_spec: 'deb http://ppa.launchpad.net/git-core/ppa/ubuntu {{ansible_distribution_release}} main'
     test_ppa_key: 'E1DF1F24' # http://keyserver.ubuntu.com:11371/pks/lookup?search=0xD06AAF4C11DAB86DF421421EFE6B20ECA7AD98A1&op=index
 
+- name: show python version
+  debug: var=ansible_python_version
+
+- name: use python-apt
+  set_fact:
+    python_apt: python-apt
+  when: ansible_python_version | version_compare('3', '<')
+
+- name: use python3-apt
+  set_fact:
+    python_apt: python3-apt
+  when: ansible_python_version | version_compare('3', '>=')
+
 # UNINSTALL 'python-apt'
 #  The `apt_repository` module has the smarts to auto-install `python-apt`.  To
 # test, we will first uninstall `python-apt`.
-- name: check python-apt with dpkg
-  shell: dpkg -s python-apt
+- name: check {{ python_apt }} with dpkg
+  shell: dpkg -s {{ python_apt }}
   register: dpkg_result
   ignore_errors: true
 
-- name: uninstall python-apt with apt
-  apt: pkg=python-apt state=absent purge=yes
+- name: uninstall {{ python_apt }} with apt
+  apt: pkg={{ python_apt }} state=absent purge=yes
   register: apt_result
   when: dpkg_result|success
 


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

Integration Tests
##### ANSIBLE VERSION

```
ansible 2.2.0 (apt-test 7ac1b70371) last updated 2016/09/08 17:35:55 (GMT -700)
  lib/ansible/modules/core: (detached HEAD db38f0c876) last updated 2016/09/08 10:37:13 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 8bfdcfcab2) last updated 2016/09/08 10:37:13 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Add python 3 support to test_apt_repository.
