### PR TITLE
Enable more integration tests for python 3.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -24,6 +24,7 @@ matrix:
     - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1204 PRIVILEGED=true
     - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1404 PRIVILEGED=true
     - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1604
+    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1604py3 PYTHON3=1
 
     - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:centos6
     - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:centos7
@@ -33,6 +34,7 @@ matrix:
     - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1204
     - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1404
     - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1604
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1604py3 PYTHON3=1
 
     - env: TEST=integration TARGET=other IMAGE=ansible/ansible:centos6
     - env: TEST=integration TARGET=other IMAGE=ansible/ansible:centos7
@@ -42,8 +44,7 @@ matrix:
     - env: TEST=integration TARGET=other IMAGE=ansible/ansible:ubuntu1204
     - env: TEST=integration TARGET=other IMAGE=ansible/ansible:ubuntu1404
     - env: TEST=integration TARGET=other IMAGE=ansible/ansible:ubuntu1604
-
-    - env: TEST=integration TARGET=all IMAGE=ansible/ansible:ubuntu1604py3 PYTHON3=1
+    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:ubuntu1604py3 PYTHON3=1
 
     - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py24
       python: 2.7

--- a/test/utils/shippable/python3-test-tag-blacklist.txt
+++ b/test/utils/shippable/python3-test-tag-blacklist.txt
@@ -1,6 +1,4 @@
 test_apache2_module
-test_apt
-test_apt_repository
 test_assemble
 test_authorized_key
 test_filters


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

Integration Tests
##### ANSIBLE VERSION

```
ansible 2.2.0 (py3-tests 4f37627b31) last updated 2016/09/08 18:20:58 (GMT -700)
  lib/ansible/modules/core: (detached HEAD bf5b3de83e) last updated 2016/09/08 18:10:26 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD f83aa9fff3) last updated 2016/09/08 18:10:26 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Enable more integration tests for python 3.
