### PR TITLE
Start WinRM service automatically on reboot

### DIFF
--- a/examples/scripts/ConfigureRemotingForAnsible.ps1
+++ b/examples/scripts/ConfigureRemotingForAnsible.ps1
@@ -103,6 +103,8 @@ ElseIf ((Get-Service "WinRM").Status -ne "Running")
 {
     Write-Verbose "Starting WinRM service."
     Start-Service -Name "WinRM" -ErrorAction Stop
+    Write-Verbose "Start WinRM service automatic"
+    Set-Service -Name "WinRM" -StartupType Automatic
 }
 
 # WinRM should be running; check that we have a PS session config.


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

Example scripts
##### ANSIBLE VERSION

```
ansible 2.1.1.0
```
##### SUMMARY

The Windows remoting configure script ensures that the WinRM service is started automatically on boot.
