### PR TITLE
Fix fileglob filter to work just like fileglob lookup plugin

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -126,8 +126,8 @@ def quote(a):
     return pipes.quote(a)
 
 def fileglob(pathname):
-    ''' return list of matched files for glob '''
-    return glob.glob(pathname)
+    ''' return list of matched regular files for glob '''
+    return [ g for g in glob.glob(pathname) if os.path.isfile(g) ]
 
 def regex_replace(value='', pattern='', replacement='', ignorecase=False):
     ''' Perform a `re.sub` returning a string '''


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

fileglob filter plugin
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

v2.2 and older
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

The fileglob lookup plugin only returns files, not directories.
This is to be expected, as a mixed list would not be very useful in with_fileglob.
However the fileglob filter does return anything glob.glob() returns.

This change fixes this, so that fileglob returns files (as the name indicates).

PS We could also offer a glob filter for thos that would need it ?

This relates to comments in issue #17136 and fixes confusion in #17269.
