### PR TITLE
minor update to catch expection if trying close a non existent session

### DIFF
--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -105,8 +105,10 @@ class Netconf(object):
         self._connected = True
 
     def disconnect(self):
-        if self.device:
+        try:
             self.device.close()
+        except AttributeError:
+            pass
         self._connected = False
 
     ### Command methods ###


### PR DESCRIPTION
This will prevent the junos shared module from throwing an exception if
the session is trying to be closed when it doesn't exist
