### PR TITLE
Filesystem blocks are of size `f_frsize`

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -581,8 +581,8 @@ class Facts(object):
         size_available = None
         try:
             statvfs_result = os.statvfs(mountpoint)
-            size_total = statvfs_result.f_bsize * statvfs_result.f_blocks
-            size_available = statvfs_result.f_bsize * (statvfs_result.f_bavail)
+            size_total = statvfs_result.f_frsize * statvfs_result.f_blocks
+            size_available = statvfs_result.f_frsize * (statvfs_result.f_bavail)
         except OSError:
             pass
         return size_total, size_available


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

`setup`
##### ANSIBLE VERSION

```
ansible 2.2.0 (f_frsize 8b1062c9bf) last updated 2016/09/09 20:56:30 (GMT +100)
  lib/ansible/modules/core: (detached HEAD bf5b3de83e) last updated 2016/09/09 21:59:51 (GMT +100)
  lib/ansible/modules/extras: (detached HEAD f83aa9fff3) last updated 2016/09/09 21:59:52 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

The statvfs(3) manpage on Linux states that `f_blocks` is the "size of fs in `f_frsize` units".  The manpages on Solaris and AIX state something similar.

With ext4 on Linux, I suspect that `f_bsize` and `f_frsize` are always identical, masking this error.  On Solaris, the sizes differ for each of ufs, vxfs and zfs filesystem types, causing the `size_available` and `size_total` facts to be set incorrectly on this OS without this patch.
