### PR TITLE
Feature/add ansible play hosts all

### DIFF
--- a/docsite/rst/playbooks_delegation.rst
+++ b/docsite/rst/playbooks_delegation.rst
@@ -224,7 +224,7 @@ This approach is similar to applying a conditional to a task such as::
 .. note::
      When used together with "serial", tasks marked as "run_once" will be run on one host in *each* serial batch.
      If it's crucial that the task is run only once regardless of "serial" mode, use
-     :code:`when: inventory_hostname == ansible_play_hosts_all[0]` construct.
+     :code:`when: inventory_hostname == ansible_play_hosts[0]` construct.
 
 .. _local_playbooks:
 

--- a/docsite/rst/playbooks_delegation.rst
+++ b/docsite/rst/playbooks_delegation.rst
@@ -224,7 +224,7 @@ This approach is similar to applying a conditional to a task such as::
 .. note::
      When used together with "serial", tasks marked as "run_once" will be run on one host in *each* serial batch.
      If it's crucial that the task is run only once regardless of "serial" mode, use
-     :code:`inventory_hostname == my_group_name[0]` construct.
+     :code:`when: inventory_hostname == ansible_play_hosts_all[0]` construct.
 
 .. _local_playbooks:
 

--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -669,6 +669,7 @@ reasons.  If you have a long FQDN, ``inventory_hostname_short`` also contains th
 period, without the rest of the domain.
 
 ``play_hosts`` is available as a list of hostnames that are in scope for the current play. This may be useful for filling out templates with multiple hostnames or for injecting the list into the rules for a load balancer.
+``ansible_play_hosts_all`` is the same as ``play_hosts`` but includes all hosts in all ``serial`` batches, if you're not using ``serial`` it's the same as ``play_hosts``.
 
 Don't worry about any of this unless you think you need it.  You'll know when you do.
 

--- a/docsite/rst/playbooks_variables.rst
+++ b/docsite/rst/playbooks_variables.rst
@@ -669,7 +669,7 @@ reasons.  If you have a long FQDN, ``inventory_hostname_short`` also contains th
 period, without the rest of the domain.
 
 ``play_hosts`` is available as a list of hostnames that are in scope for the current play. This may be useful for filling out templates with multiple hostnames or for injecting the list into the rules for a load balancer.
-``ansible_play_hosts_all`` is the same as ``play_hosts`` but includes all hosts in all ``serial`` batches, if you're not using ``serial`` it's the same as ``play_hosts``.
+``ansible_play_hosts`` is the same as ``play_hosts`` but includes all hosts in all ``serial`` batches, if you're not using ``serial`` it's the same as ``play_hosts``.
 
 Don't worry about any of this unless you think you need it.  You'll know when you do.
 

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -164,7 +164,7 @@ class Inventory(object):
             self.get_group_vars(group)
 
         # get host vars from host_vars/ files and vars plugins
-        for host in self.get_hosts(ignore_limits_and_restrictions=True):
+        for host in self.get_hosts(ignore_limits=True, ignore_restrictions=True):
             host.vars = combine_vars(host.vars, self.get_host_variables(host.name))
             self.get_host_vars(host)
 
@@ -192,7 +192,7 @@ class Inventory(object):
                 results.append(item)
         return results
 
-    def get_hosts(self, pattern="all", ignore_limits_and_restrictions=False):
+    def get_hosts(self, pattern="all", ignore_limits=False, ignore_restrictions=False):
         """
         Takes a pattern or list of patterns and returns a list of matching
         inventory host names, taking into account any active restrictions
@@ -205,11 +205,11 @@ class Inventory(object):
         else:
             pattern_hash = pattern
 
-        if not ignore_limits_and_restrictions:
-            if self._subset:
-                pattern_hash += u":%s" % to_text(self._subset)
-            if self._restriction:
-                pattern_hash += u":%s" % to_text(self._restriction)
+        if not ignore_limits and self._subset:
+            pattern_hash += u":%s" % to_text(self._subset)
+
+        if not ignore_restrictions and self._restriction:
+            pattern_hash += u":%s" % to_text(self._restriction)
 
         if pattern_hash not in HOSTS_PATTERNS_CACHE:
 
@@ -217,15 +217,14 @@ class Inventory(object):
             hosts = self._evaluate_patterns(patterns)
 
             # mainly useful for hostvars[host] access
-            if not ignore_limits_and_restrictions:
+            if not ignore_limits and self._subset:
                 # exclude hosts not in a subset, if defined
-                if self._subset:
-                    subset = self._evaluate_patterns(self._subset)
-                    hosts = [ h for h in hosts if h in subset ]
+                subset = self._evaluate_patterns(self._subset)
+                hosts = [ h for h in hosts if h in subset ]
 
+            if not ignore_restrictions and self._restriction:
                 # exclude hosts mentioned in any restriction (ex: failed hosts)
-                if self._restriction:
-                    hosts = [ h for h in hosts if h.name in self._restriction ]
+                hosts = [ h for h in hosts if h.name in self._restriction ]
 
             seen = set()
             HOSTS_PATTERNS_CACHE[pattern_hash] = [x for x in hosts if x not in seen and not seen.add(x)]

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -413,8 +413,7 @@ class VariableManager:
                 # DEPRECATED: play_hosts should be deprecated in favor of ansible_play_hosts,
                 #             however this would take work in the templating engine, so for now
                 #             we'll add both so we can give users something transitional to use
-                host_list = [x.name for x in self._inventory.get_hosts()]
-                variables['play_hosts'] = host_list
+                variables['play_hosts'] = [x.name for x in self._inventory.get_hosts()]
                 variables['ansible_play_hosts'] = [x.name for x in self._inventory.get_hosts(pattern=play.hosts or 'all', ignore_restrictions=True)]
 
         # the 'omit' value alows params to be left out if the variable they are based on is undefined

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -416,6 +416,7 @@ class VariableManager:
                 host_list = [x.name for x in self._inventory.get_hosts()]
                 variables['play_hosts'] = host_list
                 variables['ansible_play_hosts'] = host_list
+                variables['ansible_play_hosts_all'] = [x.name for x in self._inventory.get_hosts(pattern=play.hosts, ignore_restrictions=True)]
 
         # the 'omit' value alows params to be left out if the variable they are based on is undefined
         variables['omit'] = self._omit_token

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -415,8 +415,7 @@ class VariableManager:
                 #             we'll add both so we can give users something transitional to use
                 host_list = [x.name for x in self._inventory.get_hosts()]
                 variables['play_hosts'] = host_list
-                variables['ansible_play_hosts'] = host_list
-                variables['ansible_play_hosts_all'] = [x.name for x in self._inventory.get_hosts(pattern=play.hosts or 'all', ignore_restrictions=True)]
+                variables['ansible_play_hosts'] = [x.name for x in self._inventory.get_hosts(pattern=play.hosts or 'all', ignore_restrictions=True)]
 
         # the 'omit' value alows params to be left out if the variable they are based on is undefined
         variables['omit'] = self._omit_token

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -490,7 +490,7 @@ class VariableManager:
                     if delegated_host_name in C.LOCALHOST:
                         delegated_host = self._inventory.localhost
                     else:
-                        for h in self._inventory.get_hosts(ignore_limits_and_restrictions=True):
+                        for h in self._inventory.get_hosts(ignore_limits=True, ignore_restrictions=True):
                             # check if the address matches, or if both the delegated_to host
                             # and the current host are in the list of localhost aliases
                             if h.address == delegated_host_name:

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -416,7 +416,7 @@ class VariableManager:
                 host_list = [x.name for x in self._inventory.get_hosts()]
                 variables['play_hosts'] = host_list
                 variables['ansible_play_hosts'] = host_list
-                variables['ansible_play_hosts_all'] = [x.name for x in self._inventory.get_hosts(pattern=play.hosts, ignore_restrictions=True)]
+                variables['ansible_play_hosts_all'] = [x.name for x in self._inventory.get_hosts(pattern=play.hosts or 'all', ignore_restrictions=True)]
 
         # the 'omit' value alows params to be left out if the variable they are based on is undefined
         variables['omit'] = self._omit_token

--- a/lib/ansible/vars/hostvars.py
+++ b/lib/ansible/vars/hostvars.py
@@ -29,7 +29,7 @@ from ansible.template import Templar
 STATIC_VARS = [
     'inventory_hostname', 'inventory_hostname_short',
     'inventory_file', 'inventory_dir', 'playbook_dir',
-    'ansible_play_hosts', 'play_hosts', 'ansible_play_hosts_all', 'groups',
+    'ansible_play_hosts', 'play_hosts', 'groups',
     'ungrouped', 'group_names', 'ansible_version', 'omit', 'role_names'
 ]
 

--- a/lib/ansible/vars/hostvars.py
+++ b/lib/ansible/vars/hostvars.py
@@ -20,19 +20,17 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import collections
-import sys
 
 from jinja2 import Undefined as j2undefined
 
 from ansible import constants as C
-from ansible.inventory.host import Host
 from ansible.template import Templar
 
 STATIC_VARS = [
-  'inventory_hostname', 'inventory_hostname_short',
-  'inventory_file', 'inventory_dir', 'playbook_dir',
-  'ansible_play_hosts', 'play_hosts', 'groups', 'ungrouped', 'group_names',
-  'ansible_version', 'omit', 'role_names'
+    'inventory_hostname', 'inventory_hostname_short',
+    'inventory_file', 'inventory_dir', 'playbook_dir',
+    'ansible_play_hosts', 'play_hosts', 'ansible_play_hosts_all', 'groups',
+    'ungrouped', 'group_names', 'ansible_version', 'omit', 'role_names'
 ]
 
 try:

--- a/lib/ansible/vars/hostvars.py
+++ b/lib/ansible/vars/hostvars.py
@@ -97,15 +97,15 @@ class HostVars(collections.Mapping):
         return self._find_host(host_name) is not None
 
     def __iter__(self):
-        for host in self._inventory.get_hosts(ignore_limits_and_restrictions=True):
+        for host in self._inventory.get_hosts(ignore_limits=True, ignore_restrictions=True):
             yield host
 
     def __len__(self):
-        return len(self._inventory.get_hosts(ignore_limits_and_restrictions=True))
+        return len(self._inventory.get_hosts(ignore_limits=True, ignore_restrictions=True))
 
     def __repr__(self):
         out = {}
-        for host in self._inventory.get_hosts(ignore_limits_and_restrictions=True):
+        for host in self._inventory.get_hosts(ignore_limits=True, ignore_restrictions=True):
             name = host.name
             out[name] = self.get(name)
         return repr(out)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

Varible `ansible_play_hosts`
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

When using serial, `ansible_play_hosts` includes only the hosts in the current batch, currently there's no way to get 'all' the hosts regardless of serial.

This PR adds `ansible_play_hosts_all` which does just that. There an [old PR](https://github.com/ansible/ansible/pull/9047) against ansible v1.x that also has some relevant discussion.

This is my first foray into the ansible source, I hope the approach I've taken is reasonable, if it's not please suggest an alternative.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
