### PR TITLE
jenkins_job: add integration tests

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -272,6 +272,11 @@ exoscale:
 	RC=$$? ; \
 	exit $$RC;
 
+jenkins:
+	ansible-playbook jenkins.yml -i $(INVENTORY) -e @$(VARS_FILE) -v $(TEST_FLAGS) ; \
+	RC=$$? ; \
+	exit $$RC;
+
 cloudflare: $(CREDENTIALS_FILE)
 	ansible-playbook cloudflare.yml -i $(INVENTORY) -e @$(VARS_FILE) -e @$(CREDENTIALS_FILE) -e "resource_prefix=$(CLOUD_RESOURCE_PREFIX)" -v $(TEST_FLAGS) ; \
 	RC=$$? ; \

--- a/test/integration/jenkins.yml
+++ b/test/integration/jenkins.yml
@@ -1,0 +1,8 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  tags:
+    - jenkins
+  roles:
+    - test_jenkins_job

--- a/test/integration/roles/test_jenkins_job/defaults/main.yml
+++ b/test/integration/roles/test_jenkins_job/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+jenkins_url: http://localhost:8080
+jenkins_user: admin
+jenkins_password: ""
+jenkins_days_to_keep: 20

--- a/test/integration/roles/test_jenkins_job/tasks/main.yml
+++ b/test/integration/roles/test_jenkins_job/tasks/main.yml
@@ -1,0 +1,157 @@
+---
+- name: setup
+  local_action:
+     module: jenkins_job
+     name: test.job
+     url: "{{ jenkins_url }}"
+     user: "{{ jenkins_user }}"
+     password: "{{ jenkins_password }}"
+     state: absent
+  register: result
+- name: verify setup
+  assert:
+    that:
+    - result|success
+
+- name: test create a job
+  local_action:
+     module: jenkins_job
+     config: "{{ lookup('template', 'config.xml.j2') }}"
+     name: test.job
+     url: "{{ jenkins_url }}"
+     user: "{{ jenkins_user }}"
+     password: "{{ jenkins_password }}"
+  register: result
+- name: verify test create a job
+  assert:
+    that:
+    - result|success
+    - result|changed
+    - result.enabled
+
+- name: test create a job idempotence
+  local_action:
+     module: jenkins_job
+     config: "{{ lookup('template', 'config.xml.j2') }}"
+     name: test.job
+     url: "{{ jenkins_url }}"
+     user: "{{ jenkins_user }}"
+     password: "{{ jenkins_password }}"
+  register: result
+- name: verify test create a job idempotence
+  assert:
+    that:
+    - result|success
+    - not result|changed
+    - result.enabled
+
+- name: test create a enabled job idempotence
+  local_action:
+     module: jenkins_job
+     name: test.job
+     url: "{{ jenkins_url }}"
+     user: "{{ jenkins_user }}"
+     password: "{{ jenkins_password }}"
+     enabled: true
+  register: result
+- name: verify test create a enabled job idempotence
+  assert:
+    that:
+    - result|success
+    - not result|changed
+    - result.enabled
+
+- name: test update a job
+  local_action:
+     module: jenkins_job
+     config: "{{ lookup('template', 'config.xml.j2') }}"
+     name: test.job
+     url: "{{ jenkins_url }}"
+     user: "{{ jenkins_user }}"
+     password: "{{ jenkins_password }}"
+  register: result
+  vars:
+    jenkins_days_to_keep: 10
+- name: verify test create a enabled job idempotence
+  assert:
+    that:
+    - result|success
+    - result|changed
+    - result.enabled
+
+- name: test disable an exising job without config
+  local_action:
+     module: jenkins_job
+     name: test.job
+     url: "{{ jenkins_url }}"
+     user: "{{ jenkins_user }}"
+     password: "{{ jenkins_password }}"
+     enabled: false
+  register: result
+- name: verify test disable an exising job without config
+  assert:
+    that:
+    - result|success
+    - result|changed
+    - not result.enabled
+
+- name: test disable an exising job without config idempotence
+  local_action:
+     module: jenkins_job
+     name: test.job
+     url: "{{ jenkins_url }}"
+     user: "{{ jenkins_user }}"
+     password: "{{ jenkins_password }}"
+     enabled: false
+  register: result
+- name: verify test disable an exising job without config idempotence
+  assert:
+    that:
+    - result|success
+    - not result|changed
+    - not result.enabled
+
+- name: test reset to config job
+  local_action:
+     module: jenkins_job
+     config: "{{ lookup('template', 'config.xml.j2') }}"
+     name: test.job
+     url: "{{ jenkins_url }}"
+     user: "{{ jenkins_user }}"
+     password: "{{ jenkins_password }}"
+  register: result
+- name: verify test reset to config job
+  assert:
+    that:
+    - result|success
+    - result|changed
+
+- name: test remove job
+  local_action:
+     module: jenkins_job
+     name: test.job
+     url: "{{ jenkins_url }}"
+     user: "{{ jenkins_user }}"
+     password: "{{ jenkins_password }}"
+     state: absent
+  register: result
+- name: verify test remove job
+  assert:
+    that:
+    - result|success
+    - result|changed
+
+- name: test remove job idempotence
+  local_action:
+     module: jenkins_job
+     name: test.job
+     url: "{{ jenkins_url }}"
+     user: "{{ jenkins_user }}"
+     password: "{{ jenkins_password }}"
+     state: absent
+  register: result
+- name: verify test remove job idempotence
+  assert:
+    that:
+    - result|success
+    - not result|changed

--- a/test/integration/roles/test_jenkins_job/templates/config.xml.j2
+++ b/test/integration/roles/test_jenkins_job/templates/config.xml.j2
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <jenkins.model.BuildDiscarderProperty>
+      <strategy class="hudson.tasks.LogRotator">
+        <daysToKeep>{{ jenkins_days_to_keep }}</daysToKeep>
+        <numToKeep>20</numToKeep>
+        <artifactDaysToKeep>-1</artifactDaysToKeep>
+        <artifactNumToKeep>-1</artifactNumToKeep>
+      </strategy>
+    </jenkins.model.BuildDiscarderProperty>
+    <org.jenkinsci.plugins.gitbucket.GitBucketProjectProperty plugin="gitbucket@0.8">
+      <linkEnabled>false</linkEnabled>
+    </org.jenkinsci.plugins.gitbucket.GitBucketProjectProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

integration tests for jenkins_job
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.2
```
##### SUMMARY

integration tests for extra module `jenkins_job`.

Results:

```
 $ ansible-playbook test.yml --diff -v -e "url=http://build.ngine.ch:8080 user=admin password=$JENKINS_PASSWORD"
No config file found; using defaults
 [WARNING]: Host file not found: /etc/ansible/hosts

 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [localhost] ***************************************************************

TASK [test_jenkins_job : setup] ************************************************
ok: [localhost -> localhost] => {"changed": false, "enabled": null, "name": "test.job", "state": "absent", "url": "http://build.ngine.ch:8080", "user": "admin"}

TASK [test_jenkins_job : verify setup] *****************************************
ok: [localhost] => {"changed": false, "msg": "all assertions passed"}

TASK [test_jenkins_job : test create a job] ************************************
changed: [localhost -> localhost] => {"changed": true, "enabled": true, "name": "test.job", "state": "present", "url": "http://build.ngine.ch:8080", "user": "admin"}
--- before
+++ after
@@ -0,0 +1,136 @@
+<project>
+  <actions/>
+  <description/>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <jenkins.model.BuildDiscarderProperty>
+      <strategy class="hudson.tasks.LogRotator">
+        <daysToKeep>20</daysToKeep>
+        <numToKeep>20</numToKeep>
+        <artifactDaysToKeep>-1</artifactDaysToKeep>
+        <artifactNumToKeep>-1</artifactNumToKeep>
+      </strategy>
+    </jenkins.model.BuildDiscarderProperty>
+    <org.jenkinsci.plugins.gitbucket.GitBucketProjectProperty plugin="gitbucket@0.8">
+      <linkEnabled>false</linkEnabled>
+    </org.jenkinsci.plugins.gitbucket.GitBucketProjectProperty>
+  </properties>
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@2.4.2">
+    <configVersion>2</configVersion>
+    <userRemoteConfigs>
+      <hudson.plugins.git.UserRemoteConfig>
+        <refspec>+refs/pull/*:refs/remotes/origin/pr/*</refspec>
+        <url>https://github.com/ansible/ansible.git</url>
+      </hudson.plugins.git.UserRemoteConfig>
+    </userRemoteConfigs>
+    <branches>
+      <hudson.plugins.git.BranchSpec>
+        <name>origin/devel</name>
+      </hudson.plugins.git.BranchSpec>
+    </branches>
+    <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+    <submoduleCfg class="list"/>
+    <extensions>
+      <hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
+        <relativeTargetDir>ansible</relativeTargetDir>
+      </hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
+    </extensions>
+  </scm>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>true</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+    <hudson.triggers.SCMTrigger>
+      <spec>1 12 * * * </spec>
+      <ignorePostCommitHooks>false</ignorePostCommitHooks>
+    </hudson.triggers.SCMTrigger>
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>export ANSIBLE_FORCE_COLOR=true
+git clone https://github.com/resmo/test-ansible.git
+cd test-ansible
+#ansible-playbook playbooks/site.yml -v -e "ansible_repo=resmo ansible_branch=test/support-debian core_repo=resmo core_branch=integration"
+ansible-playbook playbooks/site.yml -v</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers>
+    <hudson.plugins.parameterizedtrigger.BuildTrigger plugin="parameterized-trigger@2.30">
+      <configs>
+        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>WORKSPACE=$WORKSPACE
+</properties>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>ansible.test.ubuntu-14.04</projects>
+          <condition>SUCCESS</condition>
+          <triggerWithNoParameters>true</triggerWithNoParameters>
+        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>WORKSPACE=$WORKSPACE</properties>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>ansible.test.ubuntu-12.04, </projects>
+          <condition>SUCCESS</condition>
+          <triggerWithNoParameters>true</triggerWithNoParameters>
+        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>WORKSPACE=$WORKSPACE</properties>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>ansible.test.ubuntu-16.04</projects>
+          <condition>SUCCESS</condition>
+          <triggerWithNoParameters>true</triggerWithNoParameters>
+        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>WORKSPACE=$WORKSPACE</properties>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>ansible.test.debian-7</projects>
+          <condition>SUCCESS</condition>
+          <triggerWithNoParameters>true</triggerWithNoParameters>
+        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>hostname=all</properties>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>ansible.test.cleanup-worker</projects>
+          <condition>FAILED</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+          <configs>
+            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+              <properties>WORKSPACE=$WORKSPACE</properties>
+            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
+          </configs>
+          <projects>ansible.test.debian-8</projects>
+          <condition>SUCCESS</condition>
+          <triggerWithNoParameters>false</triggerWithNoParameters>
+        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
+      </configs>
+    </hudson.plugins.parameterizedtrigger.BuildTrigger>
+  </publishers>
+  <buildWrappers>
+    <hudson.plugins.ws__cleanup.PreBuildCleanup plugin="ws-cleanup@0.28">
+      <deleteDirs>false</deleteDirs>
+      <cleanupParameter/>
+      <externalDelete/>
+    </hudson.plugins.ws__cleanup.PreBuildCleanup>
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.2">
+      <colorMapName>xterm</colorMapName>
+    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+  </buildWrappers>
+</project>

TASK [test_jenkins_job : verify test create a job] *****************************
ok: [localhost] => {"changed": false, "msg": "all assertions passed"}

TASK [test_jenkins_job : test create a job idempotence] ************************
ok: [localhost -> localhost] => {"changed": false, "enabled": true, "name": "test.job", "state": "present", "url": "http://build.ngine.ch:8080", "user": "admin"}

TASK [test_jenkins_job : verify test create a job idempotence] *****************
ok: [localhost] => {"changed": false, "msg": "all assertions passed"}

TASK [test_jenkins_job : test create a enabled job idempotence] ****************
ok: [localhost -> localhost] => {"changed": false, "enabled": true, "name": "test.job", "state": "present", "url": "http://build.ngine.ch:8080", "user": "admin"}

TASK [test_jenkins_job : verify test create a enabled job idempotence] *********
ok: [localhost] => {"changed": false, "msg": "all assertions passed"}

TASK [test_jenkins_job : test update a job] ************************************
changed: [localhost -> localhost] => {"changed": true, "enabled": true, "name": "test.job", "state": "present", "url": "http://build.ngine.ch:8080", "user": "admin"}
--- before
+++ after
@@ -5,7 +5,7 @@
   <properties>
     <jenkins.model.BuildDiscarderProperty>
       <strategy class="hudson.tasks.LogRotator">
-        <daysToKeep>20</daysToKeep>
+        <daysToKeep>10</daysToKeep>
         <numToKeep>20</numToKeep>
         <artifactDaysToKeep>-1</artifactDaysToKeep>
         <artifactNumToKeep>-1</artifactNumToKeep>


TASK [test_jenkins_job : verify test create a enabled job idempotence] *********
ok: [localhost] => {"changed": false, "msg": "all assertions passed"}

TASK [test_jenkins_job : test disable an exising job without config] ***********
changed: [localhost -> localhost] => {"changed": true, "enabled": false, "name": "test.job", "state": "present", "url": "http://build.ngine.ch:8080", "user": "admin"}

TASK [test_jenkins_job : verify test disable an exising job without config] ****
ok: [localhost] => {"changed": false, "msg": "all assertions passed"}

TASK [test_jenkins_job : test disable an exising job without config idempotence] ***
ok: [localhost -> localhost] => {"changed": false, "enabled": false, "name": "test.job", "state": "present", "url": "http://build.ngine.ch:8080", "user": "admin"}

TASK [test_jenkins_job : verify test disable an exising job without config idempotence] ***
ok: [localhost] => {"changed": false, "msg": "all assertions passed"}

TASK [test_jenkins_job : test reset to config job] *****************************
changed: [localhost -> localhost] => {"changed": true, "enabled": true, "name": "test.job", "state": "present", "url": "http://build.ngine.ch:8080", "user": "admin"}
--- before
+++ after
@@ -5,7 +5,7 @@
   <properties>
     <jenkins.model.BuildDiscarderProperty>
       <strategy class="hudson.tasks.LogRotator">
-        <daysToKeep>10</daysToKeep>
+        <daysToKeep>20</daysToKeep>
         <numToKeep>20</numToKeep>
         <artifactDaysToKeep>-1</artifactDaysToKeep>
         <artifactNumToKeep>-1</artifactNumToKeep>
@@ -37,7 +37,7 @@
     </extensions>
   </scm>
   <canRoam>true</canRoam>
-  <disabled>true</disabled>
+  <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>true</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
   <triggers>


TASK [test_jenkins_job : verify test reset to config job] **********************
ok: [localhost] => {"changed": false, "msg": "all assertions passed"}

TASK [test_jenkins_job : test remove job] **************************************
changed: [localhost -> localhost] => {"changed": true, "enabled": null, "name": "test.job", "state": "absent", "url": "http://build.ngine.ch:8080", "user": "admin"}
--- before
+++ after
@@ -1,136 +0,0 @@
-<project>
-  <actions/>
-  <description/>
-  <keepDependencies>false</keepDependencies>
-  <properties>
-    <jenkins.model.BuildDiscarderProperty>
-      <strategy class="hudson.tasks.LogRotator">
-        <daysToKeep>20</daysToKeep>
-        <numToKeep>20</numToKeep>
-        <artifactDaysToKeep>-1</artifactDaysToKeep>
-        <artifactNumToKeep>-1</artifactNumToKeep>
-      </strategy>
-    </jenkins.model.BuildDiscarderProperty>
-    <org.jenkinsci.plugins.gitbucket.GitBucketProjectProperty plugin="gitbucket@0.8">
-      <linkEnabled>false</linkEnabled>
-    </org.jenkinsci.plugins.gitbucket.GitBucketProjectProperty>
-  </properties>
-  <scm class="hudson.plugins.git.GitSCM" plugin="git@2.4.2">
-    <configVersion>2</configVersion>
-    <userRemoteConfigs>
-      <hudson.plugins.git.UserRemoteConfig>
-        <refspec>+refs/pull/*:refs/remotes/origin/pr/*</refspec>
-        <url>https://github.com/ansible/ansible.git</url>
-      </hudson.plugins.git.UserRemoteConfig>
-    </userRemoteConfigs>
-    <branches>
-      <hudson.plugins.git.BranchSpec>
-        <name>origin/devel</name>
-      </hudson.plugins.git.BranchSpec>
-    </branches>
-    <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
-    <submoduleCfg class="list"/>
-    <extensions>
-      <hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
-        <relativeTargetDir>ansible</relativeTargetDir>
-      </hudson.plugins.git.extensions.impl.RelativeTargetDirectory>
-    </extensions>
-  </scm>
-  <canRoam>true</canRoam>
-  <disabled>false</disabled>
-  <blockBuildWhenDownstreamBuilding>true</blockBuildWhenDownstreamBuilding>
-  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-  <triggers>
-    <hudson.triggers.SCMTrigger>
-      <spec>1 12 * * * </spec>
-      <ignorePostCommitHooks>false</ignorePostCommitHooks>
-    </hudson.triggers.SCMTrigger>
-  </triggers>
-  <concurrentBuild>false</concurrentBuild>
-  <builders>
-    <hudson.tasks.Shell>
-      <command>export ANSIBLE_FORCE_COLOR=true
-git clone https://github.com/resmo/test-ansible.git
-cd test-ansible
-#ansible-playbook playbooks/site.yml -v -e "ansible_repo=resmo ansible_branch=test/support-debian core_repo=resmo core_branch=integration"
-ansible-playbook playbooks/site.yml -v</command>
-    </hudson.tasks.Shell>
-  </builders>
-  <publishers>
-    <hudson.plugins.parameterizedtrigger.BuildTrigger plugin="parameterized-trigger@2.30">
-      <configs>
-        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
-          <configs>
-            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-              <properties>WORKSPACE=$WORKSPACE
-</properties>
-            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-          </configs>
-          <projects>ansible.test.ubuntu-14.04</projects>
-          <condition>SUCCESS</condition>
-          <triggerWithNoParameters>true</triggerWithNoParameters>
-        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
-        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
-          <configs>
-            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-              <properties>WORKSPACE=$WORKSPACE</properties>
-            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-          </configs>
-          <projects>ansible.test.ubuntu-12.04, </projects>
-          <condition>SUCCESS</condition>
-          <triggerWithNoParameters>true</triggerWithNoParameters>
-        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
-        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
-          <configs>
-            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-              <properties>WORKSPACE=$WORKSPACE</properties>
-            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-          </configs>
-          <projects>ansible.test.ubuntu-16.04</projects>
-          <condition>SUCCESS</condition>
-          <triggerWithNoParameters>true</triggerWithNoParameters>
-        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
-        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
-          <configs>
-            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-              <properties>WORKSPACE=$WORKSPACE</properties>
-            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-          </configs>
-          <projects>ansible.test.debian-7</projects>
-          <condition>SUCCESS</condition>
-          <triggerWithNoParameters>true</triggerWithNoParameters>
-        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
-        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
-          <configs>
-            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-              <properties>hostname=all</properties>
-            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-          </configs>
-          <projects>ansible.test.cleanup-worker</projects>
-          <condition>FAILED</condition>
-          <triggerWithNoParameters>false</triggerWithNoParameters>
-        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
-        <hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
-          <configs>
-            <hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-              <properties>WORKSPACE=$WORKSPACE</properties>
-            </hudson.plugins.parameterizedtrigger.PredefinedBuildParameters>
-          </configs>
-          <projects>ansible.test.debian-8</projects>
-          <condition>SUCCESS</condition>
-          <triggerWithNoParameters>false</triggerWithNoParameters>
-        </hudson.plugins.parameterizedtrigger.BuildTriggerConfig>
-      </configs>
-    </hudson.plugins.parameterizedtrigger.BuildTrigger>
-  </publishers>
-  <buildWrappers>
-    <hudson.plugins.ws__cleanup.PreBuildCleanup plugin="ws-cleanup@0.28">
-      <deleteDirs>false</deleteDirs>
-      <cleanupParameter/>
-      <externalDelete/>
-    </hudson.plugins.ws__cleanup.PreBuildCleanup>
-    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.2">
-      <colorMapName>xterm</colorMapName>
-    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
-  </buildWrappers>
-</project>

TASK [test_jenkins_job : verify test remove job] *******************************
ok: [localhost] => {"changed": false, "msg": "all assertions passed"}

TASK [test_jenkins_job : test remove job idempotence] **************************
ok: [localhost -> localhost] => {"changed": false, "enabled": null, "name": "test.job", "state": "absent", "url": "http://build.ngine.ch:8080", "user": "admin"}

TASK [test_jenkins_job : verify test remove job idempotence] *******************
ok: [localhost] => {"changed": false, "msg": "all assertions passed"}

PLAY RECAP *********************************************************************
localhost                  : ok=20   changed=5    unreachable=0    failed=0   

 resmo@titan  ~/Projects/resmo/ansible-jenkins-test  
 $ gedit roles/test_jenkins_job/templates/config.xml.j2 
 resmo@titan  ~/Projects/resmo/ansible-jenkins-test  
 $ ansible-playbook test.yml --diff -v -e "url=http://build.ngine.ch:8080 user=admin password=Switch88"
No config file found; using defaults
 [WARNING]: Host file not found: /etc/ansible/hosts

 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [localhost] ***************************************************************

TASK [test_jenkins_job : setup] ************************************************
ok: [localhost -> localhost] => {"changed": false, "enabled": null, "name": "test.job", "state": "absent", "url": "http://build.ngine.ch:8080", "user": "admin"}

TASK [test_jenkins_job : verify setup] *****************************************
ok: [localhost] => {"changed": false, "msg": "all assertions passed"}

TASK [test_jenkins_job : test create a job] ************************************
changed: [localhost -> localhost] => {"changed": true, "enabled": true, "name": "test.job", "state": "present", "url": "http://build.ngine.ch:8080", "user": "admin"}
--- before
+++ after
@@ -0,0 +1,28 @@
+<project>
+  <actions/>
+  <description/>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <jenkins.model.BuildDiscarderProperty>
+      <strategy class="hudson.tasks.LogRotator">
+        <daysToKeep>20</daysToKeep>
+        <numToKeep>20</numToKeep>
+        <artifactDaysToKeep>-1</artifactDaysToKeep>
+        <artifactNumToKeep>-1</artifactNumToKeep>
+      </strategy>
+    </jenkins.model.BuildDiscarderProperty>
+    <org.jenkinsci.plugins.gitbucket.GitBucketProjectProperty plugin="gitbucket@0.8">
+      <linkEnabled>false</linkEnabled>
+    </org.jenkinsci.plugins.gitbucket.GitBucketProjectProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>

TASK [test_jenkins_job : verify test create a job] *****************************
ok: [localhost] => {"changed": false, "msg": "all assertions passed"}

TASK [test_jenkins_job : test create a job idempotence] ************************
ok: [localhost -> localhost] => {"changed": false, "enabled": true, "name": "test.job", "state": "present", "url": "http://build.ngine.ch:8080", "user": "admin"}

TASK [test_jenkins_job : verify test create a job idempotence] *****************
ok: [localhost] => {"changed": false, "msg": "all assertions passed"}

TASK [test_jenkins_job : test create a enabled job idempotence] ****************
ok: [localhost -> localhost] => {"changed": false, "enabled": true, "name": "test.job", "state": "present", "url": "http://build.ngine.ch:8080", "user": "admin"}

TASK [test_jenkins_job : verify test create a enabled job idempotence] *********
ok: [localhost] => {"changed": false, "msg": "all assertions passed"}

TASK [test_jenkins_job : test update a job] ************************************
changed: [localhost -> localhost] => {"changed": true, "enabled": true, "name": "test.job", "state": "present", "url": "http://build.ngine.ch:8080", "user": "admin"}
--- before
+++ after
@@ -5,7 +5,7 @@
   <properties>
     <jenkins.model.BuildDiscarderProperty>
       <strategy class="hudson.tasks.LogRotator">
-        <daysToKeep>20</daysToKeep>
+        <daysToKeep>10</daysToKeep>
         <numToKeep>20</numToKeep>
         <artifactDaysToKeep>-1</artifactDaysToKeep>
         <artifactNumToKeep>-1</artifactNumToKeep>


TASK [test_jenkins_job : verify test create a enabled job idempotence] *********
ok: [localhost] => {"changed": false, "msg": "all assertions passed"}

TASK [test_jenkins_job : test disable an exising job without config] ***********
changed: [localhost -> localhost] => {"changed": true, "enabled": false, "name": "test.job", "state": "present", "url": "http://build.ngine.ch:8080", "user": "admin"}

TASK [test_jenkins_job : verify test disable an exising job without config] ****
ok: [localhost] => {"changed": false, "msg": "all assertions passed"}

TASK [test_jenkins_job : test disable an exising job without config idempotence] ***
ok: [localhost -> localhost] => {"changed": false, "enabled": false, "name": "test.job", "state": "present", "url": "http://build.ngine.ch:8080", "user": "admin"}

TASK [test_jenkins_job : verify test disable an exising job without config idempotence] ***
ok: [localhost] => {"changed": false, "msg": "all assertions passed"}

TASK [test_jenkins_job : test reset to config job] *****************************
changed: [localhost -> localhost] => {"changed": true, "enabled": true, "name": "test.job", "state": "present", "url": "http://build.ngine.ch:8080", "user": "admin"}
--- before
+++ after
@@ -5,7 +5,7 @@
   <properties>
     <jenkins.model.BuildDiscarderProperty>
       <strategy class="hudson.tasks.LogRotator">
-        <daysToKeep>10</daysToKeep>
+        <daysToKeep>20</daysToKeep>
         <numToKeep>20</numToKeep>
         <artifactDaysToKeep>-1</artifactDaysToKeep>
         <artifactNumToKeep>-1</artifactNumToKeep>
@@ -17,7 +17,7 @@
   </properties>
   <scm class="hudson.scm.NullSCM"/>
   <canRoam>true</canRoam>
-  <disabled>true</disabled>
+  <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
   <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
   <triggers/>


TASK [test_jenkins_job : verify test reset to config job] **********************
ok: [localhost] => {"changed": false, "msg": "all assertions passed"}

TASK [test_jenkins_job : test remove job] **************************************
changed: [localhost -> localhost] => {"changed": true, "enabled": null, "name": "test.job", "state": "absent", "url": "http://build.ngine.ch:8080", "user": "admin"}
--- before
+++ after
@@ -1,28 +0,0 @@
-<project>
-  <actions/>
-  <description/>
-  <keepDependencies>false</keepDependencies>
-  <properties>
-    <jenkins.model.BuildDiscarderProperty>
-      <strategy class="hudson.tasks.LogRotator">
-        <daysToKeep>20</daysToKeep>
-        <numToKeep>20</numToKeep>
-        <artifactDaysToKeep>-1</artifactDaysToKeep>
-        <artifactNumToKeep>-1</artifactNumToKeep>
-      </strategy>
-    </jenkins.model.BuildDiscarderProperty>
-    <org.jenkinsci.plugins.gitbucket.GitBucketProjectProperty plugin="gitbucket@0.8">
-      <linkEnabled>false</linkEnabled>
-    </org.jenkinsci.plugins.gitbucket.GitBucketProjectProperty>
-  </properties>
-  <scm class="hudson.scm.NullSCM"/>
-  <canRoam>true</canRoam>
-  <disabled>false</disabled>
-  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
-  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-  <triggers/>
-  <concurrentBuild>false</concurrentBuild>
-  <builders/>
-  <publishers/>
-  <buildWrappers/>
-</project>

TASK [test_jenkins_job : verify test remove job] *******************************
ok: [localhost] => {"changed": false, "msg": "all assertions passed"}

TASK [test_jenkins_job : test remove job idempotence] **************************
ok: [localhost -> localhost] => {"changed": false, "enabled": null, "name": "test.job", "state": "absent", "url": "http://build.ngine.ch:8080", "user": "admin"}

TASK [test_jenkins_job : verify test remove job idempotence] *******************
ok: [localhost] => {"changed": false, "msg": "all assertions passed"}

PLAY RECAP *********************************************************************
localhost                  : ok=20   changed=5    unreachable=0    failed=0
```
