### PR TITLE
minor clean of openswitch shared module

### DIFF
--- a/lib/ansible/module_utils/openswitch.py
+++ b/lib/ansible/module_utils/openswitch.py
@@ -34,9 +34,6 @@ from ansible.module_utils.network import add_argument, register_transport, to_li
 from ansible.module_utils.shell import CliBase
 from ansible.module_utils.urls import fetch_url, url_argument_spec
 
-# temporary fix until modules are update.  to be removed before 2.2 final
-from ansible.module_utils.network import get_module
-
 add_argument('use_ssl', dict(default=True, type='bool'))
 add_argument('validate_certs', dict(default=True, type='bool'))
 
@@ -209,13 +206,7 @@ class Cli(CliBase):
     ]
 
     CLI_ERRORS_RE = [
-        re.compile(r"% ?Error"),
-        re.compile(r"% ?Bad secret"),
-        re.compile(r"invalid input", re.I),
-        re.compile(r"(?:incomplete|ambiguous) command", re.I),
-        re.compile(r"connection timed out", re.I),
-        re.compile(r"[^\r\n]+ not found", re.I),
-        re.compile(r"'[^']' +returned error code: ?\d+"),
+        re.compile(r"(?:unknown|incomplete|ambiguous) command", re.I),
     ]
 
     NET_PASSWD_RE = re.compile(r"[\r\n]?password: $", re.I)


### PR DESCRIPTION
- updates regexp entries
- removes legacy 2.1 code for get_module()
