### PR TITLE
raise exception when src file is not found in net_config

### DIFF
--- a/lib/ansible/plugins/action/net_config.py
+++ b/lib/ansible/plugins/action/net_config.py
@@ -95,7 +95,7 @@ class ActionModule(ActionBase):
                 source = self._loader.path_dwim_relative(working_path, src)
 
         if not os.path.exists(source):
-            return
+            raise ValueError('path specified in src not found')
 
         try:
             with open(source, 'r') as f:


### PR DESCRIPTION
This will now raise an exception if the file path specified in src is not
found and the module will gracefully error.

ref ansible/ansible-modules-core#4797
