### PR TITLE
Vyos cleanup

### DIFF
--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -262,7 +262,7 @@ class CliBase(object):
     def get_config(self, commands):
         raise NotImplementedError
 
-    def load_config(self, commands):
+    def load_config(self, commands, **kwargs):
         raise NotImplementedError
 
     def save_config(self):

--- a/lib/ansible/module_utils/vyos.py
+++ b/lib/ansible/module_utils/vyos.py
@@ -66,10 +66,10 @@ class Cli(CliBase):
         response = self.execute(commands)
         return response[1:-2]
 
-    def load_config(self, config, commit=False, comment=None, save=False):
+    def load_config(self, config, commit=False, comment=None, save=False, **kwargs):
         try:
             config.insert(0, 'configure')
-            response = self.execute(config)
+            self.execute(config)
         except NetworkError:
             # discard any changes in case of failure
             self.execute(['exit discard'])


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

`module_utls/vyos.py`
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (vyos_cleanup 31a6558f7c) last updated 2016/09/12 10:59:46 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 1a0e15094f) last updated 2016/09/12 10:08:07 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD f83aa9fff3) last updated 2016/09/09 15:54:31 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Addresses #17416
