### PR TITLE
mv test_git to 'destructive' integration tests

### DIFF
--- a/test/integration/destructive.yml
+++ b/test/integration/destructive.yml
@@ -23,3 +23,5 @@
     - { role: test_uri, tags: test_uri }
     - { role: test_get_url, tags: test_get_url }
     - { role: test_apache2_module, tags: test_apache2_module }
+    # This removes ~/.ssh/known_hosts and /etc/ssh/known_hosts
+    - { role: test_git, tags: test_git }

--- a/test/integration/non_destructive.yml
+++ b/test/integration/non_destructive.yml
@@ -29,7 +29,6 @@
     - { role: test_synchronize, tags: test_synchronize }
     - { role: test_assemble, tags: test_assemble }
     - { role: test_subversion, tags: test_subversion }
-    - { role: test_git, tags: test_git }
     - { role: test_hg, tags: test_hg }
     - { role: test_lineinfile, tags: test_lineinfile }
     - { role: test_unarchive, tags: test_unarchive }


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

test/integration/
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (test_git_to_destructive 752e62ac63) last updated 2016/09/12 14:35:45 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 1a0e15094f) last updated 2016/09/12 10:00:41 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD f83aa9fff3) last updated 2016/09/09 09:07:48 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = ['/home/adrian/src/ansible-modules-core', '/home/adrian/src/ansible-modules-extras']


```
##### SUMMARY

The test_git role removes ~/.ssh/known_hosts currently
and that is destructive.
