### PR TITLE
Fixes to the controller text model

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -91,9 +91,16 @@ if __name__ == '__main__':
             else:
                 raise
 
-        cli = mycli(sys.argv)
-        cli.parse()
-        exit_code = cli.run()
+        try:
+            args = [to_text(a, errors='surrogate_or_strict') for a in sys.argv]
+        except UnicodeError:
+            display.error('Command line args are not in utf-8, unable to continue.  Ansible currently only understands utf-8')
+            display.display(u"The full traceback was:\n\n%s" % to_text(traceback.format_exc()))
+            exit_code = 6
+        else:
+            cli = mycli(args)
+            cli.parse()
+            exit_code = cli.run()
 
     except AnsibleOptionsError as e:
         cli.parser.print_help()

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -124,7 +124,7 @@ class Display:
                 # Convert back to text string on python3
                 # We first convert to a byte string so that we get rid of
                 # characters that are invalid in the user's locale
-                msg2 = to_text(msg2, self._output_encoding(stderr=stderr))
+                msg2 = to_text(msg2, self._output_encoding(stderr=stderr), errors='replace')
 
             if not stderr:
                 fileobj = sys.stdout

--- a/test/integration/unicode.yml
+++ b/test/integration/unicode.yml
@@ -32,7 +32,7 @@
         groups: 'ĪīĬĭ'
         ansible_ssh_host: 127.0.0.1
         ansible_connection: local
-      with_items: hostnames
+      with_items: "{{ hostnames }}"
 
     - name: 'A task with unicode extra vars'
       debug: var=extra_var


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

Throughout ansible cli.
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
devel
```
##### SUMMARY
- Change command line args to text type
- Make display replace undecodable bytes with replacement chars.  This
  is only a problem on pyhton3 where surrogates can enter into the msg
  but sys.stdout doesn't know how to handle them.
- Remove a deprecated playbook syntax in unicode.yml
