### PR TITLE
Add config option to tee stdout and stderr to temp files

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -177,6 +177,7 @@ DEFAULT_SFTP_BATCH_MODE   = get_config(p, 'ssh_connection', 'sftp_batch_mode', '
 DEFAULT_MANAGED_STR       = get_config(p, DEFAULTS, 'ansible_managed',  None,           'Ansible managed: {file} modified on %Y-%m-%d %H:%M:%S by {uid} on {host}')
 DEFAULT_SYSLOG_FACILITY   = get_config(p, DEFAULTS, 'syslog_facility',  'ANSIBLE_SYSLOG_FACILITY', 'LOG_USER')
 DEFAULT_KEEP_REMOTE_FILES = get_config(p, DEFAULTS, 'keep_remote_files', 'ANSIBLE_KEEP_REMOTE_FILES', False, boolean=True)
+DEFAULT_TEE_REMOTE_OUTPUT = get_config(p, DEFAULTS, 'tee_remote_output', 'ANSIBLE_TEE_REMOTE_OUTPUT', False, boolean=True)
 DEFAULT_HASH_BEHAVIOUR    = get_config(p, DEFAULTS, 'hash_behaviour', 'ANSIBLE_HASH_BEHAVIOUR', 'replace')
 DEFAULT_PRIVATE_ROLE_VARS = get_config(p, DEFAULTS, 'private_role_vars', 'ANSIBLE_PRIVATE_ROLE_VARS', False, boolean=True)
 DEFAULT_JINJA2_EXTENSIONS = get_config(p, DEFAULTS, 'jinja2_extensions', 'ANSIBLE_JINJA2_EXTENSIONS', None)

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -142,6 +142,8 @@ def invoke_module(module, modlib_path, json_params):
     else:
         os.environ['PYTHONPATH'] = modlib_path
 
+    os.environ['ANSIBLE_TMPDIR'] = os.path.dirname(__file__)
+
     p = subprocess.Popen([%(interpreter)s, module], env=os.environ, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
     (stdout, stderr) = p.communicate(json_params)
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -389,6 +389,10 @@ class TaskExecutor:
             if not self._play_context.remote_addr:
                 self._play_context.remote_addr = self._host.address
 
+            # Preserve the real host information, since remote_addr can be overridden
+            # by delegation and knowing the intended host can be useful
+            self._play_context.host = self._host
+
             # We also add "magic" variables back into the variables dict to make sure
             # a certain subset of variables exist.
             self._play_context.update_vars(variables)

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -182,6 +182,7 @@ class TaskQueueManager:
                     )
                     self._workers[worker_idx][0] = worker_prc
                     worker_prc.start()
+                    self.send_callback('v2_runner_on_start', host, task)
                     display.debug("worker is %d (out of %d available)" % (worker_idx+1, len(self._workers)))
 
                 except (EOFError, IOError, AssertionError) as e:

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -34,6 +34,7 @@ from ansible.errors import AnsibleError
 from ansible.playbook.attribute import FieldAttribute
 from ansible.playbook.base import Base
 from ansible.utils.boolean import boolean
+from ansible.inventory.host import Host
 
 __all__ = ['PlayContext']
 
@@ -157,6 +158,7 @@ class PlayContext(Base):
     # connection fields, some are inherited from Base:
     # (connection, port, remote_user, environment, no_log)
     _docker_extra_args  = FieldAttribute(isa='string')
+    _host             = FieldAttribute(isa='class', class_type=Host)
     _remote_addr      = FieldAttribute(isa='string')
     _password         = FieldAttribute(isa='string')
     _private_key_file = FieldAttribute(isa='string', default=C.DEFAULT_PRIVATE_KEY_FILE)

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -604,6 +604,9 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         # let module know about filesystems that selinux treats specially
         module_args['_ansible_selinux_special_fs'] = C.DEFAULT_SELINUX_SPECIAL_FS
 
+        # let module know if stdout/stderr should also be kept on the remote filesystem
+        module_args['_ansible_tee_output'] = C.DEFAULT_TEE_REMOTE_OUTPUT
+
         (module_style, shebang, module_data, module_path) = self._configure_module(module_name=module_name, module_args=module_args, task_vars=task_vars)
         display.vvv("Using module file %s" % module_path)
         if not shebang and module_style != 'binary':

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -208,7 +208,12 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         Create and return a temporary path on a remote box.
         '''
 
-        basefile = 'ansible-tmp-%s-%s' % (time.time(), random.randint(0, 2**48))
+        # For captured (teed) output to be useful, it should be in a predictable directory
+        # But to minimize risk, that's the only time we'll use that predictable structure
+        if C.DEFAULT_TEE_REMOTE_OUTPUT:
+            basefile = '%s-%s' % (self._play_context.host, self._task._uuid)
+        else:
+            basefile = 'ansible-tmp-%s-%s' % (time.time(), random.randint(0, 2**48))
         use_system_tmp = False
 
         if self._play_context.become and self._play_context.become_user not in ('root', remote_user):

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -260,6 +260,9 @@ class CallbackBase:
     def v2_on_any(self, *args, **kwargs):
         self.on_any(args, kwargs)
 
+    def v2_runner_on_start(self, host, task):
+        pass #no v1 correspondance
+
     def v2_runner_on_failed(self, result, ignore_errors=False):
         host = result._host.get_name()
         self.runner_on_failed(host, result._result, ignore_errors)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

executor / actions plugin
##### ANSIBLE VERSION

based off of devel at 036650cb097352a9810c6acfe2bd3354859a5149
##### SUMMARY

This is a WIP PR to address #17350.

The basic idea:

With the 3 commits here, and a plugin installed that looks something like:

```
from ansible.plugins.callback import CallbackBase

class CallbackModule(CallbackBase):
    CALLBACK_VERSION = 2.0
    CALLBACK_TYPE = 'logging'
    CALLBACK_NAME = 'logger'

    def __init__(self, display=None):
        super(CallbackModule, self).__init__(display)

    def v2_runner_on_start(self, host, task):
        print "You can tail the logs at ~/.ansible/tmp/%s-%s/std{out,err}" % (host, task._uuid)
```

The logs are now available on disk on the remote system and available for inspection through whatever means are handy.

The 3 commits are to:
1. Add a new callback for when the runner starts, since both host and task information is necessary
2. Add a config variable to control the `tee` behavior, buffering to `stdout` and `stderr`
3. Change the temporary directory formula, which currently includes a random number, to use host and the task uuid instead to make the full path predictable.  Passing the tmp dir in or out would seem like a better solution, but it seems like that would be more intrusive.

*\* Opening as a WIP for discussion **
