### PR TITLE
eos: matched error in response: dir all-filesystems | json

### DIFF
--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -317,7 +317,7 @@ def prepare_commands(commands):
     jsonify = lambda x: '%s | json' % x
     for item in to_list(commands):
         if item.output == 'json':
-            cmd = jsonify(cmd)
+            cmd = jsonify(item)
         elif item.command.endswith('| json'):
             item.output = 'json'
             cmd = str(item)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

eos
##### ANSIBLE VERSION

```
ansible --version
ansible 2.2.0 (eos_cmd_v_item 15cf123420) last updated 2016/09/13 12:04:55 (GMT +100)
  lib/ansible/modules/core: (devel ae6992bf8c) last updated 2016/09/13 09:19:01 (GMT +100)
  lib/ansible/modules/extras: (devel 1f6f3b72db) last updated 2016/09/13 09:19:10 (GMT +100)
```
##### SUMMARY

During https://github.com/ansible/ansible/commit/7fe64ef9b89428d82b5851b5d33b5bba4beb2082
 the loop variable was changed from `cmd` to `item`, however not all instances of `cmd` were updated

Was changed during
however not all look variables were updated.

Steps to reproduce

```
cd test-network-module
git pull
time ansible-playbook -vvv  eos.yaml -i ../inventory-testnetwork   -e "limit_to=eos_facts" 
```

**Before**

```
TASK [test_eos_facts : test getting all facts] *********************************
task path: /home/johnb/git/ansible-inc/test-network-modules/roles/test_eos_facts/tests/cli/all_facts.yaml:5
Using module file /home/johnb/git/ansible-inc/ansible/lib/ansible/modules/core/network/eos/eos_facts.py
<veos01> ESTABLISH LOCAL CONNECTION FOR USER: johnb
<veos01> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1473761517.29-255437665346436 `" && echo ansible-tmp-1473761517.29-255437665346436="` echo $HOME/.ansible/tmp/ansible-tmp-1473761517.29-255437665346436 `" ) && sleep 0'
<veos01> PUT /tmp/tmpsOzsq7 TO /home/johnb/.ansible/tmp/ansible-tmp-1473761517.29-255437665346436/eos_facts.py
<veos01> EXEC /bin/sh -c 'chmod u+x /home/johnb/.ansible/tmp/ansible-tmp-1473761517.29-255437665346436/ /home/johnb/.ansible/tmp/ansible-tmp-1473761517.29-255437665346436/eos_facts.py && sleep 0'
<veos01> EXEC /bin/sh -c 'python /home/johnb/.ansible/tmp/ansible-tmp-1473761517.29-255437665346436/eos_facts.py; rm -rf "/home/johnb/.ansible/tmp/ansible-tmp-1473761517.29-255437665346436/" > /dev/null 2>&1 && sleep 0'
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_aZg5Gw/ansible_module_eos_facts.py", line 380, in <module>
    main()
  File "/tmp/ansible_aZg5Gw/ansible_module_eos_facts.py", line 361, in main
    runner.run()
  File "/tmp/ansible_aZg5Gw/ansible_modlib.zip/ansible/module_utils/netcli.py", line 153, in run
  File "/tmp/ansible_aZg5Gw/ansible_modlib.zip/ansible/module_utils/netcli.py", line 85, in run_commands
  File "/tmp/ansible_aZg5Gw/ansible_modlib.zip/ansible/module_utils/eos.py", line 288, in run_commands
  File "/tmp/ansible_aZg5Gw/ansible_modlib.zip/ansible/module_utils/shell.py", line 252, in execute
ansible.module_utils.network.NetworkError: matched error in response: dir all-filesystems | json
% Invalid input
veos01#

fatal: [veos01]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "invocation": {
        "module_name": "eos_facts"
    }, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_aZg5Gw/ansible_module_eos_facts.py\", line 380, in <module>\n    main()\n  File \"/tmp/ansible_aZg5Gw/ansible_module_eos_facts.py\", line 361, in main\n    runner.run()\n  File \"/tmp/ansible_aZg5Gw/ansible_modlib.zip/ansible/module_utils/netcli.py\", line 153, in run\n  File \"/tmp/ansible_aZg5Gw/ansible_modlib.zip/ansible/module_utils/netcli.py\", line 85, in run_commands\n  File \"/tmp/ansible_aZg5Gw/ansible_modlib.zip/ansible/module_utils/eos.py\", line 288, in run_commands\n  File \"/tmp/ansible_aZg5Gw/ansible_modlib.zip/ansible/module_utils/shell.py\", line 252, in execute\nansible.module_utils.network.NetworkError: matched error in response: dir all-filesystems | json\r\n% Invalid input\r\nveos01#\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE"
}

```

**After**
Tests pass
