### PR TITLE
Fix for Issue #16946 - hipchat plugin

### DIFF
--- a/lib/ansible/plugins/callback/hipchat.py
+++ b/lib/ansible/plugins/callback/hipchat.py
@@ -96,7 +96,7 @@ class CallbackModule(CallbackBase):
     def v2_playbook_on_start(self, playbook):
         """Display playbook start messages"""
         self.playbook_name = os.path.basename(playbook._file_name)
-        self.send_msg("Starting play: %s" %
+        self.send_msg("Starting playbook: %s" %
                       (self.playbook_name))
 
 

--- a/lib/ansible/plugins/callback/hipchat.py
+++ b/lib/ansible/plugins/callback/hipchat.py
@@ -82,24 +82,18 @@ class CallbackModule(CallbackBase):
         params['message_format'] = msg_format
         params['color'] = color
         params['notify'] = int(self.allow_notify and notify)
-
-      
         url = ('%s?auth_token=%s' % (self.msg_uri, self.token))
         try:
             response = open_url(url, data=urlencode(params))
             return response.read()
         except:
             self._display.warning('Could not submit message to hipchat')
-
-    
     
     def v2_playbook_on_start(self, playbook):
         """Display playbook start messages"""
         self.playbook_name = os.path.basename(playbook._file_name)
         self.send_msg("Starting playbook: %s" %
                       (self.playbook_name))
-
-
 
     def v2_playbook_on_play_start(self, play):
         """Display play start messages"""
@@ -110,16 +104,11 @@ class CallbackModule(CallbackBase):
         self.send_msg("Starting play: %s" % 
                       (name))
 
-
-
-
     def playbook_on_stats(self, stats):
         """Display info about playbook statistics"""
         hosts = sorted(stats.processed.keys())
-
         t = prettytable.PrettyTable(['Host', 'Ok', 'Changed', 'Unreachable',
                                      'Failures'])
-
         failures = False
         unreachable = False
 

--- a/lib/ansible/plugins/callback/hipchat.py
+++ b/lib/ansible/plugins/callback/hipchat.py
@@ -31,20 +31,16 @@ from ansible.plugins.callback import CallbackBase
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.urls import open_url
 
-
 class CallbackModule(CallbackBase):
     """This is an example ansible callback plugin that sends status
     updates to a HipChat channel during playbook execution.
-
     This plugin makes use of the following environment variables:
         HIPCHAT_TOKEN (required): HipChat API token
         HIPCHAT_ROOM  (optional): HipChat room to post in. Default: ansible
         HIPCHAT_FROM  (optional): Name to post as. Default: ansible
         HIPCHAT_NOTIFY (optional): Add notify flag to important messages ("true" or "false"). Default: true
-
     Requires:
         prettytable
-
     """
     CALLBACK_VERSION = 2.0
     CALLBACK_TYPE = 'notification'
@@ -76,9 +72,9 @@ class CallbackModule(CallbackBase):
         self.playbook_name = None
         self.play = None
 
+
     def send_msg(self, msg, msg_format='text', color='yellow', notify=False):
         """Method for sending a message to HipChat"""
-
         params = {}
         params['room_id'] = self.room
         params['from'] = self.from_name[:15]  # max length is 15
@@ -87,6 +83,7 @@ class CallbackModule(CallbackBase):
         params['color'] = color
         params['notify'] = int(self.allow_notify and notify)
 
+      
         url = ('%s?auth_token=%s' % (self.msg_uri, self.token))
         try:
             response = open_url(url, data=urlencode(params))
@@ -94,38 +91,27 @@ class CallbackModule(CallbackBase):
         except:
             self._display.warning('Could not submit message to hipchat')
 
-    def v2_playbook_on_play_start(self, play):
-        """Display Playbook and play start messages"""
+    
+    
+    def v2_playbook_on_start(self, playbook):
+        """Display playbook start messages"""
+        self.playbook_name = os.path.basename(playbook._file_name)
+        self.send_msg("Starting play: %s" %
+                      (self.playbook_name))
 
+
+
+    def v2_playbook_on_play_start(self, play):
+        """Display play start messages"""
+      
         self.play = play
         name = play.name
-        # This block sends information about a playbook when it starts
-        # The playbook object is not immediately available at
-        # playbook_on_start so we grab it via the play
-        #
-        # Displays info about playbook being started by a person on an
-        # inventory, as well as Tags, Skip Tags and Limits
-        if not self.printed_playbook:
-            self.playbook_name, _ = os.path.splitext(
-                os.path.basename(self.play.playbook.filename))
-            host_list = self.play.playbook.inventory.host_list
-            inventory = os.path.basename(os.path.realpath(host_list))
-            self.send_msg("%s: Playbook initiated by %s against %s" %
-                          (self.playbook_name,
-                           self.play.playbook.remote_user,
-                           inventory), notify=True)
-            self.printed_playbook = True
-            subset = self.play.playbook.inventory._subset
-            skip_tags = self.play.playbook.skip_tags
-            self.send_msg("%s:\nTags: %s\nSkip Tags: %s\nLimit: %s" %
-                          (self.playbook_name,
-                           ', '.join(self.play.playbook.only_tags),
-                           ', '.join(skip_tags) if skip_tags else None,
-                           ', '.join(subset) if subset else subset))
-
         # This is where we actually say we are starting a play
-        self.send_msg("%s: Starting play: %s" %
-                      (self.playbook_name, name))
+        self.send_msg("Starting play: %s" % 
+                      (name))
+
+
+
 
     def playbook_on_stats(self, stats):
         """Display info about playbook statistics"""
@@ -159,3 +145,5 @@ class CallbackModule(CallbackBase):
             color = 'green'
 
         self.send_msg("/code %s:\n%s" % (self.playbook_name, t), color=color)
+
+


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->
- hipchat.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Added the v2_playbook_on_start method and modified the v2_playbook_on_play_start method.
v2_playbook_on_start method sets the playbook property of the CallbackModule object

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Fixes #16946

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
Before change:
PLAY [Staging Packages] ********************************************************
 [WARNING]: Failure using method (v2_playbook_on_play_start) in callback plugin (</usr/lib/python2.7/site-packages/ansible/plugins/callback/hipchat.CallbackModule object at 0x31c4750>):
'Play' object has no attribute 'playbook'

After change:
Message on hipchat.


```
