### PR TITLE
Fix slaac filter

### DIFF
--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -608,7 +608,7 @@ def slaac(value, query = ''):
         elif vtype == 'network':
             v = ipaddr(value, 'subnet')
 
-        if v.version != 6:
+        if ipaddr(value, 'version') != 6:
             return False
 
         value = netaddr.IPNetwork(v)


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

slaac filter module
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

The code which attempts to test an IP address version attribute doesn't work, the address is a string. I've followed the style of the existing code and used the ipaddr() function to do so.

Using the template data `{{ 'fe80::' | slaac('00:11:22:33:44:55') }}` the slaac filter output changes from False to a SLAAC address:

```
TASK [template] ****************************************************************
--- before: /tmp/testfile
+++ after: dynamically generated
@@ -1 +1 @@
-False
+fe80::211:22ff:fe33:4455
```
