### PR TITLE
Add action plugin to support dnos6_template module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Ansible Changes By Release
   * cs_snapshot_policy
 - dnos6
   * dnos6_command
+  * dnos6_template
 - dnos9
   * dnos9_command
   * dnos9_config

--- a/lib/ansible/plugins/action/dnos6_template.py
+++ b/lib/ansible/plugins/action/dnos6_template.py
@@ -1,0 +1,28 @@
+#
+# Copyright 2015 Peter Sprygada <psprygada@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+from ansible.plugins.action.net_template import ActionModule as NetActionModule
+
+class ActionModule(NetActionModule, ActionBase):
+    pass
+
+


### PR DESCRIPTION
##### ISSUE TYPE
- New Module Pull Request
##### COMPONENT NAME
- modules/core/network/dnos6/dnos6_template
##### ANSIBLE VERSION
- 
  ansible 2.2.0 (devel a194740) last updated 2016/09/08 17:44:28 (GMT -700) lib/ansible/modules/core: (detached HEAD db38f0c876) last updated 2016/09/08 17:44:58 (GMT -700) lib/ansible/modules/extras: (detached HEAD 8bfdcfcab2) last updated 2016/09/08 17:44:58 (GMT -700) config file = /home/skg/lothlorien/ansible.cfg configured module search path = Default w/o overrides
##### SUMMARY
- Add action plugin to support dnos6_template module
