### PR TITLE
[wip] Let jsonfile and memcached cache plugins understand fact_caching_timeout=0

### DIFF
--- a/lib/ansible/plugins/cache/jsonfile.py
+++ b/lib/ansible/plugins/cache/jsonfile.py
@@ -108,6 +108,9 @@ class CacheModule(BaseCacheModule):
 
     def has_expired(self, key):
 
+        if self._timeout == 0:
+            return False
+
         cachefile = "%s/%s" % (self._cache_dir, key)
         try:
             st = os.stat(cachefile)

--- a/lib/ansible/plugins/cache/memcached.py
+++ b/lib/ansible/plugins/cache/memcached.py
@@ -157,7 +157,7 @@ class CacheModule(BaseCacheModule):
     def _expire_keys(self):
         if self._timeout > 0:
             expiry_age = time.time() - self._timeout
-        self._keys.remove_by_timerange(0, expiry_age)
+            self._keys.remove_by_timerange(0, expiry_age)
 
     def get(self, key):
         value = self._cache.get(self._make_key(key))


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
- Bugfix Pull Request
##### COMPONENT NAME

plugins/cache/
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (cache_timeout_0 e1eb8568bc) last updated 2016/09/14 13:01:43 (GMT -400)
  lib/ansible/modules/core: (detached HEAD ae6992bf8c) last updated 2016/09/14 13:01:17 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD afd0b23836) last updated 2016/09/14 13:01:17 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = ['/home/adrian/src/ansible-modules-core', '/home/adrian/src/ansible-modules-extras']


```
##### SUMMARY

A rebase of extension of https://github.com/ansible/ansible/pull/14381

In addition to the changes for jsonfile.py, this also includes a bug fix for memcached so that it understands fact_caching_timeout=0 as well.
