### PR TITLE
Fix error using jsonfile with incomplete config

### DIFF
--- a/lib/ansible/plugins/cache/jsonfile.py
+++ b/lib/ansible/plugins/cache/jsonfile.py
@@ -50,7 +50,11 @@ class CacheModule(BaseCacheModule):
 
         self._timeout = float(C.CACHE_PLUGIN_TIMEOUT)
         self._cache = {}
-        self._cache_dir = os.path.expanduser(os.path.expandvars(C.CACHE_PLUGIN_CONNECTION))
+        self._cache_dir = None
+
+        if C.CACHE_PLUGIN_CONNECTION:
+            # expects a dir path
+            self._cache_dir = os.path.expanduser(os.path.expandvars(C.CACHE_PLUGIN_CONNECTION))
 
         if not self._cache_dir:
             raise AnsibleError("error, 'jsonfile' cache plugin requires the 'fact_caching_connection' config option to be set (to a writeable directory path)")


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

lib/ansible/plugins/cache/jsonfile.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (jsonfile_no_caching_connection_config 316465f91e) last updated 2016/09/14 13:37:16 (GMT -400)
  lib/ansible/modules/core: (detached HEAD ae6992bf8c) last updated 2016/09/14 13:01:17 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD afd0b23836) last updated 2016/09/14 13:01:17 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = ['/home/adrian/src/ansible-modules-core', '/home/adrian/src/ansible-modules-extras']

```
##### SUMMARY

If 'fact_caching=jsonfile' was configured, but 'fact_caching_connection' was not configured, jsonfile
would fail and ansible-playbook would exit with a traceback.

This just handles that error more gracefully without a traceback.

Fixes #17566
