### PR TITLE
Add python 3 awareness to apt module tests.

### DIFF
--- a/test/integration/roles/test_apt/tasks/apt.yml
+++ b/test/integration/roles/test_apt/tasks/apt.yml
@@ -1,15 +1,26 @@
+- name: show python version
+  debug: var=ansible_python_version
 
+- name: use python-apt
+  set_fact:
+    python_apt: python-apt
+  when: ansible_python_version | version_compare('3', '<')
+
+- name: use python3-apt
+  set_fact:
+    python_apt: python3-apt
+  when: ansible_python_version | version_compare('3', '>=')
 
 # UNINSTALL 'python-apt'
 #  The `apt` module has the smarts to auto-install `python-apt`.  To test, we
 #  will first uninstall `python-apt`.
-- name: check python-apt with dpkg
-  shell: dpkg -s python-apt
+- name: check {{ python_apt }} with dpkg
+  shell: dpkg -s {{ python_apt }}
   register: dpkg_result
   ignore_errors: true
 
-- name: uninstall python-apt with apt
-  apt: pkg=python-apt state=absent purge=yes
+- name: uninstall {{ python_apt }} with apt
+  apt: pkg={{ python_apt }} state=absent purge=yes
   register: apt_result
   when: dpkg_result|success
 

--- a/test/utils/docker/ubuntu1604py3/Dockerfile
+++ b/test/utils/docker/ubuntu1604py3/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update -y && \
     mysql-server \
     openssh-client \
     openssh-server \
-    python3-apt \
     python3-coverage \
     python3-dbus \
     python3-httplib2 \


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

Integration Tests (apt)
##### ANSIBLE VERSION

```
ansible 2.2.0 (py3-apt 7dbb59add0) last updated 2016/09/14 13:44:37 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 683e5e4d1a) last updated 2016/09/14 13:42:21 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 8749c40fee) last updated 2016/09/14 13:42:21 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Add python 3 awareness to apt module tests.
Also remove unnecessary dependency from ubuntu1604py3 Dockerfile.
