### PR TITLE
Set Suse family for openSUSE Tumbleweed & Leap

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -650,7 +650,7 @@ class Distribution(object):
         SLC = 'RedHat', Ascendos = 'RedHat', CloudLinux = 'RedHat', PSBM = 'RedHat',
         OracleLinux = 'RedHat', OVS = 'RedHat', OEL = 'RedHat', Amazon = 'RedHat',
         XenServer = 'RedHat', Ubuntu = 'Debian', Debian = 'Debian', Raspbian = 'Debian', Slackware = 'Slackware', SLES = 'Suse',
-        SLED = 'Suse', openSUSE = 'Suse', SuSE = 'Suse', SLES_SAP = 'Suse', Gentoo = 'Gentoo', Funtoo = 'Gentoo',
+        SLED = 'Suse', openSUSE = 'Suse', openSUSE_Tumbleweed = 'Suse', SuSE = 'Suse', SLES_SAP = 'Suse', SUSE_LINUX = 'Suse', Gentoo = 'Gentoo', Funtoo = 'Gentoo',
         Archlinux = 'Archlinux', Manjaro = 'Archlinux', Mandriva = 'Mandrake', Mandrake = 'Mandrake', Altlinux = 'Altlinux',
         Solaris = 'Solaris', Nexenta = 'Solaris', OmniOS = 'Solaris', OpenIndiana = 'Solaris',
         SmartOS = 'Solaris', AIX = 'AIX', Alpine = 'Alpine', MacOSX = 'Darwin',

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -172,6 +172,24 @@ ID_LIKE="suse"
                    'os_family': u'Suse',
                    'distribution_version': u'13.2'}
     },
+    {
+        "platform.dist": [
+            "", 
+            "", 
+            ""
+        ], 
+        "input": {
+            "/etc/os-release": "NAME=\"openSUSE Tumbleweed\"\n# VERSION=\"20160917\"\nID=opensuse\nID_LIKE=\"suse\"\nVERSION_ID=\"20160917\"\nPRETTY_NAME=\"openSUSE Tumbleweed\"\nANSI_COLOR=\"0;32\"\nCPE_NAME=\"cpe:/o:opensuse:tumbleweed:20160917\"\nBUG_REPORT_URL=\"https://bugs.opensuse.org\"\nHOME_URL=\"https://www.opensuse.org/\"\n"
+        }, 
+        "name": "openSUSE Tumbleweed 20160917", 
+        "result": {
+            "distribution_release": "NA", 
+            "distribution": "openSUSE Tumbleweed", 
+            "distribution_major_version": "NA", 
+            "os_family": "Suse", 
+            "distribution_version": "20160917"
+        }
+    },
     { # see https://github.com/ansible/ansible/issues/14837
         "name": "SLES 11.3",
         "input": {


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

core
##### ANSIBLE VERSION

```
ansible --version
ansible 2.0.2.0 (stable-2.0 26078418e9) last updated 2016/09/14 11:21:45 (GMT -700)
```
##### SUMMARY

On openSUSE Tumbleweed, lsb-release -a currently reports
the distributor ID as "openSUSE Tumbleweed". On openSUSE
Leap, the distributor ID is "SUSE LINUX".

Add them to the OS_FAMILY dict as Suse family systems.

Fixes #17573 

Add the correct items to the OS_FAMILY dict.

```
before:

ansible -m setup -c local -i playbooks/inventory/localhost localhost | grep -i suse
        "ansible_distribution": "openSUSE Tumbleweed", 
            "MACHTYPE": "x86_64-suse-linux", 
            "description": "openSUSE Tumbleweed", 
            "id": "openSUSE Tumbleweed", 
        "ansible_os_family": "openSUSE Tumbleweed",

after:

ansible -m setup -c local -i playbooks/inventory/localhost localhost | grep -i suse
        "ansible_distribution": "openSUSE Tumbleweed", 
            "MACHTYPE": "x86_64-suse-linux", 
            "description": "openSUSE Tumbleweed", 
            "id": "openSUSE Tumbleweed", 
        "ansible_os_family": "Suse",
```
