### PR TITLE
Add state machine capabilities for use by modules

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -114,6 +114,12 @@ except ImportError:
         print('\n{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
         sys.exit(1)
 
+from ansible.module_utils.simple_state_machine import StateMachine, TransitionError
+# This is so that developers who want to use this with AnsibleModuleFSM don't
+# have to know about the simple_state_machine package. The NOQA comment is
+# added to avoid linters from tripping on it.
+from ansible.module_utils.simple_state_machine import create_events, create_states  # NOQA
+
 AVAILABLE_HASH_ALGORITHMS = dict()
 try:
     import hashlib
@@ -2291,6 +2297,234 @@ class AnsibleModule(object):
 
     # In 2.0, moved from inside the module to the toplevel
     is_executable = is_executable
+
+
+class AnsibleModuleFSM(object):
+    """
+    A drop in replacement for AnsibleModule that provides state machine
+    capabilities.
+    """
+
+    def __init__(self, state_machine, render_path=None, **kwargs):
+        """
+        :param dict state_machine: A dict that contains arguments to configure
+            the underlying state machine. See state_machine keys below for a
+            description of valid keys and values.
+
+        :param str render_path: Optional. A valid path where you, the module
+            developer, would like to save a visual representation of the
+            state table. Note that setting this will cause the module to exit
+            immediately after rendering. This is to ensure that you don't
+            accidentally release your module with rendering turned on which
+            can negatively impact its performance. Users of your modules won't
+            be able to render your state machine but they rarely have any
+            reason to do that if at all.
+
+        Any other arguments that you provide aside from the above are forwarded
+        to the underlying AnsibleModule object.
+
+        state_machine Keys:
+            transitions: A dictionary representation of your state table. The
+                keys are expected to be tuples of (current_state, event) and
+                their corresponding values are expected to be tuples of
+                (next_state, function_name). The function provided is expected
+                to receive two arguments: the underlying AnsibleModule object
+                and a dictionary containing any data that your functions
+                want to share with each other. These same functions are also
+                expected to return two values: an event and the passed in data
+                which may or may not have been modified by the function. If
+                this seems like a lot to take in, it is. You might want to
+                pause for a bit and then check out the sample code below.
+            starting_state: A value taken from any of the 'current_states'
+                that you declared in your transitions argument. The underlying
+                state machine will start with this state.
+            starting_action: Any of the functions available in your module.
+                This may or may not be included in your transitions argument.
+                However, it must return an event that is paired with any of
+                the 'current_states' in your transitions argument otherwise
+                a TransitionError will be raised.
+            exit_event: An event that signals the end of the module's
+                execution. Once this event is received, no other functions will
+                be called and the module exits immediately. Do not put this
+                event in your transitions argument. If you do, the paired
+                (next_state, function_name) tuple will not be processed.
+
+        Example:
+
+        .. code-block:: python
+
+            #!/usr/bin/env python
+
+            # Note the additional imports, create_events and create_states.
+            # These are optional helper functions that allow you to define
+            # more descriptive events and states without too much boilerplate.
+            from ansible.module_utils.basic import \
+                AnsibleModuleFSM, create_events, create_states
+
+            # Use create_states to define descriptive state names/values.
+            # The following allows us to, for example, use S.initializing
+            # in our code below.
+            S = create_states('choosing_action',
+                              'creating',
+                              'deleting',
+                              'exiting',
+                              'initializing',
+                              'getting',
+                              'waiting')
+
+            # This allows us to define descriptive event names/values
+            E = create_events('create_started',
+                              'delete_started',
+                              'initialized',
+                              'exited',
+                              'found',
+                              'not_found',
+                              'must_wait',
+                              'must_create',
+                              'must_delete',
+                              'must_exit')
+
+
+            def main():
+                # Define the module's transitions. Note how we are using the
+                # states and events we defined above.
+                #
+                # Note how we pass in functions such as get_obj, choose_action,
+                # create_obj, etc. You will find the definition of these
+                # functions further down this example.
+                transitions = {
+                    (S.initializing, E.initialized): (S.getting, get_obj),
+
+                    (S.getting, E.found): (S.choosing_action, choose_action),
+                    (S.getting, E.not_found): (S.choosing_action, choose_action),
+
+                    (S.choosing_action, E.must_create): (S.creating, create_obj),
+                    (S.choosing_action, E.must_delete): (S.deleting, delete_obj),
+                    (S.choosing_action, E.must_exit): (S.exiting, exit_now),
+
+                    (S.creating, E.create_started): (S.waiting, wait),
+
+                    (S.deleting, E.delete_started): (S.waiting, wait),
+
+                    (S.waiting, E.must_wait): (S.waiting, wait),
+                    (S.waiting, E.must_exit): (S.exiting, exit_now)
+                }
+
+                # Instantiate the object.
+                AnsibleModuleFSM(
+                    # Uncomment this argument to make the module render
+                    # the state diagram and exit immediately. The file
+                    # extension will be appended automatically.
+                    # render_path="/tmp/mymodule",
+
+                    state_machine=dict(
+                        starting_state=S.initializing,
+                        starting_action=initialize,
+                        exit_event=E.exited,
+                        transitions=transitions
+                    ),
+
+                    argument_spec=dict(
+                        module_arg1=dict(required=True, type='str'),
+                        module_arg2=dict(required=False, default=100, type='int')
+                    )
+                )
+
+
+            # =======
+            # ACTIONS
+            # =======
+
+            def create_obj(module, data):
+                #
+                # Do stuff here
+                #
+
+                return E.create_started, data
+
+
+            def delete_obj(module, data):
+                #
+                # Do stuff here
+                #
+
+                return E.delete_started, data
+
+
+            def choose_action(module, data):
+                #
+                # Do stuff here
+                #
+
+                return E.must_create, data
+
+
+            def exit_now(module, data):
+                #
+                # Do stuff here
+                #
+                module.exit_json(msg="Done with the thing")
+                return E.exited, data
+
+
+            def get_obj(module, data):
+                #
+                # Do stuff here
+                #
+
+                return E.found, data
+
+
+            def initialize(module, data):
+                #
+                # Do stuff here
+                #
+
+                return E.initialized, data
+
+
+            def wait(module, data):
+                #
+                # Do stuff here
+                #
+
+                return E.must_exit, data
+
+            # ======
+
+            if __name__ == '__main__':
+                main()
+        """
+        try:
+            starting_state = state_machine["starting_state"]
+            starting_action = state_machine["starting_action"]
+            exit_event = state_machine["exit_event"]
+            transitions = state_machine["transitions"]
+        except KeyError:
+            err = sys.exc_info()[1]
+            raise TypeError("Missing key '%s' for state_machine argument" %
+                            err.args[0])
+
+        module = AnsibleModule(**kwargs)
+        machine = StateMachine(transitions, starting_state, starting_action)
+        data = dict()
+
+        if render_path:
+            machine.render(render_path)
+            # Fail immediately so that the module developer will always
+            # remember to remove the render_path argument. Having the module
+            # unintentionally render in production is a bad thing(tm)!
+            module.fail_json(msg="State chart saved to %s.png" % render_path)
+
+        event, data = starting_action(module, data)
+        while event != exit_event:
+            try:
+                action = machine.send_event(event)
+            except TransitionError:
+                err = sys.exc_info()[1]
+                module.fail_json(msg=err.message)
+
+            event, data = action(module, data)
 
 
 def get_module_path():

--- a/lib/ansible/module_utils/simple_state_machine.py
+++ b/lib/ansible/module_utils/simple_state_machine.py
@@ -1,0 +1,130 @@
+import os
+
+try:
+    import graphviz
+    HAS_GRAPHVIZ = True
+except ImportError:
+    HAS_GRAPHVIZ = False
+
+
+def create_enum(name, *members):
+    members_dict = {}
+
+    for member in members:
+        members_dict[member] = member
+
+    return type(name, (object,), members_dict)
+
+
+def create_events(*events):
+    return create_enum('E', *events)
+
+
+def create_states(*states):
+    return create_enum('S', *states)
+
+
+class StateMachine(object):
+    # Inspired by http://notahat.com/2014/11/07/state-machines-in-ruby.html
+
+    def __init__(self, transitions, starting_state, starting_action):
+        self._transitions = TransitionTable(transitions)
+
+        self._state = starting_state
+
+        # This part ensures we remember our starting state just in case
+        # we call render() after one or more transitions have happened
+        self._starting_state = starting_state
+
+        self._starting_action = starting_action
+
+    # ==========
+    # PROPERTIES
+    # ==========
+
+    @property
+    def state(self):
+        return self._state
+
+    # =======
+    # METHODS
+    # =======
+
+    def send_event(self, event):
+        self._state, action = self._transitions.call(self._state, event)
+        return action
+
+    def render(self, path, fmt='png'):
+        formatter = GraphvizFormatter(self._transitions,
+                                      starting_node=self._starting_state,
+                                      starting_action=self._starting_action)
+        formatter.save(os.path.splitext(path)[0], fmt)
+
+
+class GraphvizLibraryMissing(Exception):
+    pass
+
+
+class GraphvizFormatter(object):
+    # Based on http://matthiaseisen.com/pp/patterns/p0204/
+
+    def __init__(self, transitions, starting_node, starting_action):
+        if not HAS_GRAPHVIZ:
+            raise GraphvizLibraryMissing("visualize method requires "
+                                         "the graphviz library.")
+        self._transitions = transitions
+        self._starting_node = starting_node
+        self._starting_action = starting_action
+
+    def save(self, path, fmt):
+        node_label = '%s\n---\nentry / %s'
+        nodes = []
+        edges = []
+
+        values = (self._starting_node, self._starting_action.__name__)
+        nodes.append((self._starting_node, {'label': node_label % values}))
+
+        for source, target in self._transitions.items():
+            node1 = str(source[0])
+            edge = str(source[1])
+            node2 = str(target[0])
+            action = str(target[1].__name__)
+
+            nodes.append((node1, {}))
+            nodes.append((node2, {'label': node_label % (node2, action)}))
+            edges.append(((node1, node2), {'label': '[%s]' % edge}))
+
+        graph = graphviz.Digraph(format=fmt)
+        graph = self.add_nodes(graph, nodes)
+        graph = self.add_edges(graph, edges)
+        graph.render(path)
+
+    def add_nodes(self, graph, nodes):
+        for node in nodes:
+            graph.node(node[0], **node[1])
+        return graph
+
+    def add_edges(self, graph, edges):
+        for edge in edges:
+            graph.edge(*edge[0], **edge[1])
+        return graph
+
+
+class TransitionError(Exception):
+    pass
+
+
+class TransitionTable(object):
+
+    def __init__(self, transitions):
+        self._transitions = transitions
+
+    def call(self, state, event):
+        try:
+            return self._transitions[(state, event)]
+        except KeyError:
+            raise TransitionError("No transition for state: %s, event: %s" %
+                                  (state, event))
+
+    def items(self):
+        return self._transitions.items()

--- a/test/units/module_utils/basic/test_ansible_module_fsm.py
+++ b/test/units/module_utils/basic/test_ansible_module_fsm.py
@@ -1,0 +1,67 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Make coding more python3-ish
+from __future__ import absolute_import, division, print_function
+
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import call, Mock, patch
+from ansible.module_utils.basic import AnsibleModuleFSM
+
+
+class TestAnsibleModuleFSM(unittest.TestCase):
+
+    @patch('ansible.module_utils.basic.AnsibleModule', autospec=True)
+    def test_happy_path(self, ansible_mod_cls):
+        ansible_mod = ansible_mod_cls.return_value
+
+        state1 = 1
+        state2 = 2
+        state3 = 3
+
+        event1 = 1
+        event2 = 2
+        event3 = 3
+
+        action1 = Mock(return_value=(event1, {}))
+        action2 = Mock(return_value=(event2, {}))
+        action3 = Mock(return_value=(event3, {}))
+
+        argument_spec = dict(
+            arg1=dict(default='na', choices=['na', 'other']),
+            arg2=dict(required=True, type='str')
+        )
+
+        AnsibleModuleFSM(
+            state_machine=dict(
+                starting_state=state1,
+                starting_action=action1,
+                exit_event=event3,
+                transitions={
+                    (state1, event1): (state2, action2),
+                    (state2, event2): (state3, action3),
+                }
+            ),
+            argument_spec=argument_spec
+        )
+
+        expected = set(['argument_spec'])
+        actual = set(ansible_mod_cls.call_args[1].keys())
+        self.assertTrue(expected.issubset(actual),
+                        "%r is not a subjset of %r" % (expected, actual))
+
+        self.assertEqual(action1.call_args, call(ansible_mod, {}))
+        self.assertEqual(action2.call_args, call(ansible_mod, {}))
+        self.assertEqual(action3.call_args, call(ansible_mod, {}))

--- a/test/units/module_utils/simple_state_machine/test_create_enum.py
+++ b/test/units/module_utils/simple_state_machine/test_create_enum.py
@@ -1,0 +1,36 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division)
+__metaclass__ = type
+
+
+from ansible.compat.tests import unittest
+from ansible.module_utils.simple_state_machine import create_enum
+
+
+class TestCreateEnum(unittest.TestCase):
+
+    # =====
+    # TESTS
+    # =====
+
+    def test_create_happy_path(self):
+        E = create_enum('E', 'one', 'two', 'three')
+
+        self.assertEqual('one', str(E.one))
+        self.assertEqual('two', str(E.two))
+        self.assertEqual('three', str(E.three))

--- a/test/units/module_utils/simple_state_machine/test_state_machine.py
+++ b/test/units/module_utils/simple_state_machine/test_state_machine.py
@@ -1,0 +1,130 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division)
+__metaclass__ = type
+
+import os
+
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import patch, call
+from ansible.module_utils.simple_state_machine \
+    import create_events, create_states, StateMachine, TransitionError
+
+
+class TestStateMachineWithValidInitialization(unittest.TestCase):
+
+    # =======
+    # HELPERS
+    # =======
+
+    @property
+    def events(self):
+        if not hasattr(self, '_events'):
+            self._events = create_events('one',
+                                         'two',
+                                         'three',
+                                         'four',
+                                         'ninetynine')
+        return self._events
+
+    @property
+    def states(self):
+        if not hasattr(self, '_states'):
+            self._states = create_states('one',
+                                         'two',
+                                         'three',
+                                         'four')
+        return self._states
+
+    @property
+    def starting_state(self):
+        return self.states.one
+
+    @property
+    def transitions(self):
+        return {
+            (self.states.one, self.events.one):
+                (self.states.two, self.action1),
+            (self.states.one, self.events.two):
+                (self.states.three, self.action2),
+            (self.states.two, self.events.three):
+                (self.states.four, self.action3)
+        }
+
+    def action1(self):
+        pass
+
+    def action2(self):
+        pass
+
+    def action3(self):
+        pass
+
+    # ==============
+    # SETUP/TEARDOWN
+    # ==============
+
+    def setUp(self):
+        self.subject = StateMachine(self.transitions,
+                                    self.starting_state,
+                                    self.action1)
+
+    # =====
+    # TESTS
+    # =====
+
+    @patch('ansible.module_utils.simple_state_machine.graphviz', autospec=True)
+    def test_render(self, graphviz_cls):
+        graph = graphviz_cls.Digraph.return_value
+
+        path = '/tmp/state_machine_visual_3e18676'
+
+        self.subject.render(path)
+
+        self.assertEqual(graph.render.call_count, 1)
+        self.assertEqual(graph.render.call_args, call(path))
+
+    def test_send_event(self):
+        # Double check that we are at the correct state
+        self.assertEqual(self.starting_state, self.subject.state)
+
+        action = self.subject.send_event(self.events.two)
+
+        self.assertEqual(self.action2, action)
+        self.assertEqual(self.states.three, self.subject.state)
+
+    def test_send_event_multiple_transitions(self):
+        # Double check that we are at the correct state
+        self.assertEqual(self.starting_state, self.subject.state)
+
+        self.subject.send_event(self.events.one)
+        action = self.subject.send_event(self.events.three)
+
+        self.assertEqual(self.action3, action)
+        self.assertEqual(self.states.four, self.subject.state)
+
+    def test_send_event_invalid_event(self):
+        # Double check that we are at the correct state
+        self.assertEqual(self.starting_state, self.subject.state)
+
+        with self.assertRaises(TransitionError):
+            self.subject.send_event(self.events.ninetynine)
+
+        self.assertEqual(self.states.one, self.subject.state)
+
+    def test_state(self):
+        self.assertEqual(self.starting_state, self.subject.state)

--- a/test/utils/tox/requirements-py3.txt
+++ b/test/utils/tox/requirements-py3.txt
@@ -7,6 +7,7 @@ mock >= 1.0.1, < 1.1
 passlib
 coverage
 coveralls
+graphviz
 unittest2
 redis
 python3-memcached

--- a/test/utils/tox/requirements.txt
+++ b/test/utils/tox/requirements.txt
@@ -7,6 +7,7 @@ mock >= 1.0.1, < 1.1
 passlib
 coverage
 coveralls
+graphviz
 unittest2
 redis
 python-memcached


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### COMPONENT NAME

N/A
##### ANSIBLE VERSION

```
ansible 2.2.0 (detached HEAD 6787fc70a6) last updated 2016/09/14 14:52:45 (GMT -700)
  lib/ansible/modules/core: (detached HEAD db5cb54b23) last updated 2016/09/08 14:25:22 (GMT -700)
  lib/ansible/modules/extras: (load-balancer-rewrite 0f3df9a68f) last updated 2016/09/13 15:52:35 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

This change adds a new class called AnsibleModuleFSM which is built on top of AnsibleModule via composition (not inheritance). The main advantage of using this class is that a module developer can now write modules as state machines which can be easier to manage especially for those that have a complex decision tree.
##### RATIONALE

Non-interactive code with decision trees that range from mid to high complexity becomes hard to
manage very quickly if implemented using procedural methods (if conditions). Take for example this part of the `ec2_customer_gateway` module:

``` python
if module.params['state'] == 'present':
    if existing['CustomerGateways']:
        results['gateway']=existing
        if existing['CustomerGateways'][0]['Tags']:
            tag_array = existing['CustomerGateways'][0]['Tags']
            for key, value in enumerate(tag_array):
                if value['Key'] == 'Name':
                    current_name = value['Value']
                    if current_name != name:
                        results['name'] = gw_mgr.tag_cgw_name(
                            results['gateway']['CustomerGateways'][0]['CustomerGatewayId'],
                            module.params['name'],
                        )
                        results['changed'] = True
    else:
        if not module.check_mode:
            results['gateway'] = gw_mgr.ensure_cgw_present(
                module.params['bgp_asn'],
                module.params['ip_address'],
            )
            results['name'] = gw_mgr.tag_cgw_name(
                results['gateway']['CustomerGateway']['CustomerGatewayId'],
                module.params['name'],
            )
        results['changed'] = True

elif module.params['state'] == 'absent':
    if existing['CustomerGateways']:
        results['gateway']=existing
        if not module.check_mode:
            results['gateway'] = gw_mgr.ensure_cgw_absent(
                existing['CustomerGateways'][0]['CustomerGatewayId']
            )
        results['changed'] = True
```

Note the 5 layers of if conditions with two of them belonging inside a for loop. If one or more parts of this behavior were to change, the developer would need to be very careful to ensure that a change in one or more conditions/variables doesn't affect any other part unintentionally since there's no way to scope variables within a single if condition.

Other modules get around this problem by moving some parts of the code to their own function. While that solves the deeply-nested-if problem, it introduces another complexity in that a developer will have to scroll up and down the module's code to understand its workflow.

This change addresses both problems by providing a means for the module developer to implement a module using state machines. Using state machines allows the developer to avoid deeply-nested if conditions while still keeping the workflow information in a single place.
##### SAMPLE USAGE

Using this feature is a matter of using the AnsibleModuleFSM class instead of AnsibleModule. The former accepts the same arguments as the latter plus two additional keyword args, `state_machine` and `render_path`.

``` python
#!/usr/bin/env python
# Note the additional imports, create_events and create_states.
# These are optional helper functions that allow you to define
# more descriptive events and states without too much boilerplate.
from ansible.module_utils.basic import AnsibleModuleFSM, create_events, create_states

# Use create_states to define descriptive state names/values.
# The following allows us to, for example, use S.initializing
# in our code below.
S = create_states('choosing_action',
                  'creating',
                  'deleting',
                  'exiting',
                  'initializing',
                  'getting',
                  'waiting')

# This allows us to define descriptive event names/values
E = create_events('create_started',
                  'delete_started',
                  'initialized',
                  'exited',
                  'found',
                  'not_found',
                  'must_wait',
                  'must_create',
                  'must_delete',
                  'must_exit')
def main():
    # Define the module's transitions. Note how we are using the
    # states and events we defined above.
    #
    # Note how we pass in functions such as get_obj, choose_action,
    # create_obj, etc. You will find the definition of these
    # functions further down this example.
    #
    # The dict's structure is:
    #    (CURRENT_STATE, EVENT): (NEW_STATE, ENTRY_ACTION)
    #
    # The state machine purposely doesn't support exit actions to
    # keep its implementation simple.
    transitions = {
        (S.initializing, E.initialized):    (S.getting, get_obj),
        (S.getting, E.found):               (S.choosing_action, choose_action),
        (S.getting, E.not_found):           (S.choosing_action, choose_action),
        (S.choosing_action, E.must_create): (S.creating, create_obj),
        (S.choosing_action, E.must_delete): (S.deleting, delete_obj),
        (S.choosing_action, E.must_exit):   (S.exiting, exit_now),
        (S.creating, E.create_started):     (S.waiting, wait),
        (S.deleting, E.delete_started):     (S.waiting, wait),
        (S.waiting, E.must_wait):           (S.waiting, wait),
        (S.waiting, E.must_exit):           (S.exiting, exit_now)
    }

    # Instantiate the object.
    AnsibleModuleFSM(
        # Uncomment this argument to make the module render
        # the state diagram and exit immediately. The file
        # extension will be appended automatically.
        # render_path="/tmp/mymodule",

        state_machine=dict(
            starting_state=S.initializing,
            starting_action=initialize,
            exit_event=E.exited,
            transitions=transitions
        ),

        argument_spec=dict(
            module_arg1=dict(required=True, type='str'),
            module_arg2=dict(required=False, default=100, type='int')
        )
    )

    # No further code is needed in `main()`. The AnsibleModuleFSM object
    # will call the functions/actions below in proper order until the exit_event
    # is returned or `fail_json` or `exit_json` is called.

# =======
# ACTIONS
# =======

def create_obj(module, data):
    #
    # Do stuff here
    #
    # The `module` argument is a standard AnsibleModule object
    # while `data` is a standard dict that gets passed from one function
    # to another as the state machine progresses through the transitions.
    #
    return E.create_started, data

def delete_obj(module, data):
    #
    # Do stuff here
    #
    return E.delete_started, data

def choose_action(module, data):
    if data['some_key'] == 'value1':
        event = E.must_create
    elif data['some_key'] == 'value2':
        event = E.must_delete
    else:
        event = E.must_exit

    return event, data

def exit_now(module, data):
    #
    # Do stuff here
    #
    module.exit_json(msg="Done with the thing.")

def get_obj(module, data):
    data['some_key'] = 'value1'
    return E.found, data

def initialize(module, data):
    #
    # Do stuff here
    #
    return E.initialized, data

def wait(module, data):
    #
    # Do stuff here
    #
    return E.must_exit, data

# ======

if __name__ == '__main__':
    main()
```

For more information on AnsibleModuleFSM, please see its docstring documentation.
##### AUTOGENERATED STATE CHART

By uncommenting the `render_path="/tmp/mymodule"` keyword argument in the example above and executing the module (via `$ hacking/test-module -m path/to/mymodule.py -a "module_arg1='something'"` or via the normal playbook way), a chart is automatically rendered (provided that graphviz is installed). The following image is an actual rendering generated by the above code:

![](https://dl.dropboxusercontent.com/u/1355795/mymodule.png)

Note that if the `render_path` argument is set, the module will always fail immediately after rendering the chart. This is so that the developer will not accidentally release a module with the rendering enabled since this can negatively impact module performance.
###### ADVANTAGES OF CHANGE
- State machines are excellent for modules that have complex decision trees that would otherwise have to be implemented with multiple nested if conditions;
- Separates workflow from action implementation. The workflow is clearly stated in the transition table whereas the action implementations are defined in their own functions;
- Auto-generation of state diagram which is also very useful for debugging/understanding the internals of complex modules.
- Encapsulates all state-machine-related boilerplate code so that modules that do want to use a state machine are as DRY as possible.
