### PR TITLE
Ensure parent tempdir's existence

### DIFF
--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -647,7 +647,7 @@ def _find_snippet_imports(module_name, module_data, module_path, module_args, ta
                     if not os.path.exists(lookup_path):
                         # Note -- if we have a global function to setup, that would
                         # be a better place to run this
-                        os.mkdir(lookup_path)
+                        os.makedirs(lookup_path)
                     display.debug('ANSIBALLZ: Writing module')
                     with open(cached_module_filename + '-part', 'wb') as f:
                         f.write(zipdata)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

_find_snippet_imports
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 2e28227d2b) last updated 2016/09/15 08:21:26 (GMT -500)
  lib/ansible/modules/core: (detached HEAD 683e5e4d1a) last updated 2016/09/15 08:17:24 (GMT -500)
  lib/ansible/modules/extras: (detached HEAD 8749c40fee) last updated 2016/09/15 08:17:24 (GMT -500)
  config file = /home/mordred/src/openstack-infra/zuul/testansible.egg/ansible.cfg
  configured module search path = ['/home/mordred/src/openstack-infra/zuul/testansible.egg/library']
```
##### SUMMARY

While doing evil things with action plugins, I hit a code path in which
the mkdir here was failing due to lack of parent dir. Changing this to
makedirs made everything happy. Now, I'd obviously like to understand
why the parent dir exists in some places and not others - but I could
not find anywhere that C.DEFAULT_LOCAL_TMP is ensured to be created.
