### PR TITLE
Add possibility to limit the list of examined network interfaces during fact gathering

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -52,6 +52,10 @@
 # environment. 
 # gather_timeout = 10
 
+# by default retrieve facts for all interfaces
+# list interfaces to limit the gather process to here
+#gather_network_interfaces = lo,eth0,eth1
+
 # additional paths to search for roles in, colon separated
 #roles_path    = /etc/ansible/roles
 

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -184,6 +184,8 @@ DEFAULT_EXECUTABLE        = get_config(p, DEFAULTS, 'executable', 'ANSIBLE_EXECU
 DEFAULT_GATHERING         = get_config(p, DEFAULTS, 'gathering', 'ANSIBLE_GATHERING', 'implicit').lower()
 DEFAULT_GATHER_SUBSET     = get_config(p, DEFAULTS, 'gather_subset', 'ANSIBLE_GATHER_SUBSET', 'all').lower()
 DEFAULT_GATHER_TIMEOUT    = get_config(p, DEFAULTS, 'gather_timeout', 'ANSIBLE_GATHER_TIMEOUT', 10, integer=True)
+DEFAULT_GATHER_NETWORK_INTERFACES = get_config(p, DEFAULTS, 'gather_network_interfaces', 'ANSIBLE_GATHER_NETWORK_INTERFACES', None)
+
 DEFAULT_LOG_PATH          = get_config(p, DEFAULTS, 'log_path',           'ANSIBLE_LOG_PATH', '', ispath=True)
 DEFAULT_FORCE_HANDLERS    = get_config(p, DEFAULTS, 'force_handlers', 'ANSIBLE_FORCE_HANDLERS', False, boolean=True)
 DEFAULT_INVENTORY_IGNORE  = get_config(p, DEFAULTS, 'inventory_ignore_extensions', 'ANSIBLE_INVENTORY_IGNORE', ["~", ".orig", ".bak", ".ini", ".cfg", ".retry", ".pyc", ".pyo"], islist=True)

--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -159,6 +159,7 @@ class PlayIterator:
         # Default options to gather
         gather_subset = C.DEFAULT_GATHER_SUBSET
         gather_timeout = C.DEFAULT_GATHER_TIMEOUT
+        gather_interfaces = C.DEFAULT_GATHER_NETWORK_INTERFACES
 
         # Retrieve subset to gather
         if self._play.gather_subset is not None:
@@ -166,6 +167,9 @@ class PlayIterator:
         # Retrieve timeout for gather
         if self._play.gather_timeout is not None:
             gather_timeout = self._play.gather_timeout
+        # Retrieve list of interfaces to gather
+        if self._play.gather_network_interfaces is not None:
+            gather_interfaces = self._play.gather_network_interfaces
 
         setup_block = Block(play=self._play)
         setup_task = Task(block=setup_block)
@@ -173,6 +177,7 @@ class PlayIterator:
         setup_task.tags   = ['always']
         setup_task.args   = {
           'gather_subset': gather_subset,
+          'gather_network_interfaces': gather_interfaces,
         }
         if gather_timeout:
             setup_task.args['gather_timeout'] = gather_timeout

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -66,6 +66,7 @@ class Play(Base, Taggable, Become):
     _gather_facts        = FieldAttribute(isa='bool', default=None, always_post_validate=True)
     _gather_subset       = FieldAttribute(isa='barelist', default=None, always_post_validate=True)
     _gather_timeout      = FieldAttribute(isa='int', default=None, always_post_validate=True)
+    _gather_network_interfaces = FieldAttribute(isa='barelist', default=None, always_post_validate=True)
     _hosts               = FieldAttribute(isa='list', required=True, listof=string_types, always_post_validate=True)
     _name                = FieldAttribute(isa='string', default='', always_post_validate=True)
 


### PR DESCRIPTION
We run Ansible against hosts that have more than 100 network interfaces configured. The setup task does take multiple minutes to complete which results in problems in our day to day operations.

We know exactly that we're only interested in a limited subset of interfaces facts so we need to limit the examined data.

This patch allows us to limit the fact gathering via a configuration entry like:

```
gather_network_interfaces = lo*,eth0,eth1
```

The overall gain here is the runtime for each setup task which drops from multiple minutes (2 - 10 minutes depending on the instance) to about 5 seconds.

This PR needs the additional change in https://github.com/ansible/ansible-modules-core/pull/4865
