### PR TITLE
Improve inventory script error messages.

### DIFF
--- a/lib/ansible/inventory/dir.py
+++ b/lib/ansible/inventory/dir.py
@@ -52,7 +52,6 @@ def get_file_parser(hostsfile, groups, loader):
     except:
         pass
 
-
     #FIXME: make this 'plugin loop'
     # script
     if loader.is_executable(hostsfile):
@@ -62,7 +61,8 @@ def get_file_parser(hostsfile, groups, loader):
         except Exception as e:
             myerr.append(str(e))
     elif shebang_present:
-        myerr.append("The file %s looks like it should be an executable inventory script, but is not marked executable. Perhaps you want to correct this with `chmod +x %s`?" % (hostsfile, hostsfile))
+
+        myerr.append("The inventory file \'%s\' looks like it should be an executable inventory script, but is not marked executable. Perhaps you want to correct this with `chmod +x %s`?" % (hostsfile, hostsfile))
 
     # YAML/JSON
     if not processed and not shebang_present and os.path.splitext(hostsfile)[-1] in C.YAML_FILENAME_EXTENSIONS:
@@ -81,7 +81,7 @@ def get_file_parser(hostsfile, groups, loader):
             myerr.append(str(e))
 
     if not processed and myerr:
-        raise AnsibleError( '\n'.join(myerr) )
+        raise AnsibleError('\n'.join(myerr))
 
     return parser
 
@@ -191,7 +191,6 @@ class InventoryDirectory(object):
                     # info
                     allgroup.child_groups.remove(group)
 
-
     def _add_group(self, group):
         """ Merge an existing group or add a new one;
             Track parent and child groups, and hosts of the new one """
@@ -225,7 +224,7 @@ class InventoryDirectory(object):
 
         # name
         if group.name != newgroup.name:
-            raise AnsibleError("Cannot merge group %s with %s" % (group.name, newgroup.name))
+            raise AnsibleError("Cannot merge inventory group %s with %s" % (group.name, newgroup.name))
 
         # depth
         group.depth = max([group.depth, newgroup.depth])
@@ -245,7 +244,6 @@ class InventoryDirectory(object):
                 for hostgroup in [g for g in host.groups]:
                     if hostgroup.name == group.name and hostgroup != self.groups[group.name]:
                         self.hosts[host.name].groups.remove(hostgroup)
-
 
         # group child membership relation
         for newchild in newgroup.child_groups:
@@ -298,4 +296,3 @@ class InventoryDirectory(object):
         for i in self.parsers:
             vars.update(i.get_host_variables(host))
         return vars
-


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

lib/ansible/inventory/dir.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

ansible 2.2.0 (inventory_file ee03631b75) last updated 2016/09/15 12:53:56 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 4a74c58ead) last updated 2016/09/15 12:24:47 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD aa45bd8a94) last updated 2016/09/15 12:24:47 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = ['/home/adrian/src/ansible-modules-core', '/home/adrian/src/ansible-modules-extras']

```

```
##### SUMMARY

When an inventory file looks executable (with a #!) but
isn't, the error message could be confusing. Especially
if the inventory file was named something like 'inventory'
or 'hosts'. Add some context and quote the filename.

This is based on https://github.com/ansible/ansible/pull/15758

examples:

```
[fedora-23:ansible (devel % u=)]$ ansible-playbook -vvvvv -i inventory ping.yml 
Using /home/adrian/ansible/ansible.cfg as config file
ERROR! The file inventory looks like it should be an executable inventory script, but is not marked executable. Perhaps you want to correct this with `chmod +x inventory`?
[fedora-23:ansible (devel % u=)]$ git checkout inventory_file 
Switched to branch 'inventory_file'
[fedora-23:ansible (inventory_file %)]$ ansible-playbook -vvvvv -i inventory ping.yml 
Using /home/adrian/ansible/ansible.cfg as config file
ERROR! The inventory file 'inventory' looks like it should be an executable inventory script, but is not marked executable. Perhaps you want to correct this with `chmod +x inventory`?
```
