### PR TITLE
During initial argument evaluation, cast args to string.

### DIFF
--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -165,6 +165,8 @@ class ModuleArgsParser:
         # we don't allow users to set them directy in arguments
         if args and action not in ('command', 'win_command', 'shell', 'win_shell', 'script', 'raw'):
             for arg in args:
+                if not isinstance(arg, str) or not isinstance(arg, unicode):
+                    arg = str(arg)
                 if arg.startswith('_ansible_'):
                     raise AnsibleError("invalid parameter specified for action '%s': '%s'" % (action, arg))
 

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -167,7 +167,7 @@ class ModuleArgsParser:
         if args and action not in ('command', 'win_command', 'shell', 'win_shell', 'script', 'raw'):
             for arg in args:
                 if not isinstance(arg, text_type):
-                    arg = str(arg)
+                    arg = text_type(arg)
                 if arg.startswith('_ansible_'):
                     raise AnsibleError("invalid parameter specified for action '%s': '%s'" % (action, arg))
 

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -21,8 +21,8 @@ __metaclass__ = type
 
 from ansible.compat.six import iteritems, string_types
 
-from ansible.compat.six import string_types, text_type
 from ansible.errors import AnsibleParserError,AnsibleError
+from ansible.module_utils._text import to_text
 from ansible.plugins import module_loader
 from ansible.parsing.splitter import parse_kv, split_args
 from ansible.template import Templar
@@ -166,8 +166,7 @@ class ModuleArgsParser:
         # we don't allow users to set them directy in arguments
         if args and action not in ('command', 'win_command', 'shell', 'win_shell', 'script', 'raw'):
             for arg in args:
-                if not isinstance(arg, text_type):
-                    arg = text_type(arg)
+                arg = to_text(arg)
                 if arg.startswith('_ansible_'):
                     raise AnsibleError("invalid parameter specified for action '%s': '%s'" % (action, arg))
 

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -21,6 +21,7 @@ __metaclass__ = type
 
 from ansible.compat.six import iteritems, string_types
 
+from ansible.compat.six import string_types, text_type
 from ansible.errors import AnsibleParserError,AnsibleError
 from ansible.plugins import module_loader
 from ansible.parsing.splitter import parse_kv, split_args
@@ -165,7 +166,7 @@ class ModuleArgsParser:
         # we don't allow users to set them directy in arguments
         if args and action not in ('command', 'win_command', 'shell', 'win_shell', 'script', 'raw'):
             for arg in args:
-                if not isinstance(arg, str) or not isinstance(arg, unicode):
+                if not isinstance(arg, text_type):
                     arg = str(arg)
                 if arg.startswith('_ansible_'):
                     raise AnsibleError("invalid parameter specified for action '%s': '%s'" % (action, arg))


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

argument parser
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.2
```
##### SUMMARY

During initial argument evaluation, cast args to string.

Later in the stack, further code will check and inform the user that var names must start with a letter
or underscore, so this fix only allows us to get to that previously existing policy.

Fixes #16008
