### PR TITLE
Fix test_play_context fail with local config.

### DIFF
--- a/test/units/playbook/test_play_context.py
+++ b/test/units/playbook/test_play_context.py
@@ -53,7 +53,7 @@ class TestPlayContext(unittest.TestCase):
     def test_play_context(self):
         (options, args) = self._parser.parse_args(['-vv', '--check'])
         play_context = PlayContext(options=options)
-        self.assertEqual(play_context.connection, 'smart')
+        self.assertEqual(play_context.connection, C.DEFAULT_TRANSPORT)
         self.assertEqual(play_context.remote_addr, None)
         self.assertEqual(play_context.remote_user, None)
         self.assertEqual(play_context.password, '')


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

test/units/test_play_context.py
##### ANSIBLE VERSION

```
ansible 2.2.0 (test_play_context_transport a2eaab42fe) last updated 2016/09/15 15:59:32 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 48d932643b) last updated 2016/09/15 15:04:14 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD aa45bd8a94) last updated 2016/09/15 12:24:47 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = ['/home/adrian/src/ansible-modules-core', '/home/adrian/src/ansible-modules-extras']


```
##### SUMMARY

If the current ansible enviroment has a config setup
that doesn't use 'smart' as the configured transport
test_play_context would fail when it assumes the
transport will be 'smart'.

Before:

```
[fedora-23:ansible (devel % u=)]$ echo $ANSIBLE_CONFIG
/home/adrian/ansible/ansible.cfg
[fedora-23:ansible (devel % u=)]$ grep transport $ANSIBLE_CONFIG
#transport      = smart
#transport = paramiko
transport = ssh
[fedora-23:ansible (devel % u=)]$ PYTHONPATH=./lib nosetests-3.5 --with-noselog --noselog-level=DEBUG  -d -v -s -w test/units/ playbook/test_play_context.py
test_play_context (units.playbook.test_play_context.TestPlayContext) ... FAIL
test_play_context_make_become_cmd (units.playbook.test_play_context.TestPlayContext) ... ok
test_override_magic_variables (units.playbook.test_play_context.TestTaskAndVariableOverrride) ... ok

======================================================================
FAIL: test_play_context (units.playbook.test_play_context.TestPlayContext)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/adrian/src/ansible/test/units/playbook/test_play_context.py", line 55, in test_play_context
    self.assertEqual(play_context.connection, 'smart')
AssertionError: 'ssh' != 'smart'
- ssh
+ smart

    """Fail immediately, with the given message."""
>>  raise self.failureException("'ssh' != 'smart'\n- ssh\n+ smart\n")


----------------------------------------------------------------------
Ran 3 tests in 0.026s

FAILED (failures=1)
```

After:

```
[fedora-23:ansible (test_play_context_transport %)]$ PYTHONPATH=./lib nosetests-3.5 --with-noselog --noselog-level=DEBUG  -d -v -s -w test/units/ playbook/test_play_context.py
test_play_context (units.playbook.test_play_context.TestPlayContext) ... [DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..
This feature will be removed in version 2.4. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.
ok
test_play_context_make_become_cmd (units.playbook.test_play_context.TestPlayContext) ... ok
test_override_magic_variables (units.playbook.test_play_context.TestTaskAndVariableOverrride) ... ok

----------------------------------------------------------------------
Ran 3 tests in 0.011s

OK
```
