### PR TITLE
Do not use bare vars in integration tests.

### DIFF
--- a/test/integration/roles/test_conditionals/tasks/main.yml
+++ b/test/integration/roles/test_conditionals/tasks/main.yml
@@ -292,7 +292,7 @@
 
 - name: test a with_items loop skipping a single item
   debug: var=item
-  with_items: cond_list_of_items.results
+  with_items: "{{cond_list_of_items.results}}"
   when: item != 'b'
   register: result
 

--- a/test/integration/roles/test_iterators/tasks/main.yml
+++ b/test/integration/roles/test_iterators/tasks/main.yml
@@ -115,7 +115,7 @@
 - name: test with_subelements
   set_fact: "{{ '_'+ item.0.id + item.1 }}={{ item.1 }}"
   with_subelements:
-    - element_data
+    - "{{element_data}}"
     - the_list
 
 - name: verify with_subelements results
@@ -129,7 +129,7 @@
 - name: test with_subelements in subkeys
   set_fact: "{{ '_'+ item.0.id + item.1 }}={{ item.1 }}"
   with_subelements:
-    - element_data
+    - "{{element_data}}"
     - the.sub.key.list
 
 - name: verify with_subelements in subkeys results
@@ -143,7 +143,7 @@
 - name: test with_subelements with missing key or subkey
   set_fact: "{{ '_'+ item.0.id + item.1 }}={{ item.1 }}"
   with_subelements:
-    - element_data_missing
+    - "{{element_data_missing}}"
     - the.sub.key.list
     - skip_missing: yes
   register: _subelements_missing_subkeys
@@ -227,7 +227,7 @@
 
 - name: create indexed list
   set_fact: "{{ item[1] + item[0]|string }}=set"
-  with_indexed_items: list_data.stdout_lines  
+  with_indexed_items: "{{list_data.stdout_lines}}"
 
 - name: verify with_indexed_items result
   assert:

--- a/test/integration/roles/test_lookups/tasks/main.yml
+++ b/test/integration/roles/test_lookups/tasks/main.yml
@@ -170,7 +170,7 @@
 
 - name: use bare interpolation
   debug: msg="got {{item}}"
-  with_items: things1
+  with_items: "{{things1}}"
   register: bare_var
 
 - name: verify that list was interpolated
@@ -187,7 +187,7 @@
 
 - name: use list with undefined var in it
   debug: msg={{item}}
-  with_items: things2
+  with_items: "{{things2}}"
   ignore_errors: True
 
 

--- a/test/integration/roles/test_mysql_user/tasks/main.yml
+++ b/test/integration/roles/test_mysql_user/tasks/main.yml
@@ -112,7 +112,7 @@
 
 - name: assert grant access for user2 on multiple database
   assert: { that: "'{{ item }}' in result.stdout" }
-  with_items: db_names
+  with_items: "{{db_names}}"
 
 - include: remove_user.yml user_name={{user_name_1}} user_password={{ user_password_1 }}
 

--- a/test/integration/roles/test_uri/tasks/main.yml
+++ b/test/integration/roles/test_uri/tasks/main.yml
@@ -232,7 +232,7 @@
 - name: install OS packages that are needed for SNI on old python
   package:
     name: "{{ item }}"
-  with_items: "{{ uri_os_packages[ansible_os_family] }}"
+  with_items: "{{ uri_os_packages[ansible_os_family] | default([]) }}"
   when: not ansible_python.has_sslcontext and not is_ubuntu_precise|bool
 
 - name: install python modules for Older Python SNI verification
@@ -268,7 +268,7 @@
   package:
     name: "{{ item }}"
     state: absent
-  with_items: "{{ uri_os_packages[ansible_os_family] }}"
+  with_items: "{{ uri_os_packages[ansible_os_family] | default([]) }}"
   when: not ansible_python.has_sslcontext and not is_ubuntu_precise|bool
 
 - name: validate the status_codes are correct

--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -61,7 +61,6 @@ class TestTemplar(unittest.TestCase):
         self.assertEqual(templar.template("{{foo}}\n"), "bar\n")
         self.assertEqual(templar.template("{{foo}}\n", preserve_trailing_newlines=True), "bar\n")
         self.assertEqual(templar.template("{{foo}}\n", preserve_trailing_newlines=False), "bar")
-        self.assertEqual(templar.template("foo", convert_bare=True), "bar")
         self.assertEqual(templar.template("{{bam}}"), "bar")
         self.assertEqual(templar.template("{{num}}"), 1)
         self.assertEqual(templar.template("{{var_true}}"), True)


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

Integration and Unit Tests
##### ANSIBLE VERSION

```
ansible 2.2.0 (no-bare-vars 4f0febc6a0) last updated 2016/09/15 14:30:15 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 48d932643b) last updated 2016/09/15 14:30:21 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD aa45bd8a94) last updated 2016/09/15 14:30:21 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Bare vars are deprecated and will be removed before 2.2 is released. This PR updates unit and integration tests to avoid use of bare vars so support for them can be removed.
