### PR TITLE
Use default on undefined vars in tests.

### DIFF
--- a/test/integration/roles/test_conditionals/tasks/main.yml
+++ b/test/integration/roles/test_conditionals/tasks/main.yml
@@ -281,7 +281,7 @@
 - block:
   - name: test a with_items loop using a variable with a missing attribute
     debug: var=item
-    with_items: "{{cond_bad_attribute.results}}"
+    with_items: "{{cond_bad_attribute.results | default('')}}"
     register: result
   - set_fact: skipped_bad_attribute=False
   - name: assert the task was skipped

--- a/test/integration/vars_file.yml
+++ b/test/integration/vars_file.yml
@@ -8,5 +8,5 @@ things1:
     - 2
 things2:
     - "{{ foo }}"
-    - "{{ foob }}"
+    - "{{ foob | default('') }}"
 vars_file_var: 321


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

Integration Tests
##### ANSIBLE VERSION

```
ansible 2.2.0 (no-undefined f8ff8e5118) last updated 2016/09/15 15:35:37 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 48d932643b) last updated 2016/09/15 14:30:21 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD aa45bd8a94) last updated 2016/09/15 14:30:21 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Skipping an undefined attribute or var in a loop is deprecated and will be removed before 2.2 is released. This PR updates integration tests to provide default values for undefined vars/attributes so the deprecated skipping behavior can be removed.
