### PR TITLE
Unescape cli output and error messages

### DIFF
--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -18,6 +18,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import codecs
 import fcntl
 import textwrap
 import os
@@ -105,6 +106,10 @@ class Display:
 
         # FIXME: this needs to be implemented
         #msg = utils.sanitize_output(msg)
+
+        msg, unused = codecs.escape_decode(msg.encode('utf8'))
+        msg = msg.decode()
+
         nocolor = msg
         if color:
             msg = stringc(msg, color)


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

lib/ansible/utils/display.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (minimal_better_ssh_failures 456a6bc9ad) last updated 2016/09/15 18:55:37 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 48d932643b) last updated 2016/09/15 17:01:15 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD aa45bd8a94) last updated 2016/09/15 17:01:15 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = ['/home/adrian/src/ansible-modules-core', '/home/adrian/src/ansible-modules-extras']

```
##### SUMMARY

Use escape_decode() to unescape things like '\n'
from error messages and other strings.

Especially useful when used with https://github.com/ansible/ansible/pull/17598
