### PR TITLE
copy action plugin: recurse into sub folders of the source

### DIFF
--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -121,7 +121,7 @@ class ActionModule(ActionBase):
 
                 # recurse into subdirs
                 for sf in sub_folders:
-                    source_files += self._get_recursive_files(os.path.join(source, sf), sz=sz)
+                    source_files += self._get_recursive_files(os.path.join(source, to_text(sf)), sz=sz)
 
             # If it's recursive copy, destination is always a dir,
             # explicitly mark it so (note - copy module relies on this).

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -324,7 +324,7 @@ class ActionModule(ActionBase):
                 r_files.append((full_path, rel_path))
 
                 for sf in sub_folders:
-                    r_files += self._get_recursive_files(os.path.join(topdir, sf), sz=sz)
+                    r_files += self._get_recursive_files(os.path.join(topdir, to_text(sf)), sz=sz)
         return r_files
 
     def _create_content_tempfile(self, content):

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -119,6 +119,10 @@ class ActionModule(ActionBase):
                         rel_path = rel_path[1:]
                     source_files.append((full_path, rel_path))
 
+                # recurse into subdirs
+                for sf in sub_folders:
+                    source_files += self._get_recursive_files(os.path.join(source, sf), sz=sz)
+
             # If it's recursive copy, destination is always a dir,
             # explicitly mark it so (note - copy module relies on this).
             if not self._connection._shell.path_has_trailing_slash(dest):
@@ -307,6 +311,21 @@ class ActionModule(ActionBase):
             result['diff'] = diffs
 
         return result
+
+    def _get_recursive_files(self, topdir, sz=0):
+        ''' Recursively create file tuples for sub folders '''
+        r_files = []
+        for base_path, sub_folders, files in os.walk(to_bytes(topdir)):
+            for fname in files:
+                full_path = to_text(os.path.join(base_path, fname), errors='surrogate_or_strict')
+                rel_path = full_path[sz:]
+                if rel_path.startswith('/'):
+                    rel_path = rel_path[1:]
+                r_files.append((full_path, rel_path))
+
+                for sf in sub_folders:
+                    r_files += self._get_recursive_files(os.path.join(topdir, sf), sz=sz)
+        return r_files
 
     def _create_content_tempfile(self, content):
         ''' Create a tempfile containing defined content '''

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -325,6 +325,7 @@ class ActionModule(ActionBase):
 
                 for sf in sub_folders:
                     r_files += self._get_recursive_files(os.path.join(topdir, to_text(sf)), sz=sz)
+
         return r_files
 
     def _create_content_tempfile(self, content):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

copy action plugin
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.2
```
##### SUMMARY

Fixes #13013
