### PR TITLE
Fix dataloader using deprecated version of is_encrypted

### DIFF
--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -31,7 +31,7 @@ from ansible.errors import AnsibleFileNotFound, AnsibleParserError, AnsibleError
 from ansible.errors.yaml_strings import YAML_SYNTAX_ERROR
 from ansible.module_utils.basic import is_executable
 from ansible.module_utils._text import to_bytes, to_native, to_text
-from ansible.parsing.vault import VaultLib
+from ansible.parsing.vault import VaultLib, is_encrypted, is_encrypted_file
 from ansible.parsing.quoting import unquote
 from ansible.parsing.yaml.loader import AnsibleLoader
 from ansible.parsing.yaml.objects import AnsibleBaseYAMLObject, AnsibleUnicode
@@ -174,7 +174,7 @@ class DataLoader():
         try:
             with open(b_file_name, 'rb') as f:
                 data = f.read()
-                if self._vault.is_encrypted(data):
+                if is_encrypted(data):
                     data = self._vault.decrypt(data, filename=b_file_name)
                     show_content = False
 
@@ -395,7 +395,7 @@ class DataLoader():
 
         try:
             with open(to_bytes(real_path), 'rb') as f:
-                if self._vault.is_encrypted_file(f):
+                if is_encrypted_file(f):
                     # if the file is encrypted and no password was specified,
                     # the decrypt call would throw an error, but we check first
                     # since the decrypt function doesn't know the file name

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -111,7 +111,7 @@ class Play(Base, Taggable, Become):
             if isinstance(data['hosts'], list):
                 data['name'] = ','.join(data['hosts'])
             else:
-                 data['name'] = data['hosts']
+                data['name'] = data['hosts']
         p = Play()
         return p.load_data(data, variable_manager=variable_manager, loader=loader)
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

dataloader.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
devel
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```
