### PR TITLE
Fix distribution fact on DragonFly

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -673,7 +673,7 @@ class Distribution(object):
         self.facts['distribution'] = self.system
         self.facts['distribution_release'] = platform.release()
         self.facts['distribution_version'] = platform.version()
-        systems_implemented = ('AIX', 'HP-UX', 'Darwin', 'FreeBSD', 'OpenBSD', 'SunOS')
+        systems_implemented = ('AIX', 'HP-UX', 'Darwin', 'FreeBSD', 'OpenBSD', 'SunOS', 'DragonFly')
 
         self.facts['distribution'] = self.system
 
@@ -776,6 +776,9 @@ class Distribution(object):
             self.facts['distribution_version'] = match.groups()[0]
         else:
             self.facts['distribution_version'] = 'release'
+
+    def get_distribution_DragonFly(self):
+        pass
 
     def get_distribution_Slackware(self, name, data, path):
         if 'Slackware' not in data:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.2.0 0.0.devel
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

ansible_distribution is not set on DragonFly systems, preventing useful tests from being written.
The change sets ansible_distribution to "DragonFly" on DragonFly systems.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
ansible all -c local -i inventory -m setup
before:
        "ansible_distribution": "NA", 
        "ansible_distribution_major_version": "NA", 
        "ansible_distribution_release": "NA", 
        "ansible_distribution_version": "NA", 
after:
       "ansible_distribution": "DragonFly", 
        "ansible_distribution_release": "4.7-DEVELOPMENT", 
        "ansible_distribution_version": "DragonFly v4.7.0.385.g1f249-DEV", 
```
- By default, ansible_distribution is not set on DragonFly systems,
  preventing some distribution-specific tests from being written
- This commit fixes the issue by returning the quite logical value
  of "DragonFly" when appropriate
