### PR TITLE
fixes AttributeError: 'Task' object has no attribute '_block'

### DIFF
--- a/lib/ansible/plugins/action/net_config.py
+++ b/lib/ansible/plugins/action/net_config.py
@@ -108,10 +108,11 @@ class ActionModule(ActionBase):
         searchpath = [working_path]
         if self._task._role is not None:
             searchpath.append(self._task._role._role_path)
-            dep_chain = self._task._block.get_dep_chain()
-            if dep_chain is not None:
-                for role in dep_chain:
-                    searchpath.append(role._role_path)
+            if hasattr(self._task, "_block:"):
+                dep_chain = self._task._block.get_dep_chain()
+                if dep_chain is not None:
+                    for role in dep_chain:
+                        searchpath.append(role._role_path)
         searchpath.append(os.path.dirname(source))
         self._templar.environment.loader.searchpath = searchpath
         self._task.args['src'] = self._templar.template(template_data)

--- a/lib/ansible/plugins/action/net_template.py
+++ b/lib/ansible/plugins/action/net_template.py
@@ -101,10 +101,11 @@ class ActionModule(ActionBase):
         searchpath = [working_path]
         if self._task._role is not None:
             searchpath.append(self._task._role._role_path)
-            dep_chain = self._task._block.get_dep_chain()
-            if dep_chain is not None:
-                for role in dep_chain:
-                    searchpath.append(role._role_path)
+            if hasattr(self._task, "_block:"):
+                dep_chain = self._task._block.get_dep_chain()
+                if dep_chain is not None:
+                    for role in dep_chain:
+                        searchpath.append(role._role_path)
         searchpath.append(os.path.dirname(source))
         self._templar.environment.loader.searchpath = searchpath
         self._task.args['src'] = self._templar.template(template_data)


### PR DESCRIPTION
This addresses a problem when *_config or *_template network modules are
being used in roles.  The module will error with the above message.  This
fixes that problem

fixed ansible/ansible-modules-core#4840
