### PR TITLE
Fixed transport issues when calling self.execute from Cli

### DIFF
--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -201,14 +201,20 @@ class Nxapi(NxapiConfigMixin):
 
         for cmd in commands:
             if output and output != cmd.output:
-                responses.extend(self.execute(cmds, output=output))
+                try:
+                    responses.extend(self.execute(cmds, output=output))
+                except ValueError:
+                    responses.extend(self.execute(cmds))
                 cmds = list()
 
             output = cmd.output
             cmds.append(str(cmd))
 
         if cmds:
-            responses.extend(self.execute(cmds, output=output))
+            try:
+                responses.extend(self.execute(cmds, output=output))
+            except ValueError:
+                responses.extend(self.execute(cmds))
 
         return responses
 
@@ -217,7 +223,10 @@ class Nxapi(NxapiConfigMixin):
 
     def configure(self, commands):
         commands = to_list(commands)
-        return self.execute(commands, output='config')
+        try:
+            return self.execute(commands, output='config')
+        except ValueError:
+            return self.execute(commands)
 
     def _jsonify(self, data):
         for encoding in ("utf-8", "latin-1"):

--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -201,20 +201,14 @@ class Nxapi(NxapiConfigMixin):
 
         for cmd in commands:
             if output and output != cmd.output:
-                try:
-                    responses.extend(self.execute(cmds, output=output))
-                except ValueError:
-                    responses.extend(self.execute(cmds))
+                responses.extend(self.execute(cmds, output=output))
                 cmds = list()
 
             output = cmd.output
             cmds.append(str(cmd))
 
         if cmds:
-            try:
-                responses.extend(self.execute(cmds, output=output))
-            except ValueError:
-                responses.extend(self.execute(cmds))
+            responses.extend(self.execute(cmds, output=output))
 
         return responses
 
@@ -223,10 +217,7 @@ class Nxapi(NxapiConfigMixin):
 
     def configure(self, commands):
         commands = to_list(commands)
-        try:
-            return self.execute(commands, output='config')
-        except ValueError:
-            return self.execute(commands)
+        return self.execute(commands, output='config')
 
     def _jsonify(self, data):
         for encoding in ("utf-8", "latin-1"):

--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -43,7 +43,10 @@ class NxapiConfigMixin(object):
 
     def load_config(self, config):
         checkpoint = 'ansible_%s' % int(time.time())
-        self.execute(['checkpoint %s' % checkpoint], output='text')
+        try:
+            self.execute(['checkpoint %s' % checkpoint], output='text')
+        except TypeError:
+            self.execute(['checkpoint %s' % checkpoint])
 
         try:
             self.configure(config)
@@ -51,14 +54,21 @@ class NxapiConfigMixin(object):
             self.load_checkpoint(checkpoint)
             raise
 
-        self.execute(['no checkpoint %s' % checkpoint], output='text')
+        try:
+            self.execute(['no checkpoint %s' % checkpoint], output='text')
+        except TypeError:
+            self.execute(['no checkpoint %s' % checkpoint])
 
     def save_config(self, **kwargs):
         self.execute(['copy running-config startup-config'])
 
     def load_checkpoint(self, checkpoint):
-        self.execute(['rollback running-config checkpoint %s' % checkpoint,
-                      'no checkpoint %s' % checkpoint], output='text')
+        try:
+            self.execute(['rollback running-config checkpoint %s' % checkpoint,
+                          'no checkpoint %s' % checkpoint], output='text')
+        except TypeError:
+            self.execute(['rollback running-config checkpoint %s' % checkpoint,
+                          'no checkpoint %s' % checkpoint])
 
 
 class Nxapi(NxapiConfigMixin):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

nxos
##### ANSIBLE VERSION

```
ansible 2.2.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

PR #17622 introduces another error in nxos.py when a module is using Cli as transport.  The Cli class has no "output" variable in the method definition.  This PR simply adds a try/except block to call the correct version of self.execute from nxos.py.  This fix uncovers other bugs in ansible-modules-core.  I will work on those under a different PR to that repo.

```

```
