### PR TITLE
Fix #17624

### DIFF
--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -163,8 +163,7 @@ def _net_query(v):
             return str(v.network) + '/' + str(v.prefixlen)
 
 def _netmask_query(v):
-    if v.size > 1:
-        return str(v.netmask)
+    return str(v.netmask)
 
 def _network_query(v):
     if v.size > 1:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ipaddr filter
##### SUMMARY

Even if the size of the network is 0, it should have a netmask.
