### PR TITLE
cloudstack: fix has_changed dict values comparsion

### DIFF
--- a/lib/ansible/module_utils/cloudstack.py
+++ b/lib/ansible/module_utils/cloudstack.py
@@ -158,7 +158,17 @@ class AnsibleCloudStack(object):
                 continue
 
             if key in current_dict:
-                if isinstance(current_dict[key], (int, long, float, complex)):
+                if isinstance(value, (int, float, long, complex)):
+                    # ensure we compare the same type
+                    if isinstance(value, int):
+                        current_dict[key] = int(current_dict[key])
+                    elif isinstance(value, float):
+                        current_dict[key] = float(current_dict[key])
+                    elif isinstance(value, long):
+                        current_dict[key] = long(current_dict[key])
+                    elif isinstance(value, complex):
+                        current_dict[key] = complex(current_dict[key])
+
                     if value != current_dict[key]:
                         return True
                 else:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

module_utils/cloudstack.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.1
```
##### SUMMARY

In some rare situations, the CloudStack API returns string for numbers
when we expected int. This results in comparing different things `current_dict[key]` (str) with `wanted_dict[key]` alias value (int) and in a specific case in a traceback when trying to lowercase a int.

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'int' object has no attribute 'lower'
```

With this fix, we switch to look at the type of the `wanted_dict` item, of which we have much more control and cast the `current_dict` to ensure we compare the types expected.
