### PR TITLE
Fix to handle the prompt on saving startup config

### DIFF
--- a/lib/ansible/module_utils/dellos9.py
+++ b/lib/ansible/module_utils/dellos9.py
@@ -123,7 +123,10 @@ class Cli(CliBase):
 
 
     def save_config(self):
-        self.execute(['copy running-config startup-config'])
+        cmdlist = list()
+        cmd = 'copy running-config startup-config'
+        cmdlist.append(Command(cmd, prompt=self.WARNING_PROMPTS_RE, response='yes'))
+        self.execute(cmdlist)
 
 
 Cli = register_transport('cli', default=True)(Cli)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME
- modules/core/network/dellos10/dellos10_config
##### ANSIBLE VERSION
- ansible 2.2.0 (devel 42a2875b83) last updated 2016/09/19 14:03:09 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 27d2950e2d) last updated 2016/09/19 14:03:22 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD ddbd63c8a6) last updated 2016/09/19 14:03:22 (GMT -700)
  config file = /home/skg/lothlorien/test-network-modules/ansible.cfg
  configured module search path = Default w/o overrides
##### SUMMARY
- Fix to handle prompt when, when the startup config file, already exists. In current release, we don't support, user options y/n in the playbook for handling prompts. Its always 'yes' by default.
