### PR TITLE
Implements verbose always to assert action plugin module

### DIFF
--- a/lib/ansible/plugins/action/assert.py
+++ b/lib/ansible/plugins/action/assert.py
@@ -51,6 +51,7 @@ class ActionModule(ActionBase):
         # by this point, and is not used again, so we don't care about mangling
         # that value now
         cond = Conditional(loader=self._loader)
+        result['_ansible_verbose_always'] = True
         for that in thats:
             cond.when = [that]
             test_result = cond.evaluate_conditional(templar=self._templar, all_vars=task_vars)
@@ -65,5 +66,5 @@ class ActionModule(ActionBase):
                 return result
 
         result['changed'] = False
-        result['msg'] = 'all assertions passed'
+        result['msg'] = 'All assertions passed'
         return result


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

assert module
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.2.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Added verbose_always to results of assert module return so msg actually displays
