### PR TITLE
Append exceptions to retry

### DIFF
--- a/lib/ansible/module_utils/cloud.py
+++ b/lib/ansible/module_utils/cloud.py
@@ -67,7 +67,7 @@ class CloudRetry(object):
         pass
 
     @classmethod
-    def backoff(cls, tries=10, delay=3, backoff=1.1):
+    def backoff(cls, tries=10, delay=3, backoff=1.1, added_exceptions=list()):
         """ Retry calling the Cloud decorated function using an exponential backoff.
         Kwargs:
             tries (int): Number of times to try (not retry) before giving up
@@ -76,6 +76,8 @@ class CloudRetry(object):
                 default=3
             backoff (int): backoff multiplier e.g. value of 2 will double the delay each retry
                 default=2
+            added_exceptions (list): Other exceptions to retry on.
+                default=[]
 
         """
         def deco(f):
@@ -89,7 +91,7 @@ class CloudRetry(object):
                         e = get_exception()
                         if isinstance(e, cls.base_class):
                             response_code = cls.status_code_from_exception(e)
-                            if cls.found(response_code):
+                            if cls.found(response_code, added_exceptions):
                                 msg = "{0}: Retrying in {1} seconds...".format(str(e), max_delay)
                                 syslog.syslog(syslog.LOG_INFO, msg)
                                 time.sleep(max_delay)

--- a/lib/ansible/module_utils/cloud.py
+++ b/lib/ansible/module_utils/cloud.py
@@ -48,7 +48,13 @@ class CloudRetry(object):
     """
     # This is the base class of the exception.
     # AWS Example botocore.exceptions.ClientError
-    base_class = None
+    @staticmethod
+    def base_class(error):
+        """ Return the base class of the error you are matching against
+        Args:
+            error (object): The exception itself.
+        """
+        pass
 
     @staticmethod
     def status_code_from_exception(error):
@@ -89,7 +95,8 @@ class CloudRetry(object):
                         return f(*args, **kwargs)
                     except Exception:
                         e = get_exception()
-                        if isinstance(e, cls.base_class):
+                        base_exception_class = cls.base_class(e)
+                        if isinstance(e, base_exception_class):
                             response_code = cls.status_code_from_exception(e)
                             if cls.found(response_code, added_exceptions):
                                 msg = "{0}: Retrying in {1} seconds...".format(str(e), max_delay)

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -65,8 +65,7 @@ def _botocore_exception_maybe():
     """
     if HAS_BOTO3:
         return botocore.exceptions.ClientError
-    else:
-        return boto.exceptions
+    return type(None)
 
 
 class AWSRetry(CloudRetry):

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -76,13 +76,14 @@ class AWSRetry(CloudRetry):
         return error.response['Error']['Code']
 
     @staticmethod
-    def found(response_code):
+    def found(response_code, added_exceptions):
         # This list of failures is based on this API Reference
         # http://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html
         retry_on = [
             'RequestLimitExceeded', 'Unavailable', 'ServiceUnavailable',
             'InternalFailure', 'InternalError'
         ]
+        retry_on.extend(added_exceptions)
 
         not_found = re.compile(r'^\w+.NotFound')
         if response_code in retry_on or not_found.search(response_code):

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -65,15 +65,28 @@ def _botocore_exception_maybe():
     """
     if HAS_BOTO3:
         return botocore.exceptions.ClientError
-    return type(None)
+    else:
+        return boto.exceptions
 
 
 class AWSRetry(CloudRetry):
-    base_class = _botocore_exception_maybe()
+    @staticmethod
+    def base_class(error):
+        if isinstance(error, botocore.exceptions.ClientError):
+            return botocore.exceptions.ClientError
+
+        elif isinstance(error, boto.compat.StandardError):
+            return boto.compat.StandardError
+
+        else:
+            return type(None)
 
     @staticmethod
     def status_code_from_exception(error):
-        return error.response['Error']['Code']
+        if isinstance(error, botocore.exceptions.ClientError):
+            return error.response['Error']['Code']
+        else:
+            return error.error_code
 
     @staticmethod
     def found(response_code, added_exceptions):

--- a/test/units/module_utils/ec2/test_aws.py
+++ b/test/units/module_utils/ec2/test_aws.py
@@ -17,6 +17,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
+import boto
 import botocore
 import boto3
 
@@ -34,7 +35,7 @@ class RetryTestCase(unittest.TestCase):
         r = no_failures()
         self.assertEqual(self.counter, 1)
 
-    def test_extend_failures(self):
+    def test_extend_boto3_failures(self):
         self.counter = 0
         err_msg = {'Error': {'Code': 'MalformedPolicyDocument'}}
 
@@ -43,6 +44,22 @@ class RetryTestCase(unittest.TestCase):
             self.counter += 1
             if self.counter < 2:
                 raise botocore.exceptions.ClientError(err_msg, 'Could not find you')
+            else:
+                return 'success'
+
+        r = extend_failures()
+        self.assertEqual(r, 'success')
+        self.assertEqual(self.counter, 2)
+
+    def test_extend_boto_failures(self):
+        self.counter = 0
+        err_msg = {'Error': {'Code': 'MalformedPolicy'}}
+
+        @AWSRetry.backoff(tries=2, delay=0.1, added_exceptions=['MalformedPolicy'])
+        def extend_failures():
+            self.counter += 1
+            if self.counter < 2:
+                raise boto.exception.S3ResponseError(200, 'Could not find you', body=err_msg)
             else:
                 return 'success'
 

--- a/test/units/module_utils/ec2/test_aws.py
+++ b/test/units/module_utils/ec2/test_aws.py
@@ -34,6 +34,22 @@ class RetryTestCase(unittest.TestCase):
         r = no_failures()
         self.assertEqual(self.counter, 1)
 
+    def test_extend_failures(self):
+        self.counter = 0
+        err_msg = {'Error': {'Code': 'MalformedPolicyDocument'}}
+
+        @AWSRetry.backoff(tries=2, delay=0.1, added_exceptions=['MalformedPolicyDocument'])
+        def extend_failures():
+            self.counter += 1
+            if self.counter < 2:
+                raise botocore.exceptions.ClientError(err_msg, 'Could not find you')
+            else:
+                return 'success'
+
+        r = extend_failures()
+        self.assertEqual(r, 'success')
+        self.assertEqual(self.counter, 2)
+
     def test_retry_once(self):
         self.counter = 0
         err_msg = {'Error': {'Code': 'InstanceId.NotFound'}}

--- a/test/utils/tox/requirements-py3.txt
+++ b/test/utils/tox/requirements-py3.txt
@@ -11,5 +11,6 @@ unittest2
 redis
 python3-memcached
 python-systemd
+boto
 botocore
 boto3

--- a/test/utils/tox/requirements.txt
+++ b/test/utils/tox/requirements.txt
@@ -12,5 +12,6 @@ redis
 python-memcached
 python-systemd
 pycrypto
+boto
 botocore
 boto3


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

AWSRetry Decorator
##### ANSIBLE VERSION

```
ansible 2.2.0
```
##### SUMMARY
- Added support for boto. AWSRetry Now supports Boto and Boto3
- Added the ability to extend the default list of exceptions in AWSRetry

```
@AWSRetry.backoff(tries=2, delay=0.1, added_exceptions=['MalformedPolicy'])
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/17656)

<!-- Reviewable:end -->
