### PR TITLE
fixed mode conversion on python3 to behave as on python2

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1058,7 +1058,10 @@ class AnsibleModule(object):
         return changed
 
     def _symbolic_mode_to_octal(self, path_stat, symbolic_mode):
-        new_mode = stat.S_IMODE(path_stat.st_mode)
+        try:
+          new_mode = stat.S_IMODE(path_stat.st_mode)
+        except OverflowError:
+          raise ValueError("bad symbolic permission for mode: %s" % path_stat.st_mode)
 
         mode_re = re.compile(r'^(?P<users>[ugoa]+)(?P<operator>[-+=])(?P<perms>[rwxXst-]*|[ugo])$')
         for mode in symbolic_mode.split(','):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

module_utls/basic
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 702f405a4e) last updated 2016/09/20 15:32:56 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 600228ca7f) last updated 2016/09/20 14:52:28 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD db7a3f48e1) last updated 2016/09/20 14:52:28 (GMT +200)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

`make tests` failed as follows when running with python 3 on OS X El Capitan, either because of changes from python 2 to 3 or because the underlying implementation of os.stat is different.

This change catches the (apparently new) OverflowError exception and rethrows it as the expected ValueError.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

before:

```
# make tests
(...)
======================================================================
ERROR: test_module_utils_basic_ansible_module__symbolic_mode_to_octal (units.module_utils.test_basic.TestModuleUtilsBasic)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/matthi/projects/ansible/test/units/module_utils/test_basic.py", line 990, in test_module_utils_basic_ansible_module__symbolic_mode_to_octal
    self.assertRaises(ValueError, am._symbolic_mode_to_octal, mock_stat, 'a=foo')
  File "/usr/local/Cellar/python3/3.5.2_1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/unittest/case.py", line 727, in assertRaises
    return context.handle('assertRaises', args, kwargs)
  File "/usr/local/Cellar/python3/3.5.2_1/Frameworks/Python.framework/Versions/3.5/lib/python3.5/unittest/case.py", line 176, in handle
    callable_obj(*args, **kwargs)
  File "/Users/matthi/projects/ansible/lib/ansible/module_utils/basic.py", line 1062, in _symbolic_mode_to_octal
    new_mode = stat.S_IMODE(path_stat.st_mode)
OverflowError: mode out of range
```

after:

```
 test_module_utils_basic_ansible_module__symbolic_mode_to_octal (units.module_utils.test_basic.TestModuleUtilsBasic) ... ok
```
