### PR TITLE
Adding raw check to nxos.py

### DIFF
--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -269,7 +269,7 @@ class Cli(NxapiConfigMixin, CliBase):
         cmds = list(prepare_commands(commands))
         responses = self.execute(cmds)
         for index, cmd in enumerate(commands):
-            if cmd.output == 'json':
+            if cmd.output == 'json' and cmd.args.get('raw') is False:
                 try:
                     responses[index] = json.loads(responses[index])
                 except ValueError:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

nxos.py
##### ANSIBLE VERSION

```
ansible 2.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

This will be useful to fix some nxos modules bugs.
