### PR TITLE
Test "pip list" support only when available.

### DIFF
--- a/test/integration/roles/test_pip/tasks/main.yml
+++ b/test/integration/roles/test_pip/tasks/main.yml
@@ -120,15 +120,23 @@
 
 # Test pip package in check mode doesn't always report changed.
 
+- name: detect support for 'pip list'
+  command: pip list
+  register: pip_list
+  ignore_errors: yes
+
 - name: check for pip package
   pip: name=pip virtualenv={{ output_dir }}/pipenv state=present
+  when: "pip_list.rc == 0"
 
 - name: check for pip package in check_mode
   pip: name=pip virtualenv={{ output_dir }}/pipenv state=present
   check_mode: True
   register: pip_check_mode
+  when: "pip_list.rc == 0"
 
 - name: make sure pip in check_mode doesn't report changed
   assert:
     that:
       - "not pip_check_mode.changed"
+  when: "pip_list.rc == 0"


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

Integration Tests
##### ANSIBLE VERSION

```
ansible 2.2.0 (pip-test adda1e42ef) last updated 2016/09/20 09:51:39 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 70d4ff8e38) last updated 2016/09/20 09:43:52 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD db7a3f48e1) last updated 2016/09/20 09:43:52 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Test `pip list` support only when available.

The `make sure pip in check_mode doesn't report changed` test requires a new enough version of pip that supports `pip list`. Otherwise the pip module will fall back to the old behavior of using `pip freeze` which doesn't pass the test.
