### PR TITLE
Remove test-docs from module search ignore list.

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -338,4 +338,4 @@ TREE_DIR                  = None
 LOCALHOST                 = frozenset(['127.0.0.1', 'localhost', '::1'])
 # module search
 BLACKLIST_EXTS = ('.pyc', '.swp', '.bak', '~', '.rpm', '.md', '.txt')
-IGNORE_FILES = [ "COPYING", "CONTRIBUTING", "LICENSE", "README", "VERSION", "GUIDELINES", "test-docs.sh"]
+IGNORE_FILES = ["COPYING", "CONTRIBUTING", "LICENSE", "README", "VERSION", "GUIDELINES"]


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

constants
##### ANSIBLE VERSION

```
ansible 2.2.0 (constants 09992c67ca) last updated 2016/09/20 12:33:09 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 3486395970) last updated 2016/09/20 12:25:43 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 1f2319c3f3) last updated 2016/09/20 12:25:43 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Remove `test-docs.sh` from the module search ignore list now that the file is no longer present in the module repositories.
