### PR TITLE
Remove test for deprecated first_available_file.

### DIFF
--- a/test/integration/roles/test_copy/tasks/main.yml
+++ b/test/integration/roles/test_copy/tasks/main.yml
@@ -258,9 +258,3 @@
   assert:
     that:
     - replace_follow_result.checksum == target_file_result.stdout
-
-- name: test first avialable file
-  copy: dest={{output_dir}}/faf_test
-  first_available_file: 
-        - doesntexist.txt
-        - foo.txt


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

Integration Tests
##### ANSIBLE VERSION

```
ansible 2.2.0 (no-first-avail 7f7e1cf5b5) last updated 2016/09/20 13:17:59 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 3486395970) last updated 2016/09/20 12:56:20 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 1f2319c3f3) last updated 2016/09/20 12:56:20 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Remove test for deprecated first_available_file. The feature is deprecated and will be removed in the 2.2 release.
