### PR TITLE
Add more options to magic vars

### DIFF
--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -79,6 +79,10 @@ class AdHocCLI(CLI):
         elif len(self.args) > 1:
             raise AnsibleOptionsError("Extranous options or arguments")
 
+        if self.options.subset:
+            self.options.subset += ',%s' % self.args
+        else:
+            self.options.subset = self.args
         display.verbosity = self.options.verbosity
         self.validate_conflicts(runas_opts=True, vault_opts=True, fork_opts=True)
 

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -117,9 +117,18 @@ def load_extra_vars(loader, options):
 
 def load_options_vars(options):
     options_vars = {}
-    # For now only return check mode, but we can easily return more
+    # For now only return a few options, but we can easily return more
     # options if we need variables for them
     options_vars['ansible_check_mode'] = options.check
+    try:
+        options_vars['ansible_tags'] = options.tags.split(',')
+    except AttributeError:
+        pass
+    try:
+        options_vars['ansible_skip_tags'] = options.skip_tags.split(',')
+    except AttributeError:
+        pass
+    options_vars['ansible_limit'] = options.subset
     return options_vars
 
 

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -44,7 +44,7 @@ from ansible.utils.vars import combine_vars
 from ansible.vars.unsafe_proxy import wrap_var
 
 try:
-    from __main__ import display
+    from __main__ import display, cli
 except ImportError:
     from ansible.utils.display import Display
     display = Display()

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -44,7 +44,7 @@ from ansible.utils.vars import combine_vars
 from ansible.vars.unsafe_proxy import wrap_var
 
 try:
-    from __main__ import display, cli
+    from __main__ import display
 except ImportError:
     from ansible.utils.display import Display
     display = Display()


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### COMPONENT NAME

N/A
##### ANSIBLE VERSION

```
devel
```
##### SUMMARY

This PR adds the CLI options of `tags`, `subset` and `skip_tags` to magic vars.

The mapping is currently:
- `options.tags` -> `ansible_tags`
- `options.skip_tags` -> `ansible_skip_tags`
- `options.subset` -> `ansible_limit`

My concern with this is naming confusion.  I think `skip_tags` is fine.  I am concerned that `ansible_tags` could be confused with the tags you have placed on a task, rather than supplied on the CLI.  This goes for `ansible_limit` as well, since it could be confused with `hosts:`.

Open to suggestions.

Also, to support `ansible_limit` for adhoc, I am combining `self.args` and `self.options.subset` for adhoc.  This is effectively what adhoc does anyway.
