### PR TITLE
Additional tests for check mode idempotence

### DIFF
--- a/test/integration/roles/test_pip/tasks/main.yml
+++ b/test/integration/roles/test_pip/tasks/main.yml
@@ -117,9 +117,9 @@
     that:
       - "not url_installed.changed"
 
-
 # Test pip package in check mode doesn't always report changed.
 
+# Special case for pip
 - name: check for pip package
   pip: name=pip virtualenv={{ output_dir }}/pipenv state=present
 
@@ -132,3 +132,33 @@
   assert:
     that:
       - "not pip_check_mode.changed"
+
+# Special case for setuptools
+- name: check for setuptools package
+  pip: name=setuptools virtualenv={{ output_dir }}/pipenv state=present
+
+- name: check for setuptools package in check_mode
+  pip: name=setuptools virtualenv={{ output_dir }}/pipenv state=present
+  check_mode: True
+  register: setuptools_check_mode
+
+- name: make sure setuptools in check_mode doesn't report changed
+  assert:
+    that:
+      - "not setuptools_check_mode.changed"
+
+
+# Normal case
+- name: check for q package
+  pip: name=q virtualenv={{ output_dir }}/pipenv state=present
+
+- name: check for q package in check_mode
+  pip: name=q virtualenv={{ output_dir }}/pipenv state=present
+  check_mode: True
+  register: q_check_mode
+
+- name: make sure q in check_mode doesn't report changed
+  assert:
+    that:
+      - "not q_check_mode.changed"
+


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

test/integration/roles/test_pip
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
devel
```
##### SUMMARY

Test pip reports changed correctly in check mode for setuptools and normal packages as well as pip.
