### PR TITLE
Remove deprecated roll path arg from docs #13563

### DIFF
--- a/docsite/rst/galaxy.rst
+++ b/docsite/rst/galaxy.rst
@@ -90,7 +90,6 @@ Content of the webserver.yml file.
  
      # from github installing to a relative path
      - src: https://github.com/bennojoy/nginx
-      path: vagrant/roles/
 
 Advanced Control over Role Requirements Files
 =============================================


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

ansible-galaxy
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

I don't agree with the feature depreciation, but it at least should be removed from docs.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```

Signed-off-by: Daniel Farrell dfarrell@redhat.com
