### PR TITLE
gen_distribution_version_testcase.py should fail if ansible run fails

### DIFF
--- a/hacking/tests/gen_distribution_version_testcase.py
+++ b/hacking/tests/gen_distribution_version_testcase.py
@@ -12,6 +12,7 @@ import platform
 import os.path
 import subprocess
 import json
+import sys
 
 filelist = [
         '/etc/oracle-release',
@@ -46,7 +47,15 @@ dist = platform.dist()
 
 
 facts = ['distribution', 'distribution_version', 'distribution_release', 'distribution_major_version', 'os_family']
-ansible_out = subprocess.Popen(['ansible', 'localhost', '-m', 'setup'], stdout=subprocess.PIPE).communicate()[0]
+
+try:
+    ansible_out = subprocess.check_output(
+        ['ansible', 'localhost', '-m', 'setup'])
+except subprocess.CalledProcessError as e:
+    print("ERROR: ansible run failed, output was: \n")
+    print(e.output)
+    sys.exit(e.returncode)
+
 parsed = json.loads(ansible_out[ansible_out.index('{'):])
 ansible_facts = {}
 for fact in facts:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

hacking scripts
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 2bd1869628) last updated 2016/09/19 20:03:55 (GMT +000)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras:  not found - use git submodule update --init lib/ansible/modules/extras
  config file = /home/stephane/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Currently, "ansible localhost -m setup" can fail silently during the run of gen_distribution_version_testcase.py, resulting in incorrect output. Use check_output() rather than communicate() and handle the exception if we get a nonzero return value.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
before (assuming ansible error exit):
{
    "platform.dist": [
        "Ubuntu", 
        "14.04", 
        "trusty"
    ], 
    "input": {
        "/etc/os-release": "NAME=\"Ubuntu\"\nVERSION=\"14.04.4 LTS, Trusty Tahr\"\nID=ubuntu\nID_LIKE=debian\nPRETTY_NAME=\"Ubuntu 14.04.4 LTS\"\nVERSION_ID=\"14.04\"\nHOME_URL=\"http://www.ubuntu.com/\"\nSUPPORT_URL=\"http://help.ubuntu.com/\"\nBUG_REPORT_URL=\"http://bugs.launchpad.net/ubuntu/\"\n", 
        "/etc/lsb-release": "DISTRIB_ID=Ubuntu\nDISTRIB_RELEASE=14.04\nDISTRIB_CODENAME=trusty\nDISTRIB_DESCRIPTION=\"Ubuntu 14.04.4 LTS\"\n"
    }, 
    "name": "N/A N/A", 
    "result": {
        "distribution_release": "N/A", 
        "distribution": "N/A", 
        "distribution_major_version": "N/A", 
        "os_family": "N/A", 
        "distribution_version": "N/A"
    }
}

after (error exit handled):
ERROR: ansible run failed, output was: 

localhost | FAILED! => {
    "failed": true, 
    "msg": "The module setup was not found in configured module paths. Additionally, core modules are missing. If this is a checkout, run 'git submodule update --init --recursive' to correct this problem."
}
```
