### PR TITLE
Set default value for Do-Until loop retries.

### DIFF
--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -81,7 +81,7 @@ class Task(Base, Conditional, Taggable, Become):
     _notify = FieldAttribute(isa='list')
     _poll = FieldAttribute(isa='int', default=10)
     _register = FieldAttribute(isa='string')
-    _retries = FieldAttribute(isa='int')
+    _retries = FieldAttribute(isa='int', default=3)
     _until = FieldAttribute(isa='list', default=[])
 
     def __init__(self, block=None, role=None, task_include=None):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### SUMMARY

When trying to run a task as a Do-Until loop, ansible errors out if you don't specify a "retries" value. Per the documentation at http://docs.ansible.com/ansible/playbooks_loops.html#do-until-loops, this should be 3.

Fixes #17695
