### PR TITLE
Add '--cover-erase' to 'make tests' cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,10 +100,10 @@ NOSETESTS3 ?= nosetests-3.5
 all: clean python
 
 tests:
-	PYTHONPATH=./lib $(NOSETESTS) -d -w test/units -v --with-coverage --cover-package=ansible --cover-branches
+	PYTHONPATH=./lib $(NOSETESTS) -d -w test/units -v --with-coverage --cover-package=ansible --cover-branches --cover-erase
 
 tests-py3:
-	PYTHONPATH=./lib $(NOSETESTS3) -d -w test/units -v --with-coverage --cover-package=ansible --cover-branches
+	PYTHONPATH=./lib $(NOSETESTS3) -d -w test/units -v --with-coverage --cover-package=ansible --cover-branches --cover-erase
 
 authors:
 	sh hacking/authors.sh


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

Makefile
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (cover_erase 62deb3c804) last updated 2016/09/22 14:51:20 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 0f505378c3) last updated 2016/09/22 14:03:18 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 935a3ab2cb) last updated 2016/09/22 14:03:18 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

Otherwise the coverage is cumulative over multiple
runs and can be misleading.

(Could also likely be done as a .coveragerc change or possibly a tox.ini change)
