### PR TITLE
add a default test image for integration.sh

### DIFF
--- a/test/utils/shippable/integration.sh
+++ b/test/utils/shippable/integration.sh
@@ -2,7 +2,8 @@
 
 source_root=$(python -c "from os import path; print(path.abspath(path.join(path.dirname('$0'), '../../..')))")
 
-test_image="${IMAGE}"
+default_test_image="docker.io/ansible/ansible:centos7"
+test_image="${IMAGE:-$default_test_image}"
 test_privileged="${PRIVILEGED:-false}"
 test_flags="${TEST_FLAGS:-}"
 test_target="${TARGET:-}"

--- a/test/utils/shippable/integration.sh
+++ b/test/utils/shippable/integration.sh
@@ -2,12 +2,10 @@
 
 source_root=$(python -c "from os import path; print(path.abspath(path.join(path.dirname('$0'), '../../..')))")
 
-default_test_image="docker.io/ansible/ansible:centos7"
-default_test_target="all"
-test_image="${IMAGE:-$default_test_image}"
+test_image="${IMAGE:-ansible/ansible:centos7}"
 test_privileged="${PRIVILEGED:-false}"
 test_flags="${TEST_FLAGS:-}"
-test_target="${TARGET:-$default_test_target}"
+test_target="${TARGET:-all}"
 test_ansible_dir="${TEST_ANSIBLE_DIR:-/root/ansible}"
 test_python3="${PYTHON3:-}"
 

--- a/test/utils/shippable/integration.sh
+++ b/test/utils/shippable/integration.sh
@@ -3,10 +3,11 @@
 source_root=$(python -c "from os import path; print(path.abspath(path.join(path.dirname('$0'), '../../..')))")
 
 default_test_image="docker.io/ansible/ansible:centos7"
+default_test_target="all"
 test_image="${IMAGE:-$default_test_image}"
 test_privileged="${PRIVILEGED:-false}"
 test_flags="${TEST_FLAGS:-}"
-test_target="${TARGET:-}"
+test_target="${TARGET:-$default_test_target}"
 test_ansible_dir="${TEST_ANSIBLE_DIR:-/root/ansible}"
 test_python3="${PYTHON3:-}"
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

test/utils/shippable/integration.sh
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (integration_sh_default af27ab27b0) last updated 2016/09/22 15:02:34 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 0f505378c3) last updated 2016/09/22 14:03:18 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 935a3ab2cb) last updated 2016/09/22 14:03:18 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Add a default image to 'integration.sh'
