### PR TITLE
Add a 'make integration' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,9 @@ tests:
 tests-py3:
 	PYTHONPATH=./lib $(NOSETESTS3) -d -w test/units -v --with-coverage --cover-package=ansible --cover-branches
 
+integration:
+	test/utils/shippable/integration.sh
+
 authors:
 	sh hacking/authors.sh
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

Makefile
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (make_integration 2e999de34c) last updated 2016/09/22 15:08:06 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 0f505378c3) last updated 2016/09/22 14:03:18 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 935a3ab2cb) last updated 2016/09/22 14:03:18 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

Add a 'make integration' make target. Because I'm lazy and 'make' can autocomplete

Runs test/utils/shippable/integration.sh
