### PR TITLE
Add keep on failure option to integration.sh.

### DIFF
--- a/test/utils/shippable/integration.sh
+++ b/test/utils/shippable/integration.sh
@@ -34,6 +34,7 @@ fi
 
 container_id=
 httptester_id=
+tests_completed=
 
 function show_environment
 {
@@ -49,6 +50,10 @@ function cleanup
     if [ "${controller_shared_dir}" ]; then
         cp -av "${controller_shared_dir}/shippable" "${SHIPPABLE_BUILD_DIR}"
         rm -rf "${controller_shared_dir}"
+    fi
+
+    if [ "${keep_containers}" == "onfailure" ] && [ "${tests_completed}" != "" ]; then
+        keep_containers=
     fi
 
     if [ "${keep_containers}" == "" ]; then
@@ -111,3 +116,5 @@ docker exec "${container_id}" mkdir -p "${test_shared_dir}/shippable/testresults
 docker exec "${container_id}" /bin/sh -c "cd '${test_ansible_dir}' && . hacking/env-setup && cd test/integration && \
     JUNIT_OUTPUT_DIR='${test_shared_dir}/shippable/testresults' ANSIBLE_CALLBACK_WHITELIST=junit \
     HTTPTESTER=1 TEST_FLAGS='${test_flags}' LC_ALL=en_US.utf-8 make ${test_target}"
+
+tests_completed=1


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### COMPONENT NAME

test/utils/shippable/integration.sh
##### ANSIBLE VERSION

```
ansible 2.2.0 (test-script 07f718e39b) last updated 2016/09/22 12:21:52 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 3486395970) last updated 2016/09/20 17:31:49 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 1f2319c3f3) last updated 2016/09/20 17:31:49 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Add `KEEP_CONTAINERS=onfailure` to `integration.sh` to allow keeping containers only on failure of integration tests.
