### PR TITLE
fixes issue with net_template failing unless src argument provided.

### DIFF
--- a/lib/ansible/plugins/action/net_template.py
+++ b/lib/ansible/plugins/action/net_template.py
@@ -75,6 +75,9 @@ class ActionModule(ActionBase):
 
     def _handle_template(self):
         src = self._task.args.get('src')
+        if not src:
+            return
+
         working_path = self._get_working_path()
 
         if os.path.isabs(src) or urlparse.urlsplit('src').scheme:


### PR DESCRIPTION
This fixes an issue where the net_template action will fail if a non
required argument (src) is not provided.

fixes ansible/ansible-modules-core#4978
