### PR TITLE
fixes issue introduced with raw kwarg

### DIFF
--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -269,7 +269,8 @@ class Cli(NxapiConfigMixin, CliBase):
         cmds = list(prepare_commands(commands))
         responses = self.execute(cmds)
         for index, cmd in enumerate(commands):
-            if cmd.output == 'json' and cmd.args.get('raw') is False:
+            raw = cmd.args.get('raw') or False
+            if cmd.output == 'json' and not raw:
                 try:
                     responses[index] = json.loads(responses[index])
                 except ValueError:


### PR DESCRIPTION
The raw kwarg was added to return raw output from devices with if the
attempt to convert to json failed.  The change was causing all json
output to be returned raw.  This fixes that issue.
