### PR TITLE
docsite/rst/playbooks_tags.rst: Added section on tag reuse

### DIFF
--- a/docsite/rst/playbooks_tags.rst
+++ b/docsite/rst/playbooks_tags.rst
@@ -35,7 +35,7 @@ On the other hand, if you want to run a playbook *without* certain tasks, you co
 Tag Resuse
 ```````````````
 You can apply the same tag name to more than one task, in the same file 
-or included files. Which will run all tasks with that tag.
+or included files. This will run all tasks with that tag.
 
 Example::
     ---

--- a/docsite/rst/playbooks_tags.rst
+++ b/docsite/rst/playbooks_tags.rst
@@ -30,6 +30,31 @@ On the other hand, if you want to run a playbook *without* certain tasks, you co
     ansible-playbook example.yml --skip-tags "notification"
 
 
+.. _tag_reuse:
+
+Tag Resuse
+```````````````
+You can apply the same tag name to more than one task, in the same file 
+or included files. Which will run all tasks with that tag.
+
+Example::
+    ---
+    # file: roles/common/tasks/main.yml
+
+    - name: be sure ntp is installed
+      yum: name=ntp state=installed
+      tags: ntp
+
+    - name: be sure ntp is configured
+      template: src=ntp.conf.j2 dest=/etc/ntp.conf
+      notify:
+        - restart ntpd
+      tags: ntp
+
+    - name: be sure ntpd is running and enabled
+      service: name=ntpd state=started enabled=yes
+      tags: ntp
+
 .. _tag_inheritance:
 
 Tag Inheritance


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

playbooks_tags
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Added section on reuse of tags to playbook tags documentation
