### PR TITLE
add hint to use hash filters for password in FAQ

### DIFF
--- a/docsite/rst/faq.rst
+++ b/docsite/rst/faq.rst
@@ -276,6 +276,9 @@ Once the library is ready, SHA512 password values can then be generated as follo
 
     python -c "from passlib.hash import sha512_crypt; import getpass; print sha512_crypt.encrypt(getpass.getpass())"
 
+Use the integrated :ref:`hash_filters` to generate a hashed version of a password.
+You shouldn't put plaintext passwords in your playbook or host_vars, better use :doc:`playbooks_vault` to encrypt sensitive data.
+
 .. _commercial_support:
 
 Can I get training on Ansible or find commercial support?


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### SUMMARY

The docs don't helped me with my problem, so i had to search the web until i found this solution:

http://stackoverflow.com/a/29910294/2611995

To save the time of others who need this information, i added it to the official docs.

You may correct my wording, i'm not a native speaker.

---

successfully built with Sphinx v1.4.6
