### PR TITLE
Disable expect continue in ansible-core-ci.

### DIFF
--- a/test/utils/shippable/ansible-core-ci
+++ b/test/utils/shippable/ansible-core-ci
@@ -334,9 +334,13 @@ class HttpRequest:
     def request(self, method, url, data=None, headers=None):
         args = ['/usr/bin/curl', '-s', '-S', '-i', '-X', method]
 
-        if headers is not None:
-            for header in headers:
-                args += ['-H', '%s: %s' % (header, headers[header])]
+        if headers is None:
+            headers = {}
+
+        headers['Expect'] = ''  # don't send expect continue header
+
+        for header in headers:
+            args += ['-H', '%s: %s' % (header, headers[header])]
 
         if data is not None:
             args += ['-d', data]


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

ansible-core-ci
##### ANSIBLE VERSION

```
ansible 2.2.0 (core-ci 5db2753b7f) last updated 2016/09/23 21:06:46 (GMT -700)
  lib/ansible/modules/core: (detached HEAD d843204575) last updated 2016/09/23 14:11:47 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 6444cb3f70) last updated 2016/09/23 14:11:47 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Disable expect continue in ansible-core-ci.

This will allow use of larger SSH keys.
