### PR TITLE
Revert "Set PRIVILEGED=true for non_destructive tests. (#17733)"

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -26,15 +26,15 @@ matrix:
     - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1604
     - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1604py3 PYTHON3=1
 
-    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:centos6 PRIVILEGED=true
-    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:centos7 PRIVILEGED=true
-    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:fedora-rawhide PRIVILEGED=true
-    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:fedora23 PRIVILEGED=true
-    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:opensuseleap PRIVILEGED=true
-    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1204 PRIVILEGED=true
-    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1404 PRIVILEGED=true
-    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1604 PRIVILEGED=true
-    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1604py3 PYTHON3=1 PRIVILEGED=true
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:centos6
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:centos7
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:fedora-rawhide
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:fedora23
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:opensuseleap
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1204
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1404
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1604
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1604py3 PYTHON3=1
 
     - env: TEST=integration TARGET=other IMAGE=ansible/ansible:centos6
     - env: TEST=integration TARGET=other IMAGE=ansible/ansible:centos7


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

shippable.yml
##### ANSIBLE VERSION

```
ansible 2.2.0 (revert b26eb7a038) last updated 2016/09/23 23:21:43 (GMT -700)
  lib/ansible/modules/core: (detached HEAD edf361a5d4) last updated 2016/09/23 23:21:48 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 8aa338ddfa) last updated 2016/09/23 23:21:48 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

This reverts commit 1384270ccd50cc7660c9375708fda148639ab797.

Restoring previous configuration to avoid timeouts on centos6.
