### PR TITLE
Fix issue #17739 Service NoneType error

### DIFF
--- a/lib/ansible/module_utils/service.py
+++ b/lib/ansible/module_utils/service.py
@@ -50,7 +50,6 @@ class Service(object):
         # states
         self.running        = None
         self.enabled        = None
-        self.action         = None
 
         # outcome
         self.changed        = False


### PR DESCRIPTION
##### ISSUE TYPE
- Bug Report
##### COMPONENT NAME

`lib/ansible/module_utils/service.py`
##### ANSIBLE VERSION

```
ansible 2.1.1.0
```
##### CONFIGURATION

Nothing particular
##### OS / ENVIRONMENT

N/A
##### SUMMARY

When creating a subclass of `Service` class provided by module_utils, 3 methods has to be redefined : `status`, `enable` and `action`.
Problem is that `action` is currently also defined in constructor as a variable (with `None` value) and that `action` is used as a method in `run` method.
##### STEPS TO REPRODUCE

Create a custom module like this:

``` python
#!/usr/bin/python

from ansible.module_utils.service import Service, service_shared_arg_spec
from ansible.module_utils.basic import AnsibleModule

class MyService(Service):


    def action(self):
        pass


    def enable(self):
        pass


    def status(self):
        return 'stopped'


def main():
    module = AnsibleModule(
        argument_spec = dict(
            name = dict(required=True),
            state = dict(choices=['running', 'started', 'stopped', 'restarted', 'reloaded']),
            enabled = dict(type='bool'),
            #arguments = dict(aliases=['args'], default=''),
            pattern = dict(required=False, default=None),
            #sleep = dict(required=False, type='int', default=None),
            #runlevel = dict(required=False, default='default'),
        ),
        supports_check_mode=True,
    )

    module.name = 'myservice'

    myservice = MyService(module)
    result = myservice.run()

    if module.params['state'] != result['state']:
        module.fail_json(**result)

    module.exit_json(**result)


if __name__ == '__main__':
    main()
```

Run this module against a host.
##### EXPECTED RESULTS

Fails properly (without Exception)
##### ACTUAL RESULTS

This call causes a `NoneType` error : 

```
[...]ansible/module_utils/service.py", line 205, in run
TypeError: 'NoneType' object is not callable
```
