### PR TITLE
Ignore error when setting permissions fail due to EPERM

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1998,11 +1998,18 @@ class AnsibleModule(object):
         if creating:
             # make sure the file has the correct permissions
             # based on the current value of umask
-            umask = os.umask(0)
-            os.umask(umask)
-            os.chmod(b_dest, DEFAULT_PERM & ~umask)
-            if switched_user:
-                os.chown(b_dest, os.getuid(), os.getgid())
+            try:
+                umask = os.umask(0)
+                os.umask(umask)
+                os.chmod(dest, DEFAULT_PERM & ~umask)
+                if switched_user:
+                    os.chown(dest, os.getuid(), os.getgid())
+            except OSError:
+                # Some filesystems like vfat will fail with EPERM if
+                # you try to chmod or chown a file.
+                e = get_exception()
+                if e.errno != errno.EPERM:
+                    raise
 
         if self.selinux_enabled():
             # rename might not preserve context


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

`AnsibleModule.atomic_move`
##### ANSIBLE VERSION

```
ansible 2.1.0.0
```
##### SUMMARY

Some network equipment uses `vfat` as their filesystem of choice. As vfat doesn't support `chmod` and `chown` operations, the method `atomic_move` will fail when trying to set the permissions.

This PR tries to address that issue. If we get to the point where the file is already in place and we just have to fix permissions, the most likely reason to get an `EPERM` error is due to the fact that the underlying filesystem doesn't support those operations in, which case, is safe to ignore the error.
