### PR TITLE
fixes issue where arguments for regexp search() where transposed

### DIFF
--- a/lib/ansible/module_utils/netcli.py
+++ b/lib/ansible/module_utils/netcli.py
@@ -296,5 +296,5 @@ class Conditional(object):
         return str(self.value) in value
 
     def matches(self, value):
-        match = re.search(value, self.value, re.M)
+        match = re.search(self.value, value, re.M)
         return match is not None


### PR DESCRIPTION
The arguments for the regex search() function were transposed in the
netcli match() method that caused conditionals to fail. Switched the
arguments to fixe the bug

fixes #17749
