### PR TITLE
Fix gathering=smart ignoring gather_facts

### DIFF
--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -314,7 +314,7 @@ class PlayIterator:
 
                     if (gathering == 'implicit' and implied) or \
                        (gathering == 'explicit' and boolean(self._play.gather_facts)) or \
-                       (gathering == 'smart' and implied and not host._gathered_facts):
+                       (gathering == 'smart' and not host._gathered_facts):
                         # The setup block is always self._blocks[0], as we inject it
                         # during the play compilation in __init__ above.
                         setup_block = self._blocks[0]


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

lib/ansible/executor/play_iterator.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (gathering_smart_17213 16758b956b) last updated 2016/09/27 12:49:24 (GMT -400)
  lib/ansible/modules/core: (detached HEAD c03697c81e) last updated 2016/09/27 09:58:42 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD aeecd8b09e) last updated 2016/09/27 12:49:08 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

The combination of 'gathering=smart' and a per task
'gather_facts: yes' can cause setup/fact gathering
to be skipped.

Fixes #17213
