### PR TITLE
DigitalOcean inventory: typo, do_tags, do_volume_ids

### DIFF
--- a/contrib/inventory/digital_ocean.py
+++ b/contrib/inventory/digital_ocean.py
@@ -58,7 +58,7 @@ When run against a specific host, this script returns the following variables:
  - do_private_ip_address
  - do_kernel - object
  - do_locked
- - de_memory
+ - do_memory
  - do_name
  - do_networks - object
  - do_next_backup_window
@@ -67,7 +67,9 @@ When run against a specific host, this script returns the following variables:
  - do_size_slug
  - do_snapshot_ids - list
  - do_status
+ - do_tags
  - do_vcpus
+ - do_volume_ids
 
 -----
 ```


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

DigitalOcean Inventory
##### SUMMARY

Fixes typo and adds the `do_tags` and `do_volumes_ids` variables

Signed-off-by: Thomas Sjögren konstruktoid@users.noreply.github.com
