### PR TITLE
Document `copy` module vault decryption behavior

### DIFF
--- a/docsite/rst/playbooks_vault.rst
+++ b/docsite/rst/playbooks_vault.rst
@@ -18,6 +18,8 @@ The vault feature can encrypt any structured data file used by Ansible.  This ca
 
 Ansible tasks, handlers, and so on are also data so these can be encrypted with vault as well. To hide the names of variables that you're using, you can encrypt the task files in their entirety. However, that might be a little too much and could annoy your coworkers :)
 
+The vault feature can also encrypt arbitrary files, even binary files.  If a vault-encrypted file is given as the `src` argument to the `copy` module, the file will be placed at the destination on the target host decrypted (assuming a valid vault password is supplied when running the play).
+
 .. _creating_files:
 
 Creating Encrypted Files


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

vault
##### ANSIBLE VERSION

```
ansible 2.2.0 (copy-module-docs-vault 91d8f8fd4f) last updated 2016/09/27 15:11:53 (GMT -500)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras:  not found - use git submodule update --init lib/ansible/modules/extras
  config file = 
  configured module search path = Default w/o overrides

```
##### SUMMARY

There is no documentation that I can see that describes how the `ansible-vault` can be used to encrypt arbitrary and even binary files, and that the `copy` module will decrypt them transparently if they are specified in the `src` argument.  I have also submitted a PR to the `copy` module docs: https://github.com/ansible/ansible-modules-core/pull/5063
