### PR TITLE
Graceful error handling when delegate_to host null (#17453)

### DIFF
--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -458,6 +458,8 @@ class VariableManager:
 
             templar.set_available_variables(vars_copy)
             delegated_host_name = templar.template(task.delegate_to, fail_on_undefined=False)
+            if not delegated_host_name:
+                raise AnsibleError(message="Undefined delegate_to host for task:", obj=task._ds)
             if delegated_host_name in delegated_host_vars:
                 # no need to repeat ourselves, as the delegate_to value
                 # does not appear to be tied to the loop item variable


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

`lib/ansible/vars/__init__.py`
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel cf7822e201) last updated 2016/09/27 16:35:37 (GMT +000)
  lib/ansible/modules/core: (detached HEAD c03697c81e) last updated 2016/09/27 17:45:52 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD aeecd8b09e) last updated 2016/09/27 17:45:57 (GMT +000)
  config file = /home/stephane/.ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Currently, if the host specified in delegate_to for a task is null,
Ansible will crash with a stack trace. Add a check for this state
and handle the error appropriately. Fixes #17453 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
before:

PLAY [localhost] ***************************************************************
ERROR! Unexpected Exception: 'NoneType' object has no attribute 'split'
to see the full traceback, use -vvv

after:
PLAY [localhost] ***************************************************************
ERROR! Undefined delegate_to host for task:

The error appears to have been in '/home/stephane/test-playbooks/test.yml': line 8, column 7, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  tasks:
    - command: "true"
      ^ here

```
