### PR TITLE
Revert "Clear the plugin path cache when adding new directories"

### DIFF
--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -219,7 +219,6 @@ class PluginLoader:
             if directory not in self._extra_dirs:
                 # append the directory and invalidate the path cache
                 self._extra_dirs.append(directory)
-                self._plugin_path_cache.clear()
                 self._paths = None
 
     def find_plugin(self, name, mod_type=''):


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

`lib/ansible/plugins/__init__.py`
##### ANSIBLE VERSION

```
ansible 2.2.0 (revert 28e60ed18c) last updated 2016/09/27 15:59:39 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 0a7ebef14e) last updated 2016/09/27 15:58:15 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD aeecd8b09e) last updated 2016/09/27 15:58:15 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

This reverts commit 5a57313dd72e574d38272364df3ef01d6a3646ef, as it is causing integration tests to fail: https://app.shippable.com/runs/57eacd1ef59fdd0e00b52d22/15/console
