### PR TITLE
Update get_url test to use httptester.

### DIFF
--- a/test/integration/roles/test_get_url/tasks/main.yml
+++ b/test/integration/roles/test_get_url/tasks/main.yml
@@ -209,5 +209,5 @@
 #https://github.com/ansible/ansible/issues/16191
 - name: Test url split with no filename
   get_url: 
-    url: http://www.google.com 
+    url: https://{{ httpbin_host }}
     dest: "{{ output_dir }}"


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### COMPONENT NAME

Integration Tests
##### ANSIBLE VERSION

```
ansible 2.2.0 (get-url-test 857f9b98cd) last updated 2016/09/27 16:43:39 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 0a7ebef14e) last updated 2016/09/27 15:58:15 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD aeecd8b09e) last updated 2016/09/27 15:58:15 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Update get_url test to use httptester.
