### PR TITLE
Enable unarchive tests for OS X and FreeBSD.

### DIFF
--- a/test/utils/shippable/remote-integration.sh
+++ b/test/utils/shippable/remote-integration.sh
@@ -14,7 +14,7 @@ test_flags="${TEST_FLAGS:-}"
 force_color="${FORCE_COLOR:-1}"
 
 # FIXME: these tests fail
-skip_tags='test_unarchive,test_service,test_postgresql,test_mysql_db,test_mysql_user,test_mysql_variables,test_uri,test_get_url'
+skip_tags='test_service,test_postgresql,test_mysql_db,test_mysql_user,test_mysql_variables,test_uri,test_get_url'
 
 cd ~/
 
@@ -37,6 +37,7 @@ if [ "${container}" = "freebsd" ]; then
     pkg install -y \
         bash \
         devel/ruby-gems \
+        gtar \
         mercurial \
         rsync \
         ruby \


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

Integration Tests
##### ANSIBLE VERSION

```
ansible 2.2.0 (test-unarchive 434f7b7684) last updated 2016/09/27 17:20:21 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 0a7ebef14e) last updated 2016/09/27 15:58:15 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD aeecd8b09e) last updated 2016/09/27 15:58:15 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Enable unarchive tests for OS X and FreeBSD.
