### PR TITLE
The mode that we fake from stat is checked more closely under python3.5 on El Capitan

### DIFF
--- a/test/units/module_utils/test_basic.py
+++ b/test/units/module_utils/test_basic.py
@@ -1032,5 +1032,5 @@ class TestModuleUtilsBasic(ModuleTestCase):
         self.assertEqual(am._symbolic_mode_to_octal(mock_stat, 'u=rwx'), 0o0700)
 
         # invalid modes
-        mock_stat.st_mode = 0o0400000
+        mock_stat.st_mode = 0o040000
         self.assertRaises(ValueError, am._symbolic_mode_to_octal, mock_stat, 'a=foo')


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

unittests for the symbolic mode conversion in basic.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
devel
```
##### SUMMARY

Python2 seems to allow any integer.  Python3.5 on Linux seems to allow
a 32 bit unsigned int.  Python3.5 on El Capitan seems to limit it to
a smaller size...  perhaps a 16 bit int.
