### PR TITLE
Enable roles to override modules

### DIFF
--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -219,6 +219,9 @@ class PluginLoader:
             if directory not in self._extra_dirs:
                 # append the directory and invalidate the path cache
                 self._extra_dirs.append(directory)
+                # invalidate path caches
+                self._plugin_path_cache.clear()
+                self._searched_paths.clear()
                 self._paths = None
 
     def find_plugin(self, name, mod_type=''):


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

lib/ansible/plugins/**init**.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (plugin_path_cache_clear 866f8d99a8) last updated 2016/09/28 11:23:41 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 0a7ebef14e) last updated 2016/09/28 09:37:55 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD aeecd8b09e) last updated 2016/09/27 14:35:05 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

When directories are added to plugin and module search
paths, clear the plugin_path_cache and the _search_paths
values, so that find_plugin will look on fs (including added
role specific paths) for plugins/modules instead of using
previously found plugin/module from cache.

_searched_paths is used for bookkeeping and to reduce unneeded
searches, so it needs to be emptied as well.

(revised version of 5a57313dd72e574d38272364df3ef01d6a3646ef)
