### PR TITLE
adds overwrite kwarg to load_config in junos

### DIFF
--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -171,11 +171,17 @@ class Netconf(object):
             return ele
 
     def load_config(self, config, commit=False, replace=False, confirm=None,
-                    comment=None, config_format='text'):
+                    comment=None, config_format='text', overwrite=False):
+
+        if all([replace, overwrite]):
+            self.raise_exc('setting both replace and overwrite to True is invalid')
 
         if replace:
             merge = False
-            overwrite = True
+            overwrite = False
+        elif overwrite:
+            merge = True
+            overwrite = False
         else:
             merge = True
             overwrite = False


### PR DESCRIPTION
The junos load_config() method supports operations of overwrite, replace
and merge.  This adds the missing overwrite keyword arg to load_config()
so that action in junos_template can be procesed correctly.
