### PR TITLE
Fix gathering=smart and custom module facts

### DIFF
--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -196,10 +196,7 @@ class PlayIterator:
         start_at_matched = False
         for host in inventory.get_hosts(self._play.hosts):
             self._host_states[host.name] = HostState(blocks=self._blocks)
-            # if the host's name is in the variable manager's fact cache, then set
-            # its _gathered_facts flag to true for smart gathering tests later
-            if host.name in variable_manager._fact_cache:
-                host._gathered_facts = True
+
             # if we're looking to start at a specific task, iterate through
             # the tasks for this host until we find the specified task
             if play_context.start_at_task is not None and not start_at_done:

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -481,6 +481,8 @@ class StrategyBase:
                                 if original_task.action == 'set_fact':
                                     self._variable_manager.set_nonpersistent_facts(target_host, result_item['ansible_facts'].copy())
                                 else:
+                                    if original_task.action == 'setup':
+                                        target_host._gathered_facts = True
                                     self._variable_manager.set_host_facts(target_host, result_item['ansible_facts'].copy())
 
                 if 'diff' in task_result._result:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

fact gathering policy
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (gather_smart_facts_17213 4649e70eec) last updated 2016/09/28 15:56:26 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 7808f42aff) last updated 2016/09/28 15:39:58 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 881d2f95a8) last updated 2016/09/28 15:39:58 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!-- Paste verbatim command output below, e.g. before and after your change -->

If the 'gathering' facts collection config was set
to 'smart', any module that returned ansible_facts would
mark a host as having had _gathered_facts=True, by way
of adding the hostname to the fact cache for module facts,
even if 'setup' itself was never invoked and no other facts
were cached.

Instead of allowing existense of the hostname key in fact
cache to determine initial _gathered_facts, only set if
if the 'setup' action was invoked.

Fixes #17213
