### PR TITLE
Fix length of quickstart video mentioned in docs

### DIFF
--- a/docsite/rst/quickstart.rst
+++ b/docsite/rst/quickstart.rst
@@ -3,7 +3,7 @@ Quickstart Video
 
 We've recorded a short video that shows how to get started with Ansible that you may like to use alongside the documentation.
 
-The `quickstart video <https://www.ansible.com/quick-start-video>`_ is about 30 minutes long and will show you some of the basics about your
+The `quickstart video <https://www.ansible.com/quick-start-video>`_ is about 13 minutes long and will show you some of the basics about your
 first steps with Ansible.
 
 Enjoy, and be sure to visit the rest of the documentation to learn more.


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

Quickstart video
##### ANSIBLE VERSION

```
ansible 2.1.1.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

I just fixed the displayed video-length. Said 30min before, but the video is "only" 13min long. 30min may scare some people away ;)
