### PR TITLE
Bugfix: fixes new-alias bug when debugging powershell

### DIFF
--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -154,8 +154,12 @@ Function Get-AnsibleParam($obj, $name, $default = $null, $resultobj, $failifempt
     }
 }
 
-#Alias Get-attr-->Get-AnsibleParam for backwards compat.
-New-Alias -Name Get-attr -Value Get-AnsibleParam
+#Alias Get-attr-->Get-AnsibleParam for backwards compat. Only add when needed to ease debugging of scripts
+If (!(Get-Alias -Name "Get-attr" -ErrorAction SilentlyContinue))
+{
+    New-Alias -Name Get-attr -Value Get-AnsibleParam
+}
+
 
 # Helper filter/pipeline function to convert a value to boolean following current
 # Ansible practices


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

powershell.ps1
##### ANSIBLE VERSION

```
2.2.1
```
##### SUMMARY

This fixes the bug where powershell throws an error when re-running the generated powershell script during debugging. The fix is simply to check whether the get-attr alias exists before setting it. Should make debugging a tiny bit easier since' it wont require manually editing the generated script to get around the bug anymore.
