### PR TITLE
Profile tasks style

### DIFF
--- a/lib/ansible/plugins/callback/profile_tasks.py
+++ b/lib/ansible/plugins/callback/profile_tasks.py
@@ -81,7 +81,7 @@ class CallbackModule(CallbackBase):
         self.task_output_limit = os.getenv('PROFILE_TASKS_TASK_OUTPUT_LIMIT', 20)
 
         if self.sort_order == 'ascending':
-            self.sort_order = False;
+            self.sort_order = False
 
         if self.task_output_limit == 'all':
             self.task_output_limit = None

--- a/lib/ansible/plugins/callback/profile_tasks.py
+++ b/lib/ansible/plugins/callback/profile_tasks.py
@@ -86,7 +86,7 @@ class CallbackModule(CallbackBase):
         if self.task_output_limit == 'all':
             self.task_output_limit = None
         else:
-            self.task_output_limit = int(self.task_output_limit) 
+            self.task_output_limit = int(self.task_output_limit)
 
         super(CallbackModule, self).__init__()
 
@@ -101,7 +101,7 @@ class CallbackModule(CallbackBase):
         self.current = task._uuid
         self.stats[self.current] = {'time': time.time(), 'name': task.get_name()}
         if self._display.verbosity >= 2:
-            self.stats[self.current][ 'path'] = task.get_path()
+            self.stats[self.current]['path'] = task.get_path()
 
     def v2_playbook_on_task_start(self, task, is_conditional):
         self._record_task(task)
@@ -118,7 +118,7 @@ class CallbackModule(CallbackBase):
 
         timestamp(self)
 
-        results = self.stats.items() 
+        results = self.stats.items()
 
         # Sort the tasks by the specified sort
         if self.sort_order != 'none':
@@ -128,12 +128,12 @@ class CallbackModule(CallbackBase):
                 reverse=self.sort_order,
             )
 
-        # Display the number of tasks specified or the default of 20 
+        # Display the number of tasks specified or the default of 20
         results = results[:self.task_output_limit]
 
         # Print the timings
         for uuid, result in results:
-            msg=u"{0:-<70}{1:->9}".format(result['name'] + u' ',u' {0:.02f}s'.format(result['time']))
+            msg = u"{0:-<70}{1:->9}".format(result['name'] + u' ',u' {0:.02f}s'.format(result['time']))
             if 'path' in result:
                 msg += u"\n{0:-<79}".format(result['path'] + u' ')
             self._display.display(msg)


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

lib/ansible/plugins/callbacks/profile_tasks.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (remove_self_display 23b8dc87f0) last updated 2016/09/29 18:48:00 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 537a7eb924) last updated 2016/09/29 16:48:01 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD a58e1d59c0) last updated 2016/09/29 16:48:01 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

Profile tasks style cleanups, spurred by seeing the line with the trailing semicolon.
