### PR TITLE
Use a alt constructor for Conditional

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -522,13 +522,13 @@ class TaskExecutor:
             # helper methods for use below in evaluating changed/failed_when
             def _evaluate_changed_when_result(result):
                 if self._task.changed_when is not None and self._task.changed_when:
-                    cond = Conditional(loader=self._loader)
+                    cond = Conditional.from_loader(loader=self._loader)
                     cond.when = self._task.changed_when
                     result['changed'] = cond.evaluate_conditional(templar, vars_copy)
 
             def _evaluate_failed_when_result(result):
                 if self._task.failed_when:
-                    cond = Conditional(loader=self._loader)
+                    cond = Conditional.from_loader(loader=self._loader)
                     cond.when = self._task.failed_when
                     failed_when_result = cond.evaluate_conditional(templar, vars_copy)
                     result['failed_when_result'] = result['failed'] = failed_when_result
@@ -551,7 +551,7 @@ class TaskExecutor:
                 _evaluate_failed_when_result(result)
 
             if retries > 1:
-                cond = Conditional(loader=self._loader)
+                cond = Conditional.from_loader(loader=self._loader)
                 cond.when = self._task.until
                 result['attempts'] = attempt
                 if cond.evaluate_conditional(templar, vars_copy):

--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -26,7 +26,6 @@ from jinja2.exceptions import UndefinedError
 from ansible.compat.six import text_type
 from ansible.errors import AnsibleError, AnsibleUndefinedVariable
 from ansible.playbook.attribute import FieldAttribute
-from ansible.template import Templar
 from ansible.module_utils._text import to_native
 
 DEFINED_REGEX = re.compile(r'(hostvars\[.+\]|[\w_]+)\s+(not\s+is|is|is\s+not)\s+(defined|undefined)')
@@ -40,20 +39,16 @@ class Conditional:
 
     _when = FieldAttribute(isa='list', default=[])
 
-    def __init__(self, loader=None):
-        # when used directly, this class needs a loader, but we want to
-        # make sure we don't trample on the existing one if this class
-        # is used as a mix-in with a playbook base class
-        if not hasattr(self, '_loader'):
-            if loader is None:
-                raise AnsibleError("a loader must be specified when using Conditional() directly")
-            else:
-                self._loader = loader
-        super(Conditional, self).__init__()
+    @classmethod
+    def from_loader(cls, loader):
+        assert loader is not None, "a loader must be specified when using Conditional() directly"
+        instance = cls()
+        instance._loader = loader
+        return instance
 
     def _validate_when(self, attr, name, value):
         if not isinstance(value, list):
-            setattr(self, name, [ value ])
+            setattr(self, name, [value])
 
     def _get_attr_when(self):
         '''

--- a/lib/ansible/plugins/action/assert.py
+++ b/lib/ansible/plugins/action/assert.py
@@ -50,7 +50,7 @@ class ActionModule(ActionBase):
         # the built in evaluate function. The when has already been evaluated
         # by this point, and is not used again, so we don't care about mangling
         # that value now
-        cond = Conditional(loader=self._loader)
+        cond = Conditional.from_loader(loader=self._loader)
         result['_ansible_verbose_always'] = True
         for that in thats:
             cond.when = [that]


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- code cleanup
##### COMPONENT NAME

lib/ansible/playbook/conditional.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (Conditional_classmethod_constructor ded30ac93e) last updated 2016/09/29 19:23:58 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 537a7eb924) last updated 2016/09/29 16:48:01 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD a58e1d59c0) last updated 2016/09/29 16:48:01 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = Default w/o overrides


```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```

Since Conditional is primarily a mixin class, remove
it's **init** that had to avoid clobbering self._loader
and add a @classmethod alt constructor ('from_loader') that
creates and returns an instance with the loader associated
to it.

Replace the runtime exception with a (runtime) assert to
throw errors on improper api usage.
