### PR TITLE
Filetree deindent

### DIFF
--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -109,10 +109,12 @@ def walk(path, topdown=None):
             relpath = os.path.relpath(os.path.join(root, entry), path)
 
             # Skip if relpath was already processed (from another root)
-            if relpath not in [entry['path'] for entry in ret]:
-                props = file_props(path, relpath)
-                if props is not None:
-                    ret.append(props)
+            if relpath in [entry['path'] for entry in ret]:
+                continue
+
+            props = file_props(path, relpath)
+            if props is not None:
+                ret.append(props)
     return ret
 
 class LookupModule(LookupBase):

--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -22,10 +22,10 @@ import pwd
 import grp
 import stat
 
-HAVE_SELINUX=False
+HAVE_SELINUX = False
 try:
     import selinux
-    HAVE_SELINUX=True
+    HAVE_SELINUX = True
 except ImportError:
     pass
 
@@ -100,6 +100,20 @@ def file_props(root, path):
 
     return ret
 
+def walk(path, topdown=None):
+    topdown = topdown or False
+
+    ret = []
+    for root, dirs, files in os.walk(path, topdown=True):
+        for entry in dirs + files:
+            relpath = os.path.relpath(os.path.join(root, entry), path)
+
+            # Skip if relpath was already processed (from another root)
+            if relpath not in [entry['path'] for entry in ret]:
+                props = file_props(path, relpath)
+                if props is not None:
+                    ret.append(props)
+    return ret
 
 class LookupModule(LookupBase):
 
@@ -111,14 +125,5 @@ class LookupModule(LookupBase):
             term_file = os.path.basename(term)
             dwimmed_path = self._loader.path_dwim_relative(basedir, 'files', os.path.dirname(term))
             path = os.path.join(dwimmed_path, term_file)
-            for root, dirs, files in os.walk(path, topdown=True):
-                for entry in dirs + files:
-                    relpath = os.path.relpath(os.path.join(root, entry), path)
-
-                    # Skip if relpath was already processed (from another root)
-                    if relpath not in [ entry['path'] for entry in ret ]:
-                        props = file_props(path, relpath)
-                        if props is not None:
-                            ret.append(props)
-
+            ret = walk(path, topdown=True)
         return ret


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Cleanup
##### COMPONENT NAME

lib/ansible/plugins/lookup/filetree.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (Conditional_classmethod_constructor ded30ac93e) last updated 2016/09/29 19:23:58 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 537a7eb924) last updated 2016/09/29 16:48:01 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD a58e1d59c0) last updated 2016/09/29 16:48:01 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Reduce code nesting in filetree.py

```
Move the use of os.walk() into it's own
method to lessen the indent level (7)
```

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```
