### PR TITLE
Fixes Issue:17825 Responses not correctly sanitized from remote devices

### DIFF
--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -177,7 +177,7 @@ class Shell(object):
     def sanitize(self, cmd, resp):
         cleaned = []
         for line in resp.splitlines():
-            if line.startswith(str(cmd)) or self.find_prompt(line):
+            if re.search(str(cmd), line) or self.find_prompt(line):
                 continue
             cleaned.append(line)
         return "\n".join(cleaned)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

shell.py library from module_utils
##### ANSIBLE VERSION

```
ansible 2.1.1.0
```
##### SUMMARY

Fixes Issue:17825 Responses not correctly sanitized from remote devices
Remote devices that use ssh clients to execute commands remotely e.g. on Cisco N9K, 
may return extraneous spaces in their responses. As a result, if the response is not 
appropriately sanitized to conform to JSON format, it may result in exceptions such 
as "Command does not support JSON output" in the calling ansible modules e.g. nxos_interface.

The sanitize method of the shell.py module removes the cli command from the output using "startswith()".  However if there are extraneous spaces in the beginning of the line, it will skip sanitizing the output and result in an invalid JSON output.  The patch replaces "startswith()" with "re.search()" which will match the cli command anywhere in the string.
