### PR TITLE
add path arg to _write_backup method

### DIFF
--- a/lib/ansible/plugins/action/net_config.py
+++ b/lib/ansible/plugins/action/net_config.py
@@ -36,8 +36,8 @@ class ActionModule(ActionBase):
 
     TRANSFERS_FILES = False
 
-    def run(self, tmp=None, task_vars=None):
-        result = super(ActionModule, self).run(tmp, task_vars)
+    def run(self, tmp=None, task_vars=None, path=None):
+        result = super(ActionModule, self).run(tmp, task_vars, path)
         result['changed'] = False
 
         if self._task.args.get('src'):
@@ -55,7 +55,7 @@ class ActionModule(ActionBase):
             # User requested backup and no error occurred in module.
             # NOTE: If there is a parameter error, _backup key may not be in results.
             filepath = self._write_backup(task_vars['inventory_hostname'],
-                                          result['__backup__'])
+                                          result['__backup__'], path)
             result['backup_path'] = filepath
 
         # strip out any keys that have two leading and two trailing
@@ -72,10 +72,13 @@ class ActionModule(ActionBase):
             cwd = self._task._role._role_path
         return cwd
 
-    def _write_backup(self, host, contents):
-        backup_path = self._get_working_path() + '/backup'
+    def _write_backup(self, host, contents, path=None):
+        if path is None:
+            backup_path = os.path.join(self._get_working_path(), 'backup')
+        else:
+            backup_path = os.path.abspath(path)
         if not os.path.exists(backup_path):
-            os.mkdir(backup_path)
+            os.makedirs(backup_path)
         for fn in glob.glob('%s/%s*' % (backup_path, host)):
             os.remove(fn)
         tstamp = time.strftime("%Y-%m-%d@%H:%M:%S", time.localtime(time.time()))


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

add functionality to be able to specify backup path
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

From conversations in [issue #4386 in ansibles-module-core](https://github.com/ansible/ansible-modules-core/issues/4386)
This adds the ability to specify the backup path where device configurations can be written, instead of just defaulting to a directory called backups in the cwd. This is especially useful when running Ansible in a Vagrant environment on windows hosts when using shared directories, as it is often not possible for ansible to write to the shared directory. I realise this reason is fairly niche, but I expect this functionality may still be useful

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

I considered adding a `try/except` block around the file write operation:

```
try:
    with open(filename, 'w') as f:
                f.write(contents)
except EnvironmentError as exc:
    return dict(failed=True, msg=exc.message)
```

to catch any exceptions due to the specified path not being writable but didn't want to return a different type to the `filepath` variable in the `run` method. Is this an exception that needs catching in another manner?

This is a first code contribution to Ansible, and I'm not certain I've done everything I should do, so any comments, suggestions, criticisms are welcome.
