### PR TITLE
fixes issue when calling save_config() and transport is nxapi

### DIFF
--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -60,7 +60,10 @@ class NxapiConfigMixin(object):
             self.execute(['no checkpoint %s' % checkpoint])
 
     def save_config(self, **kwargs):
-        self.execute(['copy running-config startup-config'])
+        try:
+            self.execute(['copy running-config startup-config'], output='text')
+        except TypeError:
+            self.execute(['copy running-config startup-config'])
 
     def load_checkpoint(self, checkpoint):
         try:


### PR DESCRIPTION
An unhandled exception is raised with using nxapi transport and setting
the save argument to true.  This fix will allow the configuration to be
saved regardless of the transport.

fixes ansible/ansible-modules-core#5094
