### PR TITLE
Look for 'module_setup' to set _gathered_facts

### DIFF
--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -199,7 +199,12 @@ class PlayIterator:
             # if the host's name is in the variable manager's fact cache, then set
             # its _gathered_facts flag to true for smart gathering tests later
             if host.name in variable_manager._fact_cache:
-                host._gathered_facts = True
+                # But only consider the setup module having been run as having '_gathered_facts',
+                # so that tasks/modules that return other facts don't cause all fact gathering to
+                # be skipped. The 'module_setup' item in facts is provided when setup is run.
+                # Fixes https://github.com/ansible/ansible/issues/17213
+                if 'module_setup' in variable_manager._fact_cache[host.name]:
+                    host._gathered_facts = True
             # if we're looking to start at a specific task, iterate through
             # the tasks for this host until we find the specified task
             if play_context.start_at_task is not None and not start_at_done:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

lib/ansible/playbook/play_iterator.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (gather_facts_module_setup_17213 a3b2424abe) last updated 2016/09/30 14:38:01 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 537a7eb924) last updated 2016/09/30 12:13:05 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD a58e1d59c0) last updated 2016/09/30 12:13:05 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```

If a ansible-playbook runs with 'gathering=smart', and
a play explicitly sets gather=false _and_ runs a task
that returns facts, previously, then 'smart' gathering
would not attempt to run setup even if a later play
explicitly sets gather=false, because the existence of
module_facts caused host._gathered_facts to be set.

Fix is to only set host._gathered_facts if the host
has a 'module_setup' item in fact_cache, indicating that
the setup module has run.

ie, before gathering=smart considered existense of any facts
as evidence that facts were already collected, but now it
is based on 'setup' module having been run.

Fixes #17213
