### PR TITLE
adds better error handling when conditional fails

### DIFF
--- a/lib/ansible/module_utils/netcli.py
+++ b/lib/ansible/module_utils/netcli.py
@@ -228,7 +228,7 @@ class Conditional(object):
         if self.encoding in ['json', 'text']:
             try:
                 return self.get_json(result)
-            except (IndexError, TypeError):
+            except (IndexError, TypeError, AttributeError):
                 msg = 'unable to apply conditional to result'
                 raise FailedConditionalError(msg, self.raw)
 


### PR DESCRIPTION
When the conditional cannot extract a value from the result string,
an unhandled exception would be raised.  This fix now gracefully handles
the exception
