### PR TITLE
fixes unicode conversation from junos get_config() method

### DIFF
--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -166,7 +166,7 @@ class Netconf(object):
         ele = self.rpc('get_configuration', output=config_format)
 
         if config_format == 'text':
-            return str(ele.text).strip()
+            return unicode(ele.text).strip()
         else:
             return ele
 


### PR DESCRIPTION
The junos config should convert the returning configuration to unicode
not str.  This fixes that issue.
