### PR TITLE
Disable privileged mode on Shippable.

### DIFF
--- a/test/integration/destructive.yml
+++ b/test/integration/destructive.yml
@@ -3,7 +3,7 @@
   roles:
     # In destructive because it creates and removes a user
     - { role: test_become, tags: test_become}
-    - { role: test_service, tags: test_service }
+    - { role: test_service, tags: [test_service, needs_privileged] }
     # Current pip unconditionally uses md5.  We can re-enable if pip switches
     # to a different hash or allows us to not check md5
     - { role: test_pip, tags: test_pip, when: ansible_fips != True }
@@ -11,7 +11,7 @@
     - { role: test_yum, tags: test_yum, when: ansible_python.version.major == '2' }
     - { role: test_apt, tags: test_apt }
     - { role: test_apt_repository, tags: [test_apt_repository, test_apt_key] }
-    - { role: test_postgresql, tags: [test_postgresql, test_postgresql_db, test_postgresql_privs, test_postgresql_user] }
+    - { role: test_postgresql, tags: [test_postgresql, test_postgresql_db, test_postgresql_privs, test_postgresql_user, needs_privileged] }
     - { role: test_mysql_db, tags: test_mysql_db}
     - { role: test_mysql_user, tags: test_mysql_user}
     - { role: test_mysql_variables, tags: test_mysql_variables}

--- a/test/utils/shippable/integration.sh
+++ b/test/utils/shippable/integration.sh
@@ -31,6 +31,7 @@ if [ "${SHIPPABLE_BUILD_DIR:-}" ]; then
     host_shared_dir="/home/shippable/cache/build-${BUILD_NUMBER}"
     controller_shared_dir="/home/shippable/cache/build-${BUILD_NUMBER}"
     share_source=1
+    test_privileged=false # temporarily disabled to troubleshoot performance issues
 else
     host_shared_dir="${source_root}"
     controller_shared_dir=""

--- a/test/utils/shippable/integration.sh
+++ b/test/utils/shippable/integration.sh
@@ -102,16 +102,21 @@ container_id=$(docker run -d \
 
 show_environment
 
+skip=
+
 if [ "${test_python3}" ]; then
     docker exec "${container_id}" ln -s /usr/bin/python3 /usr/bin/python
     docker exec "${container_id}" ln -s /usr/bin/pip3 /usr/bin/pip
 
-    skip_tags=$(tr '\n' ',' < "${source_root}/test/utils/shippable/python3-test-tag-blacklist.txt")
-    test_flags="--skip-tags ${skip_tags} ${test_flags}"
+    skip+=",$(tr '\n' ',' < "${source_root}/test/utils/shippable/python3-test-tag-blacklist.txt")"
 fi
 
 if [ "${test_privileged}" = 'false' ]; then
-    test_flags="--skip-tags needs_privileged ${test_flags}"
+    skip+=",needs_privileged"
+fi
+
+if [ "${skip}" ]; then
+    test_flags="--skip-tags ${skip} ${test_flags}"
 fi
 
 if [ -z "${share_source}" ]; then


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

Integration Tests
##### ANSIBLE VERSION

```
ansible 2.2.0 (no-priv 8daf465690) last updated 2016/09/30 18:12:53 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 18f710fe32) last updated 2016/09/30 18:08:52 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD a58e1d59c0) last updated 2016/09/28 23:42:29 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Disable privileged mode on Shippable to help with troubleshooting performance issues.
