### PR TITLE
handler: replace error with warning for undefined handlers

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -399,7 +399,7 @@ class StrategyBase:
                                     for listening_handler_name in self._listening_handlers[handler_name]:
                                         listening_handler = search_handler_blocks(listening_handler_name, iterator._play.handlers)
                                         if listening_handler is None:
-                                            raise AnsibleError("The requested handler listener '%s' was not found in any of the known handlers" % listening_handler_name)
+                                            display.warning("The requested handler listener '%s' was not found in any of the known handlers" % listening_handler_name)
                                         if original_host not in self._notified_handlers[listening_handler]:
                                             self._notified_handlers[listening_handler].append(original_host)
                                             display.vv("NOTIFIED HANDLER %s" % (listening_handler_name,))
@@ -423,7 +423,7 @@ class StrategyBase:
 
                                         # and if none were found, then we raise an error
                                         if not found:
-                                            raise AnsibleError("The requested handler '%s' was found in neither the main handlers list nor the listening handlers list" % handler_name)
+                                            display.warning("The requested handler '%s' was found in neither the main handlers list nor the listening handlers list" % handler_name)
 
 
                     if 'add_host' in result_item:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

handlers listen
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.2
```
##### SUMMARY

Fixes #17848. We warn only for notifying a undefined handler:

```
$ ansible-playbook test_handlers_listen2.yml    
 [WARNING]: Host file not found: /etc/ansible/hosts

 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [test handlers listen] ****************************************************

TASK [notify some handlers] ****************************************************
 [WARNING]: The requested handler 'notify_listen_not_there' was found in neither the main handlers list nor the listening handlers list

changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0
```
