### PR TITLE
Normalize text and byte type in the ssh plugin helper method that builds up an ssh command

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -97,6 +97,8 @@ def _get_config(p, section, key, env_var, default):
             return value
     if p is not None:
         try:
+            # TODO: Once we branch Ansible-2.2, change to the following in devel
+            #return to_text(p.get(section, key, raw=True), errors='surrogate_or_strict')
             return p.get(section, key, raw=True)
         except:
             return default
@@ -277,7 +279,7 @@ MAX_FILE_SIZE_FOR_DIFF         = get_config(p, DEFAULTS, 'max_diff_size', 'ANSIB
 
 # CONNECTION RELATED
 ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', '-C -o ControlMaster=auto -o ControlPersist=60s')
-ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', "%(directory)s/ansible-ssh-%%h-%%p-%%r")
+ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', u"%(directory)s/ansible-ssh-%%h-%%p-%%r")
 ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', False, boolean=True)
 ANSIBLE_SSH_RETRIES            = get_config(p, 'ssh_connection', 'retries', 'ANSIBLE_SSH_RETRIES', 0, integer=True)
 ANSIBLE_SSH_EXECUTABLE         = get_config(p, 'ssh_connection', 'ssh_executable', 'ANSIBLE_SSH_EXECUTABLE', 'ssh')

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -140,6 +140,7 @@ class ConnectionBase(with_metaclass(ABCMeta, object)):
             # ['t\x00\x00\x00', '\x00\x00\x00e\x00\x00\x00']
             return [to_text(x.strip()) for x in shlex.split(to_bytes(argstring)) if x.strip()]
         except AttributeError:
+            # In Python3, shlex.split doesn't work on a byte string.
             return [to_text(x.strip()) for x in shlex.split(argstring) if x.strip()]
 
     @abstractproperty


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

lib/ansible/plugins/connection/ssh.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.2
```
##### SUMMARY

Mostly cleanups to make the code more efficient, more pythonic, and obey
the unicode sandwich strategy more but also Fixes #17832
