### PR TITLE
fixes issue with run_commands raising error

### DIFF
--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -139,6 +139,9 @@ class Netconf(object):
                 responses[index] = xml_to_json(responses[index])
             elif cmd.args.get('command_type') == 'rpc':
                 responses[index] = str(responses[index].text).strip()
+            elif 'RpcError' in responses[index]:
+                raise NetworkError(responses[index])
+
 
         return responses
 


### PR DESCRIPTION
The junos run_commands() method should raise an error when an RpcError is
returned but didn't when using display=text.  This fixes that error
