### PR TITLE
Make 'setup'/facts.py not crash on py3

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2268,7 +2268,7 @@ class AnsibleModule(object):
         # reset the pwd
         os.chdir(prev_dir)
 
-        return (rc, stdout, stderr)
+        return (rc, stdout.decode(), stderr.decode())
 
     def append_to_file(self, filename, str):
         filename = os.path.expandvars(os.path.expanduser(filename))


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

lib/ansible/module_utils/facts.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 64c446d9c0) last updated 2016/10/02 18:19:27 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 4b3c892284) last updated 2016/10/02 17:34:40 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD a58e1d59c0) last updated 2016/10/01 18:14:18 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides


```
##### SUMMARY

Quick fix to get 'python3.5 bin/ansible localhost -m setup' working.
Likely there are better approaches (some mention in the commit message).

module_utils.basic.run_command returns stdout and
stderr as bytes. Lots of code in facts.py implicitly
expects a str type (for example, by attempting to split
by '\n').

This change just forces the stdout/stderr output returned from
run_command into the native string type.

Long term, it probably makes more sense to either:
- use the subprocess 'universal_newlines' kwarg to handle
   unix/dos EOL and force stderr/stdout to strings
- assume run_command/subprocess output is byte strings and
   update run_command() calling code to deal with it.
- add an arg to run_command to do either

Looks like some code in facts.py may be doing avoidable string
manipulation that could be removed as well (strip()'ing or
split()'ing on strngs returned by splitlines() for example)
