### PR TITLE
Let docker-py decode pull response

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -446,8 +446,7 @@ class AnsibleDockerClient(Client):
         '''
         self.log("Pulling image %s:%s" % (name, tag))
         try:
-            for line in self.pull(name, tag=tag, stream=True):
-                line = json.loads(line)
+            for line in self.pull(name, tag=tag, stream=True, decode=True):
                 self.log(line, pretty_print=True)
                 if line.get('error'):
                     if line.get('errorDetail'):


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request
##### COMPONENT NAME

docker_common.py
##### ANSIBLE VERSION

```
ansible 2.2.0 (fix_3964 fa7e572a96) last updated 2016/10/03 11:38:49 (GMT -400)
  lib/ansible/modules/core: (detached HEAD e4c5a13a7a) last updated 2016/10/03 09:29:48 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD df35d324d6) last updated 2016/10/03 09:29:48 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

When calling the image pull method pass decode=True, allowing the docker-py module to handle decoding the response. Should fix [#3964](https://github.com/ansible/ansible-modules-core/issues/3964).
