### PR TITLE
cast/copy keys() to list to avoid py3 errors

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -114,7 +114,7 @@ class ActionModule(ActionBase):
         # connection to the remote host
         if 'ansible_syslog_facility' in task_vars:
             del task_vars['ansible_syslog_facility']
-        for key in task_vars.keys():
+        for key in list(task_vars.keys()):
             if key.startswith("ansible_") and key.endswith("_interpreter"):
                 del task_vars[key]
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

lib/ansible/plugins/actions/synchronize.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 78a02555e5) last updated 2016/10/03 10:37:48 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 6c4d71a7fa) last updated 2016/10/03 11:53:28 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD df35d324d6) last updated 2016/10/03 11:53:28 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides

```
##### SUMMARY

Fixes for py3

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```

In py3, dict.keys() is a view and not a copy of the
dicts keys, so attempting to delete items from the dict
while iterating over the keys results int

RuntimeError: dictionary changed size during iteration

Resolve by casting .keys() to a list() type.
