### PR TITLE
open ANSIBALLZ payload 'wb' for py3 in debug path

### DIFF
--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -212,12 +212,12 @@ def debug(command, zipped_mod, json_params):
                 directory = os.path.dirname(dest_filename)
                 if not os.path.exists(directory):
                     os.makedirs(directory)
-                f = open(dest_filename, 'w')
+                f = open(dest_filename, 'wb')
                 f.write(z.read(filename))
                 f.close()
 
         # write the args file
-        f = open(args_path, 'w')
+        f = open(args_path, 'wb')
         f.write(json_params)
         f.close()
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

lib/ansible/executor/module_common.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (module_common_py3_binary_file abe366d42f) last updated 2016/10/03 12:05:01 (GMT -400)
  lib/ansible/modules/core: (detached HEAD e4c5a13a7a) last updated 2016/10/03 08:42:50 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD df35d324d6) last updated 2016/10/03 08:42:50 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = Default w/o overrides


```
##### SUMMARY

If running with ansible_python_executable=python3.5 and ANSIBLE_KEEP_REMOTE_FILES=1, then
attempt to 'explode' the module files throws a type error when. This change mirrors changes to the equivalent path in the made module execution flow.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```
