### PR TITLE
Allow for namespaced galaxy module calls

### DIFF
--- a/lib/ansible/galaxy/helpers.py
+++ b/lib/ansible/galaxy/helpers.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import ansible.constants as C
+import os
+
+from ansible.errors import AnsibleError
+from ansible.galaxy import Galaxy
+from ansible.galaxy.options import GalaxyOptions
+from ansible.galaxy.role import GalaxyRole
+
+
+class GalaxyOptions(object):
+    '''Stub to initialize the Galaxy object'''
+    def __init__(self):
+        self.ignore_certs = True
+        self.api_server = C.GALAXY_SERVER
+
+def get_role_by_module_fqn(module_fqn):
+    '''Use the module FQN to enumerate role and install it'''
+    iparts = module_fqn.split('.')
+    role_fqn = '.'.join(iparts[0:2])
+    gopts = GalaxyOptions()
+    galaxy = Galaxy(gopts)
+    galaxy.roles_paths = C.DEFAULT_ROLES_PATH
+    gr = GalaxyRole(galaxy, role_fqn)
+    install_info = gr.install_info
+    if not gr.install_info:
+        # not installed to cache, so install it
+        installed = gr.install()
+        if not installed:
+            raise AnsibleError('failed to install %s: %s' % (role_fqn, installed))
+    gr.module_file = os.path.join(gr.path, 'library', '%s.py' % iparts[-1])
+    return gr
+
+

--- a/lib/ansible/galaxy/helpers.py
+++ b/lib/ansible/galaxy/helpers.py
@@ -8,8 +8,14 @@ import ansible.constants as C
 import os
 
 from ansible.errors import AnsibleError
-from ansible.galaxy import Galaxy
-from ansible.galaxy.role import GalaxyRole
+
+galaxy_imported = None
+try:
+    from ansible.galaxy import Galaxy
+    from ansible.galaxy.role import GalaxyRole
+    galaxy_imported = True
+except ImportError as e:
+    galaxy_imported = False
 
 
 class GalaxyOptions(object):
@@ -18,8 +24,15 @@ class GalaxyOptions(object):
         self.ignore_certs = True
         self.api_server = C.GALAXY_SERVER
 
+
 def get_role_by_module_fqn(module_fqn):
     '''Use the module FQN to enumerate role and install it'''
+
+    # deferred galaxy imports (because the plugin loader mucks things up)
+    if not galaxy_imported:
+        from ansible.galaxy import Galaxy
+        from ansible.galaxy.role import GalaxyRole
+
     iparts = module_fqn.split('.')
     role_fqn = '.'.join(iparts[0:2])
     gopts = GalaxyOptions()

--- a/lib/ansible/galaxy/helpers.py
+++ b/lib/ansible/galaxy/helpers.py
@@ -9,7 +9,6 @@ import os
 
 from ansible.errors import AnsibleError
 from ansible.galaxy import Galaxy
-from ansible.galaxy.options import GalaxyOptions
 from ansible.galaxy.role import GalaxyRole
 
 

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -27,9 +27,6 @@ from ansible.plugins import module_loader
 from ansible.parsing.splitter import parse_kv, split_args
 from ansible.template import Templar
 
-# dynamically installed roles ...
-from ansible.galaxy.helpers import get_role_by_module_fqn
-
 # For filtering out modules correctly below
 RAW_PARAM_MODULES = ([
     'command',
@@ -287,11 +284,6 @@ class ModuleArgsParser:
 
         # walk the input dictionary to see we recognize a module name
         for (item, value) in iteritems(self._task_ds):
-            if item.count('.') == 2:
-                # This is a module from a galaxy role
-                gr = get_role_by_module_fqn(item)
-                if gr.module_file not in module_loader._module_cache:
-                    module_loader.add_module_by_file(item, gr.module_file)
 
             if item in module_loader or item in ['meta', 'include', 'include_role']:
                 # finding more than one module name is a problem

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -27,6 +27,9 @@ from ansible.plugins import module_loader
 from ansible.parsing.splitter import parse_kv, split_args
 from ansible.template import Templar
 
+# dynamically installed roles ...
+from ansible.galaxy.helpers import get_role_by_module_fqn
+
 # For filtering out modules correctly below
 RAW_PARAM_MODULES = ([
     'command',
@@ -284,6 +287,12 @@ class ModuleArgsParser:
 
         # walk the input dictionary to see we recognize a module name
         for (item, value) in iteritems(self._task_ds):
+            if item.count('.') == 2:
+                # This is a module from a galaxy role
+                gr = get_role_by_module_fqn(item)
+                if gr.module_file not in module_loader._module_cache:
+                    module_loader.add_module_by_file(item, gr.module_file)
+
             if item in module_loader or item in ['meta', 'include', 'include_role']:
                 # finding more than one module name is a problem
                 if action is not None:

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -284,7 +284,6 @@ class ModuleArgsParser:
 
         # walk the input dictionary to see we recognize a module name
         for (item, value) in iteritems(self._task_ds):
-
             if item in module_loader or item in ['meta', 'include', 'include_role']:
                 # finding more than one module name is a problem
                 if action is not None:

--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -420,7 +420,7 @@ class PluginLoader:
         # Add a module to the cache by filepath
         self._module_cache[name] = self._load_module_source(name, filename)
         self._plugin_path_cache[''][name] = filename
-        self.find_plugin(name):
+        self.find_plugin(name)
 
 
 action_loader = PluginLoader(

--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -235,6 +235,7 @@ class PluginLoader:
             # they can have any suffix
             suffix = ''
 
+            # naive assumption that this is a namespace module from a role
             if name.count('.') == 2:
                 gr = get_role_by_module_fqn(name)
                 self.add_module_by_file(name, gr.module_file)

--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -33,6 +33,7 @@ from collections import defaultdict
 from ansible import constants as C
 from ansible.module_utils._text import to_text
 
+from ansible.galaxy.helpers import get_role_by_module_fqn
 
 try:
     from __main__ import display
@@ -234,6 +235,10 @@ class PluginLoader:
             # they can have any suffix
             suffix = ''
 
+            if name.count('.') == 2:
+                gr = get_role_by_module_fqn(name)
+                self.add_module_by_file(name, gr.module_file)
+
         # The particular cache to look for modules within.  This matches the
         # requested mod_type
         pull_cache = self._plugin_path_cache[suffix]
@@ -420,7 +425,6 @@ class PluginLoader:
         # Add a module to the cache by filepath
         self._module_cache[name] = self._load_module_source(name, filename)
         self._plugin_path_cache[''][name] = filename
-        self.find_plugin(name)
 
 
 action_loader = PluginLoader(

--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -416,6 +416,16 @@ class PluginLoader:
             setattr(obj, '_original_path', path)
             yield obj
 
+    def add_module_by_file(self, name, filename):
+        self._module_cache[name] = self._load_module_source(name, filename)
+        # self._plugin_path_cache[suffix]
+        #self._plugin_path_cache[name] = filename
+        self._plugin_path_cache[''][name] = filename
+        #self.add_directory(os.path.dirname(filename))
+        if not self.find_plugin(name):
+            import sys; sys.exit(1)
+
+
 action_loader = PluginLoader(
     'ActionModule',
     'ansible.plugins.action',

--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -417,13 +417,10 @@ class PluginLoader:
             yield obj
 
     def add_module_by_file(self, name, filename):
+        # Add a module to the cache by filepath
         self._module_cache[name] = self._load_module_source(name, filename)
-        # self._plugin_path_cache[suffix]
-        #self._plugin_path_cache[name] = filename
         self._plugin_path_cache[''][name] = filename
-        #self.add_directory(os.path.dirname(filename))
-        if not self.find_plugin(name):
-            import sys; sys.exit(1)
+        self.find_plugin(name):
 
 
 action_loader = PluginLoader(


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

plugin loader
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.3
```
##### SUMMARY

Allow for a playbook such as ...

```
- hosts: el6host
  connection: local
  gather_facts: False
  tasks:
    - jctanner.pinger.pinger:
```

"jctanner.pinger" is the galaxy role reference and "pinger" is a module file in the role's library path. Once the playbook is run, a few things will happen:
1. Check if the module has two periods in it
2. Split the name into the role name and the module name
3. Check if the role is installed, and install if not
4. Put the module's FQN into the plugin loader

The task will then operate like any other module was called.
