### PR TITLE
Create groups from tags

### DIFF
--- a/contrib/inventory/digital_ocean.py
+++ b/contrib/inventory/digital_ocean.py
@@ -46,6 +46,7 @@ The following groups are generated from --list:
  - region_NAME
  - size_NAME
  - status_STATUS
+ - tag_TAG
 
 When run against a specific host, this script returns the following variables:
  - do_backup_ids
@@ -399,6 +400,12 @@ or environment variables (DO_API_TOKEN)\n''')
                         self.inventory[image] = { 'hosts': [ ], 'vars': {} }
                     self.inventory[image]['hosts'].append(dest)
 
+            # create a group for each tag.
+            for tag in droplet['tags']:
+                group = 'tag_' + tag
+                if group not in self.inventory:
+                    self.inventory[group] = { 'hosts': [ ], 'vars': {} }
+                self.inventory[group]['hosts'].append(dest)
 
 
     def load_droplet_variables_for_host(self):


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

compat/inventory/digital_ocean.py
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 5bc3cb278c) last updated 2016/10/03 01:22:59 (GMT -700)
  lib/ansible/modules/core: (detached HEAD e4c5a13a7a) last updated 2016/10/03 01:23:04 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD df35d324d6) last updated 2016/10/03 01:23:08 (GMT -700)
  config file = /home/mj/ansible/etc/ansible/config
  configured module search path = Default w/o overrides
```
##### SUMMARY

This change creates groups based on the tags assigned to droplets to allow more fine grain controls over groups.

```
No output provided as it contains private information I would rather not publish.
```
