### PR TITLE
no need for warnings in first_found

### DIFF
--- a/lib/ansible/plugins/lookup/__init__.py
+++ b/lib/ansible/plugins/lookup/__init__.py
@@ -102,7 +102,7 @@ class LookupBase(with_metaclass(ABCMeta, object)):
         """
         pass
 
-    def find_file_in_search_path(self, myvars, subdir, needle):
+    def find_file_in_search_path(self, myvars, subdir, needle, ignore_missing=False):
         '''
         Return a file (needle) in the task's expected search path.
         '''
@@ -113,7 +113,7 @@ class LookupBase(with_metaclass(ABCMeta, object)):
             paths = self.get_basedir(myvars)
 
         result = self._loader.path_dwim_relative_stack(paths, subdir, needle)
-        if result is None:
+        if result is None and not ignore_missing:
             self._display.warning("Unable to find '%s' in expected paths." % needle)
 
         return result

--- a/lib/ansible/plugins/lookup/first_found.py
+++ b/lib/ansible/plugins/lookup/first_found.py
@@ -181,7 +181,7 @@ class LookupModule(LookupBase):
              # get subdir if set by task executor, default to files otherwise
             subdir = getattr(self, '_subdir', 'files')
             path = None
-            path = self.find_file_in_search_path(variables, subdir, fn)
+            path = self.find_file_in_search_path(variables, subdir, fn, ignore_missing=True)
             if path is not None:
                 return [path]
         else:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

lookups
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.2
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

with search path changes, first_found became very noisy, this fixes that.

example task:
https://github.com/jbergstroem/build/blob/feature/refactor-the-world/ansible/roles/baselayout/tasks/main.yml#L76..L85

example output:
https://gist.github.com/jbergstroem/053fa45ec0cd876c41296cdc461b8189#file-gistfile1-txt-L150..L166
