### PR TITLE
Fix minor typo on testing paths example

### DIFF
--- a/docsite/rst/playbooks_tests.rst
+++ b/docsite/rst/playbooks_tests.rst
@@ -88,7 +88,7 @@ Testing paths
 The following tests can provide information about a path on the controller::
 
     - debug: msg="path is a directory"
-      when: mypath|isdir
+      when: mypath|is_dir
 
     - debug: msg="path is a file"
       when: mypath|is_file


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

docsite
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0 (devel 0a86ddc251) last updated 2016/10/05 13:51:38 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 0ee774ff15) last updated 2016/10/05 13:51:46 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 5cc72c3f06) last updated 2016/10/05 13:51:53 (GMT +200)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

This PR just fix a minor typo on a jinja2 test example using `isdir`.

The correct test name is `is_dir` as you can see in https://github.com/ansible/ansible/blob/0a86ddc25125359c244ac7040036a5080dd5bb04/lib/ansible/plugins/test/files.py#L31

Using `isdir` you will see a `no filter named 'isdir'` error:

```
TASK [check-dir : debug] *****************************************
fatal: [server-0]: FAILED! => {"failed": true, "msg": "The conditional check 'mypath|isdir' failed. The error was: template error while templating string: no filter named 'isdir'. String: {% if mypath|isdir %} True {% else %} False {% endif %}\n\nThe error appears to have been in '/home/pabluk/dev/projects/check-dir/ansible/roles/check-dir/tasks/main.yml': line 12, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- debug: msg=\"path is a directory\"\n  ^ here\n"}
```

using `is_dir` instead there is no error:

```
TASK [check-dir : debug] *****************************************
ok: [server-0] => {
    "msg": "path is a directory"
}
```
