### PR TITLE
Add dynamic inventory for oVirt version 4 and RHV version 4

### DIFF
--- a/contrib/inventory/ovirt.ini
+++ b/contrib/inventory/ovirt.ini
@@ -31,3 +31,4 @@ ovirt_api_secrets =
 ovirt_url =
 ovirt_username =
 ovirt_password =
+ovirt_ca_file =

--- a/contrib/inventory/ovirt4.py
+++ b/contrib/inventory/ovirt4.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Red Hat, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+oVirt dynamic inventory script
+=================================
+
+Generates dynamic inventory file for oVirt.
+
+Script will return following attributes for each virtual machine:
+ - id
+ - name
+ - host
+ - cluster
+ - status
+ - description
+ - fqdn
+ - os_type
+ - template
+ - tags
+ - statistics
+ - devices
+
+When run in --list mode, virtual machines are grouped by the following categories:
+ - cluster
+ - tag
+ - status
+
+ Note: If there is some virtual machine which has has more tags it will be in both tag
+       records.
+
+Examples:
+  # Execute update of system on webserver virtual machine:
+
+    $ ansible -i contrib/inventory/ovirt4.py webserver -m yum -a "name=* state=latest"
+
+  # Get webserver virtual machine information:
+
+    $ contrib/inventory/ovirt4.py --host webserver
+
+Author: Ondra Machacek (@machacekondra)
+"""
+
+import argparse
+import ConfigParser
+import os
+import sys
+
+from collections import defaultdict
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
+try:
+    import ovirtsdk4 as sdk
+    import ovirtsdk4.types as otypes
+except ImportError:
+    print('oVirt inventory script requires ovirt-engine-sdk-python >= 4.0.0')
+    sys.exit(1)
+
+
+def parse_args():
+    """
+    Create command line parser for oVirt dynamic inventory script.
+    """
+    parser = argparse.ArgumentParser(
+        description='Ansible dynamic inventory script for oVirt.',
+    )
+    parser.add_argument(
+        '--list',
+        action='store_true',
+        default=True,
+        help='Get data of all virtual machines (default: True).',
+    )
+    parser.add_argument(
+        '--host',
+        help='Get data of virtual machines running on specified host.',
+    )
+    parser.add_argument(
+        '--pretty',
+        action='store_true',
+        default=False,
+        help='Pretty format (default: False).',
+    )
+    return parser.parse_args()
+
+
+def create_connection():
+    """
+    Create a connection to oVirt engine API.
+    """
+    # Get the path of the configuration file, by default use
+    # 'ovirt.ini' file in script directory:
+    default_path = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        'ovirt.ini',
+    )
+    config_path = os.environ.get('OVIRT_INI_PATH', default_path)
+
+    # Create parser and add ovirt section if it doesn't exist:
+    config = ConfigParser.SafeConfigParser()
+    if not config.has_section('ovirt'):
+        config.add_section('ovirt')
+    config.read(config_path)
+
+    # Create a connection with options defined in ini file:
+    return sdk.Connection(
+        url=config.get('ovirt', 'ovirt_url'),
+        username=config.get('ovirt', 'ovirt_username'),
+        password=config.get('ovirt', 'ovirt_password'),
+        ca_file=config.get('ovirt', 'ovirt_ca_file'),
+        insecure=config.get('ovirt', 'ovirt_ca_file') is None,
+    )
+
+
+def get_dict_of_struct(connection, vm):
+    """
+    Transform SDK Vm Struct type to Python dictionary.
+    """
+    vms_service = connection.system_service().vms_service()
+    vm_service = vms_service.vm_service(vm.id)
+    devices = vm_service.reported_devices_service().list()
+    tags = vm_service.tags_service().list()
+    stats = vm_service.statistics_service().list()
+
+    return {
+        'id': vm.id,
+        'name': vm.name,
+        'host': connection.follow_link(vm.host).name if vm.host else None,
+        'cluster': connection.follow_link(vm.cluster).name,
+        'status': str(vm.status),
+        'description': vm.description,
+        'fqdn': vm.fqdn,
+        'os_type': vm.os.type,
+        'template': connection.follow_link(vm.template).name,
+        'tags': [tag.name for tag in tags],
+        'statistics': dict(
+            (stat.name, stat.values[0].datum) for stat in stats
+        ),
+        'devices': dict(
+            (device.name, [ip.address for ip in device.ips]) for device in devices
+        ),
+        'ansible_host': devices[0].ips[0].address if len(devices) > 0 else None,
+    }
+
+
+def get_data(connection, vm_name=None):
+    """
+    Obtain data of `vm_name` if specified, otherwise obtain data of all vms.
+    """
+    # Locate vms service:
+    vms_service = connection.system_service().vms_service()
+
+    if vm_name:
+        data = get_dict_of_struct(
+            connection=connection,
+            vm=vms_service.list(search='name=%s' % vm_name)[0]
+        )
+    else:
+        vms = dict()
+        data = defaultdict(list)
+        for vm in vms_service.list():
+            name = vm.name
+
+            # Add vm to vms dict:
+            vms[name] = get_dict_of_struct(connection, vm)
+
+            # Add vm to cluster group:
+            cluster_name = connection.follow_link(vm.cluster).name
+            data['cluster_%s' % cluster_name].append(name)
+
+            # Add vm to tag group:
+            tags_service = vms_service.vm_service(vm.id).tags_service()
+            for tag in tags_service.list():
+                data['tag_%s' % tag.name].append(name)
+
+            # Add vm to status group:
+            data['status_%s' % vm.status].append(name)
+
+        data["_meta"] = {
+            'hostvars': vms,
+        }
+
+    return data
+
+
+def main():
+    args = parse_args()
+    connection = create_connection()
+
+    print(
+        json.dumps(
+            obj=get_data(
+                connection=connection,
+                vm_name=args.host,
+            ),
+            sort_keys=args.pretty,
+            indent=args.pretty * 2,
+        )
+    )
+
+if __name__ == '__main__':
+    main()

--- a/contrib/inventory/rhv.py
+++ b/contrib/inventory/rhv.py
@@ -1,0 +1,1 @@
+ovirt4.py


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

contrib/inventory/ovirt4.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible --version
ansible 2.1.1.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

This patch adds new dynamic inventory script for oVirt version 4.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
 $ contrib/inventory/ovirt4.py --host rhel7 --pretty
{
  "ansible_ssh_host": "10.34.60.149", 
  "cluster": "mycluster", 
  "description": null, 
  "devices": {
    "eth0": [
      "10.34.60.149", 
      "fe80::21a:4aff:fe16:151", 
      "2620:52:0:223c:21a:4aff:fe16:151"
    ]
  }, 
  "fqdn": "mydomain.local", 
  "host": "pm", 
  "id": "dba0125e-f53d-4b87-8b42-7ce8bfa6a0e4", 
  "name": "rhel7", 
  "os_type": "rhel_7x64", 
  "statistics": {
    "cpu.current.guest": 1.0, 
    "cpu.current.hypervisor": 0.0, 
    "cpu.current.total": 1.0, 
    "memory.buffered": 2789376.0, 
    "memory.cached": 253116416.0, 
    "memory.free": 862937088.0, 
    "memory.installed": 1073741824.0, 
    "memory.used": 204010946.0, 
    "migration.progress": 0.0
  }, 
  "status": "up", 
  "tags": [], 
  "template": "rhel7"
}

```
