### PR TITLE
adds new option to get_config to grab config with passwords

### DIFF
--- a/lib/ansible/module_utils/asa.py
+++ b/lib/ansible/module_utils/asa.py
@@ -35,8 +35,6 @@ from ansible.module_utils.network import to_list
 from ansible.module_utils.shell import CliBase
 from ansible.module_utils.netcli import Command
 
-add_argument('show_command', dict(default='show running-config',
-             choices=['show running-config', 'more system:running-config']))
 add_argument('context', dict(required=False))
 
 
@@ -88,10 +86,16 @@ class Cli(CliBase):
         responses = self.execute(cmds)
         return responses[1:]
 
-    def get_config(self, include_defaults=False):
+    def get_config(self, include=None):
+        if include not in [None, 'defaults', 'passwords']:
+            raise ValueError('include must be one of None, defaults, passwords')
         cmd = 'show running-config'
-        if include_defaults:
-            cmd += ' all'
+        if include == 'passwords':
+            cmd = 'more system:running-config'
+        elif include_defaults:
+            cmd = 'show running-config all'
+        else:
+            cmd = 'show running-config'
         return self.run_commands(cmd)[0]
 
     def load_config(self, commands):

--- a/lib/ansible/utils/module_docs_fragments/asa.py
+++ b/lib/ansible/utils/module_docs_fragments/asa.py
@@ -90,18 +90,6 @@ options:
         met either by individual arguments or values in this dict.
     required: false
     default: null
-  show_command:
-    description:
-      - Specifies which command will be used to get the current configuration.
-        By default the C(show running-config) command will be used, this command
-        masks some passwords. For example passwords for VPN. If you need to
-        match against masked passwords use C(more system:running-config).
-        Note that the C(more system:running-config) only works in the system
-        context if you are running the ASA in multiple context mode.
-        before sending any commands.
-    required: false
-    default: show running-config
-    choices: ['show running-config', 'more system:running-config']
   context:
     description:
       - Specifies which context to target if you are running in the ASA in


### PR DESCRIPTION
In order for the config to be returned with vpn passwords, the get_config()
method now supports a keyword arg include=passwords to return the desired
configuration.
