### PR TITLE
Moves 'statically included' messages to -vv verbosity

### DIFF
--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -197,7 +197,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                         # the same fashion used by the on_include callback. We also do it here,
                         # because the recursive nature of helper methods means we may be loading
                         # nested includes, and we want the include order printed correctly
-                        display.display("statically included: %s" % include_file, color=C.COLOR_SKIP)
+                        display.vv("statically included: %s" % include_file)
                     except AnsibleFileNotFound:
                         if t.static or \
                            C.DEFAULT_TASK_INCLUDES_STATIC or \


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

Helper
##### ANSIBLE VERSION

```
ansible 2.3.0 (print-statically-included-in-vv 4d1ff0f17f) last updated 2016/10/06 15:31:02 (GMT +200)
```
##### SUMMARY

In version 2.1.2, `ansible-playbook` introduced the printing of `statically included: /path/to/included/file.yml` while it parses the passed playbook. This wasn't the case in 2.1.1 and it's bad that a bugfix release changes what Ansible prints by default. Also the devel version prints the same thing. I like this addition, but it shouldn't be printed with default verbosity, it should be printed with `-vv`. 

This pull request moves `statically included:` messages to verbosity level 2.

So for example this playbook:

``` yml
# test_include.yml

---
- hosts: localhost
  gather_facts: no
  tasks:
    - include: include.yml
```

``` yml
- debug: msg='Test'
```

if run with:

```
ansible-playbook -i localhost, test_include.yml
```

So with this change running that won't print `statically included` messages:

```
$ ansible-playbook -i localhost, test_include.yml 

PLAY [localhost] ***************************************************************
...
```

and with `-vv` it will:

```
% ansible-playbook -i localhost, test_include.yml -vv
Using /home/user/ansible_playbooks/ansible.cfg as config file
statically included: /home/user/ansible_playbooks/include.yml

PLAYBOOK: test_include.yml *****************************************************
1 plays in test_include.yml

PLAY [localhost] ***************************************************************


```
