### PR TITLE
Fix #17920

### DIFF
--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -184,7 +184,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                         # the same fashion used by the on_include callback. We also do it here,
                         # because the recursive nature of helper methods means we may be loading
                         # nested includes, and we want the include order printed correctly
-                        display.vv("statically included: %s" % include_file, color=C.COLOR_SKIP)
+                        display.vv("statically included: %s" % include_file)
                     except AnsibleFileNotFound as e:
                         if t.static or \
                            C.DEFAULT_TASK_INCLUDES_STATIC or \


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

ansible core
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.2.0 (bug-17920 402935caab) last updated 2016/10/06 16:11:41 (GMT +000)
  lib/ansible/modules/core: (detached HEAD 4602021670) last updated 2016/10/06 16:12:28 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD d312f34d9b) last updated 2016/10/06 16:12:35 (GMT +000)
  config file = /home/stephane/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

6db31bb4c6f8b6338a38ae602d3b4f5ca8cbce5b broke the stable-2.1
branch because an incorrect version of
https://github.com/ansible/ansible/pull/17918 got applied. Fixes #17920 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
```
