### PR TITLE
[GCE] Integration test for gce_tag module.

### DIFF
--- a/test/integration/gce.yml
+++ b/test/integration/gce.yml
@@ -5,4 +5,5 @@
     - { role: test_gce_pd, tags: test_gce_pd }
     - { role: test_gce_mig, tags: test_gce_mig }
     - { role: test_gcdns, tags: test_gcdns }
+    - { role: test_gce_tag, tags: test_gce_tag }
     # TODO: tests for gce_lb, gce_net, gc_storage

--- a/test/integration/roles/test_gce_tag/defaults/main.yml
+++ b/test/integration/roles/test_gce_tag/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+# defaults file for test_gce_tags
+instance_name: "{{ resource_prefix|lower }}"
+service_account_email: "{{ gce_service_account_email }}"
+pem_file: "{{ gce_pem_file }}"
+project_id: "{{ gce_project_id }}"
+zone: "us-central1-c"
+machine_type: f1-micro
+image: debian-8
+

--- a/test/integration/roles/test_gce_tag/tasks/main.yml
+++ b/test/integration/roles/test_gce_tag/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# test role for gce_tag
+- include: setup.yml
+- include: test.yml
+- include: teardown.yml

--- a/test/integration/roles/test_gce_tag/tasks/setup.yml
+++ b/test/integration/roles/test_gce_tag/tasks/setup.yml
@@ -1,0 +1,20 @@
+# GCE Tag Setup.
+# ============================================================
+- name: "Create instance for executing gce_tag tests"
+  gce:
+    instance_names: "{{ instance_name }}"
+    machine_type: "{{ machine_type }}"
+    image: "{{ image }}"
+    zone: "{{ zone }}"
+    project_id: "{{ project_id }}"
+    pem_file: "{{ pem_file }}"
+    service_account_email: "{{ service_account_email }}"
+    state: present
+  register: result
+
+- name: assert VM created
+  assert:
+    that:
+      - 'result.changed'
+      - 'result.instance_names[0] == "{{ instance_name }}"'
+      - 'result.state == "present"'

--- a/test/integration/roles/test_gce_tag/tasks/teardown.yml
+++ b/test/integration/roles/test_gce_tag/tasks/teardown.yml
@@ -1,0 +1,18 @@
+# GCE Tag Teardown.
+# ============================================================
+- name: "Teardown instance used in gce_tag test"
+  gce:
+    instance_names: "{{ instance_name }}"
+    zone: "{{ zone }}"
+    project_id: "{{ project_id }}"
+    pem_file: "{{ pem_file }}"
+    service_account_email: "{{ service_account_email }}"
+    state: absent
+  register: result
+
+- name: assert VM removed
+  assert:
+    that:
+      - 'result.changed'
+      - 'result.instance_names[0] == "{{ instance_name }}"'
+      - 'result.state == "absent"'

--- a/test/integration/roles/test_gce_tag/tasks/test.yml
+++ b/test/integration/roles/test_gce_tag/tasks/test.yml
@@ -1,0 +1,133 @@
+# GCE Tag Integration Tests.
+
+## Parameter checking tests ##
+# ============================================================
+- name: "test missing param: instance_name"
+  gce_tag:
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+  register: result
+  ignore_errors: true
+  tags:
+    - param-check
+
+- name: "assert failure when param: instance_name missing"
+  assert:
+    that:
+       - 'result.failed'
+       - 'result.msg == "missing required arguments: instance_name"'
+
+
+# ============================================================
+- name: "test missing param: tags"
+  gce_tag:
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    zone: "{{ zone }}"
+    instance_name: "{{ instance_name }}"
+  register: result
+  ignore_errors: true
+  tags:
+    - param-check
+
+- name: "assert failure when param: tags missing"
+  assert:
+    that:
+       - 'result.failed'
+       - 'result.msg == "Must specify \"tags\""'
+
+
+## Non-existant instance tests ##
+# # ============================================================
+- name: "test tag non-existant instance (state==present)"
+  gce_tag:
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    instance_name: "blahblahblah123"
+    zone: "{{ zone }}"
+    state: present
+    tags: foo,bar
+  register: result
+  ignore_errors: true
+
+- name: "assert tag failed"
+  assert:
+    that:
+       - 'result.failed'
+
+# # ============================================================
+- name: "test tag non-existant instance (state==absent)"
+  gce_tag:
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    instance_name: "blahblahblah123"
+    zone: "{{ zone }}"
+    state: absent
+    tags: foo,bar
+  register: result
+  ignore_errors: true
+
+- name: "assert tag failed"
+  assert:
+    that:
+       - 'result.failed'
+       
+## tagging tests ##
+# # ============================================================
+- name: "test tags added (state==present)"
+  gce_tag:
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    instance_name: "{{ instance_name }}"
+    zone: "{{ zone }}"
+    tags: foo,bar
+    state: present
+  register: result
+
+- name: "assert tag successful"
+  assert:
+    that:
+       - 'result.changed'
+       - 'result.tags|length == 2'
+       - 'result.tags == ["foo", "bar"]'
+       
+# # ============================================================
+- name: "add existing tags, no change (state==present)"
+  gce_tag:
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    instance_name: "{{ instance_name }}"
+    zone: "{{ zone }}"
+    tags: foo,bar
+    state: present
+  register: result
+
+- name: "assert tag successful"
+  assert:
+    that:
+       - 'result.changed == False'
+       - 'result.tags == None'
+
+# # ============================================================
+- name: "test tags removed from instance (state==absent)"
+  gce_tag:
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    instance_name: "{{ instance_name }}"
+    zone: "{{ zone }}"
+    tags: foo,bar
+    state: absent
+  register: result
+
+- name: "assert tags removed"
+  assert:
+    that:
+       - 'result.changed'
+       - 'result.tags == ["foo", "bar"]'


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Integration Test Pull Request
##### COMPONENT NAME

Integration Test for gce_tag module
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0 (int-gce-tag 403fa67363) last updated 2016/10/06 22:50:41 (GMT +000)
  lib/ansible/modules/core: (gce-doc b4f6a25195) last updated 2016/10/06 16:34:06 (GMT +000)
  lib/ansible/modules/extras: (gcdns-record-data 54c5e160c0) last updated 2016/09/21 21:27:31 (GMT +000)
  config file = /home/supertom/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Basic integration test for gce_tag module.

Also includes setup and teardown of a single (f1-micro) VM to execute the tests against.
##### RUN TESTS

```
cd tests/integration
cp credentials.template credentials.yml (fill in GCE credentials)
TEST_FLAGS='--tags "test_gce_tag"' make gce
```

/cc @ryansb
