### PR TITLE
Restore "skipping: no hosts matched" message

### DIFF
--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -142,12 +142,11 @@ class PlaybookExecutor:
 
                         break_play = False
                         # we are actually running plays
-                        for batch in self._get_serialized_batches(new_play):
-                            if len(batch) == 0:
-                                self._tqm.send_callback('v2_playbook_on_play_start', new_play)
-                                self._tqm.send_callback('v2_playbook_on_no_hosts_matched')
-                                break
-
+                        batches = self._get_serialized_batches(new_play)
+                        if len(batches) == 0:
+                            self._tqm.send_callback('v2_playbook_on_play_start', new_play)
+                            self._tqm.send_callback('v2_playbook_on_no_hosts_matched')
+                        for batch in batches:
                             # restrict the inventory to the hosts in the serialized batch
                             self._inventory.restrict_to_hosts(batch)
                             # and run it...


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
nsible 2.3.0 (upstream-devel f012159860) last updated 2016/10/06 18:25:58 (GMT +000)
  lib/ansible/modules/core: (detached HEAD b4f6a25195) last updated 2016/10/06 22:34:01 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 118fe8283e) last updated 2016/10/06 22:34:04 (GMT +000)
  config file = /home/stephane/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

In https://github.com/ansible/ansible/commit/159aa26b36a6455ebc38d527c294c60899892c04 the result of _get_serialized_branches when no hosts were matched changed from [[]] to []. Thus, the v2_playbook_on_no_hosts_matched callback would not fire. Change the check so we get the error message again. Fixes #17706

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
before:
PLAYBOOK: test.yml *************************************************************
1 plays in test.yml

PLAY RECAP *********************************************************************


after:
PLAYBOOK: test.yml *************************************************************
1 plays in test.yml

PLAY [fnord] *******************************************************************
skipping: no hosts matched

PLAY RECAP *********************************************************************


```
