### PR TITLE
Adding self.log() on IOErrors and OSErrros

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2266,11 +2266,11 @@ class AnsibleModule(object):
             rc = cmd.returncode
         except (OSError, IOError):
             e = get_exception()
-            self.log("%s: Error Executing CMD:%s PERM:%s Exception:%s" % (args[0] , args[1] , str(e)))
+            self.log("Error Executing CMD:%s Exception:%s" % (clean_args, to_native(e)))
             self.fail_json(rc=e.errno, msg=to_native(e), cmd=clean_args)
         except Exception:
             e = get_exception()
-            self.log("%s: Error Executing CMD:%s PERM:%s Exception:%s" % (args[0] , args[1] , str(traceback.format_exc())))
+            self.log("Error Executing CMD:%s Exception:%s" % (clean_args,to_native(traceback.format_exc())))
             self.fail_json(rc=257, msg=to_native(e), exception=traceback.format_exc(), cmd=clean_args)
 
         # Restore env settings

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2266,9 +2266,11 @@ class AnsibleModule(object):
             rc = cmd.returncode
         except (OSError, IOError):
             e = get_exception()
+            self.log("%s: Error Executing CMD:%s PERM:%s Exception:%s" % (args[0] , args[1] , str(e)))
             self.fail_json(rc=e.errno, msg=to_native(e), cmd=clean_args)
         except Exception:
             e = get_exception()
+            self.log("%s: Error Executing CMD:%s PERM:%s Exception:%s" % (args[0] , args[1] , str(traceback.format_exc())))
             self.fail_json(rc=257, msg=to_native(e), exception=traceback.format_exc(), cmd=clean_args)
 
         # Restore env settings


### PR DESCRIPTION
##### ISSUE TYPE
- Feature request

##### COMPONENT NAME

Basic
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0.0 (stable-2.2-logging d24341a359) last updated 2016/10/07 10:25:03 (GMT +100)

```
##### SUMMARY
Add syslog logging when commands fail due to IOError or OSError

These two lines just add self.log() to IOErrors and OSErrors , so users will be able to see what went wrong on syslog and be able to send it to kibana and others.
