### PR TITLE
Add warnings when installing container type roles

### DIFF
--- a/lib/ansible/galaxy/api.py
+++ b/lib/ansible/galaxy/api.py
@@ -91,7 +91,8 @@ class GalaxyAPI(object):
             headers = self.__auth_header()
         try:
             display.vvv(url)
-            resp = open_url(url, data=args, validate_certs=self._validate_certs, headers=headers, method=method)
+            resp = open_url(url, data=args, validate_certs=self._validate_certs, headers=headers, method=method,
+                            timeout=20)
             data = json.load(resp)
         except HTTPError as e:
             res = json.load(e)

--- a/lib/ansible/galaxy/data/metadata_template.j2
+++ b/lib/ansible/galaxy/data/metadata_template.j2
@@ -18,18 +18,21 @@ galaxy_info:
 
   min_ansible_version: {{ min_ansible_version }}
 
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
   # Optionally specify the branch Galaxy will use when accessing the GitHub
   # repo for this role. During role install, if no tags are available,
   # Galaxy will use this branch. During import Galaxy will access files on
-  # this branch. If travis integration is cofigured, only notification for this
+  # this branch. If Travis integration is configured, only notifications for this
   # branch will be accepted. Otherwise, in all cases, the repo's default branch
   # (usually master) will be used.
   #github_branch:
 
   #
-  # Below are all platforms currently available. Just uncomment
-  # the ones that apply to your role. If you don't see your
-  # platform on this list, let us know and we'll get it added!
+  # Below are all platforms currently available. Just uncomment the ones that apply
+  # to your role. If you don't see your platform on this list, let us know,
+  # and we'll get it added!
   #
   #platforms:
   {%- for platform,versions in platforms.items() %}
@@ -42,18 +45,16 @@ galaxy_info:
   {%- endfor %}
 
   galaxy_tags: []
-    # List tags for your role here, one per line. A tag is
-    # a keyword that describes and categorizes the role.
-    # Users find roles by searching for tags. Be sure to
-    # remove the '[]' above if you add tags to this list.
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
     #
-    # NOTE: A tag is limited to a single word comprised of
-    # alphanumeric characters. Maximum 20 tags per role.
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
 
 dependencies: []
-  # List your role dependencies here, one per line.
-  # Be sure to remove the '[]' above if you add dependencies
-  # to this list.
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
   {%- for dependency in dependencies %}
   #- {{ dependency }}
   {%- endfor %}

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -49,7 +49,6 @@ class GalaxyRole(object):
     META_INSTALL = os.path.join('meta', '.galaxy_install_info')
     ROLE_DIRS = ('defaults','files','handlers','meta','tasks','templates','vars','tests')
 
-
     def __init__(self, galaxy, name, src=None, version=None, scm=None, path=None):
 
         self._metadata = None
@@ -82,6 +81,7 @@ class GalaxyRole(object):
                 # create list of possible paths
                 self.paths = [x for x in galaxy.roles_paths]
                 self.paths = [os.path.join(x, self.name) for x in self.paths]
+
 
     def __eq__(self, other):
         return self.name == other.name
@@ -136,6 +136,8 @@ class GalaxyRole(object):
             version=self.version,
             install_date=datetime.datetime.utcnow().strftime("%c"),
         )
+        if not os.path.exists(os.path.join(self.path, 'meta')):
+            os.makedirs(os.path.join(self.path, 'meta'))
         info_path = os.path.join(self.path, self.META_INSTALL)
         with open(info_path, 'w+') as f:
             try:
@@ -209,6 +211,16 @@ class GalaxyRole(object):
                 role_data = api.lookup_role_by_name(self.src)
                 if not role_data:
                     raise AnsibleError("- sorry, %s was not found on %s." % (self.src, api.api_server))
+
+                if role_data.get('role_type') == 'CON':
+                    # Container Enabled
+                    display.warning("%s is a Container Enabled role and should only be installed using "
+                                    "Ansible Container" % self.name)
+
+                if role_data.get('role_type') == 'APP':
+                    # Container Role
+                    display.warning("%s is a Container App role and should only be installed using Ansible "
+                                    "Container" % self.name)
 
                 role_versions = api.fetch_role_related('versions', role_data['id'])
                 if not self.version:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

lib/ansible/galaxy/role.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0 (galaxy_type_warning 412d0b3371) last updated 2016/10/08 04:12:19 (GMT -400)
  lib/ansible/modules/core: (detached HEAD e4c5a13a7a) last updated 2016/10/03 09:29:48 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD df35d324d6) last updated 2016/10/03 09:29:48 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY
- Display warning when installing a Container Enabled or Container App role
- Clean up meta/main.yml template
- Increate API request timeout to 20 seconds
