### PR TITLE
Allow the Openstack dynamic inventory to discover ansible_user

### DIFF
--- a/contrib/inventory/openstack.py
+++ b/contrib/inventory/openstack.py
@@ -44,6 +44,9 @@
 #                has failed (for example, bad credentials or being offline).
 #                When set to False, the inventory will return hosts from
 #                whichever other clouds it can contact. (Default: True)
+#
+# Also it is possible to pass the correct user by setting an ansible_user: $myuser
+# metadata attribute.
 
 import argparse
 import collections
@@ -122,6 +125,11 @@ def append_hostvars(hostvars, groups, key, server, namegroup=False):
     hostvars[key] = dict(
         ansible_ssh_host=server['interface_ip'],
         openstack=server)
+
+    metadata = server.get('metadata', {})
+    if 'ansible_user' in metadata:
+        hostvars[key]['ansible_user'] = metadata['ansible_user']
+
     for group in get_groups_from_server(server, namegroup=namegroup):
         groups[group].append(key)
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

Openstack dynamic inventory
##### SUMMARY

This change allows the Openstack inventory script to discover `ansible_user` by setting it as instance metadata.
