### PR TITLE
cloudstack: add additional env vars

### DIFF
--- a/docsite/rst/guide_cloudstack.rst
+++ b/docsite/rst/guide_cloudstack.rst
@@ -97,6 +97,43 @@ Or by looping over a regions list if you want to do the task in every region:
           - exmaple_cloud_one
           - exmaple_cloud_two
 
+Environment Variables
+`````````````````````
+.. versionadded:: 2.3
+
+Since Ansible 2.3 it is possible to use environment variables for domain (``CLOUDSTACK_DOMAIN``), account (``CLOUDSTACK_ACCOUNT``), project (``CLOUDSTACK_PROJECT``) and zone (``CLOUDSTACK_ZONE``). This simplifies the tasks by not repeating the arguments for every tasks.
+
+Below you see an example how it can be used in combination with Ansible's block feature:
+
+.. code-block:: yaml
+
+    - hosts: cloud-vm
+      tasks:
+        - block:
+            - name: ensure my ssh public key
+              local_action:
+                module: cs_sshkeypair
+                name: my-ssh-key
+                public_key: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
+
+            - name: ensure my ssh public key
+              local_action:
+                module: cs_instance:
+                  display_name: "{{ inventory_hostname_short }}"
+                  template: Linux Debian 7 64-bit 20GB Disk
+                  service_offering: "{{ cs_offering }}"
+                  ssh_key: my-ssh-key
+                  state: running
+
+          environment:
+            CLOUDSTACK_DOMAIN: root/customers
+            CLOUDSTACK_PROJECT: web-app
+            CLOUDSTACK_ZONE: sf-1
+
+.. Note:: You are still able overwrite the environment variables using the module arguments, e.g.``zone: sf-2``
+
+.. Note:: Unlike ``CLOUDSTACK_REGION`` these additional environment variables are ingored in the CLI ``cs``.
+
 Use Cases
 `````````
 The following should give you some ideas how to use the modules to provision VMs to the cloud. As always, there isn't only one way to do it. But as always: keep it simple for the beginning is always a good start.

--- a/lib/ansible/module_utils/cloudstack.py
+++ b/lib/ansible/module_utils/cloudstack.py
@@ -27,6 +27,7 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import os
 import time
 
 try:
@@ -253,6 +254,8 @@ class AnsibleCloudStack(object):
 
         project = self.module.params.get('project')
         if not project:
+            project = os.environ.get('CLOUDSTACK_PROJECT')
+        if not project:
             return None
         args = {}
         args['account'] = self.get_account(key='name')
@@ -341,6 +344,8 @@ class AnsibleCloudStack(object):
             return self._get_by_key(key, self.zone)
 
         zone = self.module.params.get('zone')
+        if not zone:
+            zone = os.environ.get('CLOUDSTACK_ZONE')
         zones = self.cs.listZones()
 
         # use the first zone if no zone param given
@@ -398,6 +403,8 @@ class AnsibleCloudStack(object):
 
         account = self.module.params.get('account')
         if not account:
+            account = os.environ.get('CLOUDSTACK_ACCOUNT')
+        if not account:
             return None
 
         domain = self.module.params.get('domain')
@@ -420,6 +427,8 @@ class AnsibleCloudStack(object):
             return self._get_by_key(key, self.domain)
 
         domain = self.module.params.get('domain')
+        if not domain:
+            domain = os.environ.get('CLOUDSTACK_DOMAIN')
         if not domain:
             return None
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

cloudstack
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.3
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

These env vars:
- CLOUDSTACK_ZONE
- CLOUDSTACK_DOMAIN
- CLOUDSTACK_ACCOUNT
- CLOUDSTACK_PROJECT

help to DRY on every task, args still have precedence.

/cc @sontags 
