### PR TITLE
Openstack dynamic inventory: respect OS_CLOUD env var

### DIFF
--- a/contrib/inventory/openstack.py
+++ b/contrib/inventory/openstack.py
@@ -218,6 +218,7 @@ def main():
             refresh=args.refresh,
             config_files=config_files,
             private=args.private,
+            cloud=os.environ.get('OS_CLOUD')
         )
         if hasattr(shade.inventory.OpenStackInventory, 'extra_config'):
             inventory_args.update(dict(

--- a/contrib/inventory/openstack.py
+++ b/contrib/inventory/openstack.py
@@ -29,8 +29,11 @@
 #  - /etc/openstack/clouds.yaml
 #  - /etc/ansible/openstack.yml
 # The clouds.yaml file can contain entries for multiple clouds and multiple
-# regions of those clouds. If it does, this inventory module will connect to
-# all of them and present them as one contiguous inventory.
+# regions of those clouds. If it does, this inventory module will by default
+# connect to all of them and present them as one contiguous inventory.  You
+# can limit to one cloud by passing the `--cloud` parameter, or use the
+# OS_CLOUD environment variable.  If caching is enabled, and a cloud is
+# selected, then per-cloud cache folders will be used.
 #
 # See the adjacent openstack.yml file for an example config file
 # There are two ansible inventory specific options that can be set in
@@ -108,8 +111,8 @@ def get_groups_from_server(server_vars, namegroup=True):
     return groups
 
 
-def get_host_groups(inventory, refresh=False):
-    (cache_file, cache_expiration_time) = get_cache_settings()
+def get_host_groups(inventory, refresh=False, cloud=None):
+    (cache_file, cache_expiration_time) = get_cache_settings(cloud)
     if is_cache_stale(cache_file, cache_expiration_time, refresh=refresh):
         groups = to_json(get_host_groups_from_cloud(inventory))
         open(cache_file, 'w').write(groups)
@@ -176,12 +179,14 @@ def is_cache_stale(cache_file, cache_expiration_time, refresh=False):
     return True
 
 
-def get_cache_settings():
+def get_cache_settings(cloud=None):
     config = os_client_config.config.OpenStackConfig(
         config_files=os_client_config.config.CONFIG_FILES + CONFIG_FILES)
     # For inventory-wide caching
     cache_expiration_time = config.get_cache_expiration_time()
     cache_path = config.get_cache_path()
+    if cloud:
+        cache_path = '{0}_{1}'.format(cache_path, cloud)
     if not os.path.exists(cache_path):
         os.makedirs(cache_path)
     cache_file = os.path.join(cache_path, 'ansible-inventory.cache')
@@ -194,6 +199,8 @@ def to_json(in_dict):
 
 def parse_args():
     parser = argparse.ArgumentParser(description='OpenStack Inventory Module')
+    parser.add_argument('--cloud', default=os.environ.get('OS_CLOUD'),
+                        help='Cloud name (default: None')
     parser.add_argument('--private',
                         action='store_true',
                         help='Use private address for ansible host')
@@ -218,7 +225,7 @@ def main():
             refresh=args.refresh,
             config_files=config_files,
             private=args.private,
-            cloud=os.environ.get('OS_CLOUD')
+            cloud=args.cloud,
         )
         if hasattr(shade.inventory.OpenStackInventory, 'extra_config'):
             inventory_args.update(dict(
@@ -233,7 +240,7 @@ def main():
         inventory = shade.inventory.OpenStackInventory(**inventory_args)
 
         if args.list:
-            output = get_host_groups(inventory, refresh=args.refresh)
+            output = get_host_groups(inventory, refresh=args.refresh, cloud=args.cloud)
         elif args.host:
             output = to_json(inventory.get_host(args.host))
         print(output)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

Openstack dynamic inventory
##### ANSIBLE VERSION

```
devel
```
##### SUMMARY

RIght now the Openstack inventory script always requests -all- defined clouds. This is an extremely expensive operation. This change makes it possible to use the OS_CLOUD environment variable to specify a cloud the same way the openstack command uses it:

``` shell
openstack --help|grep -B1 OS_CLOUD
  --os-cloud <cloud-config-name>
                        Cloud name in clouds.yaml (Env: OS_CLOUD)
```
