### PR TITLE
Fixes #17958: use stderr instead of the default stdout for fatal errors

### DIFF
--- a/lib/ansible/plugins/callback/stderr.py
+++ b/lib/ansible/plugins/callback/stderr.py
@@ -1,0 +1,81 @@
+# (c) 2017, Frederic Van Espen <github@freh.be>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible import constants as C
+from ansible.plugins.callback.default import CallbackModule as CallbackModule_default
+
+
+class CallbackModule(CallbackModule_default):
+
+    '''
+    This is the stderr callback plugin, which reuses the default
+    callback plugin but sends error output to stderr.
+    '''
+
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'stdout'
+    CALLBACK_NAME = 'stderr'
+
+    def __init__(self):
+
+        self.super_ref = super(CallbackModule, self)
+        self.super_ref.__init__()
+
+    def v2_runner_on_failed(self, result, ignore_errors=False):
+
+        delegated_vars = result._result.get('_ansible_delegated_vars', None)
+        self._clean_results(result._result, result._task.action)
+
+        if self._play.strategy == 'free' and self._last_task_banner != result._task._uuid:
+            self._print_task_banner(result._task)
+
+        self._handle_exception(result._result, errors_to_stderr=True)
+        self._handle_warnings(result._result)
+
+        if result._task.loop and 'results' in result._result:
+            self._process_items(result)
+
+        else:
+            if delegated_vars:
+                self._display.display("fatal: [%s -> %s]: FAILED! => %s" % (result._host.get_name(), delegated_vars['ansible_host'],
+                                                                            self._dump_results(result._result)), color=C.COLOR_ERROR,
+                                                                            stderr=True)
+            else:
+                self._display.display("fatal: [%s]: FAILED! => %s" % (result._host.get_name(), self._dump_results(result._result)),
+                                      color=C.COLOR_ERROR, stderr=True)
+
+        if ignore_errors:
+            self._display.display("...ignoring", color=C.COLOR_SKIP)
+
+    def _handle_exception(self, result, errors_to_stderr=False):
+
+        if 'exception' in result:
+            msg = "An exception occurred during task execution. "
+            if self._display.verbosity < 3:
+                # extract just the actual error message from the exception text
+                error = result['exception'].strip().split('\n')[-1]
+                msg += "To see the full traceback, use -vvv. The error was: %s" % error
+            else:
+                msg = "The full traceback is:\n" + result['exception']
+                del result['exception']
+
+            self._display.display(msg, color=C.COLOR_ERROR, stderr=errors_to_stderr)
+

--- a/lib/ansible/plugins/callback/stderr.py
+++ b/lib/ansible/plugins/callback/stderr.py
@@ -57,7 +57,7 @@ class CallbackModule(CallbackModule_default):
             if delegated_vars:
                 self._display.display("fatal: [%s -> %s]: FAILED! => %s" % (result._host.get_name(), delegated_vars['ansible_host'],
                                                                             self._dump_results(result._result)), color=C.COLOR_ERROR,
-                                                                            stderr=True)
+                                      stderr=True)
             else:
                 self._display.display("fatal: [%s]: FAILED! => %s" % (result._host.get_name(), self._dump_results(result._result)),
                                       color=C.COLOR_ERROR, stderr=True)
@@ -78,4 +78,3 @@ class CallbackModule(CallbackModule_default):
                 del result['exception']
 
             self._display.display(msg, color=C.COLOR_ERROR, stderr=errors_to_stderr)
-


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.0.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Fixes #17958 
The changes in this PR send any error output to stderr instead of the default stdout. This is useful for deployments where ansible is running e.g. from cron and you only want error output to be sent in an e-mail (redirect stdout to /dev/null)

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

Before change:

```
~# ansible-playbook /usr/local/share/ansible/playbook/site.yml --limit unreachablehost.example.com >/dev/null

PLAY [sops] ********************************************************************

TASK [pubkeys : include] *******************************************************
included: /usr/local/share/ansible/playbook/roles/pubkeys/tasks/pubkeys.yml for unreachablehost.example.com

TASK [pubkeys : Get user information] ***********************************
fatal: [unreachablehost.example.com]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh.", "unreachable": true}
    to retry, use: --limit @/usr/local/share/ansible/playbook/site.retry

PLAY RECAP *********************************************************************
unreachablehost.example.com : ok=1    changed=0    unreachable=1    failed=0   

```

After change:

```
~# ansible-playbook /usr/local/share/ansible/playbook/site.yml --limit unreachablehost.example.com >/dev/null
fatal: [unreachablehost.example.com]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh.", "unreachable": true}

```
