### PR TITLE
vars_files work with directories

### DIFF
--- a/docs/docsite/rst/playbooks_variables.rst
+++ b/docs/docsite/rst/playbooks_variables.rst
@@ -727,7 +727,9 @@ important variables private.  Similarly, sometimes you may just
 want to keep certain information in different files, away from
 the main playbook.
 
-You can do this by using an external variables file, or files, just like this::
+You can do this by using an external variables files or directories.
+If you specify directories, Ansible will read all files in these directories.
+An example::
 
     ---
 
@@ -737,6 +739,7 @@ You can do this by using an external variables file, or files, just like this::
         favcolor: blue
       vars_files:
         - /vars/external_vars.yml
+        - /vars/external_vars_dir/
 
       tasks:
 

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -344,6 +344,18 @@ class VariableManager:
                 if not isinstance(vars_file_list, list):
                     vars_file_list = [vars_file_list]
 
+                # if 'vars_files' is directory, all files in dir are appended to vars_file_list.
+                tmp_vars_file_list = []
+                for vars_file in vars_file_list:
+                    tmp_vars_file_path = self._loader.path_dwim(templar.template(vars_file))
+                    if self._loader.is_directory(tmp_vars_file_path):
+                        tmp_var_files = [(vars_file + "/" + x) for x in os.listdir(tmp_vars_file_path)]
+                        # marge vars_file_list
+                        tmp_vars_file_list.extend(tmp_var_files)
+                    else:
+                        tmp_vars_file_list.append(vars_file)
+                vars_file_list = tmp_vars_file_list
+
                 # now we iterate through the (potential) files, and break out
                 # as soon as we read one from the list. If none are found, we
                 # raise an error, which is silently ignored at this point.


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
core

##### ANSIBLE VERSION
N/A

##### SUMMARY

add vars_dirs parameter in playbook.
If you specific vars_dirs, all vars files in dirs is included and appended to vars_files.
It helps to manage many vars_files and referrence from many playbook.
##### EXAMPLE
###### dir tree

```
<PLAYBOOK_DIR>
    └── vars_dir
        ├── foo.yml
        ├── bar.yml
        └── hoge.yml
```
###### playbook

_normaly_

```
- hosts: hoge
  vars_files:
    - "vars_dir/foo.yml"
    - "vars_dir/bar.yml"
    - "vars_dir/hoge.yml"
```

_after_

```
- hosts: hoge
  vars_dirs:
    - "vars_dir"
```
