### PR TITLE
restored 'results' filters

### DIFF
--- a/lib/ansible/plugins/test/core.py
+++ b/lib/ansible/plugins/test/core.py
@@ -121,17 +121,13 @@ class TestModule(object):
         return {
             # failure testing
             'failed'    : failed,
-            'failure'   : failed,
-            'success'   : success,
             'succeeded' : success,
 
             # changed testing
             'changed' : changed,
-            'change'  : changed,
 
             # skip testing
             'skipped' : skipped,
-            'skip'    : skipped,
 
             # regex
             'match': match,


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

filters
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.2
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

tests do not work the same, restoring old filters to keep backwards compat
tests now only implement the new normalized 'tense'
