### PR TITLE
Correct delegated_host_name check

### DIFF
--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -459,7 +459,7 @@ class VariableManager:
 
             templar.set_available_variables(vars_copy)
             delegated_host_name = templar.template(task.delegate_to, fail_on_undefined=False)
-            if not delegated_host_name:
+            if delegated_host_name is None:
                 raise AnsibleError(message="Undefined delegate_to host for task:", obj=task._ds)
             if delegated_host_name in delegated_host_vars:
                 # no need to repeat ourselves, as the delegate_to value


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

ansible core
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0 (host-none 70706378ab) last updated 2016/10/11 18:09:12 (GMT +000)
  lib/ansible/modules/core: (detached HEAD b4f6a25195) last updated 2016/10/11 18:12:51 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 734aa8f8e9) last updated 2016/10/11 18:12:54 (GMT +000)
  config file = /home/stephane/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

In https://github.com/ansible/ansible/commit/fb50698da32f36aaff5359f466679a7b8ff3f80b a check for delegated_host_name being defined was added. Make this
check safer as it breaks some playbooks. Bug reported by crab on IRC.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```
