### PR TITLE
docs: Tweak sentence for interaction of loops + register

### DIFF
--- a/docsite/rst/playbooks_loops.rst
+++ b/docsite/rst/playbooks_loops.rst
@@ -459,7 +459,7 @@ That's how!
 Using register with a loop
 ``````````````````````````
 
-When using ``register`` with a loop the data structure placed in the variable during a loop, will contain a ``results`` attribute, that is a list of all responses from the module.
+When using ``register`` with a loop, the data structure placed in the variable will contain a ``results`` attribute that is a list of all responses from the module.
 
 Here is an example of using ``register`` with ``with_items``::
 


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

Docs
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

The previous version had an extra `during a loop` and the comma broke
the sentence in the middle weirdly.  I think this new version reads
better.
