### PR TITLE
Making the ANSI escape regexes configurable in the Shell class in the…

### DIFF
--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -37,6 +37,7 @@ except ImportError:
 from ansible.module_utils.basic import get_exception
 from ansible.module_utils.network import NetworkError
 
+# Default ANSI and terminal escape sequence regexes
 ANSI_RE = [
     re.compile(r'(\x1b\[\?1h\x1b=)'),
     re.compile(r'\x08.')
@@ -61,7 +62,7 @@ class ShellError(Exception):
 
 class Shell(object):
 
-    def __init__(self, prompts_re=None, errors_re=None, kickstart=True):
+    def __init__(self, prompts_re=None, errors_re=None, ansi_re=None, kickstart=True):
         self.ssh = None
         self.shell = None
 
@@ -70,6 +71,7 @@ class Shell(object):
 
         self.prompts = prompts_re or list()
         self.errors = errors_re or list()
+        self.ansi = ansi_re or ANSI_RE
 
     def open(self, host, port=22, username=None, password=None, timeout=10,
              key_filename=None, pkey=None, look_for_keys=None,
@@ -118,7 +120,7 @@ class Shell(object):
         self.receive()
 
     def strip(self, data):
-        for regex in ANSI_RE:
+        for regex in self.ansi:
             data = regex.sub('', data)
         return data
 
@@ -222,6 +224,7 @@ class CliBase(object):
                 kickstart=kickstart,
                 prompts_re=self.CLI_PROMPTS_RE,
                 errors_re=self.CLI_ERRORS_RE,
+                ansi_re=self.CLI_ANSI_RE,
             )
             self.shell.open(
                 host, port=port, username=username, password=password,

--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -224,7 +224,7 @@ class CliBase(object):
                 kickstart=kickstart,
                 prompts_re=self.CLI_PROMPTS_RE,
                 errors_re=self.CLI_ERRORS_RE,
-                ansi_re=self.CLI_ANSI_RE,
+                ansi_re=getattr(self, "CLI_ANSI_RE", ANSI_RE)
             )
             self.shell.open(
                 host, port=port, username=username, password=password,


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

Shell and CliBase
##### ANSIBLE VERSION

```
ansible 2.3.0 (devel 0641225e74) last updated 2016/10/11 14:58:00 (GMT -700)
  lib/ansible/modules/core: (detached HEAD b4f6a25195) last updated 2016/10/11 11:18:35 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 734aa8f8e9) last updated 2016/10/11 11:18:40 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

In trying to use ansible with a network appliance similar to a cisco switch, I ran into an issue where the ios_command "show version" would hang.  After debugging, I determined that the cause was unusual ANSI escape sequences in the appliance's shell.  These weren't being filtered out by the ANSI_RE regexes in module_utils/shell.py.

To facilitate these sorts of devices, this change lets the Cli override the ANSI_RE regexes using the same code pattern that it uses to provide the prompts and errors regexes.
