### PR TITLE
Module examples should be in YAML format

### DIFF
--- a/docsite/rst/dev_guide/developing_modules.rst
+++ b/docsite/rst/dev_guide/developing_modules.rst
@@ -426,13 +426,13 @@ for URL, module, italic, and constant-width respectively. It is suggested
 to use ``C()`` for file and option names, and ``I()`` when referencing
 parameters; module names should be specified as ``M(module)``.
 
-Examples (which typically contain colons, quotes, etc.) are difficult
-to format with YAML, so these must be
-written in plain text in an ``EXAMPLES`` string within the module
-like this::
+Examples should be written in YAML format in plain text in an
+``EXAMPLES`` string within the module like this::
 
     EXAMPLES = '''
-    - action: modulename opt1=arg1 opt2=arg2
+    - modulename:
+        opt1: arg1
+        opt2: arg2
     '''
 
 The EXAMPLES section, just like the documentation section, is required in

--- a/docsite/rst/developing_modules.rst
+++ b/docsite/rst/developing_modules.rst
@@ -432,13 +432,13 @@ for URL, module, italic, and constant-width respectively. It is suggested
 to use ``C()`` for file and option names, and ``I()`` when referencing
 parameters; module names should be specified as ``M(module)``.
 
-Examples (which typically contain colons, quotes, etc.) are difficult
-to format with YAML, so these must be
-written in plain text in an ``EXAMPLES`` string within the module
-like this::
+Examples should be written in YAML format in plain text in an
+``EXAMPLES`` string within the module like this::
 
     EXAMPLES = '''
-    - action: modulename opt1=arg1 opt2=arg2
+    - modulename:
+        opt1: arg1
+        opt2: arg2
     '''
 
 The EXAMPLES section, just like the documentation section, is required in


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

developing_modules docs
##### ANSIBLE VERSION

```
ansible 2.3.0 (devel e5478a212f) last updated 2016/10/12 15:55:05 (GMT +1000)
  lib/ansible/modules/core: (detached HEAD 275fa3f055) last updated 2016/10/12 15:55:39 (GMT +1000)
  lib/ansible/modules/extras: (detached HEAD 6c31d91fa5) last updated 2016/10/12 15:55:42 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides

```
##### SUMMARY

Given that Ansible best practices say to use YAML format, our
documentation should not make the excuse that it's too hard,
but rather represent examples in YAML format.

This will allow those using the examples to instantly see
best practices
