### PR TITLE
docs_fragments formatting and typo improvements

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/asa.py
+++ b/lib/ansible/utils/module_docs_fragments/asa.py
@@ -32,21 +32,20 @@ options:
   port:
     description:
       - Specifies the port to use when building the connection to the remote
-        device.  The port value will default to the well known SSH port
-        of 22
+        device.
     required: false
     default: 22
   username:
     description:
       - Configures the username to use to authenticate the connection to
-        the remote device.  The value of I(username) is used to authenticate
+        the remote device.  This value is used to authenticate
         the SSH session. If the value is not specified in the task, the
         value of environment variable C(ANSIBLE_NET_USERNAME) will be used instead.
     required: false
   password:
     description:
       - Specifies the password to use to authenticate the connection to
-        the remote device.   The value of I(password) is used to authenticate
+        the remote device.   This value is used to authenticate
         the SSH session. If the value is not specified in the task, the
         value of environment variable C(ANSIBLE_NET_PASSWORD) will be used instead.
     required: false
@@ -54,7 +53,7 @@ options:
   ssh_keyfile:
     description:
       - Specifies the SSH key to use to authenticate the connection to
-        the remote device.   The value of I(ssh_keyfile) is the path to the
+        the remote device.   This value is the path to the
         key used to authenticate the SSH session. If the value is not specified
         in the task, the value of environment variable C(ANSIBLE_NET_SSH_KEYFILE)
         will be used instead.
@@ -79,7 +78,7 @@ options:
     default: none
   timeout:
     description:
-      - Specifies idle timeout for the connection. Useful if the console
+      - Specifies idle timeout for the connection, in seconds. Useful if the console
         freezes before continuing. For example when saving configurations.
     required: false
     default: 10

--- a/lib/ansible/utils/module_docs_fragments/aws.py
+++ b/lib/ansible/utils/module_docs_fragments/aws.py
@@ -29,7 +29,7 @@ options:
     aliases: []
   aws_secret_key:
     description:
-      - AWS secret key. If not set then the value of the AWS_SECRET_ACCESS_KEY, AWS_SECRET_KEY, or EC2_SECRET_KEY environment variable is used. 
+      - AWS secret key. If not set then the value of the AWS_SECRET_ACCESS_KEY, AWS_SECRET_KEY, or EC2_SECRET_KEY environment variable is used.
     required: false
     default: null
     aliases: [ 'ec2_secret_key', 'secret_key' ]
@@ -56,7 +56,7 @@ options:
     version_added: "1.5"
   profile:
     description:
-      - uses a boto profile. Only works with boto >= 2.24.0
+      - Uses a boto profile. Only works with boto >= 2.24.0.
     required: false
     default: null
     aliases: []

--- a/lib/ansible/utils/module_docs_fragments/dellos10.py
+++ b/lib/ansible/utils/module_docs_fragments/dellos10.py
@@ -3,7 +3,8 @@
 #
 # Copyright (c) 2016 Dell Inc.
 #
-# This file is part of Ansible 
+# This file is part of Ansible
+#
 # Ansible is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -37,23 +38,22 @@ options:
     default: 22
   username:
     description:
-      - This value I(username) is used to authenticate the SSH session to the
-        remote device. If the value is not specified in the task, the
-        value of environment variable ANSIBLE_NET_USERNAME will be used instead.
+      - User to authenticate the SSH session to the remote device. If the
+        value is not specified in the task, the value of environment variable
+        C(ANSIBLE_NET_USERNAME) will be used instead.
     required: false
   password:
     description:
-      - This value I(password) is used to authenticate the SSH session to 
-        the remote device. If the value is not specified in the task, the
-        value of environment variable ANSIBLE_NET_PASSWORD will be used instead.
+      - Password to authenticate the SSH session to the remote device. If the
+        value is not specified in the task, the value of environment variable
+        C(ANSIBLE_NET_PASSWORD) will be used instead.
     required: false
     default: null
   ssh_keyfile:
     description:
-      - This value I(ssh_keyfile) is the path to the key used to authenticate 
-        the SSH session to the remote device.  If the value is not specified
-        in the task, the value of environment variable ANSIBLE_NET_SSH_KEYFILE
-        will be used instead.
+      - Path to an ssh key used to authenticate the SSH session to the remote
+        device.  If the value is not specified in the task, the value of
+        environment variable C(ANSIBLE_NET_SSH_KEYFILE) will be used instead.
     required: false
   timeout:
     description:
@@ -64,7 +64,7 @@ options:
     default: 10
   provider:
     description:
-      - Convenience method that allows all M(dellos10) arguments to be passed as
+      - Convenience method that allows all I(dellos10) arguments to be passed as
         a dict object.  All constraints (required, choices, etc) must be
         met either by individual arguments or values in this dict.
     required: false

--- a/lib/ansible/utils/module_docs_fragments/dellos6.py
+++ b/lib/ansible/utils/module_docs_fragments/dellos6.py
@@ -40,28 +40,28 @@ options:
     description:
       - User to authenticate the SSH session to the remote device. If the
         value is not specified in the task, the value of environment variable
-        ANSIBLE_NET_USERNAME will be used instead.
+        C(ANSIBLE_NET_USERNAME) will be used instead.
     required: false
   password:
     description:
       - Password to authenticate the SSH session to the remote device. If the
         value is not specified in the task, the value of environment variable
-        ANSIBLE_NET_PASSWORD will be used instead.
+        C(ANSIBLE_NET_PASSWORD) will be used instead.
     required: false
     default: null
   ssh_keyfile:
     description:
       - Path to an ssh key used to authenticate the SSH session to the remote
         device.  If the value is not specified in the task, the value of
-        environment variable ANSIBLE_NET_SSH_KEYFILE will be used instead.
+        environment variable C(ANSIBLE_NET_SSH_KEYFILE) will be used instead.
     required: false
   authorize:
     description:
-      - Instructs the module to enter priviledged mode on the remote device
+      - Instructs the module to enter privileged mode on the remote device
         before sending any commands.  If not specified, the device will
-        attempt to excecute all commands in non-priviledged mode. If the value
+        attempt to execute all commands in non-privileged mode. If the value
         is not specified in the task, the value of environment variable
-        ANSIBLE_NET_AUTHORIZE will be used instead.
+        C(ANSIBLE_NET_AUTHORIZE) will be used instead.
     required: false
     default: no
     choices: ['yes', 'no']
@@ -70,7 +70,7 @@ options:
       - Specifies the password to use if required to enter privileged mode
         on the remote device.  If I(authorize) is false, then this argument
         does nothing. If the value is not specified in the task, the value of
-        environment variable ANSIBLE_NET_AUTH_PASS will be used instead.
+        environment variable C(ANSIBLE_NET_AUTH_PASS) will be used instead.
     required: false
     default: none
   timeout:
@@ -82,7 +82,7 @@ options:
     default: 10
   provider:
     description:
-      - Convenience method that allows all M(dellos6) arguments to be passed as
+      - Convenience method that allows all I(dellos6) arguments to be passed as
         a dict object.  All constraints (required, choices, etc) must be
         met either by individual arguments or values in this dict.
     required: false

--- a/lib/ansible/utils/module_docs_fragments/dellos9.py
+++ b/lib/ansible/utils/module_docs_fragments/dellos9.py
@@ -40,28 +40,28 @@ options:
     description:
       - User to authenticate the SSH session to the remote device. If the
         value is not specified in the task, the value of environment variable
-        ANSIBLE_NET_USERNAME will be used instead.
+        C(ANSIBLE_NET_USERNAME) will be used instead.
     required: false
   password:
     description:
       - Password to authenticate the SSH session to the remote device. If the
         value is not specified in the task, the value of environment variable
-        ANSIBLE_NET_PASSWORD will be used instead.
+        C(ANSIBLE_NET_PASSWORD) will be used instead.
     required: false
     default: null
   ssh_keyfile:
     description:
       - Path to an ssh key used to authenticate the SSH session to the remote
         device.  If the value is not specified in the task, the value of
-        environment variable ANSIBLE_NET_SSH_KEYFILE will be used instead.
+        environment variable C(ANSIBLE_NET_SSH_KEYFILE) will be used instead.
     required: false
   authorize:
     description:
-      - Instructs the module to enter priviledged mode on the remote device
+      - Instructs the module to enter privileged mode on the remote device
         before sending any commands.  If not specified, the device will
-        attempt to excecute all commands in non-priviledged mode. If the value
+        attempt to execute all commands in non-privileged mode. If the value
         is not specified in the task, the value of environment variable
-        ANSIBLE_NET_AUTHORIZE will be used instead.
+        C(ANSIBLE_NET_AUTHORIZE) will be used instead.
     required: false
     default: no
     choices: ['yes', 'no']
@@ -70,7 +70,7 @@ options:
       - Specifies the password to use if required to enter privileged mode
         on the remote device.  If I(authorize) is false, then this argument
         does nothing. If the value is not specified in the task, the value of
-        environment variable ANSIBLE_NET_AUTH_PASS will be used instead.
+        environment variable C(ANSIBLE_NET_AUTH_PASS) will be used instead.
     required: false
     default: none
   timeout:
@@ -82,7 +82,7 @@ options:
     default: 10
   provider:
     description:
-      - Convenience method that allows all M(dellos9) arguments to be passed as
+      - Convenience method that allows all I(dellos9) arguments to be passed as
         a dict object.  All constraints (required, choices, etc) must be
         met either by individual arguments or values in this dict.
     required: false

--- a/lib/ansible/utils/module_docs_fragments/files.py
+++ b/lib/ansible/utils/module_docs_fragments/files.py
@@ -25,39 +25,39 @@ options:
     required: false
     default: null
     description:
-      - mode the file or directory should be. For those used to I(/usr/bin/chmod) remember that modes are actually octal numbers (like 0644). Leaving off the leading zero will likely have unexpected results. As of version 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r)).
+      - Mode the file or directory should be. For those used to I(/usr/bin/chmod) remember that modes are actually octal numbers (like 0644). Leaving off the leading zero will likely have unexpected results. As of version 1.8, the mode may be specified as a symbolic mode (for example, C(u+rwx) or C(u=rw,g=r,o=r)).
   owner:
     required: false
     default: null
     description:
-      - name of the user that should own the file/directory, as would be fed to I(chown)
+      - Name of the user that should own the file/directory, as would be fed to I(chown).
   group:
     required: false
     default: null
     description:
-      - name of the group that should own the file/directory, as would be fed to I(chown)
+      - Name of the group that should own the file/directory, as would be fed to I(chown).
   seuser:
     required: false
     default: null
     description:
-      - user part of SELinux file context. Will default to system policy, if
+      - User part of SELinux file context. Will default to system policy, if
         applicable. If set to C(_default), it will use the C(user) portion of the
-        policy if available
+        policy if available.
   serole:
     required: false
     default: null
     description:
-      - role part of SELinux file context, C(_default) feature works as for I(seuser).
+      - Role part of SELinux file context, C(_default) feature works as for I(seuser).
   setype:
     required: false
     default: null
     description:
-      - type part of SELinux file context, C(_default) feature works as for I(seuser).
+      - Type part of SELinux file context, C(_default) feature works as for I(seuser).
   selevel:
     required: false
     default: "s0"
     description:
-      - level part of the SELinux file context. This is the MLS/MCS attribute,
+      - Level part of the SELinux file context. This is the MLS/MCS attribute,
         sometimes known as the C(range). C(_default) feature works as for
         I(seuser).
   unsafe_writes:

--- a/lib/ansible/utils/module_docs_fragments/ios.py
+++ b/lib/ansible/utils/module_docs_fragments/ios.py
@@ -30,31 +30,31 @@ options:
     required: true
   port:
     description:
-      - Specifies the port to use when buiding the connection to the remote.
+      - Specifies the port to use when building the connection to the remote.
         device.
     required: false
     default: 22
   username:
     description:
       - Configures the username to use to authenticate the connection to
-        the remote device.  The value of I(username) is used to authenticate
+        the remote device.  This value is used to authenticate
         the SSH session. If the value is not specified in the task, the
-        value of environment variable ANSIBLE_NET_USERNAME will be used instead.
+        value of environment variable C(ANSIBLE_NET_USERNAME) will be used instead.
     required: false
   password:
     description:
       - Specifies the password to use to authenticate the connection to
-        the remote device.   The value of I(password) is used to authenticate
+        the remote device.   This value is used to authenticate
         the SSH session. If the value is not specified in the task, the
-        value of environment variable ANSIBLE_NET_PASSWORD will be used instead.
+        value of environment variable C(ANSIBLE_NET_PASSWORD) will be used instead.
     required: false
     default: null
   ssh_keyfile:
     description:
       - Specifies the SSH key to use to authenticate the connection to
-        the remote device.   The value of I(ssh_keyfile) is the path to the
+        the remote device.   This value is the path to the
         key used to authenticate the SSH session. If the value is not specified
-        in the task, the value of environment variable ANSIBLE_NET_SSH_KEYFILE
+        in the task, the value of environment variable C(ANSIBLE_NET_SSH_KEYFILE)
         will be used instead.
     required: false
   authorize:
@@ -63,7 +63,7 @@ options:
         before sending any commands.  If not specified, the device will
         attempt to execute all commands in non-privileged mode. If the value
         is not specified in the task, the value of environment variable
-        ANSIBLE_NET_AUTHORIZE will be used instead.
+        C(ANSIBLE_NET_AUTHORIZE) will be used instead.
     required: false
     default: no
     choices: ['yes', 'no']
@@ -72,18 +72,18 @@ options:
       - Specifies the password to use if required to enter privileged mode
         on the remote device.  If I(authorize) is false, then this argument
         does nothing. If the value is not specified in the task, the value of
-        environment variable ANSIBLE_NET_AUTH_PASS will be used instead.
+        environment variable C(ANSIBLE_NET_AUTH_PASS) will be used instead.
     required: false
     default: none
   timeout:
     description:
-      - Specifies idle timeout for the connection. Useful if the console
+      - Specifies idle timeout for the connection, in seconds. Useful if the console
         freezes before continuing. For example when saving configurations.
     required: false
     default: 10
   provider:
     description:
-      - Convience method that allows all M(ios) arguments to be passed as
+      - Convenience method that allows all I(ios) arguments to be passed as
         a dict object.  All constraints (required, choices, etc) must be
         met either by individual arguments or values in this dict.
     required: false

--- a/lib/ansible/utils/module_docs_fragments/iosxr.py
+++ b/lib/ansible/utils/module_docs_fragments/iosxr.py
@@ -30,21 +30,21 @@ options:
     required: true
   port:
     description:
-      - Specifies the port to use when building the connection to the remote
+      - Specifies the port to use when building the connection to the remote.
         device.
     required: false
     default: 22
   username:
     description:
       - Configures the username to use to authenticate the connection to
-        the remote device.  The value of I(username) is used to authenticate
+        the remote device.  This value is used to authenticate
         the SSH session. If the value is not specified in the task, the
         value of environment variable C(ANSIBLE_NET_USERNAME) will be used instead.
     required: false
   password:
     description:
       - Specifies the password to use to authenticate the connection to
-        the remote device.   The value of I(password) is used to authenticate
+        the remote device.   This value is used to authenticate
         the SSH session. If the value is not specified in the task, the
         value of environment variable C(ANSIBLE_NET_PASSWORD) will be used instead.
     required: false
@@ -52,7 +52,7 @@ options:
   ssh_keyfile:
     description:
       - Specifies the SSH key to use to authenticate the connection to
-        the remote device.   The value of I(ssh_keyfile) is the path to the
+        the remote device.   This value is the path to the
         key used to authenticate the SSH session. If the value is not specified
         in the task, the value of environment variable C(ANSIBLE_NET_SSH_KEYFILE)
         will be used instead.
@@ -64,5 +64,4 @@ options:
         met either by individual arguments or values in this dict.
     required: false
     default: null
-
-  """
+"""

--- a/lib/ansible/utils/module_docs_fragments/junos.py
+++ b/lib/ansible/utils/module_docs_fragments/junos.py
@@ -39,24 +39,24 @@ options:
   username:
     description:
       - Configures the username to use to authenticate the connection to
-        the remote device.  The value of I(username) is used to authenticate
+        the remote device.  This value is used to authenticate
         the SSH session. If the value is not specified in the task, the
-        value of environment variable ANSIBLE_NET_USERNAME will be used instead.
+        value of environment variable C(ANSIBLE_NET_USERNAME) will be used instead.
     required: false
   password:
     description:
       - Specifies the password to use to authenticate the connection to
-        the remote device.   The value of I(password) is used to authenticate
+        the remote device.   This value is used to authenticate
         the SSH session. If the value is not specified in the task, the
-        value of environment variable ANSIBLE_NET_PASSWORD will be used instead.
+        value of environment variable C(ANSIBLE_NET_PASSWORD) will be used instead.
     required: false
     default: null
   ssh_keyfile:
     description:
       - Specifies the SSH key to use to authenticate the connection to
-        the remote device.   The value of I(ssh_keyfile) is the path to the key
+        the remote device.   This value is the path to the key
         used to authenticate the SSH session. If the value is not specified in
-        the task, the value of environment variable ANSIBLE_NET_SSH_KEYFILE
+        the task, the value of environment variable C(ANSIBLE_NET_SSH_KEYFILE)
         will be used instead.
     required: false
   provider:

--- a/lib/ansible/utils/module_docs_fragments/mysql.py
+++ b/lib/ansible/utils/module_docs_fragments/mysql.py
@@ -24,27 +24,27 @@ class ModuleDocFragment(object):
 options:
   login_user:
     description:
-      - The username used to authenticate with
+u      - The username used to authenticate with.
     required: false
     default: null
   login_password:
     description:
-      - The password used to authenticate with
+      - The password used to authenticate with.
     required: false
     default: null
   login_host:
     description:
-      - Host running the database
+      - Host running the database.
     required: false
     default: localhost
   login_port:
     description:
-      - Port of the MySQL server. Requires login_host be defined as other then localhost if login_port is used
+      - Port of the MySQL server. Requires I(login_host) be defined as other then localhost if login_port is used.
     required: false
     default: 3306
   login_unix_socket:
     description:
-      - The path to a Unix domain socket for local connections
+      - The path to a Unix domain socket for local connections.
     required: false
     default: null
   connect_timeout:
@@ -55,7 +55,7 @@ options:
     version_added: "2.1"
   config_file:
     description:
-      - Specify a config file from which user and password are to be read
+      - Specify a config file from which user and password are to be read.
     required: false
     default: '~/.my.cnf'
     version_added: "2.0"

--- a/lib/ansible/utils/module_docs_fragments/openstack.py
+++ b/lib/ansible/utils/module_docs_fragments/openstack.py
@@ -83,12 +83,12 @@ options:
     default: None
   cert:
     description:
-      - A path to a client certificate to use as part of the SSL transaction
+      - A path to a client certificate to use as part of the SSL transaction.
     required: false
     default: None
   key:
     description:
-      - A path to a client key to use as part of the SSL transaction
+      - A path to a client key to use as part of the SSL transaction.
     required: false
     default: None
   endpoint_type:

--- a/lib/ansible/utils/module_docs_fragments/openswitch.py
+++ b/lib/ansible/utils/module_docs_fragments/openswitch.py
@@ -41,7 +41,7 @@ options:
   username:
     description:
       - Configures the username to use to authenticate the connection to
-        the remote device.  The value of I(username) is used to authenticate
+        the remote device.  This value is used to authenticate
         either the CLI login or the eAPI authentication depending on which
         transport is used. Note this argument does not affect the SSH
         transport. If the value is not specified in the task, the value of

--- a/lib/ansible/utils/module_docs_fragments/rackspace.py
+++ b/lib/ansible/utils/module_docs_fragments/rackspace.py
@@ -23,31 +23,31 @@ class ModuleDocFragment(object):
 options:
   api_key:
     description:
-      - Rackspace API key (overrides I(credentials))
+      - Rackspace API key, overrides I(credentials).
     aliases:
       - password
   credentials:
     description:
-      - File to find the Rackspace credentials in (ignored if I(api_key) and
-        I(username) are provided)
+      - File to find the Rackspace credentials in. Ignored if I(api_key) and
+        I(username) are provided.
     default: null
     aliases:
       - creds_file
   env:
     description:
-      - Environment as configured in ~/.pyrax.cfg,
-        see U(https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#pyrax-configuration)
+      - Environment as configured in I(~/.pyrax.cfg),
+        see U(https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#pyrax-configuration).
     version_added: 1.5
   region:
     description:
-      - Region to create an instance in
+      - Region to create an instance in.
     default: DFW
   username:
     description:
-      - Rackspace username (overrides I(credentials))
+      - Rackspace username, overrides I(credentials).
   verify_ssl:
     description:
-      - Whether or not to require SSL validation of API endpoints
+      - Whether or not to require SSL validation of API endpoints.
     version_added: 1.5
 requirements:
   - "python >= 2.6"
@@ -67,49 +67,49 @@ notes:
 options:
   api_key:
     description:
-      - Rackspace API key (overrides I(credentials))
+      - Rackspace API key, overrides I(credentials).
     aliases:
       - password
   auth_endpoint:
     description:
-      - The URI of the authentication service
+      - The URI of the authentication service.
     default: https://identity.api.rackspacecloud.com/v2.0/
     version_added: 1.5
   credentials:
     description:
-      - File to find the Rackspace credentials in (ignored if I(api_key) and
-        I(username) are provided)
+      - File to find the Rackspace credentials in. Ignored if I(api_key) and
+        I(username) are provided.
     default: null
     aliases:
       - creds_file
   env:
     description:
-      - Environment as configured in ~/.pyrax.cfg,
-        see U(https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#pyrax-configuration)
+      - Environment as configured in I(~/.pyrax.cfg),
+        see U(https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#pyrax-configuration).
     version_added: 1.5
   identity_type:
     description:
-      - Authentication machanism to use, such as rackspace or keystone
+      - Authentication mechanism to use, such as rackspace or keystone.
     default: rackspace
     version_added: 1.5
   region:
     description:
-      - Region to create an instance in
+      - Region to create an instance in.
     default: DFW
   tenant_id:
     description:
-      - The tenant ID used for authentication
+      - The tenant ID used for authentication.
     version_added: 1.5
   tenant_name:
     description:
-      - The tenant name used for authentication
+      - The tenant name used for authentication.
     version_added: 1.5
   username:
     description:
-      - Rackspace username (overrides I(credentials))
+      - Rackspace username, overrides I(credentials).
   verify_ssl:
     description:
-      - Whether or not to require SSL validation of API endpoints
+      - Whether or not to require SSL validation of API endpoints.
     version_added: 1.5
 requirements:
   - "python >= 2.6"

--- a/lib/ansible/utils/module_docs_fragments/return_common.py
+++ b/lib/ansible/utils/module_docs_fragments/return_common.py
@@ -21,32 +21,32 @@ class ModuleDocFragment(object):
     # Standard documentation fragment
     RETURN= '''
 changed:
-    description: whether the module affected changes on the target
+    description: Whether the module affected changes on the target.
     returned: always
     type: bool
     sample: False
 failed:
-    description: whether the module failed to execute
+    description: Whether the module failed to execute.
     returned: always
     type: bool
     sample: True
 msg:
-    description: human-readable message
+    description: Human-readable message.
     returned: as needed
     type: string
     sample: "all ok"
 skipped:
-    description: whether the module was skipped
+    description: Whether the module was skipped.
     returned: always
     type: bool
     sample: False
 results:
-    description: list of module results,
-    returned: when using a loop
+    description: List of module results,
+    returned: when using a loop.
     type: list
     sample:[ {changed: True, msg: 'first item changed'}, {changed: False, msg: 'second item ok'}]
 exception:
-    description: optional information from a handled error
+    description: Optional information from a handled error.
     returned: on some errors
     type: string
     sample: 'Unknown error'

--- a/lib/ansible/utils/module_docs_fragments/sros.py
+++ b/lib/ansible/utils/module_docs_fragments/sros.py
@@ -31,36 +31,35 @@ options:
   port:
     description:
       - Specifies the port to use when building the connection to the remote
-        device.  The port value will default to the well known SSH port
-        of 22
+        device.
     required: false
     default: 22
   username:
     description:
       - Configures the username to use to authenticate the connection to
-        the remote device.  The value of I(username) is used to authenticate
+        the remote device.  This value is used to authenticate
         the SSH session. If the value is not specified in the task, the
-        value of environment variable ANSIBLE_NET_USERNAME will be used instead.
+        value of environment variable C(ANSIBLE_NET_USERNAME) will be used instead.
     required: false
   password:
     description:
       - Specifies the password to use to authenticate the connection to
-        the remote device.   The value of I(password) is used to authenticate
+        the remote device.   This value is used to authenticate
         the SSH session. If the value is not specified in the task, the
-        value of environment variable ANSIBLE_NET_PASSWORD will be used instead.
+        value of environment variable C(ANSIBLE_NET_PASSWORD) will be used instead.
     required: false
     default: null
   ssh_keyfile:
     description:
       - Specifies the SSH key to use to authenticate the connection to
-        the remote device.   The value of I(ssh_keyfile) is the path to the
+        the remote device.   This value is the path to the
         key used to authenticate the SSH session. If the value is not specified
-        in the task, the value of environment variable ANSIBLE_NET_SSH_KEYFILE
+        in the task, the value of environment variable C(ANSIBLE_NET_SSH_KEYFILE)
         will be used instead.
     required: false
   timeout:
     description:
-      - Specifies idle timeout for the connection. Useful if the console
+      - Specifies idle timeout for the connection, in seconds. Useful if the console
         freezes before continuing. For example when saving configurations.
     required: false
     default: 10

--- a/lib/ansible/utils/module_docs_fragments/vca.py
+++ b/lib/ansible/utils/module_docs_fragments/vca.py
@@ -22,13 +22,13 @@ class ModuleDocFragment(object):
 options:
     username:
       description:
-        - The vca username or email address, if not set the environment variable VCA_USER is checked for the username.
+        - The vca username or email address, if not set the environment variable C(VCA_USER) is checked for the username.
       required: false
       default: None
       aliases: ['user']
     password:
       description:
-        - The vca password, if not set the environment variable VCA_PASS is checked for the password
+        - The vca password, if not set the environment variable C(VCA_PASS) is checked for the password.
       required: false
       default: None
       aliases: ['pass', 'pwd']
@@ -39,34 +39,34 @@ options:
       default: None
     instance_id:
       description:
-        - The instance id in a vchs environment to be used for creating the vapp
+        - The instance id in a vchs environment to be used for creating the vapp.
       required: false
       default: None
     host:
       description:
-        - The authentication host to be used when service type  is vcd.
+        - The authentication host to be used when service type is vcd.
       required: false
       default: None
     api_version:
       description:
-        - The api version to be used with the vca
+        - The api version to be used with the vca.
       required: false
       default: "5.7"
     service_type:
       description:
-        - The type of service we are authenticating against
+        - The type of service we are authenticating against.
       required: false
       default: vca
       choices: [ "vca", "vchs", "vcd" ]
     state:
       description:
-        - if the object should be added or removed
+        - If the object should be added or removed.
       required: false
       default: present
       choices: [ "present", "absent" ]
     verify_certs:
       description:
-        - If the certificates of the authentication is to be verified
+        - If the certificates of the authentication is to be verified.
       required: false
       default: True
     vdc_name:
@@ -76,7 +76,7 @@ options:
       default: None
     gateway_name:
       description:
-        - The name of the gateway of the vdc where the rule should be added
+        - The name of the gateway of the vdc where the rule should be added.
       required: false
       default: gateway
 """

--- a/lib/ansible/utils/module_docs_fragments/vmware.py
+++ b/lib/ansible/utils/module_docs_fragments/vmware.py
@@ -17,28 +17,28 @@
 
 
 class ModuleDocFragment(object):
-    # Paramaters for VMware modules
+    # Parameters for VMware modules
     DOCUMENTATION = '''
 options:
     hostname:
         description:
-            - The hostname or IP address of the vSphere vCenter
+            - The hostname or IP address of the vSphere vCenter.
         required: True
     username:
         description:
-            - The username of the vSphere vCenter
+            - The username of the vSphere vCenter.
         required: True
         aliases: ['user', 'admin']
     password:
         description:
-            - The password of the vSphere vCenter
+            - The password of the vSphere vCenter.
         required: True
         aliases: ['pass', 'pwd']
-    validate_certs: 
-        description: 
-            - Allows connection when SSL certificates are not valid. Set to 
-              false when certificates are not trusted 
-        required: False 
-        default: 'True' 
-        choices: ['True', 'False'] 
+    validate_certs:
+        description:
+            - Allows connection when SSL certificates are not valid. Set to
+              false when certificates are not trusted.
+        required: False
+        default: 'True'
+        choices: ['True', 'False']
 '''

--- a/lib/ansible/utils/module_docs_fragments/vyos.py
+++ b/lib/ansible/utils/module_docs_fragments/vyos.py
@@ -37,14 +37,14 @@ options:
   username:
     description:
       - Configures the username to use to authenticate the connection to
-        the remote device.  The value of I(username) is used to authenticate
+        the remote device.  This value is used to authenticate
         the SSH session. If the value is not specified in the task, the
         value of environment variable C(ANSIBLE_NET_USERNAME) will be used instead.
     required: false
   password:
     description:
       - Specifies the password to use to authenticate the connection to
-        the remote device.   The value of I(password) is used to authenticate
+        the remote device.   This value is used to authenticate
         the SSH session. If the value is not specified in the task, the
         value of environment variable C(ANSIBLE_NET_PASSWORD) will be used instead.
     required: false
@@ -52,14 +52,14 @@ options:
   ssh_keyfile:
     description:
       - Specifies the SSH key to use to authenticate the connection to
-        the remote device.   The value of I(ssh_keyfile) is the path to the
+        the remote device.   This value is the path to the
         key used to authenticate the SSH session. If the value is not specified
         in the task, the value of environment variable C(ANSIBLE_NET_SSH_KEYFILE)
         will be used instead.
     required: false
   timeout:
     description:
-      - Specifies idle timeout for the connection. Useful if the console
+      - Specifies idle timeout for the connection, in seconds. Useful if the console
         freezes before continuing. For example when saving configurations.
     required: false
     default: 10


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME
##### ANSIBLE VERSION

```
ansible 2.3.0 (devel aa1ec8af17) last updated 2016/10/07 11:07:23 (GMT +100)
  lib/ansible/modules/core: (devel 149f10f8b7) last updated 2016/10/07 11:07:26 (GMT +100)
  lib/ansible/modules/extras: (devel cc2651422a) last updated 2016/10/07 11:07:27 (GMT +100)
```
##### SUMMARY
- Fix spelling mistakes
- Consistent formatting
  - `ANSIBLE_` should be in `C(...)`
  - `M(..)` only works on modules, not classes of modules
- Don't repeat parameter name, especially in italics `I(...)`, it's distracting.
- Remove duplication of defaults (listed in `description` _and_ `defaults:`)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/17981)

<!-- Reviewable:end -->
