### PR TITLE
Support multiple vault passwords in keyring script

### DIFF
--- a/contrib/vault/vault-keyring.py
+++ b/contrib/vault/vault-keyring.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # (c) 2014, Matt Martz <matt@sivel.net>
+# (c) 2016, Justin Mayer <https://justinmayer.com/>
 #
-# This file is part of Ansible
+# This file is part of Ansible.
 #
 # Ansible is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,59 +18,77 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
+# =============================================================================
 #
-# Script to be used with vault_password_file or --vault-password-file
-# to retrieve the vault password via your OSes native keyring application
+# This script is to be used with vault_password_file or --vault-password-file
+# to retrieve the vault password via your OS's native keyring application.
 #
-# This script requires the ``keyring`` python module
+# This file *MUST* be saved with executable permissions. Otherwise, Ansible
+# will try to parse as a password file and display: "ERROR! Decryption failed"
 #
-# Add a [vault] section to your ansible.cfg file,
-# the only option is 'username'. Example:
+# The `keyring` Python module is required: https://pypi.python.org/pypi/keyring
+#
+# By default, this script will store the specified password in the keyring of
+# the user that invokes the script. To specify a user keyring, add a [vault]
+# section to your ansible.cfg file with a 'username' option. Example:
 #
 # [vault]
-# username = 'ansible_vault'
+# username = 'ansible-vault'
 #
-# Additionally, it would be a good idea to configure vault_password_file in
-# ansible.cfg
+# Another optional setting is for the key name, which allows you to use this
+# script to handle multiple project vaults with different passwords:
+#
+# [vault]
+# keyname = 'ansible-vault-yourproject'
+#
+# You can configure the `vault_password_file` option in ansible.cfg:
 #
 # [defaults]
 # ...
 # vault_password_file = /path/to/vault-keyring.py
 # ...
 #
-# To set your password: python /path/to/vault-keyring.py set
+# To set your password, `cd` to your project directory and run:
 #
-# If you choose to not configure the path to vault_password_file in ansible.cfg
-# your ansible-playbook command may look like:
+# python /path/to/vault-keyring.py set
+#
+# If you choose not to configure the path to `vault_password_file` in
+# ansible.cfg, your `ansible-playbook` command might look like:
 #
 # ansible-playbook --vault-password-file=/path/to/vault-keyring.py site.yml
 
 import sys
 import getpass
 import keyring
-import ConfigParser
-
 
 import ansible.constants as C
 
+
 def main():
-    (parser,config_path)  = C.load_config_file()
-    try:
+    (parser, config_path) = C.load_config_file()
+    if parser.has_option('vault', 'username'):
         username = parser.get('vault', 'username')
-    except ConfigParser.NoSectionError:
-        sys.stderr.write('No [vault] section configured in config file: %s\n' % config_path)
-        sys.exit(1)
+    else:
+        username = getpass.getuser()
+
+    if parser.has_option('vault', 'keyname'):
+        keyname = parser.get('vault', 'keyname')
+    else:
+        keyname = 'ansible'
 
     if len(sys.argv) == 2 and sys.argv[1] == 'set':
+        intro = 'Storing password in "{}" user keyring using key name: {}\n'
+        sys.stdout.write(intro.format(username, keyname))
         password = getpass.getpass()
         confirm = getpass.getpass('Confirm password: ')
         if password == confirm:
-            keyring.set_password('ansible', username, password)
+            keyring.set_password(keyname, username, password)
         else:
             sys.stderr.write('Passwords do not match\n')
             sys.exit(1)
     else:
-        sys.stdout.write('%s\n' % keyring.get_password('ansible', username))
+        sys.stdout.write('{}\n'.format(keyring.get_password(keyname,
+                                                            username)))
 
     sys.exit(0)
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

`contrib/vault/vault-keyring.py`
##### ANSIBLE VERSION

```
ansible 2.3.0 (vault-keyring-multiple-passwords 1023923885) last updated 2016/10/12 11:16:00 (GMT -600)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras:  not found - use git submodule update --init lib/ansible/modules/extras
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

**Problem**

By hard-coding the `ansible` key name, the current `contrib/vault/vault-keyring.py` script seems to assume you will always use the same password for all vaults. It apparently does not handle cases in which people use Ansible for multiple projects containing vaults with different passwords.

**Proposed Solution**

By allowing the user to specify a key name in a given project’s `ansible.cfg` file, vault passwords can be “namespaced” such that keyring integration can be used to handle vaults with different passwords. If no key name is specified, the original default `ansible` key name will be used — just as before.

**Ancillary Problem**

For teams that utilize per-project `ansible.cfg` files, requiring users to specify a keyring username means hard-coding that single value for everyone who uses that project (since Ansible does not merge settings — see: #17914). For example, if Alice stores her password in her login user keyring and sets `username = 'alice'` in the shared project’s `ansible.cfg` file, Bob will have a difficult time storing that vault’s password in his own login user keyring since `username = 'alice'` is now hard-coded into the project’s `ansible.cfg` file.

**Proposed Solution**

The vast majority of people using this script will most likely store vault passwords in their login user keyrings. By assuming that the user invoking the script is the owner of the keyring in which the password is to be stored, we obviate the need to explicitly specify a username and allow teams to use their login user keyrings by default. At the same time, anyone who wants to specify a user keyring may still do so via the same option as before.

**Bonus Advantages**

These changes have the side effect of greatly simplifying vault keyring integration and set-up, particularly since there is now no need for most users to add the `[vault]` section or any of its optional settings.

Last but not least, this removes the need to check for the presence of a `[vault]` section. If the options are there, they will be utilized. If not, the default values will be used. In order to comply with the “principle of least astonishment,” invoking `python /path/to/vault-keyring.py set` will now display the user keyring and key name that will be used when setting the password:

```
Storing password in "justin" user keyring using key name: ansible-vault-yourproject
Password:
Confirm password:
```

**Other Notes**

Other improvements include:
- change string interpolation to new `.format()` style
- clean up and expand upon documentation
- enforce PEP 8 compliance
