### PR TITLE
Fix search path for relative paths in roles (fixes #17877)

### DIFF
--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -313,7 +313,11 @@ class DataLoader():
                         search.append(os.path.join(os.path.dirname(b_mydir), b_dirname, b_source))
                         search.append(os.path.join(b_mydir, b_source))
                     else:
-                        search.append(os.path.join(b_upath, b_dirname, b_source))
+                        # don't add dirname if user already is using it in source
+                        if b_source.split(b'/')[0] == b_dirname:
+                            search.append(os.path.join(b_upath, b_source))
+                        else:
+                            search.append(os.path.join(b_upath, b_dirname, b_source))
                         search.append(os.path.join(b_upath, b'tasks', b_source))
                 elif b_dirname not in b_source.split(b'/'):
                     # don't add dirname if user already is using it in source


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

file search paths
##### ANSIBLE VERSION

```
ansible 2.3.0 (fix_role_search_path f4477f5f85) last updated 2016/10/12 21:37:58 (GMT -600)
```
##### SUMMARY

This commit adds the role base dir (as well as a few other locations as a side effect), which allows `src=files/foo` to work inside a role again. This may not be a proper fix, but it does fix the issue.

Search paths before:

```
  5126 1476327940.53620: search_path:
        /home/agaffney/dev/ansible_stuff/roles/homedir/files/files/vimrc
        /home/agaffney/dev/ansible_stuff/roles/homedir/tasks/files/vimrc
        /home/agaffney/dev/ansible_stuff/roles/homedir/tasks/files/files/vimrc
        /home/agaffney/dev/ansible_stuff/roles/homedir/tasks/tasks/files/vimrc
        /home/agaffney/dev/ansible_stuff/files/files/vimrc
        /home/agaffney/dev/ansible_stuff/files/vimrc
```

Search paths after:

```
  7633 1476329712.58281: search_path:
        /home/agaffney/dev/ansible_stuff/roles/homedir/files/files/vimrc
        /home/agaffney/dev/ansible_stuff/roles/homedir/tasks/files/vimrc
        /home/agaffney/dev/ansible_stuff/roles/homedir/files/vimrc
        /home/agaffney/dev/ansible_stuff/roles/homedir/tasks/files/files/vimrc
        /home/agaffney/dev/ansible_stuff/roles/homedir/tasks/tasks/files/vimrc
        /home/agaffney/dev/ansible_stuff/roles/homedir/tasks/files/vimrc
        /home/agaffney/dev/ansible_stuff/files/files/vimrc
        /home/agaffney/dev/ansible_stuff/files/vimrc
```
