### PR TITLE
SSL ipv6 support for certificate handler in urls.py

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -663,11 +663,10 @@ class SSLValidationHandler(urllib_request.BaseHandler):
             return req
 
         try:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             if https_proxy:
                 proxy_parts = generic_urlparse(urlparse(https_proxy))
                 port = proxy_parts.get('port') or 443
-                s.connect((proxy_parts.get('hostname'), port))
+                s = socket.create_connection((proxy_parts.get('hostname'), port))
                 if proxy_parts.get('scheme') == 'http':
                     s.sendall(self.CONNECT_COMMAND % (self.hostname, self.port))
                     if proxy_parts.get('username'):
@@ -686,7 +685,7 @@ class SSLValidationHandler(urllib_request.BaseHandler):
                 else:
                     raise ProxyError('Unsupported proxy scheme: %s. Currently ansible only supports HTTP proxies.' % proxy_parts.get('scheme'))
             else:
-                s.connect((self.hostname, self.port))
+                s = socket.create_connection((self.hostname, self.port))
                 if context:
                     ssl_s = context.wrap_socket(s, server_hostname=self.hostname)
                 elif HAS_URLLIB3_SNI_SUPPORT:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

urls.py
##### ANSIBLE VERSION

```
ansible 2.1.0.0
```
##### SUMMARY

get_url on a ipv6 machine currently fails towards ipv6 web server on SSL with 
"Failed to validate the SSL certificate for hostname:443. Make sure your managed systems have a valid CA certificate installed. You can use validate_certs=False if you do not need to confirm the servers identity but this is unsafe and not recommended. Paths checked for this platform: /etc/ssl/certs, /etc/pki/ca-trust/extracted/pem, /etc/pki/tls/certs, /usr/share/ca-certificates/cacert.org, /etc/ansible" 

The error message is totally misleading, but after some debugging i figured out that it is caused by the certificate handler which can't establish a ipv6 connection. 

This is fixed by using socket.create_connection (figures out ipv4/ipv6 automatically) instead of socket.socket. 

Before:

```
TASK [myrole : Install jdk using https] *************************
Thursday 13 October 2016  13:34:15 +0200 (0:00:00.160)       0:06:21.364 ****** 
failed: [server.domain.dk] (item={u'jce': True, u'version': u'1.8.0_45', u'name': u'jdk-8u45-linux-x64.tar.gz'}) => {"failed": true, "item": {"jce": true, "name": "jdk-8u45-linux-x64.tar.gz", "version": "1.8.0_45"}, "msg": "Failed to validate the SSL certificate for myreposerver.domain:443. Make sure your managed systems have a valid CA certificate installed. You can use validate_certs=False if you do not need to confirm the servers identity but this is unsafe and not recommended. Paths checked for this platform: /etc/ssl/certs, /etc/pki/ca-trust/extracted/pem, /etc/pki/tls/certs, /usr/share/ca-certificates/cacert.org, /etc/ansible"}
```

After:

```
TASK [myrole : Install jdk using https] *************************
Thursday 13 October 2016  13:49:03 +0200 (0:00:00.234)       0:06:16.652 ****** 
ok: [server.domain.dk] => (item={u'jce': True, u'version': u'1.8.0_45', u'name': u'jdk-8u45-linux-x64.tar.gz'})
```
