### PR TITLE
minor fix for checking kwargs in get_config()

### DIFF
--- a/lib/ansible/module_utils/asa.py
+++ b/lib/ansible/module_utils/asa.py
@@ -92,7 +92,7 @@ class Cli(CliBase):
         cmd = 'show running-config'
         if include == 'passwords':
             cmd = 'more system:running-config'
-        elif include_defaults:
+        elif include == 'defaults':
             cmd = 'show running-config all'
         else:
             cmd = 'show running-config'


### PR DESCRIPTION
The get_config() method was checking for a nonexistent kwarg that would
cause an exception.  This fixes that problem.
