### PR TITLE
adds additional exception handling in open()

### DIFF
--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -106,6 +106,8 @@ class Shell(object):
             raise ShellError("unable to resolve host name")
         except AuthenticationException:
             raise ShellError('Unable to authenticate to remote device')
+        except socket.timeout:
+            raise ShellError("timeout trying to connect to remote device")
         except socket.error:
             exc = get_exception()
             if exc.errno == 60:


### PR DESCRIPTION
The open() method will now catch a socket.timeout exception and raise
a ShellError.
