### PR TITLE
new callback plugin wildcard methods and '_callback_method_name' arg

### DIFF
--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -342,15 +342,10 @@ class TaskQueueManager:
         for method_name in method_names:
             gotit = getattr(callback_plugin, method_name, None)
             if gotit is not None:
-                print(getattr(gotit, '_callback_disabled', '3333'))
                 if hasattr(gotit, '_callback_disabled'):
                     continue
-                return gotit
+                return gotit, method_name
         return None
-
-    def find_cb_method_v1(self, callback_plugin, method_name):
-        method_names = self._callback_method_expand(method_name)
-        return self.find_callback_method(callback_plugin, method_names)
 
     def send_callback(self, method_name, *args, **kwargs):
         display.v('SEND_CALLBAC: method_name=%s' % method_name)
@@ -392,7 +387,9 @@ class TaskQueueManager:
             if new_method:
                 methods.append(new_method)
 
-            for method in methods:
+            for method, method_name in methods:
+                # add origin method name to kwargs if the method has the right attribute
+                kwargs['_callback_method_name'] = method_name
                 try:
                     # temporary hack, required due to a change in the callback API, so
                     # we don't break backwards compatibility with callbacks which were

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -67,7 +67,7 @@ class CallbackBase:
             name = getattr(self, 'CALLBACK_NAME', 'unnamed')
             ctype = getattr(self, 'CALLBACK_TYPE', 'old')
             version = getattr(self, 'CALLBACK_VERSION', '1.0')
-            self._display.vvvv('Loading callback plugin %s of type %s, v%s from %s' % (name, ctype, version, __file__))
+            self._display.vvvv('Loading callback plugin %s of type %s, v%s from %s' % (name, ctype, version, self.__class__.__module__))
 
     ''' helper for callbacks, so they don't all have to include deepcopy '''
     _copy_result = deepcopy
@@ -257,8 +257,6 @@ class CallbackBase:
         pass
 
     ####### V2 METHODS, by default they call v1 counterparts if possible ######
-    def v2_on_any(self, *args, **kwargs):
-        self.on_any(args, kwargs)
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
         host = result._host.get_name()
@@ -361,3 +359,42 @@ class CallbackBase:
 
     def v2_runner_retry(self, result):
         pass
+
+    # The existences of the following methods matter, so they are not included in the base plugin class.
+    # callback plugins can implement them to get various 'wildcard' behaviors.
+
+    # 'v2_on_missing'
+    #
+    # if the plugin does not have any method that could match (ie, the correct one or the v1 version)
+    # then check for a 'v2_on_missing'.
+    # If a plugin class doesn't find an exact match, it will call v2_on_missing.
+    # if 'v2_on_missing' exists, it will be call in preference to 'v2_on_any'.
+    # Existence of 'v2_on_missing' will stop 'v2_on_any' from being called. In the cases
+    # where 'v2_on_any' would have been called previously, if there is a 'v2_on_missing', it will
+    # be called instead. If there is no 'v2_on_missing', then 'v2_on_any' will be tried.
+    #def v2_on_missing(self, *args, **kwargs):
+    #    self.on_missing(args, kwargs)
+
+    # 'v2_on_any'
+    #
+    # if there isn't a matching method and there is no 'v2_on_missing', then check for 'v2_on_any'
+    # In other worse, v2_on_any is not called if there is a v2_on_missing or a exact match.
+    # Note: Callback methods that subclass CallbackBase will provide most methods by default
+    # methods that a callback plugin could provide, but are not required
+
+    #def v2_on_any(self, *args, **kwargs):
+    #    self.on_any(args, kwargs)
+
+    # 'v2_on_all'
+    #
+    # This method will always be invoked for every callback method invocation
+    # (if it exists).
+    #
+    # A 'v2_on_all' if it exists, will always be called. Always. Even if
+    # there was an exact match, or a 'v2_on_missing', or a 'v2_on_any'. If it exists, it is always called.
+    # Note: If you are tracking any context based on callback methods, the 'v2_on_all' method could be called
+    # in _addition_ to another matching method. More than one method from a single callback plugin could be called
+    # if the plugin provides a 'v2_on_all'
+
+    #def v2_on_all(self, *args, **kwargs):
+    #    self.on_missing(args, kwargs)

--- a/lib/ansible/plugins/callback/generic_stdlog.py
+++ b/lib/ansible/plugins/callback/generic_stdlog.py
@@ -1,0 +1,104 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import logging
+import logging.handlers
+import re
+
+# from ansible.utils.unicode import to_bytes
+from ansible.plugins.callback import CallbackBase
+
+
+# NOTE: in Ansible 1.2 or later general logging is available without
+# this plugin, just set ANSIBLE_LOG_PATH as an environment variable
+# or log_path in the DEFAULTS section of your ansible configuration
+# file.  This callback is an example of per hosts logging for those
+# that want it.
+
+DEBUG_LOG_FORMAT = "%(asctime)s [%(name)s %(levelname)s %(playbook)s] (%(process)d):%(funcName)s:%(lineno)d - %(message)s"
+CONTEXT_DEBUG_LOG_FORMAT = "%(asctime)s [%(name)s %(levelname)s] [playbook=%(playbook)s:%(playbook_uuid)s play=%(play)s:%(play_uuid)s task=%(task)s:%(task_uuid)s] (%(process)d):%(funcName)s:%(lineno)d - %(message)s"
+LOG_FORMAT = "%(asctime)s [%(levelname)s] %(process)d @%(filename)s:%(lineno)d - %(message)s"
+MIN_LOG_FORMAT = "%(asctime)s %(funcName)s:%(lineno)d - %(message)s"
+
+
+def sluggify(value):
+    return '%s' % (re.sub(r'[^\w-]', '_', value).lower().lstrip('_'))
+
+
+class CallbackModule(CallbackBase):
+    """
+    Logging callbacks using python stdlin logging
+    """
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'notification'
+    # CALLBACK_TYPE = "aggregate"
+    CALLBACK_NAME = 'generic_stdlog'
+    CALLBACK_NEEDS_WHITELIST = True
+
+    log_level = logging.DEBUG
+    #log_name = 'ansible_generic_stdlog'
+    #log_format = CONTEXT_DEBUG_LOG_FORMAT
+    log_format = LOG_FORMAT
+
+    def __init__(self):
+        super(CallbackModule, self).__init__()
+
+        # TODO: replace with a stack
+        self.host = None
+
+        self.logger = logging.getLogger('ansible.plugins.callbacks.generic_stdlog')
+        self.logger.setLevel(self.log_level)
+
+        # Note: by default, ansible doesn't setup any log handlers, so this wont do
+        # anything without doing that. To enable, something like this:
+        self.setup_stream_handler()
+        self.setup_file_handler()
+
+    def setup_stream_handler(self):
+        stream_handler = logging.StreamHandler()
+        stream_handler.setLevel(logging.DEBUG)
+        formatter = logging.Formatter(fmt=self.log_format)
+        stream_handler.setFormatter(formatter)
+        self.logger.addHandler(stream_handler)
+
+    def setup_file_handler(self):
+        file_handler = logging.FileHandler('/tmp/ansible_callback.log')
+        file_handler.setLevel(logging.DEBUG)
+        formatter = logging.Formatter(fmt=self.log_format)
+        file_handler.setFormatter(formatter)
+        self.logger.addHandler(file_handler)
+
+    # Note: it would be useful to have a 'always called'
+    # callback, and a 'only called if not handled' callback
+    def _v2_on_generic(self, *args, **kwargs):
+        method_name = kwargs.pop('_callback_method_name', None)
+        if method_name:
+            self.logger.debug('_v2_on_generic being called to handle request for %s', method_name)
+
+        for arg in args:
+            self.logger.debug(arg)
+
+        for k, v in kwargs.items():
+            self.logger.debug('kw_k=%s', k)
+            self.logger.debug('kw_v=%s', v)
+
+    # this setup will call v2_on_missing for unknown callbacks and always call v2_on_all
+    #v2_on_any = _v2_on_generic
+    v2_on_all = _v2_on_generic
+    v2_on_missing = _v2_on_generic


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

lib/ansible/plugins/callback
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0 (on_missing_callback c70d825144) last updated 2016/10/13 12:44:30 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 275fa3f055) last updated 2016/10/12 14:06:23 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 3e1ea76a75) last updated 2016/10/13 11:34:41 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### Preface

This is a prototype of an idea, but it seems to work. If the idea seems reasonable I can flesh it out (tests etc)
##### SUMMARY

This adds two new callback plugin wildcard methods, and a new '_callback_method_name' arg for the wildcard method.
### **New methods**
- v2_on_missing
- v2_on_all

v2_on_missing is only called if the callback plugin does not provide a exact match method and it provides a v2_on_missing method. 

The current v2_on_any can be used in place of a missing callback method, but if it exists, it will be used in place of the requested method. But the plugin cant tell if it's falling back to v2_on_any intentionally (being used as a generic method) or if it is falling back because the plugin is incomplete.

v2_on_missing is 'I think plugin is complete, but if I missed a method, call v2_on_missing for the missed cases'
v2_on_any is 'I know the plugin is not complete, but if I missed a method, call v2_on_any for the other cases'

expected miss vs unexpected miss. signature and implementation can be essentially the same

v2_on_missing is overrides v2_on_any. A plugin could consider v2_on_missing indicates an error, or it could treat it the same as v2_on_any. However a v2_on_missing that acts the same as v2_on_any doesn't accomplish anything (providing v2_on_any and not v2_on_missing would be equivalent to  v2_on_missing and v2_on_any being the same).

v2_on_all however, if it exists, is **always** called, regardless if the original requested method exists in the plugin or not. It is called **in addition** to any other callback methods that may also match. 
### **New _callback_method_name kwarg for wildcard methods**

For the wildcard methods [with (_args, *_kwargs) signature], they now get a '_callback_method_name' item in kwargs added when called. This allows v2_on_any/v2_on_all/v2_on_missing to know what method they are pretending to be. The generic wildcard methods can use that info to implement more specific behaviors if useful.

One potential use of _callback_method_name would be a callback plugin that only provides a single wildcard method, v2_on_all for ex. Then the plugins impl of v2_on_all could then handle any callback and route the method name and args to a sub-plugins. A generic plugin could have-a v1 plugin and a v2 plugin and route method invocations to the right implementation. 

That would allow a callback plugin to implement much of the logic of task_queue_manager.send_callback(). Potentially, the base CallbackModule class could do this, routing subsets of callback api to a new type of plugins[1]

[1] for ex, a PlaybookCallback and a TaskCallback and  a StatsCallback.
