### PR TITLE
Quick ansible-doc fix -- don't run pager if there was an error (no text)

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -137,7 +137,8 @@ class DocCLI(CLI):
                 display.vvv(traceback.print_exc())
                 raise AnsibleError("module %s missing documentation (or could not parse documentation): %s\n" % (module, str(e)))
 
-        self.pager(text)
+        if text:
+            self.pager(text)
         return 0
 
     def find_modules(self, path):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ansible-doc
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0 (fix_doc_pager aba729d925) last updated 2016/10/13 14:35:45 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 275fa3f055) last updated 2016/10/13 14:12:11 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 3e1ea76a75) last updated 2016/10/13 14:12:11 (GMT -400)
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Very simple, quick fix, I noticed if you run 'ansible-doc foo' it launches the pager even if there is no text to display when it doesn't find a module.

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
You'll see the error instead of a blank screen ;)

 [WARNING]: module foo not found in /home/ ...
```
