### PR TITLE
fixes issue when checking if sessions are supported

### DIFF
--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -125,7 +125,7 @@ class EosConfigMixin(object):
     def supports_sessions(self):
         try:
             if isinstance(self, Eapi):
-                self.execute('show configuration sessions', output='text')
+                self.execute(['show configuration sessions'], output='text')
             else:
                 self.execute('show configuration sessions')
             return True


### PR DESCRIPTION
the supports_sessions() call was sending the command as a string instead
of a list which is required when transport is eapi.  This fixes that bug
