### PR TITLE
Increment changed stat for a failed task if changed.

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -362,6 +362,8 @@ class StrategyBase:
                                 )
                 else:
                     self._tqm._stats.increment('ok', original_host.name)
+                    if 'changed' in task_result._result and task_result._result['changed']:
+                        self._tqm._stats.increment('changed', original_host.name)
                 self._tqm.send_callback('v2_runner_on_failed', task_result, ignore_errors=original_task.ignore_errors)
             elif task_result.is_unreachable():
                 self._tqm._unreachable_hosts[original_host.name] = True


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

TQM / `playbook_on_stats` callback event.
##### ANSIBLE VERSION

```
ansible 1.9.6
```

vs.

```
ansible 2.3.0 (devel 05531b99d0) last updated 2016/10/13 16:04:59 (GMT -400)
  lib/ansible/modules/core: (devel 6795954dc8) last updated 2016/10/13 16:03:29 (GMT -400)
  lib/ansible/modules/extras: (devel 8e477dad89) last updated 2016/10/13 16:03:52 (GMT -400)
```
##### SUMMARY

Tasks that fail and specify `ignore_errors: true`, but indicate `changed: true` in the task result used to increment the `changed` counter in 1.9 (https://github.com/ansible/ansible/blob/stable-1.9/lib/ansible/callbacks.py#L226), but no longer do so in 2.x.  This change restores that behavior.

A related bug appears to have been reported in #14877.

Example playbook:

```
- hosts: all
  gather_facts: false
  tasks:
    - command: "false"
      ignore_errors: true
```

Running the above playbook with Ansible 1.9.6:

```
PLAY [all] ********************************************************************

TASK: [command false] *********************************************************
failed: [localhost] => {"changed": true, "cmd": ["false"], "delta": "0:00:00.003635", "end": "2016-10-13 16:08:40.275800", "rc": 1, "start": "2016-10-13 16:08:40.272165", "warnings": []}
...ignoring

PLAY RECAP ********************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0
```

Running the above playbook with Ansible 2.3.0 (devel 05531b99d0):

```
PLAY [all] *********************************************************************

TASK [command] *****************************************************************
fatal: [localhost]: FAILED! => {"changed": true, "cmd": ["false"], "delta": "0:00:00.003060", "end": "2016-10-13 16:09:32.269361", "failed": true, "rc": 1, "start": "2016-10-13 16:09:32.266301", "stderr": "", "stdout": "", "stdout_lines": [], "warnings": []}
...ignoring

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0
```
