### PR TITLE
Change <support@ansible.com> - it's being retired.

### DIFF
--- a/docsite/rst/community.rst
+++ b/docsite/rst/community.rst
@@ -251,7 +251,7 @@ Tower Support Questions
 
 Ansible `Tower <http://ansible.com/tower>`_ is a UI, Server, and REST endpoint for Ansible, produced by Ansible, Inc.
 
-If you have a question about Tower, email `support@ansible.com <mailto:support@ansible.com>`_ rather than using the IRC
+If you have a question about Tower, visit `support.ansible.com <https://support.ansible.com/>`_ rather than using the IRC
 channel or the general project mailing list.
 
 IRC Channel

--- a/lib/ansible/executor/action_write_locks.py
+++ b/lib/ansible/executor/action_write_locks.py
@@ -1,4 +1,4 @@
-# (c) 2016 - Red Hat, Inc. <support@ansible.com>
+# (c) 2016 - Red Hat, Inc. <info@ansible.com>
 #
 # This file is part of Ansible
 #

--- a/lib/ansible/utils/helpers.py
+++ b/lib/ansible/utils/helpers.py
@@ -1,4 +1,4 @@
-# (c) 2016, Ansible by Red Hat <support@ansible.com>
+# (c) 2016, Ansible by Red Hat <info@ansible.com>
 #
 # This file is part of Ansible
 #

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -2,76 +2,76 @@ ansible (%VERSION%-%RELEASE%~%DIST%) %DIST%; urgency=low
 
   * %VERSION% release
 
- -- Ansible, Inc. <support@ansible.com>  %DATE%
+ -- Ansible, Inc. <info@ansible.com>  %DATE%
 
 ansible (2.0.1.0) unstable; urgency=low
 
   * 2.0.1.0
 
- -- Ansible, Inc. <support@ansible.com>  Wed, 24 Feb 2016 18:28:59 -0500
+ -- Ansible, Inc. <info@ansible.com>  Wed, 24 Feb 2016 18:28:59 -0500
 
 
 ansible (2.0.0.2) unstable; urgency=low
 
   * 2.0.0.2
 
- -- Ansible, Inc. <support@ansible.com>  Thu, 14 Jan 2016 17:17:41 -0500
+ -- Ansible, Inc. <info@ansible.com>  Thu, 14 Jan 2016 17:17:41 -0500
 
 
 ansible (2.0.0.1) unstable; urgency=low
 
   * 2.0.0.1
 
- -- Ansible, Inc. <support@ansible.com>  Tue, 12 Jan 2016 17:53:29 -0500
+ -- Ansible, Inc. <info@ansible.com>  Tue, 12 Jan 2016 17:53:29 -0500
 
 
 ansible (2.0.0.0) unstable; urgency=low
 
   * 2.0.0.0
 
- -- Ansible, Inc. <support@ansible.com>  Tue, 12 Jan 2016 08:33:59 -0500
+ -- Ansible, Inc. <info@ansible.com>  Tue, 12 Jan 2016 08:33:59 -0500
 
 ansible (1.9.4) unstable; urgency=low
 
   * 1.9.4
 
- -- Ansible, Inc. <support@ansible.com>  Fri, 09 Oct 2015 15:00:00 -0500
+ -- Ansible, Inc. <info@ansible.com>  Fri, 09 Oct 2015 15:00:00 -0500
 
 ansible (1.9.3) unstable; urgency=low
 
   * 1.9.3
 
- -- Ansible, Inc. <support@ansible.com>  Thu, 03 Sep 2015 18:30:00 -0500
+ -- Ansible, Inc. <info@ansible.com>  Thu, 03 Sep 2015 18:30:00 -0500
 
 ansible (1.9.2) unstable; urgency=low
 
   * 1.9.2
 
- -- Ansible, Inc. <support@ansible.com>  Wed, 24 Jun 2015 14:00:00 -0500
+ -- Ansible, Inc. <info@ansible.com>  Wed, 24 Jun 2015 14:00:00 -0500
 
 ansible (1.9.1) unstable; urgency=low
 
   * 1.9.1
 
- -- Ansible, Inc. <support@ansible.com>  Mon, 27 Apr 2015 17:00:00 -0500
+ -- Ansible, Inc. <info@ansible.com>  Mon, 27 Apr 2015 17:00:00 -0500
 
 ansible (1.9.0.1) unstable; urgency=low
 
   * 1.9.0.1
 
- -- Ansible, Inc. <support@ansible.com>  Wed, 25 Mar 2015 15:00:00 -0500
+ -- Ansible, Inc. <info@ansible.com>  Wed, 25 Mar 2015 15:00:00 -0500
 
 ansible (1.8.4) unstable; urgency=low
 
   * 1.8.4
 
- -- Ansible, Inc. <support@ansible.com>  Thu, 19 Feb 2015 12:00:00 -0500
+ -- Ansible, Inc. <info@ansible.com>  Thu, 19 Feb 2015 12:00:00 -0500
 
 ansible (1.8.3) unstable; urgency=low
 
   * 1.8.3
 
- -- Ansible, Inc. <support@ansible.com>  Tue, 17 Feb 2015 16:00:00 -0500
+ -- Ansible, Inc. <info@ansible.com>  Tue, 17 Feb 2015 16:00:00 -0500
 
 ansible (1.8.2) unstable; urgency=low
 

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -2,7 +2,7 @@ Source: ansible
 Section: admin
 Priority: optional
 Standards-Version: 3.9.3
-Maintainer: Ansible, Inc. <support@ansible.com>
+Maintainer: Ansible, Inc. <info@ansible.com>
 Build-Depends: cdbs, debhelper (>= 5.0.0), asciidoc, python, dh-python | python-support, python-setuptools
 Homepage: http://ansible.github.com/
 

--- a/packaging/release/release.yml
+++ b/packaging/release/release.yml
@@ -7,7 +7,7 @@
     release_date: "{{lookup('pipe', 'date +\"%m-%d-%Y\"')}}"
     rpm_spec_line: |
 
-      * {{lookup('pipe', 'date +"%a %b %d %Y"')}} Ansible, Inc. <support@ansible.com> - {{ansible_release_version}}-{{ansible_release_string}}
+      * {{lookup('pipe', 'date +"%a %b %d %Y"')}} Ansible, Inc. <info@ansible.com> - {{ansible_release_version}}-{{ansible_release_string}}
       - Release {{ansible_release_version}}-{{ansible_release_string}}
     deb_changelog_line: |
 
@@ -15,7 +15,7 @@
 
         * {{ansible_release_version}}
 
-       -- Ansible, Inc. <support@ansible.com>  {{lookup('pipe', 'date -R')}}
+       -- Ansible, Inc. <info@ansible.com>  {{lookup('pipe', 'date -R')}}
 
   vars_prompt:
   - name: ansible_release_branch
@@ -99,7 +99,7 @@
         dest: "{{release_dir}}/packaging/debian/changelog"
         regexp: "^ansible ({{ansible_release_version}})"
         line: "{{deb_changelog_line}}"
-        insertafter: "-- Ansible, Inc. <support@ansible.com>  %DATE%"
+        insertafter: "-- Ansible, Inc. <info@ansible.com>  %DATE%"
     - name: Update RELEASES.txt
       template:
         dest: "{{release_dir}}/RELEASES.txt"

--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -125,37 +125,37 @@ rm -rf %{buildroot}
 
 %changelog
 
-* Wed Feb 24 2016 Ansible, Inc. <support@ansible.com> - 2.0.1.0-1
+* Wed Feb 24 2016 Ansible, Inc. <info@ansible.com> - 2.0.1.0-1
 - Release 2.0.1.0-1
 
-* Thu Jan 14 2016 Ansible, Inc. <support@ansible.com> - 2.0.0.2-1
+* Thu Jan 14 2016 Ansible, Inc. <info@ansible.com> - 2.0.0.2-1
 - Release 2.0.0.2-1
 
-* Tue Jan 12 2016 Ansible, Inc. <support@ansible.com> - 2.0.0.1-1
+* Tue Jan 12 2016 Ansible, Inc. <info@ansible.com> - 2.0.0.1-1
 - Release 2.0.0.1-1
 
-* Tue Jan 12 2016 Ansible, Inc. <support@ansible.com> - 2.0.0.0-1
+* Tue Jan 12 2016 Ansible, Inc. <info@ansible.com> - 2.0.0.0-1
 - Release 2.0.0.0-1
 
-* Fri Oct 09 2015 Ansible, Inc. <support@ansible.com> - 1.9.4
+* Fri Oct 09 2015 Ansible, Inc. <info@ansible.com> - 1.9.4
 - Release 1.9.4
 
-* Thu Sep 03 2015 Ansible, Inc. <support@ansible.com> - 1.9.3
+* Thu Sep 03 2015 Ansible, Inc. <info@ansible.com> - 1.9.3
 - Release 1.9.3
 
-* Wed Jun 24 2015 Ansible, Inc. <support@ansible.com> - 1.9.2
+* Wed Jun 24 2015 Ansible, Inc. <info@ansible.com> - 1.9.2
 - Release 1.9.2
 
-* Mon Apr 27 2015 Ansible, Inc. <support@ansible.com> - 1.9.1
+* Mon Apr 27 2015 Ansible, Inc. <info@ansible.com> - 1.9.1
 - Release 1.9.1
 
-* Wed Mar 25 2015 Ansible, Inc. <support@ansible.com> - 1.9.0
+* Wed Mar 25 2015 Ansible, Inc. <info@ansible.com> - 1.9.0
 - Release 1.9.0
 
-* Thu Feb 19 2015 Ansible, Inc. <support@ansible.com> - 1.8.4
+* Thu Feb 19 2015 Ansible, Inc. <info@ansible.com> - 1.8.4
 - Release 1.8.4
 
-* Tue Feb 17 2015 Ansible, Inc. <support@ansible.com> - 1.8.3
+* Tue Feb 17 2015 Ansible, Inc. <info@ansible.com> - 1.8.3
 - Release 1.8.3
 
 * Thu Dec 04 2014 Michael DeHaan <michael@ansible.com> - 1.8.2

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='ansible',
       version=__version__,
       description='Radically simple IT automation',
       author=__author__,
-      author_email='support@ansible.com',
+      author_email='info@ansible.com',
       url='http://ansible.com/',
       license='GPLv3',
       # Ansible will also make use of a system copy of python-six if installed but use a


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

(assorted references)
##### ANSIBLE VERSION

```
ansible 2.1.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

The support@ansible.com email support alias is being retired. Remove it.
