### PR TITLE
Minor cleanup/speedup to hacking/env-setup

### DIFF
--- a/docsite/rst/intro_installation.rst
+++ b/docsite/rst/intro_installation.rst
@@ -144,6 +144,10 @@ If you want to suppress spurious warnings/errors, use::
 
     $ source ./hacking/env-setup -q
 
+If you want to make ansible always avaialble in your environment, add it to your shell's profile (assumes you already source'd this above to set $ANSIBLE_HOME)::
+
+    echo source $ANSIBLE_HOME/hacking/env-setup -q >> ~/.bash_profile
+
 If you don't have pip installed in your version of Python, install pip::
 
     $ sudo easy_install pip

--- a/docsite/rst/intro_installation.rst
+++ b/docsite/rst/intro_installation.rst
@@ -140,13 +140,13 @@ Using Fish::
 
     $ . ./hacking/env-setup.fish
 
-If you want to suppress spurious warnings/errors, use::
+You can use *-q* if you want to suppress spurious warnings/errors, and *-b* to background a few longer-running tasks so it returns faster for interactive or .profile use.::
 
     $ source ./hacking/env-setup -q
 
 If you want to make ansible always avaialble in your environment, add it to your shell's profile (assumes you already source'd this above to set $ANSIBLE_HOME)::
 
-    echo source $ANSIBLE_HOME/hacking/env-setup -q >> ~/.bash_profile
+    echo source $ANSIBLE_HOME/hacking/env-setup -q -b >> ~/.bash_profile
 
 If you don't have pip installed in your version of Python, install pip::
 

--- a/docsite/rst/intro_installation.rst
+++ b/docsite/rst/intro_installation.rst
@@ -144,7 +144,7 @@ You can use *-q* if you want to suppress spurious warnings/errors, and *-b* to b
 
     $ source ./hacking/env-setup -q
 
-If you want to make ansible always avaialble in your environment, add it to your shell's profile (assumes you already source'd this above to set $ANSIBLE_HOME)::
+If you want to make ansible always available in your environment, add it to your shell's profile (assumes you already source'd this above to set $ANSIBLE_HOME)::
 
     echo source $ANSIBLE_HOME/hacking/env-setup -q -b >> ~/.bash_profile
 

--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -8,11 +8,15 @@ MANPATH=${MANPATH-""}
 PYTHON=$(which python 2>/dev/null || which python3 2>/dev/null)
 PYTHON_BIN=${PYTHON_BIN-$PYTHON}
 
-verbosity=${1-info} # Defaults to `info' if unspecified
+verbosity=info # Defaults to `info' if unspecified
+background=no
 
-if [ "$verbosity" = -q ]; then
-    verbosity=silent
-fi
+for opt in "$@"; do
+    case $opt in
+      -q ) verbosity=silent ;;
+      -b ) background=yes ;;
+    esac
+done
 
 # When run using source as directed, $0 gets set to bash, so we must use $BASH_SOURCE
 if [ -n "$BASH_SOURCE" ] ; then
@@ -79,4 +83,8 @@ if [ "$verbosity" != silent ] ; then
 	EOF
 fi
 
-unset PREFIX_PATH PREFIX_MANPATH PREFIX_PYTHONPATH
+if [ $background = no ]; then
+  wait >/dev/null 2>&1
+fi
+
+unset PREFIX_PATH PREFIX_MANPATH PREFIX_PYTHONPATH HACKING_DIR PYTHON FULL_PATH verbosity background

--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -34,9 +34,9 @@ PREFIX_PYTHONPATH="$ANSIBLE_HOME/lib"
 PREFIX_PATH="$ANSIBLE_HOME/bin"
 PREFIX_MANPATH="$ANSIBLE_HOME/docs/man"
 
-expr "$PYTHONPATH" : "${PREFIX_PYTHONPATH}.*" > /dev/null || export PYTHONPATH="$PREFIX_PYTHONPATH:$PYTHONPATH"
-expr "$PATH" : "${PREFIX_PATH}.*" > /dev/null || export PATH="$PREFIX_PATH:$PATH"
-expr "$MANPATH" : "${PREFIX_MANPATH}.*" > /dev/null || export MANPATH="$PREFIX_MANPATH:$MANPATH"
+expr "$PYTHONPATH" : "${PREFIX_PYTHONPATH}" > /dev/null || export PYTHONPATH="$PREFIX_PYTHONPATH:$PYTHONPATH"
+expr "$PATH" : "${PREFIX_PATH}" > /dev/null || export PATH="$PREFIX_PATH:$PATH"
+expr "$MANPATH" : "${PREFIX_MANPATH}" > /dev/null || export MANPATH="$PREFIX_MANPATH:$MANPATH"
 
 #
 # Generate egg_info so that pkg_resources works
@@ -46,26 +46,21 @@ expr "$MANPATH" : "${PREFIX_MANPATH}.*" > /dev/null || export MANPATH="$PREFIX_M
 gen_egg_info()
 {
     if [ -e "$PREFIX_PYTHONPATH/ansible.egg-info" ] ; then
-        \rm -rf "$PREFIX_PYTHONPATH/ansible.egg-info"
+       \rm -rf "$PREFIX_PYTHONPATH/ansible.egg-info"
     fi
     $PYTHON_BIN setup.py egg_info
 }
 
-if [ "$ANSIBLE_HOME" != "$PWD" ] ; then
-    current_dir="$PWD"
-else
-    current_dir="$ANSIBLE_HOME"
-fi
 (
 	cd "$ANSIBLE_HOME"
 	if [ "$verbosity" = silent ] ; then
-	    gen_egg_info > /dev/null 2>&1
-            find . -type f -name "*.pyc" -exec rm -f {} \; > /dev/null 2>&1
+	    # In silent mode run in background just to speed up sourcing this file
+	    (gen_egg_info; 
+             find . -type f -name "*.pyc" -exec rm -f {} \; ) > /dev/null 2>&1 &
 	else
-	    gen_egg_info
-            find . -type f -name "*.pyc" -exec rm -f {} \;
+	    gen_egg_info # still in foreground since it prints output
+            find . -type f -name "*.pyc" -exec rm -f {} \; &
 	fi
-	cd "$current_dir"
 )
 
 if [ "$verbosity" != silent ] ; then
@@ -83,3 +78,5 @@ if [ "$verbosity" != silent ] ; then
 	
 	EOF
 fi
+
+unset PREFIX_PATH PREFIX_MANPATH PREFIX_PYTHONPATH


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

hacking/env-setup
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0 (fix_env-setup 26c4d6065c) last updated 2016/10/13 16:50:09 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 275fa3f055) last updated 2016/10/13 14:12:11 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 3e1ea76a75) last updated 2016/10/13 14:12:11 (GMT -400)
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Made it faster to source the hacking/env-setup by allowing gen_egg_info and removal of .pyc files to be run in the background.   I went down a path to make gen_egg dependent on file-timestamps as well, but backed out of that option.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
Nothing to see here.
```

Allow egg-info creation (and .pyc removal) to happen in background when -q is
used to speedup sourcing hacking/env-setup.  Couple other minor fixes:
chdir back to parent was unnecessary due to already in subshell,
.\* on expr matches was extraneous.

Added doc info to make env-setup a bit more static by adding a source command
to your profile
