### PR TITLE
Remove callback.CallbackBase._copy_result_exclude

### DIFF
--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -72,18 +72,6 @@ class CallbackBase:
     ''' helper for callbacks, so they don't all have to include deepcopy '''
     _copy_result = deepcopy
 
-    def _copy_result_exclude(self, result, exclude):
-        values = []
-        for e in exclude:
-            values.append(getattr(result, e))
-            setattr(result, e, None)
-
-        result_copy = deepcopy(result)
-        for i,e in enumerate(exclude):
-            setattr(result, e, values[i])
-
-        return result_copy
-
     def _dump_results(self, result, indent=None, sort_keys=True, keep_invocation=False):
         if result.get('_ansible_no_log', False):
             return json.dumps(dict(censored="the output has been hidden due to the fact that 'no_log: true' was specified for this result"))

--- a/test/units/plugins/callback/test_callback.py
+++ b/test/units/plugins/callback/test_callback.py
@@ -19,64 +19,13 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from six import PY3
-from copy import deepcopy
-
 from ansible.compat.tests import unittest
-from ansible.compat.tests.mock import patch, mock_open
 
 from ansible.plugins.callback import CallbackBase
-import ansible.plugins.callback as callish
 
-class TestCopyResultExclude(unittest.TestCase):
-    def setUp(self):
-        class DummyClass():
-            def __init__(self):
-                self.bar = [ 1, 2, 3 ]
-                self.a = {
-                    "b": 2,
-                    "c": 3,
-                }
-                self.b = {
-                    "c": 3,
-                    "d": 4,
-                }
-        self.foo = DummyClass()
-        self.cb = CallbackBase()
 
-    def tearDown(self):
-        pass
-
-    def test_copy_logic(self):
-        res = self.cb._copy_result_exclude(self.foo, ())
-        self.assertEqual(self.foo.bar, res.bar)
-    
-    def test_copy_deep(self):
-        res = self.cb._copy_result_exclude(self.foo, ())
-        self.assertNotEqual(id(self.foo.bar), id(res.bar))
-
-    def test_no_exclude(self):
-        res = self.cb._copy_result_exclude(self.foo, ())
-        self.assertEqual(self.foo.bar, res.bar)
-        self.assertEqual(self.foo.a, res.a)
-        self.assertEqual(self.foo.b, res.b)
-    
-    def test_exclude(self):
-        res = self.cb._copy_result_exclude(self.foo, ['bar', 'b'])
-        self.assertIsNone(res.bar)
-        self.assertIsNone(res.b)
-        self.assertEqual(self.foo.a, res.a)
-
-    def test_result_unmodified(self):
-        bar_id = id(self.foo.bar)
-        a_id = id(self.foo.a)
-        res = self.cb._copy_result_exclude(self.foo, ['bar', 'a'])
-
-        self.assertEqual(self.foo.bar, [ 1, 2, 3 ])
-        self.assertEqual(bar_id, id(self.foo.bar))
-
-        self.assertEqual(self.foo.a, dict(b=2, c=3))
-        self.assertEqual(a_id, id(self.foo.a))
-
-        self.assertRaises(AttributeError, self.cb._copy_result_exclude, self.foo, ['a', 'c', 'bar'])
-
+class TestCallback(unittest.TestCase):
+    # FIXME: This doesn't really test anything...
+    def test(self):
+        cb = CallbackBase()
+        cb.v2_on_any('foo', 'bar', blip='blippy')


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

lib/ansible/plugins/callback/**init**.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0 (remove_copy_result_exclude b5224e7ae4) last updated 2016/10/13 17:49:30 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 275fa3f055) last updated 2016/10/12 14:06:23 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 3e1ea76a75) last updated 2016/10/13 11:34:41 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides


```
##### SUMMARY

Nothing seems to use this now.

Was added originally added in2d11cfab92f9d26448461b4bc81f466d1910a15e
but the code that used it was removed in
e02b98274b60cdbc12ef4a4c74ae0f74207384e8
