### PR TITLE
Update dev_guide with Python3 porting advice.

### DIFF
--- a/docsite/rst/dev_guide/developing_modules.rst
+++ b/docsite/rst/dev_guide/developing_modules.rst
@@ -632,8 +632,8 @@ Module checklist
 
 The following  checklist items are important guidelines for people who want to contribute to the development of modules to Ansible on GitHub. Please read the guidelines before you submit your PR/proposal.
 
-* The shebang should always be ``#!/usr/bin/python``, this allows ansible_python_interpreter to work
-* Modules must be written to support Python 2.4. If this is not possible, required minimum python version and rationale should be explained in the requirements section in DOCUMENTATION.
+* The shebang must always be ``#!/usr/bin/python``.  This allows ``ansible_python_interpreter`` to work
+* Modules must be written to support Python 2.4. If this is not possible, required minimum python version and rationale should be explained in the requirements section in ``DOCUMENTATION``.  This minimum requirement will be advanced to Python-2.6 in Ansible-2.4.
 * Modules must be written to use proper Python-3 syntax.  At some point in the future we'll come up with rules for running on Python-3 but we're not there yet.  See :doc:`developing_modules_python3` for help on how to do this.
 * Documentation: Make sure it exists
     * Module documentation should briefly and accurately define what each module and option does, and how it works with others in the underlying system. Documentation should be written for broad audience--readable both by experts and non-experts. This documentation is not meant to teach a total novice, but it also should not be reserved for the Illuminati (hard balance).


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

dev_guide
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
devel, 2.2 (but no need to backport)
```
##### SUMMARY

One of the requests from the contrib summit was more information on how to port to Python-3.  Added some of the scenarios we've encountered so far.

Also update the date that Python2.4 support will be dropped to say
Ansible-2.4 will no longer have python-2.4 support.
