### PR TITLE
Remove pbrun's '-b' option.

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -517,8 +517,8 @@ class PlayContext(Base):
 
             elif self.become_method == 'pbrun':
 
-                prompt='assword:'
-                becomecmd = '%s -b %s -u %s %s' % (exe, flags, self.become_user, success_cmd)
+                prompt='Password:'
+                becomecmd = '%s %s -u %s %s' % (exe, flags, self.become_user, success_cmd)
 
             elif self.become_method == 'ksu':
                 def detect_ksu_prompt(data):


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0
```
##### COMPONENT NAME

```
ansible
```
##### SUMMARY

This PR removes the '-b' option. It is still possible to pass it by setting `become_flags`.

I am not 100% sure why but `assword:` stopped working (Timeout waiting for esc prompt) with the rest of the changes.. but `Password:` works. Would anyone be able to shed some light on that? I left it as an extra commit so it can be cherry picked out if needed. 
