### PR TITLE
Add SSH agent support for network modules

### DIFF
--- a/lib/ansible/module_utils/network.py
+++ b/lib/ansible/module_utils/network.py
@@ -40,6 +40,7 @@ NET_TRANSPORT_ARGS = dict(
     username=dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
     password=dict(no_log=True, fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD'])),
     ssh_keyfile=dict(fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE']), type='path'),
+    allow_agent=dict(fallback=(env_fallback, ['ANSIBLE_NET_ALLOW_AGENT']), type='path'),
 
     authorize=dict(default=False, fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
     auth_pass=dict(no_log=True, fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS'])),

--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -21,6 +21,7 @@ import re
 import socket
 import time
 
+
 # py2 vs py3; replace with six via ansiballz
 try:
     from StringIO import StringIO
@@ -218,6 +219,11 @@ class CliBase(object):
         password = params.get('password')
         key_file = params.get('ssh_keyfile')
         timeout = params['timeout']
+        allow_agent = params.get('allow_agent') or False
+
+        f = open("/tmp/afile", 'w')
+        f.write(str(params))
+        f.close()
 
         try:
             self.shell = Shell(
@@ -227,7 +233,7 @@ class CliBase(object):
             )
             self.shell.open(
                 host, port=port, username=username, password=password,
-                key_filename=key_file, timeout=timeout,
+                key_filename=key_file, timeout=timeout, allow_agent=allow_agent,
             )
         except ShellError:
             exc = get_exception()

--- a/lib/ansible/utils/module_docs_fragments/asa.py
+++ b/lib/ansible/utils/module_docs_fragments/asa.py
@@ -58,6 +58,13 @@ options:
         in the task, the value of environment variable C(ANSIBLE_NET_SSH_KEYFILE)
         will be used instead.
     required: false
+  allow_agent:
+    description:
+      - Specifies whether to allow SSH agents to be used. If the value is not
+        specified in the task, the value of the variable C(ANSIBLE_NET_ALLOW_AGENT)
+        will be used instead
+    required: false
+    default: false
   authorize:
     description:
       - Instructs the module to enter privileged mode on the remote device

--- a/lib/ansible/utils/module_docs_fragments/asa.py
+++ b/lib/ansible/utils/module_docs_fragments/asa.py
@@ -62,7 +62,7 @@ options:
     description:
       - Specifies whether to allow SSH agents to be used. If the value is not
         specified in the task, the value of the variable C(ANSIBLE_NET_ALLOW_AGENT)
-        will be used instead
+        will be used instead.
     required: false
     default: false
   authorize:

--- a/lib/ansible/utils/module_docs_fragments/dellos10.py
+++ b/lib/ansible/utils/module_docs_fragments/dellos10.py
@@ -55,6 +55,13 @@ options:
         device.  If the value is not specified in the task, the value of
         environment variable C(ANSIBLE_NET_SSH_KEYFILE) will be used instead.
     required: false
+  allow_agent:
+    description:
+      - Specifies whether to allow SSH agents to be used. If the value is not
+        specified in the task, the value of the variable C(ANSIBLE_NET_ALLOW_AGENT)
+        will be used instead
+    required: false
+    default: false
   timeout:
     description:
       - Specifies idle timeout (in seconds) for the connection. Useful if the

--- a/lib/ansible/utils/module_docs_fragments/dellos10.py
+++ b/lib/ansible/utils/module_docs_fragments/dellos10.py
@@ -59,7 +59,7 @@ options:
     description:
       - Specifies whether to allow SSH agents to be used. If the value is not
         specified in the task, the value of the variable C(ANSIBLE_NET_ALLOW_AGENT)
-        will be used instead
+        will be used instead.
     required: false
     default: false
   timeout:

--- a/lib/ansible/utils/module_docs_fragments/dellos6.py
+++ b/lib/ansible/utils/module_docs_fragments/dellos6.py
@@ -59,7 +59,7 @@ options:
     description:
       - Specifies whether to allow SSH agents to be used.  If the value is not
         specified in the task, the value of the variable C(ANSIBLE_NET_ALLOW_AGENT)
-        will be used instead
+        will be used instead.
     required: false
     default: false
   authorize:

--- a/lib/ansible/utils/module_docs_fragments/dellos6.py
+++ b/lib/ansible/utils/module_docs_fragments/dellos6.py
@@ -55,6 +55,13 @@ options:
         device.  If the value is not specified in the task, the value of
         environment variable C(ANSIBLE_NET_SSH_KEYFILE) will be used instead.
     required: false
+  allow_agent:
+    description:
+      - Specifies whether to allow SSH agents to be used.  If the value is not
+        specified in the task, the value of the variable C(ANSIBLE_NET_ALLOW_AGENT)
+        will be used instead
+    required: false
+    default: false
   authorize:
     description:
       - Instructs the module to enter privileged mode on the remote device

--- a/lib/ansible/utils/module_docs_fragments/eos.py
+++ b/lib/ansible/utils/module_docs_fragments/eos.py
@@ -64,7 +64,7 @@ options:
       - Specifies whether to allow SSH agents to be used.  This argument
         is only used for the I(cli) transport.  If the value is not specified in
         the task, the value of the variable C(ANSIBLE_NET_ALLOW_AGENT) will be used
-        instead
+        instead.
     required: false
     default: false
   authorize:

--- a/lib/ansible/utils/module_docs_fragments/eos.py
+++ b/lib/ansible/utils/module_docs_fragments/eos.py
@@ -59,6 +59,14 @@ options:
         If the value is not specified in the task, the value of environment
         variable C(ANSIBLE_NET_SSH_KEYFILE) will be used instead.
     required: false
+  allow_agent:
+    description:
+      - Specifies whether to allow SSH agents to be used.  This argument
+        is only used for the I(cli) transport.  If the value is not specified in
+        the task, the value of the variable C(ANSIBLE_NET_ALLOW_AGENT) will be used
+        instead
+    required: false
+    default: false
   authorize:
     description:
       - Instructs the module to enter privileged mode on the remote device

--- a/lib/ansible/utils/module_docs_fragments/ios.py
+++ b/lib/ansible/utils/module_docs_fragments/ios.py
@@ -61,7 +61,7 @@ options:
     description:
       - Specifies whether to allow SSH agents to be used.  If the value is not
         specified in the task, the value of the variable C(ANSIBLE_NET_ALLOW_AGENT)
-        will be used instead
+        will be used instead.
     required: false
     default: false
   authorize:

--- a/lib/ansible/utils/module_docs_fragments/ios.py
+++ b/lib/ansible/utils/module_docs_fragments/ios.py
@@ -57,6 +57,13 @@ options:
         in the task, the value of environment variable C(ANSIBLE_NET_SSH_KEYFILE)
         will be used instead.
     required: false
+  allow_agent:
+    description:
+      - Specifies whether to allow SSH agents to be used.  If the value is not
+        specified in the task, the value of the variable C(ANSIBLE_NET_ALLOW_AGENT)
+        will be used instead
+    required: false
+    default: false
   authorize:
     description:
       - Instructs the module to enter privileged mode on the remote device

--- a/lib/ansible/utils/module_docs_fragments/iosxr.py
+++ b/lib/ansible/utils/module_docs_fragments/iosxr.py
@@ -57,6 +57,13 @@ options:
         in the task, the value of environment variable C(ANSIBLE_NET_SSH_KEYFILE)
         will be used instead.
     required: false
+  allow_agent:
+    description:
+      - Specifies whether to allow SSH agents to be used.  If the value is not
+        specified in the task, the value of the variable C(ANSIBLE_NET_ALLOW_AGENT)
+        will be used instead.
+    required: false
+    default: false
   provider:
     description:
       - Convenience method that allows all I(iosxr) arguments to be passed as

--- a/lib/ansible/utils/module_docs_fragments/junos.py
+++ b/lib/ansible/utils/module_docs_fragments/junos.py
@@ -59,6 +59,13 @@ options:
         the task, the value of environment variable C(ANSIBLE_NET_SSH_KEYFILE)
         will be used instead.
     required: false
+  allow_agent:
+    description:
+      - Specifies whether to allow SSH agents to be used.  If the value is not
+        specified in the task, the value of the variable C(ANSIBLE_NET_ALLOW_AGENT)
+        will be used instead.
+    required: false
+    default: false
   provider:
     description:
       - Convenience method that allows all I(ios) arguments to be passed as

--- a/lib/ansible/utils/module_docs_fragments/nxos.py
+++ b/lib/ansible/utils/module_docs_fragments/nxos.py
@@ -59,6 +59,14 @@ options:
         transport. If the value is not specified in the task, the
         value of environment variable C(ANSIBLE_NET_SSH_KEYFILE) will be used instead.
     required: false
+  allow_agent:
+    description:
+      - Specifies whether to allow SSH agents to be used.  This argument
+        is only used for the I(cli) transport.  If the value is not specified in
+        the task, the value of the variable C(ANSIBLE_NET_ALLOW_AGENT) will be used
+        instead.
+    required: false
+    default: false
   transport:
     description:
       - Configures the transport connection to use when connecting to the

--- a/lib/ansible/utils/module_docs_fragments/openswitch.py
+++ b/lib/ansible/utils/module_docs_fragments/openswitch.py
@@ -63,6 +63,14 @@ options:
         transports. If the value is not specified in the task, the value of
         environment variable C(ANSIBLE_NET_SSH_KEYFILE) will be used instead.
     required: false
+  allow_agent:
+    description:
+      - Specifies whether to allow SSH agents to be used.  This argument
+        is only used for the I(cli) transport.  If the value is not specified in
+        the task, the value of the variable C(ANSIBLE_NET_ALLOW_AGENT) will be used
+        instead.
+    required: false
+    default: false
   transport:
     description:
       - Configures the transport connection to use when connecting to the

--- a/lib/ansible/utils/module_docs_fragments/sros.py
+++ b/lib/ansible/utils/module_docs_fragments/sros.py
@@ -57,6 +57,13 @@ options:
         in the task, the value of environment variable C(ANSIBLE_NET_SSH_KEYFILE)
         will be used instead.
     required: false
+  allow_agent:
+    description:
+      - Specifies whether to allow SSH agents to be used.  If the value is not
+        specified in the task, the value of the variable C(ANSIBLE_NET_ALLOW_AGENT)
+        will be used instead.
+    required: false
+    default: false
   timeout:
     description:
       - Specifies idle timeout for the connection, in seconds. Useful if the console

--- a/lib/ansible/utils/module_docs_fragments/vyos.py
+++ b/lib/ansible/utils/module_docs_fragments/vyos.py
@@ -57,6 +57,14 @@ options:
         in the task, the value of environment variable C(ANSIBLE_NET_SSH_KEYFILE)
         will be used instead.
     required: false
+  allow_agent:
+    description:
+      - Specifies whether to allow SSH agents to be used.  This argument
+        is only used for the I(cli) transport.  If the value is not specified in
+        the task, the value of the variable C(ANSIBLE_NET_ALLOW_AGENT) will be used
+        instead.
+    required: false
+    default: false
   timeout:
     description:
       - Specifies idle timeout for the connection, in seconds. Useful if the console


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

module_utils.shell
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0 (allow-ssh-agents 5bef826483) last updated 2016/10/14 16:53:24 (GMT -500)
  lib/ansible/modules/core: (detached HEAD 275fa3f055) last updated 2016/10/14 16:02:37 (GMT -500)
  lib/ansible/modules/extras: (detached HEAD 3e1ea76a75) last updated 2016/10/14 16:02:41 (GMT -500)
  config file = 
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Paramiko includes SSH agent support, and this support
is exposed in the modules_utils.shell.Shell class.  This
patch exposes the functionality to CliBase class,
and all of the network helpers that inherit from it.  This allows users to use an existing SSH agent instead having keys with no passphrase, or having to enter the passphrase on the command line or via
environment variables.

Default for allow_agent is currently left as false, however it could be easily changed to allow
SSH agents by default.

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```
