### PR TITLE
Fix uninitialized variable in deserialize method

### DIFF
--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -251,7 +251,7 @@ class Block(Base, Become, Conditional, Taggable):
                 p = TaskInclude()
             elif parent_type == 'HandlerTaskInclude':
                 p = HandlerTaskInclude()
-            p.deserialize(pb_data)
+            p.deserialize(parent_data)
             self._parent = p
             self._dep_chain = self._parent.get_dep_chain()
 

--- a/test/units/playbook/test_block.py
+++ b/test/units/playbook/test_block.py
@@ -75,3 +75,14 @@ class TestBlock(unittest.TestCase):
         self.assertEqual(len(b.block), 1)
         self.assertIsInstance(b.block[0], Task)
 
+    def test_deserialize(self):
+        ds = dict(
+           block = [dict(action='block')],
+           rescue = [dict(action='rescue')],
+           always = [dict(action='always')],
+        )
+        b = Block.load(ds)
+        data = dict(parent = ds, parent_type = 'Block')
+        b.deserialize(data)
+        self.assertIsInstance(b._parent, Block)
+


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

playbook/block.py
##### ANSIBLE VERSION

git devel (probably since 2016-08-01)
##### SUMMARY

Fix uninitialized variable in deserialize method

The bug was introduced with commit 06d4f4ad0e8f62c6b02b01833b94a0e44be008d0.
Added a simple test.
