### PR TITLE
Add a SIGTERM handler that just exits.

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -45,6 +45,12 @@ from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
 from ansible.utils.display import Display
 from ansible.module_utils._text import to_text
 
+import signal
+def signal_handler(signum, frame):
+	sys.exit(0)
+
+signal.signal(signal.SIGTERM, signal_handler)
+
 
 ########################################
 ### OUTPUT OF LAST RESORT ###


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task
bin/ansible

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0 (devel 578170a908) last updated 2016/10/14 19:16:23 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 275fa3f055) last updated 2016/10/12 14:06:23 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 3e1ea76a75) last updated 2016/10/13 11:34:41 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```

Prevents the main process from ending up
being orphaned if it gets a SIGTERM.

Fixes ansible-tower issue #3617
