### PR TITLE
unarchive tests now pass on python3

### DIFF
--- a/test/utils/shippable/python3-test-tag-blacklist.txt
+++ b/test/utils/shippable/python3-test-tag-blacklist.txt
@@ -9,5 +9,4 @@ test_pip
 test_service
 test_subversion
 test_synchronize
-test_unarchive
 test_uri


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

test unarchive.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
devel and 2.2
```
##### SUMMARY

mscherer fixed unarchive to run on python3.  Enable running unarchive tests on python3.
