### PR TITLE
Debian need build-essential package to build deb package

### DIFF
--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -5,7 +5,7 @@ To create an Ansible DEB package:
 
     sudo apt-get install python-paramiko python-yaml python-jinja2 python-httplib2 python-setuptools python-six sshpass
     sudo apt-get install cdbs debhelper dpkg-dev git-core reprepro fakeroot asciidoc devscripts docbook-xml xsltproc libxml2-utils
-    sudo apt-get install dh-python
+    sudo apt-get install dh-python build-essential
     git clone git://github.com/ansible/ansible.git
     cd ansible
     make deb

--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -4,7 +4,7 @@ Ansible Debian Package
 To create an Ansible DEB package:
 
     sudo apt-get install python-paramiko python-yaml python-jinja2 python-httplib2 python-setuptools python-six sshpass
-    sudo apt-get install cdbs debhelper dpkg-dev git-core reprepro fakeroot asciidoc devscripts docbook-xml xsltproc libxml2-utils
+    sudo apt-get install cdbs debhelper git-core reprepro fakeroot asciidoc devscripts docbook-xml xsltproc libxml2-utils
     sudo apt-get install dh-python build-essential
     git clone git://github.com/ansible/ansible.git
     cd ansible


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

README.md
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

dpkg-buildpackage need build-essential package to build deb package.
Without there is an error during the make deb process.
