### PR TITLE
Add timeout option for nxapi

### DIFF
--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -158,10 +158,7 @@ class Nxapi(NxapiConfigMixin):
 
         headers = {'Content-Type': 'application/json'}
         result = list()
-        try:
-            timeout = self.url_args.params['timeout']
-        except:
-            timeout = 10
+        timeout = self.url_args.params['timeout']
         for req in requests:
             if self._nxapi_auth:
                 headers['Cookie'] = self._nxapi_auth

--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -29,6 +29,7 @@ from ansible.module_utils.urls import fetch_url, url_argument_spec
 
 add_argument('use_ssl', dict(default=False, type='bool'))
 add_argument('validate_certs', dict(default=True, type='bool'))
+add_argument('timeout', dict(default=10, type='int'))
 
 class NxapiConfigMixin(object):
 
@@ -115,6 +116,7 @@ class Nxapi(NxapiConfigMixin):
         self.url_args.params['url_username'] = params['username']
         self.url_args.params['url_password'] = params['password']
         self.url_args.params['validate_certs'] = params['validate_certs']
+        self.url_args.params['timeout'] = params['timeout']
 
         if params['use_ssl']:
             proto = 'https'

--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -158,13 +158,16 @@ class Nxapi(NxapiConfigMixin):
 
         headers = {'Content-Type': 'application/json'}
         result = list()
-
+        try:
+            timeout = self.url_args.params['timeout']
+        except:
+            timeout = 10
         for req in requests:
             if self._nxapi_auth:
                 headers['Cookie'] = self._nxapi_auth
 
             response, headers = fetch_url(
-                self.url_args, self.url, data=data, headers=headers, method='POST'
+                self.url_args, self.url, data=data, headers=headers, timeout=timeout, method='POST'
             )
             self._nxapi_auth = headers.get('set-cookie')
 

--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -29,7 +29,6 @@ from ansible.module_utils.urls import fetch_url, url_argument_spec
 
 add_argument('use_ssl', dict(default=False, type='bool'))
 add_argument('validate_certs', dict(default=True, type='bool'))
-add_argument('timeout', dict(default=10, type='int'))
 
 class NxapiConfigMixin(object):
 

--- a/lib/ansible/utils/module_docs_fragments/nxos.py
+++ b/lib/ansible/utils/module_docs_fragments/nxos.py
@@ -75,10 +75,11 @@ options:
     choices: ['yes', 'no']
   timeout:
     description:
-      - Specifies idle timeout for the connection.  NX-API can be slow to 
+      - Specifies idle timeout in seconds.  NX-API can be slow to 
         return on long-running commands (sh mac, sh bgp, etc).
     required: false
     default: 10
+    version_added: 2.3
   provider:
     description:
       - Convenience method that allows all I(nxos) arguments to be passed as

--- a/lib/ansible/utils/module_docs_fragments/nxos.py
+++ b/lib/ansible/utils/module_docs_fragments/nxos.py
@@ -73,6 +73,12 @@ options:
     required: false
     default: no
     choices: ['yes', 'no']
+  timeout:
+    description:
+      - Specifies idle timeout for the connection.  NX-API can be slow to 
+        return on long-running commands (sh mac, sh bgp, etc).
+    required: false
+    default: 10
   provider:
     description:
       - Convenience method that allows all I(nxos) arguments to be passed as


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

nxos.py
##### ANSIBLE VERSION

```
ansible 2.2.0 (timeout bebb6b9fb4) last updated 2016/10/17 14:31:47 (GMT -500)
  lib/ansible/modules/core: (detached HEAD 488f082761) last updated 2016/10/17 14:20:51 (GMT -500)
  lib/ansible/modules/extras: (detached HEAD 24da3602c6) last updated 2016/10/17 14:21:14 (GMT -500)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

This PR allows you to configure a custom timeout value for transport using nx-api.  PR 14973 added timeout to ios, and those changes are carried into the cli transport for nxos (whether or not by design :) ).  I added code to set timeout in the url module as well.

```

---
- hosts: all
  gather_facts: no
  connection: local
  tasks:
  - name: return show commands output
    nxos_command:
      host: "{{ ansible_host }}"
      username: user
      password: password
      transport: nxapi
      commands:
        - show version
      timeout: 30
    register: output

  - debug: var=output
```

```
modified:   lib/ansible/module_utils/nxos.py
- added configurable timeout to module paramaters
modified:   lib/ansible/utils/module_docs_fragments/nxos.py
- added documentation for timeout
```
