### PR TITLE
Fix ansible-pull on python3

### DIFF
--- a/lib/ansible/utils/cmd_functions.py
+++ b/lib/ansible/utils/cmd_functions.py
@@ -24,7 +24,7 @@ import shlex
 import subprocess
 import select
 
-from ansible.compat.six import PY2
+from ansible.compat.six import PY2, PY3
 from ansible.module_utils._text import to_bytes
 
 def run_cmd(cmd, live=False, readsize=10):
@@ -51,7 +51,11 @@ def run_cmd(cmd, live=False, readsize=10):
         if p.stdout in rfd:
             dat = os.read(p.stdout.fileno(), readsize)
             if live:
-                sys.stdout.write(dat)
+                # On python3, stdout has a codec to go from text type to bytes
+                if PY3:
+                    sys.stdout.buffer.write(dat)
+                else:
+                    sys.stdout.write(dat)
             stdout += dat
             if dat == b'':
                 rpipes.remove(p.stdout)
@@ -59,7 +63,11 @@ def run_cmd(cmd, live=False, readsize=10):
             dat = os.read(p.stderr.fileno(), readsize)
             stderr += dat
             if live:
-                sys.stdout.write(dat)
+                # On python3, stdout has a codec to go from text type to bytes
+                if PY3:
+                    sys.stdout.buffer.write(dat)
+                else:
+                    sys.stdout.write(dat)
             if dat == b'':
                 rpipes.remove(p.stderr)
         # only break out if we've emptied the pipes, or there is nothing to

--- a/test/utils/shippable/python3-test-target-blacklist.txt
+++ b/test/utils/shippable/python3-test-target-blacklist.txt
@@ -1,3 +1,0 @@
-s/ pull_run / /
-s/ pull_no_127 / /
-s/ pull_limit_inventory / /


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ansible-pull via utils/cmd_functions.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
devel, 2.2
```
##### SUMMARY

On python3, we can't write bytes directly to sys.stdout.

Write to sys.stdout.buffer instead.
