### PR TITLE
epdb doesn't work on python3 so we need a different package to test pip

### DIFF
--- a/test/integration/integration_config.yml
+++ b/test/integration/integration_config.yml
@@ -2,5 +2,5 @@
 win_output_dir: 'C:\ansible_testing'
 output_dir: ~/ansible_testing
 non_root_test_user: ansible
-pip_test_package: epdb
+pip_test_package: isort
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

test for pip
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
devel 2.2
```
##### SUMMARY

epdb doesn't work on python3 so pip is unable to install it for python3.  Use a different package to test pip.
