### PR TITLE
Fish hacking setup fix

### DIFF
--- a/hacking/env-setup.fish
+++ b/hacking/env-setup.fish
@@ -57,7 +57,6 @@ if [ $QUIET ]
 else
     python setup.py egg_info
 end
-mv ansible*egg-info $PREFIX_PYTHONPATH
 find . -type f -name "*.pyc" -delete
 popd
 

--- a/hacking/env-setup.fish
+++ b/hacking/env-setup.fish
@@ -9,11 +9,11 @@ set PREFIX_PATH $ANSIBLE_HOME/bin
 set PREFIX_MANPATH $ANSIBLE_HOME/docs/man
 
 # set quiet flag
-if set -q argv
+if test (count $argv) -ge 1
     switch $argv
-    case '-q' '--quiet'
-        set QUIET "true"
-    case '*'
+        case '-q' '--quiet'
+            set QUIET "true"
+        case '*'
     end
 end
 

--- a/hacking/env-setup.fish
+++ b/hacking/env-setup.fish
@@ -4,8 +4,8 @@
 set HACKING_DIR (dirname (status -f))
 set FULL_PATH (python -c "import os; print(os.path.realpath('$HACKING_DIR'))")
 set ANSIBLE_HOME (dirname $FULL_PATH)
-set PREFIX_PYTHONPATH $ANSIBLE_HOME/lib 
-set PREFIX_PATH $ANSIBLE_HOME/bin 
+set PREFIX_PYTHONPATH $ANSIBLE_HOME/lib
+set PREFIX_PATH $ANSIBLE_HOME/bin
 set PREFIX_MANPATH $ANSIBLE_HOME/docs/man
 
 # set quiet flag
@@ -49,13 +49,13 @@ set -gx ANSIBLE_LIBRARY $ANSIBLE_HOME/library
 
 # Generate egg_info so that pkg_resources works
 pushd $ANSIBLE_HOME
+if test -e $PREFIX_PYTHONPATH/ansible*.egg-info
+    rm -r $PREFIX_PYTHONPATH/ansible*.egg-info
+end
 if [ $QUIET ]
     python setup.py -q egg_info
 else
     python setup.py egg_info
-end
-if test -e $PREFIX_PYTHONPATH/ansible*.egg-info
-    rm -r $PREFIX_PYTHONPATH/ansible*.egg-info
 end
 mv ansible*egg-info $PREFIX_PYTHONPATH
 find . -type f -name "*.pyc" -delete


### PR DESCRIPTION
##### ISSUE TYPE
- Bug Report
##### COMPONENT NAME

```
env-setup.fish
```
##### ANSIBLE VERSION

```
ansible 2.3.0 (us/devel ea479001f0) last updated 2016/10/18 10:26:05 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 3266efb02f) last updated 2016/10/18 10:26:06 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 3f77bb6857) last updated 2016/10/18 09:15:21 (GMT -400)
```
##### CONFIGURATION

<!---
Mention any settings you have changed/added/removed in ansible.cfg
(or using the ANSIBLE_* environment variables).
-->
##### OS / ENVIRONMENT

```
ProductName:    Mac OS X
ProductVersion: 10.12
BuildVersion:   16A323

fish, version 2.3.1
```
##### SUMMARY

There are several minor bugs in `env-setup.fish`.
- Checking for whether or not arguments were passed using `set -q argv` results in an error message. A better method is to check the length of the `argv` list.
- `ansible*.egg-info` is removed _after_ it is generated by `setup.py`. It should be removed before.
- It is not necessary to move `ansible*egg-info` from `$ANSIBLE_HOME` to `$PREFIX_PYTHONPATH` since `setup.py` creates it there already. 
##### STEPS TO REPRODUCE

Run `source hacking/env-setup.fish`.
##### EXPECTED RESULTS

If no arguments are passed, then no error messages from the `switch` command should be reported.

After running `source hacking/env-setup.fish`, `lib/ansible.egg-info` should exist.

```
ansible
├── CHANGELOG.md
├── CODING_GUIDELINES.md
...
├── lib
│   ├── ansible
│   └── ansible.egg-info
...
```

The script should not attempt to move `ansible*egg-info` to `$PREFIX_PYTHONPATH`.
##### ACTUAL RESULTS

Error message due to bad test:

```
switch: Expected exactly one argument, got 0

hacking/env-setup.fish (line 13):     switch $argv
                                             ^
from sourcing file hacking/env-setup.fish
    called on standard input
...
```

Missing `lib/ansible.egg-info`:

```
ansible
├── CHANGELOG.md
├── CODING_GUIDELINES.md
...
├── lib
│   └── ansible
...
```

Attempting to move `ansible*egg-info` to `lib`:

```
No matches for wildcard 'ansible*egg-info'.
hacking/env-setup.fish (line 60): mv ansible*egg-info $PREFIX_PYTHONPATH
                                     ^
from sourcing file hacking/env-setup.fish
    called on standard input
```

The error itself is by design since `fish` reports when wildcards match nothing. The command to attempt to move these files should be removed since the egg files do not get created at `$ANSIBLE_HOME`.
