### PR TITLE
azure inventory: capture only the winrm protocol value

### DIFF
--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -565,7 +565,7 @@ class AzureInventory(object):
                     if machine.os_profile.windows_configuration.win_rm.listeners is not None:
                         host_vars['windows_rm']['listeners'] = []
                         for listener in machine.os_profile.windows_configuration.win_rm.listeners:
-                            host_vars['windows_rm']['listeners'].append(dict(protocol=listener.protocol,
+                            host_vars['windows_rm']['listeners'].append(dict(protocol=listener.protocol.value,
                                                                              certificate_url=listener.certificate_url))
 
             for interface in machine.network_profile.network_interfaces:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

dynamic inventory for azure @ `contrib/inventory/azure_rm.py`
##### ANSIBLE VERSION

```
ansible --version
ansible 2.1.1.0
  config file = /home/deploy/rms-ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

Also note the python azure sdk version

```
pip show azure

---
Metadata-Version: 2.0
Name: azure
Version: 2.0.0rc5
Summary: Microsoft Azure Client Libraries for Python
Home-page: https://github.com/Azure/azure-sdk-for-python
Author: Microsoft Corporation
Author-email: ptvshelp@microsoft.com
Installer: pip
License: MIT License
Location: /usr/lib/python3.4/site-packages
Requires: azure-graphrbac, azure-mgmt, azure-batch, azure-servicebus, azure-storage, azure-servicemanagement-legacy
Classifiers:
  Development Status :: 5 - Production/Stable
  Programming Language :: Python
  Programming Language :: Python :: 2
  Programming Language :: Python :: 2.7
  Programming Language :: Python :: 3
  Programming Language :: Python :: 3.3
  Programming Language :: Python :: 3.4
  Programming Language :: Python :: 3.5
  License :: OSI Approved :: MIT License
```
##### SUMMARY

When querying azure virtual machines that are:
1. Windows OS based
2. Have winrm enabled and listeners added.

The `listener.protocol` returns a complex object that causes the JSON parse to fail.
The error is:

```
Inventory script (inventory/azure/azure_rm.py) had an execution error: Traceback (most recent call last):
  File "/home/deploy/rms-ansible/inventory/azure/azure_rm.py", line 763, in <module>
    main()
  File "/home/deploy/rms-ansible/inventory/azure/azure_rm.py", line 759, in main
    AzureInventory()
  File "/home/deploy/rms-ansible/inventory/azure/azure_rm.py", line 400, in __init__
    print (self._json_format_dict(pretty=self._args.pretty))
  File "/home/deploy/rms-ansible/inventory/azure/azure_rm.py", line 642, in _json_format_dict
    return json.dumps(self._inventory)
  File "/usr/lib64/python2.7/json/__init__.py", line 243, in dumps
    return _default_encoder.encode(obj)
  File "/usr/lib64/python2.7/json/encoder.py", line 207, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib64/python2.7/json/encoder.py", line 270, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib64/python2.7/json/encoder.py", line 184, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: <ProtocolTypes.http: 'Http'> is not JSON serializable
```

Updating the return to store `listener.protocol.value` captures the setting and allows the JSON parser work as intended.
