### PR TITLE
Make blowfish/bcrypt work correctly in password_hash filter with passlib

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -257,7 +257,11 @@ def get_encrypted_password(password, hashtype='sha512', salt=None):
             saltstring =  "$%s$%s" % (cryptmethod[hashtype],salt)
             encrypted = crypt.crypt(password, saltstring)
         else:
-            cls = getattr(passlib.hash, '%s_crypt' % hashtype)
+            if hashtype == 'blowfish':
+                cls = passlib.hash.bcrypt;
+            else:
+                cls = getattr(passlib.hash, '%s_crypt' % hashtype)
+
             encrypted = cls.encrypt(password, salt=salt)
 
         return encrypted


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME
- `password_hash` filter
##### ANSIBLE VERSION

```
ansible 2.3.0 (passlib-bcrypt 99ad0b07ac) last updated 2016/10/18 20:03:27 (GMT +100)
  lib/ansible/modules/core: (detached HEAD 3266efb02f) last updated 2016/10/18 20:14:07 (GMT +100)
  lib/ansible/modules/extras: (detached HEAD 3f77bb6857) last updated 2016/10/18 20:14:08 (GMT +100)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

If hashtype for the password_hash filter is `blowfish` and passlib is available, hashing fails as the hash function for this is named `bcrypt` (and not `blowfish_crypt`).  This PR special cases blowfish so that the correct function is called.

Command output before change:

```
failed: [server1] => {"failed": true, "msg": "AttributeError: unknown password hash: 'blowfish_crypt'"}
```

Command output after change:

```
ok: [server1]
```
