### PR TITLE
[GCE] updates to gce integration test

### DIFF
--- a/test/integration/roles/test_gce/tasks/main.yml
+++ b/test/integration/roles/test_gce/tasks/main.yml
@@ -5,12 +5,14 @@
   gce:
   register: result
   ignore_errors: true
+  tags:
+    - param-check
 
 - name: assert failure when called with no parameters
   assert:
     that:
        - 'result.failed'
-       - 'result.msg == "Missing GCE connection parameters in libcloud secrets file."'
+       - 'result.msg == "Must specify a \"name\" or \"instance_names\""'
 
 # ============================================================
 - name: test missing name
@@ -20,8 +22,10 @@
     project_id: "{{ project_id }}"
   register: result
   ignore_errors: true
+  tags:
+    - param-check
 
-- name: assert failure when called with no parameters
+- name: assert failure when missing name
   assert:
     that:
        - 'result.failed'
@@ -94,6 +98,43 @@
        - 'not result.changed'
        - 'result.name == "{{ instance_name }}"'
        - 'result.state == "absent"'
+
+# ============================================================
+- name: test num_instances state=present (expected changed=true)
+  gce:
+    base_name: "{{ instance_name }}"
+    num_instances: 2
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    state: present
+  register: result
+
+- name: assert state=present (expected changed=true)
+  assert:
+    that:
+       - 'result.changed'
+       - 'result.name == "{{ instance_name }}"'
+       - 'result.state == "present"'
+       - 'result.instance_data|length == 2'
+
+# ============================================================
+- name: test num_instances state=absent (expected changed=true)
+  gce:
+    base_name: "{{ instance_name }}"
+    num_instances: 2
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+    state: absent
+  register: result
+
+- name: assert num_instances state=absent (expected changed=true)
+  assert:
+    that:
+       - 'result.changed'
+       - 'result.state == "absent"'
+       - 'result.instance_names == ["{{ instance_name }}-000", "{{ instance_name }}-001"]'
 
 # ============================================================
 - name: test disks given (expected changed=true)


### PR DESCRIPTION
##### ISSUE TYPE
- Test Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

gce
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0 (int-gce-num-instances 80fe3a4797) last updated 2016/10/19 02:39:18 (GMT +000)
  lib/ansible/modules/core: (pr-4276-number 0806b76817) last updated 2016/10/18 22:47:34 (GMT +000)
  lib/ansible/modules/extras: (gcdns-record-data 54c5e160c0) last updated 2016/09/21 21:27:31 (GMT +000)
  config file = /home/supertom/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY
- Added test for sequenced-name instance generation (num_instances)
- Added param-check tags to tests that only do argument checking

Should be merged AFTER ansible/ansible-modules-core#4276
