### PR TITLE
Change POST body in axapi_call_v3() and axapi_authenticate_v3()

### DIFF
--- a/lib/ansible/module_utils/a10.py
+++ b/lib/ansible/module_utils/a10.py
@@ -30,6 +30,7 @@ import json
 
 from ansible.module_utils.urls import fetch_url
 
+
 AXAPI_PORT_PROTOCOLS = {
     'tcp': 2,
     'udp': 3,
@@ -91,7 +92,7 @@ def axapi_authenticate(module, base_url, username, password):
 def axapi_authenticate_v3(module, base_url, username, password):
     url = base_url
     auth_payload = {"credentials": {"username": username, "password": password}}
-    result = axapi_call_v3(module, url, method='POST', body=auth_payload)
+    result = axapi_call_v3(module, url, method='POST', body=json.dumps(auth_payload))
     if axapi_failure(result):
         return module.fail_json(msg=result['response']['err']['msg'])
     signature = result['authresponse']['signature']
@@ -105,7 +106,7 @@ def axapi_call_v3(module, url, method=None, body=None, signature=None):
         headers = {'content-type': 'application/json', 'Authorization': 'A10 %s' % signature}
     else:
         headers = {'content-type': 'application/json'}
-    rsp, info = fetch_url(module, url, method=method, data=json.dumps(body), headers=headers)
+    rsp, info = fetch_url(module, url, method=method, data=body, headers=headers)
     if not rsp or info['status'] >= 400:
         module.fail_json(msg="failed to connect (status code %s), error was %s" % (info['status'], info.get('msg', 'no error given')))
     try:


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

lib/ansible/module_utils/a10.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0 (devel 2fbf61136d) last updated 2016/10/19 08:54:31 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 0a7ebef14e) last updated 2016/09/27 14:21:16 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD aeecd8b09e) last updated 2016/09/27 14:21:20 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible']
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Makes more sense to push a POST body in axapi_call_v3() that is consistent with the type that it ingest instead of assume it needs be put in JSon format. This change impacts axapi_call_authenticate_v3(), therefore change the body type there as well. 

<!---
Not fixing an existing issue, just refracting. 
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
Not Applicable
```
