### PR TITLE
Fix #17308 test_filters fails because of dict sort

### DIFF
--- a/test/integration/targets/filters/files/foo.txt
+++ b/test/integration/targets/filters/files/foo.txt
@@ -11,7 +11,7 @@ Dumping the same structure to YAML
 
 Dumping the same structure to JSON, but don't pretty print
 
-["this is a list element", {"this": "is a hash element in a list", "where": "endor", "warp": 9}]
+["this is a list element", {"this": "is a hash element in a list", "warp": 9, "where": "endor"}]
 
 Dumping the same structure to YAML, but don't pretty print
 

--- a/test/integration/targets/filters/templates/foo.j2
+++ b/test/integration/targets/filters/templates/foo.j2
@@ -7,7 +7,7 @@ Dumping the same structure to YAML
 
 Dumping the same structure to JSON, but don't pretty print
 
-{{ some_structure | to_json }}
+{{ some_structure | to_json(sort_keys=true) }}
 
 Dumping the same structure to YAML, but don't pretty print
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
  -
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

test/integration/targets/filters
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0 (filters_sort 1258290f09) last updated 2016/10/19 12:31:53 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 6145e24ed4) last updated 2016/10/19 12:31:40 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD accb04b867) last updated 2016/10/19 12:31:41 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```

Fix test_filters fail because of dict sort

```
Fixes #17308
```
