### PR TITLE
Add playbook and packer file for building httptester

### DIFF
--- a/test/utils/docker/httptester/README.rst
+++ b/test/utils/docker/httptester/README.rst
@@ -1,0 +1,50 @@
+httptester
+==========
+
+HTTP Testing endpoint which provides httpbin, nginx, SSL and SNI
+capabilities, for providing a local HTTP endpoint for testing
+
+Building
+--------
+
+Docker
+~~~~~~
+
+Both ways of building docker utilize the ``nginx:alpine`` image, but can
+be customized for ``Fedora``, ``Red Hat``, ``CentOS``, ``Ubuntu``,
+``Debian`` and other variants of ``Alpine``
+
+When utilizing ``packer`` or configuring with ``ansible-playbook``
+the services will not automtically start on launch, and will have to be
+manually started using::
+
+    $ /services.sh
+
+Such as when starting a docker container::
+
+    docker run -ti --rm -p 80:80 -p 443:443 --name httptester ansible/httptester /services.sh
+
+docker build
+^^^^^^^^^^^^
+
+::
+
+    docker build -t ansible/httptester .
+
+packer
+^^^^^^
+
+The packer build will use ``ansible-playbook`` to perform the
+configuration, and will tag the image as ``ansible/httptester``
+
+::
+
+    packer build packer.json
+
+Ansible
+~~~~~~~
+
+::
+
+    ansible-playbook -i hosts -v httptester.yml
+

--- a/test/utils/docker/httptester/httptester.yml
+++ b/test/utils/docker/httptester/httptester.yml
@@ -1,0 +1,127 @@
+---
+- name: Configure httptester
+  hosts: all
+  vars:
+    os_packages:
+      apk:
+        - openssl
+        - py-pip
+      apt:
+        - openssl
+        - python-pip
+      yum:
+        - openssl
+        - python-pip
+      dnf:
+        - openssl
+        - python-pip
+  tasks:
+    - name: Check for nginx
+      stat:
+        path: /usr/sbin/nginx
+      register: nginx
+
+    - name: Install nginx
+      package:
+        name: nginx
+        update_cache: "{{ (ansible_pkg_mgr == 'dnf')|ternary(omit, 'yes') }}"
+      when: not nginx.stat.exists
+
+    - name: Install OS Packages
+      package:
+        name: "{{ item }}"
+        update_cache: "{{ (ansible_pkg_mgr == 'dnf')|ternary(omit, 'yes') }}"
+      with_items: "{{ os_packages[ansible_pkg_mgr] }}"
+
+    - name: Create cert directories
+      file:
+        path: "{{ item }}"
+        state: directory
+      with_items:
+        - /root/ca/certs
+        - /root/ca/private
+        - /root/ca/newcerts
+
+    - name: Set ca serial
+      copy:
+        dest: /root/ca/serial
+        content: 1000
+
+    - name: Create ca index
+      copy:
+        dest: /root/ca/index.txt
+        content: ""
+
+    - name: Check for /etc/pki/tls/openssl.cnf
+      stat:
+        path: /etc/pki/tls/openssl.cnf
+      register: etc_pki_tls_openssl
+
+    - name: Copy openssl.cnf to /etc/ssl
+      copy:
+        src: /etc/pki/tls/openssl.cnf
+        dest: /etc/ssl/openssl.cnf
+        remote_src: true
+      when: etc_pki_tls_openssl.stat.exists
+
+    - name: Update openssl ca path
+      replace:
+        dest: /etc/ssl/openssl.cnf
+        regexp: '(\./demoCA|/etc/pki/CA)'
+        replace: '/root/ca'
+
+    - name: Generate ca key
+      command: >
+        openssl req -new -x509 -days 3650 -nodes -extensions v3_ca -keyout /root/ca/private/cakey.pem -out /root/ca/cacert.pem
+          -subj "/C=US/ST=North Carolina/L=Durham/O=Ansible/CN=ansible.http.tests"
+
+    - name: Generate ansible.http.tests key
+      command: >
+        openssl req -new -nodes -out /root/ca/ansible.http.tests-req.pem -keyout /root/ca/private/ansible.http.tests-key.pem
+          -subj "/C=US/ST=North Carolina/L=Durham/O=Ansible/CN=ansible.http.tests"
+
+    - name: Generate ansible.http.tests cert
+      shell: >
+        yes | openssl ca -config /etc/ssl/openssl.cnf -out /root/ca/ansible.http.tests-cert.pem -infiles /root/ca/ansible.http.tests-req.pem
+
+    - name: Generate sni1.ansible.http.tests key
+      command: >
+        openssl req -new -nodes -out /root/ca/sni1.ansible.http.tests-req.pem -keyout /root/ca/private/sni1.ansible.http.tests-key.pem -config /etc/ssl/openssl.cnf
+          -subj "/C=US/ST=North Carolina/L=Durham/O=Ansible/CN=sni1.ansible.http.tests"
+
+    - name: Generate sni1.ansible.http.tests cert
+      shell: >
+        yes | openssl ca -config /etc/ssl/openssl.cnf -out /root/ca/sni1.ansible.http.tests-cert.pem -infiles /root/ca/sni1.ansible.http.tests-req.pem
+
+    - name: Generate sni2.ansible.http.tests key
+      command: >
+        openssl req -new -nodes -out /root/ca/sni2.ansible.http.tests-req.pem -keyout /root/ca/private/sni2.ansible.http.tests-key.pem -config /etc/ssl/openssl.cnf
+          -subj "/C=US/ST=North Carolina/L=Durham/O=Ansible/CN=sni2.ansible.http.tests"
+
+    - name: Generate sni2.ansible.http.tests cert
+      shell: >
+        yes | openssl ca -config /etc/ssl/openssl.cnf -out /root/ca/sni2.ansible.http.tests-cert.pem -infiles /root/ca/sni2.ansible.http.tests-req.pem
+
+    - name: Copy cacert.pem into nginx doc root for easy retrieval
+      copy:
+        src: /root/ca/cacert.pem
+        dest: /usr/share/nginx/html/cacert.pem
+        remote_src: true
+
+    - name: Install gunicorn and httpbin
+      pip:
+        name: "{{ item }}"
+      with_items:
+        - gunicorn
+        - httpbin
+
+    - name: Copy services.sh script
+      copy:
+        src: services.sh
+        dest: /services.sh
+        mode: 0755
+
+    - name: Copy nginx sites configuration
+      copy:
+        src: nginx.sites.conf
+        dest: /etc/nginx/conf.d/default.conf

--- a/test/utils/docker/httptester/packer.json
+++ b/test/utils/docker/httptester/packer.json
@@ -1,0 +1,43 @@
+{
+    "builders": [
+        {
+            "type": "docker",
+            "image": "nginx:alpine",
+            "commit": true,
+            "run_command": [
+                "-d",
+                "-i",
+                "-t",
+                "{{.Image}}",
+                "/bin/sh"
+            ]
+        }
+    ],
+    "provisioners": [
+        {
+            "type": "shell",
+            "inline": [
+                "set -x",
+                "[ -f /sbin/apk ] && /sbin/apk add -U ansible || true",
+                "[ -f /usr/bin/dnf ] && /usr/bin/dnf -y install ansible python2-dnf || true",
+                "[ ! -f /usr/bin/dnf -a -f /usr/bin/yum ] && /usr/bin/yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-`grep -o [0-9] /etc/redhat-release | head -1`.noarch.rpm || true",
+                "[ ! -f /usr/bin/dnf -a -f /usr/bin/yum ] && /usr/bin/yum -y install ansible || true",
+                "[ -f /usr/bin/apt-get ] && /usr/bin/apt-get update && /usr/bin/apt-get -y install ansible || true"
+            ]
+        },
+        {
+            "type": "ansible-local",
+            "playbook_file": "httptester.yml",
+            "playbook_dir": "{{template_dir}}",
+            "extra_arguments": [
+                "-v"
+            ]
+        }
+    ],
+    "post-processors": [
+        {
+            "type": "docker-tag",
+            "repository": "ansible/httptester"
+        }
+    ]
+}


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### COMPONENT NAME

httptester
##### ANSIBLE VERSION

```
v2
```
##### SUMMARY

Adds an ansible playbook for configuring a machine as an httptester instance, and building the docker image with packer.
