### PR TITLE
Galaxy init no rest

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -192,18 +192,6 @@ class GalaxyCLI(CLI):
                             "however it will reset any main.yml files that may have\n"
                             "been modified there already." % role_path)
 
-        platforms = []
-        if not offline:
-            platforms = self.api.get_list("platforms") or []
-
-        # group the list of platforms from the api based
-        # on their names, with the release field being
-        # appended to a list of versions
-        platform_groups = defaultdict(list)
-        for platform in platforms:
-            platform_groups[platform['name']].append(platform['release'])
-            platform_groups[platform['name']].sort()
-
         inject_data = dict(
             role_name=role_name,
             author='your name',
@@ -212,7 +200,6 @@ class GalaxyCLI(CLI):
             license='license (GPLv2, CC-BY, etc)',
             issue_tracker_url='http://example.com/issue/tracker',
             min_ansible_version='1.2',
-            platforms=platform_groups,
             container_enabled=self.options.container_enabled
         )
 

--- a/lib/ansible/galaxy/data/default/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/default/meta/main.yml.j2
@@ -30,19 +30,19 @@ galaxy_info:
   #github_branch:
 
   #
-  # Below are all platforms currently available. Just uncomment the ones that apply
-  # to your role. If you don't see your platform on this list, let us know,
-  # and we'll get it added!
+  # platforms is a list of platforms, and each platform has a name and a list of versions.
   #
-  #platforms:
-  {%- for platform,versions in platforms.items() %}
-  #- name: {{ platform }}
-  #  versions:
-  #  - all
-    {%- for version in versions %}
-  #  - {{ version }}
-    {%- endfor -%}
-  {%- endfor %}
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
 
   galaxy_tags: []
     # List tags for your role here, one per line. A tag is a keyword that describes


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

lib/ansible/cli/galaxy.py
##### ANSIBLE VERSION

```
ansible 2.3.0 (galaxy_init_no_rest 1ff3c83863) last updated 2016/10/19 15:08:43 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 6145e24ed4) last updated 2016/10/19 12:31:40 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD accb04b867) last updated 2016/10/19 12:31:41 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Remove platforms api request from galaxy 'init'

Instead of populating the platform comment in the default meta/main.yml with a dict of platforms fetch from the galaxy REST api, just use the default now included in the template.

Fixes #18103
