### PR TITLE
group_vars: host_vars: warn for non-yaml files in dirs

### DIFF
--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -557,13 +557,17 @@ class VariableManager:
         else:
             file_name, ext = os.path.splitext(path)
             data = None
-            if not ext:
+            if not ext or ext not in C.YAML_FILENAME_EXTENSIONS:
+                # Warn for non yaml extensions or backup files
+                if ext or file_name.endswith('~'):
+                    display.warning("Loaded vars in %s although the vars file has not proper name or valid extension" % (path,))
+
                 for test_ext in C.YAML_FILENAME_EXTENSIONS:
                     new_path = path + test_ext
                     if loader.path_exists(new_path):
                         data = loader.load_from_file(new_path)
                         break
-            elif ext in C.YAML_FILENAME_EXTENSIONS:
+            else:
                 if loader.path_exists(path):
                     data = loader.load_from_file(path)
 

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -557,13 +557,13 @@ class VariableManager:
         else:
             file_name, ext = os.path.splitext(path)
             data = None
-            if not ext or ext not in C.YAML_FILENAME_EXTENSIONS:
+            if not ext:
                 for test_ext in C.YAML_FILENAME_EXTENSIONS:
                     new_path = path + test_ext
                     if loader.path_exists(new_path):
                         data = loader.load_from_file(new_path)
                         break
-            else:
+            elif ext in C.YAML_FILENAME_EXTENSIONS:
                 if loader.path_exists(path):
                     data = loader.load_from_file(path)
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

host_vars, group_vars
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
devel, 2.2, 2.1
```
##### SUMMARY

fixes #17968 
~~ignore~~ warn for files without a known yaml extension in group_/host_vars if directories like group_vars/group/... are used.
