### PR TITLE
Now that we convert salt inside of do_encryptas needed, keep salt as text_type until then

### DIFF
--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -248,8 +248,7 @@ class LookupModule(LookupBase):
                 _write_password_file(b_path, content)
 
             if params['encrypt']:
-                password = do_encrypt(plaintext_password, params['encrypt'],
-                                      salt=to_bytes(salt, encoding='ascii', errors='strict'))
+                password = do_encrypt(plaintext_password, params['encrypt'], salt=salt)
                 ret.append(password)
             else:
                 ret.append(plaintext_password)

--- a/lib/ansible/utils/encrypt.py
+++ b/lib/ansible/utils/encrypt.py
@@ -67,7 +67,7 @@ except ImportError:
 
 from ansible import constants as C
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_text, to_native
+from ansible.module_utils._text import to_text, to_bytes
 
 __all__ = ['do_encrypt']
 
@@ -84,8 +84,10 @@ def do_encrypt(result, encrypt, salt_size=None, salt=None):
         if salt_size:
             result = crypt.encrypt(result, salt_size=salt_size)
         elif salt:
-            if not crypt._salt_is_bytes:
-                salt = to_native(salt)
+            if crypt._salt_is_bytes:
+                salt = to_bytes(salt, encoding='ascii', errors='strict')
+            else:
+                salt = to_text(salt, encoding='ascii', errors='strict')
             result = crypt.encrypt(result, salt=salt)
         else:
             result = crypt.encrypt(result)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

do_encrypt (called in lookup/password.py implemented in utils/encrypt.py)
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
devel 2.2
```
##### SUMMARY
