### PR TITLE
add integration tests for authorized_key

### DIFF
--- a/test/integration/targets/authorized_key/defaults/main.yml
+++ b/test/integration/targets/authorized_key/defaults/main.yml
@@ -13,3 +13,28 @@ dss_key_command_multiple_options: >
   no-port-forwarding,idle-timeout=5m,command="/bin/true" ssh-dss DATA_COMMAND_MULTIPLE_OPTIONS root@testing
 dss_key_trailing: >
   ssh-dss DATA_TRAILING root@testing foo bar baz
+rsa_key_basic: >
+  ssh-rsa DATA_BASIC root@testing
+multiple_key_base: |
+                    ssh-rsa DATA_BASIC 1@testing
+                    ssh-dss DATA_TRAILING 2@testing foo bar baz
+                    ssh-dss DATA_TRAILING 3@testing foo bar baz
+                    ecdsa-sha2-nistp521 ECDSA_DATA 4@testing
+multiple_key_different_order: |
+                              ssh-dss DATA_TRAILING 2@testing foo bar baz
+                              ssh-dss DATA_TRAILING 3@testing foo bar baz
+                              ssh-rsa DATA_BASIC 1@testing
+                              ecdsa-sha2-nistp521 ECDSA_DATA 4@testing
+multiple_key_different_order_2: |
+                                ssh-dss DATA_TRAILING 2@testing foo bar baz
+                                ssh-rsa WHATEVER 2.5@testing
+                                ssh-dss DATA_TRAILING 3@testing foo bar baz
+                                ssh-rsa DATA_BASIC 1@testing
+                                ecdsa-sha2-nistp521 ECDSA_DATA 4@testing
+multiple_key_exclusive: |
+                    ssh-rsa DATA_BASIC 1@testing
+                    ecdsa-sha2-nistp521 ECDSA_DATA 4@testing
+multiple_keys_comments: |
+  ssh-rsa DATA_BASIC 1@testing
+  # I like adding comments yo-dude-this-is-not-a-key INVALID_DATA 2@testing
+  ecdsa-sha2-nistp521 ECDSA_DATA 4@testing

--- a/test/integration/targets/authorized_key/files/existing_authorized_keys
+++ b/test/integration/targets/authorized_key/files/existing_authorized_keys
@@ -1,0 +1,5 @@
+# I like candy
+ssh-rsa somekeydata somekeyalias
+# It is a very pleasant temperature outside today.
+ssh-rsa otherkeydata otherkeyalias
+

--- a/test/integration/targets/authorized_key/tasks/main.yml
+++ b/test/integration/targets/authorized_key/tasks/main.yml
@@ -20,6 +20,38 @@
 # -------------------------------------------------------------
 # Setup steps
 
+
+- name: copy an existing file in place with comments
+  copy: src=existing_authorized_keys dest="{{output_dir|expanduser}}/authorized_keys"
+
+- name: add multiple keys different order
+  authorized_key:
+    user: root
+    key: "{{ multiple_key_different_order_2 }}"
+    state: present
+    path: "{{output_dir|expanduser}}/authorized_keys"
+  register: result
+
+- name: get the file content
+  shell: cat "{{output_dir|expanduser}}/authorized_keys"
+  register: multiple_keys_existing
+
+- name: assert that the key was added and comments and ordering preserved
+  assert:
+    that:
+    - 'result.changed == True'
+    - '"# I like candy" in multiple_keys_existing.stdout'
+    - '"# I like candy" in multiple_keys_existing.stdout_lines[0]'
+    - '"ssh-rsa DATA_BASIC 1@testing" in multiple_keys_existing.stdout'
+    # The specific index is a little fragile, but I want to verify the line shows up
+    # as the 3rd line in the new entries after the existing entries and comments are preserved
+    - '"ssh-rsa DATA_BASIC 1@testing" in multiple_keys_existing.stdout_lines[7]'
+
+# start afresh
+
+- name: remove file foo.txt
+  file: path="{{output_dir|expanduser}}/authorized_keys" state=absent
+
 - name: touch the authorized_keys file
   file: dest="{{output_dir}}/authorized_keys" state=touch
   register: result
@@ -29,6 +61,100 @@
     that:
     - 'result.changed == True'
     - 'result.state == "file"'
+
+- name: add multiple keys
+  authorized_key:
+    user: root
+    key: "{{ multiple_key_base }}"
+    state: present
+    path: "{{output_dir|expanduser}}/authorized_keys"
+  register: result
+
+- name: assert that the key was added
+  assert:
+    that:
+    - 'result.changed == True'
+    - 'result.key == multiple_key_base'
+    - 'result.key_options == None'
+
+- name: add multiple keys different order
+  authorized_key:
+    user: root
+    key: "{{ multiple_key_different_order }}"
+    state: present
+    path: "{{output_dir|expanduser}}/authorized_keys"
+  register: result
+
+- name: assert that the key was added
+  assert:
+    that:
+    - 'result.changed == True'
+    - 'result.key == multiple_key_different_order'
+    - 'result.key_options == None'
+
+- name: add multiple keys exclusive
+  authorized_key:
+    user: root
+    key: "{{ multiple_key_exclusive }}"
+    state: present
+    path: "{{output_dir|expanduser}}/authorized_keys"
+    exclusive: true
+  register: result
+
+- name: assert that the key was added
+  assert:
+    that:
+    - 'result.changed == True'
+    - 'result.key == multiple_key_exclusive'
+    - 'result.key_options == None'
+
+- name: add multiple keys in different calls
+  authorized_key:
+    user: root
+    key: "ecdsa-sha2-nistp521 ECDSA_DATA 4@testing"
+    state: present
+    path: "{{output_dir|expanduser}}/authorized_keys"
+  register: result
+
+- name: add multiple keys in different calls
+  authorized_key:
+    user: root
+    key: "ssh-rsa DATA_BASIC 1@testing"
+    state: present
+    path: "{{output_dir|expanduser}}/authorized_keys"
+  register: result
+
+- name: get the file content
+  shell: cat "{{output_dir|expanduser}}/authorized_keys"
+  register: multiple_keys_at_a_time
+
+- name: assert that the key was added
+  assert:
+    that:
+    - 'result.changed == false'
+    - 'multiple_keys_at_a_time.stdout  == multiple_key_exclusive.strip()'
+
+- name: add multiple keys comment
+  authorized_key:
+    user: root
+    key: "{{ multiple_keys_comments }}"
+    state: present
+    path: "{{output_dir|expanduser}}/authorized_keys"
+    exclusive: true
+  register: result
+
+- name: get the file content
+  shell: cat "{{output_dir|expanduser}}/authorized_keys"
+  register: multiple_keys_comments
+
+- name: assert that the keys exist and comment only lines were not added
+  assert:
+    that:
+    - 'result.changed == False'
+    - 'multiple_keys_comments.stdout == multiple_key_exclusive.strip()'
+    - 'result.key_options == None'
+
+
 
 # -------------------------------------------------------------
 # basic ssh-dss key


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

test/integration/targets/authorized_key
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0 (authorized_key_test 7237236b17) last updated 2016/10/20 17:24:39 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 653ec28a97) last updated 2016/10/20 17:22:39 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD a14ba9b505) last updated 2016/10/20 17:22:39 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = ['/home/adrian/src/ansible-modules-core', '/home/adrian/src/ansible-modules-extras']

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```

Primarily for behavior related to
https://github.com/ansible/ansible-modules-core/issues/4780

Will fail until
https://github.com/ansible/ansible-modules-core/pull/5339 is
merged.
