### PR TITLE
Restructure .gitignore for readability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ ansible.egg-info/
 AUTHORS.TXT
 build
 
-# RPM stuff... #
+# RPM #
 dist
 MANIFEST
 rpm-build
@@ -29,31 +29,31 @@ venv
 
 ## IDE's ##
 
-# Eclipse/PyDev stuff... #
+# Eclipse/PyDev #
 .project
 .pydevproject
 
-# Emacs backup files... #
+# Emacs backup #
 *~
 .\#*
 
-# IntelliJ IDEA stuff.. #
+# IntelliJ IDEA #
 *.iml
 
-# PyCharm stuff... #
+# PyCharm #
 .idea
 
-# Sublime stuff #
+# Sublime #
 *.sublime-project
 *.sublime-workspace
 
-# Vim swap files #
+# Vim swap #
 *.swo
 *.swp
 
 ## Operating System ##
 
-# Mac OS X stuff...
+# Mac OS X #
 .DS_Store
 
 ## Virtualization ##
@@ -84,7 +84,7 @@ results.xml
 #### Documentation ####
 #######################
 
-## Docsite stuff... ##
+## Docsite ##
 
 docs-api/_build/
 docs-api/rst/

--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,106 @@
-# build products...
+#### Building ####
+
+## General ##
+
+# Build products.. #
 *.py[co]
-build
+ansible.egg-info/
 AUTHORS.TXT
-# Emacs backup files...
-*~
-.\#*
-# RPM stuff...
-MANIFEST
+build
+
+# RPM stuff... #
 dist
+MANIFEST
 rpm-build
-# Eclipse/PyDev stuff...
+
+## Operating systems ##
+
+# Debian #
+deb-build
+debian/
+
+#### Development ####
+#####################
+
+## Python ##
+
+# Virtualenv #
+venv
+
+## IDE's ##
+
+# Eclipse/PyDev stuff... #
 .project
 .pydevproject
-# PyCharm stuff...
-.idea
-#IntelliJ IDEA stuff..
+
+# Emacs backup files... #
+*~
+.\#*
+
+# IntelliJ IDEA stuff.. #
 *.iml
+
+# PyCharm stuff... #
+.idea
+
+# Sublime stuff #
+*.sublime-project
+*.sublime-workspace
+
+# Vim swap files #
+*.swo
+*.swp
+
+## Operating System ##
+
 # Mac OS X stuff...
 .DS_Store
-# manpage build stuff...
+
+## Virtualization ##
+
+# Vagrent #
+.vagrant
+Vagrantfile
+
+## Testing ##
+
+# Code coverage #
+.coverage
+coverage.xml
+/test/units/cover-html
+
+# In progress tests ?? #
+/test/develop
+
+# Shipable #
+/shippable/
+
+# Tox #
+*.out
+*.retry
+.tox
+results.xml
+
+#### Documentation ####
+#######################
+
+## Docsite stuff... ##
+
+docs-api/_build/
+docs-api/rst/
+docsite/*.html
+docsite/htmlout
+docsite/rst/list_of_*.rst
+docsite/rst/*_module.rst
+docsite/rst/modules_by_category.rst
+docsite/rst/playbooks_directives.rst
+docsite/searchindex.js
+docsite/_static/*.gif
+docsite/_static/*.png
+docsite/_static/websupport.js
+
+## Manpage build stuff... ##
+
 docs/man/man1/ansible.1
 docs/man/man1/ansible-doc.1
 docs/man/man1/ansible-galaxy.1
@@ -26,41 +108,10 @@ docs/man/man1/ansible-playbook.1
 docs/man/man1/ansible-pull.1
 docs/man/man1/ansible-vault.1
 docs/man/man3/*
-# Sublime stuff
-*.sublime-project
-*.sublime-workspace
-# docsite stuff...
-docsite/rst/modules_by_category.rst
-docsite/rst/playbooks_directives.rst
-docsite/rst/list_of_*.rst
-docsite/rst/*_module.rst
-docsite/*.html
-docsite/_static/*.gif
-docsite/_static/*.png
-docsite/_static/websupport.js
-docsite/searchindex.js
-docsite/htmlout
-docs-api/rst/
-docs-api/_build/
-# deb building stuff...
-debian/
-deb-build
-# Vim swap files
-*.swp
-*.swo
+
+#### Secrets ####
+
+## Build ##
+
+# Concourse ?? #
 credentials.yml
-# test output
-*.retry
-*.out
-.coverage
-.tox
-results.xml
-coverage.xml
-/test/units/cover-html
-# Development
-/test/develop
-venv
-Vagrantfile
-.vagrant
-ansible.egg-info/
-/shippable/


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.2.0
  config file = /home/andreas/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Restructure the `.gitignore` file to be readable.

It has been rebuilt into a 3 level hirachical structure. With
the area highest, then grouping then final tool.

All entries within a grouping were sorted alphabetically.

During the restructure ignores that were already in a caregory and
could fit that category were kept in that category. Even if I
disagreed with their placements. Ignores that I was uncertain on
were also kept in their only original category, only files that
were clearly misplaced or where their original category were split
was moved.

As an example credentials.yml is not a vim swap file and so it was
moved.

*.retry I believe to be a ansible retry file and misplaced under
testing, but since I couldn't be sure that it wasn't also a tox
ignore file, it's been kept under tox.

Category names have not been changed either, except for
capitalization of the first word.
