### PR TITLE
test-module _ansible_selinux_special_fs arg added

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -105,6 +105,10 @@ def boilerplate_module(modfile, args, interpreter, check, destfile):
     #included_boilerplate = module_data.find(module_common.REPLACER) != -1 or module_data.find("import ansible.module_utils") != -1
 
     complex_args = {}
+
+    # default selinux fs list is pass in as _ansible_selinux_special_fs arg
+    complex_args['_ansible_selinux_special_fs'] = C.DEFAULT_SELINUX_SPECIAL_FS
+
     if args.startswith("@"):
         # Argument is a YAML file (JSON is a subset of YAML)
         complex_args = utils_vars.combine_vars(complex_args, loader.load_from_file(args[1:]))


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

hacking/test-module
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0 (test_module_selinux_special 683debd63f) last updated 2016/10/21 10:24:34 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 653ec28a97) last updated 2016/10/20 17:22:39 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD a14ba9b505) last updated 2016/10/20 17:22:39 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```

modules need to have _ansible_selinux_special_fs passed in
as an arg, so add the default to the args.

otherwise test-module will fail on modules that use atomic_move for example

```
raceback (most recent call last):
  File "/home/adrian/debug_dir/ansible_module_authorized_key.py", line 555, in <module>
    main()
  File "/home/adrian/debug_dir/ansible_module_authorized_key.py", line 551, in main
    results = enforce_state(module, module.params)
  File "/home/adrian/debug_dir/ansible_module_authorized_key.py", line 527, in enforce_state
    writekeys(module, keyfile(module, user, do_write, path, manage_dir), existing_keys)
  File "/home/adrian/debug_dir/ansible_module_authorized_key.py", line 417, in writekeys
    module.atomic_move(tmp_path, filename)
  File "/home/adrian/debug_dir/ansible/module_utils/basic.py", line 2010, in atomic_move
    self.set_context_if_different(dest, context, False)
  File "/home/adrian/debug_dir/ansible/module_utils/basic.py", line 890, in set_context_if_different
    (is_special_se, sp_context) = self.is_special_selinux_path(path)
  File "/home/adrian/debug_dir/ansible/module_utils/basic.py", line 868, in is_special_selinux_path
    for fs in self._selinux_special_fs:
AttributeError: 'AnsibleModule' object has no attribute '_selinux_special_fs'
```
