### PR TITLE
Dict filtering

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -387,6 +387,29 @@ def extract(item, container, morekeys=None):
 
     return value
 
+def dict_with_attr(d, attr, val=None):
+    if isinstance(d, dict):
+        res = {}
+        for (k, v) in six.iteritems(d):
+            if attr in v and (val is None or v[attr] == val):
+                res[k] = v
+        return res
+    else:
+        raise errors.AnsibleFilterError('|dict_with_attr expects a dictionnary, got ' + repr(d))
+
+
+def dictlist_with_attr(l, attr, val=None):
+    if isinstance(l, list):
+        res = []
+        for d in l:
+            if not isinstance(d, dict):
+                raise errors.AnsibleFilterError('|dictlist_with_attr list element expects a dictionnary, got ' + repr(d))
+            if attr in d and (val is None or d[attr] == val):
+                res += [d, ]
+        return res
+    else:
+        raise errors.AnsibleFilterError('|dictlist_with_attr expects a list, got ' + repr(l))
+
 def failed(*a, **kw):
     ''' Test if task result yields failed '''
     item = a[0]
@@ -501,6 +524,12 @@ class FilterModule(object):
 
             # merge dicts
             'combine': combine,
+
+            # dict filtering
+            'dict_with_attr': dict_with_attr,
+
+            # dict list filtering
+            'dictlist_with_attr': dictlist_with_attr,
 
             # comment-style decoration
             'comment': comment,

--- a/test/integration/targets/filters/templates/foo.j2
+++ b/test/integration/targets/filters/templates/foo.j2
@@ -46,6 +46,14 @@ files to exist and are passthrus to the python os.path functions
 /etc/motd with basename = {{ '/etc/motd' | basename }}
 /etc/motd with dirname  = {{ '/etc/motd' | dirname }}
 
+We can also filter list of dicts
+
+User object for steve name = {{ users | dictlist_with_attr('name', 'steve') | to_nice_yaml }}
+
+And a dict of dicts
+
+Object for age 20 = {{ some_dict_structure | dict_with_attr('age', 20) | to_nice_yaml }}
+
 TODO: realpath follows symlinks.  There isn't a test for this just now.
 
 TODO: add tests for set theory operations like union

--- a/test/integration/targets/filters/vars/main.yml
+++ b/test/integration/targets/filters/vars/main.yml
@@ -16,3 +16,11 @@ users:
       - host: host_c
         password: default
       - host: host_d
+
+some_dict_structure:
+  foo:
+    name: jack
+    age: 10
+  bar:
+    name: averell
+    age: 20


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

plugin/filters

_new filters_
- dict_with_attr: filter dict subelements depending on a key presence or value
- dictlist_with_attr: filter list elements depending on dict key presence or value
##### ANSIBLE VERSION

```
2804e64ed5b883959eed5aab1b6d9a2017e13493 (2.2.0+)
```
##### SUMMARY

This adds two filters permitting to loop over dict or list but filter elements before targeting when condition, this permit to remove many tests on dict elements in the when condition and loop on required elements only.

Example:

```
apache_modules:
  - {name: cgid,            state: absent}
  - { name: mpm_event,      state: "{{ 'present' if app_apache_mpm == 'event' else 'absent' }}" }
  - { name: mpm_worker,     state: "{{ 'present' if app_apache_mpm == 'worker' else 'absent' }}" }
  - { name: mpm_prefork,    state: "{{ 'present' if app_apache_mpm == 'prefork' else 'absent' }}" }
  - {name: access_compat,   state: present}
  - {name: alias,           state: present}
  - {name: auth_basic,      state: present}
  - {name: authn_core,      state: present}
  - {name: authn_file,      state: present}
```

I have a list of all my apache modules here.
If i want to do a specific action depending on one element, without extracting the value to another variable on mpm_worker presence i should do:

```
- name: "Apache2 | mpm_worker Configuration"
  template: src="mpm_worker.conf" dest="{{ apache.config_path }}/mods-available/mpm_worker.conf" owner=root group={{ root_group }}
  when: "item.name == 'mpm_worker' and item.state == 'present'"
  with_items: "{{ apache.modules }}"
  notify: reload apache
```

With this filtering mode i can do:

```
- name: "Apache2 | mpm_worker Configuration"
  template: src="mpm_worker.conf" dest="{{ apache.config_path }}/mods-available/mpm_worker.conf" owner=root group={{ root_group }}
  when: "item.state == 'present'"
  with_items: "{{ apache.modules | dictlist_with_attr('name', 'mpm_worker') }}"
  notify: reload apache
```

This has two effects:
- We don't call the template module on each apache module in the list, this reduce the process time
- We don't filter the processing in the when condition, then output doesn't show massively skipped actions

module output before this filter:

```
TASK [apache : Apache2 | mpm_worker Configuration] *****************************
skipping: [srv114] => (item={u'state': u'absent', u'name': u'cgid'}) 
skipping: [srv116] => (item={u'state': u'absent', u'name': u'cgid'}) 
skipping: [srv114] => (item={u'state': u'absent', u'name': u'mpm_event'}) 
skipping: [srv116] => (item={u'state': u'absent', u'name': u'mpm_event'}) 
ok: [srv114] => (item={u'state': u'present', u'name': u'mpm_worker'})
ok: [srv116] => (item={u'state': u'present', u'name': u'mpm_worker'})
skipping: [srv114] => (item={u'state': u'absent', u'name': u'mpm_prefork'}) 
skipping: [srv116] => (item={u'state': u'absent', u'name': u'mpm_prefork'}) 
skipping: [srv114] => (item={u'state': u'present', u'name': u'access_compat'}) 
skipping: [srv116] => (item={u'state': u'present', u'name': u'access_compat'}) 
skipping: [srv114] => (item={u'state': u'present', u'name': u'alias'}) 
skipping: [srv116] => (item={u'state': u'present', u'name': u'alias'}) 
skipping: [srv114] => (item={u'state': u'present', u'name': u'auth_basic'}) 
skipping: [srv116] => (item={u'state': u'present', u'name': u'auth_basic'}) 
skipping: [srv114] => (item={u'state': u'present', u'name': u'authn_core'}) 
skipping: [srv116] => (item={u'state': u'present', u'name': u'authn_core'}) 
skipping: [srv114] => (item={u'state': u'present', u'name': u'authn_file'}) 
skipping: [srv116] => (item={u'state': u'present', u'name': u'authn_file'}) 
skipping: [srv114] => (item={u'state': u'present', u'name': u'authz_core'}) 
skipping: [srv116] => (item={u'state': u'present', u'name': u'authz_core'}) 
skipping: [srv114] => (item={u'state': u'present', u'name': u'authz_groupfile'}) 
skipping: [srv116] => (item={u'state': u'present', u'name': u'authz_groupfile'}) 
skipping: [srv114] => (item={u'state': u'present', u'name': u'authz_host'}) 
skipping: [srv116] => (item={u'state': u'present', u'name': u'authz_host'}) 
skipping: [srv114] => (item={u'state': u'present', u'name': u'authz_user'}) 
skipping: [srv116] => (item={u'state': u'present', u'name': u'authz_user'}) 
skipping: [srv114] => (item={u'state': u'present', u'name': u'autoindex'}) 
skipping: [srv114] => (item={u'state': u'present', u'name': u'cache'}) 
```

Module output after this filter

```
TASK [apache : Apache2 | mpm_worker Configuration] *****************************
ok: [srv114] => (item={u'state': u'present', u'name': u'mpm_worker'})
ok: [srv116] => (item={u'state': u'present', u'name': u'mpm_worker'})
```
