### PR TITLE
Urls client cert auth

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -401,15 +401,14 @@ class HTTPSClientAuthHandler(urllib_request.HTTPSHandler):
         urllib_request.HTTPSHandler.__init__(self, *args, **kwargs)
         self.client_cert = client_cert
         self.client_cert_key = client_cert_key
-        self.ctx = kwargs.get('context')
 
     def https_open(self, req):
-        return self.do_open(self.getConnection, req)
-
-    def getConnection(self, *args, **kwargs):
-        return httplib.HTTPSConnection(*args, key_file=self.client_cert_key,
-                                       cert_file=self.client_cert,
-                                       context=self.ctx, **kwargs)
+        kwargs = {
+            'cert_file': self.client_cert,
+            'key_file': self.client_cert_key,
+            'context': self._context,
+        }
+        return self.do_open(httplib.HTTPSConnection, req, **kwargs)
 
 
 def generic_urlparse(parts):

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -403,8 +403,8 @@ class HTTPSClientAuthHandler(urllib_request.HTTPSHandler):
     in place of HTTPSHandler
     '''
 
-    def __init__(self, client_cert, client_key, *args, **kwargs):
-        urllib_request.HTTPSHandler.__init__(self, *args, **kwargs)
+    def __init__(self, client_cert=None, client_key=None, **kwargs):
+        urllib_request.HTTPSHandler.__init__(self, **kwargs)
         self.client_cert = client_cert
         self.client_key = client_key
 
@@ -885,16 +885,12 @@ def open_url(url, data=None, headers=None, method=None, use_proxy=True,
         context.options |= ssl.OP_NO_SSLv3
         context.verify_mode = ssl.CERT_NONE
         context.check_hostname = False
-        if client_cert:
-            handlers.append(HTTPSClientAuthHandler(client_cert,
-                                                   client_key,
-                                                   context=context))
-        else:
-            handlers.append(urllib_request.HTTPSHandler(context=context))
-    else:
-        if client_cert:
-            handlers.append(HTTPSClientAuthHandler(client_cert,
-                                                   client_key))
+        handlers.append(HTTPSClientAuthHandler(client_cert=client_cert,
+                                               client_key=client_key,
+                                               context=context))
+    elif client_cert:
+        handlers.append(HTTPSClientAuthHandler(client_cert=client_cert,
+                                               client_key=client_key))
 
     # pre-2.6 versions of python cannot use the custom https
     # handler, since the socket class is lacking create_connection.

--- a/lib/ansible/modules/network/basics/get_url.py
+++ b/lib/ansible/modules/network/basics/get_url.py
@@ -166,9 +166,9 @@ options:
     description:
       - PEM formatted certificate chain file to be used for SSL client
         authentication. This file can also include the key as well, and if
-        the key is included, I(client_cert_key) is not required
+        the key is included, I(client_key) is not required
     version_added: 2.3
-  client_cert_key:
+  client_key:
     required: false
     default: null
     description:

--- a/lib/ansible/modules/network/basics/get_url.py
+++ b/lib/ansible/modules/network/basics/get_url.py
@@ -160,6 +160,22 @@ options:
     required: false
     choices: [ "yes", "no" ]
     default: "no"
+  client_cert:
+    required: false
+    default: null
+    description:
+      - PEM formatted certificate chain file to be used for SSL client
+        authentication. This file can also include the key as well, and if
+        the key is included, I(client_cert_key) is not required
+    version_added: 2.3
+  client_cert_key:
+    required: false
+    default: null
+    description:
+      - PEM formatted file that contains your private key to be used for SSL
+        client authentication. If I(client_cert) contains both the certificate
+        and key, this option is not required.
+    version_added: 2.3
   others:
     description:
       - all arguments accepted by the M(file) module also work here

--- a/lib/ansible/modules/network/basics/get_url.py
+++ b/lib/ansible/modules/network/basics/get_url.py
@@ -167,7 +167,7 @@ options:
       - PEM formatted certificate chain file to be used for SSL client
         authentication. This file can also include the key as well, and if
         the key is included, I(client_key) is not required
-    version_added: 2.3
+    version_added: 2.4
   client_key:
     required: false
     default: null
@@ -175,7 +175,7 @@ options:
       - PEM formatted file that contains your private key to be used for SSL
         client authentication. If I(client_cert) contains both the certificate
         and key, this option is not required.
-    version_added: 2.3
+    version_added: 2.4
   others:
     description:
       - all arguments accepted by the M(file) module also work here

--- a/lib/ansible/modules/network/basics/uri.py
+++ b/lib/ansible/modules/network/basics/uri.py
@@ -161,9 +161,9 @@ options:
     description:
       - PEM formatted certificate chain file to be used for SSL client
         authentication. This file can also include the key as well, and if
-        the key is included, I(client_cert_key) is not required
+        the key is included, I(client_key) is not required
     version_added: 2.3
-  client_cert_key:
+  client_key:
     required: false
     default: null
     description:

--- a/lib/ansible/modules/network/basics/uri.py
+++ b/lib/ansible/modules/network/basics/uri.py
@@ -155,6 +155,22 @@ options:
     default: 'yes'
     choices: ['yes', 'no']
     version_added: '1.9.2'
+  client_cert:
+    required: false
+    default: null
+    description:
+      - PEM formatted certificate chain file to be used for SSL client
+        authentication. This file can also include the key as well, and if
+        the key is included, I(client_cert_key) is not required
+    version_added: 2.3
+  client_cert_key:
+    required: false
+    default: null
+    description:
+      - PEM formatted file that contains your private key to be used for SSL
+        client authentication. If I(client_cert) contains both the certificate
+        and key, this option is not required.
+    version_added: 2.3
 notes:
   - The dependency on httplib2 was removed in Ansible 2.1
 author: "Romeo Theriault (@romeotheriault)"

--- a/lib/ansible/modules/network/basics/uri.py
+++ b/lib/ansible/modules/network/basics/uri.py
@@ -162,7 +162,7 @@ options:
       - PEM formatted certificate chain file to be used for SSL client
         authentication. This file can also include the key as well, and if
         the key is included, I(client_key) is not required
-    version_added: 2.3
+    version_added: 2.4
   client_key:
     required: false
     default: null
@@ -170,7 +170,7 @@ options:
       - PEM formatted file that contains your private key to be used for SSL
         client authentication. If I(client_cert) contains both the certificate
         and key, this option is not required.
-    version_added: 2.3
+    version_added: 2.4
 notes:
   - The dependency on httplib2 was removed in Ansible 2.1
 author: "Romeo Theriault (@romeotheriault)"

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -211,3 +211,17 @@
   get_url: 
     url: https://{{ httpbin_host }}
     dest: "{{ output_dir }}"
+
+
+- name: Test client cert auth, with certs
+  get_url:
+    url: "https://ansible.http.tests/ssl_client_verify"
+    client_cert: "{{ output_dir }}/client.pem"
+    client_key: "{{ output_dir }}/client.key"
+    dest: "{{ output_dir }}/ssl_client_verify"
+  when: has_httptester
+
+- name: Assert that the ssl_client_verify file contains the correct content
+  assert:
+    that:
+      - 'lookup("file", "{{ output_dir }}/ssl_client_verify") == "ansible.http.tests:SUCCESS"'

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -225,3 +225,4 @@
   assert:
     that:
       - 'lookup("file", "{{ output_dir }}/ssl_client_verify") == "ansible.http.tests:SUCCESS"'
+  when: has_httptester

--- a/test/integration/targets/prepare_http_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_http_tests/tasks/main.yml
@@ -18,6 +18,14 @@
         dest: "/etc/pki/ca-trust/source/anchors/ansible.pem"
       when: ansible_os_family == 'RedHat'
 
+    - name: Get client cert/key
+      get_url:
+        url: "http://ansible.http.tests/{{ item }}"
+        dest: "{{ output_dir }}/{{ item }}"
+      with_items:
+        - client.pem
+        - client.key
+
     - name: Suse - Retrieve test cacert
       get_url:
         url: "http://ansible.http.tests/cacert.pem"

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -312,3 +312,14 @@
   register: result
   failed_when: result.content != "ansible.http.tests:SUCCESS"
   when: has_httptester
+
+- name: Test client cert auth, with no validation
+  uri:
+    url: "https://fail.ansible.http.tests/ssl_client_verify"
+    client_cert: "{{ output_dir }}/client.pem"
+    client_key: "{{ output_dir }}/client.key"
+    return_content: true
+    validate_certs: no
+  register: result
+  failed_when: result.content != "ansible.http.tests:SUCCESS"
+  when: has_httptester

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -306,8 +306,8 @@
 - name: Test client cert auth, with certs
   uri:
     url: "https://ansible.http.tests/ssl_client_verify"
-    client_cert: /Users/matt/tmp/client.key.crt
-    client_cert_key: /Users/matt/tmp/client.key
+    client_cert: "{{ output_dir }}/client.pem"
+    client_key: "{{ output_dir }}/client.key"
     return_content: true
   register: result
   failed_when: result.content != "ansible.http.tests:SUCCESS"

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -323,3 +323,14 @@
   register: result
   failed_when: result.content != "ansible.http.tests:SUCCESS"
   when: has_httptester
+
+- name: Test client cert auth, with validation and ssl mismatch
+  uri:
+    url: "https://fail.ansible.http.tests/ssl_client_verify"
+    client_cert: "{{ output_dir }}/client.pem"
+    client_key: "{{ output_dir }}/client.key"
+    return_content: true
+    validate_certs: yes
+  register: result
+  failed_when: not result|failed
+  when: has_httptester

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -293,3 +293,22 @@
     return_content: true
   register: result
   failed_when: result.json.headers['Content-Type'] != 'text/json'
+
+- name: Test client cert auth, no certs
+  uri:
+    url: "https://ansible.http.tests/ssl_client_verify"
+    status_code: 200
+    return_content: true
+  register: result
+  failed_when: result.content != "ansible.http.tests:NONE"
+  when: has_httptester
+
+- name: Test client cert auth, with certs
+  uri:
+    url: "https://ansible.http.tests/ssl_client_verify"
+    client_cert: /Users/matt/tmp/client.key.crt
+    client_cert_key: /Users/matt/tmp/client.key
+    return_content: true
+  register: result
+  failed_when: result.content != "ansible.http.tests:SUCCESS"
+  when: has_httptester


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### COMPONENT NAME

urls/get_url/uri

##### ANSIBLE VERSION

```
v2.3
```
##### SUMMARY

Adds support for client cert auth in urls, via new `client_cert` and `client_key`.

Only `client_cert` needs to be provided if it contains both the key and cert.

Depends on https://github.com/ansible/ansible/pull/19912 for httptester functionality.
