### PR TITLE
Implement docker support for synchronize module.

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -354,7 +354,7 @@ class ActionModule(ActionBase):
         # If launching synchronize against docker container
         # use rsync_opts to support container to override rsh options
         if self._remote_transport in [ 'docker' ]:
-            self._task.args['rsync_opts'] = "--rsh='%s exec -i'" % self._docker_cmd
+            self._task.args['rsync_opts'] = "--rsh='%s exec -u %s -i'" % (self._docker_cmd, user)
 
         # run the module and store the result
         result.update(self._execute_module('synchronize', task_vars=task_vars))


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### COMPONENT NAME

action plugin for module synchronize: support for docker connection
##### ANSIBLE VERSION

```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [ ]
```
##### SUMMARY

This pull request implements synchronize support on container type connection

You can take a look at https://github.com/ansible/ansible-container/issues/226 or https://github.com/ansible/ansible/issues/16306 for more details.

Before:

```
fatal: [robert]: FAILED! => {"changed": false, "failed": true, "msg": "synchronize uses rsync to function. rsync needs to connect to the remote host via ssh or a direct filesystem copy. This remote host is being accessed via docker instead so it cannot work."}
```

After:

```
ansible -i hosts -m synchronize -a "src=/tmp/test dest=/tmp/test" robert
robert | SUCCESS => {
    "changed": false, 
    "cmd": "/usr/bin/rsync --delay-updates -F --compress --archive --rsh 'ssh  -S none -o StrictHostKeyChecking=no' --rsh='docker exec -i' --out-format='<<CHANGED>>%i %n%L' \"/tmp/test\" \"robert:/tmp/test\"", 
    "msg": "", 
    "rc": 0, 
    "stdout_lines": []
}
```

Note : you need rsync installation on your docker container.
