### PR TITLE
contrib/inventory/digital_ocean: Correctly read use_private_network as boolean

### DIFF
--- a/contrib/inventory/digital_ocean.py
+++ b/contrib/inventory/digital_ocean.py
@@ -260,7 +260,7 @@ or environment variables (DO_API_TOKEN)\n''')
 
         # Private IP Address
         if config.has_option('digital_ocean', 'use_private_network'):
-            self.use_private_network = config.get('digital_ocean', 'use_private_network')
+            self.use_private_network = config.getboolean('digital_ocean', 'use_private_network')
 
         # Group variables
         if config.has_option('digital_ocean', 'group_variables'):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

contrib/inventory/digital_ocean
##### ANSIBLE VERSION

```
ansible 2.1.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

The DigitalOcean dynamic inventory script incorrectly reads the `use_private_network` setting from its associated .ini file as a string if it is defined, causing the later check in `build_inventory` to always fail regardless of value and use the private IP in the generated hosts.

This issue is not present if the .ini file does not define the `use_private_network` setting.

Below are a few examples of script execution output, in this case the private IP of the host is `10.135.46.147` and the public IP is `138.68.104.49`. The .ini file used is the reference one (`contrib/inventory/digital_ocean.ini`).

Using the reference .ini file which has `use_private_network = False`, we get the private IP instead of the expected public IP:

```
{"all": {"hosts": ["10.135.46.147"], "vars": {}}, ... }
```

With `use_private_network` commented out in the .ini file the default in the script is `False`, so public IP is used:

```
{"all": {"hosts": ["138.68.104.49"], "vars": {}}, ... }
```

With this change applied to the script and the (restored) reference .ini file, the public IP is now correctly reported:

```
{"all": {"hosts": ["138.68.104.49"], "vars": {}}, ... }
```

Similarly as a sanity check, setting `use_private_network = True` has the desired effect:

```
{"all": {"hosts": ["10.135.46.147"], "vars": {}}, ... }
```
