### PR TITLE
Add support for getting network facts on GNU Hurd

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2969,6 +2969,58 @@ class SunOSNetwork(GenericBsdIfconfigNetwork):
             macaddress += (octet + ':')
         current_if['macaddress'] = macaddress[0:-1]
 
+class HurdPfinetNetwork(Network):
+    """
+    This is a GNU Hurd specific subclass of Network. It use fsysopts to
+    get the ip address and support only pfinet.
+    """
+    platform = 'GNU'
+    _socket_dir = '/servers/socket/'
+
+    def populate(self):
+        fsysopts_path = self.module.get_bin_path('fsysopts')
+        if fsysopts_path is None:
+            return self.facts
+        socket_path = None
+        for l in ('inet', 'inet6'):
+            link = os.path.join(self._socket_dir, l)
+            if os.path.exists(link):
+                socket_path = link
+                break
+
+        if socket_path:
+            rc, out, err = self.module.run_command([fsysopts_path, '-L', socket_path])
+            self.facts['interfaces'] = []
+            for i in out.split():
+                if '=' in i and i.startswith('--'):
+                    k,v = i.split('=',1)
+                    # remove '--'
+                    k = k[2:]
+                    if k == 'interface':
+                        # remove /dev/ from /dev/eth0
+                        v = v[5:]
+                        self.facts['interfaces'].append(v)
+                        self.facts[v] = {
+                            'active': True,
+                            'device': v,
+                            'ipv4': {},
+                            'ipv6': [],
+                        }
+                        current_if = v
+                    elif k == 'address':
+                        self.facts[current_if]['ipv4']['address'] = v
+                    elif k == 'netmask':
+                        self.facts[current_if]['ipv4']['netmask'] = v
+                    elif k == 'address6':
+                        address,prefix = v.split('/')
+                        self.facts[current_if]['ipv6'].append({
+                            'address': address,
+                            'prefix': prefix,
+                        })
+
+        return self.facts
+
+
 class Virtual(Facts):
     """
     This is a generic Virtual subclass of Facts.  This should be further


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

setup
##### SUMMARY

Add support for getting network facts on GNU Hurd

Since ifconfig/ip are not present on the system, and there is no /proc
to be parsed, the only way to get information is by looking at the
argument of the pfinet translator, the process in charge of network.

In turn, this is done with fsysopts on the appropriate path, who return
something like this:

```
# fsysopts -L /servers/socket/inet
/hurd/pfinet --interface=/dev/eth0 --address=192.168.122.130
--netmask=255.255.255.0 --gateway=192.168.122.1 --address6=fe80::5254:12:ced/10
--address6=fe80::5054:ff:fe12:ced/10 --gateway6=::
```

So to get the IP addresses, one has to parse that string and fill the appropriate
structure.

More information on the system and on limitation can be found on
- https://www.gnu.org/software/hurd/hurd/translator/pfinet.html
- https://www.gnu.org/software/hurd/hurd/translator/pfinet/implementation.html
- https://www.debian.org/ports/hurd/hurd-install
