### PR TITLE
Add support for getting hardware facts on GNU Hurd

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2163,6 +2163,20 @@ class Darwin(Hardware):
         if rc == 0:
             self.facts['memfree_mb'] = int(out.splitlines()[-1].split()[1]) / 1024 / 1024
 
+class HurdHardware(LinuxHardware):
+    """
+    GNU Hurd specific subclass of Hardware. Define memory and mount facts
+    based on procfs compatibility translator mimicking the interface of 
+    the Linux kernel.
+    """
+
+    platform = 'GNU'
+
+    def populate(self):
+        self.get_uptime_facts()
+        self.get_memory_facts()
+        self.get_mount_facts()
+        return self.facts
 
 class Network(Facts):
     """

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1281,7 +1281,11 @@ class LinuxHardware(Hardware):
         return bind_mounts
 
     def _mtab_entries(self):
-        mtab = get_file_content('/etc/mtab', '')
+        mtab_file = '/etc/mtab'
+        if not os.path.exists(mtab_file):
+            mtab_file = '/proc/mounts'
+
+        mtab = get_file_content(mtab_file, '')
         mtab_entries = []
         for line in mtab.splitlines():
             fields = line.split()


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

facts
##### SUMMARY

This add support for detecting more facts on GNU Hurd. Since the system has a limited compatible procfs since 2008 (done during GSOC), we can just reuse the code from LinuxHardwqare to detect memory, uptime and mount. There is however no /proc/cpuinfo for the moment, so we do not have anything else.
