### PR TITLE
Fixes 17922 - variables not displaying correctly in handler name

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -699,8 +699,14 @@ class StrategyBase:
             #        but this may take some work in the iterator and gets tricky when
             #        we consider the ability of meta tasks to flush handlers
             for handler in handler_block.block:
+                handler_vars = self._variable_manager.get_vars(loader=self._loader, play=iterator._play, task=handler)
+                templar = Templar(loader=self._loader, variables=handler_vars)
+                try:
+                    handler_name = templar.template(handler.name)
+                except (UndefinedError, AnsibleUndefinedVariable):
+                    continue
                 if handler in self._notified_handlers and len(self._notified_handlers[handler]):
-                    result = self._do_handler_run(handler, handler.get_name(), iterator=iterator, play_context=play_context)
+                    result = self._do_handler_run(handler, handler_name, iterator=iterator, play_context=play_context)
                     if not result:
                         break
         return result


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

strategy plugin
##### ANSIBLE VERSION

```
ansible 2.3.0 (fixes-17922 00a67c5b55) last updated 2016/10/23 22:30:20 (GMT +000)
  lib/ansible/modules/core: (detached HEAD ce44f0a0ae) last updated 2016/10/23 20:06:44 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 89a8c18c6a) last updated 2016/10/23 20:06:44 (GMT +000)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes [17922](https://github.com/ansible/ansible/issues/17922) (handler names don't display variables names properly). 

Handler name shows the raw variable:

```
RUNNING HANDLER [restart {{ appname }}] ****************************************
changed: [localhost]
```

Variable now shows correctly:

```
RUNNING HANDLER [restart foo] **************************************************
changed: [localhost]
```
