### PR TITLE
Fix the uri testserver to run on python3

### DIFF
--- a/test/integration/targets/uri/files/testserver.py
+++ b/test/integration/targets/uri/files/testserver.py
@@ -1,7 +1,17 @@
-import mimetypes
+import sys
 
 if __name__ == '__main__':
-    mimetypes.init()
-    mimetypes.add_type('application/json', '.json')
-    import SimpleHTTPServer
-    SimpleHTTPServer.test()
+    if sys.version_info[0] >= 3:
+        import http.server
+        import socketserver
+        PORT = int(sys.argv[1])
+        Handler = http.server.SimpleHTTPRequestHandler
+        httpd = socketserver.TCPServer(("", PORT), Handler)
+        httpd.serve_forever()
+    else:
+        import mimetypes
+        mimetypes.init()
+        mimetypes.add_type('application/json', '.json')
+        import SimpleHTTPServer
+        SimpleHTTPServer.test()
+


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

uri tests
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
devel 2.2
```
##### SUMMARY

The API of the builting simple http server has changed between python2 and python3.  Have to conditionalize the code that serves the json files to do different things on py2 and py3.
