### PR TITLE
Docs fragment for common a10 options

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/a10.py
+++ b/lib/ansible/utils/module_docs_fragments/a10.py
@@ -1,0 +1,62 @@
+#
+# (c) 2016, John Barker <jobarker@redhat.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class ModuleDocFragment(object):
+
+    # Standard files documentation fragment
+    DOCUMENTATION = """
+notes:
+    - "Requires A10 Networks aXAPI 2.1"
+options:
+  host:
+    description:
+      - Hostname or IP of the A10 Networks device.
+    required: true
+    default: null
+  username:
+    description:
+      - An account with administrator privileges.
+    required: true
+    aliases: ['user', 'admin']
+    default: null
+  password:
+    description:
+      - Password for the C(username) account.
+    required: true
+    aliases: ['pass', 'pwd']
+    default: null
+  write_config:
+    description:
+      - If C(yes), any changes will cause a write of the running configuration
+        to non-volatile memory. This will save I(all) configuration changes,
+        including those that may have been made manually or through other modules,
+        so care should be taken when specifying C(yes).
+    required: false
+    version_added: 2.2
+    default: "no"
+    choices: ["yes", "no"]
+  validate_certs:
+    description:
+      - If C(no), SSL certificates will not be validated. This should only be used
+        on personally controlled devices using self-signed certificates.
+    required: false
+    version_added: 2.2
+    default: 'yes'
+    choices: ['yes', 'no']
+"""


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

a10_*
##### ANSIBLE VERSION

```
ansible 2.3.0 (a10_docs_fragment b1bd63c2ca) last updated 2016/10/24 12:53:57 (GMT +100)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras: (devel 6b0a204e74) last updated 2016/10/24 11:43:03 (GMT +100)
```
##### SUMMARY

Noticed that we were duplicating (inconsistently) documentation options for the `a10` network modules

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/18163)

<!-- Reviewable:end -->
