### PR TITLE
Build debs with pbuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ docsite/htmlout
 docs-api/rst/
 docs-api/_build/
 # deb building stuff...
-debian/
+/debian/
 deb-build
 # Vim swap files
 *.swp

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,12 @@ DEB_PPA ?= ppa
 # Choose the desired Ubuntu release: lucid precise saucy trusty
 DEB_DIST ?= unstable
 
+# pbuilder parameters
+PBUILDER_ARCH ?= amd64
+PBUILDER_CACHE_DIR = /var/cache/pbuilder
+PBUILDER_BIN ?= pbuilder
+PBUILDER_OPTS ?= --debootstrapopts --variant=buildd --architecture $(PBUILDER_ARCH) --debbuildopts -b
+
 # RPM build parameters
 RPMSPECDIR= packaging/rpm
 RPMSPEC = $(RPMSPECDIR)/ansible.spec
@@ -230,9 +236,12 @@ debian: sdist
         sed -ie "s|%VERSION%|$(VERSION)|g;s|%RELEASE%|$(DEB_RELEASE)|;s|%DIST%|$${DIST}|g;s|%DATE%|$(DEB_DATE)|g" deb-build/$${DIST}/$(NAME)-$(VERSION)/debian/changelog ; \
 	done
 
-deb: debian
+deb: deb-src
 	@for DIST in $(DEB_DIST) ; do \
-	    (cd deb-build/$${DIST}/$(NAME)-$(VERSION)/ && $(DEBUILD) -b) ; \
+	    PBUILDER_OPTS="$(PBUILDER_OPTS) --distribution $${DIST} --basetgz $(PBUILDER_CACHE_DIR)/$${DIST}-$(PBUILDER_ARCH)-base.tgz --buildresult $(CURDIR)/deb-build/$${DIST}" ; \
+	    $(PBUILDER_BIN) create $${PBUILDER_OPTS} --othermirror "deb http://archive.ubuntu.com/ubuntu $${DIST} universe" ; \
+	    $(PBUILDER_BIN) update $${PBUILDER_OPTS} ; \
+	    $(PBUILDER_BIN) build $${PBUILDER_OPTS} deb-build/$${DIST}/$(NAME)_$(VERSION)-$(DEB_RELEASE)~$${DIST}.dsc ; \
 	done
 	@echo "#############################################"
 	@echo "Ansible DEB artifacts:"

--- a/Makefile
+++ b/Makefile
@@ -250,6 +250,19 @@ deb: deb-src
 	done
 	@echo "#############################################"
 
+# Build package outside of pbuilder, with locally installed dependencies.
+# Install BuildRequires as noted in packaging/debian/control.
+local_deb: debian
+	@for DIST in $(DEB_DIST) ; do \
+	    (cd deb-build/$${DIST}/$(NAME)-$(VERSION)/ && $(DEBUILD) -b) ; \
+	done
+	@echo "#############################################"
+	@echo "Ansible DEB artifacts:"
+	@for DIST in $(DEB_DIST) ; do \
+	    echo deb-build/$${DIST}/$(NAME)_$(VERSION)-$(DEB_RELEASE)~$${DIST}_amd64.changes ; \
+	done
+	@echo "#############################################"
+
 deb-src: debian
 	@for DIST in $(DEB_DIST) ; do \
 	    (cd deb-build/$${DIST}/$(NAME)-$(VERSION)/ && $(DEBUILD) -S) ; \

--- a/packaging/debian/Dockerfile
+++ b/packaging/debian/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:xenial
+
+RUN apt-get update && apt-get install -y \
+    asciidoc \
+    cdbs \
+    debootstrap \
+    devscripts \
+    make \
+    pbuilder \
+    python-setuptools
+
+VOLUME /ansible
+WORKDIR /ansible
+
+ENTRYPOINT ["/bin/bash", "-c"]
+CMD ["make deb"]

--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -13,6 +13,16 @@ git submodule update --init
 DEB_DIST='xenial trusty precise' make deb
 ```
 
+Building in Docker:
+
+```
+git clone git://github.com/ansible/ansible.git
+cd ansible
+git submodule update --init
+docker build -t ansible-deb-builder -f packaging/debian/Dockerfile .
+docker run --privileged -e DEB_DIST='trusty' -v $(pwd):/ansible ansible-deb-builder
+```
+
 The debian package file will be placed in the `deb-build` directory. This can then be added to an APT repository or installed with `dpkg -i <package-file>`.
 
 Note that `dpkg -i` does not resolve dependencies.

--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -3,26 +3,29 @@ Ansible Debian Package
 
 To create an Ansible DEB package:
 
-    sudo apt-get install python-paramiko python-yaml python-jinja2 python-httplib2 python-setuptools python-six sshpass
-    sudo apt-get install cdbs debhelper git-core reprepro fakeroot asciidoc devscripts docbook-xml xsltproc libxml2-utils
-    sudo apt-get install dh-python build-essential
-    git clone git://github.com/ansible/ansible.git
-    cd ansible
-    make deb
+__Note__: You must run this target as root or set `PBUILDER_BIN='sudo pbuilder'`
 
-On older releases that do not have `dh-python` (like Ubuntu 12.04), install `python-support` instead:
+```
+apt-get install asciidoc cdbs debootstrap devscripts make pbuilder python-setuptools
+git clone git://github.com/ansible/ansible.git
+cd ansible
+git submodule update --init
+DEB_DIST='xenial trusty precise' make deb
+```
 
-    sudo apt-get install python-support
-
-The debian package file will be placed in the `../` directory. This can then be added to an APT repository or installed with `dpkg -i <package-file>`.
+The debian package file will be placed in the `deb-build` directory. This can then be added to an APT repository or installed with `dpkg -i <package-file>`.
 
 Note that `dpkg -i` does not resolve dependencies.
 
 To install the Ansible DEB package and resolve dependencies:
 
-    sudo dpkg -i <package-file>
-    sudo apt-get -fy install
+```
+dpkg -i <package-file>
+apt-get -fy install
+```
 
 Or, if you are running Debian Stretch (or later) or Ubuntu Xenial (or later):
 
-    sudo apt install <package-file>
+```
+apt install /path/to/<package-file>
+```

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -2,9 +2,6 @@
 # -- makefile --
 
 DEB_PYTHON2_MODULE_PACKAGES=ansible
-ifneq ($(shell dpkg-query -f '$${Version}' -W python-support 2>/dev/null),)
-DEB_PYTHON_SYSTEM=pysupport
-endif
 
 include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/class/python-distutils.mk


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

Debian packaging
##### ANSIBLE VERSION

N/A
##### SUMMARY

We started seeing failures related to build dependencies when building 16.04 debs on our 14.04 Jenkins node. `pbuilder` ensures a clean-room environment inside a chroot.
