### PR TITLE
Fix fact gathering intg test asserts

### DIFF
--- a/test/integration/targets/gathering_facts/test_gathering_facts.yml
+++ b/test/integration/targets/gathering_facts/test_gathering_facts.yml
@@ -8,14 +8,13 @@
   tasks:
     - setup:
       register: facts
-    - debug: var=facts
     - name: Test that retrieving all facts works
       assert:
         that:
-          - '"{{ ansible_user_id|default("UNDEF_MIN") }}" != "UNDEF_MIN"'
-          - '"{{ ansible_interfaces|default("UNDEF_NET") }}" != "UNDEF_NET"'
-          - '"{{ ansible_mounts|default("UNDEF_HW") }}" != "UNDEF_HW"'
-          - '"{{ ansible_virtualization_role|default("UNDEF_VIRT") }}" != "UNDEF_VIRT"'
+          - 'ansible_user_id|default("UNDEF_MIN") != "UNDEF_MIN"'
+          - 'ansible_interfaces|default("UNDEF_NET") != "UNDEF_NET"'
+          - 'ansible_mounts|default("UNDEF_NET") != "UNDEF_HW"'
+          - 'ansible_virtualization_role|default("UNDEF_VIRT") != "UNDEF_VIRT"'
 
 - hosts: facthost1
   tags: [ 'fact_min' ]
@@ -26,10 +25,10 @@
     - name: Test that only retrieving minimal facts work
       assert:
         that:
-          - '"{{ ansible_user_id|default("UNDEF_MIN") }}" != "UNDEF_MIN"'
-          - '"{{ ansible_interfaces|default("UNDEF_NET") }}" == "UNDEF_NET"'
-          - '"{{ ansible_mounts|default("UNDEF_HW") }}" == "UNDEF_HW"'
-          - '"{{ ansible_virtualization_role|default("UNDEF_VIRT") }}" == "UNDEF_VIRT"'
+          - 'ansible_user_id|default("UNDEF_MIN") != "UNDEF_MIN"'
+          - 'ansible_interfaces|default("UNDEF_NET") == "UNDEF_NET"'
+          - 'ansible_mounts|default("UNDEF_HW") == "UNDEF_HW"'
+          - 'ansible_virtualization_role|default("UNDEF_VIRT") == "UNDEF_VIRT"'
 
 - hosts: facthost2
   tags: [ 'fact_network' ]
@@ -40,10 +39,10 @@
     - name: Test that retrieving network facts work
       assert:
         that:
-          - '"{{ ansible_user_id|default("UNDEF_MIN") }}" != "UNDEF_MIN"'
-          - '"{{ ansible_interfaces|default("UNDEF_NET") }}" != "UNDEF_NET"'
-          - '"{{ ansible_mounts|default("UNDEF_HW") }}" == "UNDEF_HW"'
-          - '"{{ ansible_virtualization_role|default("UNDEF_VIRT") }}" == "UNDEF_VIRT"'
+          - 'ansible_user_id|default("UNDEF_MIN") != "UNDEF_MIN"'
+          - 'ansible_interfaces|default("UNDEF_NET") != "UNDEF_NET"'
+          - 'ansible_mounts|default("UNDEF_HW") == "UNDEF_HW"'
+          - 'ansible_virtualization_role|default("UNDEF_VIRT") == "UNDEF_VIRT"'
 
 - hosts: facthost3
   tags: [ 'fact_hardware' ]
@@ -54,10 +53,10 @@
     - name: Test that retrieving hardware facts work
       assert:
         that:
-          - '"{{ ansible_user_id|default("UNDEF_MIN") }}" != "UNDEF_MIN"'
-          - '"{{ ansible_interfaces|default("UNDEF_NET") }}" == "UNDEF_NET"'
-          - '"{{ ansible_mounts|default("UNDEF_HW") }}" != "UNDEF_HW"'
-          - '"{{ ansible_virtualization_role|default("UNDEF_VIRT") }}" == "UNDEF_VIRT"'
+          - 'ansible_user_id|default("UNDEF_MIN") != "UNDEF_MIN"'
+          - 'ansible_interfaces|default("UNDEF_NET") == "UNDEF_NET"'
+          - 'ansible_mounts|default("UNDEF_HW") != "UNDEF_HW"'
+          - 'ansible_virtualization_role|default("UNDEF_VIRT") == "UNDEF_VIRT"'
 
 - hosts: facthost4
   tags: [ 'fact_virtual' ]
@@ -68,10 +67,10 @@
     - name: Test that retrieving virtualization facts work
       assert:
         that:
-          - '"{{ ansible_user_id|default("UNDEF_MIN") }}" != "UNDEF_MIN"'
-          - '"{{ ansible_interfaces|default("UNDEF_NET") }}" == "UNDEF_NET"'
-          - '"{{ ansible_mounts|default("UNDEF_HW") }}" == "UNDEF_HW"'
-          - '"{{ ansible_virtualization_role|default("UNDEF_VIRT") }}" != "UNDEF_VIRT"'
+          - 'ansible_user_id|default("UNDEF_MIN") != "UNDEF_MIN"'
+          - 'ansible_interfaces|default("UNDEF_NET") == "UNDEF_NET"'
+          - 'ansible_mounts|default("UNDEF_HW") == "UNDEF_HW"'
+          - 'ansible_virtualization_role|default("UNDEF_VIRT") != "UNDEF_VIRT"'
 
 - hosts: facthost5
   tags: [ 'fact_comma_string' ]
@@ -82,10 +81,10 @@
     - name: Test that retrieving virtualization and network as a string works
       assert:
         that:
-          - '"{{ ansible_user_id|default("UNDEF_MIN") }}" != "UNDEF_MIN"'
-          - '"{{ ansible_interfaces|default("UNDEF_NET") }}" != "UNDEF_NET"'
-          - '"{{ ansible_mounts|default("UNDEF_HW") }}" == "UNDEF_HW"'
-          - '"{{ ansible_virtualization_role|default("UNDEF_VIRT") }}" != "UNDEF_VIRT"'
+          - 'ansible_user_id|default("UNDEF_MIN") != "UNDEF_MIN"'
+          - 'ansible_interfaces|default("UNDEF_NET") != "UNDEF_NET"'
+          - 'ansible_mounts|default("UNDEF_HW") == "UNDEF_HW"'
+          - 'ansible_virtualization_role|default("UNDEF_VIRT") != "UNDEF_VIRT"'
 
 - hosts: facthost6
   tags: [ 'fact_yaml_list' ]
@@ -98,10 +97,10 @@
     - name: Test that retrieving virtualization and network as a string works
       assert:
         that:
-          - '"{{ ansible_user_id|default("UNDEF_MIN") }}" != "UNDEF_MIN"'
-          - '"{{ ansible_interfaces|default("UNDEF_NET") }}" != "UNDEF_NET"'
-          - '"{{ ansible_mounts|default("UNDEF_HW") }}" == "UNDEF_HW"'
-          - '"{{ ansible_virtualization_role|default("UNDEF_VIRT") }}" != "UNDEF_VIRT"'
+          - 'ansible_user_id|default("UNDEF_MIN") != "UNDEF_MIN"'
+          - 'ansible_interfaces|default("UNDEF_NET") != "UNDEF_NET"'
+          - 'ansible_mounts|default("UNDEF_HW") == "UNDEF_HW"'
+          - 'ansible_virtualization_role|default("UNDEF_VIRT") != "UNDEF_VIRT"'
 
 - hosts: facthost7
   tags: [ 'fact_negation' ]
@@ -112,10 +111,10 @@
     - name: Test that negation of fact subsets work
       assert:
         that:
-          - '"{{ ansible_user_id|default("UNDEF_MIN") }}" != "UNDEF_MIN"'
-          - '"{{ ansible_interfaces|default("UNDEF_NET") }}" != "UNDEF_NET"'
-          - '"{{ ansible_mounts|default("UNDEF_HW") }}" == "UNDEF_HW"'
-          - '"{{ ansible_virtualization_role|default("UNDEF_VIRT") }}" != "UNDEF_VIRT"'
+          - 'ansible_user_id|default("UNDEF_MIN") != "UNDEF_MIN"'
+          - 'ansible_interfaces|default("UNDEF_NET") != "UNDEF_NET"'
+          - 'ansible_mounts|default("UNDEF_HW") == "UNDEF_HW"'
+          - 'ansible_virtualization_role|default("UNDEF_VIRT") != "UNDEF_VIRT"'
 
 - hosts: facthost8
   tags: [ 'fact_mixed_negation_addition' ]
@@ -126,8 +125,8 @@
     - name: Test that negation and additional subsets work together
       assert:
         that:
-          - '"{{ ansible_user_id|default("UNDEF_MIN") }}" != "UNDEF_MIN"'
-          - '"{{ ansible_interfaces|default("UNDEF_NET") }}" != "UNDEF_NET"'
-          - '"{{ ansible_mounts|default("UNDEF_HW") }}" == "UNDEF_HW"'
-          - '"{{ ansible_virtualization_role|default("UNDEF_VIRT") }}" == "UNDEF_VIRT"'
+          - 'ansible_user_id|default("UNDEF_MIN") != "UNDEF_MIN"'
+          - 'ansible_interfaces|default("UNDEF_NET") != "UNDEF_NET"'
+          - 'ansible_mounts|default("UNDEF_HW") == "UNDEF_HW"'
+          - 'ansible_virtualization_role|default("UNDEF_VIRT") == "UNDEF_VIRT"'
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

test/integration/targets/gathering_facts
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

ansible 2.3.0 (fix_gathering_facts_test_quoting 7d5ee87df2) last updated 2016/10/24 15:57:31 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 124bb92416) last updated 2016/10/24 11:26:36 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 8ffe314ea5) last updated 2016/10/24 11:26:36 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```

```
##### SUMMARY

If the facts returned by setup included strings that
had double quotes in them, the asserts in test_gathering_facts.yml
would fail with errors like:

```
"The conditional check '\"[{u'mounts': {u'options':
u'rw,context=\"system_u:\"'}}]\" != \"UNDEF_HW\"' failed. The error was:
template error while templating string: expected token 'end of statement
block', got 'system_u'. String: {% if \"[{u'mounts': {u'options':
u'rw,context=\"system_u:\"'}}]\" != \"UNDEF_HW\" %} True {% else %}
False {% endif %}"
```

For one example, if mount facts returned an 'options' field that
included double quoated selinux context ids, the test would fail.

Fix is removing the double quoting in the assert 'that:' lines.
