### PR TITLE
Template set comparisons are new in version 2.1

### DIFF
--- a/docsite/rst/playbooks_tests.rst
+++ b/docsite/rst/playbooks_tests.rst
@@ -67,6 +67,8 @@ be used.  The default is ``False``, but this setting as ``True`` uses more stric
 Group theory tests
 ------------------
 
+.. versionadded:: 2.1
+
 To see if a list includes or is included by another list, you can use 'issubset' and 'issuperset'::
 
     vars:


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

Jinja2 comparisons
##### ANSIBLE VERSION

```
2.0 ish
```
##### SUMMARY

As mentioned in the changelog for Ansible 2.1, the new `issubset()` and `issuperset()` tests aren't available before that version.
