### PR TITLE
Add a new potential su prompt

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -117,6 +117,7 @@ b_SU_PROMPT_LOCALIZATIONS = [
     to_bytes('හස්පදය'),
     to_bytes('密码'),
     to_bytes('密碼'),
+    to_bytes('口令'),
 ]
 
 TASK_ATTRIBUTE_OVERRIDES = (
@@ -510,7 +511,10 @@ class PlayContext(Base):
 
                 # passing code ref to examine prompt as simple string comparisson isn't good enough with su
                 def detect_su_prompt(b_data):
-                    b_SU_PROMPT_LOCALIZATIONS_RE = re.compile(b"|".join([b'(\w+\'s )?' + x + b' ?: ?' for x in b_SU_PROMPT_LOCALIZATIONS]), flags=re.IGNORECASE)
+                    b_password_string = b"|".join([b'(\w+\'s )?' + x for x in b_SU_PROMPT_LOCALIZATIONS])
+                    # Colon or unicode fullwidth colon
+                    b_password_string = b_password_string + to_bytes(u' ?(:|：) ?')
+                    b_SU_PROMPT_LOCALIZATIONS_RE = re.compile(b_password_string, flags=re.IGNORECASE)
                     return bool(b_SU_PROMPT_LOCALIZATIONS_RE.match(b_data))
                 prompt = detect_su_prompt
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

play_context.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
devel stable-2.2
```
##### SUMMARY

Two parts to this change:
- Add a new string that requests password
- Add a new glyph that can be used to separate the prompt from the
  user's input as it seems it can use fullwidth colon rather than colon.

Fixes #17867
