### PR TITLE
Update winrm to allow fetch_file to work on files in use by processes

### DIFF
--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -385,7 +385,7 @@ class Connection(ConnectionBase):
                     script = '''
                         If (Test-Path -PathType Leaf "%(path)s")
                         {
-                            $stream = [System.IO.File]::OpenRead("%(path)s");
+                            $stream = New-Object IO.FileStream("%(path)s", [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [IO.FileShare]::ReadWrite);
                             $stream.Seek(%(offset)d, [System.IO.SeekOrigin]::Begin) | Out-Null;
                             $buffer = New-Object Byte[] %(buffer_size)d;
                             $bytesRead = $stream.Read($buffer, 0, %(buffer_size)d);


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

connection.winrm
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
Current 2.3.0 but goes back several versions as well.
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

WinRM's fetch_file method currently calls "[System.IO.File]::OpenRead" which opens up the file not only in read mode but also [attempts to set the FileShare mode to "Read" only](https://msdn.microsoft.com/en-us/library/system.io.file.openread%28v=vs.110%29.aspx#Anchor_2) which raises the error "The process cannot access the file [path] because it is being used by another process." if the file is already open for write access by another program (a log file for instance). This patch simply calls the IO.FileStream constructor explicitly so we can set the ShareMode to ReadWrite and thus allows us to transfer files even if they're open by another program. Further information about this kind of CLR error can be found at http://coding.infoconex.com/post/2009/04/21/How-do-I-open-a-file-that-is-in-use-in-C and http://stackoverflow.com/questions/12942717/read-log-file-being-used-by-another-process 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```
