### PR TITLE
task_queue_manager: fix calc of forks when serial is %

### DIFF
--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -222,7 +222,7 @@ class TaskQueueManager:
         )
 
         # Fork # of forks, # of hosts or serial, whichever is lowest
-        num_hosts = len(self._inventory.get_hosts(new_play.hosts))
+        num_hosts = len(self._inventory.get_hosts(new_play.hosts, ignore_restrictions=True))
 
         max_serial = 0
         if new_play.serial:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

task_queue_manager
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.2, 2.3, devel
```
##### SUMMARY

if serial in % was used, the calculation of forks was incorrect. 

~~Serial can be ignored at this point since len(self._inventory.get_hosts(new_play.hosts)) is identical to amount of hosts with serial applied.~~ len(self._inventory.get_hosts(new_play.hosts, ignore_restrictions=True)) is the correct fix. Thanks @bcoca 

Fixes #18191 
