### PR TITLE
Add name to automatic setup task. (Closes #18198)

### DIFF
--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -171,6 +171,7 @@ class PlayIterator:
         setup_block = Block(play=self._play)
         setup_task = Task(block=setup_block)
         setup_task.action = 'setup'
+        setup_task.name   = 'Gathers facts about remote hosts'
         setup_task.tags   = ['always']
         setup_task.args   = {
           'gather_subset': gather_subset,


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### COMPONENT NAME

setup
play_iterator
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.3.0 0.0.devel
```
##### SUMMARY

When internal play_iterator launch setup task, it doesn't set its name. The following changes add a generic name, basically the title of the task.

See #18198 
