### PR TITLE
Ansible requires tar

### DIFF
--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -76,6 +76,7 @@ Requires: python-six
 %endif
 
 Requires: sshpass
+Requires: tar
 
 %description
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

packaging/rpm
##### ANSIBLE VERSION

devel
##### SUMMARY

We should add tar to the specfile `Requires:` so that the archive module local actions work as expected on hosts that don't previously have tar installed. Usually the case when run inside a container or limited environment. This obviously won't fix problems when tar is running on the remote system.
