### PR TITLE
Permit to have a action plugin without a empty module file

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -124,6 +124,8 @@ class DocCLI(CLI):
             try:
                 # if the plugin lives in a non-python file (eg, win_X.ps1), require the corresponding python file for docs
                 filename = loader.find_plugin(plugin, mod_type='.py', ignore_deprecated=True)
+                if filename is None and loader == module_loader:
+                    filename = action_loader.find_plugin(module, mod_type='.py')
                 if filename is None:
                     display.warning("%s %s not found in %s\n" % (plugin_type, plugin, DocCLI.print_paths(loader)))
                     continue
@@ -217,6 +219,8 @@ class DocCLI(CLI):
             # if the module lives in a non-python file (eg, win_X.ps1), require the corresponding python file for docs
             filename = loader.find_plugin(plugin, mod_type='.py', ignore_deprecated=True)
 
+            if filename is None and loader == module_loader:
+                filename = action_loader.find_plugin(module, mod_type='.py')
             if filename is None:
                 continue
             if filename.endswith(".ps1"):

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -23,7 +23,7 @@ from ansible.errors import AnsibleParserError, AnsibleError
 from ansible.module_utils.six import iteritems, string_types
 from ansible.module_utils._text import to_text
 from ansible.parsing.splitter import parse_kv, split_args
-from ansible.plugins import module_loader
+from ansible.plugins import module_loader, action_loader
 from ansible.template import Templar
 
 
@@ -281,7 +281,7 @@ class ModuleArgsParser:
 
         # walk the input dictionary to see we recognize a module name
         for (item, value) in iteritems(self._task_ds):
-            if item in module_loader or item in ['meta', 'include', 'include_role']:
+            if item in module_loader or item in action_loader or item in ['meta', 'include', 'include_role']:
                 # finding more than one module name is a problem
                 if action is not None:
                     raise AnsibleParserError("conflicting action statements: %s, %s" % (action, item), obj=self._task_ds)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

ansible
##### SUMMARY

Currently, someone writing a action plugin will also need
to have a empty file in the module path to avoid triggering
the error "no action detected in task.".

This PR verify that either a module or a action plugin correspond to a task, permitting to action plugin without a empty file (in case that's purely a action plugin controller side)

( cc @dmsimard )
