### PR TITLE
Simplify surrogate check in to_text()

### DIFF
--- a/lib/ansible/module_utils/_text.py
+++ b/lib/ansible/module_utils/_text.py
@@ -163,7 +163,7 @@ def to_text(obj, encoding='utf-8', errors=None, nonstring='simplerepr'):
         return obj
 
     if errors in (None, 'surrogate_or_replace'):
-        if HAS_SURROGATEESCAPE:
+        if HAS_SURROGATEESCAPE or PY3:
             errors = 'surrogateescape'
         else:
             errors = 'replace'
@@ -172,12 +172,6 @@ def to_text(obj, encoding='utf-8', errors=None, nonstring='simplerepr'):
             errors = 'surrogateescape'
         else:
             errors = 'strict'
-
-    if errors is None:
-        if PY3:
-            errors = 'surrogateescape'
-        else:
-            errors = 'replace'
 
     if isinstance(obj, binary_type):
         return obj.decode(encoding, errors)

--- a/lib/ansible/module_utils/_text.py
+++ b/lib/ansible/module_utils/_text.py
@@ -163,7 +163,7 @@ def to_text(obj, encoding='utf-8', errors=None, nonstring='simplerepr'):
         return obj
 
     if errors in (None, 'surrogate_or_replace'):
-        if HAS_SURROGATEESCAPE or PY3:
+        if HAS_SURROGATEESCAPE:
             errors = 'surrogateescape'
         else:
             errors = 'replace'


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

`to_text()` in `module_utils/_text.py`
##### ANSIBLE VERSION

```
devel branch
```
##### SUMMARY

I notice an odd/redundant conditional check while poking through the code.
This should have the same behaviour but simplified.

Since `error` is being checked if it has a `None` value, you can simply move the extra (specific) condition up a few lines since the fallback is the same.
