### PR TITLE
iterate through task results only if the key is not at the root level

### DIFF
--- a/lib/ansible/executor/task_result.py
+++ b/lib/ansible/executor/task_result.py
@@ -62,11 +62,13 @@ class TaskResult:
         return self._check_key('unreachable')
 
     def _check_key(self, key):
-        if self._result.get('results', []):
+        '''get a specific key from the result or it's items'''
+
+        if isinstance(self._result, dict) and key in self._result:
+            return self._result.get(key, False)
+        else:
             flag = False
             for res in self._result.get('results', []):
                 if isinstance(res, dict):
                     flag |= res.get(key, False)
             return flag
-        else:
-            return self._result.get(key, False)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

task_result.py 
##### ANSIBLE VERSION

```
2.3
```
##### SUMMARY

Fixes https://github.com/ansible/ansible-modules-core/issues/5396

The logic in _check_key was a bit off and was exposed once the check for a loop task was removed. This PR makes the location of the key less fragile by ensuring the the items are only checked if the desired key is not a top level key. Previously, it would iterate through all items (an empty list) in the yum case and look for the key.
