### PR TITLE
Exception.message gone in 3.x

### DIFF
--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -88,7 +88,7 @@ class EosConfigMixin(object):
                 self.execute(['no configure session %s' % session])
         except NetworkError:
             exc = get_exception()
-            if 'timeout trying to send command' in exc.message:
+            if 'timeout trying to send command' in str(exc):
                 # try to get control back and get out of config mode
                 if isinstance(self, Cli):
                     self.execute(['\x03', 'end'])

--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -35,6 +35,7 @@ from ansible.module_utils.network import add_argument, register_transport, to_li
 from ansible.module_utils.netcli import Command
 from ansible.module_utils.shell import CliBase
 from ansible.module_utils.urls import fetch_url, url_argument_spec
+from ansible.module_utils._text import to_native
 
 EAPI_FORMATS = ['json', 'text']
 
@@ -88,7 +89,7 @@ class EosConfigMixin(object):
                 self.execute(['no configure session %s' % session])
         except NetworkError:
             exc = get_exception()
-            if 'timeout trying to send command' in str(exc):
+            if 'timeout trying to send command' in to_native(exc):
                 # try to get control back and get out of config mode
                 if isinstance(self, Cli):
                     self.execute(['\x03', 'end'])

--- a/lib/ansible/module_utils/network.py
+++ b/lib/ansible/module_utils/network.py
@@ -105,7 +105,7 @@ class NetworkModule(AnsibleModule):
             self.fail_json(msg='Unknown transport or no default transport specified')
         except (TypeError, NetworkError):
             exc = get_exception()
-            self.fail_json(msg=exc.message)
+            self.fail_json(msg=str(exc))
 
         if connect_on_load:
             self.connect()
@@ -151,7 +151,7 @@ class NetworkModule(AnsibleModule):
                          self.params['port'], self.params['transport']))
         except NetworkError:
             exc = get_exception()
-            self.fail_json(msg=exc.message)
+            self.fail_json(msg=str(exc))
 
     def disconnect(self):
         try:
@@ -160,7 +160,7 @@ class NetworkModule(AnsibleModule):
             self.log('disconnected from %s' % self.params['host'])
         except NetworkError:
             exc = get_exception()
-            self.fail_json(msg=exc.message)
+            self.fail_json(msg=str(exc))
 
 def register_transport(transport, default=False):
     def register(cls):

--- a/lib/ansible/module_utils/network.py
+++ b/lib/ansible/module_utils/network.py
@@ -32,6 +32,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import env_fallback, get_exception
 from ansible.module_utils.netcli import Cli, Command
 from ansible.module_utils.netcfg import Config
+from ansible.module_utils._text import to_native
 
 NET_TRANSPORT_ARGS = dict(
     host=dict(required=True),
@@ -105,7 +106,7 @@ class NetworkModule(AnsibleModule):
             self.fail_json(msg='Unknown transport or no default transport specified')
         except (TypeError, NetworkError):
             exc = get_exception()
-            self.fail_json(msg=str(exc))
+            self.fail_json(msg=to_native(exc))
 
         if connect_on_load:
             self.connect()
@@ -151,7 +152,7 @@ class NetworkModule(AnsibleModule):
                          self.params['port'], self.params['transport']))
         except NetworkError:
             exc = get_exception()
-            self.fail_json(msg=str(exc))
+            self.fail_json(msg=to_native(exc))
 
     def disconnect(self):
         try:
@@ -160,7 +161,7 @@ class NetworkModule(AnsibleModule):
             self.log('disconnected from %s' % self.params['host'])
         except NetworkError:
             exc = get_exception()
-            self.fail_json(msg=str(exc))
+            self.fail_json(msg=to_native(exc))
 
 def register_transport(transport, default=False):
     def register(cls):

--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -51,7 +51,6 @@ class ShellError(Exception):
 
     def __init__(self, msg, command=None):
         super(ShellError, self).__init__(msg)
-        self.message = msg
         self.command = command
 
 
@@ -155,7 +154,7 @@ class Shell(object):
             raise ShellError("timeout trying to send command: %s" % cmd)
         except socket.error:
             exc = get_exception()
-            raise ShellError("problem sending command to host: %s" % exc.message)
+            raise ShellError("problem sending command to host: %s" % str(exc))
         return responses
 
     def close(self):
@@ -247,7 +246,7 @@ class CliBase(object):
             return self.shell.send(commands)
         except ShellError:
             exc = get_exception()
-            raise NetworkError(exc.message, commands=commands)
+            raise NetworkError(str(exc), commands=commands)
 
     def run_commands(self, commands):
         return self.execute(to_list(commands))

--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -32,6 +32,7 @@ except ImportError:
 from ansible.module_utils.basic import get_exception
 from ansible.module_utils.network import NetworkError
 from ansible.module_utils.six.moves import StringIO
+from ansible.module_utils._text import to_native
 
 ANSI_RE = [
     re.compile(r'(\x1b\[\?1h\x1b=)'),
@@ -154,7 +155,7 @@ class Shell(object):
             raise ShellError("timeout trying to send command: %s" % cmd)
         except socket.error:
             exc = get_exception()
-            raise ShellError("problem sending command to host: %s" % str(exc))
+            raise ShellError("problem sending command to host: %s" % to_native(exc))
         return responses
 
     def close(self):
@@ -227,7 +228,7 @@ class CliBase(object):
         except ShellError:
             exc = get_exception()
             raise NetworkError(
-                msg='failed to connect to %s:%s' % (host, port), exc=str(exc)
+                msg='failed to connect to %s:%s' % (host, port), exc=to_native(exc)
             )
 
         self._connected = True
@@ -246,7 +247,7 @@ class CliBase(object):
             return self.shell.send(commands)
         except ShellError:
             exc = get_exception()
-            raise NetworkError(str(exc), commands=commands)
+            raise NetworkError(to_native(exc), commands=commands)
 
     def run_commands(self, commands):
         return self.execute(to_list(commands))


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

network, shell
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.3
```
##### SUMMARY

As far as I understand, this is the proper way to get around the lack of Exception.message in Python 3.x. `ShellError` had a self-defined `message` attribute, but not `NetworkError`, and I don't think it should be necessary anyway.
