### PR TITLE
Set ansible_os_family correctly under KDE neon

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -648,7 +648,7 @@ class Distribution(object):
         Archlinux = 'Archlinux', Manjaro = 'Archlinux', Mandriva = 'Mandrake', Mandrake = 'Mandrake', Altlinux = 'Altlinux',
         Solaris = 'Solaris', Nexenta = 'Solaris', OmniOS = 'Solaris', OpenIndiana = 'Solaris',
         SmartOS = 'Solaris', AIX = 'AIX', Alpine = 'Alpine', MacOSX = 'Darwin',
-        FreeBSD = 'FreeBSD', HPUX = 'HP-UX', openSUSE_Leap = 'Suse'
+        FreeBSD = 'FreeBSD', HPUX = 'HP-UX', openSUSE_Leap = 'Suse', Neon = 'Debian'
     )
 
     def __init__(self, module):

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -403,6 +403,25 @@ VERSION_ID="12.04"
                    'distribution_version': u'12.04'}
     },
     {
+        "platform.dist": [
+            "neon",
+            "16.04",
+            "xenial"
+        ],
+        "input": {
+            "/etc/os-release": "NAME=\"KDE neon\"\nVERSION=\"5.8\"\nID=neon\nID_LIKE=\"ubuntu debian\"\nPRETTY_NAME=\"KDE neon User Edition 5.8\"\nVERSION_ID=\"16.04\"\nHOME_URL=\"http://neon.kde.org/\"\nSUPPORT_URL=\"http://neon.kde.org/\"\nBUG_REPORT_URL=\"http://bugs.kde.org/\"\nVERSION_CODENAME=xenial\nUBUNTU_CODENAME=xenial\n",
+            "/etc/lsb-release": "DISTRIB_ID=neon\nDISTRIB_RELEASE=16.04\nDISTRIB_CODENAME=xenial\nDISTRIB_DESCRIPTION=\"KDE neon User Edition 5.8\"\n"
+        },
+        "name": "KDE neon 16.04",
+        "result": {
+            "distribution_release": "xenial",
+            "distribution": "Neon",
+            "distribution_major_version": "16",
+            "os_family": "Debian",
+            "distribution_version": "16.04"
+        }
+    },
+    {
         'name': 'Core OS',
         'input': {
             '/etc/os-release':"""


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

module_utils
##### ANSIBLE VERSION

```
ansible 2.3.0 (devel 680cade77a) last updated 2016/10/27 11:30:21 (GMT +100)
  lib/ansible/modules/core: (detached HEAD c51ced56cc) last updated 2016/10/27 16:07:21 (GMT +100)
  lib/ansible/modules/extras: (detached HEAD 8ffe314ea5) last updated 2016/10/27 16:07:22 (GMT +100)
```
##### SUMMARY

As [KDE neon](https://neon.kde.org/) is derived from Ubuntu, `ansible_os_family` should have the value `Debian` instead of `Neon`.  This PR adds a test case for KDE neon and sets the `os_family` fact correctly for it.

Change in output from `ansible hostname -m setup` under KDE neon:

```
335c335
<         "ansible_os_family": "Neon", 

---
>         "ansible_os_family": "Debian", 
```
