### PR TITLE
Add tests for dnf modelled after the yum tests

### DIFF
--- a/test/integration/destructive.yml
+++ b/test/integration/destructive.yml
@@ -7,6 +7,7 @@
     - { role: pip, tags: test_pip }
     - { role: gem, tags: test_gem }
     - { role: yum, tags: test_yum }
+    - { role: dnf, tags: test_dnf }
     - { role: apt, tags: test_apt }
     - { role: apt_repository, tags: [test_apt_repository, test_apt_key] }
     - { role: postgresql, tags: [test_postgresql, test_postgresql_db, test_postgresql_privs, test_postgresql_user, needs_privileged] }

--- a/test/integration/targets/dnf/meta/main.yml
+++ b/test/integration/targets/dnf/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_tests

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -1,0 +1,212 @@
+# UNINSTALL 'python2-dnf'
+#  The `dnf` module has the smarts to auto-install the relevant python
+#  bindings.  To test, we will first uninstall python2-dnf (so that the tests
+#  on python2 will require python2-dnf)
+- name: check python2-dnf with rpm
+  shell: rpm -q python2-dnf
+  register: rpm_result
+  ignore_errors: true
+
+# Don't uninstall python2-dnf with the `dnf` module in case it needs to load
+# some dnf python files after the package is uninstalled.
+- name: uninstall python2-dnf with shell
+  shell: dnf -y remove python2-dnf
+  when: rpm_result|success
+
+# UNINSTALL
+#   With 'python2-dnf' uninstalled, the first call to 'dnf' should install
+#   python2-dnf.
+- name: uninstall sos
+  dnf:
+    name: sos
+    state: removed
+  register: dnf_result
+
+- name: check sos with rpm
+  shell: rpm -q sos
+  failed_when: False
+  register: rpm_result
+
+- debug: var=dnf_result
+- debug: var=rpm_result
+
+- name: verify uninstallation of sos
+  assert:
+    that:
+        - "not dnf_result.failed | default(False)"
+        - "rpm_result.rc == 1"
+
+# UNINSTALL AGAIN
+- name: uninstall sos
+  dnf:
+    name: sos
+    state: removed
+  register: dnf_result
+
+- name: verify no change on re-uninstall
+  assert:
+    that:
+        - "not dnf_result.changed"
+
+# INSTALL
+- name: install sos
+  dnf:
+    name: sos
+    state: present
+  register: dnf_result
+
+- name: check sos with rpm
+  shell: rpm -q sos
+  failed_when: False
+  register: rpm_result
+
+- debug: var=dnf_result
+- debug: var=rpm_result
+
+- name: verify installation of sos
+  assert:
+    that:
+        - "not dnf_result.failed | default(False)"
+        - "dnf_result.changed"
+        - "rpm_result.rc == 0"
+
+- name: verify dnf module outputs
+  assert:
+    that:
+        - "'changed' in dnf_result"
+        - "'results' in dnf_result"
+
+# INSTALL AGAIN
+- name: install sos again
+  dnf:
+    name: sos
+    state: present
+  register: dnf_result
+
+- name: verify no change on second install
+  assert:
+    that:
+        - "not dnf_result.changed"
+
+# Multiple packages
+- name: uninstall sos and sharutils
+  dnf: name=sos,sharutils state=removed
+  register: dnf_result
+
+- name: check sos with rpm
+  shell: rpm -q sos
+  failed_when: False
+  register: rpm_sos_result
+
+- name: check sharutils with rpm
+  shell: rpm -q sharutils
+  failed_when: False
+  register: rpm_sharutils_result
+
+- name: verify packages installed
+  assert:
+    that:
+        - "rpm_sos_result.rc != 0"
+        - "rpm_sharutils_result.rc != 0"
+
+- name: install sos and sharutils as comma separated
+  dnf: name=sos,sharutils state=present
+  register: dnf_result
+
+- name: check sos with rpm
+  shell: rpm -q sos
+  failed_when: False
+  register: rpm_sos_result
+
+- name: check sharutils with rpm
+  shell: rpm -q sharutils
+  failed_when: False
+  register: rpm_sharutils_result
+
+- name: verify packages installed
+  assert:
+    that:
+        - "not dnf_result.failed | default(False)"
+        - "dnf_result.changed"
+        - "rpm_sos_result.rc == 0"
+        - "rpm_sharutils_result.rc == 0"
+
+- name: uninstall sos and sharutils
+  dnf: name=sos,sharutils state=removed
+  register: dnf_result
+
+- name: install sos and sharutils as list
+  dnf:
+    name:
+      - sos
+      - sharutils
+    state: present
+  register: dnf_result
+
+- name: check sos with rpm
+  shell: rpm -q sos
+  failed_when: False
+  register: rpm_sos_result
+
+- name: check sharutils with rpm
+  shell: rpm -q sharutils
+  failed_when: False
+  register: rpm_sharutils_result
+
+- name: verify packages installed
+  assert:
+    that:
+        - "not dnf_result.failed | default(False)"
+        - "dnf_result.changed"
+        - "rpm_sos_result.rc == 0"
+        - "rpm_sharutils_result.rc == 0"
+
+- name: uninstall sos and sharutils
+  dnf:
+    name: "sos,sharutils"
+    state: removed
+  register: dnf_result
+
+- name: install sos and sharutils as comma separated with spaces
+  dnf:
+    name: "sos, sharutils"
+    state: present
+  register: dnf_result
+
+- name: check sos with rpm
+  shell: rpm -q sos
+  failed_when: False
+  register: rpm_sos_result
+
+- name: check sos with rpm
+  shell: rpm -q sharutils
+  failed_when: False
+  register: rpm_sharutils_result
+
+- name: verify packages installed
+  assert:
+    that:
+        - "not dnf_result.failed | default(False)"
+        - "dnf_result.changed"
+        - "rpm_sos_result.rc == 0"
+        - "rpm_sharutils_result.rc == 0"
+
+- name: uninstall sos and sharutils
+  dnf:
+    name:
+      - sos
+      - sharutils
+    state: removed
+
+- name: install non-existent rpm 
+  dnf:
+    name: "{{ item }}"
+  with_items:
+    - does-not-exist
+  register: non_existent_rpm
+  ignore_errors: True
+
+- name: check non-existent rpm install failed
+  assert:
+    that:
+      - non_existent_rpm|failed

--- a/test/integration/targets/dnf/tasks/main.yml
+++ b/test/integration/targets/dnf/tasks/main.yml
@@ -1,0 +1,23 @@
+# test code for the yum module
+# (c) 2014, James Tanner <tanner.jc@gmail.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Note: We install the yum package onto Fedora so that this will work on dnf systems
+# We want to test that for people who don't want to upgrade their systems.
+- include: 'dnf.yml'
+  when: (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and False) or (ansible_distribution in ['Fedora'] and ansible_distribution_major_version >= 23)
+


### PR DESCRIPTION
##### ISSUE TYPE
- Test Pull Request
##### COMPONENT NAME

test/integration/target/dnf
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
devel
```
##### SUMMARY

Integration tests for dnf.

Note that this requires https://github.com/ansible/ansible-modules-extras/pull/3309   a feature to install the python bindings for dnf if they are not installed on the box. That's a new feature so if we backport the tests we need to comment out a few tests at the very beginning of this new role.
