### PR TITLE
Remove extra display statements and add docs

### DIFF
--- a/docs/man/man1/ansible-galaxy.1.asciidoc.in
+++ b/docs/man/man1/ansible-galaxy.1.asciidoc.in
@@ -100,8 +100,9 @@ configured in your *ansible.cfg* file (/etc/ansible/roles if not configured)
 INIT
 ----
 
-The *init* command is used to create an empty role suitable for uploading
-to https://galaxy.ansible.com (or for roles in general).
+The *init* command is used to create a new role suitable for uploading
+to https://galaxy.ansible.com (or for roles in general). Creates a skeleton
+directory structure and default files.
 
 USAGE
 ~~~~~
@@ -123,6 +124,10 @@ working directory.
 *--offline*::
 
 Don't query the galaxy API when creating roles
+
+*--container-enabled*::
+
+Initialize the new role with files appropriate for a Container Enabled role.
 
 LIST
 ----

--- a/docs/man/man1/ansible-galaxy.1.asciidoc.in
+++ b/docs/man/man1/ansible-galaxy.1.asciidoc.in
@@ -277,6 +277,10 @@ Provide a specific branch to import. When a branch is not specified the
 branch found in meta/main.yml is used. If no branch is specified in
 meta/main.yml, the repo's default branch (usually master) is used.
 
+*--role-name*::
+
+Set the name of the role. Otherwise, the name is derived from the
+name of the GitHub repository.
 
 DELETE
 ------

--- a/docsite/rst/galaxy.rst
+++ b/docsite/rst/galaxy.rst
@@ -350,9 +350,21 @@ By default the command will wait for Galaxy to complete the import process, disp
     Import completed
     Status SUCCESS : warnings=0 errors=0
 
+Branch
+======
+
 Use the *--branch* option to import a specific branch. If not specified, the default branch for the repo will be used.
 
-If the *--no-wait* option is present, the command will not wait for results. Results of the most recent import for any of your roles is available on the Galaxy web site 
+Role name
+=========
+
+By default the name given to the role will be derived from the GitHub repository name. However, you can use the *--role-name
+option to override this and set the name.
+
+No wait
+=======
+
+If the *--no-wait* option is present, the command will not wait for results. Results of the most recent import for any of your roles is available on the Galaxy web site
 by visiting *My Imports*.
 
 Delete a role

--- a/docsite/rst/galaxy.rst
+++ b/docsite/rst/galaxy.rst
@@ -198,9 +198,18 @@ The above will create the following directory structure in the current working d
    vars/
        main.yml
 
+Force
+=====
 
 If a directory matching the name of the role already exists in the current working directory, the init command will result in an error. To ignore the error 
 use the *--force* option. Force will create the above subdirectories and files, replacing anything that matches.
+
+Container Enabled
+=================
+
+If you are creating a Container Enabled role, use the *--container-enabled* option. This will create the same directory structure as above, but populate it
+with default files appropriate for a Container Enabled role. For instance, the README.md has a slightly different structure, the *.travis.yml* file tests
+the role using [Ansible Container](https://github.com/ansible/ansible-container), and the meta directory includes a *container.yml* file.
 
 Search for roles
 ----------------

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -234,9 +234,7 @@ class GalaxyCLI(CLI):
                     dest_file = os.path.join(role_path, rel_root, filename)
                     template_env.get_template(src_template).stream(inject_data).dump(dest_file)
                 else:
-                    display.display("root: %s f: %s role_skeleton: %s" % (root, f, role_skeleton))
                     f_rel_path = os.path.relpath(os.path.join(root, f), role_skeleton)
-                    display.display("f_rel_path: %s" % f_rel_path)
                     shutil.copyfile(os.path.join(root, f), os.path.join(role_path, f_rel_path))
 
             for d in dirs:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ansible-galaxy
##### ANSIBLE VERSION

```
ansible 2.3.0 (devel 197098f125) last updated 2016/10/27 23:33:26 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 124bb92416) last updated 2016/10/24 11:40:34 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 8ffe314ea5) last updated 2016/10/24 11:40:34 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY
- Remove extra display statements left in `ansible-galaxy init` modification
- Adds docs for `ansible-galaxy init --container-enabled`
- Adds docs for `ansible-galaxy import --role-name`
