### PR TITLE
[network] Default key_policy to ignore

### DIFF
--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -69,7 +69,7 @@ class Shell(object):
 
     def open(self, host, port=22, username=None, password=None, timeout=10,
              key_filename=None, pkey=None, look_for_keys=None,
-             allow_agent=False, key_policy="loose"):
+             allow_agent=False, key_policy="ignore"):
 
         self.ssh = paramiko.SSHClient()
         if key_policy != "ignore":


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

shell
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0.0 (key_policy 50b6304cca) last updated 2016/10/28 11:23:39 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 9d6895ad66) last updated 2016/10/28 11:21:30 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 90f96e245f) last updated 2016/10/28 11:21:30 (GMT -400)
```
##### SUMMARY

Addresses ansible/ansible-modules-core#5308
