### PR TITLE
Handle the socket.timeout that paramiko can return

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -659,7 +659,11 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         # pre-split stdout into lines, if stdout is in the data and there
         # isn't already a stdout_lines value there
         if 'stdout' in data and 'stdout_lines' not in data:
-            data['stdout_lines'] = data.get('stdout', u'').splitlines()
+            stdout = data.get('stdout', u'')
+            if isinstance(stdout, list):
+                data['stdout_lines'] = [l.splitlines() for l in stdout]
+            else:
+                data['stdout_lines'] = stdout.splitlines()
 
         display.debug("done with _execute_module (%s, %s)" % (module_name, module_args))
         return data


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request

##### COMPONENT NAME

Network modules, shell.py

##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0 (fix_command_timeout 886f146de9) last updated 2016/10/28 15:10:13 (GMT -400)
  lib/ansible/modules/core: (fix_command_timeout 93051cf470) last updated 2016/10/28 15:02:12 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 8ffe314ea5) last updated 2016/10/25 15:34:40 (GMT -400)
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
   "msg": "timeout waiting for next prompt from remote device",
    "**stdout**": "copy running-config flash:test\r\nDestination filename [test]? ",
    "**stdout_lines**": [
        "copy running-config flash:test",
        "Destination filename [test]? "
```

The socket.timeout was not handled and causes fatal errors.
This is particularly noticeable when the device is doing alternative
prompts.  This PR also adds the output of the device to the 'stdout'
attribute and returns it to help see the hidden device interaction(s).

This PR will depend on a separate PR posted to ansible_code_modules.

Note there is a change here to stdout_lines that is set in lib/ansible/plugins/action/**init**.py as well that handles both cases of 'stdout' as a string or list.  Since the the network modules do, all of the to_list() functions duplicated across network modules could thus be removed and this will handle stdout_lines for them.  One added side effect here is that it uses splitlines() vs split("\n"), so the extra "\r" that sometimes showed in stdout will be gone.

This, in-part, is related to https://github.com/ansible/ansible-modules-core/issues/5402

Sorry to intermingle these changes somewhat, they are inter-related.
