### PR TITLE
Add 'type' filter for display the underlying python type of a variable

### DIFF
--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -519,8 +519,8 @@ Debugging Filters
 
 .. versionadded:: 2.3
 
-Use the ``type`` filter to display the underlying python type of a variable.
-Useful in debugging in some situations where you may need to know the exact
+Use the ``type`` filter to display the underlying Python type of a variable.
+This can be useful in debugging in situations where you may need to know the exact
 type of a variable::
 
     {{ myvar | type }}

--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -514,6 +514,18 @@ To get date object from string use the `to_datetime` filter, (new in version in 
     # get amount of seconds between two dates, default date format is %Y-%d-%m %H:%M:%S but you can pass your own one
     {{ (("2016-08-04 20:00:12"|to_datetime) - ("2015-10-06"|to_datetime('%Y-%d-%m'))).seconds  }}
 
+Debugging Filters
+-----------------
+
+.. versionadded:: 2.3
+
+Use the ``type`` filter to display the underlying python type of a variable.
+Useful in debugging in some situations where you may need to know the exact
+type of a variable::
+
+    {{ myvar | type }}
+
+
 A few useful filters are typically added with each new Ansible release.  The development documentation shows
 how to extend Ansible filters by writing your own as plugins, though in general, we encourage new ones
 to be added to core so everyone can make use of them.

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -525,4 +525,7 @@ class FilterModule(object):
             # skip testing
             'skipped' : skipped,
             'skip'    : skipped,
+
+            # debug
+            'type': lambda o: o.__class__.__name__,
         }


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### COMPONENT NAME

type
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0 (type-filter a6feeee50f) last updated 2016/10/28 15:41:12 (GMT -500)
```
##### SUMMARY

I find myself copying my custom `type` filter into all of my projects.  It is super useful when you are trying to debug a problem and need to inspect the type of a variable.

```
{{ myvar | type }}
```
