### PR TITLE
ops not openswitch

### DIFF
--- a/test/integration/target-prefixes.network
+++ b/test/integration/target-prefixes.network
@@ -10,7 +10,7 @@ ios
 iosxr
 junos
 nxos
-openswitch
+ops
 pn
 sros
 vyos


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
- New Module Pull Request
- Bugfix Pull Request
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```

```

The openswitch modules have a prefix of `ops`, not `openswitch`, which is the directory name.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/18256)

<!-- Reviewable:end -->
