### PR TITLE
fix jinja2 override header when the file contains none of the original markers

### DIFF
--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -54,7 +54,6 @@ class TestTemplar(unittest.TestCase):
         pass
 
     def test_templar_simple(self):
-
         templar = self.templar
         # test some basic templating
         self.assertEqual(templar.template("{{foo}}"), "bar")
@@ -103,11 +102,14 @@ class TestTemplar(unittest.TestCase):
     def test_template_jinja2_extensions(self):
         fake_loader = DictDataLoader({})
         templar = Templar(loader=fake_loader)
-        
+
         old_exts = C.DEFAULT_JINJA2_EXTENSIONS
         try:
             C.DEFAULT_JINJA2_EXTENSIONS = "foo,bar"
             self.assertEqual(templar._get_extensions(), ['foo', 'bar'])
         finally:
             C.DEFAULT_JINJA2_EXTENSIONS = old_exts
+
+    def test_template_jinja2_overrides(self):
+        self.assertEqual(self.templar.template("#jinja2: variable_start_string: '[%', variable_end_string: '%]'\n[% foo %]"), "bar")
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
template

##### ANSIBLE VERSION
```
ansible 2.3.0 (fix-template-jinja2-override-header de8a38c979) last updated 2016/10/31 10:48:59 (GMT -400)
```

##### SUMMARY
fix jinja2 override header when the file contains none of the original markers

The templar does not send the template through the templating engine
when it doesn't find any variables in the template.  It was not taking
in to consideration the override header when deciding this.

fixes #18192