### PR TITLE
Fix auth in collins.py inventory

### DIFF
--- a/contrib/inventory/collins.ini
+++ b/contrib/inventory/collins.ini
@@ -3,6 +3,8 @@
 
 [collins]
 
+# You should not have a trailing slash or collins
+# will not properly match the URI
 host = http://localhost:9000
 
 username = blake

--- a/contrib/inventory/collins.py
+++ b/contrib/inventory/collins.py
@@ -201,7 +201,8 @@ class CollinsInventory(object):
                 response = open_url(query_url,
                         timeout=self.collins_timeout_secs,
                         url_username=self.collins_username,
-                        url_password=self.collins_password)
+                        url_password=self.collins_password,
+                        force_basic_auth=True)
                 json_response = json.loads(response.read())
                 # Adds any assets found to the array of assets.
                 assets += json_response['data']['Data']


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
collins.py

##### ANSIBLE VERSION
Issue exists in devel however I encountered it fist in the version below
```
ansible --version
ansible 2.0.0.2
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

This forces basic auth to be used. Using the normal HTTPPasswordMgrWithDefaultRealm
password manager from urllib2 fails since collins doesn't send a 401 retry on failure.
More about this can be seen here http://stackoverflow.com/questions/2407126/python-urllib2-basic-auth-problem.
I added a small comment about the format of the host so others don't waste time like i did.

```
# Before change
python collins.py
{}
# After change
python collins.py
{ ... bunch of top secret stuff}
```

cc: @jbrockett