### PR TITLE
Detect vmm virtualization for OpenBSD, both host and guest.

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -3283,6 +3283,7 @@ class OpenBSDVirtual(Virtual):
     - virtualization_role
     """
     platform = 'OpenBSD'
+    DMESG_BOOT = '/var/run/dmesg.boot'
 
     def populate(self):
         self.get_virtual_facts()
@@ -3323,6 +3324,18 @@ class OpenBSDVirtual(Virtual):
                         if out.rstrip() == 'QEMU':
                             self.facts['virtualization_type'] = 'kvm'
                             self.facts['virtualization_role'] = 'guest'
+                        if out.rstrip() == 'OpenBSD':
+                            self.facts['virtualization_type'] = 'vmm'
+                            self.facts['virtualization_role'] = 'guest'
+
+        # Check the dmesg if vmm(4) attached, indicating the host is
+        # capable of virtualization.
+        dmesg_boot = get_file_content(OpenBSDVirtual.DMESG_BOOT)
+        for line in dmesg_boot.splitlines():
+            match = re.match('^vmm0 at mainbus0: (SVM/RVI|VMX/EPT)$', line)
+            if match:
+                self.facts['virtualization_type'] = 'vmm'
+                self.facts['virtualization_role'] = 'host'
 
 class HPUXVirtual(Virtual):
     """


### PR DESCRIPTION
##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME
`setup` module (facts)

##### ANSIBLE VERSION
<!--- Paste verbatim output from ?ansible --version? between quotes below -->
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
OpenBSD has recently enabled vmm(4), as a way of running virtual machines on
OpenBSD. Currently only OpenBSD guests are supported, hence the `guest`
functionality is only implemented in `OpenBSDVirtual`.

Machines that are capable of functioning as a hypervisor have one of the
following lines in dmesg, depending on the cpu vendor (amd or intel respectively):
```
vmm0 at mainbus0: SVM/RVI
vmm0 at mainbus0: VMX/EPT
```

<!-- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
    "ansible_facts": {
        "ansible_virtualization_role": "", 
        "ansible_virtualization_type": ""
    }, 
```

and after:
```
    "ansible_facts": {
        "ansible_virtualization_role": "host", 
        "ansible_virtualization_type": "vmm"
    }, 
```