### PR TITLE
Fix for #18223 - document that filenames must have a yaml, yml, or js…

### DIFF
--- a/lib/ansible/plugins/action/include_vars.py
+++ b/lib/ansible/plugins/action/include_vars.py
@@ -100,7 +100,7 @@ class ActionModule(ActionBase):
         self._mutually_exclusive()
 
     def run(self, tmp=None, task_vars=None):
-        """ Load yml files recursively from a directory.
+        """ Load yml files recursively from a directory. The filenames must have a yaml, yml, or json extension. 
         """
         self.VALID_FILE_EXTENSIONS = ['yaml', 'yml', 'json']
         if not task_vars:
@@ -267,7 +267,7 @@ class ActionModule(ActionBase):
             var_files: (list): List of files to iterate over and load into a dictionary.
 
         Returns:
-            Tuple (bool, str, dict)
+            Tuple (bool, str, dict) 
         """
         results = dict()
         failed = False


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```

…on extension.