### PR TITLE
add new test 'contains' alias in

### DIFF
--- a/lib/ansible/plugins/test/core.py
+++ b/lib/ansible/plugins/test/core.py
@@ -114,6 +114,10 @@ def version_compare(value, version, operator='eq', strict=False):
     except Exception as e:
         raise errors.AnsibleFilterError('Version comparison: %s' % e)
 
+def contains(value, values):
+    ''' Test if a value is contained in list '''
+    return value in set(values)
+
 class TestModule(object):
     ''' Ansible core jinja2 tests '''
 
@@ -133,6 +137,10 @@ class TestModule(object):
             'match': match,
             'search': search,
             'regex': regex,
+
+            # contains
+            'in': contains,
+            'contains': contains,
 
             # version comparison
             'version_compare': version_compare,


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /Users/shuji/Projects/pioneer/iotcld/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
New jinja2 filter 'contains'.

When aws module such as rds_subnet_group.
I want to subnet id list from subnet_facts.
And filter subnet from result by tag.Name list to **list**

For example:
```
vars:
  - name: Subnet Group
     subnets:
      - PrivateSubnetA
      - PrivateSubnetB
      - PrivateSubnetC
```
task
```
    - ec2_vpc_subnet_facts:
      register: _subnet_facts
    - rds_subnet_group:
        name: "{{ name }}"
        state: present
        subnets: "{{ _subnet_facts.subnets | selectattr('tags.Name', 'defined') | selectattr('tags.Name', 'contains', subnets) |  map(attribute='id') | list }}"
```
