### PR TITLE
On OpenBSD, swap the values for distribution_version and distribution…

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -764,12 +764,13 @@ class Distribution(object):
             self.facts['distribution_version'] = '%s.%s' % (data.group(1), data.group(2))
 
     def get_distribution_OpenBSD(self):
+        self.facts['distribution_version'] = platform.release()
         rc, out, err = self.module.run_command("/sbin/sysctl -n kern.version")
         match = re.match('OpenBSD\s[0-9]+.[0-9]+-(\S+)\s.*', out)
         if match:
-            self.facts['distribution_version'] = match.groups()[0]
+            self.facts['distribution_release'] = match.groups()[0]
         else:
-            self.facts['distribution_version'] = 'release'
+            self.facts['distribution_release'] = 'release'
 
     def get_distribution_DragonFly(self):
         pass


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
facts (setup module)

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This PR swap the values for the `distribution_release` and `distribution_version` facts on OpenBSD. This was done to be more inline with other platforms Ansible runs on, and to have less "surprising" values for OpenBSD users.
OpenBSD ships regular releases with a numbered version (e.g. 6.0). There are several "flavors" so to say, `release`, `current`, `beta` and `stable` which are output into the `sysctl kern.version` string.

This PR brings the values inline with for example RH7 where the `_version` is a numerical value (7.2) and the `_release` a string (Maipo).

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_distribution": "OpenBSD", 
        "ansible_distribution_release": "6.0", 
        "ansible_distribution_version": "current"
    }, 
    "changed": false
}
```
after:
```
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_distribution": "OpenBSD", 
        "ansible_distribution_release": "current", 
        "ansible_distribution_version": "6.0"
    }, 
    "changed": false
}
```

Which is closer to:
```
        "ansible_distribution": "RedHat", 
        "ansible_distribution_major_version": "7", 
        "ansible_distribution_release": "Maipo", 
        "ansible_distribution_version": "7.2", 
```

This change was discussed and agreed with several other OpenBSD developers.