### PR TITLE
Rework how OpenBSD processor facts are resolved

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1589,7 +1589,6 @@ class OpenBSDHardware(Hardware):
     In addition, it also defines number of DMI facts and device facts.
     """
     platform = 'OpenBSD'
-    DMESG_BOOT = '/var/run/dmesg.boot'
 
     def populate(self):
         self.sysctl = self.get_sysctl()
@@ -1647,19 +1646,19 @@ class OpenBSDHardware(Hardware):
 
     def get_processor_facts(self):
         processor = []
-        dmesg_boot = get_file_content(OpenBSDHardware.DMESG_BOOT)
-        if not dmesg_boot:
-            rc, dmesg_boot, err = self.module.run_command("/sbin/dmesg")
-        i = 0
-        for line in dmesg_boot.splitlines():
-            if line.split(' ', 1)[0] == 'cpu%i:' % i:
-                processor.append(line.split(' ', 1)[1])
-                i = i + 1
-        processor_count = i
+        for i in range(int(self.sysctl['hw.ncpu'])):
+            processor.append(self.sysctl['hw.model'])
+
         self.facts['processor'] = processor
-        self.facts['processor_count'] = processor_count
-        # I found no way to figure out the number of Cores per CPU in OpenBSD
-        self.facts['processor_cores'] = 'NA'
+        # The following is partly a lie because there is no reliable way to
+        # determine the number of physical CPUs in the system. We can only
+        # query the number of logical CPUs, which hides the number of cores.
+        # On amd64/i386 we could try to inspect the smt/core/package lines in
+        # dmesg, however even those have proven to be unreliable.
+        # So take a shortcut and report the logical number of processors in
+        # 'processor_count' and 'processor_cores' and leave it at that.
+        self.facts['processor_count'] = self.sysctl['hw.ncpu']
+        self.facts['processor_cores'] = self.sysctl['hw.ncpu']
 
     def get_device_facts(self):
         devices = []


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
facts (setup module)

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

This PR simplifies the resolution of the processor facts on OpenBSD by using the sysctl `hw.model` and `hw.ncpu` values Previously` /var/run/dmesg.boot` or dmesg(8) would be parsed however that could lead to bogus values (e.g. there would be `Enhanced SpeedStep 2195 MHz: speeds: 2301, 2300, 2200, 2000, 1900, 1800, 1700, 1500, 1400, 1300, 1100, 1000, 900, 800, 600, 500 MHz` entry in `ansible_processor`) if the buffer contained multiple (partial) dmesgs.

This also brings the output inline with Linux for example where the trailing `, 1234.56 MHz` isn't present either.

<!-- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
        "ansible_processor": [
            "Intel(R) Core(TM) i5-5300U CPU @ 2.30GHz, 2195.12 MHz",
            "Intel(R) Core(TM) i5-5300U CPU @ 2.30GHz, 2194.92 MHz",
            "Intel(R) Core(TM) i5-5300U CPU @ 2.30GHz, 2194.92 MHz",
            "Intel(R) Core(TM) i5-5300U CPU @ 2.30GHz, 2194.92 MHz"
        ],
        "ansible_processor_cores": "NA",
        "ansible_processor_count": 4,
```

After:
```
        "ansible_processor": [
            "Intel(R) Core(TM) i5-5300U CPU @ 2.30GHz",
            "Intel(R) Core(TM) i5-5300U CPU @ 2.30GHz",
            "Intel(R) Core(TM) i5-5300U CPU @ 2.30GHz",
            "Intel(R) Core(TM) i5-5300U CPU @ 2.30GHz"
        ],
        "ansible_processor_count": 4,
```
