### PR TITLE
Fix for #14430: 'changed_when: True' does not display the task as cha…

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -534,7 +534,7 @@ class TaskExecutor:
 
             # if we didn't skip this task, use the helpers to evaluate the changed/
             # failed_when properties
-            if 'skipped' not in result:
+            if 'skipped' not in result and 'debug' not in self._task.action:
                 _evaluate_changed_when_result(result)
                 _evaluate_failed_when_result(result)
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
callback

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel e4115e0b98) last updated 2016/11/01 12:23:33 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 679a0ae5e9) last updated 2016/11/01 12:14:14 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD cf524673e1) last updated 2016/11/01 12:14:14 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
###### The Bug
When forcing a 'debug'-task to be flagged as 'changed' with 'changed_when': True, the task itself prints as 'ok', while it is counted as 'changed' in the end-results. This is caused by the '_clean_results'-function, which removes the 'changed'-entry from the results-variable. However, this happens after the task is counted as 'changed', so an inconsistency is born.

###### The Fix
It's good that by default the 'changed'-entry is removed. However, if 'changed_when: True' is it's clear that the intention is that it should be marked as 'changed', both in task-result and in play-result. That's why it seemed best to prevent the 'changed'-result from being removed when it's value is True.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
This is the result. The first is a normal debug task, and the second one is marked with 'changed_when: True'.
```
TASK [Debug Test Ok] **************************************************************
ok: [localhost] => {
    "msg": "Test message that should be green, and ok.
}

TASK [Debug Test Changed] **************************************************************
changed: [localhost] => {
    "changed": true, 
    "msg": "Test message that should be yellow, and changed."
}
```