### PR TITLE
fix iteritems for python 3

### DIFF
--- a/lib/ansible/module_utils/cloudstack.py
+++ b/lib/ansible/module_utils/cloudstack.py
@@ -29,6 +29,7 @@
 
 import os
 import time
+from ansible.module_utils.six import iteritems
 
 try:
     from cs import CloudStack, CloudStackException, read_config


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/Cloudstack Modules

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### SUMMARY
When invoking cloudstack modules with connection local on a system that uses Pyhton3 as default, it will fail; iteritems() is no longer working in Py3:   

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'dict' object has no attribute 'iteritems'
fatal: [k8s-01.eq.prod.cargo.local]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_42cktthy/ansible_module_cs_instance.py\", line 1002, in <module>\n    main()\n  File \"/tmp/ansible_42cktthy/ansible_module_cs_instance.py\", line 975, in main\n    instance = acs_instance.present_instance()\n  File \"/tmp/ansible_42cktthy/ansible_module_cs_instance.py\", line 587, in present_instance\n    instance = self.update_instance(instance=instance, start_vm=start_vm)\n  File \"/tmp/ansible_42cktthy/ansible_module_cs_instance.py\", line 679, in update_instance\n    service_offering_changed = self.has_changed(args_service_offering, instance)\n  File \"/tmp/ansible_42cktthy/ansible_modlib.zip/ansible/module_utils/cloudstack.py\", line 151, in has_changed\nAttributeError: 'dict' object has no attribute 'iteritems'\n", "module_stdout": "", "msg": "MODULE FAILURE"}
```

Fix is implemented as suggested by @resmo 