### PR TITLE
Update syslog_json.py

### DIFF
--- a/lib/ansible/plugins/callback/syslog_json.py
+++ b/lib/ansible/plugins/callback/syslog_json.py
@@ -22,6 +22,7 @@ class CallbackModule(CallbackBase):
     This plugin makes use of the following environment variables:
         SYSLOG_SERVER   (optional): defaults to localhost
         SYSLOG_PORT     (optional): defaults to 514
+        SYSLOG_FACILITY (optional): defaults to user
     """
     CALLBACK_VERSION = 2.0
     CALLBACK_TYPE = 'aggregate'
@@ -38,7 +39,7 @@ class CallbackModule(CallbackBase):
         self.handler = logging.handlers.SysLogHandler(
             address = (os.getenv('SYSLOG_SERVER','localhost'),
                        os.getenv('SYSLOG_PORT',514)), 
-            facility=logging.handlers.SysLogHandler.LOG_USER
+            facility= os.getenv('SYSLOG_FACILITY',logging.handlers.SysLogHandler.LOG_USER)
         )
         self.logger.addHandler(self.handler)
         self.hostname = socket.gethostname()


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
plugins/callback/syslog_json.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.1.1.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I would like to  set the syslog facility to a different value then the current one when using the callback.
I was ask to send ansible output via syslog to a different facility 
The plugin was already using environment variables for configuration.

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
N/A
```

Add SYSLOG_FACILITY environment variable to set syslog facility of the callback syslog_json