### PR TITLE
set galaxy cli unit test server to None

### DIFF
--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -135,7 +135,7 @@ class TestGalaxy(unittest.TestCase):
 
     def test_exit_without_ignore(self):
         ''' tests that GalaxyCLI exits with the error specified unless the --ignore-errors flag is used '''
-        gc = GalaxyCLI(args=["install", "-c", "fake_role_name"])
+        gc = GalaxyCLI(args=["install", "--server=None", "-c", "fake_role_name"])
 
         # testing without --ignore-errors flag
         galaxy_parser = gc.parse()
@@ -145,7 +145,7 @@ class TestGalaxy(unittest.TestCase):
             self.assertTrue(mocked_display.called_once_with("- downloading role 'fake_role_name', owned by "))
 
         # testing with --ignore-errors flag
-        gc = GalaxyCLI(args=["install", "-c", "fake_role_name", "--ignore-errors"])
+        gc = GalaxyCLI(args=["install", "--server=None", "-c", "fake_role_name", "--ignore-errors"])
         galalxy_parser = gc.parse()
         with patch.object(ansible.utils.display.Display, "display", return_value=None) as mocked_display:
             # testing that error expected is not raised with --ignore-errors flag in use


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
galaxy cli unit tests

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```

##### SUMMARY

Fixes #18297

Related to https://github.com/ansible/ansible/pull/18296