### PR TITLE
Print ssh message even if it return 255

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -599,7 +599,7 @@ class Connection(ConnectionBase):
                 if return_tuple[0] != 255:
                     break
                 else:
-                    raise AnsibleConnectionFailure("Failed to connect to the host via ssh.")
+                    raise AnsibleConnectionFailure("Failed to connect to the host via ssh or something was wrong. stderr:"+return_tuple[2]+"stdout:"+return_tuple[1])
             except (AnsibleConnectionFailure, Exception) as e:
                 if attempt == remaining_tries - 1:
                     raise


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
plugin/connection

##### ANSIBLE VERSION
```
ansible 2.1.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
Return the stderr / stdout from ssh command. 255 is not always that ssh connection was not posible.

test : 
```
$ ansible -m raw -i localhost, localhost -a "echo hola; exit 255;"
localhost | UNREACHABLE! => {
    "changed": false, 
    "msg": "Failed to connect to the host via ssh.", 
    "unreachable": true
}
```
Perl default error code when it does not compile is 255

It should return stdout and stderr from ssh output:
```
$ ssh localhost "echo hola; exit 255;"
hola
$ echo $?
255
```
Before:
```
localhost | UNREACHABLE! => {
    "changed": false, 
    "msg": "Failed to connect to the host via ssh"
    "unreachable": true
}
```
After (should be unreachable: false) :
```
localhost | UNREACHABLE! => {
    "changed": false, 
    "msg": "Failed to connect to the host via ssh or something was wrong.stdout: Global symbol \"$c\" requires explicit package name (did you forget to declare \"my $c\"?) at /home/javi/.ansible/tmp/ansible-tmp-1478071077.6-230805290959721/testing line 3.\r\nExecution of /home/javi/.ansible/tmp/ansible-tmp-1478071077.6-230805290959721/testing aborted due to compilation errors.\r\nstderr:", 
    "unreachable": true
}

```

This is to fix the "no-issue" https://github.com/ansible/ansible-modules-core/issues/5410

Thanks