### PR TITLE
improving readme on dynamic inventory for ec2.ini options

### DIFF
--- a/docsite/rst/intro_dynamic_inventory.rst
+++ b/docsite/rst/intro_dynamic_inventory.rst
@@ -133,10 +133,12 @@ If you use Boto profiles to manage multiple AWS accounts, you can pass ``--profi
     aws_access_key_id = <prod access key>
     aws_secret_access_key = <prod secret key>
 
-You can then run ``ec2.py --profile prod`` to get the inventory for the prod account, this option is not supported by ``ansible-playbook`` though.
-But you can use the ``AWS_PROFILE`` variable - e.g. ``AWS_PROFILE=prod ansible-playbook -i ec2.py myplaybook.yml``
+You can then run ``ec2.py --profile prod`` to get the inventory for the prod account, although this option is not supported by ``ansible-playbook``.
+You can also use the ``AWS_PROFILE`` variable - for example: ``AWS_PROFILE=prod ansible-playbook -i ec2.py myplaybook.yml``
 
-Since each region requires its own API call, if you are only using a small set of regions, feel free to edit ``ec2.ini`` and list only the regions you are interested in. There are other config options in ``ec2.ini`` including cache control, and destination variables. The ``ec2.ini`` file presumably defaults to **all the features** which for many admins is probably appropriate. If you have limited scope of what your ``IAM`` user is capable of, i.e, you would not have access to certain component, just comment/toggle the appropriate lines. For example,if you don't have ``RDS`` and ``elasticache`` access toggle to ``False`` ::
+Since each region requires its own API call, if you are only using a small set of regions, you can edit the``ec2.ini`` file and comment out the regions you are not using. 
+
+There are other config options in ``ec2.ini``, including cache control and destination variables. By default, the ``ec2.ini`` file is configured for **all Amazon cloud services**, but you can comment out any features that aren't applicable. For example, if you don't have ``RDS`` or ``elasticache``, you can set them to ``False`` ::
 
     [ec2]
     ...

--- a/docsite/rst/intro_dynamic_inventory.rst
+++ b/docsite/rst/intro_dynamic_inventory.rst
@@ -136,7 +136,17 @@ If you use Boto profiles to manage multiple AWS accounts, you can pass ``--profi
 You can then run ``ec2.py --profile prod`` to get the inventory for the prod account, this option is not supported by ``ansible-playbook`` though.
 But you can use the ``AWS_PROFILE`` variable - e.g. ``AWS_PROFILE=prod ansible-playbook -i ec2.py myplaybook.yml``
 
-Since each region requires its own API call, if you are only using a small set of regions, feel free to edit ``ec2.ini`` and list only the regions you are interested in. There are other config options in ``ec2.ini`` including cache control, and destination variables.
+Since each region requires its own API call, if you are only using a small set of regions, feel free to edit ``ec2.ini`` and list only the regions you are interested in. There are other config options in ``ec2.ini`` including cache control, and destination variables. The ``ec2.ini`` file presumably defaults to **all the features** which for many admins is probably appropriate. If you have limited scope of what your ``IAM`` user is capable of, i.e, you would not have access to certain component, just comment/toggle the appropriate lines. For example,if you don't have ``RDS`` and ``elasticache`` access toggle to ``False`` ::
+
+    [ec2]
+    ...
+
+    # To exclude RDS instances from the inventory, uncomment and set to False.
+    rds = False
+
+    # To exclude ElastiCache instances from the inventory, uncomment and set to False.
+    elasticache = False
+    ...
 
 At their heart, inventory files are simply a mapping from some name to a destination address. The default ``ec2.ini`` settings are configured for running Ansible from outside EC2 (from your laptop for example) -- and this is not the most efficient way to manage EC2.
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
-  docsite/rst/intro_dynamic_inventory wiki-guidelines

##### ANSIBLE VERSION
```
ansible 2.1.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides```
```

##### SUMMARY
This PR is to address the old recurring unfriendly error message like this: https://github.com/ansible/ansible/issues/10840
From the discussion there, seems its better if the issues is address via proper documentation. So writing some guidelines with   _been there done that_ feeling ;) 

Basically the docs explains in more verbose how to properly configure the aws dynamic inventory script settings to avoid unnecessary headache with and example use-case that's common to newbie users fiddling with the ansible-aws-dynamic-host workflow.

@jctanner here it comes my PR 😎
