### PR TITLE
Resolves #18312 python3 support for ec2.py

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -1313,7 +1313,7 @@ class Ec2Inventory(object):
             elif key == 'ec2_tags':
                 for k, v in value.items():
                     if self.expand_csv_tags and ',' in v:
-                        v = map(lambda x: x.strip(), v.split(','))
+                        v = list(map(lambda x: x.strip(), v.split(',')))
                     key = self.to_safe('ec2_tag_' + k)
                     instance_vars[key] = v
             elif key == 'ec2_groups':


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
ec2.py inventory file

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
 $  ansible --version
ansible 2.2.0.0
  config file = /Users/akinsley/code/src/git.viasat.com/databus/databox/ansible.cfg
  configured module search path = ['./library']
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #18312 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

In python 3 map returns a generator instead of the output of the iterator. This change wraps the call in list to force the generator to operate on the data at that moment. This allows the inventory to be json serializable. 


