### PR TITLE
Support retrying `vagrant status` and `vagrant ssh-config` commands

### DIFF
--- a/contrib/inventory/vagrant.py
+++ b/contrib/inventory/vagrant.py
@@ -73,7 +73,7 @@ parser.add_option('--host', default=None, dest="host",
 
 # Given Vagrant's locking situation when communicating with instances, it's
 # possible to recover from some errors if we just wait and retry.
-def subprocess_with_retry(cmd, retry_count=3, retry_wait=1):
+def subprocess_with_retry(cmd, retry_count=3, retry_wait=10):
     pipes = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,

--- a/contrib/inventory/vagrant.py
+++ b/contrib/inventory/vagrant.py
@@ -81,7 +81,7 @@ def subprocess_with_retry(cmd, retry_count=3, retry_wait=10):
     std_out, std_err = pipes.communicate()
 
     if pipes.returncode == 0:
-        return std_out
+        return to_text(std_out, errors='surrogate_or_strict')
     else:
         retry_count -= 1
         if retry_count <= 0:
@@ -98,7 +98,7 @@ def get_ssh_config():
 # list all the running boxes
 def list_running_boxes():
 
-    output = to_text(subprocess_with_retry(["vagrant", "status"]), errors='surrogate_or_strict').split('\n')
+    output = subprocess_with_retry(["vagrant", "status"]).split('\n')
 
     boxes = []
 
@@ -114,7 +114,7 @@ def list_running_boxes():
 def get_a_ssh_config(box_name):
     """Gives back a map of all the machine's ssh configurations"""
 
-    output = to_text(subprocess_with_retry(["vagrant", "ssh-config", box_name]), errors='surrogate_or_strict')
+    output = subprocess_with_retry(["vagrant", "ssh-config", box_name])
     config = SSHConfig()
     config.parse(StringIO(output))
     host_config = config.lookup(box_name)

--- a/contrib/inventory/vagrant.py
+++ b/contrib/inventory/vagrant.py
@@ -84,7 +84,7 @@ def subprocess_with_retry(cmd, retry_count=3, retry_wait=1):
         return std_out
     else:
         retry_count -= 1
-        if retry_count < 0:
+        if retry_count <= 0:
             raise Exception(std_err.strip())
         time.sleep(retry_wait)
         return subprocess_with_retry(cmd, retry_count, retry_wait)


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
dynamic inventory / vagrant

##### ANSIBLE VERSION
```
ansible 2.1.2.0
```

##### SUMMARY
Vagrant locks when communicating with it's managed instances.  When attempting to run concurrent Ansible jobs that do not interfere with each other, this locking behavior will cause the dynamic inventory to fail on one or more of the ansible processes.

This change enables wait-and-retry on `vagrant status` and `vagrant ssh-config` commands, to give us a chance of recovering from this condition.
