### PR TITLE
Clean up shebangs for various files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-#!/usr/bin/make
 # WARN: gmake syntax
 ########################################################
 # Makefile for Ansible

--- a/contrib/inventory/brook.ini
+++ b/contrib/inventory/brook.ini
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # Copyright 2016 Doalitic.
 #
 # This file is part of Ansible

--- a/contrib/inventory/cloudforms.py
+++ b/contrib/inventory/cloudforms.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # vim: set fileencoding=utf-8 :
 #
 # Copyright (C) 2016 Guido Günther <agx@sigxcpu.org>

--- a/contrib/inventory/gce.ini
+++ b/contrib/inventory/gce.ini
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # Copyright 2013 Google Inc.
 #
 # This file is part of Ansible

--- a/contrib/inventory/nsot.py
+++ b/contrib/inventory/nsot.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 '''
 nsot

--- a/contrib/inventory/rackhd.py
+++ b/contrib/inventory/rackhd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import json
 import requests

--- a/contrib/inventory/spacewalk.py
+++ b/contrib/inventory/spacewalk.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/env python
 
 """
 Spacewalk external inventory script

--- a/docsite/Makefile
+++ b/docsite/Makefile
@@ -1,4 +1,3 @@
-#!/usr/bin/make
 SITELIB = $(shell python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")
 FORMATTER=../hacking/module_formatter.py
 DUMPER=../hacking/dump_playbook_attributes.py

--- a/examples/scripts/uptime.py
+++ b/examples/scripts/uptime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from collections import namedtuple
 from ansible.parsing.dataloader import DataLoader
 from ansible.vars import VariableManager

--- a/hacking/update_bundled.py
+++ b/hacking/update_bundled.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2 -tt
+#!/usr/bin/env python
 
 import glob
 import json
@@ -25,7 +25,7 @@ for filename in glob.glob(os.path.join(basedir, '../lib/ansible/compat/*/__init_
             continue
         metadata = json.loads(data)
         pypi_fh = open_url('https://pypi.python.org/pypi/{0}/json'.format(metadata['pypi_name']))
-        pypi_data = json.loads(pypi_fh.read())
+        pypi_data = json.loads(pypi_fh.read().decode('utf-8'))
         if LooseVersion(metadata['version']) < LooseVersion(pypi_data['info']['version']):
             print('UPDATE: {0} from {1} to {2} {3}'.format(
                 metadata['pypi_name'],

--- a/hacking/yamlcheck.py
+++ b/hacking/yamlcheck.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # long version of this one liner: python -c 'import yaml,sys;yaml.safe_load(sys.stdin)' < yamltest.txt
 import yaml
 import sys

--- a/lib/ansible/module_utils/f5.py
+++ b/lib/ansible/module_utils/f5.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # This code is part of Ansible, but is an independent component.

--- a/lib/ansible/module_utils/lxd.py
+++ b/lib/ansible/module_utils/lxd.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # (c) 2016, Hiroaki Nakamura <hnakamur@gmail.com>

--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016 Red Hat, Inc.

--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # (c) 2012-2013, Timothy Appnel <tim@appnel.com>

--- a/lib/ansible/utils/module_docs_fragments/azure.py
+++ b/lib/ansible/utils/module_docs_fragments/azure.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-#
 # Copyright (c) 2016 Matt Davis, <mdavis@ansible.com>
 #                    Chris Houseknecht, <house@redhat.com>
 #

--- a/lib/ansible/utils/module_docs_fragments/azure_tags.py
+++ b/lib/ansible/utils/module_docs_fragments/azure_tags.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-#
 # Copyright (c) 2016 Matt Davis, <mdavis@ansible.com>
 #                    Chris Houseknecht, <house@redhat.com>
 #

--- a/lib/ansible/utils/module_docs_fragments/ovirt.py
+++ b/lib/ansible/utils/module_docs_fragments/ovirt.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
 # Copyright (c) 2016 Red Hat, Inc.

--- a/test/sanity/code-smell/shebang.sh
+++ b/test/sanity/code-smell/shebang.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+grep '^#!' -RIn . 2>/dev/null | grep ':1:' | sed 's/:1:/:/' | grep -v -E \
+    -e '^\./lib/ansible/modules/' \
+    -e '^\./test/integration/targets/[^/]*/library/[^/]*:#!powershell$' \
+    -e ':#!/bin/sh$' \
+    -e ':#!/bin/bash( -[eux]|$)' \
+    -e ':#!/usr/bin/make -f$' \
+    -e ':#!/usr/bin/env python$' \
+    -e ':#!/usr/bin/env bash$' \
+    -e ':#!/usr/bin/env fish$'
+
+if [ $? -ne 1 ]; then
+    echo "One or more file(s) listed above have an unexpected shebang."
+    echo "See $0 for the list of acceptable values."
+    exit 1
+fi

--- a/test/units/modules/extras/cloud/amazon/test_ec2_vpc_nat_gateway.py
+++ b/test/units/modules/extras/cloud/amazon/test_ec2_vpc_nat_gateway.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 from nose.plugins.skip import SkipTest
 
 try:
@@ -489,9 +487,3 @@ class AnsibleEc2VpcNatGatewayFunctions(unittest.TestCase):
         )
         self.assertFalse(success)
         self.assertFalse(changed)
-
-def main():
-    unittest.main()
-
-if __name__ == '__main__':
-    main()

--- a/test/units/modules/extras/cloud/amazon/test_kinesis_stream.py
+++ b/test/units/modules/extras/cloud/amazon/test_kinesis_stream.py
@@ -1,5 +1,3 @@
-#!/usr/bin/python
-
 from nose.plugins.skip import SkipTest
 
 try:
@@ -287,10 +285,3 @@ class AnsibleKinesisStreamFunctions(unittest.TestCase):
         self.assertTrue(changed)
         self.assertEqual(results, should_return)
         self.assertEqual(err_msg, 'Kinesis Stream test updated successfully.')
-
-
-def main():
-    unittest.main()
-
-if __name__ == '__main__':
-    main()

--- a/test/units/parsing/utils/test_jsonify.py
+++ b/test/units/parsing/utils/test_jsonify.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # -*- coding: utf-8 -*-
 # (c) 2016, James Cammarata <jimi@sngx.net>
 #

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # (c) 2015, Florian Apolloner <florian@apolloner.eu>
 #

--- a/test/utils/shippable/code-smell.sh
+++ b/test/utils/shippable/code-smell.sh
@@ -20,6 +20,7 @@ test/sanity/code-smell/replace-urlopen.sh .
 test/sanity/code-smell/use-compat-six.sh lib
 test/sanity/code-smell/boilerplate.sh
 test/sanity/code-smell/required-and-default-attributes.sh
+test/sanity/code-smell/shebang.sh
 
 shellcheck \
     test/integration/targets/*/*.sh \


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

Various

##### ANSIBLE VERSION

```
ansible 2.3.0 (shebang ddb9fb1ace) last updated 2016/11/02 15:03:38 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 76fd19c3ca) last updated 2016/11/02 14:28:40 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD fcea282185) last updated 2016/11/02 14:29:02 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Clean up shebangs for various files.

- Remove shebangs from:
  - ini files
  - unit tests
  - module_utils
  - plugins
  - module_docs_fragments
  - non-executable Makefiles
- Change non-modules from `/usr/bin/python` to `/usr/bin/env python`.
- Change `/bin/env` to `/usr/bin/env`.

Also removed main functions from unit tests (since they no longer have a shebang) and fixed a python 3 compatibility issue with update_bundled.py so it does not need to specify a python 2 shebang.

A script was added to check for unexpected shebangs in files. This script is run during CI on Shippable.