### PR TITLE
Fix indentation of multiline descriptions

### DIFF
--- a/hacking/templates/rst.j2
+++ b/hacking/templates/rst.j2
@@ -79,7 +79,7 @@ Options
     {% else %}
     <td><ul>{% for choice in v.get('choices',[]) -%}<li>@{ choice }@</li>{% endfor -%}</ul></td>
     {% endif %}
-    <td>{% for desc in v.description -%}<div>@{ desc | html_ify }@</div>{% endfor -%} {% if 'aliases' in v and v.aliases -%}</br>
+    <td>{% for desc in v.description -%}<div>@{ desc | replace('\n', '\n    ') | html_ify }@</div>{% endfor -%} {% if 'aliases' in v and v.aliases -%}</br>
         <div style="font-size: small;">aliases: @{ v.aliases|join(', ') }@<div>{%- endif %}</td></tr>
     {% endfor %}
     </table>


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
hacking/templates/rst.j2

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

##### SUMMARY
When generating html docs, the options table is created as raw html rather than an rst html table.  Because the raw html is inside of an rst html block we need to keep a proper indentation level.  The description of options element wasn't doing that previously if there were embedded newlines inside of them.  This fix changes embedded newlines into a newline plus indentation so that it does not end the raw block.