### PR TITLE
Exclude floppy disks from lsblk call for uuids

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1228,7 +1228,11 @@ class LinuxHardware(Hardware):
                     self.facts[k] = 'NA'
 
     def _run_lsblk(self, lsblk_path):
-        args = ['--list', '--noheadings', '--paths',  '--output', 'NAME,UUID']
+        # call lsblk and collect all uuids
+        # --exclude 2 makes lsblk ignore floppy disks, which are slower to answer than typical timeouts
+        # this uses the linux major device number
+        # for details see https://www.kernel.org/doc/Documentation/devices.txt
+        args = ['--list', '--noheadings', '--paths',  '--output', 'NAME,UUID', '--exclude', '2']
         cmd = [lsblk_path] + args
         rc, out, err = self.module.run_command(cmd)
         return rc, out, err


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
setup
 lib/ansible/module_utils/facts.py 

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### SUMMARY
Fixes #18326

Since #17036 `lsblk` first collects uuids from all devices and then connects those to the active mounts. This also includes floppy drives, which are a lot slower to answer than HDD/SSD/network.

This patch adds the option `--exclude 2`, that excludes floppy drives from the lsblk command.

Consequences:
1. runtime of lsblk goes from 12 seconds to 0.1 seconds in our use case
2. floppy mounts are listed with `uuid: N/A`

Does anyone care for the uuid of floppy discs? If not I would favor 1. over 2. and ask you to merge this in also in 2.2 stable.