### PR TITLE
Add support for AWS profiles and IAM ARN for AssumeRole.

### DIFF
--- a/lib/ansible/plugins/lookup/credstash.py
+++ b/lib/ansible/plugins/lookup/credstash.py
@@ -41,8 +41,14 @@ class LookupModule(LookupBase):
                 version = kwargs.pop('version', '')
                 region = kwargs.pop('region', None)
                 table = kwargs.pop('table', 'credential-store')
+
+                profile = kwargs.pop('profile', None)
+                arn = kwargs.pop('arn', None)
+
+                session_params = credstash.get_session_params(profile, arn)
+
                 val = credstash.getSecret(term, version, region, table,
-                                          context=kwargs)
+                                          context=kwargs, **session_params)
             except credstash.ItemNotFound:
                 raise AnsibleError('Key {0} not found'.format(term))
             except Exception as e:


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Credstash Lookup

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = ~/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Add AWS profiles and IAM ARN for AssumeRole support to Credstash lookup plugin.

