### PR TITLE
ANSIBLE_SSH_CONTROL_PATH_DIR option added

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -295,6 +295,13 @@
 # paramiko on older platforms rather than removing it, -C controls compression use
 #ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s
 
+# The base directory for the ControlPath sockets. 
+# This is the "%(directory)s" in the control_path option
+# 
+# Example: 
+# control_path_dir = /tmp/.ansible/cp
+#control_path_dir = $HOME/.ansible/cp
+
 # The path to use for the ControlPath sockets. This defaults to
 # "%(directory)s/ansible-ssh-%%h-%%p-%%r", however on some systems with
 # very long hostnames or very long path names (caused by long user names or

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -299,6 +299,7 @@ MAX_FILE_SIZE_FOR_DIFF         = get_config(p, DEFAULTS, 'max_diff_size', 'ANSIB
 # CONNECTION RELATED
 ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'ANSIBLE_SSH_ARGS', '-C -o ControlMaster=auto -o ControlPersist=60s')
 ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', u"%(directory)s/ansible-ssh-%%h-%%p-%%r")
+ANSIBLE_SSH_CONTROL_PATH_DIR   = get_config(p, 'ssh_connection', 'control_path_dir', 'ANSIBLE_SSH_CONTROL_PATH_DIR', u'$HOME/.ansible/cp')
 ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', False, value_type='boolean')
 ANSIBLE_SSH_RETRIES            = get_config(p, 'ssh_connection', 'retries', 'ANSIBLE_SSH_RETRIES', 0, value_type='integer')
 ANSIBLE_SSH_EXECUTABLE         = get_config(p, 'ssh_connection', 'ssh_executable', 'ANSIBLE_SSH_EXECUTABLE', 'ssh')

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -228,7 +228,7 @@ class Connection(ConnectionBase):
             self._persistent = True
 
             if not controlpath:
-                cpdir = unfrackpath(u'$HOME/.ansible/cp')
+                cpdir = unfrackpath(C.ANSIBLE_SSH_CONTROL_PATH_DIR)
                 b_cpdir = to_bytes(cpdir, errors='surrogate_or_strict')
 
                 # The directory must exist and be writable.


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ssh.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible --version
ansible 2.3.0 (ssh_cp_option_fix_18325 e2f63cfa10) last updated 2016/11/03 17:14:11 (GMT +000)
  lib/ansible/modules/core: (detached HEAD 7cc4d3fe04) last updated 2016/11/03 16:38:01 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD e4bc618956) last updated 2016/11/03 16:38:01 (GMT +000)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
This removes the hardcoded value ( $HOME/.ansible/cp ) from ssh.py.
User is able to change the ControlPath directory ( the one that replaces %(directory)s ).

 Fixes #18325

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
# ansible -vvvvvi hosts all -m ping
Using /root/.ansible.cfg as config file
[...]
<localhost> SSH: found only ControlPersist; added ControlPath: (-o)(ControlPath=/tmp/ansible/cp/ansible-ssh-%h-%p-%r)
[...]


# ansible -vvvvvi hosts all -m ping
No config file found; using defaults
[...]
<localhost> SSH: found only ControlPersist; added ControlPath: (-o)(ControlPath=/root/.ansible/cp/ansible-ssh-%h-%p-%r)
[...]
```

