### PR TITLE
Playbook parsing add error info if tabs are found in the yaml

### DIFF
--- a/lib/ansible/errors/__init__.py
+++ b/lib/ansible/errors/__init__.py
@@ -24,7 +24,8 @@ from ansible.errors.yaml_strings import ( YAML_POSITION_DETAILS,
         YAML_COMMON_DICT_ERROR,
         YAML_COMMON_UNQUOTED_COLON_ERROR,
         YAML_COMMON_PARTIALLY_QUOTED_LINE_ERROR,
-        YAML_COMMON_UNBALANCED_QUOTES_ERROR )
+        YAML_COMMON_UNBALANCED_QUOTES_ERROR,
+        YAML_COMMON_LEADING_TAB_ERROR)
 from ansible.module_utils._text import to_native, to_text
 
 
@@ -111,6 +112,9 @@ class AnsibleError(Exception):
                     #header_line   = ("=" * 73)
                     error_message += "\nThe offending line appears to be:\n\n%s\n%s\n%s\n" % (prev_line.rstrip(), target_line.rstrip(), arrow_line)
 
+                    # TODO: There may be cases where there is a valid tab in a line that has other errors.
+                    if '\t' in target_line:
+                        error_message += YAML_COMMON_LEADING_TAB_ERROR
                     # common error/remediation checking here:
                     # check for unquoted vars starting lines
                     if ('{{' in target_line and '}}' in target_line) and ('"{{' not in target_line or "'{{" not in target_line):

--- a/lib/ansible/errors/yaml_strings.py
+++ b/lib/ansible/errors/yaml_strings.py
@@ -116,3 +116,20 @@ Could be written as:
     foo: '"bad" "wolf"'
 """
 
+YAML_COMMON_LEADING_TAB_ERROR = """\
+There appears to be a tab character at the start of the line.
+
+YAML does not use tabs for formatting. Tabs should be replaced with spaces.
+
+For example:
+    - name: update tooling
+      vars:
+        version: 1.2.3
+#    ^--- there is a tab there.
+
+Should be written as:
+    - name: update tooling
+      vars:
+        version: 1.2.3
+# ^--- all spaces here.
+"""

--- a/test/units/parsing/yaml/test_loader.py
+++ b/test/units/parsing/yaml/test_loader.py
@@ -37,8 +37,10 @@ from units.mock.yaml_helper import YamlTestUtils
 
 try:
     from _yaml import ParserError
+    from _yaml import ScannerError
 except ImportError:
     from yaml.parser import ParserError
+    from yaml.scanner import ScannerError
 
 
 class NameStringIO(StringIO):
@@ -144,6 +146,11 @@ class TestAnsibleLoaderBasic(unittest.TestCase):
         stream = StringIO(u"""{""")
         loader = AnsibleLoader(stream, 'myfile.yml')
         self.assertRaises(ParserError, loader.get_single_data)
+
+    def test_tab_error(self):
+        stream = StringIO(u"""---\nhosts: localhost\nvars:\n  foo: bar\n\tblip: baz""")
+        loader = AnsibleLoader(stream, 'myfile.yml')
+        self.assertRaises(ScannerError, loader.get_single_data)
 
     def test_front_matter(self):
         stream = StringIO(u"""---\nfoo: bar""")


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
lib/ansible/error
uxd

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (show_tab_errors_in_yaml 119dd0b0f3) last updated 2016/11/03 13:31:14 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 7cc4d3fe04) last updated 2016/11/03 12:00:46 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD e4bc618956) last updated 2016/11/03 12:00:46 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
If a yaml file fails to load because of tabs being used
for formatting, detect that and show a error message
with more details.

Before, a tab would cause a syntax error, and the extended yaml error message would show you
where, but it wouldn't indicate a tab was at fault. So it just pointed at an invisible error.

for ex, before:
```
[fedora-23:ansible (devel % u=)]$ cat bad_tab.yml 

---
# There is a tab in the '- name: ping' line
- name: The first Play
  hosts: localhost
  gather_facts: False
  tasks:
        - name: ping
          ping:
[fedora-23:ansible (devel % u=)]$ ansible-playbook bad_tab.yml 
 [WARNING]: provided hosts list is empty, only localhost is available

ERROR! Syntax Error while loading YAML.


The error appears to have been in '/home/adrian/src/ansible/bad_tab.yml': line 7, column 1, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  tasks:
        - name: ping
^ here
```

and after:

```
[fedora-23:ansible (show_tab_errors_in_yaml %)]$ cat bad_tab.yml 

---
# There is a tab in the '- name: ping' line
- name: The first Play
  hosts: localhost
  gather_facts: False
  tasks:
        - name: ping
          ping:
[fedora-23:ansible (show_tab_errors_in_yaml %)]$ ansible-playbook bad_tab.yml 
 [WARNING]: provided hosts list is empty, only localhost is available

ERROR! Syntax Error while loading YAML.


The error appears to have been in '/home/adrian/src/ansible/bad_tab.yml': line 7, column 1, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  tasks:
        - name: ping
^ here
There appears to be a tab character at the start of the line.

YAML does not use tabs for formatting. Tabs should be replaced with spaces.

For example:
    - name: update tooling
      vars:
        version: 1.2.3
#    ^--- there is a tab there.

Should be written as:
    - name: update tooling
      vars:
        version: 1.2.3
# ^--- all spaces here.
```