### PR TITLE
Fix setup.py install.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(name='ansible',
       package_dir={ '': 'lib' },
       packages=find_packages('lib'),
       package_data={
-         '': ['module_utils/*.ps1', 'modules/core/windows/*.ps1', 'modules/extras/windows/*.ps1', 'galaxy/data/*'],
+         '': ['module_utils/*.ps1', 'modules/core/windows/*.ps1', 'modules/extras/windows/*.ps1', 'galaxy/data/*/*.*', 'galaxy/data/*/*/*.*', 'galaxy/data/*/tests/inventory'],
       },
       classifiers=[
           'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
setup.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

##### SUMMARY

In setuptools prior to 21.2.1, package_data can't directly reference
a directory.  Modify the entry for galaxy data so that it includes the
files but not the directories

Fixes #18231