### PR TITLE
group_add: fix when key is an int

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -231,7 +231,7 @@ class Inventory(object):
 
         # Check if pattern already computed
         if isinstance(pattern, list):
-            pattern_hash = u":".join(pattern)
+            pattern_hash = u":".join(to_text(p) for p in pattern)
         else:
             pattern_hash = pattern
 
@@ -293,8 +293,8 @@ class Inventory(object):
 
         # If it's got commas in it, we'll treat it as a straightforward
         # comma-separated list of patterns.
-
-        elif ',' in pattern:
+        pattern = to_text(pattern)
+        if ',' in pattern:
             patterns = re.split('\s*,\s*', pattern)
 
         # If it doesn't, it could still be a single pattern. This accounts for

--- a/lib/ansible/plugins/action/group_by.py
+++ b/lib/ansible/plugins/action/group_by.py
@@ -17,6 +17,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from ansible.module_utils._text import to_text
 from ansible.plugins.action import ActionBase
 
 
@@ -37,7 +38,7 @@ class ActionModule(ActionBase):
             result['msg'] = "the 'key' param is required when using group_by"
             return result
 
-        group_name = self._task.args.get('key')
+        group_name = to_text(self._task.args.get('key'))
         group_name = group_name.replace(' ','-')
 
         result['changed'] = False


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
group_add

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel, 2.2, 2.1
```

##### SUMMARY
this fixes an issue if group_add key is an int. 
fixes https://github.com/ansible/ansible-modules-core/issues/5415
Inventory:
~~~
host1 groupkey=1
~~~
Playbook
~~~
- hosts: all
  gather_facts: no
  tasks:
  - group_by: key={{ groupkey }}

- hosts: "1"
  gather_facts: no
  tasks:
  - debug: msg="ok"
~~~

Without this patch the above play with error out with
~~~
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'int' object has no attribute 'replace'
fatal: [host1]: FAILED! => {"failed": true, "msg": "Unexpected failure during module execution.", "stdout": ""}
~~~

Note: in the bug description (https://github.com/ansible/ansible-modules-core/issues/5415) the play target looks like `- hosts: 1`. This is IMHO invalid syntax (valid is `- hosts: "1"`) and ansible will still complain (which is expected) with
~~~
ERROR! the field 'hosts' should be a list of (<type 'basestring'>,), but the item '1' is a <type 'int'>

The error appears to have been in '/home/resmo/Projects/resmo/ansible-bug-repo/core-5415/test.yml': line 6, column 3, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:


- hosts: 1
  ^ here
~~~