### PR TITLE
Python 3 fixes for ansible-doc.

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -101,7 +101,7 @@ class DocCLI(CLI):
                 try:
                     doc, plainexamples, returndocs = module_docs.get_docstring(filename, verbose=(self.options.verbosity > 0))
                 except:
-                    display.vvv(traceback.print_exc())
+                    display.vvv(traceback.format_exc())
                     display.error("module %s has a documentation error formatting or is missing documentation\nTo see exact traceback use -vvv" % module)
                     continue
 
@@ -134,7 +134,7 @@ class DocCLI(CLI):
                     # probably a quoting issue.
                     raise AnsibleError("Parsing produced an empty object.")
             except Exception as e:
-                display.vvv(traceback.print_exc())
+                display.vvv(traceback.format_exc())
                 raise AnsibleError("module %s missing documentation (or could not parse documentation): %s\n" % (module, str(e)))
 
         if text:

--- a/lib/ansible/utils/module_docs.py
+++ b/lib/ansible/utils/module_docs.py
@@ -97,10 +97,10 @@ def get_docstring(filename, verbose=False):
                             fragment_yaml = getattr(fragment_class, fragment_var, '{}')
                             fragment = AnsibleLoader(fragment_yaml, file_name=filename).get_single_data()
 
-                            if fragment.has_key('notes'):
+                            if 'notes' in fragment:
                                 notes = fragment.pop('notes')
                                 if notes:
-                                    if not doc.has_key('notes'):
+                                    if 'notes' not in doc:
                                         doc['notes'] = []
                                     doc['notes'].extend(notes)
 
@@ -108,7 +108,7 @@ def get_docstring(filename, verbose=False):
                                 raise Exception("missing options in fragment, possibly misformatted?")
 
                             for key, value in fragment.items():
-                                if not doc.has_key(key):
+                                if key not in doc:
                                     doc[key] = value
                                 else:
                                     if isinstance(doc[key], MutableMapping):


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-doc

##### ANSIBLE VERSION

```
ansible 2.3.0 (doc-fix c11a40be35) last updated 2016/11/03 15:46:21 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 7cc4d3fe04) last updated 2016/11/02 22:12:45 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD e4bc618956) last updated 2016/11/03 15:44:42 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Python 3 fixes for ansible-doc. Also fixes exception handling in ansible-doc.