### PR TITLE
Add support for network alias on NetBSD

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2631,6 +2631,12 @@ class GenericBsdIfconfigNetwork(Network):
         current_if['lladdr'] = words[1]
 
     def parse_inet_line(self, words, current_if, ips):
+        # netbsd show aliases like this
+        #  lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 33184
+        #         inet 127.0.0.1 netmask 0xff000000
+        #         inet alias 127.1.1.1 netmask 0xff000000
+        if words[1] == 'alias':
+            del words[1]
         address = {'address': words[1]}
         # deal with hex netmask
         if re.match('([0-9a-f]){8}', words[3]) and len(words[3]) == 8:


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
setup
##### SUMMARY
While testing on netbsd 6.0, ansible setup failed with:

    Traceback (most recent call last):
      File \"/tmp/ansible_m2ieeq/ansible_module_setup.py\", line 134, in <module>
        main()
      File \"/tmp/ansible_m2ieeq/ansible_module_setup.py\", line 126, in main
        data = get_all_facts(module)
      File \"/tmp/ansible_m2ieeq/ansible_modlib.zip/ansible/module_utils/facts.py\", line 3609, in get_all_facts
      File \"/tmp/ansible_m2ieeq/ansible_modlib.zip/ansible/module_utils/facts.py\", line 3552, in ansible_facts
      File \"/tmp/ansible_m2ieeq/ansible_modlib.zip/ansible/module_utils/facts.py\", line 2500, in populate
      File \"/tmp/ansible_m2ieeq/ansible_modlib.zip/ansible/module_utils/facts.py\", line 2584, in get_interfaces_info
      File \"/tmp/ansible_m2ieeq/ansible_modlib.zip/ansible/module_utils/facts.py\", line 2644, in parse_inet_line
    socket.error: illegal IP address string passed to inet_aton

The cause is having aliases on lo like this:

     lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 33184
         inet 127.0.0.1 netmask 0xff000000
         inet alias 127.1.1.1 netmask 0xff000000

So if the address is 'alias', we have to skip it.