### PR TITLE
Check encrypted before loading file

### DIFF
--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -173,8 +173,8 @@ class DataLoader():
         show_content = True
         try:
             with open(b_file_name, 'rb') as f:
-                data = f.read()
-                if is_encrypted(data):
+                if is_encrypted(f):
+                    data = f.read()
                     data = self._vault.decrypt(data, filename=b_file_name)
                     show_content = False
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
copy

##### ANSIBLE VERSION
```
$ ansible --version
ansible 2.2.0 (devel 15ee97d) last updated 2016/10/03 13:05:00 (GMT +000)
lib/ansible/modules/core: (detached HEAD 7de2872) last updated 2016/07/17 11:35:06 (GMT +000)
lib/ansible/modules/extras: (detached HEAD 68ca157) last updated 2016/07/17 11:35:10 (GMT +000)
config file = /etc/ansible/ansible.cfg
configured module search path = Default w/o overrides
```

##### SUMMARY
Checks if the file is vault-encrypted before loading it into memory. Memory issues are hit with copying large files. This fix was put in place https://github.com/ansible/ansible/pull/16392/, looks like this broke again because of https://github.com/ansible/ansible/pull/16329