### PR TITLE
Run validate-modules with python 2 only.

### DIFF
--- a/test/sanity/code-smell/shebang.sh
+++ b/test/sanity/code-smell/shebang.sh
@@ -4,6 +4,7 @@ grep '^#!' -RIn . 2>/dev/null | grep ':1:' | sed 's/:1:/:/' | grep -v -E \
     -e '/.tox/' \
     -e '^\./lib/ansible/modules/' \
     -e '^\./test/integration/targets/[^/]*/library/[^/]*:#!powershell$' \
+    -e '^\./test/sanity/validate-modules/validate-modules:#!/usr/bin/env python2$' \
     -e ':#!/bin/sh$' \
     -e ':#!/bin/bash( -[eux]|$)' \
     -e ':#!/usr/bin/make -f$' \

--- a/test/sanity/validate-modules/validate-modules
+++ b/test/sanity/validate-modules/validate-modules
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2015 Matt Martz <matt@sivel.net>


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

validate-modules

##### ANSIBLE VERSION

```
ansible 2.3.0 (validator 87e488feeb) last updated 2016/11/04 11:35:10 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 2584fca0ae) last updated 2016/11/04 00:00:27 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD a1dcbf9ce5) last updated 2016/11/03 16:14:54 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Run validate-modules with python 2 only.

This allows validate-modules to run in an environment where python 3 is the default. This will no longer be necessary once validate-modules is updated to work with both python 2 and 3.