### PR TITLE
resolve inventory path on init

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -38,6 +38,7 @@ from ansible.module_utils._text import to_bytes, to_text
 from ansible.parsing.utils.addresses import parse_address
 from ansible.plugins import vars_loader
 from ansible.utils.vars import combine_vars
+from ansible.utils.path import unfrackpath
 
 try:
     from __main__ import display
@@ -58,7 +59,7 @@ class Inventory(object):
 
         # the host file file, or script path, or list of hosts
         # if a list, inventory data will NOT be loaded
-        self.host_list = host_list
+        self.host_list = unfrackpath(host_list, follow=False)
         self._loader = loader
         self._variable_manager = variable_manager
         self.localhost = None

--- a/lib/ansible/utils/path.py
+++ b/lib/ansible/utils/path.py
@@ -26,10 +26,9 @@ from ansible.module_utils._text import to_bytes, to_native, to_text
 __all__ = ['unfrackpath', 'makedirs_safe']
 
 
-def unfrackpath(path):
+def unfrackpath(path, follow=True):
     '''
-    Returns a path that is free of symlinks, environment
-    variables, relative path traversals and symbols (~)
+    Returns a path that is free of symlinks (if follow=True), environment variables, relative path traversals and symbols (~)
 
     :arg path: A byte or text string representing a path to be canonicalized
     :raises UnicodeDecodeError: If the canonicalized version of the path
@@ -41,9 +40,13 @@ def unfrackpath(path):
     example::
         '$HOME/../../var/mail' becomes '/var/spool/mail'
     '''
-    canonical_path = os.path.normpath(os.path.realpath(os.path.expanduser(os.path.expandvars(to_bytes(path, errors='surrogate_or_strict')))))
-    return to_text(canonical_path, errors='surrogate_or_strict')
 
+    if follow:
+        final_path = os.path.normpath(os.path.realpath(os.path.expanduser(os.path.expandvars(to_bytes(path, errors='surrogate_or_strict')))))
+    else:
+        final_path = os.path.normpath(os.path.abspath(os.path.expanduser(os.path.expandvars(to_bytes(path, errors='surrogate_or_strict')))))
+
+    return to_text(final_path, errors='surrogate_or_strict')
 
 def makedirs_safe(path, mode=None):
     '''Safe way to create dirs in muliprocess/thread environments.

--- a/lib/ansible/utils/path.py
+++ b/lib/ansible/utils/path.py
@@ -31,6 +31,7 @@ def unfrackpath(path, follow=True):
     Returns a path that is free of symlinks (if follow=True), environment variables, relative path traversals and symbols (~)
 
     :arg path: A byte or text string representing a path to be canonicalized
+    :arg follow: A boolean to indicate of symlinks should be resolved or not
     :raises UnicodeDecodeError: If the canonicalized version of the path
         contains non-utf8 byte sequences.
     :rtype: A text string (unicode on pyyhon2, str on python3).


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3-2.1
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This allows meta refresh_inventory to work with relative paths
Added option to unfrackpath to not resolve symlinks
fixes #16857