### PR TITLE
Validate apache2 mpm module switching for bug #5328

### DIFF
--- a/test/integration/targets/apache2_module/tasks/actualtest.yml
+++ b/test/integration/targets/apache2_module/tasks/actualtest.yml
@@ -89,9 +89,88 @@
     force: True
   when: "ansible_os_family == 'Debian'"
 
-
 - name: enable evasive module, test https://github.com/ansible/ansible/issues/22635
   apache2_module:
     name: evasive
     state: present
+  when: "ansible_os_family == 'Debian'"
+
+- name: disable mpm modules
+  apache2_module:
+    name: "{{ item }}"
+    state: absent
+    ignore_configcheck: True
+  with_items:
+    - mpm_worker
+    - mpm_event
+    - mpm_prefork
+  when: "ansible_os_family == 'Debian'"
+
+- name: enabled mpm_event
+  apache2_module:
+    name: mpm_event
+    state: present
+    ignore_configcheck: True
+  register: enabledmpmevent
+  when: "ansible_os_family == 'Debian'"
+
+- name: ensure changed mpm_event
+  assert:
+    that:
+      - 'enabledmpmevent.changed'
+  when: "ansible_os_family == 'Debian'"
+
+- name: switch between mpm_event and mpm_worker
+  apache2_module:
+    name: "{{ item.name }}"
+    state: "{{ item.state }}"
+    ignore_configcheck: True
+  with_items:
+    - name: mpm_event
+      state: absent
+    - name: mpm_worker
+      state: present
+  when: "ansible_os_family == 'Debian'"
+
+- name: ensure mpm_worker is already enabled
+  apache2_module:
+    name: mpm_worker
+    state: present
+  register: enabledmpmworker
+  when: "ansible_os_family == 'Debian'"
+
+- name: ensure mpm_worker unchanged
+  assert:
+    that:
+      - 'not enabledmpmworker.changed'
+  when: "ansible_os_family == 'Debian'"
+
+- name: try to disable all mpm modules with configcheck
+  apache2_module:
+    name: "{{item}}"
+    state: absent
+  with_items:
+    - mpm_worker
+    - mpm_event
+    - mpm_prefork
+  ignore_errors: yes
+  register: remove_with_configcheck
+  when: "ansible_os_family == 'Debian'"
+
+- name: ensure configcheck fails task with when run without mpm modules
+  assert:
+    that:
+      - "{{ item.failed }}"
+  with_items: "{{ remove_with_configcheck.results }}"
+  when: "ansible_os_family == 'Debian'"
+
+- name: try to disable all mpm modules without configcheck
+  apache2_module:
+    name: "{{item}}"
+    state: absent
+    ignore_configcheck: True
+  with_items:
+    - mpm_worker
+    - mpm_event
+    - mpm_prefork
   when: "ansible_os_family == 'Debian'"


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
web_infrastructure/apache2_module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
  lib/ansible/modules/core: (detached HEAD 55b1813ebd) last updated 2016/11/01 14:02:20 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD cf524673e1) last updated 2016/11/01 12:39:51 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

This patchset updates module integration testing to
validate the changes in PR #5454

This patchset instructs apache2_module to disable all
mpm modules, enable mpm_event, then disable mpm_event
and enable mpm_worker.

Fixes: #5328