### PR TITLE
Fix media_type detection on NetBSD

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2950,6 +2950,22 @@ class NetBSDNetwork(GenericBsdIfconfigNetwork):
     """
     platform = 'NetBSD'
 
+    def parse_media_line(self, words, current_if, ips): 
+        # example of line:
+        # $ ifconfig
+        # ne0: flags=8863<UP,BROADCAST,NOTRAILERS,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+        #    ec_capabilities=1<VLAN_MTU>
+        #    ec_enabled=0
+        #    address: 00:20:91:45:00:78
+        #    media: Ethernet 10baseT full-duplex
+        #    inet 192.168.156.29 netmask 0xffffff00 broadcast 192.168.156.255
+        current_if['media'] = words[1]
+        if len(words) > 2:
+            current_if['media_type'] = words[2]
+        if len(words) > 3:
+            current_if['media_options'] = words[3].split(',')
+
+
 class SunOSNetwork(GenericBsdIfconfigNetwork):
     """
     This is the SunOS Network Class.


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
setup
##### SUMMARY

On NetBSD 7.0.1, ifconfig return this:

    $ ifconfig
    ne0: flags=8863<UP,BROADCAST,NOTRAILERS,RUNNING,SIMPLEX,MULTICAST> mtu 1500
            ec_capabilities=1<VLAN_MTU>
            ec_enabled=0
            address: 00:20:91:45:00:78
            media: Ethernet 10baseT full-duplex
            inet 192.168.156.29 netmask 0xffffff00 broadcast 192.168.156.255

Which result into setup returning:

    "media_type": "ull-duplex",

I couldn't find a good reason to skip the first char on the string looking
at the output of ifconfig on FreeBSD and NetBSD, nor imagine why it was done
like this.