### PR TITLE
Fix type detection on OpenSolaris for loopback interface

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -3023,6 +3023,8 @@ class SunOSNetwork(GenericBsdIfconfigNetwork):
         v = 'ipv4'
         if 'IPv6' in flags:
             v = 'ipv6'
+        if 'LOOPBACK' in flags:
+            current_if['type'] = 'loopback'
         current_if[v].append({'flags': flags, 'mtu': words[3]})
         current_if['macaddress'] = 'unknown'    # will be overwritten later
         return current_if


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
setup

##### SUMMARY
Extract of ifconfig output:

    # ifconfig  -a
    lo0: flags=2001000849<UP,LOOPBACK,RUNNING,MULTICAST,IPv4,VIRTUAL> mtu 8232 index 1
            inet 127.0.0.1 netmask ff000000
    rtls0: flags=1004843<UP,BROADCAST,RUNNING,MULTICAST,DHCP,IPv4> mtu 1500 index 3
            inet 192.168.125.125 netmask ffffff00 broadcast 192.168.125.255
            ether 0:20:91:83:45:82