### PR TITLE
Feature/lookup keyring

### DIFF
--- a/lib/ansible/plugins/lookup/keyring.py
+++ b/lib/ansible/plugins/lookup/keyring.py
@@ -1,0 +1,43 @@
+# (c) 2016, Samuel Boucher <boucher.samuel.c@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+import keyring
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
+from ansible.plugins.lookup import LookupBase
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, **kwargs):
+        display.vvvv(u"keyring: %s" % keyring.get_keyring() )
+        ret = []
+        for term in terms:
+            (servicename, username) = (term.split()[0], term.split()[1])
+            display.vvvv(u"username: %s, servicename: %s " %(username,servicename))
+            ret.append(keyring.get_password(servicename,username).rstrip())
+        return ret
+

--- a/lib/ansible/plugins/lookup/keyring.py
+++ b/lib/ansible/plugins/lookup/keyring.py
@@ -60,7 +60,7 @@ class LookupModule(LookupBase):
 
     def run(self, terms, **kwargs):
         if  not HAS_KEYRING:
-            raise AnsibleError(u"Can't LOOKUP(keyring): missing requried python library 'keyring'")
+            raise AnsibleError(u"Can't LOOKUP(keyring): missing required python library 'keyring'")
 
         display.vvvv(u"keyring: %s" % keyring.get_keyring() )
         ret = []

--- a/lib/ansible/plugins/lookup/keyring.py
+++ b/lib/ansible/plugins/lookup/keyring.py
@@ -60,7 +60,7 @@ class LookupModule(LookupBase):
 
     def run(self, terms, **kwargs):
         if  not HAS_KEYRING:
-            raise AnsibleError(u"Can't LOOKUP(keyring): module keyring is not installed")
+            raise AnsibleError(u"Can't LOOKUP(keyring): missing requried python library 'keyring'")
 
         display.vvvv(u"keyring: %s" % keyring.get_keyring() )
         ret = []


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
- lookup/keyring.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add a lookup keyring.py
I believe it would be useful to access the OS keychain directly to  get password  or token.
Hardcoding them in the playbook or leaving them on the filesystem is not always the best solution.
It uses python keyring module. 
This lookup access the keyring  to fetch the secret.


<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
N/A
```

I tried the lookup on both OS X  and Fedora with Gnome