### PR TITLE
Detect virtualisation on netbsd

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -3376,6 +3376,18 @@ class OpenBSDVirtual(Virtual, VirtualSysctlDetectionMixin):
                 self.facts['virtualization_type'] = 'vmm'
                 self.facts['virtualization_role'] = 'host'
 
+class NetBSDVirtual(Virtual, VirtualSysctlDetectionMixin):
+    platform = 'NetBSD'
+
+    def get_virtual_facts(self):
+        # Set empty values as default
+        self.facts['virtualization_type'] = ''
+        self.facts['virtualization_role'] = ''
+
+        self.detect_virt_product('machdep.dmi.system-product')
+        if self.facts['virtualization_type'] == '':
+            self.detect_virt_vendor('machdep.dmi.system-vendor')
+
 class HPUXVirtual(Virtual):
     """
     This is a HP-UX specific subclass of Virtual. It defines

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -3388,6 +3388,11 @@ class NetBSDVirtual(Virtual, VirtualSysctlDetectionMixin):
         if self.facts['virtualization_type'] == '':
             self.detect_virt_vendor('machdep.dmi.system-vendor')
 
+        if os.path.exists('/dev/xencons'):
+            self.facts['virtualization_type'] = 'xen'
+            self.facts['virtualization_role'] = 'guest'
+
+
 class HPUXVirtual(Virtual):
     """
     This is a HP-UX specific subclass of Virtual. It defines


### PR DESCRIPTION
##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME
setup

##### SUMMARY
This PR do refactor the code used on OpenBSD to detect virtualisation and add support for detecting guest on Netbsd. I only tested on NetBSD 7 with KVM and NetBSD 7 on Rackspace (XEN), but I assume that the string used are portable. I also verified that on OpenBSD 6.0 on KVM.