### PR TITLE
Add support for KVM in the Solaris virt detection

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -3480,6 +3480,9 @@ class SunOSVirtual(Virtual):
                     elif 'HVM domU' in line:
                         self.facts['virtualization_type'] = 'xen'
                         self.facts['virtualization_role'] = 'guest'
+                    elif 'KVM' in line:
+                        self.facts['virtualization_type'] = 'kvm'
+                        self.facts['virtualization_role'] = 'guest'
 
 class Ohai(Facts):
     """


### PR DESCRIPTION
##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME
setup

##### SUMMARY

smbios -i 256 return:

    # smbios -i 256
    ID    SIZE TYPE
    256   77   SMB_TYPE_SYSTEM (system information)

      Manufacturer: Red Hat
      Product: KVM
      Version: RHEL 6.4.0 PC

      UUID: 8a3b8b1a-ba59-1a4b-5f85-ab53a5a885a9
      Wake-Up Event: 0x6 (power switch)
      SKU Number:
      Family: Red Hat Enterprise Linux