### PR TITLE
Make facts detection work on OpenBSD with Python3

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1644,10 +1644,10 @@ class OpenBSDHardware(Hardware):
         # total: 69268k bytes allocated = 0k used, 69268k available
         rc, out, err = self.module.run_command("/sbin/swapctl -sk")
         if rc == 0:
-            swaptrans = maketrans(' ', ' ')
+            swaptrans = maketrans('kmg', '   ')
             data = out.split()
-            self.facts['swapfree_mb'] = int(data[-2].translate(swaptrans, "kmg")) // 1024
-            self.facts['swaptotal_mb'] = int(data[1].translate(swaptrans, "kmg")) // 1024
+            self.facts['swapfree_mb'] = int(data[-2].translate(swaptrans)) // 1024
+            self.facts['swaptotal_mb'] = int(data[1].translate(swaptrans)) // 1024
 
     def get_processor_facts(self):
         processor = []


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
setup

##### SUMMARY

The traceback is the following:

    Traceback (most recent call last):
      File \"/tmp/ansible_8s0bj604/ansible_module_setup.py\", line 134, in <module>
        main()
      File \"/tmp/ansible_8s0bj604/ansible_module_setup.py\", line 126, in main
        data = get_all_facts(module)
      File \"/tmp/ansible_8s0bj604/ansible_modlib.zip/ansible/module_utils/facts.py\", line 3641, in get_all_facts
      File \"/tmp/ansible_8s0bj604/ansible_modlib.zip/ansible/module_utils/facts.py\", line 3584, in ansible_facts
      File \"/tmp/ansible_8s0bj604/ansible_modlib.zip/ansible/module_utils/facts.py\", line 1600, in populate
      File \"/tmp/ansible_8s0bj604/ansible_modlib.zip/ansible/module_utils/facts.py\", line 1649, in get_memory_facts
    TypeError: translate() takes exactly one argument (2 given)

And the swapctl output is this:

    # /sbin/swapctl -sk
    total: 83090 1K-blocks allocated, 0 used, 83090 available

The only use of the code is to remove prefix in case they are present, so just
replacing them with empty space is sufficient.