### PR TITLE
On python 3.5, sys.subversion have been removed

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -597,7 +597,10 @@ class Facts(object):
         try:
             self.facts['python']['type'] = sys.subversion[0]
         except AttributeError:
-            self.facts['python']['type'] = None
+            try:
+                self.facts['python']['type'] = sys.implementation.name
+            except AttributeError:
+                self.facts['python']['type'] = None
 
 
 class Distribution(object):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
setup

##### SUMMARY
So to get the type of the python interpreter, we need to look at
sys.implementation.name which do not return 'cpython', instead of 'CPython',
but that's upstream breakage, so not much we can do.