### PR TITLE
Add DMI facts on NetBSD

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1586,8 +1586,16 @@ class GetSysctlMixin(object):
             return dict()
         sysctl = dict()
         for line in out.splitlines():
-            (key, value) = line.split('=')
-            sysctl[key] = value.strip()
+            # NetBSD do not always use '='
+            #  # sysctl machdep.diskinfo
+            #  machdep.diskinfo: 80:16777216(1023/255/63),2  wd0:80
+            # sometime, there is also '=' in the value:
+            #  # sysctl kern.timecounter.choice
+            #  kern.timecounter.choice = TSC(q=-100, f=3092928170 Hz) clockinterrupt(q=0, f=100 Hz)...
+            # so we will just take a subset of the value and defer to later if we need to parse others
+            if '=' in line:
+                (key, value) = line.split('=')
+                sysctl[key.strip()] = value.strip()
         return sysctl
 
 

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1596,7 +1596,7 @@ class OpenBSDHardware(Hardware):
     platform = 'OpenBSD'
 
     def populate(self):
-        self.sysctl = self.get_sysctl()
+        self.sysctl = self.get_sysctl('hw')
         self.get_memory_facts()
         self.get_processor_facts()
         self.get_device_facts()
@@ -1604,8 +1604,8 @@ class OpenBSDHardware(Hardware):
         self.get_dmi_facts()
         return self.facts
 
-    def get_sysctl(self):
-        rc, out, err = self.module.run_command(["/sbin/sysctl", "hw"])
+    def get_sysctl(self, prefix):
+        rc, out, err = self.module.run_command(["/sbin/sysctl", prefix])
         if rc != 0:
             return dict()
         sysctl = dict()

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1601,6 +1601,7 @@ class OpenBSDHardware(Hardware):
         self.get_processor_facts()
         self.get_device_facts()
         self.get_mount_facts()
+        self.get_dmi_facts()
         return self.facts
 
     def get_sysctl(self):


### PR DESCRIPTION
##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME
setup
##### SUMMARY

The PR refactor part of the code used by OpenBSD (and use it), make it portable on NetBSD to support DMI facts. I think I could refactor it a bit more, but I am not sure if that's worth, given that OpenBSD also use sysctl for others things, and this did make the code slightly more complex when I attempt, without (IMHO) much gain.

Tested on OpenBSD 6.0 and NetBSD 7.0.1