### PR TITLE
Improved Get-PendingRebootStatus

### DIFF
--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -236,7 +236,8 @@ Function Get-PendingRebootStatus
     #Function returns true if computer has a pending reboot
     $featureData = invoke-wmimethod -EA Ignore -Name GetServerFeature -namespace root\microsoft\windows\servermanager -Class MSFT_ServerManagerTasks
     $regData = Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager" "PendingFileRenameOperations" -EA Ignore
-    if(($featureData -and $featureData.RequiresReboot) -or $regData)
+    $CBSRebootStatus = Get-ChildItem "HKLM:\\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing"  -ErrorAction SilentlyContinue| where {$_.PSChildName -eq "RebootPending"}
+    if(($featureData -and $featureData.RequiresReboot) -or $regData -or $CBSRebootStatus)
     {
         return $True
     }


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
setup.ps1

##### ANSIBLE VERSION
```
2.3.0
```

##### SUMMARY
Fixes https://github.com/ansible/ansible-modules-core/issues/5078

The current implementation of setup.ps1 (which drives facts gathering on Windows nodes) has a bug where pending reboots aren't picked up in all cases, especially for nodes with older OSes (2008R2 has the problem 2012R2 does not). In any case, this fix implements an extra check against the "Component Based Servicing" registry key, which typically gets updated when features are added to or removed from a node.
