### PR TITLE
Fixing help message for the ansible-galaxy install command

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -87,7 +87,7 @@ class GalaxyCLI(CLI):
             self.parser.add_option('--role-skeleton', dest='role_skeleton', default=None,
                                    help='The path to a role skeleton that the new role should be based upon.')
         elif self.action == "install":
-            self.parser.set_usage("usage: %prog install [options] [-r FILE | role_name(s)[,version] | scm+role_repo_url[,version] | tar_file(s)]")
+            self.parser.set_usage("usage: %prog install [options] (-r FILE | ((role_name | scm+role_repo_url)[,[version][,name]] | tar_file[,,name])...)")
             self.parser.add_option('-i', '--ignore-errors', dest='ignore_errors', action='store_true', default=False,
                                    help='Ignore errors and continue with the next specified role.')
             self.parser.add_option('-n', '--no-deps', dest='no_deps', action='store_true', default=False, help='Don\'t download roles listed as dependencies')

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -172,7 +172,7 @@ class TestGalaxy(unittest.TestCase):
                 'delete': 'usage: %prog delete [options] github_user github_repo',
                 'info': 'usage: %prog info [options] role_name[,version]',
                 'init': 'usage: %prog init [options] role_name',
-                'install': 'usage: %prog install [options] [-r FILE | role_name(s)[,version] | scm+role_repo_url[,version] | tar_file(s)]',
+                'install': 'usage: %prog install [options] (-r FILE | ((role_name | scm+role_repo_url)[,[version][,name]] | tar_file[,,name])...)',
                 'list': 'usage: %prog list [role_name]',
                 'login': 'usage: %prog login [options]',
                 'remove': 'usage: %prog remove role1 role2 ...',


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

`ansible-galaxy`

##### ANSIBLE VERSION

`2.2`

##### SUMMARY

Current help message of the `ansible-galaxy install` command doesn't show how to specify custom name of the role under which the role is downloaded. This PR is adding this information and changing the command help message from this:

```
$ ansible-galaxy install --help
Usage: ansible-galaxy install [options] [-r FILE | role_name(s)[,version] | scm+role_repo_url[,version] | tar_file(s)]
```

to this:

```
$ ansible-galaxy install --help                                                                               
Usage: ansible-galaxy install [options] (-r FILE | ((role_name | scm+role_repo_url)[,version[,name]] | tar_file[,,name])...)
```

That corresponds with the information described in the `lib/ansible/playbook/role/requirement.py` file on the line 136. It also explicitly defines that either the requirements file or the role must be specified. The formatting of the help string is inspired by the POSIX standard IEEE Std 1003.1 used for example by [docopt](http://docopt.org/).