### PR TITLE
make default strategy configurable

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -780,6 +780,15 @@ different locations::
 
 Most users will not need to use this feature.  See :doc:`developing_plugins` for more details
 
+.. _cfg_strategy:
+
+strategy
+========
+
+Strategy allow to change the default strategy used by Ansible::
+
+    strategy = free
+
 .. _sudo_exe:
 
 sudo_exe

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -182,6 +182,11 @@
 #test_plugins       = /usr/share/ansible/plugins/test
 #strategy_plugins   = /usr/share/ansible/plugins/strategy
 
+
+# by default, ansible will use the 'linear' strategy but you may want to try
+# another one
+#strategy = free
+
 # by default callbacks are not loaded for /bin/ansible, enable this if you
 # want, for example, a notification or logging callback to also apply to
 # /bin/ansible runs

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -268,6 +268,7 @@ DEFAULT_VARS_PLUGIN_PATH       = get_config(p, DEFAULTS, 'vars_plugins',       '
 DEFAULT_FILTER_PLUGIN_PATH     = get_config(p, DEFAULTS, 'filter_plugins',     'ANSIBLE_FILTER_PLUGINS', '~/.ansible/plugins/filter:/usr/share/ansible/plugins/filter', value_type='pathlist')
 DEFAULT_TEST_PLUGIN_PATH       = get_config(p, DEFAULTS, 'test_plugins',       'ANSIBLE_TEST_PLUGINS', '~/.ansible/plugins/test:/usr/share/ansible/plugins/test', value_type='pathlist')
 DEFAULT_STRATEGY_PLUGIN_PATH   = get_config(p, DEFAULTS, 'strategy_plugins',   'ANSIBLE_STRATEGY_PLUGINS', '~/.ansible/plugins/strategy:/usr/share/ansible/plugins/strategy', value_type='pathlist')
+DEFAULT_STRATEGY               = get_config(p, DEFAULTS, 'strategy',           'ANSIBLE_STRATEGY', 'linear')
 DEFAULT_STDOUT_CALLBACK        = get_config(p, DEFAULTS, 'stdout_callback',    'ANSIBLE_STDOUT_CALLBACK', 'default')
 # cache
 CACHE_PLUGIN                   = get_config(p, DEFAULTS, 'fact_caching', 'ANSIBLE_CACHE_PLUGIN', 'memory')

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -20,6 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.compat.six import string_types
+from ansible import constants as C
 
 from ansible.errors import AnsibleParserError
 
@@ -88,7 +89,7 @@ class Play(Base, Taggable, Become):
     _force_handlers      = FieldAttribute(isa='bool', always_post_validate=True)
     _max_fail_percentage = FieldAttribute(isa='percent', always_post_validate=True)
     _serial              = FieldAttribute(isa='list', default=[], always_post_validate=True)
-    _strategy            = FieldAttribute(isa='string', default='linear', always_post_validate=True)
+    _strategy            = FieldAttribute(isa='string', default=C.DEFAULT_STRATEGY, always_post_validate=True)
 
     # =================================================================================
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
- ansible core

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible --version
ansible 2.3.0 (configurable_default_strategy 22b2befb87) last updated 2016/11/07 13:28:28 (GMT +200)
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR allow to change the default strategy used by ansible.

It use the standard way to define a constants and use this constant as the strategy option's default

This PR will also fix #14939 since it allow to change the strategy via the ```ANSIBLE_STRATEGY``` env var
