### PR TITLE
Added SlackGithub callback plugin

### DIFF
--- a/lib/ansible/plugins/callback/slack_github.py
+++ b/lib/ansible/plugins/callback/slack_github.py
@@ -5,7 +5,6 @@ import json
 import os
 import subprocess
 from ansible.module_utils.urls import open_url
-from ansible.module_utils.six import iteritems
 from ansible.plugins.callback import CallbackBase
 
 
@@ -113,7 +112,7 @@ class CallbackModule(CallbackBase):
         for host in hosts:
             summary = stats.summarize(host)
             self.log('**Host**: {}\n'.format(host))
-            for item, count in iteritems(items):
+            for item, count in summary.items():
                 self.log('> **{}**: {}\n\n'.format(item, count))
                 if item == 'failures' and count > 0:
                     color = 'danger'

--- a/lib/ansible/plugins/callback/slack_github.py
+++ b/lib/ansible/plugins/callback/slack_github.py
@@ -2,10 +2,10 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import json
-import sys
 import os
 import subprocess
 from ansible.module_utils.urls import open_url
+from ansible.module_utils.six import iteritems
 from ansible.plugins.callback import CallbackBase
 
 
@@ -113,11 +113,7 @@ class CallbackModule(CallbackBase):
         for host in hosts:
             summary = stats.summarize(host)
             self.log('**Host**: {}\n'.format(host))
-            if(sys.version_info >= (3, 0)):
-                items = summary.items()
-            else:
-                items = summary.iteritems()
-            for item, count in items:
+            for item, count in iteritems(items):
                 self.log('> **{}**: {}\n\n'.format(item, count))
                 if item == 'failures' and count > 0:
                     color = 'danger'

--- a/lib/ansible/plugins/callback/slack_github.py
+++ b/lib/ansible/plugins/callback/slack_github.py
@@ -31,6 +31,7 @@ class CallbackModule(CallbackBase):
     CALLBACK_NEEDS_WHITELIST = True
 
     def __init__(self, display=None):
+        self.disabled = False
         super(CallbackModule, self).__init__(display=display)
         self.github_api = 'https://api.github.com/'
         self._log = []
@@ -43,6 +44,8 @@ class CallbackModule(CallbackBase):
         if not os.path.isfile(config_file):
             self._display.warning(
                 'File {} not found. SlackGithub callback has been disabled'.format(config_file))
+            self.disabled = True
+            return
         with open(config_file) as config_file:
             self.config = json.load(config_file)
         try:
@@ -57,6 +60,8 @@ class CallbackModule(CallbackBase):
         self._log.append(text)
 
     def send(self, color='good'):
+        if self.disabled:
+            return
         raw_gist = {
             'description': 'Ansible play recap',
             'public': False,

--- a/lib/ansible/plugins/callback/slack_github.py
+++ b/lib/ansible/plugins/callback/slack_github.py
@@ -2,10 +2,12 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import json
+import sys
 import os
 import subprocess
 from ansible.module_utils.urls import open_url
 from ansible.plugins.callback import CallbackBase
+
 
 class CallbackModule(CallbackBase):
     """This is an ansible callback plugin that sends full
@@ -17,7 +19,6 @@ class CallbackModule(CallbackBase):
     ```json
     {
         "webhook": "Slack incoming webhook url",
-        "channel": "#slackchannel",
         "username": "Ansible"
     }
     ```
@@ -33,102 +34,101 @@ class CallbackModule(CallbackBase):
     def __init__(self, display=None):
         super(CallbackModule, self).__init__(display=display)
         self.github_api = 'https://api.github.com/'
-        self.log = u'';
+        self._log = []
 
-    def _init_config(self, playbook):
+    def init_config(self, playbook):
         self.playbook_name = os.path.basename(playbook._file_name)
-        config_file = playbook._basedir.encode('ascii','ignore') + '/slack.json'
+        config_file = os.path.join(playbook._basedir.encode('ascii', 'ignore'), 'slack.json')
         if os.path.isfile(config_file) == False:
-            self._display.warning('File ' + config_file + ' not found. SlackGithub callback has been disabled')
+            self._display.warning('File {} not found. SlackGithub callback has been disabled'.format(config_file))
         with open(config_file) as config_file:
             self.config = json.load(config_file)
         try:
             cmd = ['git', 'config', '--get', 'user.name']
             username = subprocess.check_output(cmd, universal_newlines=True).split('\0')
             self.user = username[0].rstrip()
-        except:
+        except BaseException:
             self.user = 'Anonymous'
 
+    def log(self, text):
+        self._log.append(text)
 
-    def _log(self, text):
-        self.log += text
-
-    def _send(self, color='good'):
+    def send(self, color='good'):
         raw_gist = {
-            'description': 'Ansible play recap',
-            'public': False,
-            'files': {
-                'recap.md': {
-                    'content': self.log
+                'description': 'Ansible play recap',
+                'public': False,
+                'files': {
+                    'recap.md': {
+                        'content': '\n'.join(self._log)
+                        }
+                    }
                 }
-            }
-        }
 
         data = json.dumps(raw_gist)
         try:
-            response = open_url(self.github_api + 'gists', data=data, method='POST')
+            response = open_url(
+                    self.github_api + 'gists',
+                    data=data,
+                    method='POST')
         except Exception as e:
-            self._display.warning('Could not submit play recap: %s' % str(e))
+            self._display.warning('Could not submit play recap: {}'.format(e))
 
         gist = json.loads(response.read())
-        url = gist[u'html_url'].encode('ascii','ignore')
-        hosts = '*'
-        for host in self.play.hosts:
-            hosts+= str(host) + ', '
-        hosts = hosts[:-2]
-        hosts+='*'
-        message = 'Playbook *' + self.playbook_name + '* has been played against ' + hosts + ' by *' + self.user + '*. '
-        message+= '*<' + url + '#file-recap-md|Details>*'
+        url = gist[u'html_url'].encode('ascii', 'ignore')
+        hosts = '*{}*'.format(', '.join(self.play.hosts))
+        message = 'Playbook *{}* has been played against {} by *{}* *<{}#file-recap-md|Details>*'.format(self.playbook_name, hosts, self.user, url)
         payload = {
-            'channel': self.config['channel'],
-            'username': self.config['username'],
-            'attachments': [{
-                'fallback': message,
-                'fields': [{
-                    'value': message
-                }],
-                'color': color,
-                'mrkdwn_in': ['text', 'fallback', 'fields'],
-            }],
-            'parse': 'none',
-            'icon_url': ('http://cdn2.hubspot.net/hub/330046/file-449187601-png/ansible_badge.png'),
-        }
+                'username': self.config['username'],
+                'attachments': [{
+                    'fallback': message,
+                    'fields': [{
+                        'value': message
+                        }],
+                    'color': color,
+                    'mrkdwn_in': ['text', 'fallback', 'fields'],
+                    }],
+                'parse': 'none',
+                }
 
         data = json.dumps(payload)
         try:
             response = open_url(self.config['webhook'], data=data)
         except Exception as e:
-            self._display.warning('Could not submit notification to Slack: %s' % str(e))
+            self._display.warning('Could not submit notification to Slack: {}'.format(e))
 
     def v2_playbook_on_start(self, playbook):
-        self._init_config(playbook)
-        self._log('**Playbook**: ' + self.playbook_name + '\n\n')
+        self.init_config(playbook)
+        self.log('**Playbook**: {}\n\n'.format(os.path.basename(playbook._file_name)))
 
     def v2_playbook_on_play_start(self, play):
         self.play = play
-        name = play.name or 'Not specified #' + play._uuid
-        self._log('# Play: ' + name + '\n\n')
+        name = play.name or 'Not specified #{}'.format(play._uuid)
+        self.log('# Play: {}\n\n'.format(name))
 
     def v2_playbook_on_stats(self, stats):
         color = 'good'
-        self._log('# Stats\n\n')
+        self.log('# Stats\n\n')
         hosts = sorted(stats.processed.keys())
         for host in hosts:
             summary = stats.summarize(host)
-            self._log('**Host**: ' + host + '\n')
-            for item, count in summary.iteritems():
-                self._log('> **' + item + '**: ' + str(count) + '\n\n')
+            self.log('**Host**: {}\n'.format(host))
+            if(sys.version_info >= (3,0)):
+                items = summary.items()
+            else:
+                items = summary.iteritems()
+            for item, count in items:
+                self.log('> **{}**: {}\n\n'.format(item, count))
                 if item == 'failures' and count > 0:
                     color = 'danger'
-        self._send(color)
+        self.send(color)
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
-        self._log('**_FAILED_ ' + result._host.get_name() + '** | ' + result._task.get_name().strip() + '\n\n')
-        self._log('```json\n' + json.dumps(result._result, indent=1, sort_keys=True) + '\n```\n\n')
+        self.log('**_FAILED_ {}** | {}\n\n'.format(result._host.get_name(), result._task.get_name().strip()))
+        self.log('```json\n{}\n```\n\n'.format(json.dumps(result._result, indent=1,sort_keys=True)))
 
     def v2_runner_on_ok(self, result):
-        self._log('**' + result._host.get_name() + '** | ' + result._task.get_name().strip() + '\n\n')
+        self.log('**{}** | {}\n\n'.format(result._host.get_name(), result._task.get_name().strip()))
 
     def v2_runner_on_unreachable(self, result):
-        self._log('**_UNREACHABLE_ ' + result._host.get_name() + '** | ' + result._task.get_name().strip() + '\n\n')
-        self._log('```json\n' + json.dumps(result._result, indent=1, sort_keys=True) + '\n```\n\n')
+        self.log('**_UNREACHABLE_ {}** | {}\n\n'.format(result._host.get_name(), result._task.get_name().strip))
+        self.log('```json\n{}\n```\n\n'.format(json.dumps(result._result, indent=1,sort_keys=True)))

--- a/lib/ansible/plugins/callback/slack_github.py
+++ b/lib/ansible/plugins/callback/slack_github.py
@@ -1,0 +1,120 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+import os
+from ansible.module_utils.urls import open_url
+from ansible.plugins.callback import CallbackBase
+
+class CallbackModule(CallbackBase):
+    """This is an ansible callback plugin that sends full
+    play recap to github gist and sends colored notification
+    to  a Slack channel after play ends.
+
+    This plugin makes use of file `slack.json` in your playbook folder
+    with following contents:
+    ```json
+    {
+        "webhook": "Slack incoming webhook url",
+        "channel": "#slackchannel",
+        "username": "Ansible"
+    }
+    ```
+
+    Output: https://gist.github.com/anonymous/f75e04a115ea86b730e41e2ef03cc5f0
+    """
+
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'notification'
+    CALLBACK_NAME = 'slack_github'
+    CALLBACK_NEEDS_WHITELIST = True
+
+    def __init__(self, display=None):
+        super(CallbackModule, self).__init__(display=display)
+        self.github_api = 'https://api.github.com/'
+        self.log = u'';
+
+    def _init_config(self, playbook):
+        self.playbook_name = os.path.basename(playbook._file_name)
+        config_file = playbook._basedir.encode('ascii','ignore') + '/slack.json'
+        if os.path.isfile(config_file) == False:
+            self._display.warning('File ' + config_file + ' not found. SlackGithub callback has been disabled')
+        with open(config_file) as config_file:
+            self.config = json.load(config_file)
+
+    def _log(self, text):
+        self.log += text
+
+    def _send(self, color='good'):
+        raw_gist = {
+            'description': 'Ansible play recap',
+            'public': False,
+            'files': {
+                'recap.md': {
+                    'content': self.log
+                }
+            }
+        }
+
+        data = json.dumps(raw_gist)
+        try:
+            response = open_url(self.github_api + 'gists', data=data, method='POST')
+        except Exception as e:
+            self._display.warning('Could not submit play recap: %s' % str(e))
+
+        gist = json.loads(response.read())
+        url = gist[u'html_url'].encode('ascii','ignore')
+        message = 'Playbook *' + self.playbook_name + '* has been played. '
+        message+= '*<' + url + '#file-recap-md|Details>*'
+        payload = {
+            'channel': self.config['channel'],
+            'username': self.config['username'],
+            'attachments': [{
+                'fallback': message,
+                'fields': [{
+                    'value': message
+                }],
+                'color': color,
+                'mrkdwn_in': ['text', 'fallback', 'fields'],
+            }],
+            'parse': 'none',
+            'icon_url': ('http://cdn2.hubspot.net/hub/330046/file-449187601-png/ansible_badge.png'),
+        }
+
+        data = json.dumps(payload)
+        try:
+            response = open_url(self.config['webhook'], data=data)
+        except Exception as e:
+            self._display.warning('Could not submit notification to Slack: %s' % str(e))
+
+    def v2_playbook_on_start(self, playbook):
+        self._init_config(playbook)
+        self._log('**Playbook**: ' + self.playbook_name + '\n\n')
+
+    def v2_playbook_on_play_start(self, play):
+        name = play.name or 'Not specified #' + play._uuid
+        self._log('# Play: ' + name + '\n\n')
+
+    def v2_playbook_on_stats(self, stats):
+        color = 'good'
+        self._log('# Stats\n\n')
+        hosts = sorted(stats.processed.keys())
+        for host in hosts:
+            summary = stats.summarize(host)
+            self._log('**Host**: ' + host + '\n')
+            for item, count in summary.iteritems():
+                self._log('> **' + item + '**: ' + str(count) + '\n\n')
+                if item == 'failures' and count > 0:
+                    color = 'danger'
+        self._send(color)
+
+    def v2_runner_on_failed(self, result, ignore_errors=False):
+        self._log('**_FAILED_ ' + result._host.get_name() + '** | ' + result._task.get_name().strip() + '\n\n')
+        self._log('```json\n' + json.dumps(result._result, indent=1, sort_keys=True) + '\n```\n\n')
+
+    def v2_runner_on_ok(self, result):
+        self._log('**' + result._host.get_name() + '** | ' + result._task.get_name().strip() + '\n\n')
+
+    def v2_runner_on_unreachable(self, result):
+        self._log('**_UNREACHABLE_ ' + result._host.get_name() + '** | ' + result._task.get_name().strip() + '\n\n')
+        self._log('```json\n' + json.dumps(result._result, indent=1, sort_keys=True) + '\n```\n\n')

--- a/lib/ansible/plugins/callback/slack_github.py
+++ b/lib/ansible/plugins/callback/slack_github.py
@@ -43,7 +43,7 @@ class CallbackModule(CallbackBase):
                 'ascii', 'ignore'), 'slack.json')
         if not os.path.isfile(config_file):
             self._display.warning(
-                'File {} not found. SlackGithub callback has been disabled'.format(config_file))
+                'File {0} not found. SlackGithub callback has been disabled'.format(config_file))
             self.disabled = True
             return
         with open(config_file) as config_file:
@@ -77,12 +77,12 @@ class CallbackModule(CallbackBase):
                 data=data,
                 method='POST')
         except Exception as e:
-            self._display.warning('Could not submit play recap: {}'.format(e))
+            self._display.warning('Could not submit play recap: {0}'.format(e))
 
         gist = json.loads(response.read())
         url = gist[u'html_url'].encode('ascii', 'ignore')
-        hosts = '*{}*'.format(', '.join(self.play.hosts))
-        message = 'Playbook *{}* has been played against {} by *{}* *<{}#file-recap-md|Details>*'.format(
+        hosts = '*{0}*'.format(', '.join(self.play.hosts))
+        message = 'Playbook *{0}* has been played against {1} by *{2}* *<{3}#file-recap-md|Details>*'.format(
             self.playbook_name, hosts, self.user, url)
         payload = {'username': self.config['username'],
                    'attachments': [{'fallback': message,
@@ -99,16 +99,16 @@ class CallbackModule(CallbackBase):
             response = open_url(self.config['webhook'], data=data)
         except Exception as e:
             self._display.warning(
-                'Could not submit notification to Slack: {}'.format(e))
+                'Could not submit notification to Slack: {0}'.format(e))
 
     def v2_playbook_on_start(self, playbook):
         self.init_config(playbook)
-        self.log('**Playbook**: {}\n\n'.format(os.path.basename(playbook._file_name)))
+        self.log('**Playbook**: {0}\n\n'.format(os.path.basename(playbook._file_name)))
 
     def v2_playbook_on_play_start(self, play):
         self.play = play
-        name = play.name or 'Not specified #{}'.format(play._uuid)
-        self.log('# Play: {}\n\n'.format(name))
+        name = play.name or 'Not specified #{0}'.format(play._uuid)
+        self.log('# Play: {0}\n\n'.format(name))
 
     def v2_playbook_on_stats(self, stats):
         color = 'good'
@@ -116,32 +116,32 @@ class CallbackModule(CallbackBase):
         hosts = sorted(stats.processed.keys())
         for host in hosts:
             summary = stats.summarize(host)
-            self.log('**Host**: {}\n'.format(host))
+            self.log('**Host**: {0}\n'.format(host))
             for item, count in summary.items():
-                self.log('> **{}**: {}\n\n'.format(item, count))
+                self.log('> **{0}**: {1}\n\n'.format(item, count))
                 if item == 'failures' and count > 0:
                     color = 'danger'
         self.send(color)
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
-        self.log('**_FAILED_ {}** | {}\n\n'.format(result._host.get_name(),
+        self.log('**_FAILED_ {0}** | {1}\n\n'.format(result._host.get_name(),
                                                    result._task.get_name().strip()))
         self.log(
-            '```json\n{}\n```\n\n'.format(
+            '```json\n{0}\n```\n\n'.format(
                 json.dumps(
                     result._result,
                     indent=1,
                     sort_keys=True)))
 
     def v2_runner_on_ok(self, result):
-        self.log('**{}** | {}\n\n'.format(result._host.get_name(),
+        self.log('**{0}** | {1}\n\n'.format(result._host.get_name(),
                                           result._task.get_name().strip()))
 
     def v2_runner_on_unreachable(self, result):
-        self.log('**_UNREACHABLE_ {}** | {}\n\n'.format(result._host.get_name(),
+        self.log('**_UNREACHABLE_ {0}** | {1}\n\n'.format(result._host.get_name(),
                                                         result._task.get_name().strip))
         self.log(
-            '```json\n{}\n```\n\n'.format(
+            '```json\n{0}\n```\n\n'.format(
                 json.dumps(
                     result._result,
                     indent=1,

--- a/lib/ansible/plugins/callback/slack_github.py
+++ b/lib/ansible/plugins/callback/slack_github.py
@@ -103,7 +103,8 @@ class CallbackModule(CallbackBase):
 
     def v2_playbook_on_start(self, playbook):
         self.init_config(playbook)
-        self.log('**Playbook**: {0}\n\n'.format(os.path.basename(playbook._file_name)))
+        self.log(
+            '**Playbook**: {0}\n\n'.format(os.path.basename(playbook._file_name)))
 
     def v2_playbook_on_play_start(self, play):
         self.play = play
@@ -124,8 +125,10 @@ class CallbackModule(CallbackBase):
         self.send(color)
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
-        self.log('**_FAILED_ {0}** | {1}\n\n'.format(result._host.get_name(),
-                                                   result._task.get_name().strip()))
+        self.log(
+            '**_FAILED_ {0}** | {1}\n\n'.format(
+                result._host.get_name(),
+                result._task.get_name().strip()))
         self.log(
             '```json\n{0}\n```\n\n'.format(
                 json.dumps(
@@ -135,11 +138,13 @@ class CallbackModule(CallbackBase):
 
     def v2_runner_on_ok(self, result):
         self.log('**{0}** | {1}\n\n'.format(result._host.get_name(),
-                                          result._task.get_name().strip()))
+                                            result._task.get_name().strip()))
 
     def v2_runner_on_unreachable(self, result):
-        self.log('**_UNREACHABLE_ {0}** | {1}\n\n'.format(result._host.get_name(),
-                                                        result._task.get_name().strip))
+        self.log(
+            '**_UNREACHABLE_ {0}** | {1}\n\n'.format(
+                result._host.get_name(),
+                result._task.get_name().strip))
         self.log(
             '```json\n{0}\n```\n\n'.format(
                 json.dumps(


### PR DESCRIPTION
##### ISSUE TYPE

* Feature Pull Request

##### COMPONENT NAME
* callback/slack_github.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
config file = /etc/ansible/ansible.cfg
configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This is an ansible callback plugin that sends full play recap to github gist and sends colored notification to  a Slack channel after play ends.

This plugin makes use of file `slack.json` in your playbook folder with following contents:

```json
{
    "webhook": "Slack incoming webhook url",
    "channel": "#slackchannel",
    "username": "Ansible"
}
```
Notification screenshot:

![ansible-notification](https://cloud.githubusercontent.com/assets/3428087/20076519/649bbaf8-a541-11e6-80a8-2b8167f4029e.png)

Recap output: https://gist.github.com/anonymous/f75e04a115ea86b730e41e2ef03cc5f0
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
No visual changes when running ansible, only notification in slack channel and gist with formated recap output
```

