### PR TITLE
Remove direct calls to print and cleanup imports

### DIFF
--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -195,8 +195,8 @@ class Base(with_metaclass(BaseMeta, object)):
 
     def dump_me(self, depth=0):
         if depth == 0:
-            print("DUMPING OBJECT ------------------------------------------------------")
-        print("%s- %s (%s, id=%s)" % (" " * depth, self.__class__.__name__, self, id(self)))
+            display.debug("DUMPING OBJECT ------------------------------------------------------")
+        display.debug("%s- %s (%s, id=%s)" % (" " * depth, self.__class__.__name__, self, id(self)))
         if hasattr(self, '_parent') and self._parent:
             self._parent.dump_me(depth+2)
             dep_chain = self._parent.get_dep_chain()

--- a/lib/ansible/plugins/cache/memcached.py
+++ b/lib/ansible/plugins/cache/memcached.py
@@ -19,19 +19,18 @@ __metaclass__ = type
 
 import collections
 import os
-import sys
 import time
 from multiprocessing import Lock
 from itertools import chain
 
 from ansible import constants as C
+from ansible.errors import AnsibleError
 from ansible.plugins.cache.base import BaseCacheModule
 
 try:
     import memcache
 except ImportError:
-    print('python-memcached is required for the memcached fact cache')
-    sys.exit(1)
+    raise AnsibleError("python-memcached is required for the memcached fact cache")
 
 
 class ProxyClientPool(object):

--- a/lib/ansible/plugins/callback/jabber.py
+++ b/lib/ansible/plugins/callback/jabber.py
@@ -16,7 +16,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import os,sys,re,socket
+import os
+
 HAS_XMPP = True
 try:
     import xmpp
@@ -24,9 +25,8 @@ except ImportError:
     HAS_XMPP = False
 
 from ansible.plugins.callback import CallbackBase
-from ansible import utils
-from ansible.module_utils import basic
-from ansible.utils.unicode import to_unicode, to_bytes
+
+
 class CallbackModule(CallbackBase):
 
     CALLBACK_VERSION = 2.0
@@ -39,8 +39,9 @@ class CallbackModule(CallbackBase):
         super(CallbackModule, self).__init__(display=display)
 
         if not HAS_XMPP:
-            print ("The required python xmpp library (xmpppy) is not installed"
-             "pip install git+https://github.com/ArchipelProject/xmpppy")
+            self._display.warning("The required python xmpp library (xmpppy) is not installed."
+                " pip install git+https://github.com/ArchipelProject/xmpppy")
+            self.disabled = True
 
         self.serv = os.getenv('JABBER_SERV')
         self.j_user = os.getenv('JABBER_USER')
@@ -73,7 +74,6 @@ class CallbackModule(CallbackBase):
         """Display Playbook and play start messages"""
         self.play = play
         name = play.name
-        playbook = play.name
         self.send_msg("Ansible starting play: %s" % (name))
 
     def playbook_on_stats(self, stats):

--- a/lib/ansible/plugins/callback/json.py
+++ b/lib/ansible/plugins/callback/json.py
@@ -76,7 +76,7 @@ class CallbackModule(CallbackBase):
             'stats': summary
         }
 
-        print(json.dumps(output, indent=4, sort_keys=True))
+        self._display.display(json.dumps(output, indent=4, sort_keys=True))
 
     v2_runner_on_failed = v2_runner_on_ok
     v2_runner_on_unreachable = v2_runner_on_ok


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
various

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

##### SUMMARY

All display of information should go through display instead of through print.