### PR TITLE
openstack: iterate through nova addresses with six

### DIFF
--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -28,6 +28,7 @@
 
 import os
 
+from ansible.module_utils.six import iteritems
 
 def openstack_argument_spec():
     # DEPRECATED: This argument spec is only used for the deprecated old
@@ -61,7 +62,7 @@ def openstack_argument_spec():
 def openstack_find_nova_addresses(addresses, ext_tag, key_name=None):
 
     ret = []
-    for (k, v) in addresses.iteritems():
+    for (k, v) in iteritems(addresses):
         if key_name and k == key_name:
             ret.extend([addrs['addr'] for addrs in v])
         else:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`ansible.module_utils.openstack`
part of the `os_server` module

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = 
  configured module search path = Default w/o overrides

```

##### SUMMARY
Allow the `os_server` module to work under python3.
