### PR TITLE
Create code smell test for key=value syntax

### DIFF
--- a/test/sanity/code-smell/expample-syntax.sh
+++ b/test/sanity/code-smell/expample-syntax.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Look through EXAMPLES in core modules for instanecs of key=value syntax
+# Modules can be allowed to include this syntax style in the examples
+# by adding to the WHITELIST_REGEXP
+
+BASEDIR=${1-"lib/ansible/modules/core"}
+WHITELIST_REGEXP="(.*command|mysql_user|.*lineinfile|synchronize|slurp)\.py"                     # Example: (win.*|apache2_mod_.*)\.py
+FOUND=""
+MODULES=$(find "$BASEDIR" -regextype posix-egrep -name '*.py' ! -regex ".*/$WHITELIST_REGEXP")
+
+for module in $MODULES; do
+    # Isolate lines between EXAMPLES ''' and ''', single or double quotes
+    # Exclude lines with comments, ad-hoc commands, 'with_', and several other parameters
+    test=$(sed -n "/EXAMPLES/,/\('''\|\"\"\"\)/p" "$module" | grep -Pv "(EXAMPLES|(^(\s+)?#)|(:.*?#)|(with_\w+:)|(^\s+-.*=)|((meta|nics|mode|body|url|name|key_options|src|command|shell):)|(\|\s+?\w+\(.*=.*\))|(^(\\$\s+)?ansible))" | grep -P '\w+=[^\s=]')
+    if [ -n "$test" ] ; then
+        FOUND="$FOUND#$module"
+    fi
+done
+
+if [ -n "$FOUND" ] ; then
+    echo "$FOUND" | tr '#' '\n'
+    echo "One or more of the above modules uses the key=value syntax in the EXAMPLES section."
+    echo "Please change the examples to use multi-line YAML."
+    exit 1
+fi
+
+exit 0
+


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
Feature Pull Request

##### COMPONENT NAME
Code Smell Scripts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (example-syntax-sniff e4420517ad) last updated 2016/11/07 21:46:16 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 2584fca0ae) last updated 2016/11/07 21:31:06 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD a1dcbf9ce5) last updated 2016/11/07 21:26:12 (GMT -400)
  config file = /Users/sdoran/.ansible.cfg
  configured module search path = ['/Users/sdoran/Source/ansible/library']
```

##### SUMMARY

Per Ansible Core team meeitng on [2016-11-03](https://meetbot.fedoraproject.org/ansible-meeting/2016-11-03/public_core_meeting.2016-11-03-15.02.html), create a [code smell test](https://meetbot.fedoraproject.org/ansible-meeting/2016-11-03/public_core_meeting.2016-11-03-15.02.log.html#l-194) to look for `key=value` syntax in EXAMPLES in Core modules.

The script allows modules to be excluded to the test by passing in a regexp.

I'm open to suggestions on the actual regexp that checks for the `key=value` pairs.
