### PR TITLE
Add 'to_int' jinja2 filter

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -120,6 +120,23 @@ def to_bool(a):
 def to_datetime(string, format="%Y-%d-%m %H:%M:%S"):
     return datetime.strptime(string, format)
 
+def to_int(a):
+    if a is None or isinstance(a, (int, long)):
+        return a
+    elif isinstance(a, string_types):
+        try:
+            return int(a)
+        except ValueError:
+            return a
+    elif isinstance(a, dict):
+        casted_dict = dict()
+        for k,v in a.iteritems():
+            casted_dict[k] = to_int(v)
+        return casted_dict
+    elif isinstance(a, list):
+        return map(to_int, a)
+    else:
+        return a
 
 def quote(a):
     ''' return its argument quoted for shell usage '''
@@ -455,6 +472,9 @@ class FilterModule(object):
 
             #date
             'to_datetime': to_datetime,
+
+            # int
+            'to_int': to_int,
 
             # path
             'basename': partial(unicode_wrap, os.path.basename),


### PR DESCRIPTION
##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

`to_int`

##### ANSIBLE VERSION

```
ansible 2.3.0 (feature/add_filter/to_int 32aaf298a5) last updated 2016/11/08 14:23:18 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 2584fca0ae) last updated 2016/11/08 13:42:14 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD a1dcbf9ce5) last updated 2016/11/08 13:42:17 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

`to_int` works on recursive data structure, it will convert everything that can be to integers (keeping the rest identical).

It's useful when you have a dictionary or array of things (string or nested arrays/dictionaries) and want everything inside those to be integers. The same idea can be applied to `to_bool`, `to_*` converters if it's useful to others.