### PR TITLE
Update the link to the os-client-config repository

### DIFF
--- a/contrib/inventory/openstack.py
+++ b/contrib/inventory/openstack.py
@@ -19,7 +19,7 @@
 # along with this software.  If not, see <http://www.gnu.org/licenses/>.
 
 # The OpenStack Inventory module uses os-client-config for configuration.
-# https://github.com/stackforge/os-client-config
+# https://github.com/openstack/os-client-config
 # This means it will either:
 #  - Respect normal OS_* environment variables like other OpenStack tools
 #  - Read values from a clouds.yaml file.


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
contrib/inventory/openstack.py

##### ANSIBLE VERSION
Not relevant

##### SUMMARY
This is a trivial change in a comment block: os-client-config has moved from /stackforge/ to /openstack/ a long time ago.