### PR TITLE
Fix handling of ReaderError in validate-modules.

### DIFF
--- a/test/sanity/validate-modules/validate-modules
+++ b/test/sanity/validate-modules/validate-modules
@@ -41,6 +41,7 @@ from schema import doc_schema, option_schema
 from utils import CaptureStd
 
 import yaml
+import yaml.reader
 
 
 BLACKLIST_DIRS = frozenset(('.git', 'test', '.github', '.idea'))
@@ -383,7 +384,7 @@ class ModuleValidator(Validator):
         doc_info = self._get_docs()
         try:
             doc = yaml.safe_load(doc_info['DOCUMENTATION']['value'])
-        except yaml.YAMLError as e:
+        except yaml.MarkedYAMLError as e:
             doc = None
             # This offsets the error line number to where the
             # DOCUMENTATION starts so we can just go to that line in the
@@ -397,6 +398,13 @@ class ModuleValidator(Validator):
                                'column %d' %
                                (e.problem_mark.line + 1,
                                 e.problem_mark.column + 1))
+        except yaml.reader.ReaderError as e:
+            self.traces.append(e)
+            self.errors.append('DOCUMENTATION is not valid YAML. Character 0x%x at position %d.' %
+                               (e.character, e.position))
+        except yaml.YAMLError as e:
+            self.traces.append(e)
+            self.errors.append('DOCUMENTATION is not valid YAML: %s: %s' % (type(e), e))
         except AttributeError:
             self.errors.append('No DOCUMENTATION provided')
         else:
@@ -427,7 +435,7 @@ class ModuleValidator(Validator):
         else:
             try:
                 yaml.safe_load(doc_info['RETURN']['value'])
-            except yaml.YAMLError as e:
+            except yaml.MarkedYAMLError as e:
                 e.problem_mark.line += (
                     doc_info['RETURN']['lineno'] - 1
                 )
@@ -437,6 +445,13 @@ class ModuleValidator(Validator):
                                    (e.problem_mark.line + 1,
                                     e.problem_mark.column + 1))
                 self.traces.append(e)
+            except yaml.reader.ReaderError as e:
+                self.traces.append(e)
+                self.errors.append('RETURN is not valid YAML. Character 0x%x at position %d.' %
+                                   (e.character, e.position))
+            except yaml.YAMLError as e:
+                self.traces.append(e)
+                self.errors.append('RETURN is not valid YAML: %s: %s' % (type(e), e))
 
     def _check_version_added(self, doc):
         if not self._is_new_module():


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

validate-modules

##### ANSIBLE VERSION

```
ansible 2.3.0 (validate-modules 296675f34f) last updated 2016/11/09 00:17:23 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 2584fca0ae) last updated 2016/11/04 00:00:27 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD a1dcbf9ce5) last updated 2016/11/03 16:14:54 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Fix handling of ReaderError in validate-modules.