### PR TITLE
Enable communication to management API over HTTPS. Fixes #22953

### DIFF
--- a/lib/ansible/module_utils/rabbitmq.py
+++ b/lib/ansible/module_utils/rabbitmq.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+# (c) 2016, Jorge Rodriguez <jorge.rodriguez@tiriel.eu>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+def rabbitmq_argument_spec():
+
+    return dict(
+        login_user=dict(default='guest', type='str'),
+        login_password=dict(default='guest', type='str', no_log=True),
+        login_host=dict(default='localhost', type='str'),
+        login_port=dict(default='15672', type='str'),
+        login_protocol=dict(default='http', choices=['http', 'https'], type='str'),
+        cacert=dict(required=False, type='path', default=None),
+        cert=dict(required=False, type='path', default=None),
+        key=dict(required=False, type='path', default=None),
+        vhost=dict(default='/', type='str'),
+    )

--- a/lib/ansible/module_utils/rabbitmq.py
+++ b/lib/ansible/module_utils/rabbitmq.py
@@ -1,25 +1,11 @@
 # -*- coding: utf-8 -*-
-
-# (c) 2016, Jorge Rodriguez <jorge.rodriguez@tiriel.eu>
 #
-# This file is part of Ansible
+# Copyright: (c) 2016, Jorge Rodriguez <jorge.rodriguez@tiriel.eu>
 #
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 
 def rabbitmq_argument_spec():
-
     return dict(
         login_user=dict(default='guest', type='str'),
         login_password=dict(default='guest', type='str', no_log=True),

--- a/lib/ansible/modules/messaging/rabbitmq_binding.py
+++ b/lib/ansible/modules/messaging/rabbitmq_binding.py
@@ -36,26 +36,6 @@ options:
       - source exchange to create binding on.
       required: true
       aliases: [ "src", "source" ]
-    login_user:
-      description:
-      - rabbitMQ user for the connection.
-      default: guest
-    login_password:
-      description:
-      - rabbitMQ password for the connection.
-      default: false
-    login_host:
-      description:
-      - rabbitMQ host for the connection.
-      default: localhost
-    login_port:
-      description:
-      - rabbitMQ management API port.
-      default: 15672
-    vhost:
-      description:
-      - rabbitMQ virtual host.
-      default: "/"
     destination:
       description:
       - destination exchange or queue for the binding.
@@ -72,10 +52,10 @@ options:
       - routing key for the binding.
       default: "#"
     arguments:
-        description:
-            - extra arguments for exchange. If defined this argument is a key/value dictionary
-        required: false
-        default: {}
+      description:
+      - extra arguments for exchange. If defined this argument is a key/value dictionary
+      required: false
+      default: {}
 extends_documentation_fragment:
     - rabbitmq
 '''
@@ -121,6 +101,7 @@ class RabbitMqBinding(object):
         self.login_password = self.module.params['login_password']
         self.login_host = self.module.params['login_host']
         self.login_port = self.module.params['login_port']
+        self.login_protocol = self.module.params['login_protocol']
         self.vhost = self.module.params['vhost']
         self.destination = self.module.params['destination']
         self.destination_type = 'q' if self.module.params['destination_type'] == 'queue' else 'e'
@@ -129,8 +110,9 @@ class RabbitMqBinding(object):
         self.verify = self.module.params['cacert']
         self.cert = self.module.params['cert']
         self.key = self.module.params['key']
-        self.base_url = 'http://{0}:{1}/api/bindings'.format(self.login_host,
-                                                             self.login_port)
+        self.base_url = '{0}://{1}:{2}/api/bindings'.format(self.login_protocol,
+                                                            self.login_host,
+                                                            self.login_port)
         self.url = '{0}/{1}/e/{2}/{3}/{4}/{5}'.format(self.base_url,
                                                       urllib_parse.quote(self.vhost, safe=''),
                                                       urllib_parse.quote(self.name, safe=''),

--- a/lib/ansible/modules/messaging/rabbitmq_exchange.py
+++ b/lib/ansible/modules/messaging/rabbitmq_exchange.py
@@ -202,6 +202,5 @@ def main():
         )
 
 
-
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/messaging/rabbitmq_exchange.py
+++ b/lib/ansible/modules/messaging/rabbitmq_exchange.py
@@ -35,31 +35,6 @@ options:
         choices: [ "present", "absent" ]
         required: false
         default: present
-    login_user:
-        description:
-            - rabbitMQ user for connection
-        required: false
-        default: guest
-    login_password:
-        description:
-            - rabbitMQ password for connection
-        required: false
-        default: false
-    login_host:
-        description:
-            - rabbitMQ host for connection
-        required: false
-        default: localhost
-    login_port:
-        description:
-            - rabbitMQ management api port
-        required: false
-        default: 15672
-    vhost:
-        description:
-            - rabbitMQ virtual host
-        required: false
-        default: "/"
     durable:
         description:
             - whether exchange is durable or not
@@ -90,6 +65,8 @@ options:
             - extra arguments for exchange. If defined this argument is a key/value dictionary
         required: false
         default: {}
+extends_documentation_fragment:
+    - rabbitmq
 '''
 
 EXAMPLES = '''
@@ -114,30 +91,27 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves.urllib import parse as urllib_parse
+from ansible.module_utils.rabbitmq import rabbitmq_argument_spec
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
+
+    argument_spec = rabbitmq_argument_spec()
+    argument_spec.update(
+        dict(
             state=dict(default='present', choices=['present', 'absent'], type='str'),
             name=dict(required=True, type='str'),
-            login_user=dict(default='guest', type='str'),
-            login_password=dict(default='guest', type='str', no_log=True),
-            login_host=dict(default='localhost', type='str'),
-            login_port=dict(default='15672', type='str'),
-            vhost=dict(default='/', type='str'),
             durable=dict(default=True, type='bool'),
             auto_delete=dict(default=False, type='bool'),
             internal=dict(default=False, type='bool'),
             exchange_type=dict(default='direct', aliases=['type'], type='str'),
             arguments=dict(default=dict(), type='dict')
-        ),
-        supports_check_mode=True
+        )
     )
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
-    result = dict(changed=False, name=module.params['name'])
-
-    url = "http://%s:%s/api/exchanges/%s/%s" % (
+    url = "%s://%s:%s/api/exchanges/%s/%s" % (
+        module.params['login_protocol'],
         module.params['login_host'],
         module.params['login_port'],
         urllib_parse.quote(module.params['vhost'], ''),
@@ -147,8 +121,11 @@ def main():
     if not HAS_REQUESTS:
         module.fail_json(msg="requests library is required for this module. To install, use `pip install requests`")
 
+    result = dict(changed=False, name=module.params['name'])
+
     # Check if exchange already exists
-    r = requests.get(url, auth=(module.params['login_user'], module.params['login_password']))
+    r = requests.get(url, auth=(module.params['login_user'], module.params['login_password']),
+                     verify=module.params['cacert'], cert=(module.params['cert'], module.params['key']))
 
     if r.status_code == 200:
         exchange_exists = True
@@ -199,10 +176,13 @@ def main():
                     "internal": module.params['internal'],
                     "type": module.params['exchange_type'],
                     "arguments": module.params['arguments']
-                })
+                }),
+                verify=module.params['cacert'],
+                cert=(module.params['cert'], module.params['key'])
             )
         elif module.params['state'] == 'absent':
-            r = requests.delete(url, auth=(module.params['login_user'], module.params['login_password']))
+            r = requests.delete(url, auth=(module.params['login_user'], module.params['login_password']),
+                                verify=module.params['cacert'], cert=(module.params['cert'], module.params['key']))
 
         # RabbitMQ 3.6.7 changed this response code from 204 to 201
         if r.status_code == 204 or r.status_code == 201:
@@ -216,8 +196,11 @@ def main():
             )
 
     else:
-        result['changed'] = False
-        module.exit_json(**result)
+        module.exit_json(
+            changed=False,
+            name=module.params['name']
+        )
+
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/messaging/rabbitmq_queue.py
+++ b/lib/ansible/modules/messaging/rabbitmq_queue.py
@@ -34,27 +34,6 @@ options:
             - Only present implemented atm
         choices: [ "present", "absent" ]
         default: present
-    login_user:
-        description:
-            - rabbitMQ user for connection
-        default: guest
-    login_password:
-        description:
-            - rabbitMQ password for connection
-        type: bool
-        default: 'no'
-    login_host:
-        description:
-            - rabbitMQ host for connection
-        default: localhost
-    login_port:
-        description:
-            - rabbitMQ management api port
-        default: 15672
-    vhost:
-        description:
-            - rabbitMQ virtual host
-        default: "/"
     durable:
         description:
             - whether queue is durable or not
@@ -141,8 +120,7 @@ def main():
             dead_letter_routing_key=dict(default=None, type='str'),
             arguments=dict(default=dict(), type='dict'),
             max_priority=dict(default=None, type='int')
-        ),
-        supports_check_mode=True
+        )
     )
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
@@ -271,7 +249,6 @@ def main():
             changed=False,
             name=module.params['name']
         )
-
 
 
 if __name__ == '__main__':

--- a/lib/ansible/utils/module_docs_fragments/rabbitmq.py
+++ b/lib/ansible/utils/module_docs_fragments/rabbitmq.py
@@ -1,0 +1,70 @@
+# (c) 2016, Jorge Rodriguez <jorge.rodriguez@tiriel.eu>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class ModuleDocFragment(object):
+    # Parameters for RabbitMQ modules
+    DOCUMENTATION = '''
+options:
+    login_user:
+        description:
+            - rabbitMQ user for connection
+        required: false
+        default: guest
+    login_password:
+        description:
+            - rabbitMQ password for connection
+        required: false
+        default: false
+    login_host:
+        description:
+            - rabbitMQ host for connection
+        required: false
+        default: localhost
+    login_port:
+        description:
+            - rabbitMQ management api port
+        required: false
+        default: 15672
+    login_protocol:
+        description:
+            - rabbitMQ management api protocol
+        choices: [ http , https ]
+        required: false
+        default: http
+        version_added: "2.3"
+    cacert:
+        description:
+            - CA certificate to verify SSL connection to management API.
+        required: false
+        version_added: "2.3"
+    cert:
+        description:
+            - Client certificate to send on SSL connections to management API.
+        required: false
+        version_added: "2.3"
+    key:
+        description:
+            - Private key matching the client certificate.
+        required: false
+        version_added: "2.3"
+    vhost:
+        description:
+            - rabbitMQ virtual host
+        required: false
+        default: "/"
+'''

--- a/lib/ansible/utils/module_docs_fragments/rabbitmq.py
+++ b/lib/ansible/utils/module_docs_fragments/rabbitmq.py
@@ -1,19 +1,6 @@
-# (c) 2016, Jorge Rodriguez <jorge.rodriguez@tiriel.eu>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2016, Jorge Rodriguez <jorge.rodriguez@tiriel.eu>
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 
 class ModuleDocFragment(object):
@@ -22,27 +9,27 @@ class ModuleDocFragment(object):
 options:
     login_user:
         description:
-            - rabbitMQ user for connection
+            - rabbitMQ user for connection.
         required: false
         default: guest
     login_password:
         description:
-            - rabbitMQ password for connection
+            - rabbitMQ password for connection.
         required: false
         default: false
     login_host:
         description:
-            - rabbitMQ host for connection
+            - rabbitMQ host for connection.
         required: false
         default: localhost
     login_port:
         description:
-            - rabbitMQ management api port
+            - rabbitMQ management API port.
         required: false
         default: 15672
     login_protocol:
         description:
-            - rabbitMQ management api protocol
+            - rabbitMQ management API protocol.
         choices: [ http , https ]
         required: false
         default: http
@@ -64,7 +51,7 @@ options:
         version_added: "2.3"
     vhost:
         description:
-            - rabbitMQ virtual host
+            - rabbitMQ virtual host.
         required: false
         default: "/"
 '''


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
rabbitmq utils

##### ANSIBLE VERSION
```
ansible 2.2.0 (devel 4dddea69c2) last updated 2016/11/09 16:33:00 (GMT +300)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras:  not found - use git submodule update --init lib/ansible/modules/extras
  config file = 
  configured module search path = Default w/o overrides

```

##### SUMMARY
These files complement PR ansible/ansible-modules-extras#2872

