### PR TITLE
+= keys and values filters

### DIFF
--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -140,6 +140,15 @@ To get the symmetric difference of 2 lists (items exclusive to each list)::
 
     {{ list1 | symmetric_difference(list2) }}
 
+.. versionadded:: x.x
+
+To get the keys of a dictionary or list as a list (lists get numeric keys):
+
+   {{ dict | keys }}
+
+To get the values of a dictionary or list as a list:
+
+   {{ dict | values }}
 
 .. _random_filter:
 

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -63,6 +63,20 @@ def union(a, b):
         c = unique(a + b)
     return c
 
+def keys(a):
+    if isinstance(a,collections.Hashable):
+        c = set(a)
+    else:
+        c = range(len(a))
+    return c
+
+def values(a):
+   if isinstance(a,collections.Hashable):
+        c = [ x[y] for y in set(x)]
+   else:
+        c = a
+   return c
+
 def min(a):
     _min = __builtins__.get('min')
     return _min(a);


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
plugin/filters/mathstuff

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 9aa857cf4b) last updated 2016/11/09 19:01:50 (GMT +100)
  lib/ansible/modules/core: (detached HEAD 2584fca0ae) last updated 2016/11/09 19:32:28 (GMT +100)
  lib/ansible/modules/extras: (detached HEAD a1dcbf9ce5) last updated 2016/11/09 19:32:35 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
The math functions are very nice and useful but can be hard and painful if perchance the incoming data sttructure is a dictionary rather than a list.  These two functions make that transition painless, making the mathstuff functions more accessible.

The functions work equally on dictionaries and lists - special cases cause pain so the API is intended to be intuitive, simple and just do the right thing.