### PR TITLE
Fix for import 'display' in lib/ansible/plugins/lookup/filetree.py

### DIFF
--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -32,8 +32,11 @@ except ImportError:
 from ansible.plugins.lookup import LookupBase
 from ansible.module_utils._text import to_native
 
-from __main__ import display
-
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
 
 # If selinux fails to find a default, return an array of None
 def selinux_context(path):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Module 'lookup'

##### ANSIBLE VERSION
```
2.2.0.0
```

##### SUMMARY
This change implements exception handling for importing module 'display' in lib/ansible/plugins/lookup/filetree.py.

I've got an error with plugin 'autocomplete-python' (version 1.8.11) for Atom code editor (version 1.12.0) on MacOS 10.12.1 with python 2.7.12 (installed using homebrew):
```
ImportError: cannot import name display
```

This small patch fixes this error.
