### PR TITLE
Adds `follow` parameter to `template` action

### DIFF
--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -36,14 +36,14 @@ class ActionModule(ActionBase):
 
     TRANSFERS_FILES = True
 
-    def get_checksum(self, dest, all_vars, try_directory=False, source=None, tmp=None):
+    def get_checksum(self, dest, all_vars, try_directory=False, source=None, tmp=None, follow=False):
         try:
             dest_stat = self._execute_remote_stat(dest, all_vars=all_vars, follow=False, tmp=tmp)
 
             if dest_stat['exists'] and dest_stat['isdir'] and try_directory and source:
                 base = os.path.basename(source)
                 dest = os.path.join(dest, base)
-                dest_stat = self._execute_remote_stat(dest, all_vars=all_vars, follow=False, tmp=tmp)
+                dest_stat = self._execute_remote_stat(dest, all_vars=all_vars, follow=follow, tmp=tmp)
 
         except AnsibleError:
             return dict(failed=True, msg=to_native(get_exception()))
@@ -62,6 +62,7 @@ class ActionModule(ActionBase):
         dest   = self._task.args.get('dest', None)
         force  = boolean(self._task.args.get('force', True))
         state  = self._task.args.get('state', None)
+        follow = self._task.args.get('follow', True)
 
         if state is not None:
             result['failed'] = True
@@ -178,7 +179,7 @@ class ActionModule(ActionBase):
                         src=xfered,
                         dest=dest,
                         original_basename=os.path.basename(source),
-                        follow=True,
+                        follow=follow,
                         ),
                 )
                 result.update(self._execute_module(module_name='copy', module_args=new_module_args, task_vars=task_vars, tmp=tmp, delete_remote_tmp=False))
@@ -197,7 +198,7 @@ class ActionModule(ActionBase):
                 dict(
                     src=None,
                     original_basename=os.path.basename(source),
-                    follow=True,
+                    follow=follow,
                 ),
             )
             result.update(self._execute_module(module_name='file', module_args=new_module_args, task_vars=task_vars, tmp=tmp, delete_remote_tmp=False))


### PR DESCRIPTION
##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

Action: `template`

##### ANSIBLE VERSION

Tested against current devel branch.

```
ansible-playbook --version
ansible-playbook 2.3.0 (feature/add-follow-to-template-action 36b7db8fc5) last updated 2016/11/10 17:08:11 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 2584fca0ae) last updated 2016/11/10 12:07:13 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD a1dcbf9ce5) last updated 2016/11/10 12:07:19 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This PR introduces the `follow` option to the `template` action plugin. The desired behaviour as reported in #14469 is the same as of the `copy` and `file` module, since this action plugin just relies on these modules. This means, if this template is applied to a link with `follow` set to `False` then the link will be converted to a regular file containing the template content. 

Fixes #14469 

Using this playbook:
```
- hosts: all
  vars:
    greetings: "Hello f*ck*ng hell!"
  tasks: 
    - name: test
      template: 
        src: "test"
        dest: "/tmp/link"
        follow: False
```

... and this template file:
```
{{ greetings }}
```

The following output describes the new behaviour:
```
$ echo "Hello World" > /tmp/source
$ ln -fs /tmp/source /tmp/link

$ ls -la /tmp/link 
lrwxrwxrwx 1 foo foo 11 Nov 10 17:18 /tmp/link -> /tmp/source

$ ansible-playbook -i inventory test.yml  -v
Using /etc/ansible/ansible.cfg as config file

PLAY [all] *******************************************************************************************

TASK [Gathering Facts] *******************************************************************************
ok: [localhost]

TASK [test] ******************************************************************************************
changed: [localhost] => {"changed": true, "checksum": "7bc2660f74cfd11b442505e28b54be611cc013cd", "dest": "/tmp/link", "gid": 1000, "group": "fd", "md5sum": "6ecc0909e828485c6363d203942f580e", "mode": "0664", "owner": "fd", "size": 26, "src": "/home/fd/.ansible/tmp/ansible-tmp-1478794956.02-5427137697491/source", "state": "file", "uid": 1000}

PLAY RECAP *******************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0 

$ ls -la /tmp/link
-rw-rw-r-- 1 foo foo 26 Nov 10 17:22 /tmp/link

$ cat /tmp/link
Hello f*ck*ng hell!
```

Whereas the default of this parameter is `True` to retain backward compatibility.