### PR TITLE
Fix systemd regression with service action plugin

### DIFF
--- a/lib/ansible/plugins/action/service.py
+++ b/lib/ansible/plugins/action/service.py
@@ -36,7 +36,10 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        module = self._task.args.get('use', 'auto').lower()
+        # Default to None to preserve backwards compatibility with 2.x.
+        module = self._task.args.get('use', None)
+        if module:
+            module = module.lower()
 
         if module == 'auto':
             try:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
plugins/action/service.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
$ ansible --version
ansible 2.2.0.0
  config file = /home/pabelanger/.ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
See below, however there is a regression between 2.1 and 2.2 for the service task
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
pre-patch:
TASK [windmill.nodepool : Enable nodepool service.] ****************************
fatal: [nodepool]: FAILED! => {"changed": false, "failed": true, "msg": "Could not find the requested service \"'nodepool'\": "}

post-patch:
TASK [windmill.nodepool : Enable nodepool service.] ****************************
changed: [nodepool]

```

With the release of ansible 2.2, the service action plugin will try to
use the systemd module to preform actions with ubuntu xenial. This is
problematic if users are still using init.d script that generate
systemd services.

Since the use option only applies to ansible 2.2, there is no easy way
to apply this logic in post 2.2. roles.  As such, only enable this
logic if use is explictly defined.

Documentation should also be updated to properly document this
feature.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>