### PR TITLE
Add extensible strategy plugin

### DIFF
--- a/lib/ansible/plugins/strategy/extensible.py
+++ b/lib/ansible/plugins/strategy/extensible.py
@@ -1,0 +1,27 @@
+from ansible.playbook.task_include import TaskInclude
+from ansible.playbook.block import Block
+from ansible.plugins.strategy.linear import StrategyModule as LinearStrategy
+
+
+def inject_tasks(blocks, parent=None):
+    for idx, block in enumerate(blocks):
+        if isinstance(block, Block):
+            inject_tasks(block.block, parent=block)
+        else:
+            if not block._variable_manager:
+                continue
+            override = block._variable_manager.get_vars(block._loader, task=block)['ansible_override']
+            if "include_after" in override and override['include_after']['task'] in block.name:
+                include = override['include_after']['file']
+                include_task = TaskInclude.load(
+                        {'include': include},
+                        block=parent,
+                        variable_manager=block._variable_manager,
+                        role=block._role)
+                parent.block.insert(idx + 1, include_task)
+
+
+class StrategyModule(LinearStrategy):
+    def run(self, iterator, play_context):
+        inject_tasks(iterator._blocks)
+        return super(StrategyModule, self).run(iterator, play_context)


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Extensible strategy plugin

##### ANSIBLE VERSION
```
ansible 2.1.2.0
```

##### SUMMARY
During deployment of OpenStack with Ansible, we faced issue of having multiple people reusing our playbook for different use-cases. That also added requirement to support multiple different technologies in Kolla tree, but at the long run it's not possible. We need to allow people to modify playbooks to suit their needs with minimal impact on playbooks themselves. We want to avoid asking them to fork code and support patches on top of our code.

This strategy plugin will allow to include custom tasks into ansible
playbook without changing playbook code. To include file after any task
with Aodh in name, put this into globals.yml (our ansible config run with -e @/../globals.yml)

ansible_override:
    include_after:
        task: "Aodh"
        file: "/home/ubuntu/test.yml"

This is only PoC of mechanism, mechanism itself is a matter of discussion, same as API we want to present to actually include custom tasks to roles.