### PR TITLE
Move ansible ad-hoc tests to integration targets.

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -27,7 +27,10 @@ UNAME := $(shell uname | tr '[:upper:]' '[:lower:]')
 
 all: other non_destructive destructive
 
-other: test_test_infra parsing test_var_blending test_var_precedence unicode test_templating_settings environment test_as includes blocks pull_run pull_no_127 pull_limit_inventory check_mode test_hash test_handlers test_group_by test_vault test_tags test_lookup_paths no_log test_gathering_facts test_binary_modules_posix test_hosts_field test_lookup_properties args
+other: ansible test_test_infra parsing test_var_blending test_var_precedence unicode test_templating_settings environment test_as includes blocks pull_run pull_no_127 pull_limit_inventory check_mode test_hash test_handlers test_group_by test_vault test_tags test_lookup_paths no_log test_gathering_facts test_binary_modules_posix test_hosts_field test_lookup_properties args
+
+ansible:
+	(cd targets/ansible && ./runme.sh $(TEST_FLAGS))
 
 test_test_infra:
 	(cd targets/test_infra && ./runme.sh $(TEST_FLAGS))

--- a/test/integration/targets/ansible/runme.sh
+++ b/test/integration/targets/ansible/runme.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eux
+
+env
+
+which python
+python --version
+
+which ansible
+ansible --version
+ansible testhost -i ../../inventory -vvv -e "ansible_python_interpreter=$(which python)" -m ping
+ansible testhost -i ../../inventory -vvv -e "ansible_python_interpreter=$(which python)" -m setup

--- a/test/utils/shippable/sanity.sh
+++ b/test/utils/shippable/sanity.sh
@@ -29,9 +29,4 @@ else
     coverage_file="${coverage_dir}/nosetests-coverage.xml"
 
     TOX_TESTENV_PASSENV=NOSETESTS NOSETESTS="nosetests --with-xunit --xunit-file='${xunit_file}' --cover-xml --cover-xml-file='${coverage_file}'" tox
-
-    source hacking/env-setup
-    python --version
-    ansible --version
-    ansible -m ping localhost
 fi


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

Integration Tests

##### ANSIBLE VERSION

```
ansible 2.3.0 (ansible-integration 43da6b9e39) last updated 2016/11/10 22:06:55 (GMT -700)
  lib/ansible/modules/core: (detached HEAD d52d256196) last updated 2016/11/10 17:59:44 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 00d350de4e) last updated 2016/11/10 17:59:44 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides

```

##### SUMMARY

Move ansible ad-hoc tests to integration targets.