### PR TITLE
Assume template file contains variables when override header present

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -385,6 +385,10 @@ class Templar:
         returns True if the data contains a variable pattern
         '''
         if isinstance(data, string_types):
+            # Assume that it contains variables since the user obviously wants it passed through the templating engine
+            if data.startswith(JINJA2_OVERRIDE):
+                return True
+
             for marker in (self.environment.block_start_string, self.environment.variable_start_string, self.environment.comment_start_string):
                 if marker in data:
                     return True

--- a/test/integration/targets/template/files/override.txt
+++ b/test/integration/targets/template/files/override.txt
@@ -1,0 +1,11 @@
+templated_var_loaded
+
+{
+    "bool": true,
+    "multi_part": "1Foo",
+    "null_type": null,
+    "number": 5,
+    "string_num": "5"
+}
+
+{{ templated_var }}

--- a/test/integration/targets/template/tasks/main.yml
+++ b/test/integration/targets/template/tasks/main.yml
@@ -20,6 +20,10 @@
   template: src=foo.j2 dest={{output_dir}}/foo.templated mode=0644
   register: template_result
 
+- name: fill in a basic template with an override
+  template: src=override.j2 dest={{output_dir}}/override.templated mode=0644
+  register: template_result_override
+
 - assert: 
     that: 
         - "'changed' in template_result" 
@@ -47,17 +51,30 @@
   delegate_to: localhost
 
 - name: copy known good into place
-  copy: src=foo.txt dest={{output_dir}}/foo.txt
+  copy: src={{item}}.txt dest={{output_dir}}/{{item}}.txt
+  with_items:
+    - foo
+    - override
 
 - name: compare templated file to known good
   shell: diff -w {{output_dir}}/foo.templated {{output_dir}}/foo.txt
-  register: diff_result
+  register: diff_result_foo
 
 - name: verify templated file matches known good
-  assert:  
-    that: 
-        - 'diff_result.stdout == ""' 
-        - "diff_result.rc == 0" 
+  assert:
+    that:
+        - 'diff_result_foo.stdout == ""'
+        - "diff_result_foo.rc == 0"
+
+- name: compare templated file with override to known good
+  shell: diff -w {{output_dir}}/override.templated {{output_dir}}/override.txt
+  register: diff_result_override
+
+- name: verify templated file with override matches known good
+  assert:
+    that:
+        - 'diff_result_override.stdout == ""'
+        - "diff_result_override.rc == 0"
 
 # VERIFY MODE
 

--- a/test/integration/targets/template/templates/override.j2
+++ b/test/integration/targets/template/templates/override.j2
@@ -1,0 +1,6 @@
+#jinja2:variable_start_string:'[%', variable_end_string:'%]'
+[% templated_var %]
+
+[% templated_dict | to_nice_json %]
+
+{{ templated_var }}


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
Ansible (`lib/ansible/template`)

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (jinja2-override-no-skip fea57a43bd) last updated 2016/11/12 10:59:59 (GMT +100)
  lib/ansible/modules/core: (detached HEAD 8d1fe3b444) last updated 2016/11/12 10:39:31 (GMT +100)
  lib/ansible/modules/extras: (detached HEAD 88e58df86b) last updated 2016/11/12 10:39:31 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When checking if the file should be run through the templating engine, Ansible checks whether it contains any of the the Jinja2 markers (`{{`, `}}` or `{#`) otherwise it won't call the template engine

If you use the Jinja2 override header to override any of these markers, Ansible won't take these changes into consideration at this stage.

However, rather than reading the header and checking _those_ markers instead, I chose to use the presence of the header as an indicator of whether to use the templating engine.

The use of the header shows that the user obviously wants the file passed through the templating engine and, at the very least, it should be stripped. However, it's more than likely that the file will contain variables using that marker. 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #18192
