### PR TITLE
random filter: added optional 'seed' parameter

### DIFF
--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -168,6 +168,11 @@ Get a random number from 1 to 100 but in steps of 10::
     {{ 100 |random(1, 10) }}    => 31
     {{ 100 |random(start=1, step=10) }}    => 51
 
+It's also possible to initialize random number generator from seed. This way, you can create random-but-idempotent
+numbers (new in version 2.3)::
+
+    {{ 59 |random(seed=inventory_hostname) }} * * * * root /script/from/cron
+
 
 Shuffle Filter
 --------------

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -32,7 +32,7 @@ import crypt
 import hashlib
 import string
 from functools import partial
-from random import SystemRandom, shuffle
+from random import Random, SystemRandom, shuffle
 from datetime import datetime
 import uuid
 
@@ -199,8 +199,11 @@ def from_yaml(data):
     return data
 
 @environmentfilter
-def rand(environment, end, start=None, step=None):
-    r = SystemRandom()
+def rand(environment, end, start=None, step=None, seed=None):
+    if seed is None:
+        r = SystemRandom()
+    else:
+        r = Random(seed)
     if isinstance(end, (int, long)):
         if not start:
             start = 0


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME

core filter "random"

##### ANSIBLE VERSION
```
ansible 2.3.0 (bza_rand_seed 92137f18d0) last updated 2016/11/13 09:43:04 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 8d1fe3b444) last updated 2016/11/13 08:16:30 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 88e58df86b) last updated 2016/11/13 08:16:38 (GMT +200)
  config file = /home/zarnovic/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

Adds optional `seed` parameter to `random` filter.

This feature makes possible to implement idempotent plays, while still incorporating randomness in them. Typical example is a cronjob that should run at random time, but that time should be always the same for the same host. So, when the plays re-runs, it won't be changing the cronjob over and over.

```
- name: 'cronjob foo'
- cron:
    name: 'foo'
    minute: "{{ 59 | random(seed=inventory_hostname) }}"
    hour: 0
    job: /usr/local/bin/foo.sh
```

implements #15621

##### Tests

* from the looks of it, `plugins/filter/core.py` has _zero_ code coverage in unit-tests
* after spending good 20min, I haven't found anything under `tests/` that would be calling `random` filter.

So, here are the tests I did myself..

Python compatibility :+1: 
```
$ python2.4 -c 'from random import Random, SystemRandom, shuffle; r = Random("foo"); print r.randrange(0, 100, 1)'
88
$ python2.5 -c 'from random import Random, SystemRandom, shuffle; r = Random("foo"); print r.randrange(0, 100, 1)'
88
$ python2.6 -c 'from random import Random, SystemRandom, shuffle; r = Random("foo"); print r.randrange(0, 100, 1)'
88
$ python2.7 -c 'from random import Random, SystemRandom, shuffle; r = Random("foo"); print r.randrange(0, 100, 1)'
88
$ python3.4 -c 'from random import Random, SystemRandom, shuffle; r = Random("foo"); print(r.randrange(0, 100, 1))'
58
$ python3.5 -c 'from random import Random, SystemRandom, shuffle; r = Random("foo"); print(r.randrange(0, 100, 1))'
58
$ 
```

Functional tests :+1: 
old functionality still works
```
$ ansible -i /tmp/localhost all -m debug -a 'msg={{ 59| random(start=40) }}'
localhost | SUCCESS => {
    "msg": "48"
}
```
it is returning the same response over and over
```
$ ansible -i /tmp/localhost all -m debug -a 'msg={{ 59| random(seed="foo") }}'
localhost | SUCCESS => {
    "msg": "52"
}
$ ansible -i /tmp/localhost all -m debug -a 'msg={{ 59| random(seed="foo") }}'
localhost | SUCCESS => {
    "msg": "52"
}
```
seed can be numeric as well
```
$ ansible -i /tmp/localhost all -m debug -a 'msg={{ 59| random(seed=5) }}'
localhost | SUCCESS => {
    "msg": "36"
}
```
works on choice
```
$ ansible -i /tmp/localhost all -m debug -a 'msg={{ ["a", "b", "c"]| random(seed="foo") }}'
localhost | SUCCESS => {
    "msg": "c"
}
```
example from docs works as well
```
$ ansible -i /tmp/localhost all -m debug -a 'msg={{ 59 |random(seed=inventory_hostname) }}'
localhost | SUCCESS => {
    "msg": "19"
}
$ ansible -i /tmp/localhost all -m debug -a 'msg={{ 59 |random(seed=inventory_hostname) }}'
localhost | SUCCESS => {
    "msg": "19"
}
```