### PR TITLE
Include missing _text.to_text import

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -35,7 +35,7 @@ import pwd
 from ansible.module_utils.basic import get_all_subclasses
 from ansible.module_utils.six import PY3, iteritems
 from ansible.module_utils.six.moves import configparser, StringIO
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_native, to_text
 
 try:
     import selinux


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
lib/ansible/module_utils/facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (obsd_facts_to_text_18473 aae41715fa) last updated 2016/11/14 10:52:30 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 8d1fe3b444) last updated 2016/11/11 18:08:16 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 88e58df86b) last updated 2016/11/11 18:08:16 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = Default w/o overrides


```

##### SUMMARY

Fixes "global name 'to_text' is not defined" error on
openbsd clients.

Fixes #18473