### PR TITLE
added alias to argumetns 'args' to blacklist

### DIFF
--- a/lib/ansible/plugins/action/service.py
+++ b/lib/ansible/plugins/action/service.py
@@ -26,7 +26,7 @@ class ActionModule(ActionBase):
     TRANSFERS_FILES = False
 
     UNUSED_PARAMS = {
-        'systemd': ['pattern', 'runlevels', 'sleep', 'arguments'],
+        'systemd': ['pattern', 'runlevels', 'sleep', 'arguments', 'args'],
     }
 
     def run(self, tmp=None, task_vars=None):


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
service action plugin
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.2, 2.3
```

##### SUMMARY

this should fix https://github.com/ansible/ansible-modules-core/issues/5584