### PR TITLE
Documentation fix - ipaddr('cidr') works as described in the docs

### DIFF
--- a/docsite/rst/playbooks_filters_ipaddr.rst
+++ b/docsite/rst/playbooks_filters_ipaddr.rst
@@ -311,7 +311,7 @@ This result can be canonicalised with ``ipaddr()`` to produce a subnet in CIDR f
     # {{ net_mask | ipaddr('prefix') }}
     '24'
 
-    # {{ net_mask | ipaddr('net') }}
+    # {{ net_mask | ipaddr('cidr') }}
     '192.168.0.0/24'
 
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Documentation

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
$ ansible --version
ansible 2.2.0.0
  config file = /users/username/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

Documentation for `ipaddr('net')` is incorrect - `ipaddr('cidr')` performs the behavior as documented, on this page/section: http://docs.ansible.com/ansible/playbooks_filters_ipaddr.html#converting-subnet-masks-to-cidr-notation

Test playbook showing incorrect/correct behavior:
```
---
- hosts: localhost
  connection: local
  tasks:

    - name: ipaddr('prefix')
      debug:
        msg: "{{ '192.168.0.1/255.255.255.0' | ipaddr('prefix') }}"

    - name: ipaddr('net')
      debug:
        msg: "{{ '192.168.0.1/255.255.255.0' | ipaddr('net') }}"

    - name: ipaddr('cidr')
      debug:
        msg: "{{ '192.168.0.1/255.255.255.0' | ipaddr('cidr') }}"
```
Output:
```
$ ansible-playbook test.yaml 

PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [127.0.0.1]

TASK [ipaddr('prefix')] ********************************************************
ok: [127.0.0.1] => {
    "msg": "24"
}

TASK [ipaddr('net')] ***********************************************************
ok: [127.0.0.1] => {
    "msg": ""
}

TASK [ipaddr('cidr')] **********************************************************
ok: [127.0.0.1] => {
    "msg": "192.168.0.1/24"
}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=4    changed=0    unreachable=0    failed=0   
```
