### PR TITLE
Change old recommendation about insecure variables

### DIFF
--- a/docsite/rst/intro_inventory.rst
+++ b/docsite/rst/intro_inventory.rst
@@ -218,7 +218,7 @@ ansible_port
 ansible_user
     The default ssh user name to use.
 ansible_ssh_pass
-    The ssh password to use (never store this variable in plain text: always use a vault. See :ref:`best_practices_for_variables_and_vaults`)
+    The ssh password to use (never store this variable in plain text; always use a vault. See :ref:`best_practices_for_variables_and_vaults`)
 ansible_ssh_private_key_file
     Private key file used by ssh.  Useful if using multiple keys and you don't want to use SSH agent.
 ansible_ssh_common_args
@@ -247,7 +247,7 @@ ansible_become_method
 ansible_become_user
     Equivalent to ``ansible_sudo_user`` or ``ansible_su_user``, allows to set the user you become through privilege escalation
 ansible_become_pass
-    Equivalent to ``ansible_sudo_pass`` or ``ansible_su_pass``, allows you to set the privilege escalation password (never store this variable in plain text: always use a vault. See :ref:`best_practices_for_variables_and_vaults`)
+    Equivalent to ``ansible_sudo_pass`` or ``ansible_su_pass``, allows you to set the privilege escalation password (never store this variable in plain text; always use a vault. See :ref:`best_practices_for_variables_and_vaults`)
 
 Remote host environment parameters:
 

--- a/docsite/rst/intro_inventory.rst
+++ b/docsite/rst/intro_inventory.rst
@@ -218,7 +218,7 @@ ansible_port
 ansible_user
     The default ssh user name to use.
 ansible_ssh_pass
-    The ssh password to use (this is insecure, we strongly recommend using :option:`--ask-pass` or SSH keys)
+    The ssh password to use (never store this variable in plain text: always use a vault. See :ref:`best_practices_for_variables_and_vaults`)
 ansible_ssh_private_key_file
     Private key file used by ssh.  Useful if using multiple keys and you don't want to use SSH agent.
 ansible_ssh_common_args
@@ -247,7 +247,7 @@ ansible_become_method
 ansible_become_user
     Equivalent to ``ansible_sudo_user`` or ``ansible_su_user``, allows to set the user you become through privilege escalation
 ansible_become_pass
-    Equivalent to ``ansible_sudo_pass`` or ``ansible_su_pass``, allows you to set the privilege escalation password (this is insecure, we strongly recommend using :option:`--ask-become-pass` or SSH keys)
+    Equivalent to ``ansible_sudo_pass`` or ``ansible_su_pass``, allows you to set the privilege escalation password (never store this variable in plain text: always use a vault. See :ref:`best_practices_for_variables_and_vaults`)
 
 Remote host environment parameters:
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Introduction to inventory

##### ANSIBLE VERSION
```
ansible 2.3.0
```

##### SUMMARY
Change warnings about intrinsically insecure variables `ansible_ssh_pass` and `ansible_become_pass`: they were relevant before ansible had the secure vault feature, since any secret put into a variable used to be a bad idea.

With the vault feature (available since ansible 1.5) it's no longer a bad idea to use these variables, as long as they aren't stored in plain text.