### PR TITLE
Added DIFF_ALWAYS constant

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -372,3 +372,11 @@
 #diff_add = green
 #diff_remove = red
 #diff_lines = cyan
+
+
+[diff]
+# Always print diff when running ( same as always running with -D/--diff )
+# always = no
+
+# Set how many context lines to show in diff
+# context = 3

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -343,6 +343,7 @@ COLOR_DIFF_LINES  = get_config(p, 'colors', 'diff_lines', 'ANSIBLE_COLOR_DIFF_LI
 
 # diff
 DIFF_CONTEXT = get_config(p, 'diff', 'context', 'ANSIBLE_DIFF_CONTEXT', 3, value_type='integer')
+DIFF_ALWAYS = get_config(p, 'diff', 'always', 'ANSIBLE_DIFF_ALWAYS', False, value_type='bool')
 
 # non-configurable things
 MODULE_REQUIRE_ARGS       = ['command', 'win_command', 'shell', 'win_shell', 'raw', 'script']

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -203,7 +203,7 @@ class PlayContext(Base):
     _force_handlers   = FieldAttribute(isa='bool', default=False)
     _start_at_task    = FieldAttribute(isa='string')
     _step             = FieldAttribute(isa='bool', default=False)
-    _diff             = FieldAttribute(isa='bool', default=False)
+    _diff             = FieldAttribute(isa='bool', default=C.DIFF_ALWAYS)
 
     def __init__(self, play=None, options=None, passwords=None, connection_lockfd=None):
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
constants.py - actions/__init__.py

##### ANSIBLE VERSION
N/A
##### SUMMARY
Added `C(DIFF_ALWAYS)` 
When set to True, always print the diff. Defaults to False.

Fixes #18416 #16073