### PR TITLE
cloudstack: fix distinguish VPC and other networks

### DIFF
--- a/lib/ansible/module_utils/cloudstack.py
+++ b/lib/ansible/module_utils/cloudstack.py
@@ -259,6 +259,9 @@ class AnsibleCloudStack(object):
             self.module.fail_json(msg="No networks available.")
 
         for n in networks['network']:
+            # ignore any VPC network if vpc param is not given
+            if 'vpcid' in n and not self.get_vpc(key='id'):
+                continue
             if network in [n['displaytext'], n['name'], n['id']]:
                 self.network = n
                 return self._get_by_key(key, self.network)


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
cloudstack

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```

##### SUMMARY
fix distinguish VPC and other networks, they could have the same name
/cc @sbrueseke