### PR TITLE
corrected the use of ansible_ssh_executable

### DIFF
--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -1059,7 +1059,7 @@ ansible_ssh_executable
 
 This is the location of the ssh binary. It defaults to ``ssh`` which will use the first ssh binary available in ``$PATH``. This config can also be overridden with ``ansible_ssh_executable`` inventory variable::
 
-  ssh_executable="/usr/local/bin/ssh"
+  ansible_ssh_executable="/usr/local/bin/ssh"
 
 This option is usually not required, it might be useful when access to system ssh is restricted, or when using ssh wrappers to connect to remote hosts. 
 

--- a/docsite/rst/intro_configuration.rst
+++ b/docsite/rst/intro_configuration.rst
@@ -1050,9 +1050,9 @@ recommended if you can enable it, eliminating the need for :doc:`playbooks_accel
 
     pipelining = False
 
-.. _ssh_executable:
+.. _ansible_ssh_executable:
 
-ssh_executable
+ansible_ssh_executable
 ==============
 
 .. versionadded:: 2.2


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Docs

##### ANSIBLE VERSION
```
$ ansible --version
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
The docs mentioned the use of `ssh_executable` but the correct variable is`ansible_ssh_executable`