### PR TITLE
Add link to licence file (COPYING) in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,8 @@ Ansible was created by [Michael DeHaan](https://github.com/mpdehaan) (michael.de
 
 Ansible is sponsored by [Ansible, Inc](https://ansible.com)
 
+Licence
+=======
+GNU [Link](COPYING)
+
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Ansible is sponsored by [Ansible, Inc](https://ansible.com)
 
 Licence
 =======
-GNU [Link](COPYING)
+GNU 
+Click on the [Link](COPYING) to see the full text.
 
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

Hello,
As I said in issue #18520 , I was thinking to add a link to your licence file (COPYING) in the README.md as people are often accustomed to search for the file "LICENCE" and not the file "COPYING". I will do a PR for that if you are interested :)

#18520 