### PR TITLE
asa: Disable CLI errors when typing enable

### DIFF
--- a/lib/ansible/module_utils/asa.py
+++ b/lib/ansible/module_utils/asa.py
@@ -62,8 +62,13 @@ class Cli(CliBase):
 
     def authorize(self, params, **kwargs):
         passwd = params['auth_pass']
+        errors = self.shell.errors
+        # Disable errors (if already in enable mode)
+        self.shell.errors = []
         cmd = Command('enable', prompt=self.NET_PASSWD_RE, response=passwd)
         self.execute([cmd, 'no terminal pager'])
+        # Reapply error handling
+        self.shell.errors = errors
 
     def change_context(self, params):
         context = params['context']


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/asa

##### ANSIBLE VERSION
```
$ ansible --version
ansible 2.3.0 (asa_enable 76ffa8916f) last updated 2016/11/17 19:53:49 (GMT +200)
  lib/ansible/modules/core: (devel f08ba8c7d6) last updated 2016/11/17 19:32:57 (GMT +200)
  lib/ansible/modules/extras: (devel 94ef04befe) last updated 2016/11/17 19:33:12 (GMT +200)
  config file = /Users/patrick/src/tests/ansible-asa/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
This patch fixes [Extras 3260](https://github.com/ansible/ansible-modules-extras/issues/3260).

When you try to enter enable mode on a Cisco ASA while already in the enable mode the device gives an error while Cisco IOS just ignores this command.

````
ns2903-asa-02# enable
                ^
ERROR: % Invalid input detected at '^' marker.
ns2903-asa-02#
````

Some users might have the `authorize: yes` parameter set in some {{ provider }}. This patch allows for that setup even if the user gets logged into enable mode from the start.
