### PR TITLE
Return a traceback for empty exceptions in `get_exception`util

### DIFF
--- a/lib/ansible/module_utils/pycompat24.py
+++ b/lib/ansible/module_utils/pycompat24.py
@@ -28,6 +28,7 @@
 #
 
 import sys
+import traceback
 
 def get_exception():
     """Get the current exception.
@@ -41,7 +42,16 @@ def get_exception():
             e = get_exception()
 
     """
-    return sys.exc_info()[1]
+    e, tb = sys.exc_info()[1:]
+
+    # remove original traceback obj (avoid circular refs in python < 3)
+    tb_list = traceback.format_tb(tb)
+    del tb
+
+    if any(e):
+        return e
+    else:
+        return ''.join(tb_list)
 
 try:
     # Python 2.6+

--- a/lib/ansible/module_utils/pycompat24.py
+++ b/lib/ansible/module_utils/pycompat24.py
@@ -51,7 +51,7 @@ def get_exception():
     if any(e):
         return e
     else:
-        return ''.join(tb_list)
+        return Exception(tb_list)
 
 try:
     # Python 2.6+


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
`get_exception` module util helper

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /Users/ekaufman/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

Related to (but not a complete fix for) #18513, the `get_exception` helper blindly returns any exception.

This would iterate the exception first, testing for any truthy values, and if none are found, instead return a ~~stringified traceback~~ list-formatted traceback wrapped in a generic exception.