### PR TITLE
Fix command typo in integration tests README file

### DIFF
--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -166,7 +166,7 @@ $ ANSIBLE_ROLES_PATH=targets ansible-playbook network-all.yaml
 To filter a set of test cases set `limit_to` to the name of the group, generally this is the name of the module: 
 
 ```
-$ ANSIBLE_ROLES_PATH=targets ansible-playbook -i inventory.network all.yaml -e "limit_to=eos_command"
+$ ANSIBLE_ROLES_PATH=targets ansible-playbook -i inventory.network network-all.yaml -e "limit_to=eos_command"
 ```
 
 To filter a singular test case set the tags options to eapi or cli, set limit_to to the test group,


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
Integration test README 

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel 461286f914)
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
Fix command typo in integration test README file
```

