### PR TITLE
Add the ability to fill ansible_host with VM private IP

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -832,6 +832,11 @@ files:
   contrib/inventory/openstack.py:
     keywords:
     - openstack dynamic inventory script
+  contrib/inventory/linode.py:
+    keywords:
+    - linode dynamic inventory script
+    maintainers:
+    - intheclouddan rwaweber zbal
   lib/ansible/inventory:
     keywords:
     - core inventory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ Ansible Changes By Release
 * nxos_template (use nxos_config instead)
 * ops_template (use ops_config instead)
 
+* Modules (scheduled for removal in 2.6)
+
+  * ec2_remote_facts
+
 ### Minor Changes
 * Removed previously deprecated config option `hostfile` and env var `ANSIBLE_HOSTS`
 * Removed unused and deprecated config option `pattern`
@@ -147,9 +151,20 @@ Ansible Changes By Release
   * aci_rest
 - aix_lvol
 - amazon
+  * aws_api_gateway
+  * dynamodb_ttl
+  * ec2_instance_facts
   * ec2_metadata_facts
   * ec2_vpc_endpoint
+  * ec2_vpc_endpoint_facts
+  * ec2_vpc_peering_facts
+  * elb_application_lb
+  * elb_application_lb_facts
+  * elb_target_group
+  * elb_target_group_facts
   * iam_cert_facts
+  * iam_group
+  * iam_managed_policy
   * lightsail
 - atomic
   * atomic_container

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,8 +282,11 @@ Ansible Changes By Release
   * win_security_policy
   * win_wakeonlan
 
+<a id="2.3"></a>
 
 ## 2.3 "Ramble On" - 2017-04-12
+
+Moving to Ansible 2.3 guide http://docs.ansible.com/ansible/porting_guide_2.3.html
 
 ### Major Changes
 * Documented and renamed the previously released 'single var vaulting' feature, allowing user to use vault encryption for single variables in a normal YAML vars file.
@@ -598,6 +601,7 @@ Ansible Changes By Release
   * zfs_facts
   * zpool_facts
 
+<a id="2.2.1"></a>
 
 ## 2.2.1 "The Battle of Evermore" - 2017-01-16
 
@@ -624,10 +628,11 @@ Ansible Changes By Release
 * Improvements and fixes to OpenBSD fact gathering.
 * Updated `make deb` to use pbuilder. Use `make local_deb` for the previous non-pbuilder build.
 * Fixed Windows async to avoid blocking due to handle inheritance.
-* Fixed bugs in the mount module on older Linux kernels and *BSDs
+* Fixed bugs in the mount module on older Linux kernels and BSDs
 * Various minor fixes for Python 3
 * Inserted some checks for jinja2-2.9, which can cause some issues with Ansible currently.
 
+<a id="2.2"></a>
 
 ## 2.2 "The Battle of Evermore" - 2016-11-01
 
@@ -942,11 +947,15 @@ Notice given that the following will be removed in Ansible 2.4:
   * nxos_template
   * ops_template
 
+<a id="2.1.4"></a>
+
 ## 2.1.4 "The Song Remains the Same" - 2017-01-16
 
 * Security fix for CVE-2016-9587 - An attacker with control over a client system being managed by Ansible and the ability to send facts back to the Ansible server could use this flaw to execute arbitrary code on the Ansible server as the user and group Ansible is running as.
 * Fixed a bug with conditionals in loops, where undefined variables and other errors will defer raising the error until the conditional has been evaluated.
 * Added a version check for jinja2-2.9, which does not fully work with Ansible currently.
+
+<a id="2.1.3"></a>
 
 ## 2.1.3 "The Song Remains the Same" - 2016-11-04
 
@@ -960,10 +969,12 @@ Notice given that the following will be removed in Ansible 2.4:
   login_password as no_log so the password is obscured when logging.
 * Fixed several bugs related to locating files relative to role/playbook directories.
 * Fixed a bug in the way hosts were tested for failed states, resulting in incorrectly skipped block sessions.
-* Fixed a bug in the way our custom JSON encoder is used for the to_json* filters.
+* Fixed a bug in the way our custom JSON encoder is used for the `to_json*` filters.
 * Fixed some bugs related to the use of non-ascii characters in become passwords.
 * Fixed a bug with Azure modules which may be using the latest rc6 library.
 * Backported some docker_common fixes.
+
+<a id="2.1.2"></a>
 
 ## 2.1.2 "The Song Remains the Same" - 2016-09-29
 
@@ -1026,6 +1037,8 @@ Module fixes:
   Custom action plugins using `_fixup_perms` will require changes unless they already use `recursive=False`.
   Use `_fixup_perms2` if support for previous releases is not required.
   Otherwise use `_fixup_perms` with `recursive=False`.
+
+<a id="2.1"></a>
 
 ## 2.1 "The Song Remains the Same"
 
@@ -1214,6 +1227,8 @@ Module fixes:
   completely in 2.3, after which time it will be an error.
 * play_hosts magic variable, use ansible_play_batch or ansible_play_hosts instead.
 
+<a id="2.0.2"></a>
+
 ## 2.0.2 "Over the Hills and Far Away"
 
 * Backport of the 2.1 feature to ensure per-item callbacks are sent as they occur,
@@ -1255,9 +1270,11 @@ Module fixes:
   permissions on the temporary file too leniently on a temporary file that was
   executed as a script.  Addresses CVE-2016-3096
 * Fix a bug in the uri module where setting headers via module params that
-  start with HEADER_ were causing a traceback.
+  start with `HEADER_` were causing a traceback.
 * Fix bug in the free strategy that was causing it to synchronize its workers
   after every task (making it a lot more like linear than it should have been).
+
+<a id="2.0.1"></a>
 
 ## 2.0.1 "Over the Hills and Far Away"
 
@@ -1266,7 +1283,7 @@ Module fixes:
   running rsync.  In 1.9.x and previous, sudo was run on the host that rsync
   connected to.  2.0.1 restores the 1.9.x behaviour.
 * Additionally, several other problems with where synchronize chose to run when
-  combined with delegate_to were fixed.  In particular, if a playbook targeted
+  combined with delegate_to were fixed.  In particular, if a playbook targetted
   localhost and then delegated_to a remote host the prior behavior (in 1.9.x
   and 2.0.0.x) was to copy files between the src and destination directories on
   the delegated host.  This has now been fixed to copy between localhost and
@@ -1299,6 +1316,8 @@ Module fixes:
 * Fix to make implicit fact gathering task correctly inherit settings from play,
   this might cause an error if settings environment on play depending on 'ansible_env'
   which was previouslly ignored
+
+<a id="2.0"></a>
 
 ## 2.0 "Over the Hills and Far Away" - Jan 12, 2016
 

--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -250,7 +250,8 @@ class Server():
                 break
             time.sleep(1)
             timeout -= 1
-        return 0, b'\n#SOCKET_PATH#: %s\n' % self.socket_path, ''
+        socket_bytes = to_bytes(self.socket_path, errors='surrogate_or_strict')
+        return 0, b'\n#SOCKET_PATH#: %s\n' % socket_bytes, ''
 
 
 def communicate(sock, data):

--- a/contrib/inventory/azure_rm.ini
+++ b/contrib/inventory/azure_rm.ini
@@ -20,3 +20,7 @@ group_by_resource_group=yes
 group_by_location=yes
 group_by_security_group=yes
 group_by_tag=yes
+
+# Control whether we ignore the public IP addresses from the dynamic inventory
+# Useful when our systems are behind a jumpbox/bastion host
+prefer_private_ip=no

--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -1,0 +1,3 @@
+Communicating
+=============
+

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -1,0 +1,166 @@
+The Ansible Development Process
+===============================
+
+This section discusses how the Ansible development and triage process works.
+
+The Triage Bot
+==============
+
+
+Overview
+--------
+
+The `Ansibull PR Triage Bot`_ serves many functions: \* Responds quickly
+to PR submitters to thank them for submitting their PR; \* Identifies
+the community maintainer responsible for reviewing PRs for any files
+affected; \* Tracks the current status of PRs; \* Pings responsible
+parties to remind them of any PR actions that they may be responsible
+for; \* Provides maintainers with the ability to move PRs through our
+workflow; \* Identifies PRs abandoned by their submitters so that we can
+close them; \* Identifies modules abandoned by their maintainers so that
+we can find new maintainers.
+
+Community Maintainers
+---------------------
+
+Each module in Core and Extras has at least one assigned maintainer,
+listed in two maintainers files: one for `Core`_ and one for `Extras`_.
+
+Some modules have no community maintainers assigned. In this case, the
+maintainer is listed as “ansible”. Ultimately, it’s our goal to have at
+least one community maintainer for every module.
+
+The maintainer’s job is to review PRs and decide whether that PR should
+be merged (“shipit!”) or revised (“needs\_revision”).
+
+The ultimate goal of any Pull Request is to reach “shipit” status, where
+the Core team then decides whether the PR is ready to be merged. Not
+every PR that reaches the “shipit” label is actually ready to be merged,
+but the better our reviewers are, and the better our guidelines are, the
+more likely it will be that a PR that reaches “shipit” will be
+mergeable.
+
+.. _Ansibull PR Triage Bot: https://github.com/ansible/ansibullbot/blob/master/triage.py
+.. _Core: https://github.com/ansible/ansibullbot/blob/master/MAINTAINERS-CORE.txt
+.. _Extras: https://github.com/ansible/ansibullbot/blob/master/MAINTAINERS-CORE.txt
+
+Some modules have no community maintainers assigned. In this case, the
+maintainer is listed as “ansible”. Ultimately, it’s our goal to have at
+least one community maintainer for every module.
+
+The maintainer’s job is to review PRs and decide whether that PR should
+be merged (“shipit!”) or revised (“needs\_revision”).
+
+The ultimate goal of any Pull Request is to reach “shipit” status, where
+the Core team then decides whether the PR is ready to be merged. Not
+every PR that reaches the “shipit” label is actually ready to be merged,
+but the better our reviewers are, and the better our guidelines are, the
+more likely it will be that a PR that reaches “shipit” will be
+mergeable.
+
+Workflow
+--------
+
+The triage bot runs every six hours and examines every open PR in both
+core and extras repositories, and enforces state roughly according to
+the following workflow:
+
+-  If a PR has no workflow labels, it’s considered “new”. Files in the
+   PR are identified, and the maintainers of those files are pinged by
+   the bot, along with instructions on how to review the PR. (Note:
+   sometimes we strip labels from a PR to “reboot” this process.)
+-  If the module maintainer is not “ansible”, the PR then goes into the
+   “community\_review” state.
+-  If the module maintainer is “ansible”, the PR then goes into the
+   “core\_review” state (and probably sits for a while).
+-  If the PR is in “community\_review” and has received comments from
+   the maintainer:
+-  If the maintainer says “shipit”, the PR is labeled “shipit”,
+   whereupon the Core team assesses it for final merge.
+-  If the maintainer says “needs\_info”, the PR is labeled “needs\_info”
+   and the submitter is asked for more info.
+-  If the maintainer says “needs\_revision”, the PR is labeled
+   “needs\_revision” and the submitter is asked to fix some things.
+-  If the PR is in “needs\_revision/needs\_info” and has received
+   comments from the submitter:
+-  If the submitter says “ready\_for\_review”, the PR is put back into
+   community\_review/core\_review and the maintainer is notified that
+   the PR is ready to be reviewed again.
+-  If the PR is in “needs\_revision/needs\_info” and the submitter has
+   not responded lately:
+-  The submitter is first politely pinged after two weeks, pinged again
+   after two more weeks and labeled “pending action”, and then may be
+   closed two weeks after that.
+-  If the submitter responds at all, the clock is reset.
+-  If the PR is in “community\_review” and the reviewer has not
+   responded lately:
+-  The reviewer is first politely pinged after two weeks, pinged again
+   after two more weeks and labeled “pending\_action”, and then may be
+   reassigned to “ansible” / core\_review, or often the submitter of the
+   PR is asked to step up as a maintainer.
+-  If Travis fails, or if the code is not mergable, the PR is
+   automatically put into “needs\_revision” along with a message to the
+   submitter explaining why.
+
+
+There are corner cases and frequent refinements, but this is the workflow in general. 
+
+PR Labels
+---------
+
+There are two types of PR Labels generally: *workflow labels* and
+*information labels*.
+
+Workflow Labels
+~~~~~~~~~~~~~~~
+
+-  **community\_review**: Pull requests for modules that are currently
+   awaiting review by their maintainers in the Ansible community.
+-  **core\_review**: Pull requests for modules that are currently
+   awaiting review by their maintainers on the Ansible Core team.
+-  **needs\_info**: Waiting on info from the submitter.
+-  **needs\_rebase**: Waiting on the submitter to rebase. (Note: no
+   longer used by the bot.)
+-  **needs\_revision**: Waiting on the submitter to make changes.
+-  **shipit**: Waiting for final review by the core team for potential
+   merge.
+
+Informational Labels
+~~~~~~~~~~~~~~~~~~~~
+
+-  **backport**: this is applied automatically if the PR is requested
+   against any branch that is not devel. The bot immediately assigns the
+   labels “backport” and “core\_review”.
+-  **bugfix\_pull\_request**: applied by the bot based on the
+   templatized description of the PR.
+-  **cloud**: applied by the bot based on the paths of the modified
+   files.
+-  **docs\_pull\_request**: applied by the bot based on the templatized
+   description of the PR.
+-  **easyfix**: applied manually, inconsistently used but sometimes
+   useful.
+-  **feature\_pull\_request**: applied by the bot based on the
+   templatized description of the PR.
+-  **networking**: applied by the bot based on the paths of the modified
+   files.
+-  **owner\_pr**: largely deprecated. Formerly workflow, now
+   informational. Originally, PRs submitted by the maintainer would
+   automatically go to “shipit” based on this label; now, if the
+   submitter is also a maintainer, we notify the other maintainers and
+   still require one of the maintainers (including the submitter) to
+   give a “shipit”.
+-  **P1 - P5**: deprecated for modules because they were wildly
+   inconsistent and not useful. The bot now strips these.
+-  **pending\_action**: applied by the bot to PRs that are not moving.
+   Reviewed every couple of weeks by the community team, who tries to
+   figure out the appropriate action (closure, asking for new
+   maintainers, etc).
+
+
+Special Labels
+~~~~~~~~~~~~~~
+
+-  **new\_plugin**: this is for new modules or plugins that are not yet
+   in Ansible. **Note: this kicks off a completely separate process, and
+   frankly it doesn’t work very well at present. We’re working our best
+   to improve this process.**

--- a/docs/docsite/rst/community/how_can_I_help.rst
+++ b/docs/docsite/rst/community/how_can_I_help.rst
@@ -1,0 +1,18 @@
+How To Help
+===========
+
+Types of help
+-------------
+
+Become a user
+-------------
+
+LINK: docs/community/development_process.rst
+
+Improve Docs
+
+Link to Working Groups + there how to help pages
+
+Review PRs
+
+LINK: sivel/prbyfiles

--- a/docs/docsite/rst/community/index.rst
+++ b/docs/docsite/rst/community/index.rst
@@ -1,0 +1,28 @@
+*********************
+Community Information
+*********************
+
+Ansible Community Guide
+=======================
+
+Welcome to the Ansible Community Guide!
+
+The purpose of this guide is to document how you can interact with and contribute to Ansible as a community member.
+[TODO: add something better here]
+
+To get started, select one of the following topics.
+
+
+.. toctree::
+   :maxdepth: 1
+
+   development_process
+   reporting_bugs_and_features
+   how_can_I_help
+   maintainers
+   communication
+   special_interest_groups
+   other_tools_and_programs
+
+
+

--- a/docs/docsite/rst/community/index.rst
+++ b/docs/docsite/rst/community/index.rst
@@ -7,8 +7,7 @@ Ansible Community Guide
 
 Welcome to the Ansible Community Guide!
 
-The purpose of this guide is to document how you can interact with and contribute to Ansible as a community member.
-[TODO: add something better here]
+The purpose of this guide is to teach you everything you need to know about being a contributing member of the Ansible community. 
 
 To get started, select one of the following topics.
 

--- a/docs/docsite/rst/community/maintainers.rst
+++ b/docs/docsite/rst/community/maintainers.rst
@@ -1,0 +1,3 @@
+About Maintainers
+=================
+

--- a/docs/docsite/rst/community/other_tools_and_programs.rst
+++ b/docs/docsite/rst/community/other_tools_and_programs.rst
@@ -1,0 +1,6 @@
+Other Tools And Programs
+========================
+
+Links to other things from willthames, sivels, etc
+Other tools #5
+How can I get my tool on here LINK: IRC Meetings

--- a/docs/docsite/rst/community/reporting_bugs_and_features.rst
+++ b/docs/docsite/rst/community/reporting_bugs_and_features.rst
@@ -1,0 +1,13 @@
+Reporting Bugs And Requesting Features
+======================================
+
+What is a bug
+-------------
+Has it already been filed
+Is there a PR in flight
+
+
+What's a feature
+-----------------
+
+Feature vs proposal LINK docs/community/proposal_process.rst

--- a/docs/docsite/rst/community/triage_process.rst
+++ b/docs/docsite/rst/community/triage_process.rst
@@ -1,0 +1,4 @@
+Understanding The Triage Process
+================================
+
+placeholder

--- a/docs/docsite/rst/index.rst
+++ b/docs/docsite/rst/index.rst
@@ -7,7 +7,7 @@ About Ansible
 Welcome to the Ansible documentation!
 
 Ansible is an IT automation tool.  It can configure systems, deploy software, and orchestrate more advanced IT tasks
-such as continuous deployments or zero downtime rolling updates.  
+such as continuous deployments or zero downtime rolling updates.
 
 Ansible's main goals are simplicity and ease-of-use. It also has a strong focus on security and reliability, featuring a minimum of moving parts, usage of OpenSSH for transport (with an accelerated socket mode and pull modes as alternatives), and a language that is designed around auditability by humans--even those not familiar with the program.
 
@@ -16,7 +16,7 @@ We believe simplicity is relevant to all sizes of environments, so we design for
 Ansible manages machines in an agent-less manner. There is never a question of how to
 upgrade remote daemons or the problem of not being able to manage systems because daemons are uninstalled.  Because OpenSSH is one of the most peer-reviewed open source components, security exposure is greatly reduced. Ansible is decentralized--it relies on your existing OS credentials to control access to remote machines. If needed, Ansible can easily connect with Kerberos, LDAP, and other centralized authentication management systems.
 
-This documentation covers the current released version of Ansible (|version|) and also some development version features (|versiondev|).  For recent features, we note in each section the version of Ansible where the feature was added.  
+This documentation covers the current released version of Ansible (|version|) and also some development version features (|versiondev|).  For recent features, we note in each section the version of Ansible where the feature was added.
 
 Ansible, Inc. releases a new major release of Ansible approximately every two months.  The core application evolves somewhat conservatively, valuing simplicity in language design and setup. However, the community around new modules and plugins being developed and contributed moves very quickly, typically adding 20 or so new modules in each release.
 
@@ -40,6 +40,6 @@ Ansible, Inc. releases a new major release of Ansible approximately every two mo
    faq
    glossary
    YAMLSyntax
-   porting_guide_2.0
+   porting_guides
    python_3_support
    release_and_maintenance

--- a/docs/docsite/rst/playbooks_blocks.rst
+++ b/docs/docsite/rst/playbooks_blocks.rst
@@ -9,20 +9,18 @@ by the tasks enclosed by a block. i.e. a `when` will be applied to the tasks, no
 
 
 .. code-block:: YAML
- :emphasize-lines: 2
+ :emphasize-lines: 3
  :caption: Block example
 
     tasks:
-      - block:
+      - name: Install Apache
+        block:
           - yum: name={{ item }} state=installed
             with_items:
               - httpd
               - memcached
-
           - template: src=templates/src.j2 dest=/etc/foo.conf
-
           - service: name=bar state=started enabled=True
-
         when: ansible_distribution == 'CentOS'
         become: true
         become_user: root
@@ -32,6 +30,9 @@ In the example above, each of the 3 tasks will be executed after appending the `
 and evaluating it in the task's context. Also they inherit the privilege escalation directives enabling "become to root"
 for all the enclosed tasks.
 
+. versionadded:: 2.3
+
+The `name:` keyword for `blocks:` was added in Ansible 2.3.
 
 .. _block_error_handling:
 
@@ -41,20 +42,21 @@ Error Handling
 Blocks also introduce the ability to handle errors in a way similar to exceptions in most programming languages.
 
 .. code-block:: YAML
- :emphasize-lines: 2,6,10
+ :emphasize-lines: 3,7,11
  :caption: Block error handling example
 
-  tasks:
-   - block:
-       - debug: msg='i execute normally'
-       - command: /bin/false
-       - debug: msg='i never execute, cause ERROR!'
-     rescue:
-       - debug: msg='I caught an error'
-       - command: /bin/false
-       - debug: msg='I also never execute :-('
-     always:
-       - debug: msg="this always executes"
+   tasks:
+    - name: Attempt and gracefull roll back demo
+      block:
+        - debug: msg='I execute normally'
+        - command: /bin/false
+        - debug: msg='I never execute, due to the above task failing'
+      rescue:
+        - debug: msg='I caught an error'
+        - command: /bin/false
+        - debug: msg='I also never execute :-('
+      always:
+        - debug: msg="this always executes"
 
 
 The tasks in the ``block`` would execute normally, if there is any error the ``rescue`` section would get executed
@@ -65,20 +67,21 @@ error did or did not occur in the ``block`` and ``rescue`` sections.
 Another example is how to run handlers after an error occurred :
 
 .. code-block:: YAML
- :emphasize-lines: 4,8
+ :emphasize-lines: 5,9
  :caption: Block run handlers in error handling
 
   tasks:
-   - block:
-       - debug: msg='i execute normally'
-         notify: run me even after an error
-       - command: /bin/false
-     rescue:
-       - name: make sure all handlers run
-         meta: flush_handlers
-  handlers:
-    - name: run me even after an error
-      debug: msg='this handler runs even on error'
+    - name: Attempt and gracefull roll back demo
+      block:
+        - debug: msg='I execute normally'
+          notify: run me even after an error
+        - command: /bin/false
+      rescue:
+        - name: make sure all handlers run
+          meta: flush_handlers
+   handlers:
+     - name: run me even after an error
+       debug: msg='this handler runs even on error'
 
 .. seealso::
 
@@ -90,7 +93,6 @@ Another example is how to run handlers after an error occurred :
        Have a question?  Stop by the google group!
    `irc.freenode.net <http://irc.freenode.net>`_
        #ansible IRC chat channel
-
 
 
 

--- a/docs/docsite/rst/porting_guide_2.0.rst
+++ b/docs/docsite/rst/porting_guide_2.0.rst
@@ -1,14 +1,26 @@
-Porting Guide
-=============
+.. _porting_2.0_guide:
 
+*************************
+Ansible 2.0 Porting Guide
+*************************
+
+This section discusses the behavioral changes between Ansible 1.x and Ansible 2.0.
+
+It is intended to assist in updating your playbooks, plugins and other parts of your Ansible infrastructure so they will work with this version of Ansible.
+
+
+We suggest you read this page along with `Ansible Changelog <https://github.com/ansible/ansible/blob/devel/CHANGELOG.md#2.0>`_ to understand what updates you may need to make.
+
+This document is part of a collection on porting. The complete list of porting guides can be found at :ref:`porting guides <porting_guides>`.
+
+.. contents:: Topics
 
 Playbook
---------
+========
 
-* backslash escapes When specifying parameters in jinja2 expressions in YAML
-  dicts, backslashes sometimes needed to be escaped twice. This has been fixed
-  in 2.0.x so that escaping once works. The following example shows how
-  playbooks must be modified::
+This section discusses any changes you may need to make to your playbooks.
+
+.. code-block:: yaml
 
     # Syntax in 1.9.x
     - debug:
@@ -88,16 +100,16 @@ uses key=value escaping which has not changed.  The other option is to check for
 * dnf module has been rewritten. Some minor changes in behavior may be observed.
 * win_updates has been rewritten and works as expected now.
 * from 2.0.1 onwards, the implicit setup task from gather_facts now correctly inherits everything from play, but this might cause issues for those setting
-  `environment` at the play level and depending on `ansible_env` existing. Previouslly this was ignored but now might issue an 'Undefined' error.
+  `environment` at the play level and depending on `ansible_env` existing. Previously this was ignored but now might issue an 'Undefined' error.
 
 Deprecated
-~~~~~~~~~~
+----------
 
 While all items listed here will show a deprecation warning message, they still work as they did in 1.9.x. Please note that they will be removed in 2.2 (Ansible always waits two major releases to remove a deprecated feature).
 
-* Bare variables in `with_` loops should instead use the “{{var}}” syntax, which helps eliminate ambiguity.
+* Bare variables in ``with_`` loops should instead use the ``"{ {var }}"`` syntax, which helps eliminate ambiguity.
 * The ansible-galaxy text format requirements file. Users should use the YAML format for requirements instead.
-* Undefined variables within a `with_` loop’s list currently do not interrupt the loop, but they do issue a warning; in the future, they will issue an error.
+* Undefined variables within a ``with_`` loop’s list currently do not interrupt the loop, but they do issue a warning; in the future, they will issue an error.
 * Using dictionary variables to set all task parameters is unsafe and will be removed in a future version. For example::
 
     - hosts: localhost
@@ -151,9 +163,9 @@ Should now be::
 
 
 Other caveats
-~~~~~~~~~~~~~
+-------------
 
-Here are some corner cases encountered when updating, these are mostly caused by the more stringent parser validation and the capture of errors that were previouslly ignored.
+Here are some corner cases encountered when updating. These are mostly caused by the more stringent parser validation and the capture of errors that were previously ignored.
 
 * Bad variable composition::
 
@@ -199,32 +211,33 @@ Here are some corner cases encountered when updating, these are mostly caused by
 
     with_items: "{{var1 + var2}}"
 
-  The bare feature itself is deprecated as an undefined variable is indistiguishable from a string which makes it difficult to display a proper error.
+  The bare feature itself is deprecated as an undefined variable is indistinguishable from a string which makes it difficult to display a proper error.
 
 Porting plugins
----------------
+===============
 
 In ansible-1.9.x, you would generally copy an existing plugin to create a new one. Simply implementing the methods and attributes that the caller of the plugin expected made it a plugin of that type. In ansible-2.0, most plugins are implemented by subclassing a base class for each plugin type. This way the custom plugin does not need to contain methods which are not customized.
 
 
 Lookup plugins
-~~~~~~~~~~~~~~
+--------------
+
 * lookup plugins ; import version
 
 
 Connection plugins
-~~~~~~~~~~~~~~~~~~
+------------------
 
 * connection plugins
 
 Action plugins
-~~~~~~~~~~~~~~
+--------------
 
 
 * action plugins
 
 Callback plugins
-~~~~~~~~~~~~~~~~
+----------------
 
 Although Ansible 2.0 provides a new callback API the old one continues to work
 for most callback plugins.  However, if your callback plugin makes use of
@@ -260,15 +273,15 @@ populates the callback with them.  Here's a short snippet that shows you how:
 
 
 Connection plugins
-~~~~~~~~~~~~~~~~~~
+------------------
 
 * connection plugins
 
 
 Hybrid plugins
---------------
+==============
 
-In specific cases you may want a plugin that supports both ansible-1.9.x *and* ansible-2.0. Much like porting plugins from v1 to v2, you need to understand how plugins work in each version and support both requirements. It may mean playing tricks on Ansible.
+In specific cases you may want a plugin that supports both ansible-1.9.x *and* ansible-2.0. Much like porting plugins from v1 to v2, you need to understand how plugins work in each version and support both requirements.
 
 Since the ansible-2.0 plugin system is more advanced, it is easier to adapt your plugin to provide similar pieces (subclasses, methods) for ansible-1.9.x as ansible-2.0 expects. This way your code will look a lot cleaner.
 
@@ -288,8 +301,9 @@ You may find the following tips useful:
 
 
 Lookup plugins
-~~~~~~~~~~~~~~
-As a simple example we are going to make a hybrid ``fileglob`` lookup plugin.  The ``fileglob`` lookup plugin is pretty simple to understand
+--------------
+
+As a simple example we are going to make a hybrid ``fileglob`` lookup plugin.
 
 .. code-block:: python
 
@@ -355,28 +369,28 @@ As a simple example we are going to make a hybrid ``fileglob`` lookup plugin.  T
 
 
 Connection plugins
-~~~~~~~~~~~~~~~~~~
+------------------
 
 * connection plugins
 
 Action plugins
-~~~~~~~~~~~~~~
+--------------
 
 * action plugins
 
 Callback plugins
-~~~~~~~~~~~~~~~~
+----------------
 
 * callback plugins
 
 Connection plugins
-~~~~~~~~~~~~~~~~~~
+------------------
 
 * connection plugins
 
 
 Porting custom scripts
-----------------------
+======================
 
-Custom scripts that used the ``ansible.runner.Runner`` API in 1.x have to be ported in 2.x.  Please refer to: :doc:`dev_guide//developing_api`
+Custom scripts that used the ``ansible.runner.Runner`` API in 1.x have to be ported in 2.x.  Please refer to: :doc:`dev_guide/developing_api`
 

--- a/docs/docsite/rst/porting_guide_2.3.rst
+++ b/docs/docsite/rst/porting_guide_2.3.rst
@@ -1,0 +1,246 @@
+.. _porting_2.3_guide:
+
+*************************
+Ansible 2.3 Porting Guide
+*************************
+
+This section discusses the behavioral changes between Ansible 2.2 and Ansible 2.3.
+
+It is intended to assist in updating your playbooks, plugins and other parts of your Ansible infrastructure so they will work with this version of Ansible.
+
+
+We suggest you read this page along with `Ansible Changelog <https://github.com/ansible/ansible/blob/devel/CHANGELOG.md#2.3>`_ to understand what updates you may need to make.
+
+This document is part of a collection on porting. The complete list of porting guides can be found at :ref:`porting guides <porting_guides>`.
+
+.. contents:: Topics
+
+Playbook
+========
+
+Restructued async to work with action plugins
+---------------------------------------------
+
+In Ansible 2.2 (and possibly earlier) the `async:` keyword could not be used in conjunction with the action plugins such as `service`. This limitation has been removed in Ansible 2.3
+
+**NEW** In Ansible 2.3:
+
+
+.. code-block:: yaml
+
+    - name: Install nginx asynchronously
+      service:
+        name: nginx
+        state: restarted
+      async: 45
+
+
+OpenBSD version facts
+---------------------
+
+The `ansible_distribution_release` and `ansible_distribution_version` facts on OpenBSD hosts were reversed in Ansible 2.2 and earlier. This has been changed so that version has the numeric portion and release has the name of the release.
+
+**OLD** In Ansible 2.2 (and earlier)
+
+
+.. code-block:: yaml
+
+    "ansible_distribution": "OpenBSD"
+    "ansible_distribution_release": "6.0",
+    "ansible_distribution_version": "release",
+
+**NEW** In Ansible 2.3:
+
+
+.. code-block:: yaml
+
+    "ansible_distribution": "OpenBSD",
+    "ansible_distribution_release": "release",
+    "ansible_distribution_version": "6.0",
+
+
+Names Blocks
+------------
+
+Blocks can now have names, this allows you to avoid the ugly `# this block is for...` comments.
+
+
+**NEW** In Ansible 2.3:
+
+
+.. code-block:: yaml
+
+    - name: Block test case
+      hosts: localhost
+      tasks:
+       - name: Attempt to setup foo
+         block:
+           - debug: msg='I execute normally'
+           - command: /bin/false
+           - debug: msg='I never execute, cause ERROR!'
+         rescue:
+           - debug: msg='I caught an error'
+           - command: /bin/false
+           - debug: msg='I also never execute :-('
+         always:
+           - debug: msg="this always executes"
+
+
+Use of multiple tags
+--------------------
+
+Specifying ``--tags`` (or ``--skip-tags``) multiple times on the command line currently leads to the last specified tag overriding all the other specified tags. This behaviour is deprecated. In the future, if you specify --tags multiple times the tags will be merged together. From now on, using ``--tags`` multiple times on one command line will emit a deprecation warning. Setting the ``merge_multiple_cli_tags`` option to True in the ``ansible.cfg`` file will enable the new behaviour.
+
+In 2.4, the default will be to merge the tags. You can enable the old overwriting behavior via the config option.
+In 2.5, multiple ``--tags`` options will be merged with no way to go back to the old behaviour.
+
+
+Other caveats
+-------------
+
+Here are some rare cases that might be encountered when updating. These are mostly caused by the more stringent parser validation and the capture of errors that were previously ignored.
+
+
+* Made ``any_errors_fatal`` inheritable from play to task and all other objects in between.
+
+Modules
+=======
+
+No major changes in this version.
+
+Modules removed
+---------------
+
+No major changes in this version.
+
+Deprecation notices
+-------------------
+
+The following modules will be removed in Ansible 2.5. Please update your playbooks accordingly.
+
+* :ref:`ec2_vpc <ec2_vpc>`
+* :ref:`cl_bond <cl_bond>`
+* :ref:`cl_bridge <cl_bridge>`
+* :ref:`cl_img_install <cl_img_install>`
+* :ref:`cl_interface <cl_interface>`
+* :ref:`cl_interface_policy <cl_interface_policy>`
+* :ref:`cl_license <cl_license>`
+* :ref:`cl_ports <cl_ports>`
+* :ref:`nxos_mtu <nxos_mtu>` use :ref:`nxos_system <nxos_system>` instead
+
+Noteworthy module changes
+-------------------------
+
+AWS lambda
+^^^^^^^^^^
+Previously ignored changes that only affected one parameter. Existing deployments may have outstanding changes that this bug fix will apply.
+
+
+Mount
+^^^^^
+
+Mount: Some fixes so bind mounts are not mounted each time the playbook runs.
+
+
+Plugins
+=======
+
+No major changes in this version.
+
+Porting custom scripts
+======================
+
+No major changes in this version.
+
+Networking
+==========
+
+There have been a number of changes to number of changes to how Networking Modules operate.
+
+Playbooks should still use ``connection: local``.
+
+The following changes apply to:
+
+* dellos6
+* dellos9
+* dellos10
+* eos
+* ios
+* iosxr
+* junos
+* sros
+* vyos
+
+Deprecation of top-level connection arguments
+---------------------------------------------
+
+**OLD** In Ansible 2.2:
+
+.. code-block:: yaml
+
+    - name: example of using top-level options for connection properties
+      ios_command:
+        commands: show version
+        host: "{{ inventory_hostname }}"
+        username: cisco
+        password: cisco
+        authorize: yes
+        auth_pass: cisco
+
+Will result in:
+
+.. code-block:: yaml
+
+   [WARNING]: argument username has been deprecated and will be removed in a future version
+   [WARNING]: argument host has been deprecated and will be removed in a future version
+   [WARNING]: argument password has been deprecated and will be removed in a future version
+
+
+**NEW** In Ansible 2.3:
+
+
+.. code-block:: yaml
+
+   - name: Gather facts
+     eos_facts:
+       gather_subset: all
+       provider:
+         username: myuser
+         password: "{{ networkpassword }}"
+         transport: cli
+         host: "{{ ansible_host }}"
+
+delegate_to vs ProxyCommand
+---------------------------
+
+The new connection framework for Network Modules in Ansible 2.3 no longer supports the use of the
+``delegate_to`` directive.  In order to use a bastion or intermediate jump host
+to connect to network devices, network modules now support the use of
+``ProxyCommand``.
+
+To use ``ProxyCommand`` configure the proxy settings in the Ansible inventory
+file to specify the proxy host.
+
+.. code-block:: ini
+
+    [nxos]
+    nxos01
+    nxos02
+
+    [nxos:vars]
+    ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -q bastion01"'
+
+
+With the configuration above, simply build and run the playbook as normal with
+no additional changes necessary.  The network module will now connect to the
+network device by first connecting to the host specified in
+``ansible_ssh_common_args`` which is ``bastion01`` in the above example.
+
+
+.. notes: Using ``ProxyCommand`` with passwords via variables
+
+   It is a feature that SSH doesn't support providing passwords via environment variables.
+   This is done to prevent secrets from leaking out, for example in ``ps`` output.
+
+   We recommend using SSH Keys, and if needed and ssh-agent, rather than passwords, where ever possible.
+

--- a/docs/docsite/rst/porting_guides.rst
+++ b/docs/docsite/rst/porting_guides.rst
@@ -1,0 +1,12 @@
+.. _porting_guides:
+
+**********************
+Ansible Porting Guides
+**********************
+
+This section lists porting guides that can help you playbooks, plugins and other parts of your Ansible infrastructure from one version of Ansible to the next. Please note that this is not a complete list. If you believe any extra information would be useful in these pages, you can edit by clicking `Edit on GitHub` on the top right, or raising an issue.
+
+
+* :ref:`Ansible 1.x to 2.0 porting guide <porting_2.0_guide>`
+* :ref:`Ansible 2.2 to 2.3 porting guide <porting_2.3_guide>`
+* :ref:`Ansible 2.3 to 2.4 porting guide <porting_2.4_guide>`

--- a/docs/docsite/rst/roadmap/ROADMAP_2_4.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_4.rst
@@ -90,9 +90,9 @@ Static Loop Keyword
 
 Vault
 -----
-- Support for multiple vault passwords. PR in ansible/ansible `#22756 <https://github.com/ansible/ansible/pull/22756>`_
+- Support for multiple vault passwords.  **(done)**
 
-  - Each decrypted item should know which secret to request
+  - Each decrypted item should know which secret to request **(done)**
   - Support requesting credentials (password prompt) as callbacks
 
 - Ability to open and edit file with encrypted vars deencrypted, and encrypt/format on save

--- a/lib/ansible/module_utils/aireos.py
+++ b/lib/ansible/module_utils/aireos.py
@@ -47,8 +47,9 @@ ARGS_DEFAULT_VALUE = {}
 
 
 def sanitize(resp):
-    # Takes config from device and strips whitespace from all lines
+    # Takes response from device and strips whitespace from all lines
     # Aireos adds in extra preceding whitespace which netcfg parses as children/parents, which Aireos does not do
+    # Aireos also adds in trailing whitespace that is unused
     cleaned = []
     for line in resp.splitlines():
         cleaned.append(line.strip())
@@ -112,7 +113,7 @@ def run_commands(module, commands, check_rc=True):
         rc, out, err = exec_command(module, cmd)
         if check_rc and rc != 0:
             module.fail_json(msg=to_text(err, errors='surrogate_then_replace'), rc=rc)
-        responses.append(to_text(out, errors='surrogate_then_replace'))
+        responses.append(sanitize(to_text(out, errors='surrogate_then_replace')))
     return responses
 
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2355,7 +2355,7 @@ class AnsibleModule(object):
             backupdest = '%s.%s.%s' % (fn, os.getpid(), ext)
 
             try:
-                shutil.copy2(fn, backupdest)
+                self.preserved_copy(fn, backupdest)
             except (shutil.Error, IOError):
                 e = get_exception()
                 self.fail_json(msg='Could not make backup of %s to %s: %s' % (fn, backupdest, e))
@@ -2369,6 +2369,42 @@ class AnsibleModule(object):
             except OSError:
                 e = get_exception()
                 sys.stderr.write("could not cleanup %s: %s" % (tmpfile, e))
+
+    def preserved_copy(self, src, dest):
+        """Copy a file with preserved ownership, permissions and context"""
+
+        # shutil.copy2(src, dst)
+        #   Similar to shutil.copy(), but metadata is copied as well - in fact,
+        #   this is just shutil.copy() followed by copystat(). This is similar
+        #   to the Unix command cp -p.
+        #
+        # shutil.copystat(src, dst)
+        #   Copy the permission bits, last access time, last modification time,
+        #   and flags from src to dst. The file contents, owner, and group are
+        #   unaffected. src and dst are path names given as strings.
+
+        shutil.copy2(src, dest)
+
+        # Set the context
+        if self.selinux_enabled():
+            context = self.selinux_context(src)
+            self.set_context_if_different(dest, context, False)
+
+        # chown it
+        try:
+            dest_stat = os.stat(src)
+            tmp_stat = os.stat(dest)
+            if dest_stat and (tmp_stat.st_uid != dest_stat.st_uid or tmp_stat.st_gid != dest_stat.st_gid):
+                os.chown(dest, dest_stat.st_uid, dest_stat.st_gid)
+        except OSError as e:
+            if e.errno != errno.EPERM:
+                raise
+
+        # Set the attributes
+        current_attribs = self.get_file_attributes(src)
+        current_attribs = current_attribs.get('attr_flags', [])
+        current_attribs = ''.join(current_attribs)
+        self.set_attributes_if_different(dest, current_attribs, True)
 
     def atomic_move(self, src, dest, unsafe_writes=False):
         '''atomically move src to dest, copying attributes from dest, returns true on success

--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -240,7 +240,7 @@ class Cli:
             self._module.fail_json(msg='unable to enter configuration mode', output=to_text(err, errors='surrogate_then_replace'))
 
         if replace:
-            self.exec_command('rollback clean-config', check_rc=True)
+            self.exec_command('rollback clean-config')
 
         rc, out, err = self.send_config(commands)
         if rc != 0:

--- a/lib/ansible/module_utils/oneview.py
+++ b/lib/ansible/module_utils/oneview.py
@@ -1,0 +1,433 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Copyright (2016-2017) Hewlett Packard Enterprise Development LP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import (absolute_import, division, print_function)
+
+import abc
+import collections
+import json
+import os
+import traceback
+
+try:
+    from hpOneView.oneview_client import OneViewClient
+    from hpOneView.exceptions import (HPOneViewException,
+                                      HPOneViewTaskError,
+                                      HPOneViewValueError,
+                                      HPOneViewResourceNotFound)
+    HAS_HPE_ONEVIEW = True
+except ImportError:
+    HAS_HPE_ONEVIEW = False
+
+from ansible.module_utils import six
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+
+
+def transform_list_to_dict(list_):
+    """
+    Transforms a list into a dictionary, putting values as keys.
+
+    :arg list list_: List of values
+    :return: dict: dictionary built
+    """
+
+    ret = {}
+
+    if not list_:
+        return ret
+
+    for value in list_:
+        if isinstance(value, collections.Mapping):
+            ret.update(value)
+        else:
+            ret[to_native(value, errors='surrogate_or_strict')] = True
+
+    return ret
+
+
+def merge_list_by_key(original_list, updated_list, key, ignore_when_null=[]):
+    """
+    Merge two lists by the key. It basically:
+
+    1. Adds the items that are present on updated_list and are absent on original_list.
+
+    2. Removes items that are absent on updated_list and are present on original_list.
+
+    3. For all items that are in both lists, overwrites the values from the original item by the updated item.
+
+    :arg list original_list: original list.
+    :arg list updated_list: list with changes.
+    :arg str key: unique identifier.
+    :arg list ignore_when_null: list with the keys from the updated items that should be ignored in the merge,
+        if its values are null.
+    :return: list: Lists merged.
+    """
+    if not original_list:
+        return updated_list
+
+    items_map = collections.OrderedDict([(i[key], i.copy()) for i in original_list])
+
+    merged_items = collections.OrderedDict()
+
+    for item in updated_list:
+        item_key = item[key]
+        if item_key in items_map:
+            for ignored_key in ignore_when_null:
+                if ignored_key in item and item[ignored_key] is None:
+                    item.pop(ignored_key)
+            merged_items[item_key] = items_map[item_key]
+            merged_items[item_key].update(item)
+        else:
+            merged_items[item_key] = item
+
+    return list(merged_items.values())
+
+
+def _str_sorted(obj):
+    if isinstance(obj, collections.Mapping):
+        return json.dumps(obj, sort_keys=True)
+    else:
+        return str(obj)
+
+
+def _standardize_value(value):
+    """
+    Convert value to string to enhance the comparison.
+
+    :arg value: Any object type.
+
+    :return: str: Converted value.
+    """
+    if isinstance(value, float) and value.is_integer():
+        # Workaround to avoid erroneous comparison between int and float
+        # Removes zero from integer floats
+        value = int(value)
+
+    return str(value)
+
+
+@six.add_metaclass(abc.ABCMeta)
+class OneViewModuleBase(object):
+    MSG_CREATED = 'Resource created successfully.'
+    MSG_UPDATED = 'Resource updated successfully.'
+    MSG_DELETED = 'Resource deleted successfully.'
+    MSG_ALREADY_PRESENT = 'Resource is already present.'
+    MSG_ALREADY_ABSENT = 'Resource is already absent.'
+    MSG_DIFF_AT_KEY = 'Difference found at key \'{0}\'. '
+    HPE_ONEVIEW_SDK_REQUIRED = 'HPE OneView Python SDK is required for this module.'
+
+    ONEVIEW_COMMON_ARGS = dict(
+        config=dict(required=False, type='str')
+    )
+
+    ONEVIEW_VALIDATE_ETAG_ARGS = dict(
+        validate_etag=dict(
+            required=False,
+            type='bool',
+            default=True)
+    )
+
+    resource_client = None
+
+    def __init__(self, additional_arg_spec=None, validate_etag_support=False):
+        """
+        OneViewModuleBase constructor.
+
+        :arg dict additional_arg_spec: Additional argument spec definition.
+        :arg bool validate_etag_support: Enables support to eTag validation.
+        """
+        argument_spec = self._build_argument_spec(additional_arg_spec, validate_etag_support)
+
+        self.module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
+
+        self._check_hpe_oneview_sdk()
+        self._create_oneview_client()
+
+        self.state = self.module.params.get('state')
+        self.data = self.module.params.get('data')
+
+        # Preload params for get_all - used by facts
+        self.facts_params = self.module.params.get('params') or {}
+
+        # Preload options as dict - used by facts
+        self.options = transform_list_to_dict(self.module.params.get('options'))
+
+        self.validate_etag_support = validate_etag_support
+
+    def _build_argument_spec(self, additional_arg_spec, validate_etag_support):
+
+        merged_arg_spec = dict()
+        merged_arg_spec.update(self.ONEVIEW_COMMON_ARGS)
+
+        if validate_etag_support:
+            merged_arg_spec.update(self.ONEVIEW_VALIDATE_ETAG_ARGS)
+
+        if additional_arg_spec:
+            merged_arg_spec.update(additional_arg_spec)
+
+        return merged_arg_spec
+
+    def _check_hpe_oneview_sdk(self):
+        if not HAS_HPE_ONEVIEW:
+            self.module.fail_json(msg=self.HPE_ONEVIEW_SDK_REQUIRED)
+
+    def _create_oneview_client(self):
+        if not self.module.params['config']:
+            self.oneview_client = OneViewClient.from_environment_variables()
+        else:
+            self.oneview_client = OneViewClient.from_json_file(self.module.params['config'])
+
+    @abc.abstractmethod
+    def execute_module(self):
+        """
+        Abstract method, must be implemented by the inheritor.
+
+        This method is called from the run method. It should contains the module logic
+
+        :return: dict: It must return a dictionary with the attributes for the module result,
+            such as ansible_facts, msg and changed.
+        """
+        pass
+
+    def run(self):
+        """
+        Common implementation of the OneView run modules.
+
+        It calls the inheritor 'execute_module' function and sends the return to the Ansible.
+
+        It handles any HPOneViewException in order to signal a failure to Ansible, with a descriptive error message.
+
+        """
+        try:
+            if self.validate_etag_support:
+                if not self.module.params.get('validate_etag'):
+                    self.oneview_client.connection.disable_etag_validation()
+
+            result = self.execute_module()
+
+            if "changed" not in result:
+                result['changed'] = False
+
+            self.module.exit_json(**result)
+
+        except HPOneViewException as exception:
+            error_msg = '; '.join(to_native(e) for e in exception.args)
+            self.module.fail_json(msg=error_msg, exception=traceback.format_exc())
+
+    def resource_absent(self, resource, method='delete'):
+        """
+        Generic implementation of the absent state for the OneView resources.
+
+        It checks if the resource needs to be removed.
+
+        :arg dict resource: Resource to delete.
+        :arg str method: Function of the OneView client that will be called for resource deletion.
+            Usually delete or remove.
+        :return: A dictionary with the expected arguments for the AnsibleModule.exit_json
+        """
+        if resource:
+            getattr(self.resource_client, method)(resource)
+
+            return {"changed": True, "msg": self.MSG_DELETED}
+        else:
+            return {"changed": False, "msg": self.MSG_ALREADY_ABSENT}
+
+    def get_by_name(self, name):
+        """
+        Generic get by name implementation.
+
+        :arg str name: Resource name to search for.
+
+        :return: The resource found or None.
+        """
+        result = self.resource_client.get_by('name', name)
+        return result[0] if result else None
+
+    def resource_present(self, resource, fact_name, create_method='create'):
+        """
+        Generic implementation of the present state for the OneView resources.
+
+        It checks if the resource needs to be created or updated.
+
+        :arg dict resource: Resource to create or update.
+        :arg str fact_name: Name of the fact returned to the Ansible.
+        :arg str create_method: Function of the OneView client that will be called for resource creation.
+            Usually create or add.
+        :return: A dictionary with the expected arguments for the AnsibleModule.exit_json
+        """
+
+        changed = False
+        if "newName" in self.data:
+            self.data["name"] = self.data.pop("newName")
+
+        if not resource:
+            resource = getattr(self.resource_client, create_method)(self.data)
+            msg = self.MSG_CREATED
+            changed = True
+
+        else:
+            merged_data = resource.copy()
+            merged_data.update(self.data)
+
+            if self.compare(resource, merged_data):
+                msg = self.MSG_ALREADY_PRESENT
+            else:
+                resource = self.resource_client.update(merged_data)
+                changed = True
+                msg = self.MSG_UPDATED
+
+        return dict(
+            msg=msg,
+            changed=changed,
+            ansible_facts={fact_name: resource}
+        )
+
+    def resource_scopes_set(self, state, fact_name, scope_uris):
+        """
+        Generic implementation of the scopes update PATCH for the OneView resources.
+        It checks if the resource needs to be updated with the current scopes.
+        This method is meant to be run after ensuring the present state.
+        :arg dict state: Dict containing the data from the last state results in the resource.
+            It needs to have the 'msg', 'changed', and 'ansible_facts' entries.
+        :arg str fact_name: Name of the fact returned to the Ansible.
+        :arg list scope_uris: List with all the scope URIs to be added to the resource.
+        :return: A dictionary with the expected arguments for the AnsibleModule.exit_json
+        """
+        if scope_uris is None:
+            scope_uris = []
+        resource = state['ansible_facts'][fact_name]
+        operation_data = dict(operation='replace', path='/scopeUris', value=scope_uris)
+
+        if resource['scopeUris'] is None or set(resource['scopeUris']) != set(scope_uris):
+            state['ansible_facts'][fact_name] = self.resource_client.patch(resource['uri'], **operation_data)
+            state['changed'] = True
+            state['msg'] = self.MSG_UPDATED
+
+        return state
+
+    def compare(self, first_resource, second_resource):
+        """
+        Recursively compares dictionary contents equivalence, ignoring types and elements order.
+        Particularities of the comparison:
+            - Inexistent key = None
+            - These values are considered equal: None, empty, False
+            - Lists are compared value by value after a sort, if they have same size.
+            - Each element is converted to str before the comparison.
+        :arg dict first_resource: first dictionary
+        :arg dict second_resource: second dictionary
+        :return: bool: True when equal, False when different.
+        """
+        resource1 = first_resource
+        resource2 = second_resource
+
+        debug_resources = "resource1 = {0}, resource2 = {1}".format(resource1, resource2)
+
+        # The first resource is True / Not Null and the second resource is False / Null
+        if resource1 and not resource2:
+            self.module.log("resource1 and not resource2. " + debug_resources)
+            return False
+
+        # Checks all keys in first dict against the second dict
+        for key in resource1:
+            if key not in resource2:
+                if resource1[key] is not None:
+                    # Inexistent key is equivalent to exist with value None
+                    self.module.log(self.MSG_DIFF_AT_KEY.format(key) + debug_resources)
+                    return False
+            # If both values are null, empty or False it will be considered equal.
+            elif not resource1[key] and not resource2[key]:
+                continue
+            elif isinstance(resource1[key], collections.Mapping):
+                # recursive call
+                if not self.compare(resource1[key], resource2[key]):
+                    self.module.log(self.MSG_DIFF_AT_KEY.format(key) + debug_resources)
+                    return False
+            elif isinstance(resource1[key], list):
+                # change comparison function to compare_list
+                if not self.compare_list(resource1[key], resource2[key]):
+                    self.module.log(self.MSG_DIFF_AT_KEY.format(key) + debug_resources)
+                    return False
+            elif _standardize_value(resource1[key]) != _standardize_value(resource2[key]):
+                self.module.log(self.MSG_DIFF_AT_KEY.format(key) + debug_resources)
+                return False
+
+        # Checks all keys in the second dict, looking for missing elements
+        for key in resource2.keys():
+            if key not in resource1:
+                if resource2[key] is not None:
+                    # Inexistent key is equivalent to exist with value None
+                    self.module.log(self.MSG_DIFF_AT_KEY.format(key) + debug_resources)
+                    return False
+
+        return True
+
+    def compare_list(self, first_resource, second_resource):
+        """
+        Recursively compares lists contents equivalence, ignoring types and element orders.
+        Lists with same size are compared value by value after a sort,
+        each element is converted to str before the comparison.
+        :arg list first_resource: first list
+        :arg list second_resource: second list
+        :return: True when equal; False when different.
+        """
+
+        resource1 = first_resource
+        resource2 = second_resource
+
+        debug_resources = "resource1 = {0}, resource2 = {1}".format(resource1, resource2)
+
+        # The second list is null / empty  / False
+        if not resource2:
+            self.module.log("resource 2 is null. " + debug_resources)
+            return False
+
+        if len(resource1) != len(resource2):
+            self.module.log("resources have different length. " + debug_resources)
+            return False
+
+        resource1 = sorted(resource1, key=_str_sorted)
+        resource2 = sorted(resource2, key=_str_sorted)
+
+        for i, val in enumerate(resource1):
+            if isinstance(val, collections.Mapping):
+                # change comparison function to compare dictionaries
+                if not self.compare(val, resource2[i]):
+                    self.module.log("resources are different. " + debug_resources)
+                    return False
+            elif isinstance(val, list):
+                # recursive call
+                if not self.compare_list(val, resource2[i]):
+                    self.module.log("lists are different. " + debug_resources)
+                    return False
+            elif _standardize_value(val) != _standardize_value(resource2[i]):
+                self.module.log("values are different. " + debug_resources)
+                return False
+
+        # no differences found
+        return True

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -1,18 +1,9 @@
 #!/usr/bin/python
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 # upcoming features:
 # - Ted's multifile YAML concatenation

--- a/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
@@ -133,6 +133,8 @@ EXAMPLES = '''
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import (boto3_conn, ec2_argument_spec, get_aws_connection_info)
 
+import traceback
+
 try:
     import boto
     import boto.ec2
@@ -180,7 +182,7 @@ def copy_image(module, ec2):
 
         module.exit_json(changed=True, image_id=image_id)
     except WaiterError as we:
-        module.fail_json(msg='An error occurred waiting for the image to become available. (%s)' %  we.reason)
+        module.fail_json(msg='An error occurred waiting for the image to become available. (%s)' % str(we), exception=traceback.format_exc())
     except ClientError as ce:
         module.fail_json(msg=ce.message)
     except NoCredentialsError:

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py
@@ -127,14 +127,26 @@ def ensure_tags(vpc_conn, resource_id, tags, add_only, check_mode):
         if cur_tags == tags:
             return {'changed': False, 'tags': cur_tags}
 
+        if check_mode:
+            latest_check_mode_tags = cur_tags
+
         to_delete = dict((k, cur_tags[k]) for k in cur_tags if k not in tags)
         if to_delete and not add_only:
-            vpc_conn.delete_tags(resource_id, to_delete, dry_run=check_mode)
+            if check_mode:
+                # just overwriting latest_check_mode_tags instead of deleting keys
+                latest_check_mode_tags = dict((k, cur_tags[k]) for k in cur_tags if k not in to_delete)
+            else:
+                vpc_conn.delete_tags(resource_id, to_delete)
 
         to_add = dict((k, tags[k]) for k in tags if k not in cur_tags or cur_tags[k] != tags[k])
         if to_add:
-            vpc_conn.create_tags(resource_id, to_add, dry_run=check_mode)
+            if check_mode:
+                latest_check_mode_tags.update(to_add)
+            else:
+                vpc_conn.create_tags(resource_id, to_add)
 
+        if check_mode:
+            return {'changed': True, 'tags': latest_check_mode_tags}
         latest_tags = get_resource_tags(vpc_conn, resource_id)
         return {'changed': True, 'tags': latest_tags}
     except EC2ResponseError as e:
@@ -187,6 +199,11 @@ def ensure_igw_present(vpc_conn, vpc_id, tags, check_mode):
     igw.vpc_id = vpc_id
 
     if tags != igw.tags:
+        if check_mode:
+            check_mode_tags = ensure_tags(vpc_conn, igw.id, tags, False, check_mode)
+            igw_info = get_igw_info(igw)
+            igw_info.get('tags', {}).update(check_mode_tags.get('tags', {}))
+            return {'changed': True, 'gateway': igw_info}
         ensure_tags(vpc_conn, igw.id, tags, False, check_mode)
         igw.tags = tags
         changed = True

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
@@ -140,7 +140,7 @@ def list_ec2_vpc_nacls(connection, module):
         if 'entries' in nacl:
             nacl['egress'] = [nacl_entry_to_list(entry) for entry in nacl['entries']
                               if entry['rule_number'] != 32767 and entry['egress']]
-            nacl['ingress'] = [nacl_entry_to_list(e) for entry in nacl['entries']
+            nacl['ingress'] = [nacl_entry_to_list(entry) for entry in nacl['entries']
                                if entry['rule_number'] != 32767 and not entry['egress']]
             del nacl['entries']
         if 'associations' in nacl:

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_tag.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_tag.py
@@ -108,6 +108,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
+from ansible.module_utils._text import to_text
 
 
 class Response(object):
@@ -122,10 +123,10 @@ class Response(object):
     def json(self):
         if not self.body:
             if "body" in self.info:
-                return json.loads(self.info["body"])
+                return json.loads(to_text(self.info["body"], errors='surrogate_or_strict'))
             return None
         try:
-            return json.loads(self.body)
+            return json.loads(to_text(self.body, errors='surrogate_or_strict'))
         except ValueError:
             return None
 
@@ -213,6 +214,8 @@ def core(module):
             # Check if resource is already tagged or not
             found = False
             url = "{0}?tag_name={1}".format(resource_type, name)
+            if resource_type == 'droplet':
+                url = "droplets?tag_name={0}".format(name)
             response = rest.get(url)
             status_code = response.status_code
             resp_json = response.json

--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -344,7 +344,7 @@ def get_nextvmid(module, proxmox):
 
 
 def get_vmid(proxmox, hostname):
-    return [vm['vmid'] for vm in proxmox.cluster.resources.get(type='vm') if vm['name'] == hostname]
+    return [vm['vmid'] for vm in proxmox.cluster.resources.get(type='vm') if 'name' in vm and vm['name'] == hostname]
 
 
 def get_instance(proxmox, vmid):
@@ -517,7 +517,10 @@ def main():
     if not vmid and state == 'present':
         vmid = get_nextvmid(module, proxmox)
     elif not vmid and hostname:
-        vmid = get_vmid(proxmox, hostname)[0]
+        hosts = get_vmid(proxmox, hostname)
+        if len(hosts) == 0:
+            module.fail_json(msg="Vmid could not be fetched => Hostname doesn't exist (action: %s)" % state)
+        vmid = hosts[0]
     elif not vmid:
         module.exit_json(changed=False, msg="Vmid could not be fetched for the following action: %s" % state)
 

--- a/lib/ansible/modules/clustering/kubernetes.py
+++ b/lib/ansible/modules/clustering/kubernetes.py
@@ -210,7 +210,12 @@ KIND_URL = {
     "resourcequota": "/api/v1/namespaces/{namespace}/resourcequotas",
     "secret": "/api/v1/namespaces/{namespace}/secrets",
     "service": "/api/v1/namespaces/{namespace}/services",
-    "serviceaccount": "/api/v1/namespaces/{namespace}/serviceaccounts"
+    "serviceaccount": "/api/v1/namespaces/{namespace}/serviceaccounts",
+    "daemonset": "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets",
+    "deployment": "/apis/extensions/v1beta1/namespaces/{namespace}/deployments",
+    "horizontalpodautoscaler": "/apis/extensions/v1beta1/namespaces/{namespace}/horizontalpodautoscalers",  # NOQA
+    "ingress": "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses",
+    "job": "/apis/extensions/v1beta1/namespaces/{namespace}/jobs",
 }
 USER_AGENT = "ansible-k8s-module/0.0.1"
 

--- a/lib/ansible/modules/identity/cyberark/cyberark_authentication.py
+++ b/lib/ansible/modules/identity/cyberark/cyberark_authentication.py
@@ -1,21 +1,9 @@
 #!/usr/bin/python
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',

--- a/lib/ansible/modules/identity/ipa/ipa_dnsrecord.py
+++ b/lib/ansible/modules/identity/ipa/ipa_dnsrecord.py
@@ -1,22 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# (c) 2017, Abhijeet Kasurde (akasurde@redhat.com)
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2017, Abhijeet Kasurde (akasurde@redhat.com)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.0',
@@ -118,9 +106,11 @@ dnsrecord:
   type: dict
 '''
 
+import traceback
+
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.ipa import IPAClient
+from ansible.module_utils._text import to_native
 
 
 class DNSRecordIPAClient(IPAClient):
@@ -229,9 +219,8 @@ def main():
                      password=module.params['ipa_pass'])
         changed, record = ensure(module, client)
         module.exit_json(changed=changed, record=record)
-    except Exception:
-        e = get_exception()
-        module.fail_json(msg=str(e))
+    except Exception as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/identity/ipa/ipa_group.py
+++ b/lib/ansible/modules/identity/ipa/ipa_group.py
@@ -1,19 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -140,9 +131,11 @@ group:
   type: dict
 '''
 
+import traceback
+
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.ipa import IPAClient
+from ansible.module_utils._text import to_native
 
 
 class GroupIPAClient(IPAClient):
@@ -280,9 +273,8 @@ def main():
                      password=module.params['ipa_pass'])
         changed, group = ensure(module, client)
         module.exit_json(changed=changed, group=group)
-    except Exception:
-        e = get_exception()
-        module.fail_json(msg=str(e))
+    except Exception as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/identity/ipa/ipa_hbacrule.py
+++ b/lib/ansible/modules/identity/ipa/ipa_hbacrule.py
@@ -1,19 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -171,9 +162,11 @@ hbacrule:
   type: dict
 '''
 
+import traceback
+
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.ipa import IPAClient
+from ansible.module_utils._text import to_native
 
 
 class HBACRuleIPAClient(IPAClient):
@@ -374,9 +367,8 @@ def main():
                      password=module.params['ipa_pass'])
         changed, hbacrule = ensure(module, client)
         module.exit_json(changed=changed, hbacrule=hbacrule)
-    except Exception:
-        e = get_exception()
-        module.fail_json(msg=str(e))
+    except Exception as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/identity/ipa/ipa_host.py
+++ b/lib/ansible/modules/identity/ipa/ipa_host.py
@@ -1,19 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -165,9 +156,11 @@ host_diff:
   type: list
 '''
 
+import traceback
+
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.ipa import IPAClient
+from ansible.module_utils._text import to_native
 
 
 class HostIPAClient(IPAClient):
@@ -292,10 +285,8 @@ def main():
                      password=module.params['ipa_pass'])
         changed, host = ensure(module, client)
         module.exit_json(changed=changed, host=host)
-    except Exception:
-        e = get_exception()
-        module.fail_json(msg=str(e))
-
+    except Exception as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/identity/ipa/ipa_hostgroup.py
+++ b/lib/ansible/modules/identity/ipa/ipa_hostgroup.py
@@ -1,19 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -118,9 +109,11 @@ hostgroup:
   type: dict
 '''
 
+import traceback
+
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.ipa import IPAClient
+from ansible.module_utils._text import to_native
 
 
 class HostGroupIPAClient(IPAClient):
@@ -242,9 +235,8 @@ def main():
                      password=module.params['ipa_pass'])
         changed, hostgroup = ensure(module, client)
         module.exit_json(changed=changed, hostgroup=hostgroup)
-    except Exception:
-        e = get_exception()
-        module.fail_json(msg=str(e))
+    except Exception as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/identity/ipa/ipa_role.py
+++ b/lib/ansible/modules/identity/ipa/ipa_role.py
@@ -1,19 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -160,9 +151,11 @@ role:
   type: dict
 '''
 
+import traceback
+
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.ipa import IPAClient
+from ansible.module_utils._text import to_native
 
 
 class RoleIPAClient(IPAClient):
@@ -332,9 +325,8 @@ def main():
                      password=module.params['ipa_pass'])
         changed, role = ensure(module, client)
         module.exit_json(changed=changed, role=role)
-    except Exception:
-        e = get_exception()
-        module.fail_json(msg=str(e))
+    except Exception as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/identity/ipa/ipa_sudocmd.py
+++ b/lib/ansible/modules/identity/ipa/ipa_sudocmd.py
@@ -1,19 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -97,9 +88,11 @@ sudocmd:
   type: dict
 '''
 
+import traceback
+
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.ipa import IPAClient
+from ansible.module_utils._text import to_native
 
 
 class SudoCmdIPAClient(IPAClient):
@@ -187,9 +180,8 @@ def main():
                      password=module.params['ipa_pass'])
         changed, sudocmd = ensure(module, client)
         module.exit_json(changed=changed, sudocmd=sudocmd)
-    except Exception:
-        e = get_exception()
-        module.fail_json(msg=str(e))
+    except Exception as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/identity/ipa/ipa_sudocmdgroup.py
+++ b/lib/ansible/modules/identity/ipa/ipa_sudocmdgroup.py
@@ -1,19 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -104,9 +95,11 @@ sudocmdgroup:
   type: dict
 '''
 
+import traceback
+
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.ipa import IPAClient
+from ansible.module_utils._text import to_native
 
 
 class SudoCmdGroupIPAClient(IPAClient):
@@ -213,10 +206,8 @@ def main():
                      password=module.params['ipa_pass'])
         changed, sudocmdgroup = ensure(module, client)
         module.exit_json(changed=changed, sudorule=sudocmdgroup)
-    except Exception:
-        e = get_exception()
-        module.fail_json(msg=str(e))
-
+    except Exception as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/identity/ipa/ipa_sudorule.py
+++ b/lib/ansible/modules/identity/ipa/ipa_sudorule.py
@@ -1,19 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -156,9 +147,11 @@ sudorule:
   type: dict
 '''
 
+import traceback
+
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.ipa import IPAClient
+from ansible.module_utils._text import to_native
 
 
 class SudoRuleIPAClient(IPAClient):
@@ -381,9 +374,8 @@ def main():
                      password=module.params['ipa_pass'])
         changed, sudorule = ensure(module, client)
         module.exit_json(changed=changed, sudorule=sudorule)
-    except Exception:
-        e = get_exception()
-        module.fail_json(msg=str(e))
+    except Exception as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/identity/ipa/ipa_user.py
+++ b/lib/ansible/modules/identity/ipa/ipa_user.py
@@ -1,19 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -143,10 +134,11 @@ user:
 
 import base64
 import hashlib
+import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.ipa import IPAClient
+from ansible.module_utils._text import to_native
 
 
 class UserIPAClient(IPAClient):
@@ -328,9 +320,8 @@ def main():
                      password=module.params['ipa_pass'])
         changed, user = ensure(module, client)
         module.exit_json(changed=changed, user=user)
-    except Exception:
-        e = get_exception()
-        module.fail_json(msg=str(e))
+    except Exception as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/identity/opendj/opendj_backendprop.py
+++ b/lib/ansible/modules/identity/opendj/opendj_backendprop.py
@@ -1,23 +1,11 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+# Copyright: (c) 2016, Werner Dijkerman (ikben@werner-dijkerman.nl)
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# (c) 2016, Werner Dijkerman (ikben@werner-dijkerman.nl)
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
-#
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -96,6 +84,8 @@ EXAMPLES = '''
 
 RETURN = '''
 '''
+
+from ansible.module_utils.basic import AnsibleModule
 
 
 class BackendProp(object):
@@ -208,9 +198,6 @@ def main():
             module.exit_json(changed=False)
     else:
         module.exit_json(changed=False)
-
-
-from ansible.module_utils.basic import AnsibleModule
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/aireos/aireos_config.py
+++ b/lib/ansible/modules/network/aireos/aireos_config.py
@@ -167,7 +167,7 @@ backup_path:
   type: string
   sample: /playbooks/ansible/backup/aireos_config.2016-07-16@22:28:34
 """
-from ansible.module_utils.aireos import run_commands, get_config, load_config, sanitize
+from ansible.module_utils.aireos import run_commands, get_config, load_config
 from ansible.module_utils.aireos import aireos_argument_spec
 from ansible.module_utils.aireos import check_args as aireos_check_args
 from ansible.module_utils.basic import AnsibleModule
@@ -281,7 +281,7 @@ def main():
 
     if module._diff:
         output = run_commands(module, 'show run-config commands')
-        contents = sanitize(output[0])
+        contents = output[0]
 
         # recreate the object in order to process diff_ignore_lines
         running_config = NetworkConfig(indent=1, contents=contents, ignore_lines=diff_ignore_lines)

--- a/lib/ansible/modules/network/cloudvision/cv_server_provision.py
+++ b/lib/ansible/modules/network/cloudvision/cv_server_provision.py
@@ -1,0 +1,646 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: cv_server_provision
+version_added: "2.4"
+author: "EOS+ CS (ansible-dev@arista.com) (@mharista)"
+short_description:
+    Provision server port by applying or removing template configuration to an
+    Arista CloudVision Portal configlet that is applied to a switch.
+description:
+  - This module allows a server team to provision server network ports for
+    new servers without having to access Arista CVP or asking the network team
+    to do it for them. Provide the information for connecting to CVP, switch
+    rack, port the new server is connected to, optional vlan, and an action
+    and the module will apply the configuration to the switch port via CVP.
+    Actions are add (applies template config to port),
+    remove (defaults the interface config) and
+    show (returns the current port config).
+options:
+  host:
+    description:
+      - The hostname or IP address of the CVP node being connected to.
+    required: true
+  port:
+    description:
+      - The port number to use when making API calls to the CVP node. This
+        will default to the default port for the specified protocol. Port 80
+        for http and port 443 for https.
+    default: None
+  protocol:
+    description:
+      - The protocol to use when making API calls to CVP. CVP defaults to https
+        and newer versions of CVP no longer support http.
+    default: https
+    choices: [https, http]
+  username:
+    description:
+      - The user that will be used to connect to CVP for making API calls.
+    required: true
+  password:
+    description:
+      - The password of the user that will be used to connect to CVP for API
+        calls.
+    required: true
+  server_name:
+    description:
+      - The hostname or identifier for the server that is having it's switch
+        port provisioned.
+    required: true
+  switch_name:
+    description:
+      - The hostname of the switch is being configured for the server being
+        provisioned.
+    required: true
+  switch_port:
+    description:
+      - The physical port number on the switch that the new server is
+        connected to.
+    required: true
+  port_vlan:
+    description:
+      - The vlan that should be applied to the port for this server.
+        This parameter is dependent on a proper template that supports single
+        vlan provisioning with it. If a port vlan is specified by the template
+        specified does not support this the module will exit out with no
+        changes. If a template is specified that requires a port vlan but no
+        port vlan is specified the module will exit out with no changes.
+    default: None
+  template:
+    description:
+      - A path to a Jinja formatted template file that contains the
+        configuration block that will be applied to the specified switch port.
+        This template will have variable fields replaced by the module before
+        being applied to the switch configuration.
+    required: true
+  action:
+    description:
+      - The action for the module to take. The actions are add, which applies
+        the specified template config to port, remove, which defaults the
+        specified interface configuration, and show, which will return the
+        current port configuration with no changes.
+    default: show
+    choices: [show, add, remove]
+  auto_run:
+    description:
+      - Flag that determines whether or not the module will execute the CVP
+        task spawned as a result of changes to a switch configlet. When an
+        add or remove action is taken which results in a change to a switch
+        configlet, CVP will spawn a task that needs to be executed for the
+        configuration to be applied to the switch. If this option is True then
+        the module will determined the task number created by the configuration
+        change, execute it and wait for the task to complete. If the option
+        is False then the task will remain in the Pending state in CVP for
+        a network administrator to review and execute.
+    default: False
+    type: bool
+notes:
+requirements: [Jinja2, cvprac >= 0.7.0]
+'''
+
+EXAMPLES = '''
+- name: Get current configuration for interface Ethernet2
+  cv_server_provision:
+    host: cvp_node
+    username: cvp_user
+    password: cvp_pass
+    protocol: https
+    server_name: new_server
+    switch_name: eos_switch_1
+    switch_port: 2
+    template: template_file.j2
+    action: show
+
+- name: Remove existing configuration from interface Ethernet2. Run task.
+  cv_server_provision:
+    host: cvp_node
+    username: cvp_user
+    password: cvp_pass
+    protocol: https
+    server_name: new_server
+    switch_name: eos_switch_1
+    switch_port: 2
+    template: template_file.j2
+    action: remove
+    auto_run: True
+
+- name: Add template configuration to interface Ethernet2. No VLAN. Run task.
+  cv_server_provision:
+    host: cvp_node
+    username: cvp_user
+    password: cvp_pass
+    protocol: https
+    server_name: new_server
+    switch_name: eos_switch_1
+    switch_port: 2
+    template: single_attached_trunk.j2
+    action: add
+    auto_run: True
+
+- name: Add template with VLAN configuration to interface Ethernet2. Run task.
+  cv_server_provision:
+    host: cvp_node
+    username: cvp_user
+    password: cvp_pass
+    protocol: https
+    server_name: new_server
+    switch_name: eos_switch_1
+    switch_port: 2
+    port_vlan: 22
+    template: single_attached_vlan.j2
+    action: add
+    auto_run: True
+'''
+
+RETURN = '''
+changed:
+  description: Signifies if a change was made to the configlet
+  returned: success
+  type: bool
+  sample: true
+currentConfigBlock:
+  description: The current config block for the user specified interface
+  returned: when action = show
+  type: string
+  sample: |
+    interface Ethernet4
+    !
+newConfigBlock:
+  description: The new config block for the user specified interface
+  returned: when action = add or remove
+  type: string
+  sample: |
+    interface Ethernet3
+        description example
+        no switchport
+    !
+oldConfigBlock:
+  description: The current config block for the user specified interface
+               before any changes are made
+  returned: when action = add or remove
+  type: string
+  sample: |
+    interface Ethernet3
+    !
+fullConfig:
+  description: The full config of the configlet after being updated
+  returned: when action = add or remove
+  type: string
+  sample: |
+    !
+    interface Ethernet3
+    !
+    interface Ethernet4
+    !
+updateConfigletResponse:
+  description: Response returned from CVP when configlet update is triggered
+  returned: when action = add or remove and configuration changes
+  type: string
+  sample: "Configlet veos1-server successfully updated and task initiated."
+portConfigurable:
+  description: Signifies if the user specified port has an entry in the
+               configlet that Ansible has access to
+  returned: success
+  type: bool
+  sample: true
+switchConfigurable:
+  description: Signifies if the user specified switch has a configlet
+               applied to it that CVP is allowed to edit
+  returned: success
+  type: bool
+  sample: true
+switchInfo:
+  description: Information from CVP describing the switch being configured
+  returned: success
+  type: dictionary
+  sample: {"architecture": "i386",
+           "bootupTimeStamp": 1491264298.21,
+           "complianceCode": "0000",
+           "complianceIndication": "NONE",
+           "deviceInfo": "Registered",
+           "deviceStatus": "Registered",
+           "fqdn": "veos1",
+           "hardwareRevision": "",
+           "internalBuildId": "12-12",
+           "internalVersion": "4.17.1F-11111.4171F",
+           "ipAddress": "192.168.1.20",
+           "isDANZEnabled": "no",
+           "isMLAGEnabled": "no",
+           "key": "00:50:56:5d:e5:e0",
+           "lastSyncUp": 1496432895799,
+           "memFree": 472976,
+           "memTotal": 1893460,
+           "modelName": "vEOS",
+           "parentContainerId": "container_13_5776759195930",
+           "serialNumber": "",
+           "systemMacAddress": "00:50:56:5d:e5:e0",
+           "taskIdList": [],
+           "tempAction": null,
+           "type": "netelement",
+           "unAuthorized": false,
+           "version": "4.17.1F",
+           "ztpMode": "false"}
+taskCompleted:
+  description: Signifies if the task created and executed has completed successfully
+  returned: when action = add or remove, and auto_run = true,
+            and configuration changes
+  type: bool
+  sample: true
+taskCreated:
+  description: Signifies if a task was created due to configlet changes
+  returned: when action = add or remove, and auto_run = true or false,
+            and configuration changes
+  type: bool
+  sample: true
+taskExecuted:
+  description: Signifies if the automation executed the spawned task
+  returned: when action = add or remove, and auto_run = true,
+            and configuration changes
+  type: bool
+  sample: true
+taskId:
+  description: The task ID created by CVP because of changes to configlet
+  returned: when action = add or remove, and auto_run = true or false,
+            and configuration changes
+  type: string
+  sample: "500"
+'''
+
+import re
+import time
+from ansible.module_utils.basic import AnsibleModule
+try:
+    import jinja2
+    from jinja2 import meta
+    HAS_JINJA2 = True
+except ImportError:
+    HAS_JINJA2 = False
+try:
+    from cvprac.cvp_client import CvpClient
+    from cvprac.cvp_client_errors import CvpLoginError, CvpApiError
+    HAS_CVPRAC = True
+except ImportError:
+    HAS_CVPRAC = False
+
+
+def connect(module):
+    ''' Connects to CVP device using user provided credentials from playbook.
+
+    :param module: Ansible module with parameters and client connection.
+    :return: CvpClient object with connection instantiated.
+    '''
+    client = CvpClient()
+    try:
+        client.connect([module.params['host']],
+                       module.params['username'],
+                       module.params['password'],
+                       protocol=module.params['protocol'],
+                       port=module.params['port'])
+    except CvpLoginError as e:
+        module.fail_json(msg=str(e))
+    return client
+
+
+def switch_info(module):
+    ''' Get dictionary of switch info from CVP.
+
+    :param module: Ansible module with parameters and client connection.
+    :return: Dict of switch info from CVP or exit with failure if no
+             info for device is found.
+    '''
+    switch_name = module.params['switch_name']
+    switch_info = module.client.api.get_device_by_name(switch_name)
+    if not switch_info:
+        module.fail_json(msg=str("Device with name '%s' does not exist."
+                                 % switch_name))
+    return switch_info
+
+
+def switch_in_compliance(module, sw_info):
+    ''' Check if switch is currently in compliance.
+
+    :param module: Ansible module with parameters and client connection.
+    :param sw_info: Dict of switch info.
+    :return: Nothing or exit with failure if device is not in compliance.
+    '''
+    compliance = module.client.api.check_compliance(sw_info['key'],
+                                                    sw_info['type'])
+    if compliance['complianceCode'] != '0000':
+        module.fail_json(msg=str('Switch %s is not in compliance. Returned'
+                                 ' compliance code %s.'
+                                 % (sw_info['fqdn'],
+                                    compliance['complianceCode'])))
+
+
+def server_configurable_configlet(module, sw_info):
+    ''' Check CVP that the user specified switch has a configlet assigned to
+        it that Ansible is allowed to edit.
+
+    :param module: Ansible module with parameters and client connection.
+    :param sw_info: Dict of switch info.
+    :return: Dict of configlet information or None.
+    '''
+    configurable_configlet = None
+    configlet_name = module.params['switch_name'] + '-server'
+    switch_configlets = module.client.api.get_configlets_by_device_id(
+        sw_info['key'])
+    for configlet in switch_configlets:
+        if configlet['name'] == configlet_name:
+            configurable_configlet = configlet
+    return configurable_configlet
+
+
+def port_configurable(module, configlet):
+    ''' Check configlet if the user specified port has a configuration entry
+        in the configlet to determine if Ansible is allowed to configure the
+        port on this switch.
+
+    :param module: Ansible module with parameters and client connection.
+    :param configlet: Dict of configlet info.
+    :return: True or False.
+    '''
+    configurable = False
+    regex = r'^interface Ethernet%s' % module.params['switch_port']
+    for config_line in configlet['config'].split('\n'):
+        if re.match(regex, config_line):
+            configurable = True
+    return configurable
+
+
+def configlet_action(module, configlet):
+    ''' Take appropriate action based on current state of device and user
+        requested action.
+
+        Return current config block for specified port if action is show.
+
+        If action is add or remove make the appropriate changes to the
+        configlet and return the associated information.
+
+    :param module: Ansible module with parameters and client connection.
+    :param configlet: Dict of configlet info.
+    :return: Dict of information to updated results with.
+    '''
+    result = dict()
+    existing_config = current_config(module, configlet['config'])
+    if module.params['action'] == 'show':
+        result['currentConfigBlock'] = existing_config
+        return result
+    elif module.params['action'] == 'add':
+        result['newConfigBlock'] = config_from_template(module)
+    elif module.params['action'] == 'remove':
+        result['newConfigBlock'] = ('interface Ethernet%s\n!'
+                                    % module.params['switch_port'])
+    result['oldConfigBlock'] = existing_config
+    result['fullConfig'] = updated_configlet_content(module,
+                                                     configlet['config'],
+                                                     result['newConfigBlock'])
+    resp = module.client.api.update_configlet(result['fullConfig'],
+                                              configlet['key'],
+                                              configlet['name'])
+    if 'data' in resp:
+        result['updateConfigletResponse'] = resp['data']
+        if 'task' in resp['data']:
+            result['changed'] = True
+            result['taskCreated'] = True
+    return result
+
+
+def current_config(module, config):
+    ''' Parse the full port configuration for the user specified port out of
+        the full configlet configuration and return as a string.
+
+    :param module: Ansible module with parameters and client connection.
+    :param config: Full config to parse specific port config from.
+    :return: String of current config block for user specified port.
+    '''
+    regex = r'^interface Ethernet%s' % module.params['switch_port']
+    match = re.search(regex, config, re.M)
+    if not match:
+        module.fail_json(msg=str('interface section not found - %s'
+                                 % config))
+    block_start, line_end = match.regs[0]
+
+    match = re.search(r'!', config[line_end:], re.M)
+    if not match:
+        return config[block_start:]
+    _, block_end = match.regs[0]
+
+    block_end = line_end + block_end
+    return config[block_start:block_end]
+
+
+def valid_template(port, template):
+    ''' Test if the user provided Jinja template is valid.
+
+    :param port: User specified port.
+    :param template: Contents of Jinja template.
+    :return: True or False
+    '''
+    valid = True
+    regex = r'^interface Ethernet%s' % port
+    match = re.match(regex, template, re.M)
+    if not match:
+        valid = False
+    return valid
+
+
+def config_from_template(module):
+    ''' Load the Jinja template and apply user provided parameters in necessary
+        places. Fail if template is not found. Fail if rendered template does
+        not reference the correct port. Fail if the template requires a VLAN
+        but the user did not provide one with the port_vlan parameter.
+
+    :param module: Ansible module with parameters and client connection.
+    :return: String of Jinja template rendered with parameters or exit with
+             failure.
+    '''
+    template_loader = jinja2.FileSystemLoader('./templates')
+    env = jinja2.Environment(loader=template_loader,
+                             undefined=jinja2.DebugUndefined)
+    template = env.get_template(module.params['template'])
+    if not template:
+        module.fail_json(msg=str('Could not find template - %s'
+                                 % module.params['template']))
+
+    data = {'switch_port': module.params['switch_port'],
+            'server_name': module.params['server_name']}
+
+    temp_source = env.loader.get_source(env, module.params['template'])[0]
+    parsed_content = env.parse(temp_source)
+    temp_vars = list(meta.find_undeclared_variables(parsed_content))
+    if 'port_vlan' in temp_vars:
+        if module.params['port_vlan']:
+            data['port_vlan'] = module.params['port_vlan']
+        else:
+            module.fail_json(msg=str('Template %s requires a vlan. Please'
+                                     ' re-run with vlan number provided.'
+                                     % module.params['template']))
+
+    template = template.render(data)
+    if not valid_template(module.params['switch_port'], template):
+        module.fail_json(msg=str('Template content does not configure proper'
+                                 ' interface - %s' % template))
+    return template
+
+
+def updated_configlet_content(module, existing_config, new_config):
+    ''' Update the configlet configuration with the new section for the port
+        specified by the user.
+
+    :param module: Ansible module with parameters and client connection.
+    :param existing_config: String of current configlet configuration.
+    :param new_config: String of configuration for user specified port to
+                       replace in the existing config.
+    :return: String of the full updated configuration.
+    '''
+    regex = r'^interface Ethernet%s' % module.params['switch_port']
+    match = re.search(regex, existing_config, re.M)
+    if not match:
+        module.fail_json(msg=str('interface section not found - %s'
+                                 % existing_config))
+    block_start, line_end = match.regs[0]
+
+    updated_config = existing_config[:block_start] + new_config
+    match = re.search(r'!\n', existing_config[line_end:], re.M)
+    if match:
+        _, block_end = match.regs[0]
+        block_end = line_end + block_end
+        updated_config += '\n%s' % existing_config[block_end:]
+    return updated_config
+
+
+def configlet_update_task(module):
+    ''' Poll device info of switch from CVP up to three times to see if the
+        configlet updates have spawned a task. It sometimes takes a second for
+        the task to be spawned after configlet updates. If a task is found
+        return the task ID. Otherwise return None.
+
+    :param module: Ansible module with parameters and client connection.
+    :return: Task ID or None.
+    '''
+    for num in range(3):
+        device_info = switch_info(module)
+        if (('taskIdList' in device_info) and
+                (len(device_info['taskIdList']) > 0)):
+            for task in device_info['taskIdList']:
+                if ('Configlet Assign' in task['description'] and
+                        task['data']['WORKFLOW_ACTION'] == 'Configlet Push'):
+                    return task['workOrderId']
+        time.sleep(1)
+    return None
+
+
+def wait_for_task_completion(module, task):
+    ''' Poll CVP for the executed task to complete. There is currently no
+        timeout. Exits with failure if task status is Failed or Cancelled.
+
+    :param module: Ansible module with parameters and client connection.
+    :param task: Task ID to poll for completion.
+    :return: True or exit with failure if task is cancelled or fails.
+    '''
+    task_complete = False
+    while not task_complete:
+        task_info = module.client.api.get_task_by_id(task)
+        task_status = task_info['workOrderUserDefinedStatus']
+        if task_status == 'Completed':
+            return True
+        elif task_status in ['Failed', 'Cancelled']:
+            module.fail_json(msg=str('Task %s has reported status %s. Please'
+                                     ' consult the CVP admins for more'
+                                     ' information.' % (task, task_status)))
+        time.sleep(2)
+
+
+def main():
+    """ main entry point for module execution
+    """
+    argument_spec = dict(
+        host=dict(required=True),
+        port=dict(required=False, default=None),
+        protocol=dict(default='https', choices=['http', 'https']),
+        username=dict(required=True),
+        password=dict(required=True, no_log=True),
+        server_name=dict(required=True),
+        switch_name=dict(required=True),
+        switch_port=dict(required=True),
+        port_vlan=dict(required=False, default=None),
+        template=dict(require=True),
+        action=dict(default='show', choices=['show', 'add', 'remove']),
+        auto_run=dict(type='bool', default=False))
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=False)
+    if not HAS_JINJA2:
+        module.fail_json(msg='The Jinja2 python module is required.')
+    if not HAS_CVPRAC:
+        module.fail_json(msg='The cvprac python module is required.')
+    result = dict(changed=False)
+    module.client = connect(module)
+
+    try:
+        result['switchInfo'] = switch_info(module)
+        if module.params['action'] in ['add', 'remove']:
+            switch_in_compliance(module, result['switchInfo'])
+        switch_configlet = server_configurable_configlet(module,
+                                                         result['switchInfo'])
+        if not switch_configlet:
+            module.fail_json(msg=str('Switch %s has no configurable server'
+                                     ' ports.' % module.params['switch_name']))
+        result['switchConfigurable'] = True
+        if not port_configurable(module, switch_configlet):
+            module.fail_json(msg=str('Port %s is not configurable as a server'
+                                     ' port on switch %s.'
+                                     % (module.params['switch_port'],
+                                        module.params['switch_name'])))
+        result['portConfigurable'] = True
+        result['taskCreated'] = False
+        result['taskExecuted'] = False
+        result['taskCompleted'] = False
+        result.update(configlet_action(module, switch_configlet))
+        if module.params['auto_run'] and module.params['action'] != 'show':
+            task_id = configlet_update_task(module)
+            if task_id:
+                result['taskId'] = task_id
+                note = ('Update config on %s with %s action from Ansible.'
+                        % (module.params['switch_name'],
+                           module.params['action']))
+                module.client.api.add_note_to_task(task_id, note)
+                module.client.api.execute_task(task_id)
+                result['taskExecuted'] = True
+                task_completed = wait_for_task_completion(module, task_id)
+                if task_completed:
+                    result['taskCompleted'] = True
+            else:
+                result['taskCreated'] = False
+    except CvpApiError as e:
+        module.fail_json(msg=str(e))
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -276,7 +276,7 @@ from ansible.module_utils.eos import check_args
 
 
 def get_candidate(module):
-    candidate = NetworkConfig(indent=3)
+    candidate = NetworkConfig(indent=2)
     if module.params['src']:
         candidate.load(module.params['src'])
     elif module.params['lines']:
@@ -295,7 +295,7 @@ def get_running_config(module, config=None):
             if module.params['defaults']:
                 flags.append('all')
             contents = get_config(module, flags=flags)
-    return NetworkConfig(indent=3, contents=contents)
+    return NetworkConfig(indent=2, contents=contents)
 
 
 def main():

--- a/lib/ansible/modules/network/nxos/nxos_vrrp.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrrp.py
@@ -84,7 +84,6 @@ EXAMPLES = '''
     interface: vlan10
     group: 100
     vip: 10.1.100.1
-    host: 68.170.147.165
 
 - name: Ensure removal of the vrrp group config
   # vip is required to ensure the user knows what they are removing
@@ -93,7 +92,6 @@ EXAMPLES = '''
     group: 100
     vip: 10.1.100.1
     state: absent
-    host: 68.170.147.165
 
 - name: Re-config with more params
   nxos_vrrp:
@@ -103,39 +101,15 @@ EXAMPLES = '''
     preempt: false
     priority: 130
     authentication: AUTHKEY
-    host: 68.170.147.165
 '''
 
 RETURN = '''
-proposed:
-    description: k/v pairs of parameters passed into module
-    returned: always
-    type: dict
-    sample: {"authentication": "testing", "group": "150", "vip": "10.1.15.1",
-            "admin_state": "no shutdown"}
-existing:
-    description: k/v pairs of existing vrrp info on the interface
-    returned: always
-    type: dict
-    sample: {}
-end_state:
-    description: k/v pairs of vrrp after module execution
-    returned: always
-    type: dict
-    sample: {"authentication": "testing", "group": "150", "interval": "1",
-            "preempt": true, "priority": "100", "vip": "10.1.15.1",
-            "admin_state": "no shutdown"}
-updates:
+commands:
     description: commands sent to the device
     returned: always
     type: list
     sample: ["interface vlan10", "vrrp 150", "address 10.1.15.1",
             "authentication text testing", "no shutdown"]
-changed:
-    description: check to see if a change was made on the device
-    returned: always
-    type: boolean
-    sample: true
 '''
 
 from ansible.module_utils.nxos import load_config, run_commands
@@ -148,12 +122,12 @@ def execute_show_command(command, module):
         output = 'json'
     else:
         output = 'text'
-    cmds = [{
+
+    commands = [{
         'command': command,
         'output': output,
     }]
-    body = run_commands(module, cmds)
-    return body
+    return run_commands(module, commands)[0]
 
 
 def apply_key_map(key_map, table):
@@ -161,12 +135,12 @@ def apply_key_map(key_map, table):
     for key, value in table.items():
         new_key = key_map.get(key)
         if new_key:
-            value = table.get(key)
             if value:
                 new_dict[new_key] = str(value)
             else:
                 new_dict[new_key] = value
     return new_dict
+
 
 def get_interface_type(interface):
     if interface.upper().startswith('ET'):
@@ -189,7 +163,7 @@ def is_default(interface, module):
     command = 'show run interface {0}'.format(interface)
 
     try:
-        body = execute_show_command(command, module)[0]
+        body = execute_show_command(command, module)
         if 'invalid' in body.lower():
             return 'DNE'
         else:
@@ -206,7 +180,7 @@ def get_interface_mode(interface, intf_type, module):
     command = 'show interface {0}'.format(interface)
     interface = {}
     mode = 'unknown'
-    body = execute_show_command(command, module)[0]
+    body = execute_show_command(command, module)
     interface_table = body['TABLE_interface']['ROW_interface']
     name = interface_table.get('interface')
 
@@ -223,7 +197,7 @@ def get_interface_mode(interface, intf_type, module):
 
 def get_vrr_status(group, module, interface):
     command = 'show run all | section interface.{0}$'.format(interface)
-    body = execute_show_command(command, module)[0]
+    body = execute_show_command(command, module)
     vrf_index = None
     admin_state = 'shutdown'
 
@@ -257,7 +231,7 @@ def get_existing_vrrp(interface, group, module, name):
     }
 
     try:
-        vrrp_table = body[0]['TABLE_vrrp_group']
+        vrrp_table = body['TABLE_vrrp_group']
     except (AttributeError, IndexError, TypeError):
         return {}
 
@@ -355,23 +329,21 @@ def main():
         preempt=dict(required=False, type='bool'),
         vip=dict(required=False, type='str'),
         admin_state=dict(required=False, type='str',
-                                choices=['shutdown', 'no shutdown'],
-                                default='no shutdown'),
+                         choices=['shutdown', 'no shutdown'],
+                         default='no shutdown'),
         authentication=dict(required=False, type='str'),
-        state=dict(choices=['absent', 'present'],
-                       required=False, default='present'),
+        state=dict(choices=['absent', 'present'], required=False, default='present'),
         include_defaults=dict(default=False),
         config=dict(),
         save=dict(type='bool', default=False)
     )
-
     argument_spec.update(nxos_argument_spec)
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                                supports_check_mode=True)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     warnings = list()
     check_args(module, warnings)
+    results = {'changed': False, 'commands': [], 'warnings': warnings}
 
     state = module.params['state']
     interface = module.params['interface'].lower()
@@ -418,32 +390,19 @@ def main():
         if delta:
             command = get_commands_config_vrrp(delta, group)
             commands.append(command)
-
     elif state == 'absent':
         if existing:
             commands.append(['no vrrp {0}'.format(group)])
 
     if commands:
         commands.insert(0, ['interface {0}'.format(interface)])
-
-    cmds = flatten_list(commands)
-    if cmds:
-        if module.check_mode:
-            module.exit_json(changed=True, commands=cmds)
-        else:
-            load_config(module, cmds)
-            changed = True
-            end_state = get_existing_vrrp(interface, group, module, name)
-            if 'configure' in cmds:
-                cmds.pop(0)
-
-    results = {}
-    results['proposed'] = proposed
-    results['existing'] = existing
-    results['updates'] = cmds
-    results['changed'] = changed
-    results['warnings'] = warnings
-    results['end_state'] = end_state
+        commands = flatten_list(commands)
+        results['commands'] = commands
+        results['changed'] = True
+        if not module.check_mode:
+            load_config(module, commands)
+            if 'configure' in commands:
+                commands.pop(0)
 
     module.exit_json(**results)
 

--- a/lib/ansible/modules/packaging/os/dpkg_selections.py
+++ b/lib/ansible/modules/packaging/os/dpkg_selections.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
+# Copyright: Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function

--- a/lib/ansible/modules/packaging/os/package.py
+++ b/lib/ansible/modules/packaging/os/package.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2015, Ansible, inc
+# (c) 2015, Ansible Project
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 

--- a/lib/ansible/modules/remote_management/hpe/oneview_fc_network.py
+++ b/lib/ansible/modules/remote_management/hpe/oneview_fc_network.py
@@ -1,0 +1,124 @@
+#!/usr/bin/python
+# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: oneview_fc_network
+short_description: Manage OneView Fibre Channel Network resources.
+description:
+    - Provides an interface to manage Fibre Channel Network resources. Can create, update, and delete.
+version_added: "2.4"
+requirements:
+    - "hpOneView >= 4.0.0"
+author: "Felipe Bulsoni (@fgbulsoni)"
+options:
+    state:
+        description:
+            - Indicates the desired state for the Fibre Channel Network resource.
+              C(present) will ensure data properties are compliant with OneView.
+              C(absent) will remove the resource from OneView, if it exists.
+        choices: ['present', 'absent']
+    data:
+        description:
+            - List with the Fibre Channel Network properties.
+        required: true
+
+extends_documentation_fragment:
+    - oneview
+    - oneview.validateetag
+'''
+
+EXAMPLES = '''
+- name: Ensure that the Fibre Channel Network is present using the default configuration
+  oneview_fc_network:
+    config: "{{ config_file_path }}"
+    state: present
+    data:
+      name: 'New FC Network'
+
+- name: Ensure that the Fibre Channel Network is present with fabricType 'DirectAttach'
+  oneview_fc_network:
+    config: "{{ config_file_path }}"
+    state: present
+    data:
+      name: 'New FC Network'
+      fabricType: 'DirectAttach'
+
+- name: Ensure that the Fibre Channel Network is present and is inserted in the desired scopes
+  oneview_fc_network:
+    config: "{{ config_file_path }}"
+    state: present
+    data:
+      name: 'New FC Network'
+      scopeUris:
+        - '/rest/scopes/00SC123456'
+        - '/rest/scopes/01SC123456'
+
+- name: Ensure that the Fibre Channel Network is absent
+  oneview_fc_network:
+    config: "{{ config_file_path }}"
+    state: absent
+    data:
+      name: 'New FC Network'
+'''
+
+RETURN = '''
+fc_network:
+    description: Has the facts about the managed OneView FC Network.
+    returned: On state 'present'. Can be null.
+    type: dict
+'''
+
+from ansible.module_utils.oneview import OneViewModuleBase
+
+
+class FcNetworkModule(OneViewModuleBase):
+    MSG_CREATED = 'FC Network created successfully.'
+    MSG_UPDATED = 'FC Network updated successfully.'
+    MSG_DELETED = 'FC Network deleted successfully.'
+    MSG_ALREADY_PRESENT = 'FC Network is already present.'
+    MSG_ALREADY_ABSENT = 'FC Network is already absent.'
+    RESOURCE_FACT_NAME = 'fc_network'
+
+    def __init__(self):
+
+        additional_arg_spec = dict(data=dict(required=True, type='dict'),
+                                   state=dict(
+                                       required=True,
+                                       choices=['present', 'absent']))
+
+        super(FcNetworkModule, self).__init__(additional_arg_spec=additional_arg_spec,
+                                              validate_etag_support=True)
+
+        self.resource_client = self.oneview_client.fc_networks
+
+    def execute_module(self):
+        resource = self.get_by_name(self.data['name'])
+
+        if self.state == 'present':
+            return self._present(resource)
+        else:
+            return self.resource_absent(resource)
+
+    def _present(self, resource):
+        scope_uris = self.data.pop('scopeUris', None)
+        result = self.resource_present(resource, self.RESOURCE_FACT_NAME)
+        if scope_uris is not None:
+            result = self.resource_scopes_set(result, 'fc_network', scope_uris)
+        return result
+
+
+def main():
+    FcNetworkModule().run()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/storage/purestorage/purefa_hg.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_hg.py
@@ -1,0 +1,189 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Simon Dodsley (simon@purestorage.com)
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: purefa_hg
+version_added: "2.4"
+short_description: Create, Delete and Modify hostgroups on Pure Storage FlashArray
+description:
+    - This module creates, deletes or modifies hostgroups on Pure Storage FlashArray.
+author: Simon Dodsley (@simondodsley)
+options:
+  hostgroup:
+    description:
+      - Host Name.
+    required: true
+  state:
+    description:
+      - Creates or modifies hostgroup.
+    required: false
+    default: present
+    choices: [ "present", "absent" ]
+  host:
+    description:
+      - List of existing hosts to add to hostgroup.
+    required: false
+  volume:
+    description:
+      - List of existing volumes to add to hostgroup.
+    required: false
+extends_documentation_fragment:
+    - purestorage
+'''
+
+EXAMPLES = '''
+- name: Create new hostgroup
+  purefa_hg:
+    hostgroup: foo
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Delete hostgroup - this will disconnect all hosts and volume in the hostgroup
+  purefa_hg:
+    hostgroup: foo
+    state: absent
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Create host group with hosts and volumes
+  purefa_hg:
+    hostgroup: bar
+    host:
+      - host1
+      - host2
+    volume:
+      - vol1
+      - vol2
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+'''
+
+RETURN = '''
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.pure import get_system, purefa_argument_spec
+
+
+HAS_PURESTORAGE = True
+try:
+    from purestorage import purestorage
+except ImportError:
+    HAS_PURESTORAGE = False
+
+
+def get_hostgroup(module, array):
+
+    hostgroup = None
+
+    for h in array.list_hgroups():
+        if h["name"] == module.params['hostgroup']:
+            hostgroup = h
+            break
+
+    return hostgroup
+
+
+def make_hostgroup(module, array):
+
+    changed = True
+
+    if not module.check_mode:
+        host = array.create_hgroup(module.params['hostgroup'])
+        if module.params['host']:
+            array.set_hgroup(module.params['hostgroup'], hostlist=module.params['host'])
+        if module.params['volume']:
+            for v in module.params['volume']:
+                array.connect_hgroup(module.params['hostgroup'], v)
+    module.exit_json(changed=changed)
+
+
+def update_hostgroup(module, array):
+    changed = False
+    hostgroup = module.params['hostgroup']
+    module.exit_json(changed=changed)
+
+
+def delete_hostgroup(module, array):
+    changed = True
+    if not module.check_mode:
+        for vol in array.list_hgroup_connections(module.params['hostgroup']):
+            array.disconnect_hgroup(module.params['hostgroup'], vol["vol"])
+        host = array.get_hgroup(module.params['hostgroup'])
+        array.set_hgroup(module.params['hostgroup'], remhostlist=host['hosts'])
+        array.delete_hgroup(module.params['hostgroup'])
+    module.exit_json(changed=changed)
+
+
+def main():
+    argument_spec = purefa_argument_spec()
+    argument_spec.update(
+        dict(
+            hostgroup=dict(required=True),
+            state=dict(default='present', choices=['present', 'absent']),
+            host=dict(type='list'),
+            volume=dict(type='list'),
+        )
+    )
+
+    module = AnsibleModule(argument_spec, supports_check_mode=True)
+
+    if not HAS_PURESTORAGE:
+        module.fail_json(msg='purestorage sdk is required for this module in host')
+
+    state = module.params['state']
+    array = get_system(module)
+    hostgroup = get_hostgroup(module, array)
+
+    if module.params['host']:
+        try:
+            for h in module.params['host']:
+                array.get_host(h)
+        except:
+            module.fail_json(msg='Host not found')
+
+    if module.params['volume']:
+        try:
+            for v in module.params['volume']:
+                array.get_volume(v)
+        except:
+            module.fail_json(msg='Volume not found')
+
+    if hostgroup and state == 'present':
+        update_hostgroup(module, array)
+    elif hostgroup and state == 'absent':
+        delete_hostgroup(module, array)
+    elif hostgroup is None and state == 'absent':
+        module.exit_json(changed=False)
+    else:
+        make_hostgroup(module, array)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/storage/purestorage/purefa_pg.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_pg.py
@@ -1,0 +1,217 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Simon Dodsley (simon@purestorage.com)
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: purefa_pg
+version_added: "2.4"
+short_description: Create, Delete and Modify Protection Groups on Pure Storage FlashArray
+description:
+    - This module creates, deletes or modifies protection groups on Pure Storage FlashArray.
+author: Simon Dodsley (@simondodsley)
+options:
+  pgroup:
+    description:
+      - Host Name
+    required: true
+  state:
+    description:
+      - Creates or modifies protection group.
+    required: false
+    default: present
+    choices: [ "present", "absent" ]
+  volume:
+    description:
+      - List of existing volumes to add to protection group.
+    required: false
+  host:
+    description:
+      - List of existing hosts to add to protection group.
+    required: false
+  hostgroup:
+    description:
+      - List of existing hostgroups to add to protection group.
+    required: false
+  eradicate:
+    description:
+      - Define whether to eradicate the protection group on delete and leave in trash.
+    required: false
+    type : bool
+    default: false
+extends_documentation_fragment:
+    - purestorage
+'''
+
+EXAMPLES = '''
+- name: Create new protection group
+  purefa_pg:
+    pgroup: foo
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Delete protection group
+  purefa_pg:
+    pgroup: foo
+    state: absent
+    eradicate: true
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Create protection group for hostgroups
+  purefa_pg:
+    pgroup: bar
+    hostgroup:
+      - hg1
+      - hg2
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Create protection group for hosts
+  purefa_pg:
+    pgroup: bar
+    host:
+      - host1
+      - host2
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+
+- name: Create protection group for volumes
+  purefa_pg:
+    pgroup: bar
+    volume:
+      - vol1
+      - vol2
+    fa_url: 10.10.10.2
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
+'''
+
+RETURN = '''
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.pure import get_system, purefa_argument_spec
+
+
+HAS_PURESTORAGE = True
+try:
+    from purestorage import purestorage
+except ImportError:
+    HAS_PURESTORAGE = False
+
+
+def get_pgroup(module, array):
+
+    pgroup = None
+
+    for h in array.list_pgroups():
+        if h["name"] == module.params['pgroup']:
+            pgroup = h
+            break
+
+    return pgroup
+
+
+def make_pgroup(module, array):
+
+    changed = True
+
+    if not module.check_mode:
+        host = array.create_pgroup(module.params['pgroup'])
+        if module.params['volume']:
+            array.set_pgroup(module.params['pgroup'], vollist=module.params['volume'])
+        if module.params['host']:
+            array.set_pgroup(module.params['pgroup'], hostlist=module.params['host'])
+        if module.params['hostgroup']:
+            array.set_pgroup(module.params['pgroup'], hgrouplist=module.params['hostgroup'])
+    module.exit_json(changed=changed)
+
+
+def update_pgroup(module, array):
+    changed = False
+    pgroup = module.params['pgroup']
+    module.exit_json(changed=changed)
+
+
+def delete_pgroup(module, array):
+    changed = True
+    if not module.check_mode:
+        array.destroy_pgroup(module.params['pgroup'])
+        if module.params['eradicate'] == 'true':
+            array.eradicate_pgroup(module.params['pgroup'])
+    module.exit_json(changed=changed)
+
+
+def main():
+    argument_spec = purefa_argument_spec()
+    argument_spec.update(
+        dict(
+            pgroup=dict(required=True),
+            state=dict(default='present', choices=['present', 'absent']),
+            volume=dict(type='list'),
+            host=dict(type='list'),
+            hostgroup=dict(type='list'),
+            eradicate=dict(default='false', type='bool'),
+        )
+    )
+
+    module = AnsibleModule(argument_spec, supports_check_mode=True)
+
+    if not HAS_PURESTORAGE:
+        module.fail_json(msg='purestorage sdk is required for this module in host')
+
+    state = module.params['state']
+    array = get_system(module)
+    pgroup = get_pgroup(module, array)
+
+    if module.params['host']:
+        try:
+            for h in module.params['host']:
+                array.get_host(h)
+        except:
+            module.fail_json(msg='Host {} not found'.format(h))
+
+    if module.params['hostgroup']:
+        try:
+            for hg in module.params['hostgroup']:
+                array.get_hgroup(hg)
+        except:
+            module.fail_json(msg='Hostgroup {} not found'.format(hg))
+
+    if pgroup and state == 'present':
+        update_pgroup(module, array)
+    elif pgroup and state == 'absent':
+        delete_pgroup(module, array)
+    elif pgroup is None and state == 'absent':
+        module.exit_json(changed=False)
+    else:
+        make_pgroup(module, array)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -104,6 +104,15 @@ options:
         inverts the sense of the address.
     required: false
     default: null
+  tcp_flags:
+    description:
+      - TCP flags specification. tcp_flags expects a dict with the two keys
+        "flags" and "flags_set". The "flags" list is the mask, a list of
+        flags you want to examine. The "flags_set" list tells which one(s)
+        should be set. If one of the two values is missing, the --tcp-flags option
+        will be ignored.
+    required: false
+    default: {}
   match:
     description:
       - Specifies a match to use, that is, an extension module that tests for
@@ -357,6 +366,10 @@ def append_param(rule, param, flag, is_list):
         if param is not None:
             rule.extend([flag, param])
 
+def append_tcp_flags(rule, param, flag):
+    if param:
+        if 'flags' in param and 'flags_set' in param:
+            rule.extend([flag, ','.join(param['flags']), ','.join(param['flags_set'])])
 
 def append_csv(rule, param, flag):
     if param:
@@ -379,6 +392,7 @@ def construct_rule(params):
     append_param(rule, params['source'], '-s', False)
     append_param(rule, params['destination'], '-d', False)
     append_param(rule, params['match'], '-m', True)
+    append_tcp_flags(rule, params['tcp_flags'], '--tcp-flags')
     append_param(rule, params['jump'], '-j', False)
     append_param(rule, params['to_destination'], '--to-destination', False)
     append_param(rule, params['to_source'], '--to-source', False)
@@ -499,6 +513,7 @@ def main():
             destination=dict(required=False, default=None, type='str'),
             to_destination=dict(required=False, default=None, type='str'),
             match=dict(required=False, default=[], type='list'),
+            tcp_flags=dict(required=False, default={}, type='dict'),
             jump=dict(required=False, default=None, type='str'),
             goto=dict(required=False, default=None, type='str'),
             in_interface=dict(required=False, default=None, type='str'),

--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -105,6 +105,7 @@ options:
     required: false
     default: null
   tcp_flags:
+    version_added: "2.4"
     description:
       - TCP flags specification. tcp_flags expects a dict with the two keys
         "flags" and "flags_set". The "flags" list is the mask, a list of

--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -42,7 +42,7 @@ options:
     - Additional options to pass to C(pvcreate) when creating the volume group.
     default: null
     required: false
-    version_added: "2.3"
+    version_added: "2.4"
   vg_options:
     description:
     - Additional options to pass to C(vgcreate) when creating the volume group.

--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -37,6 +37,12 @@ options:
     - The size of the physical extent in megabytes. Must be a power of 2.
     default: 4
     required: false
+  pv_options:
+    description:
+    - Additional options to pass to C(pvcreate) when creating the volume group.
+    default: null
+    required: false
+    version_added: "2.3"
   vg_options:
     description:
     - Additional options to pass to C(vgcreate) when creating the volume group.
@@ -124,6 +130,7 @@ def main():
             vg=dict(required=True),
             pvs=dict(type='list'),
             pesize=dict(type='int', default=4),
+            pv_options=dict(default=''),
             vg_options=dict(default=''),
             state=dict(choices=["absent", "present"], default='present'),
             force=dict(type='bool', default='no'),
@@ -135,6 +142,7 @@ def main():
     state = module.params['state']
     force = module.boolean(module.params['force'])
     pesize = module.params['pesize']
+    pvoptions = module.params['pv_options'].split()
     vgoptions = module.params['vg_options'].split()
 
     dev_list = []
@@ -191,7 +199,7 @@ def main():
                 ### create PV
                 pvcreate_cmd = module.get_bin_path('pvcreate', True)
                 for current_dev in dev_list:
-                    rc,_,err = module.run_command("%s -f %s" % (pvcreate_cmd,current_dev))
+                    rc,_,err = module.run_command([pvcreate_cmd] + pvoptions + ['-f', str(current_dev)])
                     if rc == 0:
                         changed = True
                     else:
@@ -232,7 +240,7 @@ def main():
                     ### create PV
                     pvcreate_cmd = module.get_bin_path('pvcreate', True)
                     for current_dev in devs_to_add:
-                        rc,_,err = module.run_command("%s -f %s" % (pvcreate_cmd, current_dev))
+                        rc,_,err = module.run_command([pvcreate_cmd] + pvoptions + ['-f', str(current_dev)])
                         if rc == 0:
                             changed = True
                         else:

--- a/lib/ansible/modules/system/setup.py
+++ b/lib/ansible/modules/system/setup.py
@@ -23,13 +23,16 @@ options:
         version_added: "2.1"
         description:
             - "if supplied, restrict the additional facts collected to the given subset.
-              Possible values: all, hardware, network, virtual, ohai, and
+              Possible values: all, min, hardware, network, virtual, ohai, and
               facter Can specify a list of values to specify a larger subset.
               Values can also be used with an initial C(!) to specify that
               that specific subset should not be collected.  For instance:
-              !hardware, !network, !virtual, !ohai, !facter.  Note that a few
-              facts are always collected.  Use the filter parameter if you do
-              not want to display those."
+              !hardware, !network, !virtual, !ohai, !facter. If !all is specified
+              then only the min subset is collected. To avoid collecting even the
+              min subset, specify !all and !min subsets. To collect only specific facts,
+              use !all, !min, and specify the particular fact subsets.
+              Use the filter parameter if you do not want to display some collected
+              facts."
         required: false
         default: 'all'
     gather_timeout:
@@ -93,17 +96,26 @@ EXAMPLES = """
 # Display only facts returned by facter.
 # ansible all -m setup -a 'filter=facter_*'
 
+# Collect only facts returned by facter.
+# ansible all -m setup -a 'gather_subset=!all,!any,facter'
+
 # Display only facts about certain interfaces.
 # ansible all -m setup -a 'filter=ansible_eth[0-2]'
 
-# Restrict additional gathered facts to network and virtual.
+# Restrict additional gathered facts to network and virtual (includes default minimum facts)
 # ansible all -m setup -a 'gather_subset=network,virtual'
+
+# Collect only network and virtual (excludes default minimum facts)
+# ansible all -m setup -a 'gather_subset=!all,!any,network,virtual'
 
 # Do not call puppet facter or ohai even if present.
 # ansible all -m setup -a 'gather_subset=!facter,!ohai'
 
-# Only collect the minimum amount of facts:
+# Only collect the default minimum amount of facts:
 # ansible all -m setup -a 'gather_subset=!all'
+
+# Collect no facts, even the default minimum subset of facts:
+# ansible all -m setup -a 'gather_subset=!all,!min'
 
 # Display facts from Windows hosts with custom facts stored in C(C:\\custom_facts).
 # ansible windows -m setup -a "fact_path='c:\\custom_facts'"

--- a/lib/ansible/modules/utilities/logic/set_fact.py
+++ b/lib/ansible/modules/utilities/logic/set_fact.py
@@ -33,11 +33,19 @@ options:
         using the C(args:) statement.
     required: true
     default: null
+  cacheable:
+    description:
+      - This boolean indicates if the facts set will also be added to the
+        fact cache, if fact caching is enabled.
+    required: false
+    default: false
+    version_added: "2.4"
 version_added: "1.2"
 notes:
     - "The `var=value` notation can only create strings or booleans.
       If you want to create lists/arrays or dictionary/hashes use `var: [val1, val2]`"
     - This module is also supported for Windows targets.
+    - Since 'cacheable' is now a module param, 'cacheable' is no longer a valid fact name as of 2.4.
 '''
 
 EXAMPLES = '''
@@ -49,6 +57,12 @@ EXAMPLES = '''
      one_fact: something
      other_fact: "{{ local_var * 2 }}"
      another_fact: "{{ some_registered_var.results | map(attribute='ansible_facts.some_fact') | list }}"
+
+# Example setting facts so that they will be persisted in the fact cache
+- set_fact:
+    one_fact: something
+    other_fact: "{{ local_var * 2 }}"
+    cacheable: true
 
 # As of 1.8, Ansible will convert boolean strings ('true', 'false', 'yes', 'no')
 # to proper boolean values when using the key=value syntax, however it is still

--- a/lib/ansible/plugins/action/set_fact.py
+++ b/lib/ansible/plugins/action/set_fact.py
@@ -35,6 +35,9 @@ class ActionModule(ActionBase):
         result = super(ActionModule, self).run(tmp, task_vars)
 
         facts = dict()
+
+        cacheable = bool(self._task.args.pop('cacheable', False))
+
         if self._task.args:
             for (k, v) in iteritems(self._task.args):
                 k = self._templar.template(k)
@@ -51,4 +54,5 @@ class ActionModule(ActionBase):
 
         result['changed'] = False
         result['ansible_facts'] = facts
+        result['ansible_facts_cacheable'] = cacheable
         return result

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -511,11 +511,13 @@ class StrategyBase:
                                 for target_host in host_list:
                                     self._variable_manager.set_host_variable(target_host, var_name, var_value)
                         else:
+                            cacheable = result_item.pop('ansible_facts_cacheable', True)
                             for target_host in host_list:
-                                if original_task.action == 'set_fact':
-                                    self._variable_manager.set_nonpersistent_facts(target_host, result_item['ansible_facts'].copy())
-                                else:
+                                if cacheable:
                                     self._variable_manager.set_host_facts(target_host, result_item['ansible_facts'].copy())
+
+                                # If we are setting a fact, it should populate non_persistent_facts as well
+                                self._variable_manager.set_nonpersistent_facts(target_host, result_item['ansible_facts'].copy())
 
                     if 'ansible_stats' in result_item and 'data' in result_item['ansible_stats'] and result_item['ansible_stats']['data']:
 

--- a/lib/ansible/utils/module_docs_fragments/oneview.py
+++ b/lib/ansible/utils/module_docs_fragments/oneview.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (2016-2017) Hewlett Packard Enterprise Development LP
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+class ModuleDocFragment(object):
+
+    # OneView doc fragment
+    DOCUMENTATION = '''
+options:
+    config:
+      description:
+        - Path to a .json configuration file containing the OneView client configuration.
+          The configuration file is optional and when used should be present in the host running the ansible commands.
+          If the file path is not provided, the configuration will be loaded from environment variables.
+          For links to example configuration files or how to use the environment variables verify the notes section.
+      required: false
+
+requirements:
+  - "python >= 2.7.9"
+
+notes:
+    - "A sample configuration file for the config parameter can be found at:
+       U(https://github.com/HewlettPackard/oneview-ansible/blob/master/examples/oneview_config-rename.json)"
+    - "Check how to use environment variables for configuration at:
+       U(https://github.com/HewlettPackard/oneview-ansible#environment-variables)"
+    - "Additional Playbooks for the HPE OneView Ansible modules can be found at:
+       U(https://github.com/HewlettPackard/oneview-ansible/tree/master/examples)"
+    '''
+
+    VALIDATEETAG = '''
+options:
+    validate_etag:
+        description:
+            - When the ETag Validation is enabled, the request will be conditionally processed only if the current ETag
+                for the resource matches the ETag provided in the data.
+        default: true
+        choices: ['true', 'false']
+'''
+
+    FACTSPARAMS = '''
+options:
+    params:
+        description:
+        - List of params to delimit, filter and sort the list of resources.
+        - "params allowed:
+            C(start): The first item to return, using 0-based indexing.
+            C(count): The number of resources to return.
+            C(filter): A general filter/query string to narrow the list of items returned.
+            C(sort): The sort order of the returned data set."
+        required: false
+'''

--- a/shippable.yml
+++ b/shippable.yml
@@ -18,7 +18,7 @@ matrix:
     - env: TEST=osx/10.11
 
     - env: TEST=freebsd/10.3-STABLE
-    - env: TEST=freebsd/11.1-STABLE
+    - env: TEST=freebsd/11.0-STABLE
 
     - env: TEST=rhel/7.4
 

--- a/shippable.yml
+++ b/shippable.yml
@@ -18,9 +18,9 @@ matrix:
     - env: TEST=osx/10.11
 
     - env: TEST=freebsd/10.3-STABLE
-    - env: TEST=freebsd/11.0-STABLE
+    - env: TEST=freebsd/11.1-STABLE
 
-    - env: TEST=rhel/7.3
+    - env: TEST=rhel/7.4
 
     - env: TEST=windows
 

--- a/test/integration/network-integration.cfg
+++ b/test/integration/network-integration.cfg
@@ -5,3 +5,6 @@
 timeout = 60
 host_key_checking = False
 log_path = /tmp/ansible-test.out
+
+[ssh_connection]
+ssh_args = '-o UserKnownHostsFile=/dev/null'

--- a/test/integration/targets/gathering_facts/test_gathering_facts.yml
+++ b/test/integration/targets/gathering_facts/test_gathering_facts.yml
@@ -1,5 +1,4 @@
 ---
-
 - hosts: facthost7
   tags: [ 'fact_negation' ]
   connection: local
@@ -12,9 +11,6 @@
            - "!hardware"
       register: not_hardware_facts
 
-    - name: debug setup with not hardware
-      debug:
-        var: not_hardware_facts
 
 - hosts: facthost0
   tags: [ 'fact_min' ]
@@ -67,6 +63,7 @@
           - 'ansible_mounts|default("UNDEF_MOUNT") == "UNDEF_MOUNT"'
           - 'ansible_virtualization_role|default("UNDEF_VIRT") == "UNDEF_VIRT"'
           - 'ansible_env|default("UNDEF_ENV") == "UNDEF_ENV"'
+          - 'ansible_pkg_mgr|default("UNDEF_PKG_MGR") == "UNDEF_PKG_MGR"'
 
 - hosts: facthost11
   tags: [ 'fact_min' ]
@@ -111,7 +108,10 @@
     - name: Test that only retrieving minimal facts work
       assert:
         that:
+          # from the min set, which should still collect
           - 'ansible_user_id|default("UNDEF_MIN") != "UNDEF_MIN"'
+          - 'ansible_env|default("UNDEF_ENV") != "UNDEF_ENV"'
+          # non min facts that are not collected
           - 'ansible_interfaces|default("UNDEF_NET") == "UNDEF_NET"'
           - 'ansible_mounts|default("UNDEF_HW") == "UNDEF_HW"'
           - 'ansible_virtualization_role|default("UNDEF_VIRT") == "UNDEF_VIRT"'
@@ -198,10 +198,16 @@
     - name: Test that negation of fact subsets work
       assert:
         that:
+          # network, not collected since it is not in min
+          - 'ansible_interfaces|default("UNDEF_NET") == "UNDEF_NET"'
+          # not collecting virt, should be undef
+          - 'ansible_virtualization_role|default("UNDEF_VIRT") == "UNDEF_VIRT"'
+          # mounts/devices are collected by hardware, so should be not collected and undef
+          - 'ansible_mounts|default("UNDEF_MOUNTS") == "UNDEF_MOUNTS"'
+          - 'ansible_devices|default("UNDEF_DEVICES") == "UNDEF_DEVICES"'
+          # from the min set, which should still collect
           - 'ansible_user_id|default("UNDEF_MIN") != "UNDEF_MIN"'
-          - 'ansible_interfaces|default("UNDEF_NET") != "UNDEF_NET"'
-          - 'ansible_mounts|default("UNDEF_HW") == "UNDEF_HW"'
-          - 'ansible_virtualization_role|default("UNDEF_VIRT") != "UNDEF_VIRT"'
+          - 'ansible_env|default("UNDEF_ENV") != "UNDEF_ENV"'
 
 - hosts: facthost8
   tags: [ 'fact_mixed_negation_addition' ]
@@ -216,6 +222,46 @@
           - 'ansible_interfaces|default("UNDEF_NET") != "UNDEF_NET"'
           - 'ansible_mounts|default("UNDEF_HW") == "UNDEF_HW"'
           - 'ansible_virtualization_role|default("UNDEF_VIRT") == "UNDEF_VIRT"'
+
+- hosts: facthost14
+  tags: [ 'fact_mixed_negation_addition_min' ]
+  connection: local
+  gather_subset: "!all,!min,network"
+  gather_facts: yes
+  tasks:
+    - name: Test that negation and additional subsets work together for min subset
+      assert:
+        that:
+          - 'ansible_user_id|default("UNDEF_MIN") == "UNDEF_MIN"'
+          - 'ansible_interfaces|default("UNDEF_NET") != "UNDEF_NET"'
+          - 'ansible_default_ipv4|default("UNDEF_DEFAULT_IPV4") != "UNDEF_DEFAULT_IPV4"'
+          - 'ansible_all_ipv4_addresses|default("UNDEF_ALL_IPV4") != "UNDEF_ALL_IPV4"'
+          - 'ansible_mounts|default("UNDEF_HW") == "UNDEF_HW"'
+          - 'ansible_virtualization_role|default("UNDEF_VIRT") == "UNDEF_VIRT"'
+          - 'ansible_env|default("UNDEF_ENV") == "UNDEF_ENV"'
+
+- hosts: facthost15
+  tags: [ 'fact_negate_all_min_add_pkg_mgr' ]
+  connection: local
+  gather_subset: "!all,!min,pkg_mgr"
+  gather_facts: yes
+  tasks:
+    - name: Test that negation and additional subsets work together for min subset
+      assert:
+        that:
+          # network, not collected since it is not in min
+          - 'ansible_interfaces|default("UNDEF_NET") == "UNDEF_NET"'
+          # not collecting virt, should be undef
+          - 'ansible_virtualization_role|default("UNDEF_VIRT") == "UNDEF_VIRT"'
+          # mounts/devices are collected by hardware, so should be not collected and undef
+          - 'ansible_mounts|default("UNDEF_MOUNTS") == "UNDEF_MOUNTS"'
+          - 'ansible_devices|default("UNDEF_DEVICES") == "UNDEF_DEVICES"'
+          # from the min set, which should not collect
+          - 'ansible_user_id|default("UNDEF_MIN") == "UNDEF_MIN"'
+          - 'ansible_env|default("UNDEF_ENV") == "UNDEF_ENV"'
+          # the pkg_mgr fact we requested explicitly
+          - 'ansible_pkg_mgr|default("UNDEF_PKG_MGR") != "UNDEF_PKGMGR"'
+
 
 - hosts: facthost9
   tags: [ 'fact_local']

--- a/test/integration/targets/junos_command/tests/netconf_xml/contains.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/contains.yaml
@@ -5,11 +5,11 @@
   junos_command:
     commands:
       - show version
-      - show interfaces fxp0
+      - show interfaces lo0
     format: xml
     wait_for:
       - "result[0].rpc-reply.software-information.host-name contains {{ inventory_hostname_short }}"
-      - "result[1].rpc-reply.interface-information.physical-interface.name contains fxp0"
+      - "result[1].rpc-reply.interface-information.physical-interface.name contains lo0"
     provider: "{{ netconf }}"
   register: result
 

--- a/test/integration/targets/junos_interface/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_interface/tests/netconf/basic.yaml
@@ -79,7 +79,6 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'<interface>' in config.xml"
       - "'<name>ge-0/0/1</name>' in config.xml"
 
 - name: Configure interface attributes
@@ -116,17 +115,10 @@
     provider: "{{ netconf }}"
   register: result
 
-- name: Get running configuration
-  junos_rpc:
-    rpc: get-configuration
-    provider: "{{ netconf }}"
-  register: config
-
 - assert:
     that:
       - "result.changed == true"
-      - "'<disable/>' in config.xml"
-      - "'<name>ge-0/0/1</name>' in config.xml"
+      - result.diff.prepared | search("\+ *disable")
 
 - name: Enable interface
   junos_interface:
@@ -136,17 +128,10 @@
     provider: "{{ netconf }}"
   register: result
 
-- name: Get running configuration
-  junos_rpc:
-    rpc: get-configuration
-    provider: "{{ netconf }}"
-  register: config
-
 - assert:
     that:
       - "result.changed == true"
-      - "'[edit interfaces ge-0/0/1]\n-   disable;' in result.diff.prepared"
-      - "'<name>ge-0/0/1</name>' in config.xml"
+      - result.diff.prepared | search("\- *disable")
 
 - name: Delete interface
   junos_interface:

--- a/test/integration/targets/junos_l3_interface/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_l3_interface/tests/netconf/basic.yaml
@@ -29,8 +29,8 @@
       - "result.changed == true"
       - "'<name>1.1.1.1/32</name>' in config.xml"
       - "'<name>fd5d:12c9:2201:1::1/128</name>' in config.xml"
-      - "'+       address 1.1.1.1/32;' in result.diff.prepared"
-      - "'+       address fd5d:12c9:2201:1::1/128;' in result.diff.prepared"
+      - result.diff.prepared | search("\+ *address 1.1.1.1/32")
+      - result.diff.prepared | search("\+ *address fd5d:12c9:2201:1::1/128")
 
 - name: Configure interface address (idempotent)
   junos_l3_interface:
@@ -65,8 +65,8 @@
     that:
       - "result.changed == true"
       - "'<address inactive=\"inactive\">' in config.xml"
-      - "'!        inactive: address 1.1.1.1/32' in result.diff.prepared"
-      - "'!        inactive: address fd5d:12c9:2201:1::1/128' in result.diff.prepared"
+      - result.diff.prepared | search("! *inactive[:] address 1.1.1.1/32")
+      - result.diff.prepared | search("! *inactive[:] address fd5d:12c9:2201:1::1/128")
 
 - name: Activate interface address
   junos_l3_interface:
@@ -78,19 +78,11 @@
     provider: "{{ netconf }}"
   register: result
 
-- name: Get running configuration
-  junos_rpc:
-    rpc: get-configuration
-    provider: "{{ netconf }}"
-  register: config
-
 - assert:
     that:
       - "result.changed == true"
-      - "'<name>1.1.1.1/32</name>' in config.xml"
-      - "'<name>fd5d:12c9:2201:1::1/128</name>' in config.xml"
-      - "'!        active: address 1.1.1.1/32' in result.diff.prepared"
-      - "'!        active: address fd5d:12c9:2201:1::1/128' in result.diff.prepared"
+      - result.diff.prepared | search("! *active[:] address 1.1.1.1/32")
+      - result.diff.prepared | search("! *active[:] address fd5d:12c9:2201:1::1/128")
 
 - name: Delete interface address
   junos_l3_interface:
@@ -101,19 +93,10 @@
     provider: "{{ netconf }}"
   register: result
 
-- name: Get running configuration
-  junos_rpc:
-    rpc: get-configuration
-    provider: "{{ netconf }}"
-  register: config
-
 - assert:
     that:
-      - "result.changed == true"
-      - "'<name>1.1.1.1/32</name>' not in config.xml"
-      - "'<name>fd5d:12c9:2201:1::1/128</name>' not in config.xml"
-      - "'-       address 1.1.1.1/32;' in result.diff.prepared"
-      - "'-       address fd5d:12c9:2201:1::1/128;' in result.diff.prepared"
+      - result.diff.prepared | search("\- *address 1.1.1.1/32")
+      - result.diff.prepared | search("\- *address fd5d:12c9:2201:1::1/128")
 
 - name: Delete interface address (idempotent)
   junos_l3_interface:

--- a/test/integration/targets/junos_lldp/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_lldp/tests/netconf/basic.yaml
@@ -38,9 +38,9 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'+   advertisement-interval 10;' in result.diff.prepared"
-      - "'+   transmit-delay 30;' in result.diff.prepared"
-      - "'+   hold-multiplier 5;' in result.diff.prepared"
+      - result.diff.prepared | search("\+ *advertisement-interval 10")
+      - result.diff.prepared | search("\+ *transmit-delay 30")
+      - result.diff.prepared | search("\+ *hold-multiplier 5")
 
 - name: configure lldp parameters and enable lldp(idempotent)
   junos_lldp:
@@ -67,7 +67,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'+   disable;' in result.diff.prepared"
+      - result.diff.prepared | search("\+ *disable")
       - "'advertisement-interval 10;' not in result.diff.prepared"
       - "'transmit-delay 30;' not in result.diff.prepared"
       - "'hold-multiplier 5;' not in result.diff.prepared"
@@ -84,7 +84,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'-   disable;' in result.diff.prepared"
+      - result.diff.prepared | search("\- *disable")
       - "'advertisement-interval 10;' not in result.diff.prepared"
       - "'transmit-delay 30;' not in result.diff.prepared"
       - "'hold-multiplier 5;' not in result.diff.prepared"
@@ -101,10 +101,10 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'+   disable;' in result.diff.prepared"
-      - "'-   advertisement-interval 10;' in result.diff.prepared"
-      - "'-   transmit-delay 30;' in result.diff.prepared"
-      - "'-   hold-multiplier 5;' in result.diff.prepared"
+      - result.diff.prepared | search("\+ *disable")
+      - result.diff.prepared | search("\- *advertisement-interval 10")
+      - result.diff.prepared | search("\- *transmit-delay 30")
+      - result.diff.prepared | search("\- *hold-multiplier 5")
 
 - name: Remove lldp (idempotent)
   junos_lldp:

--- a/test/integration/targets/junos_lldp_interface/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_lldp_interface/tests/netconf/basic.yaml
@@ -17,7 +17,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'+    interface ge-0/0/5;' in result.diff.prepared"
+      - result.diff.prepared | search("\+ *interface ge-0/0/5")
 
 - name: lldp interface configuration (idempotent)
   junos_lldp_interface:
@@ -41,7 +41,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'!     inactive: interface ge-0/0/5' in result.diff.prepared"
+      - result.diff.prepared | search("! *inactive[:] interface ge-0/0/5")
 
 - name: Activate lldp interface configuration
   junos_lldp_interface:
@@ -54,7 +54,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'!     active: interface ge-0/0/5' in result.diff.prepared"
+      - result.diff.prepared | search("! *active[:] interface ge-0/0/5")
 
 - name: Disable lldp on particular interface
   junos_lldp_interface:

--- a/test/integration/targets/junos_user/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_user/tests/netconf/basic.yaml
@@ -27,7 +27,7 @@
       - "result.changed == true"
       - "'<name>test_user</name>' in config.xml"
       - "'<full-name>test_user</full-name>' in config.xml"
-      - "'<class>read-only</class>' in config.xml"
+      - "'<class>operator</class>' in config.xml"
 
 - name: Create user again (idempotent)
   junos_user:
@@ -85,7 +85,7 @@
       - "result.changed == true"
       - "'<name>test_user</name>' in config.xml"
       - "'<full-name>test_user</full-name>' in config.xml"
-      - "'<class>read-only</class>' in config.xml"
+      - "'<class>operator</class>' in config.xml"
 
 - name: Delete user
   junos_user:

--- a/test/integration/targets/junos_vrf/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_vrf/tests/netconf/basic.yaml
@@ -23,13 +23,13 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'+   test-1' in result.diff.prepared"
-      - "'+       description test-vrf-1;' in result.diff.prepared"
-      - "'+       instance-type vrf;' in result.diff.prepared"
-      - "'+       interface ge-0/0/5.0;' in result.diff.prepared"
-      - "'+       interface ge-0/0/6.0;' in result.diff.prepared"
-      - "'+       route-distinguisher 3.3.3.3:10;' in result.diff.prepared"
-      - "'+       vrf-target target:65513:111;' in result.diff.prepared"
+      - result.diff.prepared | search("\+ *test-1")
+      - result.diff.prepared | search("\+ *description test-vrf-1")
+      - result.diff.prepared | search("\+ *instance-type vrf")
+      - result.diff.prepared | search("\+ *interface ge-0/0/5.0")
+      - result.diff.prepared | search("\+ *interface ge-0/0/6.0")
+      - result.diff.prepared | search("\+ *route-distinguisher 3.3.3.3:10")
+      - result.diff.prepared | search("\+ *vrf-target target:65513:111")
 
 - name: Configure vrf and its parameter (idempotent)
   junos_vrf:
@@ -65,16 +65,15 @@
     that:
       - "result.changed == true"
       - "'[edit routing-instances test-1]' in result.diff.prepared"
-      - "'+    interface ge-0/0/2.0;' in result.diff.prepared"
-      - "'+    interface ge-0/0/3.0;' in result.diff.prepared"
-      - "'-    interface ge-0/0/5.0;' in result.diff.prepared"
-      - "'-    interface ge-0/0/6.0;' in result.diff.prepared"
+      - result.diff.prepared | search("\+ *interface ge-0/0/2.0")
+      - result.diff.prepared | search("\+ *interface ge-0/0/3.0")
+      - result.diff.prepared | search("\- *interface ge-0/0/5.0")
+      - result.diff.prepared | search("\- *interface ge-0/0/6.0")
       - "'[edit routing-instances test-1]' in result.diff.prepared"
-      - "'-    route-distinguisher 3.3.3.3:10;' in result.diff.prepared"
-      - "'+    route-distinguisher 1.1.1.1:10;' in result.diff.prepared"
-      - "'-    vrf-target target:65513:111;' in result.diff.prepared"
-      - "'+    vrf-target target:65514:113;' in result.diff.prepared"
-
+      - result.diff.prepared | search("\- *route-distinguisher 3.3.3.3:10")
+      - result.diff.prepared | search("\+ *route-distinguisher 1.1.1.1:10")
+      - result.diff.prepared | search("\- *vrf-target target:65513:111")
+      - result.diff.prepared | search("\+ *vrf-target target:65514:113")
 
 - name: Deactivate vrf
   junos_vrf:
@@ -94,13 +93,13 @@
     that:
       - "result.changed == true"
       - "'[edit routing-instances]' in result.diff.prepared"
-      - "'!    inactive: test-1' in result.diff.prepared"
+      - result.diff.prepared | search("! *inactive[:] test-1")
       - "'[edit routing-instances test-1]' in result.diff.prepared"
-      - "'!     inactive: interface ge-0/0/2.0' in result.diff.prepared"
-      - "'!     inactive: interface ge-0/0/3.0' in result.diff.prepared"
+      - result.diff.prepared | search("! *inactive[:] interface ge-0/0/2.0")
+      - result.diff.prepared | search("! *inactive[:] interface ge-0/0/3.0")
       - "'[edit routing-instances test-1]' in result.diff.prepared"
-      - "'!     inactive: route-distinguisher' in result.diff.prepared"
-      - "'!     inactive: vrf-target' in result.diff.prepared"
+      - result.diff.prepared | search("! *inactive[:] route-distinguisher")
+      - result.diff.prepared | search("! *inactive[:] vrf-target")
 
 - name: Activate vrf
   junos_vrf:
@@ -120,13 +119,13 @@
     that:
       - "result.changed == true"
       - "'[edit routing-instances]' in result.diff.prepared"
-      - "'!    active: test-1' in result.diff.prepared"
+      - result.diff.prepared | search("! *active[:] test-1")
       - "'[edit routing-instances test-1]' in result.diff.prepared"
-      - "'!     active: interface ge-0/0/2.0' in result.diff.prepared"
-      - "'!     active: interface ge-0/0/3.0' in result.diff.prepared"
+      - result.diff.prepared | search("! *active[:] interface ge-0/0/2.0")
+      - result.diff.prepared | search("! *active[:] interface ge-0/0/3.0")
       - "'[edit routing-instances test-1]' in result.diff.prepared"
-      - "'!     active: route-distinguisher' in result.diff.prepared"
-      - "'!     active: vrf-target' in result.diff.prepared"
+      - result.diff.prepared | search("! *active[:] route-distinguisher")
+      - result.diff.prepared | search("! *active[:] vrf-target")
 
 - name: Delete vrf
   junos_vrf:
@@ -144,14 +143,13 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'[edit routing-instances]' in result.diff.prepared"
-      - "'-   test-1' in result.diff.prepared"
-      - "'-       description test-vrf-1;' in result.diff.prepared"
-      - "'-       instance-type vrf;' in result.diff.prepared"
-      - "'-       interface ge-0/0/2.0;' in result.diff.prepared"
-      - "'-       interface ge-0/0/3.0;' in result.diff.prepared"
-      - "'-       route-distinguisher 1.1.1.1:10;' in result.diff.prepared"
-      - "'-       vrf-target target:65514:113;' in result.diff.prepared"
+      - result.diff.prepared | search("\- *test-1")
+      - result.diff.prepared | search("\- *description test-vrf-1")
+      - result.diff.prepared | search("\- *instance-type vrf")
+      - result.diff.prepared | search("\- *interface ge-0/0/2.0")
+      - result.diff.prepared | search("\- *interface ge-0/0/3.0")
+      - result.diff.prepared | search("\- *route-distinguisher 1.1.1.1:10")
+      - result.diff.prepared | search("\- *vrf-target target:65514:113")
 
 - name: Delete vrf (idempotent)
   junos_vrf:

--- a/test/integration/targets/set_fact/aliases
+++ b/test/integration/targets/set_fact/aliases
@@ -1,0 +1,1 @@
+posix/ci/group3

--- a/test/integration/targets/set_fact/runme.sh
+++ b/test/integration/targets/set_fact/runme.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eux
+
+MYTMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
+trap 'rm -rf "${MYTMPDIR}"' EXIT
+
+ANSIBLE_CACHE_PLUGIN=jsonfile ANSIBLE_CACHE_PLUGIN_CONNECTION="${MYTMPDIR}" ansible-playbook -i ../../inventory "$@" set_fact_cached_1.yml
+
+ANSIBLE_CACHE_PLUGIN=jsonfile ANSIBLE_CACHE_PLUGIN_CONNECTION="${MYTMPDIR}" ansible-playbook -i ../../inventory "$@" set_fact_cached_2.yml
+
+ANSIBLE_CACHE_PLUGIN=jsonfile ANSIBLE_CACHE_PLUGIN_CONNECTION="${MYTMPDIR}" ansible-playbook -i ../../inventory --flush-cache "$@" set_fact_no_cache.yml
+

--- a/test/integration/targets/set_fact/set_fact_cached_1.yml
+++ b/test/integration/targets/set_fact/set_fact_cached_1.yml
@@ -1,0 +1,46 @@
+---
+- name: the first play
+  hosts: localhost
+  tasks:
+    - name: show foobar fact before
+      debug:
+        var: ansible_foobar
+
+    - name: set a persistent fact foobar
+      set_fact:
+        ansible_foobar: 'blippy'
+        cacheable: true
+
+    - name: show foobar fact after
+      debug:
+        var: ansible_foobar
+
+    - name: assert ansible_foobar is correct value
+      assert:
+        that:
+          - ansible_foobar == 'blippy'
+
+    - name: set a non persistent fact that will not be cached
+      set_fact:
+        ansible_foobar_not_cached: 'this_should_not_be_cached'
+
+    - name: show ansible_foobar_not_cached fact after being set
+      debug:
+        var: ansible_foobar_not_cached
+
+    - name: assert ansible_foobar_not_cached is correct value
+      assert:
+        that:
+          - ansible_foobar_not_cached == 'this_should_not_be_cached'
+
+- name: the second play
+  hosts: localhost
+  tasks:
+    - name: show foobar fact after second play
+      debug:
+        var: ansible_foobar
+
+    - name: assert ansible_foobar is correct value
+      assert:
+        that:
+          - ansible_foobar == 'blippy'

--- a/test/integration/targets/set_fact/set_fact_cached_2.yml
+++ b/test/integration/targets/set_fact/set_fact_cached_2.yml
@@ -1,0 +1,21 @@
+---
+- name: A second playbook run with fact caching enabled
+  hosts: localhost
+  tasks:
+    - name: show ansible_foobar fact
+      debug:
+        var: ansible_foobar
+
+    - name: assert ansible_foobar is correct value when read from cache
+      assert:
+        that:
+          - ansible_foobar == 'blippy'
+
+    - name: show ansible_foobar_not_cached fact
+      debug:
+        var: ansible_foobar_not_cached
+
+    - name: assert ansible_foobar_not_cached is not cached
+      assert:
+        that:
+          - ansible_foobar_not_cached is undefined

--- a/test/integration/targets/set_fact/set_fact_no_cache.yml
+++ b/test/integration/targets/set_fact/set_fact_no_cache.yml
@@ -1,0 +1,21 @@
+---
+- name: Running with fact caching enabled but with cache flushed
+  hosts: localhost
+  tasks:
+    - name: show ansible_foobar fact
+      debug:
+        var: ansible_foobar
+
+    - name: assert ansible_foobar is correct value
+      assert:
+        that:
+          - ansible_foobar is undefined
+
+    - name: show ansible_foobar_not_cached fact
+      debug:
+        var: ansible_foobar_not_cached
+
+    - name: assert ansible_foobar_not_cached is not cached
+      assert:
+        that:
+          - ansible_foobar_not_cached is undefined

--- a/test/integration/targets/template/tasks/backup_test.yml
+++ b/test/integration/targets/template/tasks/backup_test.yml
@@ -1,0 +1,60 @@
+# https://github.com/ansible/ansible/issues/24408
+
+- set_fact:
+    t_username: templateuser1
+    t_groupname: templateuser1
+
+- name: create the test group
+  group:
+    name: "{{ t_groupname }}"
+
+- name: create the test user
+  user:
+    name: "{{ t_username }}"
+    group: "{{ t_groupname }}"
+    createhome: no
+
+- name: set the dest file
+  set_fact:
+      t_dest: "{{ output_dir + '/tfile_dest.txt' }}"
+
+- name: create the old file
+  file:
+    path: "{{ t_dest }}"
+    state: touch
+    mode: 0777
+    owner: "{{ t_username }}"
+    group: "{{ t_groupname }}"
+
+- name: failsafe attr change incase underlying system does not support it
+  shell: chattr =j "{{ t_dest }}"
+  ignore_errors: True
+
+- name: run the template
+  template:
+    src: foo.j2
+    dest: "{{ t_dest }}"
+    backup: True
+  register: t_backup_res
+
+- name: check the data for the backup
+  stat:
+    path: "{{ t_backup_res.backup_file }}"
+  register: t_backup_stats
+
+- name: validate result of preserved backup
+  assert:
+      that:
+          - 't_backup_stats.stat.mode == "0777"'
+          - 't_backup_stats.stat.pw_name == t_username'
+          - 't_backup_stats.stat.gr_name == t_groupname'
+
+- name: cleanup the user
+  user:
+    name: "{{ t_username }}"
+    state: absent
+
+- name: cleanup the group
+  user:
+    name: "{{ t_groupname }}"
+    state: absent

--- a/test/integration/targets/template/tasks/main.yml
+++ b/test/integration/targets/template/tasks/main.yml
@@ -369,3 +369,6 @@
     that:
         - 'diff_result.stdout == ""'
         - "diff_result.rc == 0"
+
+# aliases file requires root for template tests so this should be safe
+- include: backup_test.yml

--- a/test/runner/completion/remote.txt
+++ b/test/runner/completion/remote.txt
@@ -1,4 +1,4 @@
 freebsd/10.3-STABLE
-freebsd/11.0-STABLE
+freebsd/11.1-STABLE
 osx/10.11
-rhel/7.3
+rhel/7.4

--- a/test/runner/completion/remote.txt
+++ b/test/runner/completion/remote.txt
@@ -1,4 +1,4 @@
 freebsd/10.3-STABLE
-freebsd/11.1-STABLE
+freebsd/11.0-STABLE
 osx/10.11
 rhel/7.4

--- a/test/sanity/code-smell/boilerplate.sh
+++ b/test/sanity/code-smell/boilerplate.sh
@@ -19,7 +19,6 @@ future2=$(find ./lib/ansible -path ./lib/ansible/modules -prune \
 
 # Eventually we want metaclass3 and future3 to get down to 0
 metaclass3=$(find ./lib/ansible/modules -path ./lib/ansible/modules/windows -prune \
-        -o -path ./lib/ansible/modules/identity -prune \
         -o -path ./lib/ansible/modules/files -prune \
         -o -path ./lib/ansible/modules/database/proxysql -prune \
         -o -path ./lib/ansible/modules/cloud/ovirt -prune \
@@ -42,7 +41,6 @@ metaclass3=$(find ./lib/ansible/modules -path ./lib/ansible/modules/windows -pru
         -o -name '*.py' -type f -size +0c -exec grep -HL '__metaclass__ = type' '{}' '+')
 
 future3=$(find ./lib/ansible/modules -path ./lib/ansible/modules/windows -prune \
-        -o -path ./lib/ansible/modules/identity -prune \
         -o -path ./lib/ansible/modules/files -prune \
         -o -path ./lib/ansible/modules/database/proxysql -prune \
         -o -path ./lib/ansible/modules/cloud/ovirt -prune \
@@ -78,7 +76,6 @@ future3=$(find ./lib/ansible/modules -path ./lib/ansible/modules/windows -prune 
 # network/netvisor
 # network/aos [!]
 # network/vyos [i]
-# identity [!]
 # network/lenovo
 # network/panos [!]
 # network/junos [i]

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -349,7 +349,6 @@ lib/ansible/modules/network/nxos/nxos_udld_interface.py
 lib/ansible/modules/network/nxos/nxos_user.py
 lib/ansible/modules/network/nxos/nxos_vrf.py
 lib/ansible/modules/network/nxos/nxos_vrf_interface.py
-lib/ansible/modules/network/nxos/nxos_vrrp.py
 lib/ansible/modules/network/nxos/nxos_vtp_domain.py
 lib/ansible/modules/network/nxos/nxos_vtp_password.py
 lib/ansible/modules/network/nxos/nxos_vtp_version.py

--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -636,18 +636,12 @@ class ModuleValidator(Validator):
                     )
 
     def _find_ps_replacers(self):
-        if 'WANT_JSON' not in self.text:
-            self.reporter.error(
-                path=self.object_path,
-                code=206,
-                msg='WANT_JSON not found in module'
-            )
-
-        if REPLACER_WINDOWS not in self.text:
+        ps_module_util_template = '#Requires -Module Ansible.ModuleUtils.'
+        if ps_module_util_template not in self.text and REPLACER_WINDOWS not in self.text:
             self.reporter.error(
                 path=self.object_path,
                 code=207,
-                msg='"%s" not found in module' % REPLACER_WINDOWS
+                msg='"%s" not found in module' % ps_module_util_template
             )
 
     def _find_ps_docs_py_file(self):

--- a/test/units/module_utils/facts/test_collector.py
+++ b/test/units/module_utils/facts/test_collector.py
@@ -37,14 +37,14 @@ class TestGetCollectorNames(unittest.TestCase):
     def test_empty_sets(self):
         res = collector.get_collector_names(valid_subsets=frozenset([]),
                                             minimal_gather_subset=frozenset([]),
-                                            gather_subset=set([]))
+                                            gather_subset=[])
         self.assertIsInstance(res, set)
         self.assertEqual(res, set([]))
 
     def test_empty_valid_and_min_with_all_gather_subset(self):
         res = collector.get_collector_names(valid_subsets=frozenset([]),
                                             minimal_gather_subset=frozenset([]),
-                                            gather_subset=set(['all']))
+                                            gather_subset=['all'])
         self.assertIsInstance(res, set)
         self.assertEqual(res, set([]))
 
@@ -52,9 +52,47 @@ class TestGetCollectorNames(unittest.TestCase):
         valid_subsets = frozenset(['my_fact'])
         res = collector.get_collector_names(valid_subsets=valid_subsets,
                                             minimal_gather_subset=frozenset([]),
-                                            gather_subset=set(['all']))
+                                            gather_subset=['all'])
         self.assertIsInstance(res, set)
         self.assertEqual(res, set(['my_fact']))
+
+    def _compare_res(self, gather_subset1, gather_subset2,
+                     valid_subsets=None, min_subset=None):
+
+        valid_subsets = valid_subsets or frozenset()
+        minimal_gather_subset = min_subset or frozenset()
+
+        res1 = collector.get_collector_names(valid_subsets=valid_subsets,
+                                             minimal_gather_subset=minimal_gather_subset,
+                                             gather_subset=gather_subset1)
+
+        res2 = collector.get_collector_names(valid_subsets=valid_subsets,
+                                             minimal_gather_subset=minimal_gather_subset,
+                                             gather_subset=gather_subset2)
+
+        return res1, res2
+
+    def test_not_all_other_order(self):
+        valid_subsets = frozenset(['min_fact', 'something_else', 'whatever'])
+        minimal_gather_subset = frozenset(['min_fact'])
+
+        res1, res2 = self._compare_res(['!all', 'whatever'],
+                                       ['whatever', '!all'],
+                                       valid_subsets=valid_subsets,
+                                       min_subset=minimal_gather_subset)
+        self.assertEqual(res1, res2)
+        self.assertEqual(res1, set(['min_fact', 'whatever']))
+
+    def test_not_all_other_order_min(self):
+        valid_subsets = frozenset(['min_fact', 'something_else', 'whatever'])
+        minimal_gather_subset = frozenset(['min_fact'])
+
+        res1, res2 = self._compare_res(['!min_fact', 'whatever'],
+                                       ['whatever', '!min_fact'],
+                                       valid_subsets=valid_subsets,
+                                       min_subset=minimal_gather_subset)
+        self.assertEqual(res1, res2)
+        self.assertEqual(res1, set(['whatever']))
 
     def test_one_minimal_with_all_gather_subset(self):
         my_fact = 'my_fact'
@@ -63,7 +101,7 @@ class TestGetCollectorNames(unittest.TestCase):
 
         res = collector.get_collector_names(valid_subsets=valid_subsets,
                                             minimal_gather_subset=minimal_gather_subset,
-                                            gather_subset=set(['all']))
+                                            gather_subset=['all'])
         self.assertIsInstance(res, set)
         self.assertEqual(res, set(['my_fact']))
 
@@ -74,7 +112,7 @@ class TestGetCollectorNames(unittest.TestCase):
         # even with '!all', the minimal_gather_subset should be returned
         res = collector.get_collector_names(valid_subsets=valid_subsets,
                                             minimal_gather_subset=minimal_gather_subset,
-                                            gather_subset=set(['all']))
+                                            gather_subset=['all'])
         self.assertIsInstance(res, set)
         self.assertEqual(res, set(['my_fact', 'something_else', 'whatever']))
 
@@ -85,21 +123,23 @@ class TestGetCollectorNames(unittest.TestCase):
         # even with '!all', the minimal_gather_subset should be returned
         res = collector.get_collector_names(valid_subsets=valid_subsets,
                                             minimal_gather_subset=minimal_gather_subset,
-                                            gather_subset=set(['!all']))
+                                            gather_subset=['!all'])
         self.assertIsInstance(res, set)
         self.assertEqual(res, set(['my_fact']))
 
     def test_gather_subset_excludes(self):
         valid_subsets = frozenset(['my_fact', 'something_else', 'whatever'])
-        minimal_gather_subset = frozenset(['my_fact'])
+        minimal_gather_subset = frozenset(['min_fact', 'min_another'])
 
         # even with '!all', the minimal_gather_subset should be returned
         res = collector.get_collector_names(valid_subsets=valid_subsets,
                                             minimal_gather_subset=minimal_gather_subset,
-                                            gather_subset=set(['all', '!my_fact', '!whatever']))
+                                            # gather_subset=set(['all', '!my_fact', '!whatever']))
+                                            # gather_subset=['all', '!my_fact', '!whatever'])
+                                            gather_subset=['!min_fact', '!whatever'])
         self.assertIsInstance(res, set)
-        # my_facts is in minimal_gather_subset, so always returned
-        self.assertEqual(res, set(['my_fact', 'something_else']))
+        # min_another is in minimal_gather_subset, so always returned
+        self.assertEqual(res, set(['min_another']))
 
     def test_gather_subset_excludes_ordering(self):
         valid_subsets = frozenset(['my_fact', 'something_else', 'whatever'])
@@ -107,11 +147,35 @@ class TestGetCollectorNames(unittest.TestCase):
 
         res = collector.get_collector_names(valid_subsets=valid_subsets,
                                             minimal_gather_subset=minimal_gather_subset,
-                                            gather_subset=set(['!all', 'whatever']))
+                                            gather_subset=['!all', 'whatever'])
         self.assertIsInstance(res, set)
         # excludes are higher precedence than includes, so !all excludes everything
         # and then minimal_gather_subset is added. so '!all', 'other' == '!all'
-        self.assertEqual(res, set(['my_fact']))
+        self.assertEqual(res, set(['my_fact', 'whatever']))
+
+    def test_gather_subset_excludes_min(self):
+        valid_subsets = frozenset(['min_fact', 'something_else', 'whatever'])
+        minimal_gather_subset = frozenset(['min_fact'])
+
+        res = collector.get_collector_names(valid_subsets=valid_subsets,
+                                            minimal_gather_subset=minimal_gather_subset,
+                                            gather_subset=['whatever', '!min'])
+        self.assertIsInstance(res, set)
+        # excludes are higher precedence than includes, so !all excludes everything
+        # and then minimal_gather_subset is added. so '!all', 'other' == '!all'
+        self.assertEqual(res, set(['whatever']))
+
+    def test_gather_subset_excludes_min_and_all(self):
+        valid_subsets = frozenset(['min_fact', 'something_else', 'whatever'])
+        minimal_gather_subset = frozenset(['min_fact'])
+
+        res = collector.get_collector_names(valid_subsets=valid_subsets,
+                                            minimal_gather_subset=minimal_gather_subset,
+                                            gather_subset=['whatever', '!all', '!min'])
+        self.assertIsInstance(res, set)
+        # excludes are higher precedence than includes, so !all excludes everything
+        # and then minimal_gather_subset is added. so '!all', 'other' == '!all'
+        self.assertEqual(res, set(['whatever']))
 
     def test_invaid_gather_subset(self):
         valid_subsets = frozenset(['my_fact', 'something_else'])
@@ -122,7 +186,7 @@ class TestGetCollectorNames(unittest.TestCase):
                                 collector.get_collector_names,
                                 valid_subsets=valid_subsets,
                                 minimal_gather_subset=minimal_gather_subset,
-                                gather_subset=set(['my_fact', 'not_a_valid_gather_subset']))
+                                gather_subset=['my_fact', 'not_a_valid_gather_subset'])
 
 
 class TestCollectorClassesFromGatherSubset(unittest.TestCase):
@@ -145,13 +209,13 @@ class TestCollectorClassesFromGatherSubset(unittest.TestCase):
 
     def test(self):
         res = self._classes(all_collector_classes=default_collectors.collectors,
-                            gather_subset=set(['!all']))
+                            gather_subset=['!all'])
         self.assertIsInstance(res, list)
         self.assertEqual(res, [])
 
     def test_env(self):
         res = self._classes(all_collector_classes=default_collectors.collectors,
-                            gather_subset=set(['env']))
+                            gather_subset=['env'])
         self.assertIsInstance(res, list)
         self.assertEqual(res, [default_collectors.EnvFactCollector])
 
@@ -181,7 +245,7 @@ class TestCollectorClassesFromGatherSubset(unittest.TestCase):
 
     def test_collector_specified_multiple_times(self):
         res = self._classes(all_collector_classes=default_collectors.collectors,
-                            gather_subset=set(['platform', 'all', 'machine']))
+                            gather_subset=['platform', 'all', 'machine'])
         self.assertIsInstance(res, list)
         self.assertIn(default_collectors.PlatformFactCollector,
                       res)
@@ -193,4 +257,4 @@ class TestCollectorClassesFromGatherSubset(unittest.TestCase):
                                 'Bad subset.*unknown_collector.*given to Ansible.*allowed\:.*all,.*env.*',
                                 self._classes,
                                 all_collector_classes=default_collectors.collectors,
-                                gather_subset=set(['env', 'unknown_collector']))
+                                gather_subset=['env', 'unknown_collector'])

--- a/test/units/modules/network/cloudvision/test_cv_server_provision.py
+++ b/test/units/modules/network/cloudvision/test_cv_server_provision.py
@@ -1,0 +1,886 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import patch, Mock
+import sys
+sys.modules['cvprac'] = Mock()
+sys.modules['cvprac.cvp_client'] = Mock()
+sys.modules['cvprac.cvp_client_errors'] = Mock()
+import ansible.modules.network.cloudvision.cv_server_provision as cv_server_provision
+
+
+class MockException(BaseException):
+    pass
+
+
+class TestCvServerProvision(unittest.TestCase):
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.CvpApiError',
+           new_callable=lambda: MockException)
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.server_configurable_configlet')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.switch_in_compliance')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.switch_info')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.connect')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.AnsibleModule')
+    def test_main_module_args(self, mock_module, mock_connect, mock_info,
+                              mock_comp, mock_server_conf, mock_exception):
+        ''' Test main module args.
+        '''
+        mock_module_object = Mock()
+        mock_module_object.params = dict(action='show', switch_name='eos')
+        mock_module_object.fail_json.side_effect = SystemExit('Exiting')
+        mock_module.return_value = mock_module_object
+        mock_connect.return_value = 'Client'
+        mock_info.side_effect = mock_exception('Error Getting Info')
+        argument_spec = dict(
+            host=dict(required=True),
+            port=dict(required=False, default=None),
+            protocol=dict(default='https', choices=['http', 'https']),
+            username=dict(required=True),
+            password=dict(required=True, no_log=True),
+            server_name=dict(required=True),
+            switch_name=dict(required=True),
+            switch_port=dict(required=True),
+            port_vlan=dict(required=False, default=None),
+            template=dict(require=True),
+            action=dict(default='show', choices=['show', 'add', 'remove']),
+            auto_run=dict(type='bool', default=False),
+        )
+        self.assertRaises(SystemExit, cv_server_provision.main)
+        mock_module.assert_called_with(argument_spec=argument_spec,
+                                       supports_check_mode=False)
+        self.assertEqual(mock_connect.call_count, 1)
+        self.assertEqual(mock_info.call_count, 1)
+        mock_comp.assert_not_called()
+        mock_server_conf.assert_not_called()
+        mock_module_object.fail_json.assert_called_with(msg='Error Getting Info')
+
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.CvpApiError',
+           new_callable=lambda: MockException)
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.server_configurable_configlet')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.switch_in_compliance')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.switch_info')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.connect')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.AnsibleModule')
+    def test_main_no_switch_configlet(self, mock_module, mock_connect,
+                                      mock_info, mock_comp, mock_server_conf,
+                                      mock_exception):
+        ''' Test main fails if switch has no configlet for Ansible to edit.
+        '''
+        mock_module_object = Mock()
+        mock_module_object.params = dict(action='add', switch_name='eos')
+        mock_module_object.fail_json.side_effect = SystemExit('Exiting')
+        mock_module.return_value = mock_module_object
+        mock_connect.return_value = 'Client'
+        mock_info.return_value = 'Info'
+        mock_server_conf.return_value = None
+        self.assertRaises(SystemExit, cv_server_provision.main)
+        self.assertEqual(mock_connect.call_count, 1)
+        self.assertEqual(mock_info.call_count, 1)
+        self.assertEqual(mock_comp.call_count, 1)
+        self.assertEqual(mock_server_conf.call_count, 1)
+        mock_module_object.fail_json.assert_called_with(
+            msg='Switch eos has no configurable server ports.')
+
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.CvpApiError',
+           new_callable=lambda: MockException)
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.port_configurable')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.server_configurable_configlet')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.switch_in_compliance')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.switch_info')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.connect')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.AnsibleModule')
+    def test_main_port_not_in_config(self, mock_module, mock_connect, mock_info,
+                                     mock_comp, mock_server_conf,
+                                     mock_port_conf, mock_exception):
+        ''' Test main fails if user specified port not in configlet.
+        '''
+        mock_module_object = Mock()
+        mock_module_object.params = dict(action='add', switch_name='eos',
+                                         switch_port='3')
+        mock_module_object.fail_json.side_effect = SystemExit('Exiting')
+        mock_module.return_value = mock_module_object
+        mock_connect.return_value = 'Client'
+        mock_info.return_value = 'Info'
+        mock_server_conf.return_value = 'Configlet'
+        mock_port_conf.return_value = None
+        self.assertRaises(SystemExit, cv_server_provision.main)
+        self.assertEqual(mock_connect.call_count, 1)
+        self.assertEqual(mock_info.call_count, 1)
+        self.assertEqual(mock_comp.call_count, 1)
+        self.assertEqual(mock_server_conf.call_count, 1)
+        self.assertEqual(mock_port_conf.call_count, 1)
+        mock_module_object.fail_json.assert_called_with(
+            msg='Port 3 is not configurable as a server port on switch eos.')
+
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.configlet_action')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.port_configurable')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.server_configurable_configlet')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.switch_in_compliance')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.switch_info')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.connect')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.AnsibleModule')
+    def test_main_show(self, mock_module, mock_connect, mock_info, mock_comp,
+                       mock_server_conf, mock_port_conf, mock_conf_action):
+        ''' Test main good with show action.
+        '''
+        mock_module_object = Mock()
+        mock_module_object.params = dict(action='show', switch_name='eos',
+                                         switch_port='3', auto_run=False)
+        mock_module.return_value = mock_module_object
+        mock_connect.return_value = 'Client'
+        mock_info.return_value = 'Info'
+        mock_server_conf.return_value = 'Configlet'
+        mock_port_conf.return_value = 'Port'
+        mock_conf_action.return_value = dict()
+        cv_server_provision.main()
+        self.assertEqual(mock_connect.call_count, 1)
+        self.assertEqual(mock_info.call_count, 1)
+        mock_comp.assert_not_called()
+        self.assertEqual(mock_server_conf.call_count, 1)
+        self.assertEqual(mock_port_conf.call_count, 1)
+        self.assertEqual(mock_conf_action.call_count, 1)
+        mock_module_object.fail_json.assert_not_called()
+        return_dict = dict(changed=False, switchInfo='Info',
+                           switchConfigurable=True, portConfigurable=True,
+                           taskCreated=False, taskExecuted=False,
+                           taskCompleted=False)
+        mock_module_object.exit_json.assert_called_with(**return_dict)
+
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.configlet_action')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.port_configurable')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.server_configurable_configlet')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.switch_in_compliance')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.switch_info')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.connect')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.AnsibleModule')
+    def test_main_add_no_auto_run(self, mock_module, mock_connect, mock_info,
+                                  mock_comp, mock_server_conf, mock_port_conf,
+                                  mock_conf_action):
+        ''' Test main good with add action and no auto_run.
+        '''
+        mock_module_object = Mock()
+        mock_module_object.params = dict(action='add', switch_name='eos',
+                                         switch_port='3', auto_run=False)
+        mock_module.return_value = mock_module_object
+        mock_connect.return_value = 'Client'
+        mock_info.return_value = 'Info'
+        mock_server_conf.return_value = 'Configlet'
+        mock_port_conf.return_value = 'Port'
+        mock_conf_action.return_value = dict(taskCreated=True)
+        cv_server_provision.main()
+        self.assertEqual(mock_connect.call_count, 1)
+        self.assertEqual(mock_info.call_count, 1)
+        self.assertEqual(mock_comp.call_count, 1)
+        self.assertEqual(mock_server_conf.call_count, 1)
+        self.assertEqual(mock_port_conf.call_count, 1)
+        self.assertEqual(mock_conf_action.call_count, 1)
+        mock_module_object.fail_json.assert_not_called()
+        return_dict = dict(changed=False, switchInfo='Info',
+                           switchConfigurable=True, portConfigurable=True,
+                           taskCreated=True, taskExecuted=False,
+                           taskCompleted=False)
+        mock_module_object.exit_json.assert_called_with(**return_dict)
+
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.wait_for_task_completion')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.configlet_update_task')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.configlet_action')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.port_configurable')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.server_configurable_configlet')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.switch_in_compliance')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.switch_info')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.connect')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.AnsibleModule')
+    def test_main_add_auto_run(self, mock_module, mock_connect, mock_info,
+                               mock_comp, mock_server_conf, mock_port_conf,
+                               mock_conf_action, mock_conf_task, mock_wait):
+        ''' Test main good with add and auto_run. Config updated, task created.
+        '''
+        mock_module_object = Mock()
+        mock_module_object.params = dict(action='add', switch_name='eos',
+                                         switch_port='3', auto_run=True)
+        mock_module.return_value = mock_module_object
+        mock_client_object = Mock()
+        mock_connect.return_value = mock_client_object
+        mock_info.return_value = 'Info'
+        mock_server_conf.return_value = 'Configlet'
+        mock_port_conf.return_value = 'Port'
+        mock_conf_action.return_value = dict(taskCreated=True, changed=True)
+        mock_conf_task.return_value = '7'
+        mock_wait.return_value = True
+        cv_server_provision.main()
+        self.assertEqual(mock_connect.call_count, 1)
+        self.assertEqual(mock_info.call_count, 1)
+        self.assertEqual(mock_comp.call_count, 1)
+        self.assertEqual(mock_server_conf.call_count, 1)
+        self.assertEqual(mock_port_conf.call_count, 1)
+        self.assertEqual(mock_conf_action.call_count, 1)
+        self.assertEqual(mock_conf_task.call_count, 1)
+        self.assertEqual(mock_wait.call_count, 1)
+        mock_module_object.fail_json.assert_not_called()
+        return_dict = dict(changed=True, switchInfo='Info', taskId='7',
+                           switchConfigurable=True, portConfigurable=True,
+                           taskCreated=True, taskExecuted=True,
+                           taskCompleted=True)
+        mock_module_object.exit_json.assert_called_with(**return_dict)
+
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.wait_for_task_completion')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.configlet_update_task')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.configlet_action')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.port_configurable')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.server_configurable_configlet')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.switch_in_compliance')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.switch_info')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.connect')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.AnsibleModule')
+    def test_main_add_auto_run_no_task(self, mock_module, mock_connect,
+                                       mock_info, mock_comp, mock_server_conf,
+                                       mock_port_conf, mock_conf_action, mock_conf_task,
+                                       mock_wait):
+        ''' Test main good with add and auto_run. Config not updated, no task.
+        '''
+        mock_module_object = Mock()
+        mock_module_object.params = dict(action='add', switch_name='eos',
+                                         switch_port='3', auto_run=True)
+        mock_module.return_value = mock_module_object
+        mock_client_object = Mock()
+        mock_connect.return_value = mock_client_object
+        mock_info.return_value = 'Info'
+        mock_server_conf.return_value = 'Configlet'
+        mock_port_conf.return_value = 'Port'
+        mock_conf_action.return_value = dict(taskCreated=True, changed=False)
+        mock_conf_task.return_value = None
+        cv_server_provision.main()
+        self.assertEqual(mock_connect.call_count, 1)
+        self.assertEqual(mock_info.call_count, 1)
+        self.assertEqual(mock_comp.call_count, 1)
+        self.assertEqual(mock_server_conf.call_count, 1)
+        self.assertEqual(mock_port_conf.call_count, 1)
+        self.assertEqual(mock_conf_action.call_count, 1)
+        self.assertEqual(mock_conf_task.call_count, 1)
+        mock_wait.assert_not_called()
+        mock_module_object.fail_json.assert_not_called()
+        return_dict = dict(changed=False, switchInfo='Info',
+                           switchConfigurable=True, portConfigurable=True,
+                           taskCreated=False, taskExecuted=False,
+                           taskCompleted=False)
+        mock_module_object.exit_json.assert_called_with(**return_dict)
+
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.CvpClient')
+    def test_connect_good(self, mock_client):
+        ''' Test connect success.
+        '''
+        module = Mock()
+        module.params = dict(host='host', username='username',
+                             password='password', protocol='https', port='10')
+        connect_mock = Mock()
+        mock_client.return_value = connect_mock
+        client = cv_server_provision.connect(module)
+        self.assertIsInstance(client, Mock)
+        self.assertEqual(mock_client.call_count, 1)
+        connect_mock.connect.assert_called_once_with(['host'], 'username',
+                                                     'password', port='10',
+                                                     protocol='https')
+        module.fail_json.assert_not_called()
+
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.CvpLoginError',
+           new_callable=lambda: MockException)
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.CvpClient')
+    def test_connect_fail(self, mock_client, mock_exception):
+        ''' Test connect failure with login error.
+        '''
+        module = Mock()
+        module.params = dict(host='host', username='username',
+                             password='password', protocol='https', port='10')
+        module.fail_json.side_effect = SystemExit
+        connect_mock = Mock()
+        connect_mock.connect.side_effect = mock_exception('Login Error')
+        mock_client.return_value = connect_mock
+        self.assertRaises(SystemExit, cv_server_provision.connect, module)
+        self.assertEqual(connect_mock.connect.call_count, 1)
+        module.fail_json.assert_called_once_with(msg='Login Error')
+
+    def test_switch_info_good(self):
+        ''' Test switch_info success.
+        '''
+        module = Mock()
+        module.params = dict(switch_name='eos')
+        module.client.api.get_device_by_name.return_value = dict(fqdn='eos')
+        info = cv_server_provision.switch_info(module)
+        self.assertEqual(module.client.api.get_device_by_name.call_count, 1)
+        self.assertEqual(info['fqdn'], 'eos')
+        module.fail_json.assert_not_called()
+
+    def test_switch_info_no_switch(self):
+        ''' Test switch_info fails.
+        '''
+        module = Mock()
+        module.params = dict(switch_name='eos')
+        module.client.api.get_device_by_name.return_value = None
+        info = cv_server_provision.switch_info(module)
+        self.assertEqual(module.client.api.get_device_by_name.call_count, 1)
+        self.assertEqual(info, None)
+        module.fail_json.assert_called_once_with(
+            msg="Device with name 'eos' does not exist.")
+
+    def test_switch_in_compliance_good(self):
+        ''' Test switch_in_compliance good.
+        '''
+        module = Mock()
+        module.client.api.check_compliance.return_value = dict(
+            complianceCode='0000')
+        sw_info = dict(key='key', type='type', fqdn='eos')
+        cv_server_provision.switch_in_compliance(module, sw_info)
+        self.assertEqual(module.client.api.check_compliance.call_count, 1)
+        module.fail_json.assert_not_called()
+
+    def test_switch_in_compliance_fail(self):
+        ''' Test switch_in_compliance fail.
+        '''
+        module = Mock()
+        module.client.api.check_compliance.return_value = dict(
+            complianceCode='0001')
+        sw_info = dict(key='key', type='type', fqdn='eos')
+        cv_server_provision.switch_in_compliance(module, sw_info)
+        self.assertEqual(module.client.api.check_compliance.call_count, 1)
+        module.fail_json.assert_called_with(
+            msg='Switch eos is not in compliance.'
+                ' Returned compliance code 0001.')
+
+    def test_server_configurable_configlet_good(self):
+        ''' Test server_configurable_configlet good.
+        '''
+        module = Mock()
+        module.params = dict(switch_name='eos')
+        configlets = [dict(name='configlet1', info='line'),
+                      dict(name='eos-server', info='info')]
+        module.client.api.get_configlets_by_device_id.return_value = configlets
+        sw_info = dict(key='key', type='type', fqdn='eos')
+        result = cv_server_provision.server_configurable_configlet(module,
+                                                                   sw_info)
+        self.assertEqual(module.client.api.get_configlets_by_device_id.call_count, 1)
+        self.assertIsNotNone(result)
+        self.assertEqual(result['name'], 'eos-server')
+        self.assertEqual(result['info'], 'info')
+
+    def test_server_configurable_configlet_not_configurable(self):
+        ''' Test server_configurable_configlet fail. No server configlet.
+        '''
+        module = Mock()
+        module.params = dict(switch_name='eos')
+        configlets = [dict(name='configlet1', info='line'),
+                      dict(name='configlet2', info='info')]
+        module.client.api.get_configlets_by_device_id.return_value = configlets
+        sw_info = dict(key='key', type='type', fqdn='eos')
+        result = cv_server_provision.server_configurable_configlet(module, sw_info)
+        self.assertEqual(module.client.api.get_configlets_by_device_id.call_count, 1)
+        self.assertIsNone(result)
+
+    def test_server_configurable_configlet_no_configlets(self):
+        ''' Test server_configurable_configlet fail. No switch configlets.
+        '''
+        module = Mock()
+        module.params = dict(switch_name='eos')
+        module.client.api.get_configlets_by_device_id.return_value = []
+        sw_info = dict(key='key', type='type', fqdn='eos')
+        result = cv_server_provision.server_configurable_configlet(module,
+                                                                   sw_info)
+        self.assertEqual(module.client.api.get_configlets_by_device_id.call_count, 1)
+        self.assertIsNone(result)
+
+    def test_port_configurable_good(self):
+        ''' Test port_configurable user provided switch port in configlet.
+        '''
+        module = Mock()
+        module.params = dict(switch_name='eos', switch_port='3')
+        config = '!\ninterface Ethernet3\n!\ninterface Ethernet4\n!'
+        configlet = dict(name='eos-server', config=config)
+        result = cv_server_provision.port_configurable(module, configlet)
+        self.assertTrue(result)
+
+    def test_port_configurable_fail(self):
+        ''' Test port_configurable user provided switch port not in configlet.
+        '''
+        module = Mock()
+        module.params = dict(switch_name='eos', switch_port='2')
+        config = '!\ninterface Ethernet3\n!\ninterface Ethernet4\n!'
+        configlet = dict(name='eos-server', config=config)
+        result = cv_server_provision.port_configurable(module, configlet)
+        self.assertFalse(result)
+
+    def test_port_configurable_fail_no_config(self):
+        ''' Test port_configurable configlet empty.
+        '''
+        module = Mock()
+        module.params = dict(switch_name='eos', switch_port='2')
+        config = ''
+        configlet = dict(name='eos-server', config=config)
+        result = cv_server_provision.port_configurable(module, configlet)
+        self.assertFalse(result)
+
+    def test_configlet_action_show_blank_config(self):
+        ''' Test configlet_action show returns current port configuration.
+        '''
+        module = Mock()
+        module.params = dict(action='show', switch_name='eos', switch_port='3')
+        config = '!\ninterface Ethernet3\n!\ninterface Ethernet4\n!'
+        configlet = dict(name='eos-server', key='key', config=config)
+        result = cv_server_provision.configlet_action(module, configlet)
+        self.assertIsNotNone(result)
+        self.assertEqual(result['currentConfigBlock'], 'interface Ethernet3\n!')
+        module.client.api.update_configlet.assert_not_called()
+
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.config_from_template')
+    def test_configlet_action_add_with_task(self, mock_template):
+        ''' Test configlet_action add with change updates configlet and adds
+            proper info to return data. Including task spawned info.
+        '''
+        module = Mock()
+        module.params = dict(action='add', switch_name='eos', switch_port='3')
+        config = '!\ninterface Ethernet3\n!\ninterface Ethernet4\n!'
+        configlet = dict(name='eos-server', key='key', config=config)
+        template_config = ('interface Ethernet3\n   description Host eos'
+                           ' managed by Ansible and Jinja template\n'
+                           '   load-interval 30\n'
+                           '   switchport\n'
+                           '   switchport mode trunk\n'
+                           '   no shutdown\n!')
+        mock_template.return_value = template_config
+        update_return = dict(data='Configlet eos-server successfully updated'
+                                  ' and task initiated.')
+        module.client.api.update_configlet.return_value = update_return
+        result = cv_server_provision.configlet_action(module, configlet)
+        self.assertIsNotNone(result)
+        self.assertEqual(result['oldConfigBlock'], 'interface Ethernet3\n!')
+        full_config = '!\n' + template_config + '\ninterface Ethernet4\n!'
+        self.assertEqual(result['fullConfig'], full_config)
+        self.assertEqual(result['updateConfigletResponse'],
+                         update_return['data'])
+        self.assertTrue(result['changed'])
+        self.assertTrue(result['taskCreated'])
+        self.assertEqual(module.client.api.update_configlet.call_count, 1)
+
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.config_from_template')
+    def test_configlet_action_add_no_task(self, mock_template):
+        ''' Test configlet_action add that doesn't change configlet adds proper
+            info to return data. Does not including any task info.
+        '''
+        module = Mock()
+        module.params = dict(action='add', switch_name='eos', switch_port='3')
+        config = ('!\ninterface Ethernet3\n   description test\n'
+                  '!\ninterface Ethernet4\n!')
+        configlet = dict(name='eos-server', key='key', config=config)
+        template_config = 'interface Ethernet3\n   description test\n!'
+        mock_template.return_value = template_config
+        update_return = dict(data='Configlet eos-server successfully updated.')
+        module.client.api.update_configlet.return_value = update_return
+        result = cv_server_provision.configlet_action(module, configlet)
+        self.assertIsNotNone(result)
+        self.assertEqual(result['oldConfigBlock'],
+                         'interface Ethernet3\n   description test\n!')
+        self.assertEqual(result['fullConfig'], config)
+        self.assertEqual(result['updateConfigletResponse'],
+                         update_return['data'])
+        self.assertNotIn('changed', result)
+        self.assertNotIn('taskCreated', result)
+        self.assertEqual(module.client.api.update_configlet.call_count, 1)
+
+    def test_configlet_action_remove_with_task(self):
+        ''' Test configlet_action remove with change updates configlet and adds
+            proper info to return data. Including task spawned info.
+        '''
+        module = Mock()
+        module.params = dict(action='remove', switch_name='eos',
+                             switch_port='3')
+        config = ('!\ninterface Ethernet3\n   description test\n'
+                  '!\ninterface Ethernet4\n!')
+        configlet = dict(name='eos-server', key='key', config=config)
+        update_return = dict(data='Configlet eos-server successfully updated'
+                                  ' and task initiated.')
+        module.client.api.update_configlet.return_value = update_return
+        result = cv_server_provision.configlet_action(module, configlet)
+        self.assertIsNotNone(result)
+        self.assertEqual(result['oldConfigBlock'],
+                         'interface Ethernet3\n   description test\n!')
+        full_config = '!\ninterface Ethernet3\n!\ninterface Ethernet4\n!'
+        self.assertEqual(result['fullConfig'], full_config)
+        self.assertEqual(result['updateConfigletResponse'],
+                         update_return['data'])
+        self.assertTrue(result['changed'])
+        self.assertTrue(result['taskCreated'])
+        self.assertEqual(module.client.api.update_configlet.call_count, 1)
+
+    def test_configlet_action_remove_no_task(self):
+        ''' Test configlet_action with remove that doesn't change configlet and
+            adds proper info to return data. Does not including any task info.
+        '''
+        module = Mock()
+        module.params = dict(action='remove', switch_name='eos',
+                             switch_port='3')
+        config = '!\ninterface Ethernet3\n!\ninterface Ethernet4\n!'
+        configlet = dict(name='eos-server', key='key', config=config)
+        update_return = dict(data='Configlet eos-server successfully updated.')
+        module.client.api.update_configlet.return_value = update_return
+        result = cv_server_provision.configlet_action(module, configlet)
+        self.assertIsNotNone(result)
+        self.assertEqual(result['oldConfigBlock'], 'interface Ethernet3\n!')
+        self.assertEqual(result['fullConfig'], config)
+        self.assertEqual(result['updateConfigletResponse'],
+                         update_return['data'])
+        self.assertNotIn('changed', result)
+        self.assertNotIn('taskCreated', result)
+        self.assertEqual(module.client.api.update_configlet.call_count, 1)
+
+    def test_current_config_empty_config(self):
+        ''' Test current_config with empty config for port
+        '''
+        module = Mock()
+        module.params = dict(switch_name='eos', switch_port='4')
+        config = '!\ninterface Ethernet3\n!\ninterface Ethernet4'
+        result = cv_server_provision.current_config(module, config)
+        self.assertIsNotNone(result)
+        self.assertEqual(result, 'interface Ethernet4')
+
+    def test_current_config_with_config(self):
+        ''' Test current_config with config for port
+        '''
+        module = Mock()
+        module.params = dict(switch_name='eos', switch_port='3')
+        config = ('!\ninterface Ethernet3\n   description test\n'
+                  '!\ninterface Ethernet4\n!')
+        result = cv_server_provision.current_config(module, config)
+        self.assertIsNotNone(result)
+        self.assertEqual(result, 'interface Ethernet3\n   description test\n!')
+
+    def test_current_config_no_match(self):
+        ''' Test current_config with no entry for port
+        '''
+        module = Mock()
+        module.fail_json.side_effect = SystemExit
+        module.params = dict(switch_name='eos', switch_port='2')
+        config = '!\ninterface Ethernet3\n   description test\n!'
+        self.assertRaises(SystemExit, cv_server_provision.current_config,
+                          module, config)
+
+    def test_valid_template_true(self):
+        ''' Test valid_template true
+        '''
+        template = 'interface Ethernet3\n   description test\n!'
+        result = cv_server_provision.valid_template('3', template)
+        self.assertTrue(result)
+
+    def test_valid_template_false(self):
+        ''' Test valid_template false
+        '''
+        template = 'interface Ethernet3\n   description test\n!'
+        result = cv_server_provision.valid_template('4', template)
+        self.assertFalse(result)
+
+    @patch('jinja2.DebugUndefined')
+    @patch('jinja2.Environment')
+    @patch('jinja2.FileSystemLoader')
+    def test_config_from_template_no_template(self, mock_file_sys, mock_env,
+                                              mock_debug):
+        ''' Test config_from_template good. No template.
+        '''
+        module = Mock()
+        module.fail_json.side_effect = SystemExit
+        module.params = dict(switch_name='eos', switch_port='3',
+                             server_name='new', template='jinja.j2')
+        mock_file_sys.return_value = 'file'
+        mock_debug.return_value = 'debug'
+        env_mock = Mock()
+        env_mock.get_template.return_value = None
+        mock_env.return_value = env_mock
+        self.assertRaises(SystemExit, cv_server_provision.config_from_template,
+                          module)
+        self.assertEqual(mock_file_sys.call_count, 1)
+        self.assertEqual(mock_env.call_count, 1)
+        self.assertEqual(module.fail_json.call_count, 1)
+
+    @patch('jinja2.meta.find_undeclared_variables')
+    @patch('jinja2.DebugUndefined')
+    @patch('jinja2.Environment')
+    @patch('jinja2.FileSystemLoader')
+    def test_config_from_template_good_no_vlan(self, mock_file_sys, mock_env, mock_debug,
+                                               mock_find):
+        ''' Test config_from_template good. No port_vlan.
+        '''
+        module = Mock()
+        module.params = dict(switch_name='eos', switch_port='3',
+                             server_name='new', template='jinja.j2')
+        mock_file_sys.return_value = 'file'
+        mock_debug.return_value = 'debug'
+        template_mock = Mock()
+        template_mock.render.return_value = ('interface Ethernet3\n'
+                                             '   description test\n'
+                                             '   switchport\n'
+                                             '   switchport mode trunk\n'
+                                             '   no shutdown\n!')
+        env_mock = Mock()
+        env_mock.loader.get_source.return_value = ['one', 'two']
+        env_mock.parse.return_value = 'parsed'
+        env_mock.get_template.return_value = template_mock
+        mock_env.return_value = env_mock
+        mock_find.return_value = dict(server_name=None, switch_port=None)
+        result = cv_server_provision.config_from_template(module)
+        self.assertIsNotNone(result)
+        expected = ('interface Ethernet3\n'
+                    '   description test\n'
+                    '   switchport\n'
+                    '   switchport mode trunk\n'
+                    '   no shutdown\n!')
+        self.assertEqual(result, expected)
+        self.assertEqual(mock_file_sys.call_count, 1)
+        self.assertEqual(mock_env.call_count, 1)
+        module.fail_json.assert_not_called()
+
+    @patch('jinja2.meta.find_undeclared_variables')
+    @patch('jinja2.DebugUndefined')
+    @patch('jinja2.Environment')
+    @patch('jinja2.FileSystemLoader')
+    def test_config_from_template_good_vlan(self, mock_file_sys, mock_env, mock_debug,
+                                            mock_find):
+        ''' Test config_from_template good. With port_vlan.
+        '''
+        module = Mock()
+        module.params = dict(switch_name='eos', switch_port='3',
+                             server_name='new', template='jinja.j2', port_vlan='7')
+        mock_file_sys.return_value = 'file'
+        mock_debug.return_value = 'debug'
+        template_mock = Mock()
+        template_mock.render.return_value = ('interface Ethernet3\n'
+                                             '   description test\n'
+                                             '   switchport\n'
+                                             '   switchport access vlan 7\n'
+                                             '   no shutdown\n!')
+        env_mock = Mock()
+        env_mock.loader.get_source.return_value = ['one', 'two']
+        env_mock.parse.return_value = 'parsed'
+        env_mock.get_template.return_value = template_mock
+        mock_env.return_value = env_mock
+        mock_find.return_value = dict(server_name=None, switch_port=None,
+                                      port_vlan=None)
+        result = cv_server_provision.config_from_template(module)
+        self.assertIsNotNone(result)
+        expected = ('interface Ethernet3\n'
+                    '   description test\n'
+                    '   switchport\n'
+                    '   switchport access vlan 7\n'
+                    '   no shutdown\n!')
+        self.assertEqual(result, expected)
+        self.assertEqual(mock_file_sys.call_count, 1)
+        self.assertEqual(mock_env.call_count, 1)
+        module.fail_json.assert_not_called()
+
+    @patch('jinja2.meta.find_undeclared_variables')
+    @patch('jinja2.DebugUndefined')
+    @patch('jinja2.Environment')
+    @patch('jinja2.FileSystemLoader')
+    def test_config_from_template_fail_wrong_port(self, mock_file_sys, mock_env,
+                                                  mock_debug, mock_find):
+        ''' Test config_from_template fail. Wrong port number in template.
+        '''
+        module = Mock()
+        module.params = dict(switch_name='eos', switch_port='4',
+                             server_name='new', template='jinja.j2')
+        mock_file_sys.return_value = 'file'
+        mock_debug.return_value = 'debug'
+        template_mock = Mock()
+        template_mock.render.return_value = ('interface Ethernet3\n'
+                                             '   description test\n!')
+        env_mock = Mock()
+        env_mock.loader.get_source.return_value = ['one', 'two']
+        env_mock.parse.return_value = 'parsed'
+        env_mock.get_template.return_value = template_mock
+        mock_env.return_value = env_mock
+        mock_find.return_value = dict(server_name=None, switch_port=None)
+        result = cv_server_provision.config_from_template(module)
+        self.assertIsNotNone(result)
+        expected = 'interface Ethernet3\n   description test\n!'
+        self.assertEqual(result, expected)
+        self.assertEqual(mock_file_sys.call_count, 1)
+        self.assertEqual(mock_env.call_count, 1)
+        module.fail_json.assert_called_with(msg='Template content does not'
+                                                ' configure proper interface'
+                                                ' - %s' % expected)
+
+    @patch('jinja2.meta.find_undeclared_variables')
+    @patch('jinja2.DebugUndefined')
+    @patch('jinja2.Environment')
+    @patch('jinja2.FileSystemLoader')
+    def test_config_from_template_fail_no_vlan(self, mock_file_sys, mock_env,
+                                               mock_debug, mock_find):
+        ''' Test config_from_template fail. Template needs vlan but none provided.
+        '''
+        module = Mock()
+        module.params = dict(switch_name='eos', switch_port='3',
+                             server_name='new', template='jinja.j2',
+                             port_vlan=None)
+        mock_file_sys.return_value = 'file'
+        mock_debug.return_value = 'debug'
+        template_mock = Mock()
+        template_mock.render.return_value = ('interface Ethernet3\n'
+                                             '   description test\n!')
+        env_mock = Mock()
+        env_mock.loader.get_source.return_value = ['one', 'two']
+        env_mock.parse.return_value = 'parsed'
+        env_mock.get_template.return_value = template_mock
+        mock_env.return_value = env_mock
+        mock_find.return_value = dict(server_name=None, switch_port=None,
+                                      port_vlan=None)
+        result = cv_server_provision.config_from_template(module)
+        self.assertIsNotNone(result)
+        expected = 'interface Ethernet3\n   description test\n!'
+        self.assertEqual(result, expected)
+        self.assertEqual(mock_file_sys.call_count, 1)
+        self.assertEqual(mock_env.call_count, 1)
+        module.fail_json.assert_called_with(msg='Template jinja.j2 requires a'
+                                                ' vlan. Please re-run with vlan'
+                                                ' number provided.')
+
+    def test_updated_configlet_content_add(self):
+        ''' Test updated_configlet_content. Add config.
+        '''
+        module = Mock()
+        module.params = dict(switch_name='eos', switch_port='3')
+        existing_config = '!\ninterface Ethernet3\n!\ninterface Ethernet4\n!'
+        new_config_block = 'interface Ethernet3\n   description test\n!'
+        result = cv_server_provision.updated_configlet_content(module,
+                                                               existing_config,
+                                                               new_config_block)
+        expected = ('!\ninterface Ethernet3\n   description test\n'
+                    '!\ninterface Ethernet4\n!')
+        self.assertEqual(result, expected)
+        module.fail_json.assert_not_called()
+
+    def test_updated_configlet_content_remove(self):
+        ''' Test updated_configlet_content. Remove config.
+        '''
+        module = Mock()
+        module.params = dict(switch_name='eos', switch_port='3')
+        existing_config = ('!\ninterface Ethernet3\n   description test\n'
+                           '!\ninterface Ethernet4')
+        new_config_block = 'interface Ethernet3\n!'
+        result = cv_server_provision.updated_configlet_content(module,
+                                                               existing_config,
+                                                               new_config_block)
+        expected = '!\ninterface Ethernet3\n!\ninterface Ethernet4'
+        self.assertEqual(result, expected)
+        module.fail_json.assert_not_called()
+
+    def test_updated_configlet_content_no_match(self):
+        ''' Test updated_configlet_content. Interface not in config.
+        '''
+        module = Mock()
+        module.fail_json.side_effect = SystemExit
+        module.params = dict(switch_name='eos', switch_port='2')
+        existing_config = '!\ninterface Ethernet3\n   description test\n!'
+        new_config_block = 'interface Ethernet3\n!'
+        self.assertRaises(SystemExit,
+                          cv_server_provision.updated_configlet_content,
+                          module, existing_config, new_config_block)
+
+    @patch('time.sleep')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.switch_info')
+    def test_configlet_update_task_good_one_try(self, mock_info, mock_sleep):
+        ''' Test configlet_update_task gets task after one try.
+        '''
+        module = Mock()
+        task = dict(data=dict(WORKFLOW_ACTION='Configlet Push'),
+                    description='Configlet Assign',
+                    workOrderId='7')
+        device_info = dict(taskIdList=[task])
+        mock_info.return_value = device_info
+        result = cv_server_provision.configlet_update_task(module)
+        self.assertEqual(result, '7')
+        mock_sleep.assert_not_called()
+        self.assertEqual(mock_info.call_count, 1)
+
+    @patch('time.sleep')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.switch_info')
+    def test_configlet_update_task_good_three_tries(self, mock_info, mock_sleep):
+        ''' Test configlet_update_task gets task on third try.
+        '''
+        module = Mock()
+        task1 = dict(data=dict(WORKFLOW_ACTION='Configlet Push'),
+                     description='Configlet Assign',
+                     workOrderId='7')
+        task2 = dict(data=dict(WORKFLOW_ACTION='Nonsense'),
+                     description='Configlet Assign',
+                     workOrderId='700')
+        device_info = dict(taskIdList=[task1, task2])
+        mock_info.side_effect = [dict(), dict(), device_info]
+        result = cv_server_provision.configlet_update_task(module)
+        self.assertEqual(result, '7')
+        self.assertEqual(mock_sleep.call_count, 2)
+        self.assertEqual(mock_info.call_count, 3)
+
+    @patch('time.sleep')
+    @patch('ansible.modules.network.cloudvision.cv_server_provision.switch_info')
+    def test_configlet_update_task_no_task(self, mock_info, mock_sleep):
+        ''' Test configlet_update_task does not get task after three tries.
+        '''
+        module = Mock()
+        mock_info.side_effect = [dict(), dict(), dict()]
+        result = cv_server_provision.configlet_update_task(module)
+        self.assertIsNone(result)
+        self.assertEqual(mock_sleep.call_count, 3)
+        self.assertEqual(mock_info.call_count, 3)
+
+    @patch('time.sleep')
+    def test_wait_for_task_completion_good_one_try(self, mock_time):
+        ''' Test wait_for_task_completion completed. One Try.
+        '''
+        module = Mock()
+        module.client.api.get_task_by_id.return_value = dict(
+            workOrderUserDefinedStatus='Completed')
+        result = cv_server_provision.wait_for_task_completion(module, '7')
+        self.assertTrue(result)
+        self.assertEqual(module.client.api.get_task_by_id.call_count, 1)
+        module.fail_json.assert_not_called()
+        mock_time.assert_not_called()
+
+    @patch('time.sleep')
+    def test_wait_for_task_completion_good_three_tries(self, mock_time):
+        ''' Test wait_for_task_completion completed. Three tries.
+        '''
+        module = Mock()
+        try_one_two = dict(workOrderUserDefinedStatus='Pending')
+        try_three = dict(workOrderUserDefinedStatus='Completed')
+        module.client.api.get_task_by_id.side_effect = [try_one_two,
+                                                        try_one_two, try_three]
+        result = cv_server_provision.wait_for_task_completion(module, '7')
+        self.assertTrue(result)
+        self.assertEqual(module.client.api.get_task_by_id.call_count, 3)
+        module.fail_json.assert_not_called()
+        self.assertEqual(mock_time.call_count, 2)
+
+    @patch('time.sleep')
+    def test_wait_for_task_completion_fail(self, mock_time):
+        ''' Test wait_for_task_completion failed.
+        '''
+        module = Mock()
+        try_one = dict(workOrderUserDefinedStatus='Failed')
+        try_two = dict(workOrderUserDefinedStatus='Completed')
+        module.client.api.get_task_by_id.side_effect = [try_one, try_two]
+        result = cv_server_provision.wait_for_task_completion(module, '7')
+        self.assertTrue(result)
+        self.assertEqual(module.client.api.get_task_by_id.call_count, 2)
+        text = ('Task 7 has reported status Failed. Please consult the CVP'
+                ' admins for more information.')
+        module.fail_json.assert_called_with(msg=text)
+        self.assertEqual(mock_time.call_count, 1)

--- a/test/units/modules/remote_management/hpe/hpe_test_utils.py
+++ b/test/units/modules/remote_management/hpe/hpe_test_utils.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (2016-2017) Hewlett Packard Enterprise Development LP
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import yaml
+from mock import Mock, patch
+from oneview_module_loader import ONEVIEW_MODULE_UTILS_PATH
+from hpOneView.oneview_client import OneViewClient
+
+
+class OneViewBaseTestCase(object):
+    mock_ov_client_from_json_file = None
+    testing_class = None
+    mock_ansible_module = None
+    mock_ov_client = None
+    testing_module = None
+    EXAMPLES = None
+
+    def configure_mocks(self, test_case, testing_class):
+        """
+        Preload mocked OneViewClient instance and AnsibleModule
+        Args:
+            test_case (object): class instance (self) that are inheriting from OneViewBaseTestCase
+            testing_class (object): class being tested
+        """
+        self.testing_class = testing_class
+
+        # Define OneView Client Mock (FILE)
+        patcher_json_file = patch.object(OneViewClient, 'from_json_file')
+        test_case.addCleanup(patcher_json_file.stop)
+        self.mock_ov_client_from_json_file = patcher_json_file.start()
+
+        # Define OneView Client Mock
+        self.mock_ov_client = self.mock_ov_client_from_json_file.return_value
+
+        # Define Ansible Module Mock
+        patcher_ansible = patch(ONEVIEW_MODULE_UTILS_PATH + '.AnsibleModule')
+        test_case.addCleanup(patcher_ansible.stop)
+        mock_ansible_module = patcher_ansible.start()
+        self.mock_ansible_module = Mock()
+        mock_ansible_module.return_value = self.mock_ansible_module
+
+        self.__set_module_examples()
+
+    def test_main_function_should_call_run_method(self):
+        self.mock_ansible_module.params = {'config': 'config.json'}
+
+        main_func = getattr(self.testing_module, 'main')
+
+        with patch.object(self.testing_class, "run") as mock_run:
+            main_func()
+            mock_run.assert_called_once()
+
+    def __set_module_examples(self):
+        # Load scenarios from module examples (Also checks if it is a valid yaml)
+        ansible = __import__('ansible')
+        testing_module = self.testing_class.__module__.split('.')[-1]
+        self.testing_module = getattr(ansible.modules.remote_management.hpe, testing_module)
+
+        try:
+            # Load scenarios from module examples (Also checks if it is a valid yaml)
+            self.EXAMPLES = yaml.load(self.testing_module.EXAMPLES, yaml.SafeLoader)
+
+        except yaml.scanner.ScannerError:
+            message = "Something went wrong while parsing yaml from {}.EXAMPLES".format(self.testing_class.__module__)
+            raise Exception(message)
+
+
+class FactsParamsTestCase(OneViewBaseTestCase):
+    """
+    FactsParamsTestCase has common test for classes that support pass additional
+        parameters when retrieving all resources.
+    """
+
+    def configure_client_mock(self, resorce_client):
+        """
+        Args:
+             resorce_client: Resource client that is being called
+        """
+        self.resource_client = resorce_client
+
+    def __validations(self):
+        if not self.testing_class:
+            raise Exception("Mocks are not configured, you must call 'configure_mocks' before running this test.")
+
+        if not self.resource_client:
+            raise Exception(
+                "Mock for the client not configured, you must call 'configure_client_mock' before running this test.")
+
+    def test_should_get_all_using_filters(self):
+        self.__validations()
+        self.resource_client.get_all.return_value = []
+
+        params_get_all_with_filters = dict(
+            config='config.json',
+            name=None,
+            params={
+                'start': 1,
+                'count': 3,
+                'sort': 'name:descending',
+                'filter': 'purpose=General',
+                'query': 'imported eq true'
+            })
+        self.mock_ansible_module.params = params_get_all_with_filters
+
+        self.testing_class().run()
+
+        self.resource_client.get_all.assert_called_once_with(start=1, count=3, sort='name:descending',
+                                                             filter='purpose=General',
+                                                             query='imported eq true')
+
+    def test_should_get_all_without_params(self):
+        self.__validations()
+        self.resource_client.get_all.return_value = []
+
+        params_get_all_with_filters = dict(
+            config='config.json',
+            name=None
+        )
+        self.mock_ansible_module.params = params_get_all_with_filters
+
+        self.testing_class().run()
+
+        self.resource_client.get_all.assert_called_once_with()

--- a/test/units/modules/remote_management/hpe/oneview_module_loader.py
+++ b/test/units/modules/remote_management/hpe/oneview_module_loader.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (2016-2017) Hewlett Packard Enterprise Development LP
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+from ansible.compat.tests.mock import patch, Mock
+sys.modules['hpOneView'] = Mock()
+sys.modules['hpOneView.oneview_client'] = Mock()
+sys.modules['hpOneView.exceptions'] = Mock()
+sys.modules['future'] = Mock()
+sys.modules['__future__'] = Mock()
+
+ONEVIEW_MODULE_UTILS_PATH = 'ansible.module_utils.oneview'
+from ansible.module_utils.oneview import (HPOneViewException,
+                                          HPOneViewTaskError,
+                                          OneViewModuleBase)
+
+from ansible.modules.remote_management.hpe.oneview_fc_network import FcNetworkModule

--- a/test/units/modules/remote_management/hpe/test_oneview_fc_network.py
+++ b/test/units/modules/remote_management/hpe/test_oneview_fc_network.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (2016-2017) Hewlett Packard Enterprise Development LP
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+from ansible.compat.tests import unittest
+from oneview_module_loader import FcNetworkModule
+from hpe_test_utils import OneViewBaseTestCase
+
+FAKE_MSG_ERROR = 'Fake message error'
+
+DEFAULT_FC_NETWORK_TEMPLATE = dict(
+    name='New FC Network 2',
+    autoLoginRedistribution=True,
+    fabricType='FabricAttach'
+)
+
+PARAMS_FOR_PRESENT = dict(
+    config='config.json',
+    state='present',
+    data=dict(name=DEFAULT_FC_NETWORK_TEMPLATE['name'])
+)
+
+PARAMS_WITH_CHANGES = dict(
+    config='config.json',
+    state='present',
+    data=dict(name=DEFAULT_FC_NETWORK_TEMPLATE['name'],
+              newName="New Name",
+              fabricType='DirectAttach')
+)
+
+PARAMS_FOR_ABSENT = dict(
+    config='config.json',
+    state='absent',
+    data=dict(name=DEFAULT_FC_NETWORK_TEMPLATE['name'])
+)
+
+
+class FcNetworkModuleSpec(unittest.TestCase,
+                          OneViewBaseTestCase):
+    """
+    OneViewBaseTestCase provides the mocks used in this test case
+    """
+
+    def setUp(self):
+        self.configure_mocks(self, FcNetworkModule)
+        self.resource = self.mock_ov_client.fc_networks
+
+    def test_should_create_new_fc_network(self):
+        self.resource.get_by.return_value = []
+        self.resource.create.return_value = DEFAULT_FC_NETWORK_TEMPLATE
+
+        self.mock_ansible_module.params = PARAMS_FOR_PRESENT
+
+        FcNetworkModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=FcNetworkModule.MSG_CREATED,
+            ansible_facts=dict(fc_network=DEFAULT_FC_NETWORK_TEMPLATE)
+        )
+
+    def test_should_not_update_when_data_is_equals(self):
+        self.resource.get_by.return_value = [DEFAULT_FC_NETWORK_TEMPLATE]
+
+        self.mock_ansible_module.params = PARAMS_FOR_PRESENT
+
+        FcNetworkModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            msg=FcNetworkModule.MSG_ALREADY_PRESENT,
+            ansible_facts=dict(fc_network=DEFAULT_FC_NETWORK_TEMPLATE)
+        )
+
+    def test_update_when_data_has_modified_attributes(self):
+        data_merged = DEFAULT_FC_NETWORK_TEMPLATE.copy()
+
+        data_merged['fabricType'] = 'DirectAttach'
+
+        self.resource.get_by.return_value = [DEFAULT_FC_NETWORK_TEMPLATE]
+        self.resource.update.return_value = data_merged
+
+        self.mock_ansible_module.params = PARAMS_WITH_CHANGES
+
+        FcNetworkModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=FcNetworkModule.MSG_UPDATED,
+            ansible_facts=dict(fc_network=data_merged)
+        )
+
+    def test_should_remove_fc_network(self):
+        self.resource.get_by.return_value = [DEFAULT_FC_NETWORK_TEMPLATE]
+
+        self.mock_ansible_module.params = PARAMS_FOR_ABSENT
+
+        FcNetworkModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=FcNetworkModule.MSG_DELETED
+        )
+
+    def test_should_do_nothing_when_fc_network_not_exist(self):
+        self.resource.get_by.return_value = []
+
+        self.mock_ansible_module.params = PARAMS_FOR_ABSENT
+
+        FcNetworkModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            msg=FcNetworkModule.MSG_ALREADY_ABSENT
+        )
+
+    def test_update_scopes_when_different(self):
+        params_to_scope = PARAMS_FOR_PRESENT.copy()
+        params_to_scope['data']['scopeUris'] = ['test']
+        self.mock_ansible_module.params = params_to_scope
+
+        resource_data = DEFAULT_FC_NETWORK_TEMPLATE.copy()
+        resource_data['scopeUris'] = ['fake']
+        resource_data['uri'] = 'rest/fc/fake'
+        self.resource.get_by.return_value = [resource_data]
+
+        patch_return = resource_data.copy()
+        patch_return['scopeUris'] = ['test']
+        self.resource.patch.return_value = patch_return
+
+        FcNetworkModule().run()
+
+        self.resource.patch.assert_called_once_with('rest/fc/fake',
+                                                    operation='replace',
+                                                    path='/scopeUris',
+                                                    value=['test'])
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            ansible_facts=dict(fc_network=patch_return),
+            msg=FcNetworkModule.MSG_UPDATED
+        )
+
+    def test_should_do_nothing_when_scopes_are_the_same(self):
+        params_to_scope = PARAMS_FOR_PRESENT.copy()
+        params_to_scope['data']['scopeUris'] = ['test']
+        self.mock_ansible_module.params = params_to_scope
+
+        resource_data = DEFAULT_FC_NETWORK_TEMPLATE.copy()
+        resource_data['scopeUris'] = ['test']
+        self.resource.get_by.return_value = [resource_data]
+
+        FcNetworkModule().run()
+
+        self.resource.patch.not_been_called()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(fc_network=resource_data),
+            msg=FcNetworkModule.MSG_ALREADY_PRESENT
+        )


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
azure_rm

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
When SSH access to VMs are proxied by a jumpbox, but these VMs still have an assigned public IP address (for example, web servers listening on SSH only from a private network), `azure_rm.py` should fill `ansible_host` value to the private IP address instead of the public one.
~Additionally a small refactoring was done and style corrections done to comply to PEP8.~