### PR TITLE
Default include_role results to empty list in linear strategy plugin

### DIFF
--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -287,7 +287,7 @@ class StrategyModule(StrategyBase):
                             loop_var = 'item'
                             if hr._task.loop_control:
                                 loop_var = hr._task.loop_control.loop_var or 'item'
-                            include_results = hr._result['results']
+                            include_results = hr._result.get('results', [])
                         else:
                             include_results = [ hr._result ]
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Linear strategy plugin

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### SUMMARY
Defaults `include_results` to an empty list when looping `include_role` over an empty list, preventing a `KeyError` being thrown.

This playbook
```
- hosts: localhost
  tasks:
  - include_role: name=anything
    with_items: []
```
previously produced this output
```
TASK [include_role] ************************************************************
ERROR! Unexpected Exception: 'results'
the full traceback was:

Traceback (most recent call last):
  File "/usr/local/bin/ansible-playbook", line 103, in <module>
    exit_code = cli.run()
  File "/usr/local/Cellar/ansible/2.2.0.0_1/libexec/lib/python2.7/site-packages/ansible/cli/playbook.py", line 159, in run
    results = pbex.run()
  File "/usr/local/Cellar/ansible/2.2.0.0_1/libexec/lib/python2.7/site-packages/ansible/executor/playbook_executor.py", line 154, in run
    result = self._tqm.run(play=play)
  File "/usr/local/Cellar/ansible/2.2.0.0_1/libexec/lib/python2.7/site-packages/ansible/executor/task_queue_manager.py", line 282, in run
    play_return = strategy.run(iterator, play_context)
  File "/usr/local/Cellar/ansible/2.2.0.0_1/libexec/lib/python2.7/site-packages/ansible/plugins/strategy/linear.py", line 290, in run
    include_results = hr._result['results']
KeyError: 'results'
```
but now (correctly) produces
```
TASK [include_role] ************************************************************
```

Fixes #18544.