### PR TITLE
fixes issue with setting the terminal length (pager) in vyos

### DIFF
--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -36,7 +36,8 @@ from ansible.module_utils._text import to_native
 
 ANSI_RE = [
     re.compile(r'(\x1b\[\?1h\x1b=)'),
-    re.compile(r'\x08.')
+    re.compile(r'\x08'),
+    re.compile(r'\x1b[^m]*m')
 ]
 
 def to_list(val):

--- a/lib/ansible/module_utils/vyos.py
+++ b/lib/ansible/module_utils/vyos.py
@@ -27,6 +27,7 @@
 #
 
 import re
+import os
 
 from ansible.module_utils.network import NetworkModule, NetworkError
 from ansible.module_utils.network import register_transport, to_list
@@ -46,9 +47,13 @@ class Cli(CliBase):
         re.compile(r"\n\s+Set failed"),
     ]
 
+    TERMINAL_LENGTH = os.getenv('ANSIBLE_VYOS_TERMINAL_LENGTH', 10000)
+
+
     def connect(self, params, **kwargs):
         super(Cli, self).connect(params, kickstart=False, **kwargs)
         self.shell.send('set terminal length 0')
+        self.shell.send('set terminal length %s' % self.TERMINAL_LENGTH)
 
 
     ### implementation of netcli.Cli ###


### PR DESCRIPTION
`set terminal length 0` actually sets `VYATTA_PAGER=cat`
`set terminal length [some number]` actually sets `stty length [some number]`