### PR TITLE
Update test to use keyserver.ubuntu.com.

### DIFF
--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -669,7 +669,7 @@
   # clone a repo checkout signed tag, verify tag
 
 - name: Import Jamie Evans GPG key
-  command: gpg --keyserver pgp.mit.edu --recv-key 61107C8E
+  command: gpg --keyserver keyserver.ubuntu.com --recv-key 61107C8E
   when: >
     not gpg_version.stderr and
     gpg_version.stdout and


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Integration Tests

##### ANSIBLE VERSION

```
ansible 2.3.0 (keyserver 2b09e032bf) last updated 2016/11/18 10:24:05 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 9724ed77de) last updated 2016/11/18 10:24:10 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 9511de1e3d) last updated 2016/11/18 10:24:10 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Update test to use `keyserver.ubuntu.com`. Use of the server `pgp.mit.edu` has been causing CI failures.