### PR TITLE
Add test cases for VyOS commands that don't honor paging settings

### DIFF
--- a/test/integration/targets/vyos_command/tests/cli/output.yaml
+++ b/test/integration/targets/vyos_command/tests/cli/output.yaml
@@ -37,7 +37,8 @@
       - show log all
       - show log authorization
       - show system boot-messages
-    register: result
+    provider: "{{ cli }}"
+  register: result
 
 - assert:
     that:

--- a/test/integration/targets/vyos_command/tests/cli/output.yaml
+++ b/test/integration/targets/vyos_command/tests/cli/output.yaml
@@ -27,4 +27,22 @@
       - result.stdout is defined
       - result.stdout | length == 2
 
+- name: Get output for multiple commands that call less explicitly
+  vyos_command:
+    commands:
+      - show hardware cpu detail
+      - show hardware mem
+      - show license
+      - show log
+      - show log all
+      - show log authorization
+      - show system boot-messages
+    register: result
+
+- assert:
+    that:
+      - result.changed == false
+      - result.stdout_lines is defined
+      - result.stdout_lines[2] | length >= 20
+
 - debug: msg="END cli/output.yaml"


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request

##### COMPONENT NAME
/test/integration/targets/vyos_command/tests/cli/output.yaml

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (vyos-command-tests a06966dc55) last updated 2016/11/18 16:39:56 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 7ed1af0a6d) last updated 2016/11/18 16:31:58 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 9511de1e3d) last updated 2016/11/18 16:31:58 (GMT -400)
  config file = /Users/sdoran/Projects/Vagrant/Ansible Lab/ansible.cfg
  configured module search path = ['/Users/sdoran/Source/ansible/library']
```

##### SUMMARY
Add tests for issue fixed in PR #18546