### PR TITLE
[GCE] inventory script supports paginated API results.

### DIFF
--- a/contrib/inventory/gce.py
+++ b/contrib/inventory/gce.py
@@ -390,13 +390,22 @@ class GceInventory(object):
         self.cache.write_to_cache(data)
         self.inventory = data
 
+    def list_nodes(self):
+        all_nodes = []
+        params, more_results = {'maxResults': 500}, True
+        while more_results:
+            self.driver.connection.gce_params=params
+            all_nodes.extend(self.driver.list_nodes())
+            more_results = 'pageToken' in params
+        return all_nodes
+
     def group_instances(self, zones=None):
         '''Group all instances'''
         groups = {}
         meta = {}
         meta["hostvars"] = {}
 
-        for node in self.driver.list_nodes():
+        for node in self.list_nodes():
 
             # This check filters on the desired instance states defined in the
             # config file with the instance_states config option.


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
contrib/inventory/gce.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (gce-inv f7ad4f4a53) last updated 2016/11/18 21:42:04 (GMT +000)
  lib/ansible/modules/core: (devel 48cd199871) last updated 2016/10/27 16:05:05 (GMT +000)
  lib/ansible/modules/extras: (gce_tag_regex f1cf3901a7) last updated 2016/11/08 04:25:30 (GMT +000)
  config file = /home/supertom/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The gce.py inventory script could not support over 500 instances as pagination was not implemented.  This PR implements pagination.

You can test with (assuming a secrets.py file is found in your PYTHONPATH):

`python contrib/inventory/gce.py --list --pretty --refresh-cache`

/cc @ryansb 