### PR TITLE
Add the proxmox node name as meta for a vm

### DIFF
--- a/contrib/inventory/proxmox.py
+++ b/contrib/inventory/proxmox.py
@@ -189,6 +189,8 @@ def main_list(options):
                         }
                     results[group]['hosts'] += [vm]
 
+            metadata['proxmox_node'] = node
+
             results['_meta']['hostvars'][vm].update(metadata)
 
     # pools


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
contrib/inventory/proxmox.py

##### ANSIBLE VERSION
```
ansible 2.3.0
```

##### SUMMARY
Adds a `proxmox_node` value for each VM/container which gives you information about where it is running.

Example:
```
$ ./contrib/inventory/proxmox.py --list --pretty

[...]

  "_meta": {
    "hostvars": {
      "env-daniel": {
        "proxmox_vmid": 101,
        "proxmox_maxdisk": 107374182400, 
        "proxmox_status": "running", 
        "proxmox_netout": 443291, 
        "proxmox_cpus": 6, 
        "proxmox_node": "pmox02", 
        "proxmox_cpu": 0.00282061084721094, 
        "proxmox_uptime": 15042, 
        "proxmox_netin": 8946716, 
        "proxmox_pid": "32129", 
        "proxmox_diskwrite": 0, 
        "proxmox_diskread": 0, 
        "groups": [
          "base"
        ], 
        "proxmox_name": "env-daniel", 
        "proxmox_template": "", 
        "proxmox_maxmem": 10737418240, 
        "proxmox_mem": 982559724, 
        "proxmox_disk": 0
      },

[...]
```