### PR TITLE
Network docs fragments: fix copy paste errors

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/asa.py
+++ b/lib/ansible/utils/module_docs_fragments/asa.py
@@ -84,7 +84,7 @@ options:
     default: 10
   provider:
     description:
-      - Convenience method that allows all I(ios) arguments to be passed as
+      - Convenience method that allows all I(asa) arguments to be passed as
         a dict object.  All constraints (required, choices, etc) must be
         met either by individual arguments or values in this dict.
     required: false

--- a/lib/ansible/utils/module_docs_fragments/eos.py
+++ b/lib/ansible/utils/module_docs_fragments/eos.py
@@ -39,7 +39,7 @@ options:
   username:
     description:
       - Configures the username to use to authenticate the connection to
-        the remote device.  The value of I(username) is used to authenticate
+        the remote device.  This value is used to authenticate
         either the CLI login or the eAPI authentication depending on which
         transport is used. If the value is not specified in the task, the
         value of environment variable C(ANSIBLE_NET_USERNAME) will be used instead.

--- a/lib/ansible/utils/module_docs_fragments/junos.py
+++ b/lib/ansible/utils/module_docs_fragments/junos.py
@@ -61,7 +61,7 @@ options:
     required: false
   provider:
     description:
-      - Convenience method that allows all I(ios) arguments to be passed as
+      - Convenience method that allows all I(junos) arguments to be passed as
         a dict object.  All constraints (required, choices, etc) must be
         met either by individual arguments or values in this dict.
     required: false

--- a/lib/ansible/utils/module_docs_fragments/nxos.py
+++ b/lib/ansible/utils/module_docs_fragments/nxos.py
@@ -39,7 +39,7 @@ options:
   username:
     description:
       - Configures the username to use to authenticate the connection to
-        the remote device.  The value of I(username) is used to authenticate
+        the remote device.  This value is used to authenticate
         either the CLI login or the nxapi authentication depending on which
         transport is used. If the value is not specified in the task, the
         value of environment variable C(ANSIBLE_NET_USERNAME) will be used instead.


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
module_utils/asa
module_utils/eos
module_utils/junos
module_utils/nxos
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```

##### SUMMARY
asa and vyos bothrefered to eos, most likely due to copy & paste error when creating. Fix that
Also when diffing the Network docs_fragments get the rest of the content consistent
