### PR TITLE
Fix unicode handling in fixup_perms2 errorhandling

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -370,7 +370,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 if execute:
                     res = self._remote_chmod(remote_paths, 'u+x')
                     if res['rc'] != 0:
-                        raise AnsibleError('Failed to set file mode on remote temporary files (rc: {0}, err: {1})'.format(res['rc'], res['stderr']))
+                        raise AnsibleError('Failed to set file mode on remote temporary files (rc: {0}, err: {1})'.format(res['rc'], to_native(res['stderr'])))
 
                 res = self._remote_chown(remote_paths, self._play_context.become_user)
                 if res['rc'] != 0 and remote_user == 'root':
@@ -386,18 +386,18 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                                 ' https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user')
                         res = self._remote_chmod(remote_paths, 'a+%s' % mode)
                         if res['rc'] != 0:
-                            raise AnsibleError('Failed to set file mode on remote files (rc: {0}, err: {1})'.format(res['rc'], res['stderr']))
+                            raise AnsibleError('Failed to set file mode on remote files (rc: {0}, err: {1})'.format(res['rc'], to_native(res['stderr'])))
                     else:
                         raise AnsibleError('Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user'
                                 ' (rc: {0}, err: {1}). For information on working around this,'
-                                ' see https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user'.format(res['rc'], res['stderr']))
+                                ' see https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user'.format(res['rc'], to_native(res['stderr'])))
         elif execute:
             # Can't depend on the file being transferred with execute
             # permissions.  Only need user perms because no become was
             # used here
             res = self._remote_chmod(remote_paths, 'u+x')
             if res['rc'] != 0:
-                raise AnsibleError('Failed to set file mode on remote files (rc: {0}, err: {1})'.format(res['rc'], res['stderr']))
+                raise AnsibleError('Failed to set file mode on remote files (rc: {0}, err: {1})'.format(res['rc'], to_native(res['stderr'])))
 
         return remote_paths
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
action

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
$ ansible --version
ansible 2.2.0.0
  config file = /Users/noseworthy/Development/nocland-devops/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Discovered this issue when trying to modify files on a system as the `postgresql` user. Determined that the output of `stderr` was using smartquotes around the `--become-user` name which were trying to be coerced into ASCII by python 2's "helpful" string handling. Decided that the best way to make sure that this was portable across systems and versions of python would be to ensure that to_text was called on all strings that make up the error message (to avoid use of the `u` prefix on python 2 unicode strings) to ensure that they were in a unicode format (as opposed to an encoded byte string format) so that when `str.format()` was called, no coercion happened and the "unicode sandwich" was in place. 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
before:
```
$ ansible test_server -m setup --become --become-user=postgresql --ask-become-pass
SUDO password:
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/Users/noseworthy/.virtualenvs/ansible/lib/python2.7/site-packages/ansible/executor/task_executor.py", line 119, in run
    res = self._execute()
  File "/Users/noseworthy/.virtualenvs/ansible/lib/python2.7/site-packages/ansible/executor/task_executor.py", line 490, in _execute
    result = self._handler.run(task_vars=variables)
  File "/Users/noseworthy/.virtualenvs/ansible/lib/python2.7/site-packages/ansible/plugins/action/normal.py", line 33, in run
    results = merge_hash(results, self._execute_module(tmp=tmp, task_vars=task_vars))
  File "/Users/noseworthy/.virtualenvs/ansible/lib/python2.7/site-packages/ansible/plugins/action/__init__.py", line 641, in _execute_module
    self._fixup_perms2(remote_files, remote_user)
  File "/Users/noseworthy/.virtualenvs/ansible/lib/python2.7/site-packages/ansible/plugins/action/__init__.py", line 417, in _fixup_perms2
    res['rc'], to_text(res['stderr']))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2018' in position 21: ordinal not in range(128)

test_server | FAILED! => {
    "failed": true,
    "msg": "Unexpected failure during module execution.",
    "stdout": ""
}
```

after:
```
$ ansible test_server -m setup --become --become-user=postgresql --ask-become-pass
SUDO password:
test_server | FAILED! => {
    "failed": true,
    "msg": "Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user (rc: 1, err: chown: invalid user: ‘postgresql’\n). For information on working around this, see https://docs.ansible.com/ansible/become.html#becoming-an-unprivileged-user"
}
```

The _fixup_perms2 method checks to see if the user that is being sudo'd
is an unprivileged user or root. If it is an unprivileged user, some
checks are done to see if becoming this user would lock the ssh user out
of temp files, among other things. If this check fails, an error prints
telling the user to check the documentation for becoming an unprivileged
user.

On some systems, the stderr prints out the unprivileged user the ssh
user was trying to become contained in smartquotes. These quotes aren't
in the ASCII range, and so when we're trying to call `str.format()` to
combine the stderr message with the error text we get a
UnicodeEncodeError as python can't coerce the smartquotes using the
system default encoding. By calling `to_text()` on the error message we
can ensure that the error message is in a python3 friendly unicode
format (`unicode` in py2, `str` in py3) so that no coercion is done and
the python unicode sandwich is maintained.

Fixes: #18444