### PR TITLE
Convert playbook basedir into unicode at the borders

### DIFF
--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -21,11 +21,12 @@ __metaclass__ = type
 
 import os
 
+from ansible import constants as C
 from ansible.errors import AnsibleParserError
+from ansible.module_utils._text import to_text
 from ansible.playbook.play import Play
 from ansible.playbook.playbook_include import PlaybookInclude
 from ansible.plugins import get_all_plugin_loaders
-from ansible import constants as C
 
 try:
     from __main__ import display
@@ -43,7 +44,7 @@ class Playbook:
         # Entries in the datastructure of a playbook may
         # be either a play or an include statement
         self._entries = []
-        self._basedir = os.getcwd()
+        self._basedir = to_text(os.getcwd(), errors='surrogate_or_strict')
         self._loader  = loader
         self._file_name = None
 


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
playbook basedir

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel, 2.2
```

##### SUMMARY
Ansible was throwing unicode error reading ansible.cfg from the playbook directory if there were non-ascii characters in the playbook diretory's path:
```
$ ansible-playbook test.yml -vvvv                                                                                                                                                         (06:54:53)
Using /var/tmp/Документы/ansible/ansible.cfg as config file
ERROR! Unexpected Exception: 'ascii' codec can't decode byte 0xd0 in position 9: ordinal not in range(128)
the full traceback was:

Traceback (most recent call last):
  File "/srv/ansible/abadger/bin/ansible-playbook", line 103, in <module>
    exit_code = cli.run()
  File "/srv/ansible/abadger/lib/ansible/cli/playbook.py", line 157, in run
    results = pbex.run()
  File "/srv/ansible/abadger/lib/ansible/executor/playbook_executor.py", line 81, in run
    pb = Playbook.load(playbook_path, variable_manager=self._variable_manager, loader=self._loader)
  File "/srv/ansible/abadger/lib/ansible/playbook/__init__.py", line 53, in load
    pb._load_playbook_data(file_name=file_name, variable_manager=variable_manager)
  File "/srv/ansible/abadger/lib/ansible/playbook/__init__.py", line 61, in _load_playbook_data
    self._basedir = os.path.normpath(os.path.join(self._basedir, os.path.dirname(file_name)))
  File "/usr/lib64/python2.7/posixpath.py", line 73, in join
    path += '/' + b
UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position 9: ordinal not in range(128)
```

This fix changes the basedir into text type when it enters ansible.