### PR TITLE
Elasticcache primaryEndpoint can be unassigned

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -1195,7 +1195,7 @@ class Ec2Inventory(object):
             return
 
         # Select the best destination address (PrimaryEndpoint)
-        dest = replication_group['NodeGroups'][0]['PrimaryEndpoint']['Address']
+        dest = replication_group['NodeGroups'][0]['PrimaryEndpoint']
 
         if not dest:
             # Skip clusters we cannot address (e.g. private VPC subnet)


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
ec2.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /Users/danielzitzman/projects/ops-tools-infrastructure/ansible.cfg
  configured module search path = ['library/']
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
If the elasticcache cluster dose not have a primary endpoint the inventory script fails