### PR TITLE
Use output_dir instead of outputdir for tests.

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -67,7 +67,7 @@ environment:
 	(cd targets/environment && ./runme.sh $(TEST_FLAGS))
 
 non_destructive: setup
-	ANSIBLE_ROLES_PATH=$(shell pwd)/targets ansible-playbook non_destructive.yml -i $(INVENTORY) -e outputdir=$(TEST_DIR) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
+	ANSIBLE_ROLES_PATH=$(shell pwd)/targets ansible-playbook non_destructive.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
 
 # Tests which can be run when running as root and a local SSH daemon is available.
 test_root_ssh: test_connection_local test_connection_chroot test_connection_ssh test_connection_paramiko_ssh test_delegate_to
@@ -138,7 +138,7 @@ test_connection_winrm:
 	(cd targets/connection_winrm && ./runme.sh $(TEST_FLAGS))
 
 destructive: setup
-	ANSIBLE_ROLES_PATH=$(shell pwd)/targets ansible-playbook destructive.yml -i $(INVENTORY) -e outputdir=$(TEST_DIR) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
+	ANSIBLE_ROLES_PATH=$(shell pwd)/targets ansible-playbook destructive.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
 
 check_mode:
 	(cd targets/check_mode && ./runme.sh $(TEST_FLAGS))
@@ -174,13 +174,13 @@ ci_win3: test_win_group3 test_connection_winrm
 test_winrm: test_win_group1 test_win_group2 test_win_group3
 
 test_win_group1:
-	ANSIBLE_ROLES_PATH=$(shell pwd)/targets ansible-playbook test_win_group1.yml -i inventory.winrm -e outputdir=$(TEST_DIR) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
+	ANSIBLE_ROLES_PATH=$(shell pwd)/targets ansible-playbook test_win_group1.yml -i inventory.winrm -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
 
 test_win_group2:
-	ANSIBLE_ROLES_PATH=$(shell pwd)/targets ansible-playbook test_win_group2.yml -i inventory.winrm -e outputdir=$(TEST_DIR) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
+	ANSIBLE_ROLES_PATH=$(shell pwd)/targets ansible-playbook test_win_group2.yml -i inventory.winrm -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
 
 test_win_group3:
-	ANSIBLE_ROLES_PATH=$(shell pwd)/targets ansible-playbook test_win_group3.yml -i inventory.winrm -e outputdir=$(TEST_DIR) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
+	ANSIBLE_ROLES_PATH=$(shell pwd)/targets ansible-playbook test_win_group3.yml -i inventory.winrm -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)
 
 test_tags:
 	(cd targets/tags && ./runme.sh $(TEST_FLAGS))
@@ -272,7 +272,7 @@ test_galaxy_spec: setup
 	mytmpdir=$(MYTMPDIR) ; \
 	ansible-galaxy install -r galaxy_rolesfile -p $$mytmpdir/roles -vvvv ; \
     cp galaxy_playbook.yml $$mytmpdir ; \
-    ansible-playbook -i $(INVENTORY) $$mytmpdir/galaxy_playbook.yml -e outputdir=$(TEST_DIR) -v $(TEST_FLAGS) ; \
+    ansible-playbook -i $(INVENTORY) $$mytmpdir/galaxy_playbook.yml -e @$(VARS_FILE) -v $(TEST_FLAGS) ; \
     RC=$$? ; \
     rm -rf $$mytmpdir ; \
     exit $$RC
@@ -281,7 +281,7 @@ test_galaxy_yaml: setup
 	mytmpdir=$(MYTMPDIR) ; \
 	ansible-galaxy install -r galaxy_roles.yml -p $$mytmpdir/roles -vvvv; \
     cp galaxy_playbook.yml $$mytmpdir ; \
-    ansible-playbook -i $(INVENTORY) $$mytmpdir/galaxy_playbook.yml -e outputdir=$(TEST_DIR) -v $(TEST_FLAGS) ; \
+    ansible-playbook -i $(INVENTORY) $$mytmpdir/galaxy_playbook.yml -e @$(VARS_FILE) -v $(TEST_FLAGS) ; \
     RC=$$? ; \
     rm -rf $$mytmpdir ; \
     exit $$RC

--- a/test/integration/targets/mount/tasks/main.yml
+++ b/test/integration/targets/mount/tasks/main.yml
@@ -18,24 +18,24 @@
 - name: Create the mount point
   file:
     state: "directory"
-    path: "{{ outputdir }}/mount_dest"
+    path: "{{ output_dir }}/mount_dest"
 
 - name: Create a directory to bind mount
   file:
     state: "directory"
-    path: "{{ outputdir }}/mount_source"
+    path: "{{ output_dir }}/mount_source"
 
 - name: Put something in the directory so we see that it worked
   copy:
     content: "Testing\n"
-    dest: "{{ outputdir }}/mount_source/test_file"
+    dest: "{{ output_dir }}/mount_source/test_file"
   register: orig_info
 
 # The opts type of bind mount only works on Linux
 - name: Bind mount a filesystem (Linux)
   mount:
-    src: "{{ outputdir }}/mount_source"
-    name: "{{ outputdir }}/mount_dest"
+    src: "{{ output_dir }}/mount_source"
+    name: "{{ output_dir }}/mount_dest"
     state: "mounted"
     fstype: "None"
     opts: "bind"
@@ -45,8 +45,8 @@
 # Nullfs is freebsd only
 - name: Bind mount a filesystem (FreeBSD)
   mount:
-    src: "{{ outputdir }}/mount_source"
-    name: "{{ outputdir }}/mount_dest"
+    src: "{{ output_dir }}/mount_source"
+    name: "{{ output_dir }}/mount_dest"
     state: "mounted"
     fstype: "nullfs"
   when: ansible_system == 'FreeBSD'
@@ -54,7 +54,7 @@
 
 - name: get checksum for bind mounted file
   stat:
-    path: "{{ outputdir }}/mount_dest/test_file"
+    path: "{{ output_dir }}/mount_dest/test_file"
   when: ansible_system in ('FreeBSD', 'Linux')
   register: dest_stat
 
@@ -69,8 +69,8 @@
 # The opts type of bind mount only works on Linux
 - name: Bind mount a filesystem (Linux)
   mount:
-    src: "{{ outputdir }}/mount_source"
-    name: "{{ outputdir }}/mount_dest"
+    src: "{{ output_dir }}/mount_source"
+    name: "{{ output_dir }}/mount_dest"
     state: "mounted"
     fstype: "None"
     opts: "bind"
@@ -80,8 +80,8 @@
 # Nullfs is freebsd only
 - name: Bind mount a filesystem (FreeBSD)
   mount:
-    src: "{{ outputdir }}/mount_source"
-    name: "{{ outputdir }}/mount_dest"
+    src: "{{ output_dir }}/mount_source"
+    name: "{{ output_dir }}/mount_dest"
     state: "mounted"
     fstype: "nullfs"
   when: ansible_system == 'FreeBSD'
@@ -96,8 +96,8 @@
 # The opts type of bind mount only works on Linux
 - name: Remount filesystem with different opts (Linux)
   mount:
-    src: "{{ outputdir }}/mount_source"
-    name: "{{ outputdir }}/mount_dest"
+    src: "{{ output_dir }}/mount_source"
+    name: "{{ output_dir }}/mount_dest"
     state: "mounted"
     fstype: "None"
     opts: "bind,ro"
@@ -107,8 +107,8 @@
 # Nullfs is freebsd only
 - name: Remount filesystem with different opts (FreeBSD)
   mount:
-    src: "{{ outputdir }}/mount_source"
-    name: "{{ outputdir }}/mount_dest"
+    src: "{{ output_dir }}/mount_source"
+    name: "{{ output_dir }}/mount_dest"
     state: "mounted"
     fstype: "nullfs"
     opts: "ro"
@@ -131,14 +131,14 @@
 
 - name: Unmount the bind mount
   mount:
-    name: "{{ outputdir }}/mount_dest"
+    name: "{{ output_dir }}/mount_dest"
     state: "absent"
   when: ansible_system in ('Linux', 'FreeBSD')
   register: unmount_result
 
 - name: Make sure the file no longer exists in dest
   stat:
-    path: "{{ outputdir }}/mount_dest/test_file"
+    path: "{{ output_dir }}/mount_dest/test_file"
   when: ansible_system in ('FreeBSD', 'Linux')
   register: dest_stat
 


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

Integration Tests

##### ANSIBLE VERSION

```
ansible 2.3.0 (output_dir 1913807bee) last updated 2016/11/21 16:24:14 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 5c986306be) last updated 2016/11/21 15:50:52 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 9511de1e3d) last updated 2016/11/18 13:10:36 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Use output_dir instead of outputdir for tests.