### PR TITLE
Get windows support to work with Python 3

### DIFF
--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -164,8 +164,8 @@ class ShellModule(object):
         return self._encode_script(script)
 
     def build_module_command(self, env_string, shebang, cmd, arg_path=None, rm_tmp=None):
-        cmd_parts = shlex.split(to_bytes(cmd), posix=False)
-        cmd_parts = map(to_text, cmd_parts)
+        cmd_parts = shlex.split(cmd, posix=False)
+        cmd_parts = list(map(to_text, cmd_parts))
         if shebang and shebang.lower() == '#!powershell':
             if not self._unquote(cmd_parts[0]).lower().endswith('.ps1'):
                 cmd_parts[0] = '"%s.ps1"' % self._unquote(cmd_parts[0])
@@ -249,7 +249,7 @@ class ShellModule(object):
         if strict_mode:
             script = u'Set-StrictMode -Version Latest\r\n%s' % script
         script = '\n'.join([x.strip() for x in script.splitlines() if x.strip()])
-        encoded_script = base64.b64encode(script.encode('utf-16-le'))
+        encoded_script = to_text(base64.b64encode(script.encode('utf-16-le')))
         cmd_parts = _common_args + ['-EncodedCommand', encoded_script]
         if as_list:
             return cmd_parts


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
winrm

##### ANSIBLE VERSION
```
ansible 2.3.0 (moriyoshi/python3-fix 3dc4aa2530) last updated 2016/11/22 11:00:53 (GMT +900)
  lib/ansible/modules/core: (detached HEAD 5c986306be) last updated 2016/11/22 08:12:39 (GMT +900)
  lib/ansible/modules/extras: (detached HEAD 9511de1e3d) last updated 2016/11/22 08:12:39 (GMT +900)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY

* This PR contains a number of fixes for the insufficient py3 support of winrm connector.
* As for the hunk containing `format_exc()`, this simply seems to be a bug.