### PR TITLE
Allow the extension ".ini" in inventory file names

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -205,7 +205,7 @@ DEFAULT_GATHER_SUBSET     = get_config(p, DEFAULTS, 'gather_subset', 'ANSIBLE_GA
 DEFAULT_GATHER_TIMEOUT    = get_config(p, DEFAULTS, 'gather_timeout', 'ANSIBLE_GATHER_TIMEOUT', 10, value_type='integer')
 DEFAULT_LOG_PATH          = get_config(p, DEFAULTS, 'log_path',           'ANSIBLE_LOG_PATH', '', value_type='path')
 DEFAULT_FORCE_HANDLERS    = get_config(p, DEFAULTS, 'force_handlers', 'ANSIBLE_FORCE_HANDLERS', False, value_type='boolean')
-DEFAULT_INVENTORY_IGNORE  = get_config(p, DEFAULTS, 'inventory_ignore_extensions', 'ANSIBLE_INVENTORY_IGNORE', ["~", ".orig", ".bak", ".ini", ".cfg", ".retry", ".pyc", ".pyo"], value_type='list')
+DEFAULT_INVENTORY_IGNORE  = get_config(p, DEFAULTS, 'inventory_ignore_extensions', 'ANSIBLE_INVENTORY_IGNORE', ["~", ".orig", ".bak", ".cfg", ".retry", ".pyc", ".pyo"], value_type='list')
 DEFAULT_VAR_COMPRESSION_LEVEL = get_config(p, DEFAULTS, 'var_compression_level', 'ANSIBLE_VAR_COMPRESSION_LEVEL', 0, value_type='integer')
 DEFAULT_INTERNAL_POLL_INTERVAL = get_config(p, DEFAULTS, 'internal_poll_interval', None, 0.001, value_type='float')
 ERROR_ON_MISSING_HANDLER  = get_config(p, DEFAULTS, 'error_on_missing_handler', 'ANSIBLE_ERROR_ON_MISSING_HANDLER', True, value_type='boolean')


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Global change (constants)

##### ANSIBLE VERSION
```
ansible 2.3.0 (inventory-ini-files a1c5cb55ce) last updated 2016/11/22 15:56:11 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 5c986306be) last updated 2016/11/22 15:58:33 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 9511de1e3d) last updated 2016/11/22 15:58:38 (GMT +200)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Since inventory files are "ini-like", allowing the corresponding extension makes it easier for users to edit them with their favourite software.

The extension ".ini" is currently blacklisted, can we allow it ?
If not, can you please explain the reason why ?