### PR TITLE
fix datacenter value in case where the datacenter is defined in the conf file

### DIFF
--- a/contrib/inventory/consul_io.py
+++ b/contrib/inventory/consul_io.py
@@ -265,6 +265,7 @@ class ConsulInventory(object):
 
   def load_data_for_datacenter(self, datacenter):
     '''processes all the nodes in a particular datacenter'''
+    self.current_dc = datacenter
     index, nodes = self.consul_api.catalog.nodes(dc=datacenter)
     for node in nodes:
       self.add_node_to_map(self.nodes_by_datacenter, datacenter, node)
@@ -273,7 +274,7 @@ class ConsulInventory(object):
   def load_data_for_node(self, node, datacenter):
     '''loads the data for a sinle node adding it to various groups based on
     metadata retrieved from the kv store and service availability'''
-
+    self.current_dc = datacenter
     index, node_data = self.consul_api.catalog.node(node, dc=datacenter)
     node = node_data['Node']
     self.add_node_to_map(self.nodes, 'all', node)


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
contrib/inventory/consul_io.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When datacenter is defined in the consul.ini conf file, kv groups are not retrieved for nodes, we should set self.current_dc with the right value to fix it

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
