### PR TITLE
Add a code-smell test for iterkeys

### DIFF
--- a/test/sanity/code-smell/no-iterkeys.sh
+++ b/test/sanity/code-smell/no-iterkeys.sh
@@ -1,17 +1,18 @@
 #!/bin/sh
 
-ITERKEYS_USERS=$(grep -r iterkeys . \
+ITERKEYS_USERS=$(grep -r -I iterkeys . \
     --exclude-dir .git \
     --exclude-dir .tox \
     --exclude-dir docsite \
     | grep -v \
     -e lib/ansible/compat/six/_six.py \
     -e lib/ansible/module_utils/six.py \
-    -e no-iterkeys.sh \
+    -e test/sanity/code-smell/no-iterkeys.sh \
     -e '^[^:]*:#'
     )
 
 if [ "${ITERKEYS_USERS}" ]; then
+    echo 'iterkeys has been removed in python3.  Use "for KEY in DICT:" instead'
     echo "${ITERKEYS_USERS}"
     exit 1
 fi

--- a/test/sanity/code-smell/no-iterkeys.sh
+++ b/test/sanity/code-smell/no-iterkeys.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+ITERKEYS_USERS=$(grep -r iterkeys . \
+    --exclude-dir .git \
+    --exclude-dir .tox \
+    --exclude-dir docsite \
+    | grep -v \
+    -e lib/ansible/compat/six/_six.py \
+    -e lib/ansible/module_utils/six.py \
+    -e no-iterkeys.sh \
+    -e '^[^:]*:#'
+    )
+
+if [ "${ITERKEYS_USERS}" ]; then
+    echo "${ITERKEYS_USERS}"
+    exit 1
+fi


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
tests/sanity/code-smell/no-iterkeys.sh

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

##### SUMMARY
code-smell test to look for iterkeys().  (Calls to iterkeys should all be replaced with something else to work on python3)
