### PR TITLE
Support script interpreters for async_wrapper.

### DIFF
--- a/lib/ansible/plugins/action/async.py
+++ b/lib/ansible/plugins/action/async.py
@@ -92,7 +92,7 @@ class ActionModule(ActionBase):
         # call the interpreter for async_wrapper directly
         # this permits use of a script for an interpreter on non-Linux platforms
         # TODO: re-implement async_wrapper as a regular module to avoid this special case
-        interpreter = shebang.replace('#!', '')
+        interpreter = shebang.replace('#!', '').strip()
         async_cmd = [interpreter, remote_async_module_path, async_jid, async_limit, remote_module_path]
 
         if env_string:

--- a/lib/ansible/plugins/action/async.py
+++ b/lib/ansible/plugins/action/async.py
@@ -89,7 +89,14 @@ class ActionModule(ActionBase):
         async_limit = self._task.async
         async_jid   = str(random.randint(0, 999999999999))
 
-        async_cmd = [env_string, remote_async_module_path, async_jid, async_limit, remote_module_path]
+        # call the interpreter for async_wrapper directly
+        # this permits use of a script for an interpreter on non-Linux platforms
+        interpreter = shebang.replace('#!', '')
+        async_cmd = [interpreter, remote_async_module_path, async_jid, async_limit, remote_module_path]
+
+        if env_string:
+            async_cmd.insert(0, env_string)
+
         if argsfile:
             async_cmd.append(argsfile)
         else:

--- a/lib/ansible/plugins/action/async.py
+++ b/lib/ansible/plugins/action/async.py
@@ -91,6 +91,7 @@ class ActionModule(ActionBase):
 
         # call the interpreter for async_wrapper directly
         # this permits use of a script for an interpreter on non-Linux platforms
+        # TODO: re-implement async_wrapper as a regular module to avoid this special case
         interpreter = shebang.replace('#!', '')
         async_cmd = [interpreter, remote_async_module_path, async_jid, async_limit, remote_module_path]
 


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

async_wrapper

##### ANSIBLE VERSION

```
ansible 2.3.0 (async-interpreter 80b5c0c14a) last updated 2016/11/22 14:44:58 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 5c986306be) last updated 2016/11/21 15:50:52 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 9511de1e3d) last updated 2016/11/18 13:10:36 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Support script interpreters for async_wrapper.

By calling the interpreter (extracted from the shebang) directly, a script can be used for the interpreter on non-Linux platforms, which typically require the interpreter to be a binary.