### PR TITLE
Fix AST nodes for Python 3 and enable dependent test_uri

### DIFF
--- a/lib/ansible/template/safe_eval.py
+++ b/lib/ansible/template/safe_eval.py
@@ -69,6 +69,7 @@ def safe_eval(expr, locals={}, include_exceptions=False):
             ast.Name,
             ast.Str,
             ast.Sub,
+            ast.USub,
             ast.Tuple,
             ast.UnaryOp,
         )

--- a/test/utils/shippable/python3-test-tag-blacklist.txt
+++ b/test/utils/shippable/python3-test-tag-blacklist.txt
@@ -1,3 +1,2 @@
 test_hg
 test_service
-test_uri


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
function `safe_eval`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
$ ansible --version
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
I met this issue when I tried to run `test_uri` under Python 3. In this test, there are some JSON files downloaded through HTTP (with `uri` module) and some local JSON files and at the end of test this two groups of files are compared to each other to check if downloaded files are the same.
The problem isn't in the task where the result of `uri` module is registered as a variable but in the task, where this registered variable with results is used to check. When this registered variable is used in the task for final check, function `safe_eval` is not capable of evaluating it from YAML template.
Problem is that under Python 2 `safe_eval` returns dictionary, but under Python 3 it returns a string because there is `invalid expression` exception inside the function.

This simple change fixes this problem under Python 3. However, this change is in the core part of the code so it should be reviewed.

Related PR with discussion and more details: https://github.com/ansible/ansible/pull/18060