### PR TITLE
adds config option to auto add keys when using paramiko

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -306,7 +306,9 @@ ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', '
 ANSIBLE_SSH_RETRIES            = get_config(p, 'ssh_connection', 'retries', 'ANSIBLE_SSH_RETRIES', 0, value_type='integer')
 ANSIBLE_SSH_EXECUTABLE         = get_config(p, 'ssh_connection', 'ssh_executable', 'ANSIBLE_SSH_EXECUTABLE', 'ssh')
 PARAMIKO_RECORD_HOST_KEYS      = get_config(p, 'paramiko_connection', 'record_host_keys', 'ANSIBLE_PARAMIKO_RECORD_HOST_KEYS', True, value_type='boolean')
+PARAMIKO_HOST_KEY_AUTO_ADD     = get_config(p, 'paramiko_connection', 'host_key_auto_add', 'ANSIBLE_PARAMIKO_HOST_KEY_AUTO_ADD', False, value_type='boolean')
 PARAMIKO_PROXY_COMMAND         = get_config(p, 'paramiko_connection', 'proxy_command', 'ANSIBLE_PARAMIKO_PROXY_COMMAND', None)
+PARAMIKO_LOOK_FOR_KEYS         = get_config(p, 'paramiko_connection', 'look_for_keys', 'ANSIBLE_PARAMIKO_LOOK_FOR_KEYS', True, value_type='boolean')
 PERSISTENT_CONNECT_TIMEOUT     = get_config(p, 'persistent_connection', 'connect_timeout', 'ANSIBLE_PERSISTENT_CONNECT_TIMEOUT', 30, value_type='integer')
 
 # obsolete -- will be formally removed

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -89,7 +89,10 @@ class MyAddPolicy(object):
 
     def missing_host_key(self, client, hostname, key):
 
-        if C.HOST_KEY_CHECKING:
+        if all((C.HOST_KEY_CHECKING, not C.PARAMIKO_HOST_KEY_AUTO_ADD)):
+
+            if C.USE_PERSISTENT_CONNECTIONS:
+                raise AnsibleConnectionFailure('rejected %s host key for host %s: %s' % (key.get_name(), hostname, hexlify(key.get_fingerprint())))
 
             self.connection.connection_lock()
 
@@ -227,7 +230,7 @@ class Connection(ConnectionBase):
                 self._play_context.remote_addr,
                 username=self._play_context.remote_user,
                 allow_agent=allow_agent,
-                look_for_keys=True,
+                look_for_keys=C.PARAMIKO_LOOK_FOR_KEYS,
                 key_filename=key_filename,
                 password=self._play_context.password,
                 timeout=self._play_context.timeout,


### PR DESCRIPTION
* updates paramiko_ssh to auto add keys
* updates constants with new config options

This commit adds a new feature that will allow paramiko to automatically
accept and save a host ssh key.  This feature is controlled by the
`host_key_auto_add` config setting in the paramiko section.  The default
is False to maintain current functionality.  It also includes a new
setting `look_for_keys` with the default to False for maintaining current the
current setting.