### PR TITLE
Make ansible-pull integration tests more robust.

### DIFF
--- a/test/integration/targets/pull_limit_inventory/runme.sh
+++ b/test/integration/targets/pull_limit_inventory/runme.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
 set -eux
+set -o pipefail
 
 # http://unix.stackexchange.com/questions/30091/fix-or-alternative-for-mktemp-in-os-x
 MYTMPDIR=$(shell mktemp -d 2>/dev/null || mktemp -d -t 'ansible-testing-XXXXXXXXXX')
 trap 'rm -rf "${MYTMPDIR}"' EXIT
 
 # test for https://github.com/ansible/ansible/issues/13688
-ansible-pull -d "${MYTMPDIR}" -U https://github.com/ansible-test-robinro/pull-integration-test "$@"
+ANSIBLE_CONFIG='' ansible-pull -d "${MYTMPDIR}" -U https://github.com/ansible-test-robinro/pull-integration-test "$@"

--- a/test/integration/targets/pull_no_127/runme.sh
+++ b/test/integration/targets/pull_no_127/runme.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
 set -eux
+set -o pipefail
 
 # http://unix.stackexchange.com/questions/30091/fix-or-alternative-for-mktemp-in-os-x
 MYTMPDIR=$(shell mktemp -d 2>/dev/null || mktemp -d -t 'ansible-testing-XXXXXXXXXX')
 trap 'rm -rf "${MYTMPDIR}"' EXIT
 
 # test for https://github.com/ansible/ansible/issues/13681
-ansible-pull -d "${MYTMPDIR}" -U https://github.com/ansible-test-robinro/pull-integration-test "$@" \
+ANSIBLE_CONFIG='' ansible-pull -d "${MYTMPDIR}" -U https://github.com/ansible-test-robinro/pull-integration-test "$@" \
     | grep -v '127\.0\.0\.1'

--- a/test/integration/targets/pull_run/runme.sh
+++ b/test/integration/targets/pull_run/runme.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
 set -eux
+set -o pipefail
 
 # http://unix.stackexchange.com/questions/30091/fix-or-alternative-for-mktemp-in-os-x
 MYTMPDIR=$(shell mktemp -d 2>/dev/null || mktemp -d -t 'ansible-testing-XXXXXXXXXX')
 trap 'rm -rf "${MYTMPDIR}"' EXIT
 
-ansible-pull -d "${MYTMPDIR}" -U https://github.com/ansible-test-robinro/pull-integration-test "$@" \
+ANSIBLE_CONFIG='' ansible-pull -d "${MYTMPDIR}" -U https://github.com/ansible-test-robinro/pull-integration-test "$@" \
     | grep MAGICKEYWORD


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Integration Tests

##### ANSIBLE VERSION

```
ansible 2.3.0 (pull-tests 7e1824f5c7) last updated 2016/11/23 16:49:33 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 5c986306be) last updated 2016/11/23 16:48:42 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 9511de1e3d) last updated 2016/11/23 16:48:42 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Make ansible-pull integration tests more robust.