### PR TITLE
Add param method to oVirt helper module

### DIFF
--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -327,6 +327,12 @@ class BaseModule(object):
         """
         pass
 
+    def param(self, name, default=None):
+        """
+        Return a module parameter specified by it's name.
+        """
+        return self._module.params.get(name, default)
+
     def update_check(self, entity):
         """
         This method handle checks whether the entity values are same as values


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
lib/ansible/module_utils/ovirt.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This patch add new param method to fetch parameters
from the Ansible module, so modules don't have to use
the long name `self._module.params.get()`.