### PR TITLE
fix docker container with empty name

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -342,7 +342,7 @@ class AnsibleDockerClient(Client):
         try:
             for container in self.containers(all=True):
                 self.log("testing container: %s" % (container['Names']))
-                if search_name in container['Names']:
+                if container['Names'] is not None and search_name in container['Names']:
                     result = container
                     break
                 if container['Id'].startswith(name):


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
module_utils.docker_common

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fix docker container with empty name
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
fatal: [****]: FAILED! => {"changed": false, "failed": true, "msg": "Error retrieving container list: argument of type 'NoneType' is not iterable"}
```

