### PR TITLE
Fix ssh plugin to correctly fetch files when using scp

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -628,7 +628,10 @@ class Connection(ConnectionBase):
                 cmd = self._build_command('sftp', to_bytes(host))
                 in_data = u"{0} {1} {2}\n".format(sftp_action, shlex_quote(in_path), shlex_quote(out_path))
             elif method == 'scp':
-                cmd = self._build_command('scp', in_path, u'{0}:{1}'.format(host, shlex_quote(out_path)))
+                if sftp_action == 'get':
+                    cmd = self._build_command('scp', u'{0}:{1}'.format(host, shlex_quote(out_path)), in_path)
+                else:
+                    cmd = self._build_command('scp', in_path, u'{0}:{1}'.format(host, shlex_quote(out_path)))
                 in_data = None
 
             in_data = to_bytes(in_data, nonstring='passthru')


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
plugins/connection/ssh.py

##### ANSIBLE VERSION
```
$ ansible --version
ansible 2.3.0 (issue/18603 b8e402b277) last updated 2016/11/24 16:45:39 (GMT +000)
  lib/ansible/modules/core: (detached HEAD 351dd9344e) last updated 2016/11/24 15:14:38 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 43bb97bc37) last updated 2016/11/24 15:14:59 (GMT +000)
  config file = /home/ubuntu/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Fix ssh plugin to correctly fetch files when using scp

Fetch module uses fetch_file() from plugin/connection/ssh.py to
retrieve files from the remote hosts which in turns uses
_file_transport_command(self, in_path, out_path, sftp_action) being
sftp_action = 'get'

When using scp rather than sftp, sftp_action variable is not used
and the scp command is formed in a way that the file is always
sent to the remote machine

This patch fixes _file_transport_command() to correctly form the scp
swaping src and dest if sftp_action is 'get'

Bug introduced at 8e47b9b
Fixes #18603

Signed-off-by: Alberto Murillo Silva <alberto.murillo.silva@intel.com>