### PR TITLE
Fix #18615 Add netconf session timeout for JUNOS

### DIFF
--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -115,6 +115,10 @@ class Netconf(object):
             exc = get_exception()
             self.raise_exc('unable to connect to %s: %s' % (host, str(exc)))
 
+        timeout = params.get('netconf_timeout', 0)
+        if timeout > 0:
+            self.device.timeout = timeout
+
         self.config = Config(self.device)
         self._connected = True
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
junos

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel 461286f914)
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
Set netconf session timeout value if 'netconf_timeout' value is mentioned in 
junos playbook
```

