### PR TITLE
WIP: Add Get-SIDFromAccountName to powershell utils

### DIFF
--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -247,3 +247,13 @@ Function Get-PendingRebootStatus
     }
 
 }
+
+Function Get-SIDFromAccountName($accountName)
+{
+    # Helper function to get the SID of an account.
+    # $accountName can be either
+    # - a User Principal Name, on the form user@domain, or
+    # - an account with domain, on the form domain\user
+    $objUser = New-Object System.Security.Principal.NTAccount($accountName)
+    return $objUser.Translate([System.Security.Principal.SecurityIdentifier]).Value
+}


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (detached HEAD 43714f859a) last updated 2016/11/25 14:43:56 (GMT +200)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras:  not found - use git submodule update --init lib/ansible/modules/extras
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Part of fixing ansible/ansible-modules-extras#2933
Add a function that's used in three windows modules for getting the user SID from an account. Proposed by @jhawkesworth as part of pull request ansible/ansible-modules-extras#3546
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
ansible 2.3.0 (devel e87275ee4b) last updated 2016/11/25 14:24:30 (GMT +200)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras:  not found - use git submodule update --init lib/ansible/modules/extras
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

