### PR TITLE
Fix unreferenced variable error

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2086,12 +2086,13 @@ class AnsibleModule(object):
                         try:
                             os.rename(b_tmp_dest_name, b_dest)
                         except (shutil.Error, OSError, IOError):
+                            exception = get_exception()
                             if unsafe_writes:
-                                self._unsafe_writes(b_tmp_dest_name, b_dest, get_exception())
+                                self._unsafe_writes(b_tmp_dest_name, b_dest, exception)
                             else:
                                 self.fail_json(msg='Could not replace file: %s to %s: %s' % (src, dest, exception))
                     except (shutil.Error, OSError, IOError):
-                        self.fail_json(msg='Could not replace file: %s to %s: %s' % (src, dest, exception))
+                        self.fail_json(msg='Could not replace file: %s to %s: %s' % (src, dest, get_exception()))
                 finally:
                     self.cleanup(b_tmp_dest_name)
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
module_utils/basic.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (unreferenced-variable 0dfc91cb27) last updated 2016/11/25 17:10:25 (GMT -400)
  lib/ansible/modules/core: (devel dedfe2becf) last updated 2016/11/24 17:12:53 (GMT -400)
  lib/ansible/modules/extras: (devel 9511de1e3d) last updated 2016/11/18 19:36:23 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This fixes [core modules issue 5616](https://github.com/ansible/ansible-modules-core/issues/5616) by making sure exception variables are assigned before being referenced.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: UnboundLocalError: local variable 'exception' referenced before assignment
localhost | FAILED! => {
    "changed": false, 
    "checksum": "70a71261e149044792ef942c9b4984d261e1458d", 
    "failed": true, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_w9jFWg/ansible_module_copy.py\", line 389, in <module>\n    main()\n  File \"/tmp/ansible_w9jFWg/ansible_module_copy.py\", line 368, in main\n    module.atomic_move(b_mysrc, dest, unsafe_writes=module.params['unsafe_writes'])\n  File \"/tmp/ansible_w9jFWg/ansible_modlib.zip/ansible/module_utils/basic.py\", line 2095, in atomic_move\nUnboundLocalError: local variable 'exception' referenced before assignment\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE"
}
```
After:
```
localhost | FAILED! => {
    "changed": false, 
    "checksum": "70a71261e149044792ef942c9b4984d261e1458d", 
    "failed": true, 
    "msg": "Could not replace file: /home/rcutmore/.ansible/tmp/ansible-tmp-1480110919.95-253676832626374/source to /mnt/remote-fs/test.txt: [Errno 13] Permission denied: '/mnt/remote-fs/.ansible_tmpGML3ZNtest.txt'"
}
```