### PR TITLE
fixes timeout param in netconf provider for junos

### DIFF
--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -111,6 +111,7 @@ class Netconf(object):
         try:
             self.device = Device(host, **kwargs)
             self.device.open()
+            self.device.timeout = params['timeout']
         except ConnectError:
             exc = get_exception()
             self.raise_exc('unable to connect to %s: %s' % (host, str(exc)))


### PR DESCRIPTION
This change will now cause the netconf provider to honor the module
timeout value when making calls to pyez.