### PR TITLE
docker_common - Add support for lookup image by Id

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -405,6 +405,15 @@ class AnsibleDockerClient(Client):
         '''
         try:
             response = self.images(name=name)
+            # check if user is trying to find an image by Id.
+            if not response:
+                images_list = self.images()
+                matched = []
+                for image in images_list:
+                    if name in image['Id']:
+                        matched = [image]
+                        break
+                return matched
         except Exception as exc:
             self.fail("Error searching for image %s - %s" % (name, str(exc)))
         images = response


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
docker_common

##### ANSIBLE VERSION
devel

##### SUMMARY
Ansible does not allow addressing docker images by ID. But, docker supports the same.

I couldn't find a method in docker-py to lookup images by its ID. As a workaround, lets fetch the list of all images in the system and operate on it.

Fixes issue ( https://github.com/ansible/ansible-modules-core/issues/5731 )

### Before:

```
# ansible -m docker_container -a 'name=foo image=ad99ce1f7ccc0eebd6dcd0543ca9e8e28ca7ec571cc533a3aea8b6378a77aa97 command=true' localhost
localhost | FAILED! => {
    "changed": false,
    "failed": true,
    "msg": "Error pulling image ad99ce1f7ccc0eebd6dcd0543ca9e8e28ca7ec571cc533a3aea8b6378a77aa97:latest - 500 Server Error: Internal Server Error (\"Invalid repository name (ad99ce1f7ccc0eebd6dcd0543ca9e8e28ca7ec571cc533a3aea8b6378a77aa97), cannot specify 64-byte hexadecimal strings\")"
}
```

### After:

```
# ansible -m docker_container -a 'name=foo image=ad99ce1f7ccc0eebd6dcd0543ca9e8e28ca7ec571cc533a3aea8b6378a77aa97 command=true' localhost
localhost | SUCCESS => {
    "ansible_facts": {},
    "changed": true
}
```

