### PR TITLE
Add test for shell indent issue

### DIFF
--- a/test/integration/targets/command_shell/tasks/main.yml
+++ b/test/integration/targets/command_shell/tasks/main.yml
@@ -217,3 +217,21 @@
 
 - name: remove the previously created file
   file: path={{output_dir_test}}/afile.txt state=absent
+
+# Multiline indentation
+# See https://github.com/ansible/ansible-modules-core/issues/5607
+
+- name: execute multiline shell command using Python
+  shell: |
+    print('hello world')
+    print('goodbye world')
+  args:
+    executable: "{{ ansible_python.executable }}"
+  register: indentation_result
+
+- name: assert multiline Python command run without indentation issues
+  assert:
+    that:
+      - "indentation_result.rc == 0"
+      - "indentation_result.stderr == ''"
+      - "indentation_result.stdout == 'hello world\ngoodbye world'"


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
Shell
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel a757a77159) last updated 2016/11/27 13:24:31 (GMT -400)
  lib/ansible/modules/core: (devel e1e64c5aef) last updated 2016/11/26 12:09:06 (GMT -400)
  lib/ansible/modules/extras: (devel 9511de1e3d) last updated 2016/11/18 19:36:23 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adds test for shell indent fix [here](https://github.com/ansible/ansible-modules-core/pull/5745). Both pull requests should be merged together.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
