### PR TITLE
Default verify to None for OpenStack modules

### DIFF
--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -78,7 +78,7 @@ def openstack_full_argument_spec(**kwargs):
         auth=dict(default=None, type='dict', no_log=True),
         region_name=dict(default=None),
         availability_zone=dict(default=None),
-        verify=dict(default=True, type='bool', aliases=['validate_certs']),
+        verify=dict(default=None, aliases=['validate_certs']),
         cacert=dict(default=None),
         cert=dict(default=None),
         key=dict(default=None, no_log=True),


### PR DESCRIPTION
This will require a new release of os-client-config.

Fixes https://github.com/ansible/ansible-modules-core/issues/3981