### PR TITLE
Fix traceback in atomic_move

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2086,12 +2086,14 @@ class AnsibleModule(object):
                         try:
                             os.rename(b_tmp_dest_name, b_dest)
                         except (shutil.Error, OSError, IOError):
+                            e = get_exception()
                             if unsafe_writes:
-                                self._unsafe_writes(b_tmp_dest_name, b_dest, get_exception())
+                                self._unsafe_writes(b_tmp_dest_name, b_dest, e)
                             else:
-                                self.fail_json(msg='Could not replace file: %s to %s: %s' % (src, dest, exception))
+                                self.fail_json(msg='Could not replace file: %s to %s: %s' % (src, dest, e))
                     except (shutil.Error, OSError, IOError):
-                        self.fail_json(msg='Could not replace file: %s to %s: %s' % (src, dest, exception))
+                        e = get_exception()
+                        self.fail_json(msg='Could not replace file: %s to %s: %s' % (src, dest, e))
                 finally:
                     self.cleanup(b_tmp_dest_name)
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
lib/ansible/module_utils/basic.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (atomic_move_exception_18628 1add90a061) last updated 2016/11/28 10:33:03 (GMT -400)
  lib/ansible/modules/core: (detached HEAD dedfe2becf) last updated 2016/11/25 14:52:26 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 43bb97bc37) last updated 2016/11/23 13:08:28 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY

Commit 8b08a28c895666b9fc673e5bf26bd91b2be77fe6 removed a
call to get_exception() that was needed. Without it, the fail_json
references an undefined variable ('exception') and throws an exception.

Add the get_exception() back in where needed and update references.

Now the proper module failure is returned.

Fixes #18628


Example before result:
```
TASK [lineinfile : insert a comment line in /etc/hosts to reproduce https://github.com/ansible/ansible/issues/18628] ***
task path: /root/ansible/test/integration/targets/lineinfile/tasks/main.yml:34
Using module file /root/ansible/lib/ansible/modules/core/files/lineinfile.py
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo ~/.ansible/tmp/ansible-tmp-1480347036.06-12926820694603 `" && echo ansible-tmp-1480347036.06-12926820694603="` echo ~/.ansible/tmp/ansible-tmp-1480347036.06-12926820694603 `" ) && sleep 0'
<127.0.0.1> PUT /tmp/tmpC05Kb8 TO /root/.ansible/tmp/ansible-tmp-1480347036.06-12926820694603/lineinfile.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1480347036.06-12926820694603/ /root/.ansible/tmp/ansible-tmp-1480347036.06-12926820694603/lineinfile.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1480347036.06-12926820694603/lineinfile.py; rm -rf "/root/.ansible/tmp/ansible-tmp-1480347036.06-12926820694603/" > /dev/null 2>&1 && sleep 0'
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_Q_ccs2/ansible_module_lineinfile.py", line 460, in <module>
    main()
  File "/tmp/ansible_Q_ccs2/ansible_module_lineinfile.py", line 452, in main
    ins_aft, ins_bef, create, backup, backrefs)
  File "/tmp/ansible_Q_ccs2/ansible_module_lineinfile.py", line 333, in present
    write_changes(module, b_lines, dest)
  File "/tmp/ansible_Q_ccs2/ansible_module_lineinfile.py", line 210, in write_changes
    unsafe_writes=module.params['unsafe_writes'])
  File "/tmp/ansible_Q_ccs2/ansible_modlib.zip/ansible/module_utils/basic.py", line 2092, in atomic_move
NameError: global name 'exception' is not defined

fatal: [testhost]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "invocation": {
        "module_name": "lineinfile"
    }, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_Q_ccs2/ansible_module_lineinfile.py\", line 460, in <module>\n    main()\n  File \"/tmp/ansible_Q_ccs2/ansible_module_lineinfile.py\", line 452, in main\n    ins_aft, ins_bef, create, backup, backrefs)\n  File \"/tmp/ansible_Q_ccs2/ansible_module_lineinfile.py\", line 333, in present\n    write_changes(module, b_lines, dest)\n  File \"/tmp/ansible_Q_ccs2/ansible_module_lineinfile.py\", line 210, in write_changes\n    unsafe_writes=module.params['unsafe_writes'])\n  File \"/tmp/ansible_Q_ccs2/ansible_modlib.zip/ansible/module_utils/basic.py\", line 2092, in atomic_move\nNameError: global name 'exception' is not defined\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE"
}
```

Example AFTER:
```
TASK [lineinfile : insert a comment line in /etc/hosts to reproduce https://github.com/ansible/ansible/issues/18628] ***
task path: /root/ansible/test/integration/targets/lineinfile/tasks/main.yml:34
Using module file /root/ansible/lib/ansible/modules/core/files/lineinfile.py
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo ~/.ansible/tmp/ansible-tmp-1480347147.18-27772190341104 `" && echo ansible-tmp-1480347147.18-27772190341104="` echo ~/.ansible/tmp/ansible-tmp-1480347147.18-27772190341104 `" ) && sleep 0'
<127.0.0.1> PUT /tmp/tmpPrLHXs TO /root/.ansible/tmp/ansible-tmp-1480347147.18-27772190341104/lineinfile.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1480347147.18-27772190341104/ /root/.ansible/tmp/ansible-tmp-1480347147.18-27772190341104/lineinfile.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1480347147.18-27772190341104/lineinfile.py; rm -rf "/root/.ansible/tmp/ansible-tmp-1480347147.18-27772190341104/" > /dev/null 2>&1 && sleep 0'
fatal: [testhost]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "invocation": {
        "module_args": {
            "attributes": null, 
            "backrefs": false, 
            "backup": false, 
            "content": null, 
            "create": false, 
            "delimiter": null, 
            "dest": "/etc/hosts", 
            "directory_mode": null, 
            "follow": false, 
            "force": null, 
            "group": null, 
            "insertafter": null, 
            "insertbefore": null, 
            "line": "# just a test comment", 
            "mode": null, 
            "owner": null, 
            "regexp": null, 
            "remote_src": null, 
            "selevel": null, 
            "serole": null, 
            "setype": null, 
            "seuser": null, 
            "src": null, 
            "state": "present", 
            "unsafe_writes": null, 
            "validate": null
        }, 
        "module_name": "lineinfile"
    }, 
    "msg": "Could not replace file: /tmp/tmpf8PAjD to /etc/hosts: [Errno 16] Device or resource busy"
}
```