### PR TITLE
hashi_vault: Get token from env var or file

### DIFF
--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -54,7 +54,16 @@ class HashiVault:
             raise AnsibleError("Please pip install hvac to use this module")
 
         self.url = kwargs.get('url', ANSIBLE_HASHI_VAULT_ADDR)
-        self.token = kwargs.get('token')
+
+        self.token = kwargs.get('token', os.environ.get('VAULT_TOKEN', None))
+        if self.token is None and os.environ.get('HOME'):
+            token_filename = os.path.join(
+                os.environ.get('HOME'),
+                '.vault-token'
+            )
+            if os.path.exists(token_filename):
+                with open(token_filename) as token_file:
+                    self.token = token_file.read().strip()
         if self.token is None:
             raise AnsibleError("No Vault Token specified")
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
`hashi_vault` lookup plugin

##### ANSIBLE VERSION
```
ansible 2.1.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
This allows getting the Vault token from the `VAULT_TOKEN` env var or from the file `$HOME/.vault-token`, as both of these are understood by the Vault CLI and are a common place to put Vault tokens. This allows avoiding hard-coding a Vault token into playbooks or having to include lookups.

`HOME/.vault-token` is nice because a user can authenticate with the CLI using `vault auth` and then the token will be stored in `$HOME/.vault-token`. If we read this file, then we allow someone to do `vault auth` "out of band" to set up Vault access.
