### PR TITLE
Support external templates directory for role init

### DIFF
--- a/docs/man/man1/ansible-galaxy.1.asciidoc.in
+++ b/docs/man/man1/ansible-galaxy.1.asciidoc.in
@@ -121,6 +121,11 @@ Force overwriting an existing role.
 The path in which the skeleton role will be created.The default is the current 
 working directory.
 
+*-t* 'TEMPLATE_PATH', *--template-path=*'TEMPLATE_PATH'::
+
+The path to the directory containing templates for new role generation. Must
+have two subdirectories: container_enabled and default.
+
 *--offline*::
 
 Don't query the galaxy API when creating roles

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -87,6 +87,7 @@ class GalaxyCLI(CLI):
         elif self.action == "init":
             self.parser.set_usage("usage: %prog init [options] role_name")
             self.parser.add_option('-p', '--init-path', dest='init_path', default="./", help='The path in which the skeleton role will be created. The default is the current working directory.')
+            self.parser.add_option('-t', '--template-path', dest='template_path', default=None, help='The path to templates used for role creation.')
             self.parser.add_option('--container-enabled', dest='container_enabled', action='store_true', default=False,
                                    help='Initialize the skeleton role with default contents for a Container Enabled role.')
         elif self.action == "install":

--- a/lib/ansible/galaxy/__init__.py
+++ b/lib/ansible/galaxy/__init__.py
@@ -47,9 +47,11 @@ class Galaxy(object):
         self.roles =  {}
 
         # load data path for resource usage
+        template_path = getattr(self.options, 'template_path', [])
         this_dir, this_filename = os.path.split(__file__)
+        data_path =  template_path if template_path else os.path.join(this_dir, 'data')
         type_path = 'container_enabled' if getattr(self.options, 'container_enabled', False) else 'default'
-        self.DATA_PATH = os.path.join(this_dir, 'data', type_path)
+        self.DATA_PATH = os.path.join(data_path, type_path)
 
     @property
     def default_role_skeleton_path(self):


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ansible-galaxy cli

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (feature/role_templates 520a12f6f0) last updated 2016/11/28 19:31:06 (GMT +900)
```

##### SUMMARY
As a role developer I want to use custom role templates for each of my projects
and still use `ansible-galaxy init` for initial role skeleton generation. The
additional `-t` argument sets the path to search for such templates instead of
standard one. It may be useful in corporate environment where each team has it's
own role templates.

Usage example: 
```
ansible-galaxy init  -p ~/Project1/roles -t ~/Project1/role_templates role1
```
