### PR TITLE
Allow variables to be passed in to the template lookup plugin

### DIFF
--- a/docs/docsite/rst/playbooks_lookups.rst
+++ b/docs/docsite/rst/playbooks_lookups.rst
@@ -556,6 +556,9 @@ Here are some examples::
 
          - debug: msg="{{ lookup('template', './some_template.j2') }} is a value from evaluation of this template"
 
+         # Since 2.4, you can pass in variables during evaluation
+         - debug: msg="{{ lookup('template', './some_template.j2', template_vars=dict(x=42)) }} is evaluated with x=42"
+
          - name: loading a json file from a template as a string
            debug: msg="{{ lookup('template', './some_json.json.j2', convert_data=False) }} is a value from evaluation of this template"
 

--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -36,6 +36,7 @@ class LookupModule(LookupBase):
     def run(self, terms, variables, **kwargs):
 
         convert_data_p = kwargs.get('convert_data', True)
+        lookup_template_vars = kwargs.get('template_vars', {})
         ret = []
 
         for term in terms:
@@ -62,10 +63,14 @@ class LookupModule(LookupBase):
                         searchpath = [self._loader._basedir, os.path.dirname(lookupfile)]
                     self._templar.environment.loader.searchpath = searchpath
 
-                    # add ansible 'template' vars
-                    temp_vars = variables.copy()
-                    temp_vars.update(generate_ansible_template_vars(lookupfile))
-                    self._templar.set_available_variables(temp_vars)
+                    # The template will have access to all existing variables,
+                    # plus some added by ansible (e.g., template_{path,mtime}),
+                    # plus anything passed to the lookup with the template_vars=
+                    # argument.
+                    vars = variables.copy()
+                    vars.update(generate_ansible_template_vars(lookupfile))
+                    vars.update(lookup_template_vars)
+                    self._templar.set_available_variables(vars)
 
                     # do the templating
                     res = self._templar.template(template_data, preserve_trailing_newlines=True,


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
plugins/lookup/template.py

##### ANSIBLE VERSION
```
devel
```

##### SUMMARY

This allows template evaluation to be controlled with inline variable
definitions that augment whatever variables are defined already:

    {{ lookup('template','x.j2',set_variables=dict(x=42)) }}