### PR TITLE
Fixes #18663. Bad handling of existing config in dellos9 module.

### DIFF
--- a/lib/ansible/module_utils/dellos10.py
+++ b/lib/ansible/module_utils/dellos10.py
@@ -42,8 +42,9 @@ def get_config(module):
     if not contents:
         contents = module.config.get_config()
         module.params['config'] = contents
-
-    return NetworkConfig(indent=1, contents=contents[0])
+        return NetworkConfig(indent=1, contents=contents[0])
+    else:
+        return NetworkConfig(indent=1, contents=contents)
 
 
 def get_sublevel_config(running_config, module):
@@ -54,11 +55,13 @@ def get_sublevel_config(running_config, module):
         contents = obj.children
     contents[:0] = module.params['parents']
 
+    indent = 0
     for c in contents:
         if isinstance(c, str):
-            current_config_contents.append(c)
+            current_config_contents.append(c.rjust(len(c) + indent, ' '))
         if isinstance(c, ConfigLine):
             current_config_contents.append(c.raw)
+        indent = indent + 1
     sublevel_config = '\n'.join(current_config_contents)
 
     return sublevel_config

--- a/lib/ansible/module_utils/dellos9.py
+++ b/lib/ansible/module_utils/dellos9.py
@@ -42,8 +42,9 @@ def get_config(module):
     if not contents:
         contents = module.config.get_config()
         module.params['config'] = contents
-
-    return NetworkConfig(indent=1, contents=contents[0])
+        return NetworkConfig(indent=1, contents=contents[0])
+    else:
+        return NetworkConfig(indent=1, contents=contents)
 
 
 def get_sublevel_config(running_config, module):
@@ -54,11 +55,13 @@ def get_sublevel_config(running_config, module):
         contents = obj.children
     contents[:0] = module.params['parents']
 
+    indent = 0
     for c in contents:
         if isinstance(c, str):
-            current_config_contents.append(c)
+            current_config_contents.append(c.rjust(len(c) + indent, ' '))
         if isinstance(c, ConfigLine):
             current_config_contents.append(c.raw)
+        indent = indent + 1
     sublevel_config = '\n'.join(current_config_contents)
 
     return sublevel_config


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

ansible.module_utils.dellos9

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```
##### SUMMARY

Fixes #18663. Bad handling of existing config in dellos9 module.

The dellos9 util module doesn't build correctly the internal  structures used to represent the existing config of the managed network device. 

This leads to apply changes every time the  playbook is run, even if the existing config is the same that the one you are trying to push into the device.

Probably this problem exist also in the dellos6 and dellos10 modules, but I only fixed it in the dellos9 module.

The fix modifies two methods. The first one is `get_config`, where the return clause didn't work correctly when the flow doesn't enter in the `if` block. In that case the `contents` variable is not an array an this should be handled.

The second fix is in the `get_sublevel_config` method. In this case the indentation whitespaces of the parents should be rebuild because further functions and methods required it to handle correctly comparisons used to check if changes should be pushed into device.