### PR TITLE
Network dut

### DIFF
--- a/test/integration/group_vars/vyos.yaml
+++ b/test/integration/group_vars/vyos.yaml
@@ -1,6 +1,6 @@
 ---
 cli:
   host: "{{ ansible_ssh_host }}"
-  username: vyos
-  password: vyos
+  username: "{{ vyos_cli_user | default('ansible-admin') }}"
+  password: "{{ vyos_cli_pass | default('adminpw') }}"
   transport: cli

--- a/test/integration/inventory.network
+++ b/test/integration/inventory.network
@@ -23,8 +23,7 @@ vsrx01
 clvx01
 
 [vyos]
-#vyos-dut-01
-vyos01
+vyos-dut-01
 
 [ops]
 ops01


### PR DESCRIPTION
Use dedicated password to avoid all instances of `vyos` being masked in the hostname when doing backups

This is an issue here as we are using `vyos-dut-01`, which has a separator in, where as the older `vyos01` does not