### PR TITLE
Fix overwrite parameter in module_utils.junos

### DIFF
--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -184,8 +184,8 @@ class Netconf(object):
             merge = False
             overwrite = False
         elif overwrite:
-            merge = True
-            overwrite = False
+            merge = False
+            overwrite = True
         else:
             merge = True
             overwrite = False


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
ansible.module_utils.junos

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The overwrite parameter is forcibly set to false, meaning a module
passing that parameter will have no effect.  The overwrite facility
is necessary to ensure that conflicting options can be written the
configuration (which, in replace mode, they cannot).

This change ensures that if overwrite is set, it will not be changed
to False in the logic.

At the moment this will have no effect, because it requires a change
to junos_config in order to take effect.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->