### PR TITLE
Fix fetching files with scp

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -629,7 +629,7 @@ class Connection(ConnectionBase):
                 in_data = u"{0} {1} {2}\n".format(sftp_action, shlex_quote(in_path), shlex_quote(out_path))
             elif method == 'scp':
                 if sftp_action == 'get':
-                    cmd = self._build_command('scp', u'{0}:{1}'.format(host, shlex_quote(out_path)), in_path)
+                    cmd = self._build_command('scp', u'{0}:{1}'.format(host, shlex_quote(in_path)), out_path)
                 else:
                     cmd = self._build_command('scp', in_path, u'{0}:{1}'.format(host, shlex_quote(out_path)))
                 in_data = None


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
plugins/connection/ssh.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
$ ansible --version
ansible 2.3.0 (devel 9b1ce5dfb9) last updated 2016/11/29 20:42:48 (GMT +000)
  lib/ansible/modules/core: (detached HEAD 30fb384e7f) last updated 2016/11/29 20:43:05 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 670ae951dc) last updated 2016/11/29 20:43:06 (GMT +000)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY

Commit ec2521f6af6730c34e01f3162f0af89c5625dcae intended to fix the
scp command to fetch files from a remote machine but it has src and
dest swapped.

This change correctly treats src as the location in the remote machine
and dest as the location in the local machine.

Signed-off-by: Alberto Murillo Silva <alberto.murillo.silva@intel.com>