### PR TITLE
with_sequence: pass AnsibleError through

### DIFF
--- a/lib/ansible/plugins/lookup/sequence.py
+++ b/lib/ansible/plugins/lookup/sequence.py
@@ -187,6 +187,8 @@ class LookupModule(LookupBase):
                 try:
                     if not self.parse_simple_args(term):
                         self.parse_kv_args(parse_kv(term))
+                except AnsibleError:
+                    raise
                 except Exception as e:
                     raise AnsibleError("unknown error parsing with_sequence arguments: %r. Error was: %s" % (term, e))
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
with_sequence

##### ANSIBLE VERSION
```
ansible 1.7.2
```

##### SUMMARY

The parsing methods try as hard as possible to generate meaningful error messages that are all ignored and immediately overwritten by a new AnsibleError instance. Better use the original one instead.