### PR TITLE
Handle tuples in `hash_params` when creating a role

### DIFF
--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -52,7 +52,7 @@ def hash_params(params):
         for k,v in iteritems(params):
             if isinstance(v, dict):
                 s.update((k, hash_params(v)))
-            elif isinstance(v, list):
+            elif isinstance(v, (list, set, tuple)):
                 things = []
                 for item in v:
                     things.append(hash_params(item))


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
include_role module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
```

##### SUMMARY
When using `with_subelements` with `include_role`, the `item` variable is a tuple containing at least one dict. This cannot be inserted into the role's set of hashed params without being passed through `hash_params` itself.

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
- hosts: localhost
  tasks:
    - include_role: name=test
      with_subelements:
        - - name: foo
            values: ['bar']
        - values
```

Before
```
TASK [include_role] ************************************************************
ERROR! Unexpected Exception: unhashable type: 'dict'
```

After
```
TASK [include_role] ************************************************************

TASK [test : debug] ************************************************************
ok: [localhost] => {
    "item": [
        {
            "name": "foo"
        }, 
        "bar"
    ]
}
```

Fixes #18680