### PR TITLE
vyos: Don't run show commands that are over ANSIBLE_VYOS_TERMINAL_LENGTH

### DIFF
--- a/test/integration/targets/vyos_command/tests/cli/output.yaml
+++ b/test/integration/targets/vyos_command/tests/cli/output.yaml
@@ -30,12 +30,12 @@
 - name: Get output for multiple commands that call less explicitly
   vyos_command:
     commands:
+        # NOTE: We only test show commands that will output <ANSIBLE_VYOS_TERMINAL_LENGTH
+        # Otherwise you will get ": "timeout trying to send command: show log authorization"
       - show hardware cpu detail
       - show hardware mem
       - show license
       - show log
-      - show log all
-      - show log authorization
       - show system boot-messages
     provider: "{{ cli }}"
   register: result


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```

