### PR TITLE
Fix compile skip path handling for targeted tests.

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -562,7 +562,7 @@ def command_compile(args):
         if skip_paths:
             cmd += ['-x', '|'.join(skip_paths)]
 
-        cmd += [target.path for target in include]
+        cmd += [target.path if target.path == '.' else './%s' % target.path for target in include]
 
         version_commands.append((version, cmd))
 


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (ansible-test-fix e0e3818dbb) last updated 2016/11/30 09:04:54 (GMT -700)
  lib/ansible/modules/core: (detached HEAD 6890003c4f) last updated 2016/11/29 14:31:21 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 20ea46642b) last updated 2016/11/29 14:31:21 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Fix compile skip path handling for targeted tests.