### PR TITLE
tell subprocess.popen to use universal_newlines

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -624,7 +624,7 @@ class CLI(with_metaclass(ABCMeta, object)):
         if loader.is_executable(this_path):
             try:
                 # STDERR not captured to make it easier for users to prompt for input in their scripts
-                p = subprocess.Popen(this_path, stdout=subprocess.PIPE)
+                p = subprocess.Popen(this_path, stdout=subprocess.PIPE, universal_newlines=True)
             except OSError as e:
                 raise AnsibleError("Problem running vault password script %s (%s). If this is not a script, remove the executable bit from the file." % (' '.join(this_path), e))
             stdout, stderr = p.communicate()


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Ansible CLI vaultpass handling

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = /opt/app/ansible.cfg
  configured module search path = ['./library']
```

##### SUMMARY
Fixes ##18684. Very straightforward unless I missed something- universal_newlines ensures that the CLI won't barf on byte/string issues.
