### PR TITLE
use log attribute %(process)d instead of os.getpid

### DIFF
--- a/test/runner/injector/injector.py
+++ b/test/runner/injector/injector.py
@@ -15,7 +15,7 @@ logger = logging.getLogger('injector')  # pylint: disable=locally-disabled, inva
 
 def main():
     """Main entry point."""
-    formatter = logging.Formatter('%(asctime)s ' + str(os.getpid()) + ' %(levelname)s %(message)s')
+    formatter = logging.Formatter('%(asctime)s %(process)d %(levelname)s %(message)s')
     log_name = 'ansible-test-coverage.%s.log' % getpass.getuser()
     self_dir = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
ansible-test
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (runner_util_ssh_auth_sock 11459cb10f) last updated 2016/11/30 18:07:18 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 6890003c4f) last updated 2016/11/30 11:31:44 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 20ea46642b) last updated 2016/11/30 11:31:44 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides


```

##### SUMMARY
use log attribute %(process)d instead of os.getpid in ansible-test logging
