### PR TITLE
Add SSH_AUTH_SOCK to default env

### DIFF
--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -189,6 +189,7 @@ def common_environment():
 
     optional = (
         'HTTPTESTER',
+        'SSH_AUTH_SOCK'
     )
 
     env.update(pass_vars(required=required, optional=optional))


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
ansible-test

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (runner_util_ssh_auth_sock 11459cb10f) last updated 2016/11/30 18:07:18 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 6890003c4f) last updated 2016/11/30 11:31:44 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 20ea46642b) last updated 2016/11/30 11:31:44 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides


```

##### SUMMARY
add SSH_AUTH_SOCK to default inherited env.

@mattclay mentioned doing this via a more generic method which would be even better