### PR TITLE
Fix bug 17934 : Azure register failure must not be blocking

### DIFF
--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -362,7 +362,10 @@ class AzureRM(object):
             resource_client = self.rm_client
             resource_client.providers.register(key)
         except Exception as exc:
-            self.fail("One-time registration of {0} failed - {1}".format(key, str(exc)))
+            self.log("One-time registration of {0} failed - {1}".format(key, str(exc)))
+            self.log("You might need to register {0} using an admin account".format(key))
+            self.log(("To register a provider using the Python CLI: "
+                      "https://docs.microsoft.com/cli/azure/provider#register"))
 
     @property
     def network_client(self):

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -365,7 +365,8 @@ class AzureRM(object):
             self.log("One-time registration of {0} failed - {1}".format(key, str(exc)))
             self.log("You might need to register {0} using an admin account".format(key))
             self.log(("To register a provider using the Python CLI: "
-                      "https://docs.microsoft.com/cli/azure/provider#register"))
+                      "https://docs.microsoft.com/azure/azure-resource-manager/"
+                      "resource-manager-common-deployment-errors#noregisteredproviderfound"))
 
     @property
     def network_client(self):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`contrib/inventory/azure_rm.py`

##### ANSIBLE VERSION
```
ansible 2.1.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Fix issue #17934 

Failing to register a provider in ARM must not be blocking for the plugin. Especially, in this issue the credentials do not have the necessary RBAC to add a provider, but it's unnecessary since the Azure subscription already has it. Since we don't check enabled provided providers before trying to register it, we failed for no reason. Keep trying to register strategy is fine, but not blocking.

Use cases matrix:

|                                                                                | Before         | After                                     |
|--------------------------------------------------------------------------------|----------------|-------------------------------------------|
| Sub. has provider registered + Credentials has register RBAC                   | Ok             | Ok                                        |
| Sub. has provider registered + Credentials doesn't have register RBAC          | #17934         | Log a warning message                     |
| Sub. doesn't have provider registered + Credentials has register RBAC          | Ok             | Ok                                        |
| Sub. doesn't have provider registered + Credentials doesn't have register RBAC | Fail on config | Log a warning message + Fail on execution |

Note that the warning message includes a link to the Azure Python CLI to register the provider using an admin credentials.

@pipern + @squillace to test this with real case scenario