### PR TITLE
ssh-keyscan can fail to find keys for a host.

### DIFF
--- a/lib/ansible/module_utils/known_hosts.py
+++ b/lib/ansible/module_utils/known_hosts.py
@@ -187,6 +187,9 @@ def add_host_key(module, fqdn, key_type="rsa", create_dir=False):
     this_cmd = "%s -t %s %s" % (keyscan_cmd, key_type, fqdn)
 
     rc, out, err = module.run_command(this_cmd)
+    # ssh-keyscan gives a 0 exit code and prints nothins on timeout
+    if rc != 0 or not out:
+        module.fail_json(msg='failed to get the hostkey for %s' % fqdn)
     module.append_to_file(user_host_file, out)
 
     return rc, out, err


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/known_hosts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel, 2.2
```

##### SUMMARY

When it does, we need to fail otherwise other code will fail later.
This bug can cause the git module to hang indefinitely (because it's waiting for user input to add the host key since we did not properly set it here).

Fixes #18676

