### PR TITLE
Do not set docker rsync use to None.

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -354,7 +354,10 @@ class ActionModule(ActionBase):
         # If launching synchronize against docker container
         # use rsync_opts to support container to override rsh options
         if self._remote_transport in [ 'docker' ]:
-            self._task.args['rsync_opts'] = "--rsh='%s exec -u %s -i'" % (self._docker_cmd, user)
+            if user is not None:
+                self._task.args['rsync_opts'] = "--rsh='%s exec -u %s -i'" % (self._docker_cmd, user)
+            else:
+                self._task.args['rsync_opts'] = "--rsh='%s exec -i'" % (self._docker_cmd)
 
         # run the module and store the result
         result.update(self._execute_module('synchronize', task_vars=task_vars))


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
synchronize

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible-playbook 2.2.0.0
  config file = /home/ubuntu/hoist/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The user variable defaults to None, and was being passed in as a user
 named None. This was breaking rsync unless a specific user was set.

 Fixes #16306
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Before, without this patch, I would get:
<!-- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [nodepool : Copy elements] ************************************************
task path: /home/ubuntu/hoist/roles/nodepool/tasks/main.yml:94
Using module file /home/ubuntu/ansible/local/lib/python2.7/site-packages/ansible/modules/core/files/synchronize.py
<allinone> ESTABLISH LOCAL CONNECTION FOR USER: ubuntu
<allinone> EXEC /bin/sh -c '/home/ubuntu/ansible/bin/python2 && sleep 0'
fatal: [allinone]: FAILED! => {
    "changed": false,
    "cmd": "/usr/bin/rsync --delay-updates -F --compress --archive --rsh 'ssh  -S none -o StrictHostKeyChecking=no' --rsh='/usr/bin/docker exec -u None -i' --out-format='<<CHANGED>>%i %n%L' \"/home/ubuntu/hoist/roles/nodepool/files/etc/nodepool/elements/\" \"allinone:/etc/nodepool/elements/\"",
    "failed": true,
    "invocation": {
        "module_args": {
            "_local_rsync_path": "rsync",
            "_substitute_controller": false,
            "archive": true,
            "checksum": false,
            "compress": true,
            "copy_links": null,
            "delete": false,
            "dest": "allinone:/etc/nodepool/elements/",
            "dest_port": null,
            "dirs": false,
            "existing_only": false,
            "group": null,
            "links": null,
            "mode": "push",
            "owner": null,
            "partial": false,
            "perms": null,
            "private_key": null,
            "recursive": null,
            "rsync_opts": [
                "--rsh='/usr/bin/docker exec -u None -i'"
            ],
            "rsync_path": null,
            "rsync_timeout": 0,
            "set_remote_user": true,
            "src": "/home/ubuntu/hoist/roles/nodepool/files/etc/nodepool/elements/",
            "ssh_args": null,
            "times": null,
            "verify_host": false
        }
    },
    "msg": "protocol version mismatch -- is your shell clean?\n(see the rsync man page for an explanation)\nrsync error: protocol incompatibility (code 2) at compat.c(176) [sender=3.1.1]\nread unix @->/var/run/docker.sock: read: connection reset by peer\n",
    "rc": 2
}
```

After:
```
TASK [nodepool : Copy elements] ************************************************
task path: /home/ubuntu/hoist/roles/nodepool/tasks/main.yml:94
Using module file /home/ubuntu/ansible/local/lib/python2.7/site-packages/ansible/modules/core/files/synchronize.py
<allinone> ESTABLISH LOCAL CONNECTION FOR USER: ubuntu
<allinone> EXEC /bin/sh -c '/home/ubuntu/ansible/bin/python2 && sleep 0'
changed: [allinone] => {
    "changed": true,
    "cmd": "/usr/bin/rsync --delay-updates -F --compress --archive --rsh 'ssh  -S none -o StrictHostKeyChecking=no' --rsh='/usr/bin/docker exec -i' --out-format='<<CHANGED>>%i %n%L' \"/home/ubuntu/hoist/roles/nodepool/files/etc/nodepool/elements/\" \"allinone:/etc/nodepool/elements/\"",
    "invocation": {
        "module_args": {
            "_local_rsync_path": "rsync",
            "_substitute_controller": false,
            "archive": true,
            "checksum": false,
            "compress": true,
            "copy_links": null,
            "delete": false,
            "dest": "allinone:/etc/nodepool/elements/",
            "dest_port": null,
            "dirs": false,
            "existing_only": false,
            "group": null,
            "links": null,
            "mode": "push",
            "owner": null,
            "partial": false,
            "perms": null,
            "private_key": null,
            "recursive": null,
            "rsync_opts": [
                "--rsh='/usr/bin/docker exec -i'"
            ],
            "rsync_path": null,
            "rsync_timeout": 0,
            "set_remote_user": true,
            "src": "/home/ubuntu/hoist/roles/nodepool/files/etc/nodepool/elements/",
            "ssh_args": null,
            "times": null,
            "verify_host": false
        }
    },
    "msg": ".d..t...... ./\ncd+++++++++ bonnyci-nodepool/\n<f+++++++++ bonnyci-nodepool/README.rst\n<f+++++++++ bonnyci-nodepool/element-deps\ncd+++++++++ bonnyci-nodepool/finalise.d/\n<f+++++++++ bonnyci-nodepool/finalise.d/99-nodepool-dir\n",
    "rc": 0,
    "stdout_lines": [
        ".d..t...... ./",
        "cd+++++++++ bonnyci-nodepool/",
        "<f+++++++++ bonnyci-nodepool/README.rst",
        "<f+++++++++ bonnyci-nodepool/element-deps",
        "cd+++++++++ bonnyci-nodepool/finalise.d/",
        "<f+++++++++ bonnyci-nodepool/finalise.d/99-nodepool-dir"
    ]
}
```