### PR TITLE
Fix formatting, minor typo in tags docs

### DIFF
--- a/docsite/rst/playbooks_tags.rst
+++ b/docsite/rst/playbooks_tags.rst
@@ -32,12 +32,13 @@ On the other hand, if you want to run a playbook *without* certain tasks, you co
 
 .. _tag_reuse:
 
-Tag Resuse
+Tag Reuse
 ```````````````
 You can apply the same tag name to more than one task, in the same file 
 or included files. This will run all tasks with that tag.
 
 Example::
+
     ---
     # file: roles/common/tasks/main.yml
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
playbooks_tags

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Missing newline was breaking code block in tags example in docs