### PR TITLE
fix stray i in developing_modules.rst

### DIFF
--- a/docsite/rst/dev_guide/developing_modules.rst
+++ b/docsite/rst/dev_guide/developing_modules.rst
@@ -17,7 +17,7 @@ by :envvar:`ANSIBLE_LIBRARY` or the ``--module-path`` command line option.
 By default, everything that ships with Ansible is pulled from its source tree, but
 additional paths can be added.
 
-The directory i:file:`./library`, alongside your top level :term:`playbooks`, is also automatically
+The directory :file:`./library`, alongside your top level :term:`playbooks`, is also automatically
 added as a search directory.
 
 Should you develop an interesting Ansible module, consider sending a pull request to the


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docsite

##### ANSIBLE VERSION
```
ansible 2.3.0 (typos 7a687f5b55) last updated 2016/12/02 10:17:50 (GMT +200)
  lib/ansible/modules/core: (detached HEAD dedfe2becf) last updated 2016/11/28 11:06:40 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 8c87805c98) last updated 2016/11/30 11:27:57 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
there was a stray "i" in the docsite, i removed it :)