### PR TITLE
Galaxy CLI: warn only when not ANSIBLE_CONTAINER

### DIFF
--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -212,8 +212,8 @@ class GalaxyRole(object):
                 if not role_data:
                     raise AnsibleError("- sorry, %s was not found on %s." % (self.src, api.api_server))
 
-                if role_data.get('role_type') == 'CON':
-                    # Container Enabled
+                if role_data.get('role_type') == 'CON' and not os.environ.get('ANSIBLE_CONTAINER'):
+                    # Container Enabled, running outside of a container
                     display.warning("%s is a Container Enabled role and should only be installed using "
                                     "Ansible Container" % self.name)
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/galaxy/role.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel 2cf40af2b2) last updated 2016/12/02 09:44:27 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 6890003c4f) last updated 2016/11/30 21:21:09 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 20ea46642b) last updated 2016/11/30 21:21:09 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
When installing an container enabled role using the Galaxy client we throw a warning, because in general Ansible Container should be used to install the role type. However, inside a container Ansible Container invokes the client code to install the container enabled role, and at that point we  do not want to see the warning. So to that end, this change prevents the warning when ANSIBLE_CONTAINER is set.
