### PR TITLE
Only read EC2 `regions_exclude` list if necessary

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -10,8 +10,9 @@
 
 # AWS regions to make calls to. Set this to 'all' to make request to all regions
 # in AWS and merge the results together. Alternatively, set this to a comma
-# separated list of regions. E.g. 'us-east-1, us-west-1, us-west-2'
-# 'auto' is AWS_REGION or AWS_DEFAULT_REGION environment variable.
+# separated list of regions. E.g. 'us-east-1,us-west-1,us-west-2' and do not
+# provide the 'regions_exclude' option. If this is set to 'auto', AWS_REGION or
+# AWS_DEFAULT_REGION environment variable will be read to determine the region.
 regions = all
 regions_exclude = us-gov-west-1, cn-north-1
 

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -249,11 +249,11 @@ class Ec2Inventory(object):
         # Regions
         self.regions = []
         configRegions = config.get('ec2', 'regions')
-        configRegions_exclude = config.get('ec2', 'regions_exclude')
         if (configRegions == 'all'):
             if self.eucalyptus_host:
                 self.regions.append(boto.connect_euca(host=self.eucalyptus_host).region.name, **self.credentials)
             else:
+                configRegions_exclude = config.get('ec2', 'regions_exclude')
                 for regionInfo in ec2.regions():
                     if regionInfo.name not in configRegions_exclude:
                         self.regions.append(regionInfo.name)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
EC2 dynamic inventory

##### ANSIBLE VERSION
```
$ ansible --version
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
When specifying a literal whitelist of AWS EC2 regions in the dynamic
inventory configuration file, it should not be necessary to also include
a literal blacklist, especially as the blacklist is not honored in this
case anyway. By reading the literal blacklist only when necessary, it is
possible for a user to provide a more minimal EC2 configuration file.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>