### PR TITLE
Support json format in junos_command module

### DIFF
--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -138,6 +138,8 @@ class Netconf(object):
         for index, cmd in enumerate(commands):
             if cmd.output == 'xml':
                 responses[index] = xml_to_json(responses[index])
+            elif cmd.output == 'json':
+                pass
             elif cmd.args.get('command_type') == 'rpc':
                 responses[index] = str(responses[index].text).strip()
             elif 'RpcError' in responses[index]:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
junos_command

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible --version
ansible 2.3.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---

-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
Add support to retrieve output in 'json' format for junos_command module.
```
Related PR https://github.com/ansible/ansible/pull/19045
Fixes issue: https://github.com/ansible/ansible-modules-core/issues/4103


