### PR TITLE
vca_vapp module: allow vcd authentication token instead of user/password combination

### DIFF
--- a/lib/ansible/module_utils/vca.py
+++ b/lib/ansible/module_utils/vca.py
@@ -42,7 +42,7 @@ def vca_argument_spec():
     return dict(
         username=dict(type='str', aliases=['user'], required=False),
         password=dict(type='str', aliases=['pass', 'passwd'], required=False, no_log=True),
-        token=dict(type='str', required=False, no_log=False),
+        token=dict(type='str', required=False, no_log=True),
         org_url=dict(type='str', required=False),
         org=dict(),
         service_id=dict(),

--- a/lib/ansible/module_utils/vca.py
+++ b/lib/ansible/module_utils/vca.py
@@ -151,7 +151,7 @@ class VcaAnsibleModule(AnsibleModule):
             self.fail('Login to VCA failed', response=self.vca.response)
 
         if login_token:
-          self.vca.token = login_token
+            self.vca.token = login_token
 
         try:
             method_name = 'login_%s' % service_type

--- a/lib/ansible/module_utils/vca.py
+++ b/lib/ansible/module_utils/vca.py
@@ -40,8 +40,10 @@ class VcaError(Exception):
 
 def vca_argument_spec():
     return dict(
-        username=dict(type='str', aliases=['user'], required=True),
-        password=dict(type='str', aliases=['pass', 'passwd'], required=True, no_log=True),
+        username=dict(type='str', aliases=['user'], required=False),
+        password=dict(type='str', aliases=['pass', 'passwd'], required=False, no_log=True),
+        token=dict(type='str', required=False, no_log=False),
+        org_url=dict(type='str', required=False),
         org=dict(),
         service_id=dict(),
         instance_id=dict(),
@@ -137,11 +139,19 @@ class VcaAnsibleModule(AnsibleModule):
         password = self.params['password']
 
         login_org = None
+        login_token = None
+        org_url = None
+
         if service_type == 'vcd':
             login_org = self.params['org']
+            login_token = self.params['token']
+            org_url = self.params['org_url']
 
-        if not self.vca.login(password=password, org=login_org):
+        if not self.vca.login(token=login_token, org_url=org_url, password=password, org=login_org):
             self.fail('Login to VCA failed', response=self.vca.response)
+
+        if login_token:
+          self.vca.token = login_token
 
         try:
             method_name = 'login_%s' % service_type


### PR DESCRIPTION
##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
vca_vapp

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### SUMMARY
We want to use single-sign-on with SAML for the vca_vapp module.
So we need to pass the vcloud director authentication token directly to the ansible module,
after obtaining the token from the single-sign-on identity provider (idp) host.

We are introducing two more parameters "token" and "org_url" to the vca_vapp ansible module, which are required by the pyvcloud VCA login method to login without a username/password.

Unfortunately the pyvcloud module does not store the token into self.token in vcd token mode, so we need to do a workaround here in ansible module_utils if we are using a token:
```
        if login_token:
          self.vca.token = login_token
```
A possibly cleaner way would be to fix this in the pyvcloud module.

Example of usage of vca_vapp module after introducing the token/org_uri parameters:
```
  - name: "delete vapp :: delete vApp {{ name }} from all virtual datacenters"
    local_action: vca_vapp
    args:
      service_type: "vcd"
      org: "{{ org.name }}"
      host: "{{ api.hostname }}"
      api_version: "{{ api.version }}"
      token: "{{ vcd_auth_token_obtained_via_saml }}"
      org_url: "{{api.url}}/org/{{org.id}}"
      vdc_name: "{{ item.value.name }}"
      vapp_name: "{{ name }}"
      state: "absent"
    with_dict: "{{ vdc }}"
```