### PR TITLE
[git] Fix switching branch of shallow clone

### DIFF
--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -715,9 +715,7 @@ def fetch(git_path, module, repo, dest, version, remote, depth, bare, refspec, g
                 # 1.8.3 is broken, 1.9.x works
                 # ensure that remote branch is available as both local and remote ref
                 refspecs.append('+refs/heads/%s:refs/heads/%s' % (version, version))
-                refspecs.append('+refs/heads/%s:refs/remotes/%s/%s' % (version, remote, version))
-            else:
-                refspecs.append(version)
+            refspecs.append('+refs/heads/%s:refs/remotes/%s/%s' % (version, remote, version))
         elif is_remote_tag(git_path, module, dest, repo, version):
             refspecs.append('+refs/tags/' + version + ':refs/tags/' + version)
         if refspecs:

--- a/test/integration/targets/git/tasks/depth.yml
+++ b/test/integration/targets/git/tasks/depth.yml
@@ -173,12 +173,12 @@
     path: "{{ checkout_dir }}"
 
 #
-# Make sure shallow fetch works when updating a branch
+# Make sure shallow fetch works when switching to (fetching) a new a branch
 #
 
 - name: DEPTH | clone from branch with depth specified
   git:
-    repo: 'file://{{ repo_dir|expanduser }}/shallow_branch'
+    repo: 'file://{{ repo_dir|expanduser }}/shallow_branches'
     dest: '{{ checkout_dir }}'
     depth: 1
     version: test_branch
@@ -194,42 +194,25 @@
       - is_shallow.stat.exists
   when: git_version.stdout is version(git_version_supporting_depth, '>=')
 
-- name: DEPTH | commit on branch in shallow_branch repo (and go back to master)
-  shell: |
-    git checkout test_branch;
-    echo "3" > a; git commit -m "3 on branch" a;
-    git checkout master;
-  args:
-    chdir: "{{repo_dir}}/shallow_branch"
-
-- name: DEPTH | fetch same updated branch with depth specified
+- name: DEPTH | switch to new branch (fetch) with the shallow clone
   git:
-    repo: 'file://{{ repo_dir|expanduser }}/shallow_branch'
+    repo: 'file://{{ repo_dir|expanduser }}/shallow_branches'
     dest: '{{ checkout_dir }}'
     depth: 1
-    version: test_branch
+    version: new_branch
   register: git_fetch
 
-- name: DEPTH | assert if branch update arrived
+- name: DEPTH | assert if switching a shallow clone to a new branch worked
   assert:
     that:
       - git_fetch is changed
 
-- name: DEPTH | assert if branch update resulted in file being updated
-  lineinfile:
-    path: '{{ checkout_dir }}/a'
-    line: 3
-    state: present
-  check_mode: yes
-  register: updated_file_contents
-  failed_when: (updated_file_contents is changed) or (updated_file_contents is failed)
-
-- name: DEPTH | check if checkout_dir is shallow
+- name: DEPTH | check if clone is still shallow
   stat: path={{ checkout_dir }}/.git/shallow
   register: is_shallow
   when: git_version.stdout is version(git_version_supporting_depth, '>=')
 
-- name: DEPTH | assert that checkout_dir still is shallow
+- name: DEPTH | assert that clone still is shallow
   assert:
     that:
       - is_shallow.stat.exists

--- a/test/integration/targets/git/tasks/depth.yml
+++ b/test/integration/targets/git/tasks/depth.yml
@@ -176,61 +176,66 @@
 # Make sure shallow fetch works when updating a branch
 #
 
-- name: create repo_dir
-  file: path={{repo_dir}} state=directory
-
-- name: prepare tmp git repo with a branch (and go back to master)
-  shell: git init; echo "1" > a; git add a; git commit -m "1"; git checkout -b test_branch; echo "2" > a; git commit -m "2 on branch" a; git checkout master;
-  args:
-    chdir: "{{repo_dir}}"
-
-- name: clone from branch with depth specified
+- name: DEPTH | clone from branch with depth specified
   git:
-    repo: "{{ repo_dir | replace('~', 'file://' + ansible_env.HOME) }}"
+    repo: 'file://{{ repo_dir|expanduser }}/shallow_branch'
     dest: '{{ checkout_dir }}'
     depth: 1
     version: test_branch
 
-- name: check if clone is shallow
+- name: DEPTH | check if clone is shallow
   stat: path={{ checkout_dir }}/.git/shallow
   register: is_shallow
-  when: git_version.stdout | version_compare("{{git_version_supporting_depth}}", '>=')
+  when: git_version.stdout is version(git_version_supporting_depth, '>=')
 
-- name: assert that clone is shallow
+- name: DEPTH | assert that clone is shallow
   assert:
     that:
       - is_shallow.stat.exists
-  when: git_version.stdout | version_compare("{{git_version_supporting_depth}}", '>=')
+  when: git_version.stdout is version(git_version_supporting_depth, '>=')
 
-- name: commit on branch in tmp repo (and go back to master)
-  shell: git checkout test_branch;echo "3" > a; git commit -m "3 on branch" a; git checkout master;
+- name: DEPTH | commit on branch in shallow_branch repo (and go back to master)
+  shell: |
+    git checkout test_branch;
+    echo "3" > a; git commit -m "3 on branch" a;
+    git checkout master;
   args:
-    chdir: "{{repo_dir}}"
+    chdir: "{{repo_dir}}/shallow_branch"
 
-- name: fetch same updated branch with depth specified
+- name: DEPTH | fetch same updated branch with depth specified
   git:
-    repo: "{{ repo_dir | replace('~', 'file://' + ansible_env.HOME ) }}"
+    repo: 'file://{{ repo_dir|expanduser }}/shallow_branch'
     dest: '{{ checkout_dir }}'
     depth: 1
     version: test_branch
   register: git_fetch
 
-- name: check if branch update arrived
+- name: DEPTH | assert if branch update arrived
   assert:
     that:
-      - git_fetch|changed
-      - "{{ lookup('file', checkout_dir+'/a') | search('3')}}"
+      - git_fetch is changed
 
-- name: check if checkout_dir is shallow
+- name: DEPTH | assert if branch update resulted in file being updated
+  lineinfile:
+    path: '{{ checkout_dir }}/a'
+    line: 3
+    state: present
+  check_mode: yes
+  register: updated_file_contents
+  failed_when: (updated_file_contents is changed) or (updated_file_contents is failed)
+
+- name: DEPTH | check if checkout_dir is shallow
   stat: path={{ checkout_dir }}/.git/shallow
   register: is_shallow
-  when: git_version.stdout | version_compare("{{git_version_supporting_depth}}", '>=')
+  when: git_version.stdout is version(git_version_supporting_depth, '>=')
 
-- name: assert that checkout_dir still is shallow
+- name: DEPTH | assert that checkout_dir still is shallow
   assert:
     that:
       - is_shallow.stat.exists
-  when: git_version.stdout | version_compare("{{git_version_supporting_depth}}", '>=')
+  when: git_version.stdout is version(git_version_supporting_depth, '>=')
 
-- name: clear checkout_dir
-  file: state=absent path={{ checkout_dir }}
+- name: DEPTH | clear checkout_dir
+  file:
+    state: absent
+    path: "{{ checkout_dir }}"

--- a/test/integration/targets/git/tasks/depth.yml
+++ b/test/integration/targets/git/tasks/depth.yml
@@ -186,7 +186,7 @@
 
 - name: clone from branch with depth specified
   git:
-    repo: '{{ repo_dir }}'
+    repo: "{{ repo_dir | replace('~', 'file://' + ansible_env.HOME) }}"
     dest: '{{ checkout_dir }}'
     depth: 1
     version: test_branch
@@ -209,7 +209,7 @@
 
 - name: fetch same updated branch with depth specified
   git:
-    repo: '{{ repo_dir }}'
+    repo: "{{ repo_dir | replace('~', 'file://' + ansible_env.HOME ) }}"
     dest: '{{ checkout_dir }}'
     depth: 1
     version: test_branch

--- a/test/integration/targets/git/tasks/depth.yml
+++ b/test/integration/targets/git/tasks/depth.yml
@@ -171,3 +171,66 @@
   file:
     state: absent
     path: "{{ checkout_dir }}"
+
+#
+# Make sure shallow fetch works when updating a branch
+#
+
+- name: create repo_dir
+  file: path={{repo_dir}} state=directory
+
+- name: prepare tmp git repo with a branch (and go back to master)
+  shell: git init; echo "1" > a; git add a; git commit -m "1"; git checkout -b test_branch; echo "2" > a; git commit -m "2 on branch" a; git checkout master;
+  args:
+    chdir: "{{repo_dir}}"
+
+- name: clone from branch with depth specified
+  git:
+    repo: '{{ repo_dir }}'
+    dest: '{{ checkout_dir }}'
+    depth: 1
+    version: test_branch
+
+- name: check if clone is shallow
+  stat: path={{ checkout_dir }}/.git/shallow
+  register: is_shallow
+  when: git_version.stdout | version_compare("{{git_version_supporting_depth}}", '>=')
+
+- name: assert that clone is shallow
+  assert:
+    that:
+      - is_shallow.stat.exists
+  when: git_version.stdout | version_compare("{{git_version_supporting_depth}}", '>=')
+
+- name: commit on branch in tmp repo (and go back to master)
+  shell: git checkout test_branch;echo "3" > a; git commit -m "3 on branch" a; git checkout master;
+  args:
+    chdir: "{{repo_dir}}"
+
+- name: fetch same updated branch with depth specified
+  git:
+    repo: '{{ repo_dir }}'
+    dest: '{{ checkout_dir }}'
+    depth: 1
+    version: test_branch
+  register: git_fetch
+
+- name: check if branch update arrived
+  assert:
+    that:
+      - git_fetch|changed
+      - "{{ lookup('file', checkout_dir+'/a') | search('3')}}"
+
+- name: check if checkout_dir is shallow
+  stat: path={{ checkout_dir }}/.git/shallow
+  register: is_shallow
+  when: git_version.stdout | version_compare("{{git_version_supporting_depth}}", '>=')
+
+- name: assert that checkout_dir still is shallow
+  assert:
+    that:
+      - is_shallow.stat.exists
+  when: git_version.stdout | version_compare("{{git_version_supporting_depth}}", '>=')
+
+- name: clear checkout_dir
+  file: state=absent path={{ checkout_dir }}

--- a/test/integration/targets/git/tasks/setup-local-repos.yml
+++ b/test/integration/targets/git/tasks/setup-local-repos.yml
@@ -5,7 +5,7 @@
   with_items:
     - "{{ repo_dir }}/minimal"
     - "{{ repo_dir }}/shallow"
-    - "{{ repo_dir }}/shallow_branch"
+    - "{{ repo_dir }}/shallow_branches"
 
 - name: SETUP-LOCAL-REPOS | prepare minimal git repo
   shell: git init; echo "1" > a; git add a; git commit -m "1"
@@ -26,11 +26,11 @@
   args:
     chdir: "{{ repo_dir }}/shallow"
 
-- name: prepare tmp git repo with a branch (and go back to master)
+- name: prepare tmp git repo with two branches
   shell: |
-    git init;
-    echo "1" > a; git add a; git commit -m "1";
-    git checkout -b test_branch; echo "2" > a; git commit -m "2 on branch" a;
-    git checkout master;
+    git init
+    echo "1" > a; git add a; git commit -m "1"
+    git checkout -b test_branch; echo "2" > a; git commit -m "2 on branch" a
+    git checkout -b new_branch; echo "3" > a; git commit -m "3 on new branch" a
   args:
-    chdir: "{{ repo_dir }}/shallow_branch"
+    chdir: "{{ repo_dir }}/shallow_branches"

--- a/test/integration/targets/git/tasks/setup-local-repos.yml
+++ b/test/integration/targets/git/tasks/setup-local-repos.yml
@@ -5,6 +5,7 @@
   with_items:
     - "{{ repo_dir }}/minimal"
     - "{{ repo_dir }}/shallow"
+    - "{{ repo_dir }}/shallow_branch"
 
 - name: SETUP-LOCAL-REPOS | prepare minimal git repo
   shell: git init; echo "1" > a; git add a; git commit -m "1"
@@ -24,3 +25,12 @@
   register: git_shallow_head_1
   args:
     chdir: "{{ repo_dir }}/shallow"
+
+- name: prepare tmp git repo with a branch (and go back to master)
+  shell: |
+    git init;
+    echo "1" > a; git add a; git commit -m "1";
+    git checkout -b test_branch; echo "2" > a; git commit -m "2 on branch" a;
+    git checkout master;
+  args:
+    chdir: "{{ repo_dir }}/shallow_branch"


### PR DESCRIPTION
##### ISSUE TYPE
feature pull request

##### COMPONENT NAME
git module

##### SUMMARY
This PR fixes an issue with switching a branch of a shallow clone (`--depth 1`)

The test fails without this PR. When the PR is merged, the test succeeds.