### PR TITLE
[git] Fix shallow cloning a tag (Fixes #19074)

### DIFF
--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -420,12 +420,15 @@ def clone(git_path, module, repo, dest, remote, depth, version, bare,
     else:
         cmd.extend([ '--origin', remote ])
     if depth:
+        # only use depth if the remote object is branch or tag (i.e. fetchable)
         if version == 'HEAD' \
            or refspec  \
-           or is_remote_branch(git_path, module, dest, repo, version) \
-           or is_remote_tag(git_path, module, dest, repo, version):
-            # only use depth if the remote object is branch or tag (i.e. fetchable)
+           or is_remote_branch(git_path, module, dest, repo, version):
             cmd.extend([ '--depth', str(depth) ])
+        elif is_remote_tag(git_path, module, dest, repo, version):
+            cmd.extend([ '--depth', str(depth) ])
+            # For remote tags, make sure that the tag is actually fetched from repo
+            cmd.extend([ '--branch', str(version) ])
     if reference:
         cmd.extend([ '--reference', str(reference) ])
     cmd.extend([ repo, dest ])

--- a/test/integration/targets/git/tasks/depth.yml
+++ b/test/integration/targets/git/tasks/depth.yml
@@ -145,3 +145,40 @@
   file:
     state: absent
     path: "{{ checkout_dir }}"
+
+# Test for https://github.com/ansible/ansible/pull/18730
+# Make sure switching from tag to branch (master) works with shallow clone
+
+- name: initial clone from tag
+  git:
+    repo: https://github.com/adamchainz/nose-randomly.git
+    dest: "{{ checkout_dir }}"
+    version: 1.2.0
+    depth: 1
+
+- name: update to branch (master)
+  git:
+    repo: https://github.com/adamchainz/nose-randomly.git
+    dest: "{{ checkout_dir }}"
+    version: master
+    depth: 1
+  register: git_update_to_branch
+
+- name: check if tag to branch (master) switch worked
+  assert:
+    that:
+      - git_update_to_branch|changed
+
+- name: check if checkout_dir is shallow
+  stat: path={{ checkout_dir }}/.git/shallow
+  register: is_shallow
+  when: git_version.stdout | version_compare("{{git_version_supporting_depth}}", '>=')
+
+- name: assert than checkout_dir is still shallow
+  assert:
+    that:
+      - is_shallow.stat.exists
+  when: git_version.stdout | version_compare("{{git_version_supporting_depth}}", '>=')
+
+- name: clear checkout_dir
+  file: state=absent path={{ checkout_dir }}


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
git module

##### SUMMARY
This PR fixes an issue with shallow (`--depth 1`) cloning a tag. (Fixes https://github.com/ansible/ansible-modules-core/issues/3817)

Unfortunately, I am unable to reproduce this without using an external git repository (like I did with #18728). So I used the git repository of the PR that trigged this fix: https://github.com/ansible/ansible-modules-core/issues/3817. If someone with a git repo for Ansible tests is willing to provide the necessary commits, I can update the PR to use the dedicated test repo.

@robinro you already have such a repo which is used by the git tests?)