### PR TITLE
fix file attributes changed detection

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1278,9 +1278,8 @@ class AnsibleModule(object):
                         if rc != 0 or err:
                             raise Exception("Error while setting attributes: %s" % (out + err))
                     except Exception as e:
-                        path = to_text(b_path)
-                        self.fail_json(path=path, msg='chattr failed', details=to_native(e),
-                                       exception=traceback.format_exc())
+                        self.fail_json(path=to_text(b_path), msg='chattr failed',
+                                       details=to_native(e), exception=traceback.format_exc())
         return changed
 
     def get_file_attributes(self, path):
@@ -1291,7 +1290,7 @@ class AnsibleModule(object):
             try:
                 rc, out, err = self.run_command(attrcmd)
                 if rc == 0:
-                    res = out.split(' ')[0:2]
+                    res = out.split()
                     output['attr_flags'] = res[1].replace('-', '').strip()
                     output['version'] = res[0].strip()
                     output['attributes'] = format_attributes(output['attr_flags'])
@@ -2391,8 +2390,7 @@ class AnsibleModule(object):
 
         # Set the attributes
         current_attribs = self.get_file_attributes(src)
-        current_attribs = current_attribs.get('attr_flags', [])
-        current_attribs = ''.join(current_attribs)
+        current_attribs = current_attribs.get('attr_flags', '')
         self.set_attributes_if_different(dest, current_attribs, True)
 
     def atomic_move(self, src, dest, unsafe_writes=False):

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -62,6 +62,22 @@
       - "file4_result.changed == true"
       - "file4_result.mode == '0600'"
 
+- name: change file attribute "A"
+  file: path={{output_dir}}/baz.txt attributes=A
+  register: file_attributes_result
+  ignore_errors: True
+
+- name: reapply file attribute "A"
+  file: path={{output_dir}}/baz.txt attributes=A
+  register: file_attributes_result_2
+  when: file_attributes_result is changed
+
+- name: verify that the file was not marked as changed
+  assert:
+    that:
+      - "file_attributes_result_2 is not changed"
+  when: file_attributes_result is changed
+
 - name: change ownership and group
   file: path={{output_dir}}/baz.txt owner=1234 group=1234
 


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

module_utils/basic

##### ANSIBLE VERSION

```
ansible 2.3.0
```

##### SUMMARY

https://docs.python.org/2/library/stdtypes.html#str.split
str.split([sep[, maxsplit]])
If sep is given, consecutive delimiters are not grouped together and are deemed
to delimit empty strings.

>>> "85563      ----------------C-- /var/lib/libvirt/images".split(' ')[0:2]
['85563', '']
>>> "85563      ----------------C-- /var/lib/libvirt/images".split()[0:2]
['85563', '----------------C--']