### PR TITLE
Gather uptime and device facts from Solarish systems

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1624,6 +1624,21 @@ class SunOSHardware(Hardware):
                 self.facts['product_name'] = found.group(1)
 
     def get_device_facts(self):
+        # Device facts are derived for sdderr kstats. This code does not use the
+        # full output, but rather queries for specific stats.
+        # Example output:
+        # sderr:0:sd0,err:Hard Errors     0
+        # sderr:0:sd0,err:Illegal Request 6
+        # sderr:0:sd0,err:Media Error     0
+        # sderr:0:sd0,err:Predictive Failure Analysis     0
+        # sderr:0:sd0,err:Product VBOX HARDDISK   9
+        # sderr:0:sd0,err:Revision        1.0
+        # sderr:0:sd0,err:Serial No       VB0ad2ec4d-074a
+        # sderr:0:sd0,err:Size    53687091200
+        # sderr:0:sd0,err:Soft Errors     0
+        # sderr:0:sd0,err:Transport Errors        0
+        # sderr:0:sd0,err:Vendor  ATA
+
         self.facts['devices'] = {}
 
         disk_stats = {
@@ -1650,9 +1665,9 @@ class SunOSHardware(Hardware):
         if rc != 0:
             return dict()
 
-        sd_instances = set(sorted([line.split(':')[1] for line in out.split('\n') if line.startswith('sderr')]))
+        sd_instances = frozenset(line.split(':')[1] for line in out.split('\n') if line.startswith('sderr'))
         for instance in sd_instances:
-            lines = (line for line in out.split('\n') if len(line) > 0 and line.split(':')[1] == instance)
+            lines = (line for line in out.split('\n') if ':' in line and line.split(':')[1] == instance)
             for line in lines:
                 text, value = line.split('\t')
                 stat = text.split(':')[3]
@@ -1662,11 +1677,17 @@ class SunOSHardware(Hardware):
                 else:
                     d[disk_stats.get(stat)] = value.rstrip()
 
-            diskname = 'sd' + str(instance)
+            diskname = 'sd' + instance
             self.facts['devices'][diskname] = d
             d = {}
 
     def get_uptime_facts(self):
+        # On Solaris, unix:0:system_misc:snaptime is created shortly after machine boots up
+        # and displays tiem in seconds. This is much easier than using uptime as we would
+        # need to have a parsing procedure for translating from human-readable to machine-readable
+        # format.
+        # Example output:
+        # unix:0:system_misc:snaptime     1175.410463590
         rc, out, err = self.module.run_command('/usr/bin/kstat -p unix:0:system_misc:snaptime')
 
         if rc != 0:

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1672,7 +1672,7 @@ class SunOSHardware(Hardware):
         if rc != 0:
             return
 
-        self.facts['uptime_secodns'] = int(float(out.split('\t')[1]))
+        self.facts['uptime_seconds'] = int(float(out.split('\t')[1]))
 
 
 class OpenBSDHardware(Hardware):

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1534,6 +1534,7 @@ class SunOSHardware(Hardware):
         self.get_memory_facts()
         self.get_dmi_facts()
         self.get_device_facts()
+        self.get_uptime_facts()
         try:
             self.get_mount_facts()
         except TimeoutError:
@@ -1664,6 +1665,15 @@ class SunOSHardware(Hardware):
             diskname = 'sd' + str(instance)
             self.facts['devices'][diskname] = d
             d = {}
+
+    def get_uptime_facts(self):
+        rc, out, err = self.module.run_command('/usr/bin/kstat -p unix:0:system_misc:snaptime')
+
+        if rc != 0:
+            return
+
+        self.facts['uptime_secodns'] = int(float(out.split('\t')[1]))
+
 
 class OpenBSDHardware(Hardware):
     """


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
module_utils/facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (solaris-devices b1574635f3) last updated 2016/11/27 11:48:50 (GMT +200)
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This module adds support for gathering device and uptime statistics. It aims for compatibility with these systems:

* Oracle Solaris 11
* OpenIndiana/OmniOS
