### PR TITLE
Fix to correctly add hostkey for non-standard git ports

### DIFF
--- a/lib/ansible/module_utils/known_hosts.py
+++ b/lib/ansible/module_utils/known_hosts.py
@@ -190,7 +190,10 @@ def add_host_key(module, fqdn, key_type="rsa", create_dir=False, port=SSH_KEYSCA
     elif not os.path.isdir(user_ssh_dir):
         module.fail_json(msg="%s is not a directory" % user_ssh_dir)
 
-    this_cmd = "%s -t %s %s" % (keyscan_cmd, key_type, fqdn)
+    if port == SSH_KEYSCAN_DEFAULT_PORT:
+        this_cmd = "%s -t %s %s" % (keyscan_cmd, key_type, fqdn)
+    else:
+        this_cmd = "%s -t %s %s -p %s" % (keyscan_cmd, key_type, fqdn, port)
 
     rc, out, err = module.run_command(this_cmd)
     # ssh-keyscan gives a 0 exit code and prints nothins on timeout

--- a/lib/ansible/module_utils/known_hosts.py
+++ b/lib/ansible/module_utils/known_hosts.py
@@ -40,6 +40,7 @@ except ImportError:
     import sha as sha1
 
 HASHED_KEY_MAGIC = "|1|"
+SSH_KEYSCAN_DEFAULT_PORT = "22"
 
 def add_git_host_key(module, url, accept_hostkey=True, create_dir=True):
 
@@ -71,10 +72,15 @@ def is_ssh_url(url):
     return False
 
 def get_fqdn(repo_url):
+    return get_fqdn_and_port(repo_url)[0]
+
+def get_fqdn_and_port(repo_url):
 
     """ chop the hostname out of a url """
 
     result = None
+    port = SSH_KEYSCAN_DEFAULT_PORT
+
     if "@" in repo_url and "://" not in repo_url:
         # most likely an user@host:path or user@host/path type URL
         repo_url = repo_url.split("@", 1)[1]
@@ -90,7 +96,7 @@ def get_fqdn(repo_url):
         # parts[1] will be empty on python2.4 on ssh:// or git:// urls, so
         # ensure we actually have a parts[1] before continuing.
         if parts[1] != '':
-            result = parts[1]
+            result = parts[1] # netloc
             if "@" in result:
                 result = result.split("@", 1)[1]
 
@@ -98,7 +104,7 @@ def get_fqdn(repo_url):
                 result = result.split(']', 1)[0] + ']'
             elif ":" in result:
                 result = result.split(":")[0]
-    return result
+    return (result, SSH_KEYSCAN_DEFAULT_PORT)
 
 def check_hostkey(module, fqdn):
    return not not_in_host_file(module, fqdn)
@@ -159,7 +165,7 @@ def not_in_host_file(self, host):
     return True
 
 
-def add_host_key(module, fqdn, key_type="rsa", create_dir=False):
+def add_host_key(module, fqdn, key_type="rsa", create_dir=False, port=SSH_KEYSCAN_DEFAULT_PORT):
 
     """ use ssh-keyscan to add the hostkey """
 

--- a/lib/ansible/module_utils/known_hosts.py
+++ b/lib/ansible/module_utils/known_hosts.py
@@ -103,8 +103,8 @@ def get_fqdn_and_port(repo_url):
             if result[0].startswith('['):
                 result = result.split(']', 1)[0] + ']'
             elif ":" in result:
-                result = result.split(":")[0]
-    return (result, SSH_KEYSCAN_DEFAULT_PORT)
+                (result, port) = result.split(":", 2)
+    return (result, port)
 
 def check_hostkey(module, fqdn):
    return not not_in_host_file(module, fqdn)

--- a/test/units/module_utils/basic/test_known_hosts.py
+++ b/test/units/module_utils/basic/test_known_hosts.py
@@ -48,7 +48,7 @@ class TestAnsibleModuleKnownHosts(unittest.TestCase):
              'port': known_hosts.SSH_KEYSCAN_DEFAULT_PORT},
         'ssh://six.example.org:21/example.org': # ssh on FTP Port? 
             {'is_ssh_url': True, 'get_fqdn': 'six.example.org',
-             'add_host_key_cmd': " -t rsa six.example.org",
+             'add_host_key_cmd': " -t rsa six.example.org -p 21", # should add port param, since it's different from default
              'port': "21"},
         'ssh://[2001:DB8::abcd:abcd]/example.git':
             {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]',
@@ -57,6 +57,8 @@ class TestAnsibleModuleKnownHosts(unittest.TestCase):
         'ssh://[2001:DB8::abcd:abcd]:22/example.git':
             {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]',
              'add_host_key_cmd': " -t rsa [2001:DB8::abcd:abcd]", 
+             # even though it's explicitly specified we do not add port here (for backwards compatibility)'
+             'add_host_key_cmd': " -t rsa [2001:DB8::abcd:abcd]",  
              'port': "22"},
         'username@[2001:DB8::abcd:abcd]/example.git':
             {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]',
@@ -68,7 +70,7 @@ class TestAnsibleModuleKnownHosts(unittest.TestCase):
              'port': "22"},
         'ssh://internal.git.server:7999/repos/repo.git':
             {'is_ssh_url': True, 'get_fqdn': 'internal.git.server',
-             'add_host_key_cmd': " -t rsa internal.git.server",
+             'add_host_key_cmd': " -t rsa internal.git.server -p 7999",
              'port': "7999"}
     }
 

--- a/test/units/module_utils/basic/test_known_hosts.py
+++ b/test/units/module_utils/basic/test_known_hosts.py
@@ -106,8 +106,8 @@ class TestAnsibleModuleKnownHosts(unittest.TestCase):
         self.module.get_bin_path = get_bin_path
 
         for u in self.urls:
-            if self.urls[u]["is_ssh_url"]:
-                known_hosts.add_host_key(self.module, self.urls[u]["get_fqdn"])
-                run_command.assert_called_with(keyscan_cmd + self.urls[u]["add_host_key_cmd"])
+            if self.urls[u]['is_ssh_url']:
+                known_hosts.add_host_key(self.module, self.urls[u]['get_fqdn'], port=self.urls[u]['port'])
+                run_command.assert_called_with(keyscan_cmd + self.urls[u]['add_host_key_cmd'])
 
 

--- a/test/units/module_utils/basic/test_known_hosts.py
+++ b/test/units/module_utils/basic/test_known_hosts.py
@@ -19,28 +19,53 @@
 from ansible.compat.tests import unittest
 from ansible.module_utils import known_hosts
 
+import json
+import ansible.module_utils.basic
+from ansible.compat.tests.mock import Mock
+from units.mock.procenv import swap_stdin_and_argv
+
 class TestAnsibleModuleKnownHosts(unittest.TestCase):
     urls = {
         'ssh://one.example.org/example.git':
-            {'is_ssh_url': True, 'get_fqdn': 'one.example.org', 'port': known_hosts.SSH_KEYSCAN_DEFAULT},
+            {'is_ssh_url': True, 'get_fqdn': 'one.example.org',
+             'add_host_key_cmd': " -t rsa one.example.org",
+             'port': known_hosts.SSH_KEYSCAN_DEFAULT_PORT},
         'ssh+git://two.example.org/example.git':
-            {'is_ssh_url': True, 'get_fqdn': 'two.example.org', 'port': known_hosts.SSH_KEYSCAN_DEFAULT},
+            {'is_ssh_url': True, 'get_fqdn': 'two.example.org',
+             'add_host_key_cmd': " -t rsa two.example.org", 
+             'port': known_hosts.SSH_KEYSCAN_DEFAULT_PORT},
         'rsync://three.example.org/user/example.git':
-            {'is_ssh_url': False, 'get_fqdn': 'three.example.org', 'port': known_hosts.SSH_KEYSCAN_DEFAULT},
+            {'is_ssh_url': False, 'get_fqdn': 'three.example.org', 
+             'add_host_key_cmd': None, # not called for non-ssh urls
+             'port': known_hosts.SSH_KEYSCAN_DEFAULT_PORT},
         'git@four.example.org:user/example.git':
-            {'is_ssh_url': True, 'get_fqdn': 'four.example.org', 'port': known_hosts.SSH_KEYSCAN_DEFAULT},
+            {'is_ssh_url': True, 'get_fqdn': 'four.example.org',
+             'add_host_key_cmd': " -t rsa four.example.org", 
+             'port': known_hosts.SSH_KEYSCAN_DEFAULT_PORT},
         'git+ssh://five.example.org/example.git':
-            {'is_ssh_url': True, 'get_fqdn': 'five.example.org', 'port': known_hosts.SSH_KEYSCAN_DEFAULT},
-        'ssh://six.example.org:21/example.org':
-            {'is_ssh_url': True, 'get_fqdn': 'six.example.org', 'port': known_hosts.SSH_KEYSCAN_DEFAULT},
+            {'is_ssh_url': True, 'get_fqdn': 'five.example.org', 
+             'add_host_key_cmd': " -t rsa five.example.org",
+             'port': known_hosts.SSH_KEYSCAN_DEFAULT_PORT},
+        'ssh://six.example.org:21/example.org': # ssh on FTP Port? 
+            {'is_ssh_url': True, 'get_fqdn': 'six.example.org',
+             'add_host_key_cmd': " -t rsa six.example.org",
+             'port': known_hosts.SSH_KEYSCAN_DEFAULT_PORT},
         'ssh://[2001:DB8::abcd:abcd]/example.git':
-            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]', 'port': known_hosts.SSH_KEYSCAN_DEFAULT},
+            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]',
+             'add_host_key_cmd': " -t rsa [2001:DB8::abcd:abcd]",
+             'port': known_hosts.SSH_KEYSCAN_DEFAULT_PORT},
         'ssh://[2001:DB8::abcd:abcd]:22/example.git':
-            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]', 'port': known_hosts.SSH_KEYSCAN_DEFAULT},
+            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]',
+             'add_host_key_cmd': " -t rsa [2001:DB8::abcd:abcd]", 
+             'port': known_hosts.SSH_KEYSCAN_DEFAULT_PORT},
         'username@[2001:DB8::abcd:abcd]/example.git':
-            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]', 'port': known_hosts.SSH_KEYSCAN_DEFAULT},
+            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]',
+             'add_host_key_cmd': " -t rsa [2001:DB8::abcd:abcd]", 
+             'port': known_hosts.SSH_KEYSCAN_DEFAULT_PORT},
         'username@[2001:DB8::abcd:abcd]:22/example.git':
-            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]', 'port': known_hosts.SSH_KEYSCAN_DEFAULT},
+            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]',
+             'add_host_key_cmd': " -t rsa [2001:DB8::abcd:abcd]", 
+             'port': known_hosts.SSH_KEYSCAN_DEFAULT_PORT},
     }
 
     def test_is_ssh_url(self):
@@ -55,5 +80,28 @@ class TestAnsibleModuleKnownHosts(unittest.TestCase):
         for u in self.urls:
             self.assertEqual(known_hosts.get_fqdn_and_port(u), (self.urls[u]['get_fqdn'], self.urls[u]['port']))
 
+    def test_add_host_key(self):
+
+        # Copied
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}))
+        # unittest doesn't have a clean place to use a context manager, so we have to enter/exit manually
+        self.stdin_swap = swap_stdin_and_argv(stdin_data=args)
+        self.stdin_swap.__enter__()
+
+        ansible.module_utils.basic._ANSIBLE_ARGS = None 
+        self.module = ansible.module_utils.basic.AnsibleModule(argument_spec=dict())
+
+        run_command = Mock()
+        run_command.return_value = (0, "Needs output, otherwise thinks ssh-keyscan timed out'", "")
+        self.module.run_command = run_command
+
+        get_bin_path = Mock()
+        get_bin_path.return_value = keyscan_cmd = "/custom/path/ssh-keyscan"
+        self.module.get_bin_path = get_bin_path
+
+        for u in self.urls:
+            if self.urls[u]["is_ssh_url"]:
+                known_hosts.add_host_key(self.module, self.urls[u]["get_fqdn"])
+                run_command.assert_called_with(keyscan_cmd + self.urls[u]["add_host_key_cmd"])
 
 

--- a/test/units/module_utils/basic/test_known_hosts.py
+++ b/test/units/module_utils/basic/test_known_hosts.py
@@ -49,7 +49,7 @@ class TestAnsibleModuleKnownHosts(unittest.TestCase):
         'ssh://six.example.org:21/example.org': # ssh on FTP Port? 
             {'is_ssh_url': True, 'get_fqdn': 'six.example.org',
              'add_host_key_cmd': " -t rsa six.example.org",
-             'port': known_hosts.SSH_KEYSCAN_DEFAULT_PORT},
+             'port': "21"},
         'ssh://[2001:DB8::abcd:abcd]/example.git':
             {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]',
              'add_host_key_cmd': " -t rsa [2001:DB8::abcd:abcd]",
@@ -57,7 +57,7 @@ class TestAnsibleModuleKnownHosts(unittest.TestCase):
         'ssh://[2001:DB8::abcd:abcd]:22/example.git':
             {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]',
              'add_host_key_cmd': " -t rsa [2001:DB8::abcd:abcd]", 
-             'port': known_hosts.SSH_KEYSCAN_DEFAULT_PORT},
+             'port': "22"},
         'username@[2001:DB8::abcd:abcd]/example.git':
             {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]',
              'add_host_key_cmd': " -t rsa [2001:DB8::abcd:abcd]", 
@@ -65,7 +65,11 @@ class TestAnsibleModuleKnownHosts(unittest.TestCase):
         'username@[2001:DB8::abcd:abcd]:22/example.git':
             {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]',
              'add_host_key_cmd': " -t rsa [2001:DB8::abcd:abcd]", 
-             'port': known_hosts.SSH_KEYSCAN_DEFAULT_PORT},
+             'port': "22"},
+        'ssh://internal.git.server:7999/repos/repo.git':
+            {'is_ssh_url': True, 'get_fqdn': 'internal.git.server',
+             'add_host_key_cmd': " -t rsa internal.git.server",
+             'port': "7999"}
     }
 
     def test_is_ssh_url(self):

--- a/test/units/module_utils/basic/test_known_hosts.py
+++ b/test/units/module_utils/basic/test_known_hosts.py
@@ -22,25 +22,25 @@ from ansible.module_utils import known_hosts
 class TestAnsibleModuleKnownHosts(unittest.TestCase):
     urls = {
         'ssh://one.example.org/example.git':
-            {'is_ssh_url': True, 'get_fqdn': 'one.example.org'},
+            {'is_ssh_url': True, 'get_fqdn': 'one.example.org', 'port': known_hosts.SSH_KEYSCAN_DEFAULT},
         'ssh+git://two.example.org/example.git':
-            {'is_ssh_url': True, 'get_fqdn': 'two.example.org'},
+            {'is_ssh_url': True, 'get_fqdn': 'two.example.org', 'port': known_hosts.SSH_KEYSCAN_DEFAULT},
         'rsync://three.example.org/user/example.git':
-            {'is_ssh_url': False, 'get_fqdn': 'three.example.org'},
+            {'is_ssh_url': False, 'get_fqdn': 'three.example.org', 'port': known_hosts.SSH_KEYSCAN_DEFAULT},
         'git@four.example.org:user/example.git':
-            {'is_ssh_url': True, 'get_fqdn': 'four.example.org'},
+            {'is_ssh_url': True, 'get_fqdn': 'four.example.org', 'port': known_hosts.SSH_KEYSCAN_DEFAULT},
         'git+ssh://five.example.org/example.git':
-            {'is_ssh_url': True, 'get_fqdn': 'five.example.org'},
+            {'is_ssh_url': True, 'get_fqdn': 'five.example.org', 'port': known_hosts.SSH_KEYSCAN_DEFAULT},
         'ssh://six.example.org:21/example.org':
-            {'is_ssh_url': True, 'get_fqdn': 'six.example.org'},
+            {'is_ssh_url': True, 'get_fqdn': 'six.example.org', 'port': known_hosts.SSH_KEYSCAN_DEFAULT},
         'ssh://[2001:DB8::abcd:abcd]/example.git':
-            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]'},
+            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]', 'port': known_hosts.SSH_KEYSCAN_DEFAULT},
         'ssh://[2001:DB8::abcd:abcd]:22/example.git':
-            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]'},
+            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]', 'port': known_hosts.SSH_KEYSCAN_DEFAULT},
         'username@[2001:DB8::abcd:abcd]/example.git':
-            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]'},
+            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]', 'port': known_hosts.SSH_KEYSCAN_DEFAULT},
         'username@[2001:DB8::abcd:abcd]:22/example.git':
-            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]'},
+            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]', 'port': known_hosts.SSH_KEYSCAN_DEFAULT},
     }
 
     def test_is_ssh_url(self):
@@ -50,6 +50,10 @@ class TestAnsibleModuleKnownHosts(unittest.TestCase):
     def test_get_fqdn(self):
         for u in self.urls:
             self.assertEqual(known_hosts.get_fqdn(u), self.urls[u]['get_fqdn'])
+
+    def test_get_fqdn_and_port(self):
+        for u in self.urls:
+            self.assertEqual(known_hosts.get_fqdn_and_port(u), (self.urls[u]['get_fqdn'], self.urls[u]['port']))
 
 
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible.module_utils.basic.known_hosts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel ea5c3df043) last updated 2016/12/02 23:56:21 (GMT +300)
  lib/ansible/modules/core: (detached HEAD 6890003c4f) last updated 2016/12/02 23:59:15 (GMT +300)
  lib/ansible/modules/extras: (detached HEAD 20ea46642b) last updated 2016/12/02 23:59:21 (GMT +300)
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This change fixes `git` module's `accept_hostkey` behavior for non-standard ports. 

Currently, when git url uses non-standard port (my repo sits on 7999, for example), incorrect hostkey is added to `~/.ssh/known_hosts`. 

After the fix, non-standard ports will be explicitly passed as an argument to `ssh-keyscan` which will then add proper hostkey.

__not sure what to write here__
```

```
