### PR TITLE
adds py3 compat changes to network_cli plugin

### DIFF
--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -116,7 +116,8 @@ class Connection(_Connection):
             data = self._shell.recv(256)
 
             recv.write(data)
-            recv.seek(recv.tell() - 256)
+            offset = recv.tell() - 256 if recv.tell() > 256 else 0
+            recv.seek(offset)
 
             window = self._strip(recv.read())
 


### PR DESCRIPTION
now calculates StringIO receive buffer and if received data is less than
buffer size, resets offset to 0