### PR TITLE
Fixes #16936 - Digest authentication not working in uri module

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -819,9 +819,11 @@ def open_url(url, data=None, headers=None, method=None, use_proxy=True,
             # use this username/password combination for  urls
             # for which `theurl` is a super-url
             authhandler = urllib_request.HTTPBasicAuthHandler(passman)
+            digest_authhandler = urllib_request.HTTPDigestAuthHandler(passman)
 
             # create the AuthHandler
             handlers.append(authhandler)
+            handlers.append(digest_authhandler)
 
         elif username and force_basic_auth:
             headers["Authorization"] = basic_auth_header(username, password)

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -175,6 +175,13 @@
     user: user
     password: passwd
 
+- name: test digest auth
+  uri:
+    url: 'http://{{ httpbin_host }}/digest-auth/auth/user/passwd'
+    user: user
+    password: passwd
+    HEADER_Cookie: "fake=fake_value"
+
 - name: test PUT
   uri:
     url: 'http://{{ httpbin_host }}/put'


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
uri
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (fix_uri_digest_auth 91ec082b1b) last updated 2016/12/03 19:55:26 (GMT -400)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras:  not found - use git submodule update --init lib/ansible/modules/extras
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #16936
https://github.com/SergK fixed the uri Digest issue by adding the appropriate AuthHandler in  lib/ansible/module_utils/urls.py: https://github.com/ansible/ansible/pull/17089, unfortunately the change did not pass integration test. It turned out, that the service used to test uri module (http://httpbin.org/digest-auth/auth/user/passwd) requires cookie to be set for connection to be successful.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### BEFORE
Example playbook:
```
- hosts: localhost
  tasks:
    - uri:
        url: 'http://httpbin.org/digest-auth/auth/user/passwd'
        user: user
        password: passwd
        HEADER_Cookie: "fake=fake_value"
```
Output:
```
TASK [uri] **************************************************************************************************************
fatal: [localhost]: FAILED! => {"access_control_allow_credentials": "true", "access_control_allow_origin": "*", "changed": false, "connection": "close", "content": "", "content_length": "0", "content_type": "text/html; charset=utf-8", "date": "Sun, 04 Dec 2016 01:13:11 GMT", "failed": true, "msg": "Status code was not [200]: HTTP Error 401: UNAUTHORIZED", "redirected": false, "server": "nginx", "set_cookie": "fake=fake_value", "status": 401, "url": "http://httpbin.org/digest-auth/auth/user/passwd", "www_authenticate": "Digest nonce=\"cabbdb390eb99241d96c4a5064aec3be\", opaque=\"68db72ac124ca87f7db26888830cba0e\", realm=\"me@kennethreitz.com\", qop=auth"}
```
##### AFTER
Same playbook as before produces:
```
TASK [uri] **************************************************************************************************************
ok: [localhost]
```

