### PR TITLE
Fix minor typo in roles doc

### DIFF
--- a/docsite/rst/playbooks_roles.rst
+++ b/docsite/rst/playbooks_roles.rst
@@ -39,7 +39,7 @@ Tasks and plays both use the `include` keyword, but implement the keyword differ
     # this is a 'play' include
     - include: listofplays
 
-    - name: antoher play
+    - name: another play
       hosts: all
       tasks:
         - debug: msg=hello


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
Playbook documentation/roles

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
minor typo : s/antoher/another


