### PR TITLE
Fixes Problem 5520 - timeout: ios_config: save

### DIFF
--- a/lib/ansible/module_utils/ios.py
+++ b/lib/ansible/module_utils/ios.py
@@ -204,6 +204,6 @@ class Cli(CliBase):
         return self.configure(commands)
 
     def save_config(self):
-        self.execute(['copy running-config startup-config'])
+        self.execute(['write memory'])
 
 Cli = register_transport('cli', default=True)(Cli)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
ansible/lib/ansible/module_utils/ios.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes Issue 5520

I know that the `write memory` command was once looked at to be deprecated, but now no longer has that designation in the latest Cisco command references.

I adjusted my local Ansible install to use the `write memory` command instead of the `copy running-config startup-config` command and the save option now works correctly within ios_config on both IOS and IOS-XE devices.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
The command timed out with the message:
timeout trying to send command: copy running-config startup-config
```
After:  No error.  Save is successful on both IOS and IOS-XE.