### PR TITLE
Stable 2.1

### DIFF
--- a/examples/playbooks/set_extra_var.yml
+++ b/examples/playbooks/set_extra_var.yml
@@ -1,0 +1,21 @@
+# Inventory :
+#     group_all = { host_1, host_2, host_3 }
+#     group_one = { host_1 }
+#     group_two = { host_2, host3 }
+
+---
+- hosts: group_one
+  tasks:
+  - name: list /tmp
+    shell: ls /tmp
+    register: out
+
+  - name: set global variable
+    setglobal: name=myvar value="{{out}}"
+
+- hosts: group_two
+  tasks:
+  - debug: msg="{{myvar}}"
+
+
+# command :  ansible-playbook  set_extra_var.yml --limit group_all

--- a/lib/ansible/executor/process/result.py
+++ b/lib/ansible/executor/process/result.py
@@ -169,6 +169,10 @@ class ResultProcess(multiprocessing.Process):
                         elif 'add_group' in result_item:
                             # this task added a new group (group_by module)
                             self._send_result(('add_group', result._host, result_item))
+                        # PV
+                        elif 'add_extra_var' in result_item:
+                            # this task added a new variable to VariableManager 'extra_vars'
+                            self._send_result(('add_extra_var', result_item))
                         elif 'ansible_facts' in result_item:
                             # if this task is registering facts, do that now
                             loop_var = 'item'

--- a/lib/ansible/modules/set_extra_var.py
+++ b/lib/ansible/modules/set_extra_var.py
@@ -1,0 +1,1 @@
+#!/usr/bin/python

--- a/lib/ansible/modules/set_extra_var.py
+++ b/lib/ansible/modules/set_extra_var.py
@@ -1,1 +1,0 @@
-#!/usr/bin/python

--- a/lib/ansible/plugins/action/set_extra_var.py
+++ b/lib/ansible/plugins/action/set_extra_var.py
@@ -1,4 +1,5 @@
 # Copyright 2016 Pieter Voet <pietervoet@nl.ibm.com>
+from __future__ import (absolute_import, division, print_function)
 from ansible.plugins.action import ActionBase
 
 class ActionModule(ActionBase):

--- a/lib/ansible/plugins/action/set_extra_var.py
+++ b/lib/ansible/plugins/action/set_extra_var.py
@@ -1,5 +1,7 @@
 # Copyright 2016 Pieter Voet <pietervoet@nl.ibm.com>
 from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 from ansible.plugins.action import ActionBase
 
 class ActionModule(ActionBase):

--- a/lib/ansible/plugins/action/set_extra_var.py
+++ b/lib/ansible/plugins/action/set_extra_var.py
@@ -1,0 +1,12 @@
+from ansible.plugins.action import ActionBase
+
+class ActionModule(ActionBase):
+    def run(self, tmp=None, task_vars=None):
+        if task_vars is None:
+           task_vars = dict()
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        result['changed'] = False
+        result['add_extra_var'] = (self._task.args['name'], self._task.args['value'])
+        return result

--- a/lib/ansible/plugins/action/set_extra_var.py
+++ b/lib/ansible/plugins/action/set_extra_var.py
@@ -1,3 +1,4 @@
+# Copyright 2016 Pieter Voet <pietervoet@nl.ibm.com>
 from ansible.plugins.action import ActionBase
 
 class ActionModule(ActionBase):

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -312,6 +312,12 @@ class StrategyBase:
                     host = get_original_host(result[1])
                     result_item = result[2]
                     self._add_group(host, result_item)
+                    
+                # PV
+                elif result[0] == 'add_extra_var':
+                    var = result[1]['add_extra_var']
+                    if var[0] not in self._variable_manager._extra_vars:
+                        self._variable_manager._extra_vars[var[0]] = var[1]
 
                 elif result[0] == 'notify_handler':
                     task_result  = result[1]


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
set_extra_var

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.1.1.0
  config file = 
  configured module search path = Default w/o overrides

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
module ( action plugin ) to set an 'extra_vars' variable from within a play. 
Consider this example 

Inventory :
     group_all = { host_1, host_2, host_3 }
     group_one = { host_1 }
     group_two = { host_2, host3 }

Playbook :

---
- hosts: group_one
  tasks:
  - name: list /tmp
    shell: ls /tmp
    register: out

  - name: set global variable
    setglobal: name=myvar value="{{out}}"

- hosts: group_two
  tasks:
  - debug: msg="{{myvar}}"


command :  ansible-playbook  my_playbook.yml --limit group_all

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
