### PR TITLE
[temp kluge] Skip test_network_cli_open_shell for now

### DIFF
--- a/test/units/plugins/connection/test_network_cli.py
+++ b/test/units/plugins/connection/test_network_cli.py
@@ -27,11 +27,11 @@ from io import StringIO
 
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch, MagicMock
+from nose.plugins.skip import SkipTest
 
 from ansible.errors import AnsibleConnectionFailure
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.connection import network_cli
-
 
 
 class TestConnectionClass(unittest.TestCase):
@@ -62,8 +62,10 @@ class TestConnectionClass(unittest.TestCase):
         self.assertEqual(conn._terminal, 'valid')
 
     def test_network_cli_open_shell(self):
+        raise SkipTest('Fixme to work in a clean env')
         pc = PlayContext()
         new_stdin = StringIO()
+
         conn = network_cli.Connection(pc, new_stdin)
 
         conn.ssh = MagicMock()
@@ -138,7 +140,6 @@ class TestConnectionClass(unittest.TestCase):
         self.assertEqual(out, 'command response')
         self.assertFalse(mock_open_shell.called)
         mock_send.assert_called_with({'command': 'command'})
-
 
     def test_network_cli_send(self):
         pc = PlayContext()


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
test/units/plugins/connection

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (fix_tests 981b40e6a3) last updated 2016/12/05 11:21:54 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 6890003c4f) last updated 2016/12/01 16:02:07 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 20ea46642b) last updated 2016/12/01 16:02:08 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides


```

##### SUMMARY
Temp kluge to skip a broken test  (plugins/connection/test_network_cli.py:TestConnectionClass.test_network_cli_open_shell)

Seems like there is some connection mocking/stubbing needed to get this to work.