### PR TITLE
Fix errors on 'ansible-playbook --flush-cache'

### DIFF
--- a/lib/ansible/cli/playbook.py
+++ b/lib/ansible/cli/playbook.py
@@ -148,8 +148,7 @@ class PlaybookCLI(CLI):
 
         # flush fact cache if requested
         if self.options.flush_cache:
-            for host in inventory.list_hosts():
-                variable_manager.clear_facts(host)
+            self._flush_cache(inventory, variable_manager)
 
         # create the playbook executor, which manages running the plays via a task queue manager
         pbex = PlaybookExecutor(playbooks=self.args, inventory=inventory, variable_manager=variable_manager, loader=loader, options=self.options, passwords=passwords)
@@ -218,3 +217,8 @@ class PlaybookCLI(CLI):
             return 0
         else:
             return results
+
+    def _flush_cache(self, inventory, variable_manager):
+        for host in inventory.list_hosts():
+            hostname = host.get_name()
+            variable_manager.clear_facts(hostname)

--- a/test/units/cli/test_playbook.py
+++ b/test/units/cli/test_playbook.py
@@ -1,0 +1,40 @@
+# (c) 2016, Adrian Likins <alikins@redhat.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.compat.tests import unittest
+from units.mock.loader import DictDataLoader
+
+from ansible.inventory import Inventory
+from ansible.vars import VariableManager
+
+from ansible.cli.playbook import PlaybookCLI
+
+
+class TestPlaybookCLI(unittest.TestCase):
+    def test_flush_cache(self):
+        cli = PlaybookCLI(args=["--flush-cache", "foobar.yml"])
+
+        variable_manager = VariableManager()
+        fake_loader = DictDataLoader({'foobar.yml': ""})
+        inventory = Inventory(loader=fake_loader, variable_manager=variable_manager, host_list=['testhost'])
+
+        cli._flush_cache(inventory, variable_manager)
+        self.assertFalse('testhost' in variable_manager._fact_cache)


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/cli/playbook.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (flush_cache_18708 3101e24db8) last updated 2016/12/05 14:31:14 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 6890003c4f) last updated 2016/12/01 16:02:07 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 20ea46642b) last updated 2016/12/01 16:02:08 (GMT -400)
  config file = ansible_redis_caching.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
Fixes #18708

```

Add a unit test, and split out the flush cache logic to
it's own method.
Fixes #18708