### PR TITLE
Provide slightly better msg on fact cache error

### DIFF
--- a/lib/ansible/plugins/cache/__init__.py
+++ b/lib/ansible/plugins/cache/__init__.py
@@ -20,6 +20,7 @@ __metaclass__ = type
 from collections import MutableMapping
 
 from ansible import constants as C
+from ansible.errors import AnsibleError
 from ansible.plugins import cache_loader
 
 try:
@@ -33,6 +34,14 @@ class FactCache(MutableMapping):
 
     def __init__(self, *args, **kwargs):
         self._plugin = cache_loader.get(C.CACHE_PLUGIN)
+        if not self._plugin:
+            raise AnsibleError('Unable to load the facts cache plugin (%s)\n'
+                               'Check fact cache config options :\n'
+                               'Current values:\n'
+                               '    fact_caching: %s\n'
+                               '    fact_caching_connection: %s' %
+                               (C.CACHE_PLUGIN, C.CACHE_PLUGIN, C.CACHE_PLUGIN_CONNECTION))
+
         # Backwards compat: self._display isn't really needed, just import the global display and use that.
         self._display = display
 

--- a/test/units/plugins/cache/test_cache.py
+++ b/test/units/plugins/cache/test_cache.py
@@ -20,6 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.compat.tests import unittest, mock
+from ansible.errors import AnsibleError
 from ansible.plugins.cache import FactCache
 from ansible.plugins.cache.base import BaseCacheModule
 from ansible.plugins.cache.memory import CacheModule as MemoryCache
@@ -55,6 +56,14 @@ class TestFactCache(unittest.TestCase):
         a_copy = self.cache.copy()
         self.assertEqual(type(a_copy), dict)
         self.assertEqual(a_copy, dict(avocado='fruit', daisy='flower'))
+
+    def test_plugin_load_failure(self):
+        # See https://github.com/ansible/ansible/issues/18751
+        # Note no fact_connection config set, so this will fail
+        with mock.patch('ansible.constants.CACHE_PLUGIN', 'json'):
+            self.assertRaisesRegexp(AnsibleError,
+                                    "Unable to load the facts cache plugin.*json.*",
+                                    FactCache)
 
 
 class TestAbstractClass(unittest.TestCase):


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/plugins/cache.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (fact_cache_fails_18751 ed869218ad) last updated 2016/12/05 16:29:33 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 6890003c4f) last updated 2016/12/01 16:02:07 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 20ea46642b) last updated 2016/12/01 16:02:08 (GMT -400)
  config file = ansible_json_caching.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY

If the configured fact_cache plugin (fact_caching config)
fails, raise a fatal error instead of failing mysteriously
later.

Fixes #18751