### PR TITLE
Correct change classification for network plugins.

### DIFF
--- a/test/runner/lib/classification.py
+++ b/test/runner/lib/classification.py
@@ -183,25 +183,43 @@ class PathMapper(object):
                     'units': 'test/units/plugins/connection/',
                 }
 
+            units_path = 'test/units/plugins/connection/test_%s.py' % name
+
+            if units_path not in self.units_paths:
+                units_path = None
+
+            integration_name = 'connection_%s' % name
+
+            if integration_name not in self.integration_targets_by_name:
+                integration_name = None
+
+            # entire integration test commands depend on these connection plugins
+
             if name == 'winrm':
                 return {
                     'windows-integration': 'all',
-                    'units': 'test/units/plugins/connection/',
+                    'units': units_path,
                 }
 
             if name == 'local':
                 return {
                     'integration': 'all',
                     'network-integration': 'all',
-                    'units': 'test/units/plugins/connections/',
+                    'units': units_path,
                 }
 
-            if 'connection_%s' % name in self.integration_targets_by_name:
+            if name == 'network_cli':
                 return {
-                    'integration': 'connection_%s' % name,
+                    'network-integration': 'all',
+                    'units': units_path,
                 }
 
-            return minimal
+            # other connection plugins have isolated integration and unit tests
+
+            return {
+                'integration': integration_name,
+                'units': units_path,
+            }
 
         if path.startswith('lib/ansible/utils/module_docs_fragments/'):
             return {


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (test-connection 6a50a2a8e9) last updated 2016/12/05 17:49:55 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 6890003c4f) last updated 2016/11/30 18:14:44 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 20ea46642b) last updated 2016/11/30 18:14:44 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Correct change classification for network plugins.