### PR TITLE
Verify path before assigning to sanity test.

### DIFF
--- a/lib/ansible/modules/packaging/os/xbps.py
+++ b/lib/ansible/modules/packaging/os/xbps.py
@@ -19,6 +19,10 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
 DOCUMENTATION = '''
 ---
 module: xbps
@@ -93,6 +97,8 @@ packages:
 
 
 import os
+
+from ansible.module_utils.basic import AnsibleModule
 
 
 def is_installed(xbps_output):
@@ -292,9 +298,6 @@ def main():
         elif p['state'] == 'absent':
             remove_packages(module, xbps_path, pkgs)
 
-
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == "__main__":
     main()

--- a/test/runner/lib/classification.py
+++ b/test/runner/lib/classification.py
@@ -9,6 +9,7 @@ from lib.target import (
     walk_integration_targets,
     walk_units_targets,
     walk_compile_targets,
+    walk_sanity_targets,
 )
 
 from lib.util import (
@@ -76,10 +77,12 @@ class PathMapper(object):
         self.module_targets = list(walk_module_targets())
         self.compile_targets = list(walk_compile_targets())
         self.units_targets = list(walk_units_targets())
+        self.sanity_targets = list(walk_sanity_targets())
 
         self.compile_paths = set(t.path for t in self.compile_targets)
         self.units_modules = set(t.module for t in self.units_targets if t.module)
         self.units_paths = set(t.path for t in self.units_targets)
+        self.sanity_paths = set(t.path for t in self.sanity_targets)
 
         self.module_names_by_path = dict((t.path, t.module) for t in self.module_targets)
         self.integration_targets_by_name = dict((t.name, t) for t in self.integration_targets)
@@ -107,7 +110,7 @@ class PathMapper(object):
             result['compile'] = path
 
         # run sanity on path unless result specified otherwise
-        if 'sanity' not in result:
+        if path in self.sanity_paths and 'sanity' not in result:
             result['sanity'] = path
 
         return result


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (at-fix 888a661ce3) last updated 2016/12/06 10:54:21 (GMT -400)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras:  not found - use git submodule update --init lib/ansible/modules/extras
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Verify path before assigning to sanity test.