### PR TITLE
Metadata Status needs to be a list, not a scalar.

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_region.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_region.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible. If not, see <http://www.gnu.org/licenses/>.
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_affinity_labels.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_affinity_labels.py
@@ -36,7 +36,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_affinity_labels_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_affinity_labels_facts.py
@@ -31,7 +31,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_clusters.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_clusters.py
@@ -37,7 +37,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_clusters_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_clusters_facts.py
@@ -30,7 +30,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_datacenters.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_datacenters.py
@@ -38,7 +38,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_datacenters_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_datacenters_facts.py
@@ -30,7 +30,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_external_providers.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_external_providers.py
@@ -37,7 +37,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_external_providers_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_external_providers_facts.py
@@ -31,7 +31,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_groups.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_groups.py
@@ -37,7 +37,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_groups_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_groups_facts.py
@@ -30,7 +30,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_mac_pools.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_mac_pools.py
@@ -36,7 +36,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_networks.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_networks.py
@@ -38,7 +38,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_networks_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_networks_facts.py
@@ -30,7 +30,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_nics.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_nics.py
@@ -38,7 +38,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_nics_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_nics_facts.py
@@ -32,7 +32,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_permissions.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_permissions.py
@@ -40,7 +40,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_permissions_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_permissions_facts.py
@@ -36,7 +36,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_quotas.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_quotas.py
@@ -38,7 +38,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_quotas_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_quotas_facts.py
@@ -32,7 +32,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
@@ -39,7 +39,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains_facts.py
@@ -30,7 +30,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
@@ -41,7 +41,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_templates_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_templates_facts.py
@@ -30,7 +30,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_users.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_users.py
@@ -36,7 +36,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_users_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_users_facts.py
@@ -30,7 +30,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vmpools.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vmpools.py
@@ -39,7 +39,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vmpools_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vmpools_facts.py
@@ -30,7 +30,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms_facts.py
@@ -30,7 +30,7 @@ from ansible.module_utils.ovirt import (
 )
 
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/database/postgresql/postgresql_schema.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_schema.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/network/a10/a10_server_axapi3.py
+++ b/lib/ansible/modules/network/a10/a10_server_axapi3.py
@@ -21,7 +21,7 @@ You should have received a copy of the GNU General Public License
 along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 

--- a/lib/ansible/modules/network/ipinfoio_facts.py
+++ b/lib/ansible/modules/network/ipinfoio_facts.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-ANSIBLE_METADATA = {'status': 'preview',
+ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
various modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

##### SUMMARY

The default metadata was specified with a string "preview" instead of
the list ["preview"].