### PR TITLE
Add missing znode module description.

### DIFF
--- a/lib/ansible/modules/clustering/znode.py
+++ b/lib/ansible/modules/clustering/znode.py
@@ -24,7 +24,8 @@ DOCUMENTATION = """
 ---
 module: znode
 version_added: "2.0"
-short_description: Create, delete, retrieve, and update znodes using ZooKeeper.
+short_description: Create, delete, retrieve, and update znodes using ZooKeeper
+description: Create, delete, retrieve, and update znodes using ZooKeeper.
 options:
     hosts:
         description:

--- a/test/sanity/ansible-doc/skip.txt
+++ b/test/sanity/ansible-doc/skip.txt
@@ -2,4 +2,3 @@ async_wrapper
 fireball
 win_dotnet_ngen
 xenserver_facts
-znode


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

znode module

##### ANSIBLE VERSION

```
ansible 2.3.0 (znode-fix e7e2ae9902) last updated 2016/12/06 17:16:42 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Add missing znode module description.