### PR TITLE
Don't error if pytest skips all unit tests.

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -515,7 +515,13 @@ def command_units(args):
 
     for version, command, env in version_commands:
         display.info('Unit test with Python %s' % version)
-        intercept_command(args, command, env=env, python_version=version)
+
+        try:
+            intercept_command(args, command, env=env, python_version=version)
+        except SubprocessError as ex:
+            # pytest exits with status code 5 when all tests are skipped, which isn't an error for our use case
+            if ex.status != 5:
+                raise
 
 
 def command_compile(args):


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (pytest-skip cc9b4644b0) last updated 2016/12/06 20:49:02 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Don't error if pytest skips all unit tests.