### PR TITLE
Fix unit test directory path target.

### DIFF
--- a/test/runner/lib/classification.py
+++ b/test/runner/lib/classification.py
@@ -281,7 +281,7 @@ class PathMapper(object):
                 }
 
             return {
-                'units': os.path.dirname(path),
+                'units': '%s/' % os.path.dirname(path),
             }
 
         if path.startswith('test/runner/'):


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (classify 633dcfbe74) last updated 2016/12/06 21:33:32 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Fix unit test directory path target.