### PR TITLE
Replace module Python 3 fix

### DIFF
--- a/lib/ansible/modules/files/replace.py
+++ b/lib/ansible/modules/files/replace.py
@@ -101,7 +101,7 @@ EXAMPLES = r"""
     validate: '/usr/sbin/apache2ctl -f %s -t'
 """
 
-def write_changes(module,contents,dest):
+def write_changes(module, contents, dest):
 
     tmpfd, tmpfile = tempfile.mkstemp()
     f = os.fdopen(tmpfd,'wb')
@@ -160,8 +160,8 @@ def main():
         contents = f.read()
         f.close()
 
-    mre = re.compile(params['regexp'], re.MULTILINE)
-    result = re.subn(mre, params['replace'], contents, 0)
+    mre = re.compile(to_bytes(params['regexp']), re.MULTILINE)
+    result = re.subn(mre, to_bytes(params['replace']), contents, 0)
 
     if result[1] > 0 and contents != result[0]:
         msg = '%s replacements made' % result[1]
@@ -189,6 +189,7 @@ def main():
 
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *
+from ansible.module_utils._text import to_bytes
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
replace module

##### ANSIBLE VERSION
```
ansible 2.3.0 (replace-python3 d3e372fc37) last updated 2016/12/08 15:27:46 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Fixes error in Python 3 where `regexp` and `replace` parameters are strings which can't be searched in a byte object. In particular, an error

`TypeError: cannot use a string pattern on a bytes-like object`

was raised in the `re.subn()` function.

replace (line 104): format `write_changes` function definition with spaces between parameters.
replace (lines 163-164): convert `params['regexp']` and `params['replace']` to bytes for searching `contents`
replace (line 192): import to_bytes