### PR TITLE
Add infiniband as a network interface type - facts

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2293,6 +2293,7 @@ class LinuxNetwork(Network):
     platform = 'Linux'
     INTERFACE_TYPE = {
         '1': 'ether',
+        '32': 'infiniband',
         '512': 'ppp',
         '772': 'loopback',
         '65534': 'tunnel',


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (feature/infiniband_type 51e665d8d2) last updated 2016/12/07 12:36:27 (GMT +300)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Add type: "infiniband" for Infiniband interfaces. 

Checked on DDR and FDR Infiniband cards from Mellanox in both HP and Bull servers and it was always /sys/class/net/ib0/type was always "32". Linux kernel code [1] also says that infiniband should have type 32.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

```
$ ansible -m setup server|grep -A 80 ansible_ib0|grep type
            "type": "unknown"
```

```
$ ansible -m setup server|grep -A 80 ansible_ib0|grep type
            "type": "infiniband"

```


[1]: https://github.com/torvalds/linux/blob/master/include/uapi/linux/if_arp.h
