### PR TITLE
Fix direct use of fact gathering

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -83,14 +83,15 @@ class TimeoutError(Exception):
 
 def timeout(seconds=10, error_message="Timer expired"):
 
+    if 'GATHER_TIMEOUT' in globals():
+        if GATHER_TIMEOUT:
+            seconds = GATHER_TIMEOUT
+
     def decorator(func):
         def _handle_timeout(signum, frame):
             raise TimeoutError(error_message)
 
         def wrapper(*args, **kwargs):
-            if 'GATHER_TIMEOUT' in globals():
-                if GATHER_TIMEOUT:
-                    seconds = GATHER_TIMEOUT
             signal.signal(signal.SIGALRM, _handle_timeout)
             signal.alarm(seconds)
             try:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
`setup`/fact gathering

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /tmp/ansible.cfg
  configured module search path = ['library']
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

When programmatically gather facts, we got an error:
>   File \"/tmp/ansible_ogBqT7/ansible_modlib.zip/ansible/module_utils/facts.py\", line 102, in wrapper
> UnboundLocalError: local variable 'seconds' referenced before assignment

See openshift/openshift-ansible#2247