### PR TITLE
ec2_group_facts: Fail correctly when boto3 is not installed

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group_facts.py
@@ -102,7 +102,7 @@ try:
     from botocore.exceptions import ClientError
     HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = Falsentry
+    HAS_BOTO3 = False
 
 import traceback
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`ec2_group_facts`

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>