### PR TITLE
set_extra_var module

### DIFF
--- a/lib/ansible/plugins/action/set_extra_var.py
+++ b/lib/ansible/plugins/action/set_extra_var.py
@@ -1,0 +1,16 @@
+# Copyright 2016 Pieter Voet <pietervoet@nl.ibm.com>
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+
+class ActionModule(ActionBase):
+    def run(self, tmp=None, task_vars=None):
+        if task_vars is None:
+           task_vars = dict()
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        result['changed'] = False
+        result['add_extra_var'] = (self._task.args['name'], self._task.args['value'])
+        return result

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -453,6 +453,12 @@ class StrategyBase:
                         # this task added a new group (group_by module)
                         self._add_group(original_host, result_item)
 
+                    # PV
+                    elif 'add_extra_var' in result_item:
+                        var = result_item['add_extra_var']
+                        if var[0] not in self._variable_manager._extra_vars:
+                            self._variable_manager._extra_vars[var[0]] = var[1]
+
                     elif 'ansible_facts' in result_item:
 
                         # set correct loop var

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -455,6 +455,7 @@ class StrategyBase:
 
                     # PV
                     elif 'add_extra_var' in result_item:
+                        # this task added a new 'extra var' variable
                         var = result_item['add_extra_var']
                         if var[0] not in self._variable_manager._extra_vars:
                             self._variable_manager._extra_vars[var[0]] = var[1]


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
set_extra_var
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = /home/pieter/PycharmProjects/first/ansible.cfg
  configured module search path = ['/home/pieter/customers/BelastingDienst/BPM/ansible/modules']
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
module ( action plugin ) to set an 'extra_vars' variable from within a play.
Consider this example

Inventory :
group_all = { host_1, host_2, host_3 }
group_one = { host_1 }
group_two = { host_2, host3 }

Playbook :
---
- hosts: group_one
  tasks:
  - name: list /tmp
    shell: ls /tmp
    register: out

  - name: set extra variable
    set_extra_var: name=myvar value="{{out}}"


- hosts: group_two
  tasks:
  - debug: msg="{{myvar}}"


command : ansible-playbook my_playbook.yml --limit group_all
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
