### PR TITLE
Docs (jenkins_plugin): Specify version as string

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -120,6 +120,8 @@ options:
         manually.
       - It might take longer to verify that the correct version is installed.
         This is especially true if a specific version number is specified.
+      - Quote the version to prevent the value to be interpreted as float. For
+        example if C(1.20) would be unquoted, it would become C(1.2).
   with_dependencies:
     required: false
     choices: ['yes', 'no']
@@ -159,7 +161,7 @@ EXAMPLES = '''
 - name: Install specific version of the plugin
   jenkins_plugin:
     name: token-macro
-    version: 1.15
+    version: "1.15"
 
 - name: Pin the plugin
   jenkins_plugin:
@@ -212,7 +214,7 @@ EXAMPLES = '''
       token-macro:
         enabled: yes
       build-pipeline-plugin:
-        version: 1.4.9
+        version: "1.4.9"
         pinned: no
         enabled: yes
   tasks:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
jenkins_plugins
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.2.0.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

If the plugin version expected is, say '1.20', then specifying it
as...
```
    version: 1.20
```
... will make the YAML parser interpret it as a float, and the
value obtained by the module will be 1.2 instead of 1.20, which
will cause downloading of wrong version of the module.

This patch updates the docs so that users don't face this issue.