### PR TITLE
Add @ to valid package name characters

### DIFF
--- a/lib/ansible/modules/packaging/os/homebrew.py
+++ b/lib/ansible/modules/packaging/os/homebrew.py
@@ -179,6 +179,7 @@ class Homebrew(object):
         \+                  # plusses
         -                   # dashes
         :                   # colons (for URLs)
+        @                   # at-sign        
     '''
 
     INVALID_PATH_REGEX        = _create_regex_group(VALID_PATH_CHARS)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Homebrew

##### SUMMARY
Add `@` to valid package name characters

NodeJS formulae are now named **node@<major_version>**

E.g. https://github.com/Homebrew/homebrew-core/blob/master/Formula/node@6.rb