### PR TITLE
Fix python 2.4 compatibility

### DIFF
--- a/lib/ansible/modules/system/known_hosts.py
+++ b/lib/ansible/modules/system/known_hosts.py
@@ -145,8 +145,8 @@ def enforce_state(module, params):
         try:
             outf=tempfile.NamedTemporaryFile(dir=os.path.dirname(path))
             if inf is not None:
-                for line_number, line in enumerate(inf, start=1):
-                    if found_line==line_number and (replace_or_add or state=='absent'):
+                for line_number, line in enumerate(inf):
+                    if found_line==(line_number + 1) and (replace_or_add or state=='absent'):
                         continue # skip this line to replace its key
                     outf.write(line)
                 inf.close()


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
Module `known_hosts`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /home/vagrant/ansibox/ansible.cfg
  configured module search path = ['library']
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

`start` keyword of `enumerate` is only available since python 2.6