### PR TITLE
Add module "launchd" to manage Mac OS X services.

### DIFF
--- a/lib/ansible/modules/system/launchd.py
+++ b/lib/ansible/modules/system/launchd.py
@@ -30,7 +30,7 @@ author:
 version_added: '2.2'
 short_description: Manage Mac OS X launchd services.
 description:
-    - Manage (start, stop & restart) Mac OS X launchd services via launchctl.
+    - Manage (start, stop and restart) Mac OS X launchd services via launchctl.
 options:
     name:
         required: true
@@ -39,7 +39,7 @@ options:
         aliases: [ 'service', 'label' ]
     state:
         required: true
-        choices: [ 'started', 'loaded', 'stopped', 'unloaded', 'restarted', 'reloaded ]
+        choices: [ 'started', 'loaded', 'stopped', 'unloaded', 'restarted', 'reloaded' ]
         description:
             - C(started), C(loaded), C(stopped) and C(unloaded) are idempotent
               actions that will not run commands unless necessary.

--- a/lib/ansible/modules/system/osx_service.py
+++ b/lib/ansible/modules/system/osx_service.py
@@ -42,8 +42,8 @@ requirements: [ launchctl ]
 '''
 
 RETURN = '''
-These values will be returned on success...
-
+---
+# These values will be returned on success...
 name:
   description: Label of job
   type: string

--- a/lib/ansible/modules/system/osx_service.py
+++ b/lib/ansible/modules/system/osx_service.py
@@ -23,7 +23,7 @@ DOCUMENTATION = '''
 ---
 module: osx_service
 author: "Björn Albers <bjoernalbers@gmail.com>"
-version_added: "2.1"
+version_added: "2.2"
 short_description: Manage Mac OS X system services via launchctl
 description:
   - Start, stop and restart Mac OS X system services that have a valid launchd

--- a/lib/ansible/modules/system/osx_service.py
+++ b/lib/ansible/modules/system/osx_service.py
@@ -41,6 +41,23 @@ options:
 requirements: [ launchctl ]
 '''
 
+RETURN = '''
+These values will be returned on success...
+
+name:
+  description: Label of job
+  type: string
+  sample: "com.docker.vmnetd"
+state:
+  description: Current state of job
+  type: string
+  sample: "started"
+changed:
+  description: Did the job state change?
+  type: boolean
+  sample: True
+'''
+
 EXAMPLES = '''
 - osx_service: name=com.docker.vmnetd state=started
 '''

--- a/lib/ansible/modules/system/osx_service.py
+++ b/lib/ansible/modules/system/osx_service.py
@@ -1,0 +1,120 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2016, Björn Albers <bjoernalbers@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+DOCUMENTATION = '''
+---
+module: osx_service
+author: "Björn Albers <bjoernalbers@gmail.com>"
+version_added: "2.1"
+short_description: Manage Mac OS X system services via launchctl
+description:
+  - Start, stop and restart Mac OS X system services that have a valid launchd
+    plist under /Library/LaunchDaemons.
+options:
+  name:
+    description:
+      Label of job
+    required: true
+  state:
+    description:
+      Desired state
+    required: true
+    choices: [ "started", "stopped", "restarted" ]
+requirements: [ launchctl ]
+'''
+
+EXAMPLES = '''
+- osx_service: name=com.docker.vmnetd state=started
+'''
+
+
+class OSXService:
+    COMMAND   = '/bin/launchctl'
+    PLIST_DIR = '/Library/LaunchDaemons'
+
+    def __init__(self, module):
+        self.module = module
+        self.name   = module.params['name']
+
+    def start(self):
+        if not self.__started():
+            return self.__launchctl(['load', '-w', self.__plist()])
+        else:
+            return False
+
+    def stop(self):
+        if self.__started():
+            return self.__launchctl(['unload', '-w', self.__plist()])
+        else:
+            return False
+
+    def restart(self):
+        self.stop()
+        return self.start()
+
+    def __started(self):
+        (rc, _, _) = self.module.run_command(
+            [self.COMMAND, 'list', self.name])
+        return rc == 0
+
+    def __plist(self):
+        return os.path.join(self.PLIST_DIR, self.name + '.plist')
+
+    def __launchctl(self, arguments):
+          (_, _, stderr) = self.module.run_command(
+              [self.COMMAND] + arguments, check_rc=True)
+          if stderr:
+              self.module.fail_json(msg=stderr)
+          else:
+              return True
+        
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec = dict(
+            name  = dict(required = True),
+            state = dict(required = True,
+                choices = ['started', 'stopped', 'restarted']),
+        ),
+        supports_check_mode = False
+    )
+
+    if os.geteuid() != 0:
+        module.fail_json(msg='Please run as root!')
+
+    name  = module.params['name']
+    state = module.params['state']
+
+    service = OSXService(module)
+    if state == 'started':
+        changed = service.start()
+    elif state == 'stopped':
+        changed = service.stop()
+    elif state == 'restarted':
+        changed = service.restart()
+
+    module.exit_json(name=name, state=state, changed=changed) 
+
+
+# import module snippets
+from ansible.module_utils.basic import *
+main()


### PR DESCRIPTION
##### ISSUE TYPE

New Module Pull Request
##### COMPONENT NAME

osx_service
##### ANSIBLE VERSION

```
ansible 2.1.1.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

This module allows to start, stop and restart Mac OS X launchd daemons
via `launchctl`.
It supports system services (stuff that has a plist under
/Library/LaunchDaemons) and must be run with root permissions.

About the implementation...

Service management on Mac OS X is a different horse and deserves its own module.
I build the first draft in Ruby: [osx_service.rb](https://gist.github.com/bjoernalbers/f40b3fc17067959b9e4663be5021c1be).
But with the help of `AnsibleModule` I was able to port it to Python so that others could use this as well.

Here is some example output...

```
TASK [stop crashplan] **********************************************************
changed: [localhost] => {"changed": true, "name": "com.crashplan.engine", "state": "stopped"}
```

Thanks in advance,
Björn
