### PR TITLE
Display proper error on group_vars syntax error

### DIFF
--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -575,8 +575,13 @@ class VariableManager:
 
         rval = AnsibleInventoryVarsData()
         rval.path = path
+
         if data is not None:
-            rval.update(data)
+            if not isinstance(data, dict):
+                raise AnsibleError("Problem parsing file '%s': line %d, column %d" % data.ansible_pos)
+            else:
+                rval.update(data)
+
         return rval
 
     def add_host_vars_file(self, path, loader):


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
vars

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.2

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
This fix ensures a proper error is shown when a group_vars files cannot
be parsed correctly. Without this patch you get:

```
[dag@moria ansible.testing]$ ansible-playbook test132.yml
ERROR! Unexpected Exception: dictionary update sequence element #0 has length 1; 2 is required
to see the full traceback, use -vvv
```

With this patch you get:
```
[dag@moria ansible.testing]$ ansible-playbook test132.yml
ERROR! Problem parsing file '/home/dag/home-made/ansible.testing/group_vars/test135': line 1, column 1
```

This fixes #18843