### PR TITLE
fixes #4441 passing subnet_name parameter

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -1243,7 +1243,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
 
         if self.subnet_name:
             try:
-                subnet = self.network_client.subnets.get(self.resource_group, virtual_network_name)
+                subnet = self.network_client.subnets.get(self.resource_group, virtual_network_name, self.subnet_name)
                 subnet_id = subnet.id
             except Exception as exc:
                 self.fail("Error: fetching subnet {0} - {1}".format(self.subnet_name, str(exc)))


### PR DESCRIPTION
As far as I could check this is related to this [function](https://github.com/Azure/azure-sdk-for-python/blob/master/azure-mgmt-network/azure/mgmt/network/operations/subnets_operations.py#L128) on azure python SDK
