### PR TITLE
cloudstack: cs_instance: fix userdata not up to date

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_instance.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instance.py
@@ -533,6 +533,10 @@ class AnsibleCloudStackInstance(AnsibleCloudStack):
                     if not vpc_id and self.is_vm_in_vpc(vm=v):
                         continue
                     if instance_name.lower() in [ v['name'].lower(), v['displayname'].lower(), v['id'] ]:
+                        # Query the user data if we need to
+                        if 'userdata' not in v and self.get_user_data() is not None:
+                            res = self.cs.getVirtualMachineUserData(virtualmachineid=v['id'])
+                            v['userdata'] = res['virtualmachineuserdata'].get('userdata',"")
                         self.instance = v
                         break
         return self.instance


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cs_instance

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.2.0
```

##### SUMMARY

Fixes unnecessary VM restart.

VM userdata is currently not returned by the API listVirtualMachine and task will always be marked as changed in has_changed(), which will result in an unnecessary VM restart if force=true.

Reported by @Mayeu