### PR TITLE
Add example for multiple authorized_keys

### DIFF
--- a/lib/ansible/modules/system/authorized_key.py
+++ b/lib/ansible/modules/system/authorized_key.py
@@ -153,6 +153,16 @@ EXAMPLES = '''
     user: ubuntu
     state: present
     key: "{{ lookup('file', lookup('env','HOME') + '/.ssh/id_rsa.pub') }}"
+
+- block:
+  - name: Set up authorized_keys exclusively with many keys
+    set_fact: pubkey_list="{{ lookup('file', 'pubkeys/' + item) }}"
+    register: pubkeys
+    with_items:
+      - key1.pub
+      - key2.pub
+  - set_fact: pubkey_string={{ pubkeys.results | map(attribute='ansible_facts.pubkey_list') | join('\n') }}
+  - authorized_key: user=root key="{{ pubkey_string }}" exclusive=yes
 '''
 
 RETURN = '''


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### ANSIBLE VERSION

```
devel
```

##### COMPONENT NAME
authorized_key

##### SUMMARY

This adds a rather complicated but important example to the authorized_keys module. It shows how to use `exclusive=yes` with multiple ssh keys. I feel that this is a common scenario for many users with no obvious solution. I've taken quite some time to come up with this solution so I think it's a good idea to share this. It looks like other people have also had trouble coming up with this: ansible/ansible#11347, #1253, http://serverfault.com/questions/665410/using-ansible-to-add-users-public-keys-to-one-users-authorized-keys-file, http://stackoverflow.com/questions/33032747/ansible-how-to-concatenate-files-contents-into-a-variable