### PR TITLE
add kubernetes beta resources to clustering/kubernetes module

### DIFF
--- a/lib/ansible/modules/clustering/kubernetes.py
+++ b/lib/ansible/modules/clustering/kubernetes.py
@@ -214,7 +214,12 @@ KIND_URL = {
     "resourcequota": "/api/v1/namespaces/{namespace}/resourcequotas",
     "secret": "/api/v1/namespaces/{namespace}/secrets",
     "service": "/api/v1/namespaces/{namespace}/services",
-    "serviceaccount": "/api/v1/namespaces/{namespace}/serviceaccounts"
+    "serviceaccount": "/api/v1/namespaces/{namespace}/serviceaccounts",
+    "daemonset": "/apis/extensions/v1beta1/namespaces/{namespace}/daemonsets",
+    "deployment": "/apis/extensions/v1beta1/namespaces/{namespace}/deployments",
+    "horizontalpodautoscaler": "/apis/extensions/v1beta1/namespaces/{namespace}/horizontalpodautoscalers",  # NOQA
+    "ingress": "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses",
+    "job": "/apis/extensions/v1beta1/namespaces/{namespace}/jobs",
 }
 USER_AGENT = "ansible-k8s-module/0.0.1"
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

kubernetes

``` yaml
- name: Create kubernetes cloud logging Daemon Set (logstash)             
  kubernetes:                                                             
    api_endpoint: 127.0.0.1:8080                                          
    insecure: yes                                                         
    inline_data: "{{ lookup('template', 'logstash-daemonset.yaml.j2' ) }}"
```
##### ANSIBLE VERSION

```
ansible 2.1.1.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Add ability to operate on kubernetes resources from `apiVersion: extensions/v1beta1`

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before

```
TASK [kube-master/cloud-logging : Create kubernetes cloud logging Daemon Set (logstash)] ***
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "", "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_x0OjsW/ansible_module_kubernetes.py\", line 399, in <module>\r\n    main()\r\n  File \"/tmp/ansible_x0OjsW/ansible_module_kubernetes.py\", line 373, in main\r\n    module.fail_json(\"invalid resource kind specified in the data: '%s'\" % kind)\r\nTypeError: fail_json() takes exactly 1 argument (2 given)\r\n", "msg": "MODULE FAILURE", "parsed": false}
```

After

```
TASK [kube-master/cloud-logging : Create kubernetes cloud logging Daemon Set (logstash)] ***
ok: [localhost]
```
