### PR TITLE
check_mode and single file install for the opkg module

### DIFF
--- a/lib/ansible/modules/packaging/os/opkg.py
+++ b/lib/ansible/modules/packaging/os/opkg.py
@@ -69,6 +69,10 @@ EXAMPLES = '''
     state: present
 
 - opkg:
+    ipk: foo_123-r0_all.ipk
+    state: present
+
+- opkg:
     name: foo
     state: present
     update_cache: yes


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
`opkg`

##### ANSIBLE VERSION
```
ansible 2.3.0 (opkg 7a860e59a1) last updated 2016/12/07 19:27:49 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
* implement check_mode for opkg module
* implement installing single ipk files, this works from either a local file or an URL, inspired by the "deb" param of the apt module
