### PR TITLE
Handle inability to read /proc for ansible_service_mgr. Fixes #18957

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -335,6 +335,10 @@ class Facts(object):
             if re.match(r' *[0-9]+ ', proc_1):
                 proc_1 = None
 
+            # The ps command above may return "COMMAND" if the user cannot read /proc, e.g. with grsecurity
+            if proc_1 == "COMMAND\n":
+                proc_1 = None
+
         if proc_1 is not None:
             proc_1 = os.path.basename(proc_1)
             proc_1 = to_native(proc_1)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible_service_mgr detection

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /Users/xxx/work/xxx/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Fixes #18957

When Ansible collects facts, it attempts to determine the init system by reading from `/proc/1/comm` and then with `ps -p 1 -o comm|tail -n 1`. This fails when the kernel has grsecurity patches. 

With the grsecurity patches configured with `CONFIG_GRKERNSEC_PROC_USER=y`, `/proc` is only readable by root, and normal users can only view their own processes. The read of `/proc/1/comm` fails with no file found, which is fine. The ps command, however, returns an "empty" result with just the header "COMMAND", causing `ansible_service_mgr` to be set to `COMMAND`. Here is an example of what ps returns for a regular user and for root. 

    $ ps -p 1 -o comm
    COMMAND

    # ps -p 1 -o comm
    COMMAND
    init

```
ansible foo-server -m setup -a 'filter=ansible_service_mgr'
```

##### EXPECTED RESULTS
```
foo-server | SUCCESS => {
    "ansible_facts": {
        "ansible_service_mgr": "systemd"
    },
    "changed": false
}
```

##### ACTUAL RESULTS
```
foo-server | SUCCESS => {
    "ansible_facts": {
        "ansible_service_mgr": "COMMAND"
    },
    "changed": false
}
```