### PR TITLE
Consul inventory : take in account boolean value in config file

### DIFF
--- a/contrib/inventory/consul.ini
+++ b/contrib/inventory/consul.ini
@@ -11,6 +11,7 @@ url = http://localhost:8500
 
 # suffix added to each service to create a group name e.g Service of 'redis' and
 # a suffix of '_servers' will add each address to the group name 'redis_servers'
+use_server_suffix = false
 servers_suffix = _servers
 
 # if specified then the inventory will generate domain names that will resolve

--- a/contrib/inventory/consul_io.py
+++ b/contrib/inventory/consul_io.py
@@ -324,7 +324,7 @@ class ConsulInventory(object):
     if self.is_service("ssh", service_name):
       self.add_metadata(node_data, "ansible_ssh_port", service['Port'])
 
-    if self.config.has_config('servers_suffix'):
+    if self.config.has_config('use_server_suffix') and self.config.has_config('servers_suffix'):
       service_name = service_name + self.config.servers_suffix
 
     self.add_node_to_map(self.nodes_by_service, service_name, node_data['Node'])
@@ -421,7 +421,11 @@ class ConsulConfig(dict):
 
   def has_config(self, name):
     if hasattr(self, name):
-      return getattr(self, name)
+      attr = getattr(self, name)
+      if attr in ['True', 'true', 'False', 'false']:
+         return self.str_to_bool(attr)
+      else:
+        return attr
     else:
       return False
 
@@ -433,7 +437,7 @@ class ConsulConfig(dict):
     config_options = ['host', 'token', 'datacenter', 'servers_suffix',
                       'tags', 'kv_metadata', 'kv_groups', 'availability',
                       'unavailable_suffix', 'available_suffix', 'url',
-                      'domain']
+                      'domain', 'use_server_suffix']
     for option in config_options:
       value = None
       if config.has_option('consul', option):
@@ -465,6 +469,11 @@ class ConsulConfig(dict):
         return self.has_config(suffix)
       return default
 
+  def str_to_bool(self, option):
+    if option == 'True' or option == 'true':
+         return True
+    else:
+         return False
 
   def get_consul_api(self):
       '''get an instance of the api based on the supplied configuration'''


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
contrib/inventory/consul

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Take in account boolean value, actually their are ignored and we can not switch off use of suffixe for groups
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```

