### PR TITLE
ecs_taskdefinition: Fix int param types (Fixes #4538)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -48,7 +48,7 @@ options:
         type: int
     containers:
         description:
-            - A list of containers definitions 
+            - A list of containers definitions
         required: False
         type: list of dicts with container definitions
     volumes:
@@ -138,8 +138,24 @@ class EcsTaskManager:
             return None
 
     def register_task(self, family, container_definitions, volumes):
+        validated_containers = []
+
+        # Ensures the number parameters are int as required by boto
+        for container in container_definitions:
+            for param in ('memory', 'cpu', 'memoryReservation'):
+                if param in container:
+                    container[param] = int(container[param])
+
+            if 'portMappings' in container:
+                for port_mapping in container['portMappings']:
+                    for port in ('hostPort', 'containerPort'):
+                        if port in port_mapping:
+                            port_mapping[port] = int(port_mapping[port])
+
+            validated_containers.append(container)
+
         response = self.ecs.register_task_definition(family=family,
-            containerDefinitions=container_definitions, volumes=volumes)
+            containerDefinitions=validated_containers, volumes=volumes)
         return response['taskDefinition']
 
     def describe_task_definitions(self, family):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ecs_taskdefinition

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### SUMMARY
This fixes [#4538 on ansible-modules-core](https://github.com/ansible/ansible-modules-core/issues/4538) where given container parameters to the module are always passed on as strings in the container definition parameters, which causes an exception by boto as [some parameters](https://github.com/ansible/ansible-modules-core/issues/4538#issuecomment-242960876) have to be integers. 
