### PR TITLE
Fix non-zero exit code on missing role file

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -357,7 +357,7 @@ class GalaxyCLI(CLI):
                         roles_left.append(GalaxyRole(self.galaxy, **role))
                 f.close()
             except (IOError, OSError) as e:
-                display.error('Unable to open %s: %s' % (role_file, str(e)))
+                raise AnsibleError('Unable to open %s: %s' % (role_file, str(e)))
         else:
             # roles were specified directly, so we'll just go out grab them
             # (and their dependencies, unless the user doesn't want us to).


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cli

##### SUMMARY
Currently a bad role file specified on the command line does not generate a non-zero exit code:

```
scott-buchanan-ripen-mac:~ scottbuchanan$ ansible-galaxy install --role-file='notafile.yml'
 [ERROR]: Unable to open notafile.yml: [Errno 2] No such file or directory: 'notafile.yml'

scott-buchanan-ripen-mac:~ scottbuchanan$ echo $?
0
```

With this patch:

```
scott-buchanan-ripen-mac:~ scottbuchanan$ ansible-galaxy install --role-file='notafile.yml'
ERROR! Unable to open notafile.yml: [Errno 2] No such file or directory: 'notafile.yml'

scott-buchanan-ripen-mac:~ scottbuchanan$ echo $?
1
```