### PR TITLE
Removing a non-existing directory complains

### DIFF
--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -201,6 +201,7 @@ def main():
 
     params = module.params
     state = params['state']
+    recurse = params['recurse']
     force = params['force']
     diff_peek = params['diff_peek']
     src = params['src']
@@ -231,6 +232,8 @@ def main():
     if state is None:
         if prev_state != 'absent':
             state = prev_state
+        elif recurse:
+            state = 'directory'
         else:
             state = 'file'
 
@@ -257,7 +260,6 @@ def main():
             b_path = to_bytes(path, errors='surrogate_or_strict')
 
     # make sure the target path is a directory when we're doing a recursive operation
-    recurse = params['recurse']
     if recurse and state != 'directory':
         module.fail_json(path=path, msg="recurse option requires state to be 'directory'")
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
file

##### ANSIBLE VERSION
v2.2

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

The following playbook:

```yaml
- hosts: localhost
  tasks:
  - file:
      path: /tmp/non-existing-foo-bar
      state: absent
      recurse: yes
```

causes this error:

```
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "recurse option requires state to be 'directory'", "path": "/tmp/non-existing-foo-bar", "state": "absent"}
```

The included fix ensures that when recurse is added, we no longer assume
it is a file, but accept that it is a directory.