### PR TITLE
unarchive: Various changes/improvements, add debugging output

### DIFF
--- a/test/integration/targets/unarchive/aliases
+++ b/test/integration/targets/unarchive/aliases
@@ -1,2 +1,3 @@
 needs/root
 posix/ci/group2
+skip/freebsd


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
unarchive

##### ANSIBLE VERSION
<!---
Paste verbatim output from “ansible --version” between quotes below,
this is to help the Ansible team determine if this is a version specific
issue which is being fixed.
-->
v2.2

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->
Various changes and improvements:

- Fixed a few issues with the existing unzip support which were related to Zipfile (which is fundamentally incompatible with unzip excludes/opts).  And issues related to forced ownership.

- Improvements to the UnarchiveError Exception, so it can report more detailed information to why an archive cannot be handled.

- A bugfix relatd to unicode filenames and crc32 handling.

- Renamed a few things so the code is easier to read.

- Ensure gtar considers size changes to unarchive its content. This fixes ansible/ansible-modules-core#5149

- Added a note about ZIP archives without directories. This fixes ansible/ansible-modules-core#5744.

The unarchive module is a hard beast to tame, corner-cases and platform-specific issues make it hard to troubleshoot individual issues.

- Improves the default output (e.g. unzip no longer shows standard output, just like gtar) and adds the ability to get debug-output when using -vvvv (verbosity >= 4) or -vvvvv. So that when issues are i reported we have the means to look what is going on internally.

- Because the output by default is reduced, proper warnings/errors are now more obvious to end-users, e.g.

```
TASK [unarchive]
***************************************************************
task path: /home/dag/home-made/ansible.testing/test126.yml:11
changed: [localhost] => {"changed": true, "dest": "/tmp/test126a", "extract_results": {"cmd":
["/usr/bin/unzip", "-q", "-o", "/home/dag/.ansible/tmp/ansible-tmp-1479989967.66-3171393713112/source",
"-x", "some.directory/", "another.directory/simple.test.file.txt", "-d", "/tmp/test126a"], "err":
"caution: excluded filename not matched: some.directory/\ncaution: excluded filename not matched:
another.directory/simple.test.file.txt\n", "out": "", "rc": 0}, "gid": 500, "group": "dag", "handler":
"ZipArchive", "mode": "0775", "owner": "dag", "secontext": "unconfined_u:object_r:user_tmp_t:s0",
"size": 4096, "src": "/home/dag/.ansible/tmp/ansible-tmp-1479989967.66-3171393713112/source",
"state": "directory", "uid": 500}
```
Whereas before the complete list of deflated files was being shown (when using -v) which was much more than anyone was willing to look at.

*Migrated from https://github.com/ansible/ansible-modules-core/pull/5721*