### PR TITLE
Fix: mysql_user - permission string with column privileges

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -62,7 +62,15 @@ options:
     version_added: "2.1"
   priv:
     description:
-      - "MySQL privileges string in the format: C(db.table:priv1,priv2)"
+      - "MySQL privileges string in the format: C(db.table:priv1,priv2)."
+      - "Multiple privileges can be specified by separating each one using
+        a forward slash: C(db.table:priv/db.table:priv)."
+      - The format is based on MySQL C(GRANT) statement.
+      - Database and table names can be quoted, MySQL-style.
+      - If column privileges are used, the C(priv1,priv2) part must be
+        exactly as returned by a C(SHOW GRANT) statement. If not followed,
+        the module will always report changes. It includes grouping columns
+        by permission (C(SELECT(col1,col2)) instead of C(SELECT(col1),SELECT(col2))).
     required: false
     default: null
   append_privs:
@@ -475,7 +483,7 @@ def privileges_unpack(priv, mode):
         if '(' in pieces[1]:
             output[pieces[0]] = re.split(r',\s*(?=[^)]*(?:\(|$))', pieces[1].upper())
             for i in output[pieces[0]]:
-                privs.append(re.sub(r'\(.*\)','',i))
+                privs.append(re.sub(r'\s*\(.*\)','',i))
         else:
             output[pieces[0]] = pieces[1].upper().split(',')
             privs = output[pieces[0]]


### PR DESCRIPTION
##### ISSUE TYPE

 Bugfix Pull Request
##### COMPONENT NAME

mysql_user
##### ANSIBLE VERSION

```
2.0.2.0
```
##### SUMMARY

MySQL returns privileges on columns as `PRIVILEGES (column)`.
For permissions to be correctly matched, it must be specified exactly the
same in the module `priv` argument. A resulting string is like
``` `dbname`.`dbtable`:PRIVILEGES (column)```. Thus, the space before the opening
parenthesis must also be removed when creating the set of privileges for
validation with the expected set.

When the space before the opening parenthesis is not present, the rights are not properly set. The privilege string is ``` `dbname`.`dbtable`:SELECT(EMAIL),UPDATE(PASSWORD)```. I got

```
+---------------------------------------------------------------------------------+
| Grants for mysqluser@localhost                                                  |
+---------------------------------------------------------------------------------+
| GRANT USAGE ON *.* TO 'mysqluser'@'localhost' IDENTIFIED BY PASSWORD '********' |
| GRANT SELECT (EMAIL) ON `dbname`.`dbtable` TO 'mysqluser'@'localhost'           |
+---------------------------------------------------------------------------------+
```

Also, the module kept telling there is changes. After the fix, and putting the space in the privilege string ``` `dbname`.`dbtable`:SELECT (EMAIL),UPDATE (PASSWORD)```. I got

```
+------------------------------------------------------------------------------------------+
| Grants for mysqluser@localhost                                                           |
+------------------------------------------------------------------------------------------+
| GRANT USAGE ON *.* TO 'mysqluser'@'localhost' IDENTIFIED BY PASSWORD '******'            |
| GRANT SELECT (EMAIL), UPDATE (PASSWORD) ON `dbname`.`dbtable` TO 'mysqluser'@'localhost' |
+------------------------------------------------------------------------------------------+
```

Which is what is expected and a rerun got the `ok` state.

Running the module with the privilege string ``` `dbname`.`dbtable`:SELECT (EMAIL),UPDATE (PASSWORD)``` before and after the change.

```
$ ansible-playbook /etc/ansible/test.pb.yaml -vv
Using /***/.ansible.cfg as config file

PLAYBOOK: test.pb.yaml *********************************************************
1 plays in /etc/ansible/test.pb.yaml

PLAY [ks] **********************************************************************

TASK [setup] *******************************************************************
ok: [server]

TASK [User] ********************************************************************
task path: /etc/ansible/test.pb.yaml:9
fatal: [server]: FAILED! => {"changed": false, "failed": true, "msg": "invalid privileges string: Invalid privileges specified: frozenset(['UPDATE ', 'SELECT '])"}

NO MORE HOSTS LEFT *************************************************************
        to retry, use: --limit @/etc/ansible/test.pb.retry

PLAY RECAP *********************************************************************
server       : ok=1    changed=0    unreachable=0    failed=1

$ ansible-playbook /etc/ansible/test.pb.yaml -vv
Using /***/.ansible.cfg as config file

PLAYBOOK: test.pb.yaml *********************************************************
1 plays in /etc/ansible/test.pb.yaml

PLAY [ks] **********************************************************************

TASK [setup] *******************************************************************
ok: [server]

TASK [User] ********************************************************************
task path: /etc/ansible/test.pb.yaml:9
changed: [server] => {"changed": true, "user": "mysqluser"}

PLAY RECAP *********************************************************************
server       : ok=2    changed=1    unreachable=0    failed=0

```
