### PR TITLE
ec2_vol_facts: Include volume encryption status

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vol_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vol_facts.py
@@ -81,6 +81,7 @@ def get_volume_info(volume):
     volume_info = {
                     'create_time': volume.create_time,
                     'id': volume.id,
+                    'encrypted': volume.encrypted,
                     'iops': volume.iops,
                     'size': volume.size,
                     'snapshot_id': volume.snapshot_id,


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

ec2_vol_facts
##### ANSIBLE VERSION

```
ansible 2.1.2.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Include whether or not a volume is encrypted in the results.

After:

```
        {
            "attachment_set": {
                "attach_time": "2016-04-18T02:41:35.000Z",
                "device": "/dev/sdi",
                "instance_id": "i-foo",
                "status": "attached"
            },
            "create_time": "2016-04-18T02:41:28.333Z",
            "encrypted": true,
            "id": "vol-foo",
            "iops": null,
            "region": "us-west-1",
            "size": 50,
            "snapshot_id": "",
            "status": "in-use",
            "tags": {},
            "type": "standard",
            "zone": "us-west-1b"
        }
```
