### PR TITLE
Initial value causing exception when vlan_range param is present

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vlan.py
+++ b/lib/ansible/modules/network/nxos/nxos_vlan.py
@@ -595,7 +595,7 @@ def main():
         vlan_id or vlan_range))
     existing_vlans_list = numerical_sort(get_list_of_vlans(module))
     commands = []
-    existing = None
+    existing = {}
 
     if vlan_range:
         if state == 'present':


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
modules/network/nxos/nxos_vlan

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR addresses an issue where a variable is initially set to `None`, but the value of the variable is never updated if a `vlan_range` parameter is specified. This results in a `AttributeError` exception when the `.get()` method is called against a `NoneType` object.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->