### PR TITLE
systemd: Add boolean option to enable --no-block

### DIFF
--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -68,6 +68,14 @@ options:
         description:
             - run systemctl talking to the service manager of the calling user, rather than the service manager
               of the system.
+    no_block:
+        required: false
+        default: no
+        choices: [ "yes", "no" ]
+        description:
+            - Do not synchronously wait for the requested operation to finish.
+              Enqueued job will continue without Ansible blocking on its completion.
+        version_added: "2.3"
 notes:
     - One option other than name is required.
 requirements:
@@ -250,8 +258,9 @@ def main():
                 state = dict(choices=[ 'started', 'stopped', 'restarted', 'reloaded'], type='str'),
                 enabled = dict(type='bool'),
                 masked = dict(type='bool'),
-                daemon_reload= dict(type='bool', default=False, aliases=['daemon-reload']),
-                user= dict(type='bool', default=False),
+                daemon_reload = dict(type='bool', default=False, aliases=['daemon-reload']),
+                user = dict(type='bool', default=False),
+                no_block = dict(type='bool', default=False),
             ),
             supports_check_mode=True,
             required_one_of=[['state', 'enabled', 'masked', 'daemon_reload']],
@@ -260,6 +269,8 @@ def main():
     systemctl = module.get_bin_path('systemctl')
     if module.params['user']:
         systemctl = systemctl + " --user"
+    if module.params['no_block']:
+        systemctl = systemctl + " --no-block"
     unit = module.params['name']
     rc = 0
     out = err = ''


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME

systemd

##### SUMMARY

In our environment we have custom services that need to be stopped and
restarted very gracefully to not interrupt active sessions.

A stop job, depending on the state, can take up to 20 minutes until the
process exits. It simply reacts to SIGTERM with a graceful shutdown.

By default, systemctl blocks until the job has completed, which leads to
Ansible hanging on this task for up to 20 minutes.

Thankfully systemctl supports the `--no-block` flag which lets the job
continue in the background.

This PR adds support for that flag as the `no_block` boolean option.

From the man page:

     --no-block
       Do not synchronously wait for the requested operation to
       finish. If this is not specified, the job will be
       verified, enqueued and systemctl will wait until the
       unit's start-up is completed. By passing this argument,
       it is only verified and enqueued. This option may not be
       combined with --wait.