### PR TITLE
Update ec2_group.py

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -42,7 +42,7 @@ options:
     required: false
   rules:
     description:
-      - List of firewall inbound rules to enforce in this group (see example). If none are supplied, a default all-out rule is assumed. If an empty list is supplied, no inbound rules will be enabled.
+      - List of firewall inbound rules to enforce in this group (see example). If none are supplied, a default all-out rule is assumed. If an empty list is supplied, no inbound rules will be enabled. Rules list may include its own name in `group_name`. This allows idempotent loopback additions (e.g. allow group to acccess itself).
     required: false
   rules_egress:
     description:


### PR DESCRIPTION
PR move of https://github.com/ansible/ansible-modules-core/pull/3588

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ec2_group.py

##### ANSIBLE VERSION

```
ansible 2.0.2.0
  config file = /Users/tpai/src/cm-secure/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Make it clear you can specify the created group in the rules list, allowing idempotent use for group<->group networking rules.

This is a really useful feature that isn't obvious enough in the docs.