### PR TITLE
Fixes #19030 -- systemd fact broken on Trusty

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -504,15 +504,28 @@ class Facts(object):
         self.facts['date_time']['tz_offset'] = time.strftime("%z")
 
     def is_systemd_managed(self):
-        # tools must be installed
-        if self.module.get_bin_path('systemctl'):
-
-            # this should show if systemd is the boot init system, if checking init faild to mark as systemd
-            # these mirror systemd's own sd_boot test http://www.freedesktop.org/software/systemd/man/sd_booted.html
-            for canary in ["/run/systemd/system/", "/dev/.run/systemd/", "/dev/.systemd/"]:
-                if os.path.exists(canary):
-                    return True
-        return False
+        try:
+            _pid1 = open('/proc/1/comm', 'rb')
+            pid1 = _pid1.read()
+            pid1 = pid1.strip()
+            _pid1.close()
+        except IOError:
+            return False  # If comm doesn't exist, old kernel, no systemd.
+        else:
+            if pid1 == 'systemd':
+                return True
+            elif pid1 == 'init':
+                return False
+            else:
+                # this should show if systemd is the boot init system these mirror
+                #  systemd's own sd_boot test.
+                #  http://www.freedesktop.org/software/systemd/man/sd_booted.html
+                for canary in ["/run/systemd/system/",
+                               "/dev/.run/systemd/", "/dev/.systemd/"]:
+                    if os.path.exists(canary):
+                        return True
+                else:
+                    return False  # Return False if SystemD is not detected.
 
     # User
     def get_user_facts(self):


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This change refactors the "is_systemd_managed" function such that it now will
attempt to read "/proc/1/comm" first and should the value of that output
be "systemd" the function will return True. If the output of
"/proc/1/comm" is "init" the function will return False. If
"/proc/1/comm" does not exist the function will look for several canary
files, ["/run/systemd/system/", "/dev/.run/systemd/", "/dev/.systemd/"]
and return True if found. If "/proc/1/comm" does not read "systemd",
does not exist, and none of the canary files are found the function will
return False.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
Closes Issue:  https://github.com/ansible/ansible/issues/19030

Signed-off-by: Kevin Carter <kevin.carter@rackspace.com>