### PR TITLE
Fix `wait` parameter in ec2 module docs

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -116,7 +116,7 @@ options:
     aliases: []
   wait:
     description:
-      - wait for the instance to be 'running' before returning.  Does not wait for SSH, see 'wait_for' example for details.
+      - wait for the instance to reach its desired state before returning.  Does not wait for SSH, see 'wait_for' example for details.
     required: false
     default: "no"
     choices: [ "yes", "no" ]


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ec2 module

##### SUMMARY
`wait` parameter can be used for any state, not just `running`
Fixes #18913.