### PR TITLE
Support json format in junos_command module

### DIFF
--- a/lib/ansible/modules/network/junos/junos_command.py
+++ b/lib/ansible/modules/network/junos/junos_command.py
@@ -98,12 +98,13 @@ options:
         output and apply the conditionals path to the result set.
     required: false
     default: 'xml'
-    choices: ['xml', 'text']
+    choices: ['xml', 'text', 'json']
 requirements:
   - junos-eznc
 notes:
   - This module requires the netconf system service be enabled on
-    the remote device being managed
+    the remote device being managed. 'json' format is supported
+    for JUNON version >= 14.2
 """
 
 EXAMPLES = """
@@ -219,7 +220,7 @@ def main():
         commands=dict(type='list'),
         rpcs=dict(type='list'),
 
-        display=dict(default='xml', choices=['text', 'xml'],
+        display=dict(default='xml', choices=['text', 'xml', 'json'],
                      aliases=['format', 'output']),
 
         wait_for=dict(type='list', aliases=['waitfor']),


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
junos_command

##### ANSIBLE VERSION
<!---
Paste verbatim output from “ansible --version” between quotes below,
this is to help the Ansible team determine if this is a version specific
issue which is being fixed.
-->
```
ansible --version
ansible 2.3.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!---
Please paste verbatim command output below, e.g. before and after your change.
Even in the event of a Docs Pull Request, this allows the Ansible team to quickly
verify that there were no accidental syntax mistakes.
-->
```
Add support to retrieve output in 'json' format for junos_command module.
```
Related PR https://github.com/ansible/ansible/pull/18726
Fixes issue: https://github.com/ansible/ansible-modules-core/issues/4103
