### PR TITLE
vmware_guest: Add multiple nics management + Bug fixes

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -821,6 +821,12 @@ class PyVmomiHelper(object):
                 nic.device.wakeOnLanEnabled = True
                 nic.device.addressType = 'assigned'
 
+                if 'type' in device:
+                    if device['type'].lower() == "e1000":
+                        nic.device = vim.vm.device.VirtualE1000()
+                    elif device['type'].lower() == "vmxnet2":
+                        nic.device = vim.vm.device.VirtualVmxnet2()
+
                 if hasattr(get_obj(self.content, [vim.Network], device['network']), 'portKeys'):
                     # VDS switch
                     pg_obj = get_obj(self.content, [vim.dvs.DistributedVirtualPortgroup], device['network'])

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -156,7 +156,8 @@ Example from Ansible playbook
         nic:
             - type: vmxnet3
               network: VM Network
-              network_type: standard
+            - type: e1000
+              network_vlan: 1000
         hardware:
             memory_mb: 512
             num_cpus: 1

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -71,11 +71,14 @@ options:
         required: False
    disk:
         description:
-            - A list of disks to add
+            - A list of disks to add.
+            - Attributes such as operation ('add' to add a new disk or undefined to edit first disk), type (thin or undefined), size_[tb|gb|mb|kb] (integer)
         required: False
    nic:
         description:
-            - A list of nics to add
+            - A list of nics to add.
+            - Attributes such as network (network name define in vcenter), network_vlan (vlan_id), type (e1000, vmxnet2, default=vmxnet3)
+              If network_vlan is defined network is ignored
         required: False
    wait_for_ip_address:
         description:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -901,7 +901,7 @@ class PyVmomiHelper(object):
             clonespec_kwargs['customization'].nicSettingMap = adaptermaps
             clonespec_kwargs['customization'].globalIPSettings = globalip
             clonespec_kwargs['customization'].identity = ident
-
+		
         clonespec = vim.vm.CloneSpec(**clonespec_kwargs)
         task = template.Clone(folder=destfolder, name=self.params['name'], spec=clonespec)
         self.wait_for_task(task)

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -794,6 +794,56 @@ class PyVmomiHelper(object):
                 clonespec_kwargs['config'].memoryMB = \
                     int(self.params['hardware']['memory_mb'])
 
+        # set nics
+        if 'nic' in self.params:
+            key = 0
+
+            devices = []
+
+            try:
+                for device in template.config.hardware.device:
+                    if hasattr(device, 'addressType'):
+                        nic = vim.vm.device.VirtualDeviceSpec()
+                        nic.operation = vim.vm.device.VirtualDeviceSpec.Operation.remove
+                        nic.device = device
+                        devices.append(nic)
+            except:
+                pass
+
+            for device in self.params.get('nic'):
+                network = get_obj(self.content, [vim.Network], device['network'])
+
+                nic = vim.vm.device.VirtualDeviceSpec()
+                nic.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
+                nic.device = vim.vm.device.VirtualVmxnet3()
+                nic.device.wakeOnLanEnabled = True
+                nic.device.addressType = 'assigned'
+
+                if hasattr(get_obj(self.content, [vim.Network], device['network']), 'portKeys'):
+                    # VDS switch
+                    pg_obj = get_obj(self.content, [vim.dvs.DistributedVirtualPortgroup], device['network'])
+                    dvs_port_connection = vim.dvs.PortConnection()
+                    dvs_port_connection.portgroupKey= pg_obj.key
+                    dvs_port_connection.switchUuid= pg_obj.config.distributedVirtualSwitch.uuid
+                    nic.device.backing = vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo()
+                    nic.device.backing.port = dvs_port_connection
+
+                else:
+                    # vSwitch
+                    nic.device.backing = vim.vm.device.VirtualEthernetCard.NetworkBackingInfo()
+                    nic.device.backing.network = get_obj(self.content, [vim.Network], device['network'])
+                    nic.device.backing.deviceName = device['network']
+
+                nic.device.connectable = vim.vm.device.VirtualDevice.ConnectInfo()
+                nic.device.connectable.startConnected = True
+                nic.device.connectable.allowGuestControl = True
+                nic.device.connectable.connected = True
+                nic.device.connectable.allowGuestControl = True
+                devices.append(nic)
+
+            # Update the spec with the added NIC
+            clonespec_kwargs['config'].deviceChange = devices
+
         # lets try and assign a static ip address
         if self.params['customize'] is True:
             ip_settings = list()
@@ -810,61 +860,7 @@ class PyVmomiHelper(object):
                                 )
                                 ip_settings.append(self.params['networks'][network])
 
-            key = 0
-            network = get_obj(self.content, [vim.Network], ip_settings[key]['network'])
-            datacenter = get_obj(self.content, [vim.Datacenter], self.params['datacenter'])
-            # get the folder where VMs are kept for this datacenter
-            destfolder = datacenter.vmFolder
-
-            cluster = get_obj(self.content, [vim.ClusterComputeResource],self.params['cluster'])
-
-            devices = []
             adaptermaps = []
-
-            try:
-                for device in template.config.hardware.device:
-                    if hasattr(device, 'addressType'):
-                        nic = vim.vm.device.VirtualDeviceSpec()
-                        nic.operation = vim.vm.device.VirtualDeviceSpec.Operation.remove
-                        nic.device = device
-                        devices.append(nic)
-            except:
-                pass
-
-                # single device support
-            nic = vim.vm.device.VirtualDeviceSpec()
-            nic.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
-            nic.device = vim.vm.device.VirtualVmxnet3()
-            nic.device.wakeOnLanEnabled = True
-            nic.device.addressType = 'assigned'
-            nic.device.deviceInfo = vim.Description()
-            nic.device.deviceInfo.label = 'Network Adapter %s' % (key + 1)
-            nic.device.deviceInfo.summary = ip_settings[key]['network']
-            
-            if hasattr(get_obj(self.content, [vim.Network], ip_settings[key]['network']), 'portKeys'):
-            # VDS switch
-                pg_obj = get_obj(self.content, [vim.dvs.DistributedVirtualPortgroup], ip_settings[key]['network'])
-                dvs_port_connection = vim.dvs.PortConnection()
-                dvs_port_connection.portgroupKey= pg_obj.key
-                dvs_port_connection.switchUuid= pg_obj.config.distributedVirtualSwitch.uuid
-                nic.device.backing = vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo()
-                nic.device.backing.port = dvs_port_connection 
-
-            else: 
-            # vSwitch
-                nic.device.backing = vim.vm.device.VirtualEthernetCard.NetworkBackingInfo()
-                nic.device.backing.network = get_obj(self.content, [vim.Network], ip_settings[key]['network'])
-                nic.device.backing.deviceName = ip_settings[key]['network']
-
-            nic.device.connectable = vim.vm.device.VirtualDevice.ConnectInfo()
-            nic.device.connectable.startConnected = True
-            nic.device.connectable.allowGuestControl = True
-            nic.device.connectable.connected = True
-            nic.device.connectable.allowGuestControl = True
-            devices.append(nic)
-            
-            # Update the spec with the added NIC
-            clonespec_kwargs['config'].deviceChange = devices
 
             guest_map = vim.vm.customization.AdapterMapping()
             guest_map.adapter = vim.vm.customization.IPSettings()


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### SUMMARY
- Fix var name:
function getfolder return folder_map instead of foldermap.

- Fix bug in deploy_template function:
If folder not start by /vm there is a "no folder matched the path" error

- Power on VM if state is set to poweredon

New feature : Move nic creation out of customizations + Add multiple nics management