### PR TITLE
Fix UnboundLocalError remote_head in git

### DIFF
--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -447,7 +447,7 @@
 - name: clear checkout_dir
   file: state=absent path={{ checkout_dir }}
 
-- name: Clone example git repo that we're going to modify
+- name: "Clone example git repo that we're going to modify"
   git:
     repo: '{{ repo_update_url_1 }}'
     dest: '{{ checkout_dir }}/repo'
@@ -652,9 +652,6 @@
   register: git_fetch
   ignore_errors: yes
 
-- name: read file
-  shell: cat {{ checkout_dir }}/a
-
 - name: check update arrived
   assert:
     that:
@@ -718,3 +715,109 @@
     gpg_version.stdout and
     (git_version.stdout | version_compare("2.1.0", '>=') or
     gpg_version.stdout | version_compare("1.4.16", '>='))
+
+- name: clear checkout_dir
+  file: state=absent path={{ checkout_dir }}
+
+# test for https://github.com/ansible/ansible-modules-core/pull/5505
+- name: prepare old git repo
+  shell: rm -rf localmods; mkdir localmods; cd localmods; git init; echo "1" > a; git add a; git commit -m "1"
+  args:
+    chdir: "{{repo_dir}}"
+
+- name: checkout old repo
+  git:
+    repo: '{{ repo_dir }}/localmods'
+    dest: '{{ checkout_dir }}'
+
+- name: "update repo"
+  shell: echo "2" > a; git commit -a -m "2"
+  args:
+    chdir: "{{repo_dir}}/localmods"
+
+- name: "add local mods"
+  shell: echo "3" > a
+  args:
+    chdir: "{{ checkout_dir }}"
+
+- name: fetch with local mods without force (should fail)
+  git:
+    repo: '{{ repo_dir }}/localmods'
+    dest: '{{ checkout_dir }}'
+  register: git_fetch
+  ignore_errors: yes
+
+- name: check fetch with localmods failed
+  assert:
+    that:
+      - git_fetch|failed
+
+- name: fetch with local mods with force
+  git:
+    repo: '{{ repo_dir }}/localmods'
+    dest: '{{ checkout_dir }}'
+    force: True
+  register: git_fetch_force
+  ignore_errors: yes
+
+- name: check update arrived
+  assert:
+    that:
+      - "{{ lookup('file', checkout_dir+'/a' )}} == 2"
+      - git_fetch_force|changed
+
+- name: clear checkout_dir
+  file: state=absent path={{ checkout_dir }}
+
+# localmods and shallow clone
+- name: prepare old git repo
+  shell: rm -rf localmods; mkdir localmods; cd localmods; git init; echo "1" > a; git add a; git commit -m "1"
+  args:
+    chdir: "{{repo_dir}}"
+
+- name: checkout old repo
+  git:
+    repo: '{{ repo_dir }}/localmods'
+    dest: '{{ checkout_dir }}'
+    depth: 1
+
+- name: "update repo"
+  shell: echo "2" > a; git commit -a -m "2"
+  args:
+    chdir: "{{repo_dir}}/localmods"
+
+- name: "add local mods"
+  shell: echo "3" > a
+  args:
+    chdir: "{{ checkout_dir }}"
+
+- name: fetch with local mods without force (should fail)
+  git:
+    repo: '{{ repo_dir }}/localmods'
+    dest: '{{ checkout_dir }}'
+    depth: 1
+  register: git_fetch
+  ignore_errors: yes
+
+- name: check fetch with localmods failed
+  assert:
+    that:
+      - git_fetch|failed
+
+- name: fetch with local mods with force
+  git:
+    repo: '{{ repo_dir }}/localmods'
+    dest: '{{ checkout_dir }}'
+    depth: 1
+    force: True
+  register: git_fetch_force
+  ignore_errors: yes
+
+- name: check update arrived
+  assert:
+    that:
+      - "{{ lookup('file', checkout_dir+'/a' )}} == 2"
+      - git_fetch_force|changed
+
+- name: clear checkout_dir
+  file: state=absent path={{ checkout_dir }}


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
git

##### ANSIBLE VERSION
```devel```

##### SUMMARY

Fixes ansible/ansible-modules-core#5505

The use of remote_head was a leftover of ansible/ansible-modules-core#4562.
remote_head is not necessary, since the repo is unchanged anyway and
after is set correctly.

Further changes:
* Set changed=True and msg once local_mods are detected and reset.
* Remove need_fetch that is always True (due to previous if) to improve
clarity.
* Don't exit early for local_mods but run submodules update and
switch_version.