### PR TITLE
Put spaces between graphs and var name - utilities/logic/include_role

### DIFF
--- a/lib/ansible/modules/utilities/logic/include_role.py
+++ b/lib/ansible/modules/utilities/logic/include_role.py
@@ -81,8 +81,8 @@ EXAMPLES = """
   include_role:
     name: myrole
   with_items:
-    - "{{roleinput1}}"
-    - "{{roleinput2}}"
+    - '{{ roleinput1 }}'
+    - '{{ roleinput2 }}'
   loop_control:
     loop_var: roleinputvar
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
network/*

##### ANSIBLE VERSION
```
2.2
```

##### SUMMARY
This is the onlly occurence in the examples in ansible-moduls-core of this way of writing variables

@gundalow