### PR TITLE
Add perm_hwaddr on Linux bonding slave nics

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2386,6 +2386,8 @@ class LinuxNetwork(Network):
                     path = os.path.join(path, 'bonding', 'all_slaves_active')
                     if os.path.exists(path):
                         interfaces[device]['all_slaves_active'] = get_file_content(path) == '1'
+            if os.path.exists(os.path.join(path, 'bonding_slave')):
+                interfaces[device]['perm_macaddress'] = get_file_content(os.path.join(path, 'bonding_slave', 'perm_hwaddr'), default='')
             if os.path.exists(os.path.join(path,'device')):
                 interfaces[device]['pciid'] = os.path.basename(os.readlink(os.path.join(path,'device')))
             if os.path.exists(os.path.join(path, 'speed')):


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/module_utils/facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Taken from: https://wiki.linuxfoundation.org/networking/bonding

```
If not explicitly configured (with ifconfig or ip link), the MAC address of the bonding device is
taken from its first slave device. This MAC address is then passed to all following slaves and
remains persistent (even if the first slave is removed) until the bonding device is brought down
or reconfigured
```

With this in mind, it would be great to get the permanent hardware address of the network interface card reported as a fact.

I called it `perm_macaddress` instead of `perm_hwaddr` to align it with the already existing `
macaddress` fact.

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_eth0": {
            "active": true, 
            "device": "eth0", 
	    [...]
            "macaddress": "00:00:00:00:00:01", 
	    [...]
            "perm_macaddress": "00:00:00:00:00:01", 
	    [...]
        }, 
        "ansible_eth1": {
            "active": true, 
            "device": "eth1", 
	    [...]
            "macaddress": "00:00:00:00:00:01", 
	    [...]
            "perm_macaddress": "00:00:00:00:00:02", 
	    [...]
        }
    }, 
    "changed": false
}
```

Related to issue #19067