### PR TITLE
Implement --host functionality to pull hostvars from FreeIPA

### DIFF
--- a/contrib/inventory/freeipa.py
+++ b/contrib/inventory/freeipa.py
@@ -2,6 +2,7 @@
 
 import argparse
 from ipalib import api
+from ipalib import errors
 import json
 
 def initialize():
@@ -66,24 +67,28 @@ def parse_args():
 
     return parser.parse_args()
 
-def print_host(host):
+def get_host_attributes(api, host):
     '''
-    This function is really a stub, it could return variables to be used in 
-    a playbook. However, at this point there are no variables stored in 
-    FreeIPA/IPA.
-
+    This function returns a hosts attributes from FreeIPA.
     This function expects one string, this hostname to lookup variables for.
     '''
-
-    print(json.dumps({}))
-
-    return None
+    try:
+        result = api.Command.host_show(unicode(host))['result']
+        try:
+            del result['usercertificate']
+        except KeyError:
+            pass
+        inv_string = json.dumps(result, indent=1, sort_keys=True)
+        return result
+    except errors.NotFound:
+       return {}
 
 if __name__ == '__main__':
     args = parse_args()
+    api = initialize()
 
     if args.host:
-        print_host(args.host)
+        host_info = get_host_attributes(api, args.host)
+        print json.dumps(host_info, indent=1, sort_keys=True)
     elif args.list:
-        api = initialize()
         list_groups(api)

--- a/contrib/inventory/freeipa.py
+++ b/contrib/inventory/freeipa.py
@@ -89,6 +89,6 @@ if __name__ == '__main__':
 
     if args.host:
         host_info = get_host_attributes(api, args.host)
-        print json.dumps(host_info, indent=1, sort_keys=True)
+        print( json.dumps(host_info, indent=1, sort_keys=True))
     elif args.list:
         list_groups(api)


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
freeipa.py inventory

##### ANSIBLE VERSION
```
ansible 2.3.0 (ipa_hostinfo 1846858165) last updated 2016/12/09 08:30:44 (GMT -600)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Implement --host functionality for freeipa.py.  This will allow users to get host attributes from FreeIPA.

####BEFORE CHANGE:
```
[rgroten@rgroten-fed ansible (devel)] $ contrib/inventory/freeipa.py --host server.example.com
{}
```
####AFTER CHANGE:
```
[rgroten@rgroten-fed ansible (ipa_hostinfo)] $ contrib/inventory/freeipa.py --host server.example.com
{
 "description": [
  "My Test Apache Server"
 ],
 "dn": "fqdn=server.example.com,cn=computers,cn=accounts,dc=example,dc=com",
 "memberof_hostgroup": [
  "apache-test"
 ],
 "memberofindirect_hostgroup": [
  "apache",
  "test"
 ],
 "nshardwareplatform": [
  "VM"
 ],
 "nshostlocation": [
  "DC1"
 ],
 "nsosversion": [
  "RHEL7"
 ]
}
```