### PR TITLE
Fix secure temp file creation

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -411,10 +411,17 @@ class JenkinsPlugin(object):
 
     def install(self):
         changed = False
+
         plugin_file = (
             '%s/plugins/%s.jpi' % (
                 self.params['jenkins_home'],
                 self.params['name']))
+
+        hpi_file = '%s/plugins/%s.hpi' % (
+            self.params['jenkins_home'],
+            self.params['name'])
+        if os.path.isfile(hpi_file):
+            os.rename(hpi_file, hpi_file+'.bak')
 
         if not self.is_installed and self.params['version'] is None:
             if not self.module.check_mode:
@@ -567,7 +574,8 @@ class JenkinsPlugin(object):
                 msg_exception="Updates download failed.")
 
             # Write the updates file
-            updates_file = tempfile.mkstemp()
+            updates_file_tuple = tempfile.mkstemp()
+            updates_file = updates_file_tuple[1]
 
             try:
                 fd = open(updates_file[1], 'wb')
@@ -644,7 +652,8 @@ class JenkinsPlugin(object):
 
     def _write_file(self, f, data):
         # Store the plugin into a temp file and then move it
-        tmp_f = tempfile.mkstemp()
+        tmp_f_tuple = tempfile.mkstemp()
+        tmp_f = tmp_f_tuple[1]
 
         try:
             fd = open(tmp_f, 'wb')

--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -416,12 +416,6 @@ class JenkinsPlugin(object):
                 self.params['jenkins_home'],
                 self.params['name']))
 
-        hpi_file = '%s/plugins/%s.hpi' % (
-            self.params['jenkins_home'],
-            self.params['name'])
-        if os.path.isfile(hpi_file):
-            os.remove(hpi_file)
-
         if not self.is_installed and self.params['version'] is None:
             if not self.module.check_mode:
                 # Install the plugin (with dependencies)
@@ -447,6 +441,12 @@ class JenkinsPlugin(object):
                     msg_status="Cannot install plugin.",
                     msg_exception="Plugin installation has failed.",
                     data=data)
+
+                hpi_file = '%s/plugins/%s.hpi' % (
+                    self.params['jenkins_home'],
+                    self.params['name'])
+                if os.path.isfile(hpi_file):
+                    os.remove(hpi_file)
 
             changed = True
         else:

--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -445,6 +445,7 @@ class JenkinsPlugin(object):
                 hpi_file = '%s/plugins/%s.hpi' % (
                     self.params['jenkins_home'],
                     self.params['name'])
+
                 if os.path.isfile(hpi_file):
                     os.remove(hpi_file)
 

--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -574,11 +574,10 @@ class JenkinsPlugin(object):
                 msg_exception="Updates download failed.")
 
             # Write the updates file
-            updates_file_tuple = tempfile.mkstemp()
-            updates_file = updates_file_tuple[1]
+            update_fd, updates_file = tempfile.mkstemp()
 
             try:
-                fd = open(updates_file[1], 'wb')
+                fd = open(updates_file, 'wb')
             except IOError:
                 e = get_exception()
                 self.module.fail_json(
@@ -651,9 +650,10 @@ class JenkinsPlugin(object):
         return r
 
     def _write_file(self, f, data):
+
         # Store the plugin into a temp file and then move it
-        tmp_f_tuple = tempfile.mkstemp()
-        tmp_f = tmp_f_tuple[1]
+        tmp_f_tuple, tmp_f = tempfile.mkstemp()
+
 
         try:
             fd = open(tmp_f, 'wb')

--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -411,7 +411,6 @@ class JenkinsPlugin(object):
 
     def install(self):
         changed = False
-
         plugin_file = (
             '%s/plugins/%s.jpi' % (
                 self.params['jenkins_home'],
@@ -421,7 +420,7 @@ class JenkinsPlugin(object):
             self.params['jenkins_home'],
             self.params['name'])
         if os.path.isfile(hpi_file):
-            os.rename(hpi_file, hpi_file+'.bak')
+            os.remove(hpi_file)
 
         if not self.is_installed and self.params['version'] is None:
             if not self.module.check_mode:
@@ -650,10 +649,8 @@ class JenkinsPlugin(object):
         return r
 
     def _write_file(self, f, data):
-
         # Store the plugin into a temp file and then move it
         tmp_f_tuple, tmp_f = tempfile.mkstemp()
-
 
         try:
             fd = open(tmp_f, 'wb')

--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -570,7 +570,7 @@ class JenkinsPlugin(object):
             updates_file = tempfile.mkstemp()
 
             try:
-                fd = open(updates_file, 'wb')
+                fd = open(updates_file[1], 'wb')
             except IOError:
                 e = get_exception()
                 self.module.fail_json(


### PR DESCRIPTION
- Bugfix Pull Request
##### COMPONENT NAME

jenkins/web_infrastructure/download_plugin
##### ANSIBLE VERSION

```
ansible 2.2.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

The execution of plugin install was failing with TypeError on file.open() and file.read() calls. tempfile.mkstemp() returns a tuple not a file path. 

No existing issue, but the bug was introduced in this PR #2887

<!--- Paste verbatim command output below, e.g. before and after your change -->

```

```
