### PR TITLE
sysctl: fixes ignoreerrors not working with sysctl_set

### DIFF
--- a/lib/ansible/modules/system/sysctl.py
+++ b/lib/ansible/modules/system/sysctl.py
@@ -250,8 +250,17 @@ class SysctlModule(object):
         if self.platform == 'openbsd':
             # openbsd doesn't accept -w, but since it's not needed, just drop it
             thiscmd = "%s %s=%s" % (self.sysctl_cmd, token, value)
+        elif self.platform == 'freebsd':
+            ignore_missing = ''
+            if self.args['ignoreerrors']:
+                ignore_missing = '-i'
+            # freebsd doesn't accept -w, but since it's not needed, just drop it
+            thiscmd = "%s %s %s=%s" % (self.sysctl_cmd, ignore_missing, token, value)
         else:
-            thiscmd = "%s -w %s=%s" % (self.sysctl_cmd, token, value)
+            ignore_missing = ''
+            if self.args['ignoreerrors']:
+                ignore_missing = '-e'
+            thiscmd = "%s %s -w %s=%s" % (self.sysctl_cmd, ignore_missing, token, value)
         rc,out,err = self.module.run_command(thiscmd)
         if rc != 0:
             self.module.fail_json(msg='setting %s failed: %s' % (token, out + err))


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
sysctl module

##### ANSIBLE VERSION
```
ansible 2.3.0 (sysctl-ignoremissning-with-sysctl_set adecec3639) last updated 2016/12/09 22:46:16 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
This is a follow up to the issue https://github.com/ansible/ansible-modules-core/issues/3401. Basically if you use `sysctl_set: yes` and `ignoreerrors: yes` together, and if the key is missing, `sysctl` module doesn't ignore errors and it fails. This pull request fixes that.

You can try how it works with the following task which uses a random key which doesn't exist:
```yml
 - sysctl:
      name: random.key.that.doesnt.exist
      value: 1
      sysctl_set: yes
      ignoreerrors: yes
```
