### PR TITLE
Fix module names in module docs.

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_publicipaddress_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_publicipaddress_facts.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 
 DOCUMENTATION = '''
 ---
-module: azure_rm_publicip_facts
+module: azure_rm_publicipaddress_facts
 
 version_added: "2.1"
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup_facts.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 
 DOCUMENTATION = '''
 ---
-module: azure_rm_resouregroup_facts
+module: azure_rm_resourcegroup_facts
 
 version_added: "2.1"
 

--- a/lib/ansible/modules/network/nxos/nxos_gir_profile_management.py
+++ b/lib/ansible/modules/network/nxos/nxos_gir_profile_management.py
@@ -22,7 +22,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 
 DOCUMENTATION = '''
 ---
-module: nxos_gir_profile
+module: nxos_gir_profile_management
 version_added: "2.2"
 short_description: Create a maintenance-mode or normal-mode profile for GIR.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_snmp_traps.py
+++ b/lib/ansible/modules/network/nxos/nxos_snmp_traps.py
@@ -23,7 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 
 DOCUMENTATION = '''
 ---
-module: nxos_snmp_trap
+module: nxos_snmp_traps
 version_added: "2.2"
 short_description: Manages SNMP traps.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_vtp_password.py
+++ b/lib/ansible/modules/network/nxos/nxos_vtp_password.py
@@ -23,7 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 
-module: nxos_vtp
+module: nxos_vtp_password
 version_added: "2.2"
 short_description: Manages VTP password configuration.
 description:


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Modules

##### ANSIBLE VERSION

```
ansible 2.3.0 (module-docs-names e266938f90) last updated 2016/12/09 17:12:12 (GMT -600)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Fix module names in module docs.