### PR TITLE
Add --all option to ansible-doc.

### DIFF
--- a/lib/ansible/utils/module_docs.py
+++ b/lib/ansible/utils/module_docs.py
@@ -41,7 +41,6 @@ except ImportError:
 # modules that are ok that they do not have documentation strings
 BLACKLIST_MODULES = frozenset((
    'async_wrapper',
-   'accelerate',
 ))
 
 def get_docstring(filename, verbose=False):


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-doc

##### ANSIBLE VERSION

```
ansible 2.3.0 (ansible-doc-all e3be4b121b) last updated 2016/12/09 18:28:33 (GMT -600)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Add `--all` option to `ansible-doc`. This provides the same functionality as executing `ansible-doc` with every module name in the argument list.