### PR TITLE
Add --blocking-io option when docker connection

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -354,10 +354,13 @@ class ActionModule(ActionBase):
         # If launching synchronize against docker container
         # use rsync_opts to support container to override rsh options
         if self._remote_transport in [ 'docker' ]:
+            if not isinstance(self._task.args.get('rsync_opts'), list):
+                self._task.args['rsync_opts'] = []
+            self._task.args['rsync_opts'].append('--blocking-io')
             if user is not None:
-                self._task.args['rsync_opts'] = "--rsh='%s exec -u %s -i'" % (self._docker_cmd, user)
+                self._task.args['rsync_opts'].append("--rsh='%s exec -u %s -i'" % (self._docker_cmd, user))
             else:
-                self._task.args['rsync_opts'] = "--rsh='%s exec -i'" % (self._docker_cmd)
+                self._task.args['rsync_opts'].append("--rsh='%s exec -i'" % self._docker_cmd)
 
         # run the module and store the result
         result.update(self._execute_module('synchronize', task_vars=task_vars))


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
synchronize.py 

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 9d2f718ccb) last updated 2016/12/10 04:40:09 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
When docker connection:

- Include --blocking-io option
- set rsync_opts to list 