### PR TITLE
Fix/win file symlink

### DIFF
--- a/test/integration/targets/win_file/tasks/main.yml
+++ b/test/integration/targets/win_file/tasks/main.yml
@@ -486,6 +486,24 @@
        - file_result.changed
        - "stat_result.stat.exists == False"
 
+- name: create folder to point set symbolic link for
+  win_file:
+    path: "{{win_output_dir}}/link-test/link-target"
+    state: directory
+
+- name: create symbolic link
+  win_command: cmd.exe /c mklink /d "{{win_output_dir}}\link-test\link" "{{win_output_dir}}\link-test\link-target"
+
+- name: remove symbolic link target
+  win_file:
+    path: "{{win_output_dir}}/link-test/link-target"
+    state: absent
+
+- name: remove parent folder with broken link
+  win_file:
+    path: "{{win_output_dir}}/link-test"
+    state: absent
+
 - name: clean up sub1
   win_file: path={{win_output_dir}}/sub1 state=absent
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_find

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Added in checks to help with deleting broken symlinks, this is for https://github.com/ansible/ansible-modules-core/pull/5120 after repo merge
