### PR TITLE
add win_service_status module

### DIFF
--- a/lib/ansible/modules/windows/win_service_status.ps1
+++ b/lib/ansible/modules/windows/win_service_status.ps1
@@ -1,0 +1,56 @@
+#!powershell
+# This file is part of Ansible
+#
+# Copyright 2014, Chris Hoffman <choffman@chathamfinancial.com>
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# WANT_JSON
+# POWERSHELL_COMMON
+$params = Parse-Args $args;
+
+$result = New-Object psobject @{
+    win_service_status = New-Object psobject
+    changed = $false
+}
+
+$name = Get-AnsibleParam $params "name" -failifempty $true -resultobj $result
+
+Try
+{
+    $svc = Get-WmiObject -Class Win32_Service -Filter "Name='$($name)'"    
+    
+    if ([string]::IsNullOrEmpty($svc))
+    {
+        # service doesn't exist
+        Set-Attr $result.win_service_status "exists" $false
+    }
+    else
+    {
+        # service exists
+        Set-Attr $result.win_service_status "exists" $true
+        Set-Attr $result.win_service_status "name" $svc.name.toString()
+        Set-Attr $result.win_service_status "start_mode" $svc.StartMode.toString()
+        Set-Attr $result.win_service_status "caption" $svc.Caption.toString()
+        Set-Attr $result.win_service_status "state" $svc.State.toString()
+        Set-Attr $result.win_service_status "path_name" $svc.PathName.toString()
+        Set-Attr $result.win_service_status "start_name" $svc.StartName.toString()
+    }
+}
+Catch
+{
+    Fail-Json $result "Error: $_.Exception.Message"
+}
+
+Exit-Json $result;

--- a/lib/ansible/modules/windows/win_service_status.py
+++ b/lib/ansible/modules/windows/win_service_status.py
@@ -1,0 +1,46 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2016, Matthew Hodgkins <matthodge@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+DOCUMENTATION = '''
+---
+module: win_service_status
+version_added: "2.2"
+short_description: Get Status of Windows services
+description:
+    - Get Status Windows services
+options:
+  name:
+    description:
+      - Name of the service
+    required: true
+    default: null
+    aliases: []
+author: "Matthew Hodgkins (@MattHodge)"
+'''
+
+EXAMPLES = '''
+- name: Get Windows service status
+  win_service_status:
+    name: spooler
+  register: spooler_service_result
+'''


### PR DESCRIPTION
##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
win_service_status

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adds `win_service_status` module which Get-WmiObject to get information about a specified Windows service. It works similar to the `win_stat` module.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

###### On a service that exists 

```yml
- name: get service status of a service that exists
  win_service_status:
    name: winrm
  register: existing_service_status

- name: debug result of service that exists
  debug:
    msg: "{{ existing_service_status }}"
```

The result will be the following:

```json
{
  "msg": {
    "changed": false,
    "win_service_status": {
      "caption": "Windows Remote Management (WS-Management)",
      "exists": true,
      "name": "WinRM",
      "path_name": "C:\\Windows\\System32\\svchost.exe -k NetworkService",
      "start_mode": "Auto",
      "start_name": "NT AUTHORITY\\NetworkService",
      "state": "Running"
    }
  }
}
```

###### On a service that doesn't exists 

```yml
- name: get service status of a service that does not exist
  win_service_status:
    name: testservice
  register: non_existing_service_status

- name: debug result of service that does not exists
  debug:
    msg: "{{ non_existing_service_status }}"
```

The result will be the following:

```json
{
  "msg": {
    "changed": false,
    "win_service_status": {
      "exists": false
    }
  }
}
```
