### PR TITLE
For docker add --blocking-io only when missing

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -355,8 +355,9 @@ class ActionModule(ActionBase):
         # use rsync_opts to support container to override rsh options
         if self._remote_transport in [ 'docker' ]:
             if not isinstance(self._task.args.get('rsync_opts'), list):
-                self._task.args['rsync_opts'] = []
-            self._task.args['rsync_opts'].append('--blocking-io')
+                self._task.args['rsync_opts'] = self._task.args.get('rsync_opts', '').split(' ')
+            if '--blocking-io' not in self._task.args['rsync_opts']:
+                self._task.args['rsync_opts'].append('--blocking-io')
             if user is not None:
                 self._task.args['rsync_opts'].append("--rsh='%s exec -u %s -i'" % (self._docker_cmd, user))
             else:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
synchronize.py

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel fac7344511) last updated 2016/12/10 10:33:27 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
For docker connection type:

- Allow for rsync_opts to contain a string, and convert it to an array
- Allow for user adding --blocking-io by only adding when not found in rsync_opts
