### PR TITLE
cron - discourage line breaks in job param

### DIFF
--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -69,6 +69,7 @@ options:
   job:
     description:
       - The command to execute or, if env is set, the value of environment variable.
+        The command should not contain line breaks.
         Required if state=present.
     required: false
     aliases: ['value']
@@ -718,6 +719,11 @@ def main():
                 changed = True
     else:
         if do_install:
+            for char in ['\r', '\n']:
+                if char in job.strip('\r\n'):
+                    warnings.append('Job should not contain line breaks')
+                    break
+
             job = crontab.get_cron_job(minute, hour, day, month, weekday, job, special_time, disabled)
             old_job = crontab.find_job(name, job)
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
`cron` module

##### ANSIBLE VERSION
```
2.1.1.0
```

##### SUMMARY
Generates a warning for any `job` containing line breaks.

Moved from ansible/ansible-modules-core#4488