### PR TITLE
cron - validate filename portion of cron_file param

### DIFF
--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -84,6 +84,8 @@ options:
       - If specified, uses this file instead of an individual user's crontab.
         If this is a relative path, it is interpreted with respect to
         /etc/cron.d. (If it is absolute, it will typically be /etc/crontab).
+        Many linux distros expect (and some require) the filename portion to consist solely
+        of upper- and lower-case letters, digits, underscores, and hyphens.
         To use the C(cron_file) parameter you must specify the C(user) as well.
     required: false
     default: null
@@ -631,6 +633,12 @@ def main():
 
     changed      = False
     res_args     = dict()
+    warnings     = list()
+
+    if cron_file:
+        cron_file_basename = os.path.basename(cron_file)
+        if not re.search(r'^[A-Z0-9_-]+$', cron_file_basename, re.I):
+            warnings.append('Filename portion of cron_file ("%s") should consist solely of upper- and lower-case letters, digits, underscores, and hyphens' % cron_file_basename)
 
     # Ensure all files generated are only writable by the owning user.  Primarily relevant for the cron_file option.
     os.umask(int('022', 8))
@@ -736,6 +744,7 @@ def main():
     res_args = dict(
         jobs = crontab.get_jobnames(),
         envs = crontab.get_envnames(),
+        warnings = warnings,
         changed = changed
     )
 

--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -638,7 +638,8 @@ def main():
     if cron_file:
         cron_file_basename = os.path.basename(cron_file)
         if not re.search(r'^[A-Z0-9_-]+$', cron_file_basename, re.I):
-            warnings.append('Filename portion of cron_file ("%s") should consist solely of upper- and lower-case letters, digits, underscores, and hyphens' % cron_file_basename)
+            warnings.append('Filename portion of cron_file ("%s") should consist' % cron_file_basename
+            + ' solely of upper- and lower-case letters, digits, underscores, and hyphens')
 
     # Ensure all files generated are only writable by the owning user.  Primarily relevant for the cron_file option.
     os.umask(int('022', 8))


### PR DESCRIPTION
##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

`cron` module

##### ANSIBLE VERSION
```
ansible 2.1.2.0
```

##### SUMMARY

Validates the filename portion of cron_file param (as some linux distros restrict what it can contain), and returns a warning if said validation fails. Also updates docs accordingly.

```
$ sudo ansible localhost -m cron -a "job=/bin/false user=deploy cron_file='.warnings-test'"

localhost | SUCCESS => {
    "changed": true, 
    "cron_file": ".warnings-test", 
    "envs": [], 
    "jobs": [
        "None"
    ], 
    "warnings": [
        "cron_file \".warnings-test\" must consist solely of upper- and lower-case letters, digits, underscores, and hyphens"
    ]
}
 [WARNING]: cron_file ".warnings-test" must consist solely of upper- and lower-case letters, digits, underscores, and hyphens
```

Moved from ansible/ansible-modules-core#5361