### PR TITLE
replace - documentation update for short form task parsing and escape sequences

### DIFF
--- a/lib/ansible/modules/files/replace.py
+++ b/lib/ansible/modules/files/replace.py
@@ -55,7 +55,6 @@ options:
       - Note that, as of ansible 2, short form tasks should have any escape
         sequences backslash-escaped in order to prevent them being parsed
         as string literal escapes. See the examples.
-
   replace:
     required: false
     description:


### PR DESCRIPTION
##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

`replace` module

##### ANSIBLE VERSION

```
ansible 2.2.0.0
  config file = /vagrant/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

Per the discussion in ansible/ansible-modules-core#5626, documented a gotcha with ansible 2 parsing of short form tasks and escape sequences.

Long story short, non-regexp escape sequences are interpreted as string literals (newlines, tabs, etc) and word boundary escape sequences (`\b`) are mistakenly interpreted as literal backspaces. Since this happens outside of the module, all I can do is document the oddity.

Moved from ansible/ansible-modules-core#5639