### PR TITLE
Un-nest nested if statements

### DIFF
--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -407,9 +407,8 @@ def clone(git_path, module, repo, dest, remote, depth, version, bare,
         cmd.extend([ '--reference', str(reference) ])
     cmd.extend([ repo, dest ])
     module.run_command(cmd, check_rc=True, cwd=dest_dirname)
-    if bare:
-        if remote != 'origin':
-            module.run_command([git_path, 'remote', 'add', remote, repo], check_rc=True, cwd=dest)
+    if bare and remote != 'origin':
+        module.run_command([git_path, 'remote', 'add', remote, repo], check_rc=True, cwd=dest)
 
     if refspec:
         cmd = [git_path, 'fetch']


### PR DESCRIPTION
Easier and clearer to write

```python
if a and b:
    foo()
```

than

```python
if a:
    if b:
        foo()
```