### PR TITLE
maven_artifact: Make default repository_url work again

### DIFF
--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -367,8 +367,12 @@ def main():
         )
     )
 
+    repository_url = module.params["repository_url"]
+    if not repository_url:
+        repository_url = "http://repo1.maven.org/maven2"
+
     try:
-        parsed_url = urlparse(module.params["repository_url"])
+        parsed_url = urlparse(repository_url)
     except AttributeError as e:
         module.fail_json(msg='url parsing went wrong %s' % e)
 
@@ -380,14 +384,10 @@ def main():
     version = module.params["version"]
     classifier = module.params["classifier"]
     extension = module.params["extension"]
-    repository_url = module.params["repository_url"]
     repository_username = module.params["username"]
     repository_password = module.params["password"]
     state = module.params["state"]
     dest = module.params["dest"]
-
-    if not repository_url:
-        repository_url = "http://repo1.maven.org/maven2"
 
     #downloader = MavenDownloader(module, repository_url, repository_username, repository_password)
     downloader = MavenDownloader(module, repository_url)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
maven_artifact

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Documentation states that repository_url defaults to the central maven repo if not specified, but it actually throws an error after S3 support was added. This change ensures the default is applied before checking if the URL is an S3 URL.

This is related to ansible/ansible-modules-extras#3429

```
$ cat t.yml
---
- hosts: localhost
  gather_facts: no
  tasks:
    - maven_artifact:
        group_id: junit
        artifact_id: junit
        version: 4.11
        dest: /tmp/junit-4.11.jar
$ ansible-playbook t.yml 
 PLAY [localhost] ***************************************************************

TASK [maven_artifact] **********************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "url parsing went wrong 'NoneType' object has no attribute 'find'"}
        to retry, use: --limit @/home/me/dev/ansible/t.retry

PLAY RECAP *********************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1   

$ ansible-playbook t.yml 
 PLAY [localhost] ***************************************************************

TASK [maven_artifact] **********************************************************
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0 
```

