### PR TITLE
Fix django_manage bug with python3 filter() returning iterator insted…

### DIFF
--- a/lib/ansible/modules/web_infrastructure/django_manage.py
+++ b/lib/ansible/modules/web_infrastructure/django_manage.py
@@ -288,7 +288,7 @@ def main():
     lines = out.split('\n')
     filt = globals().get(command + "_filter_output", None)
     if filt:
-        filtered_output = filter(filt, lines)
+        filtered_output = list(filter(filt, lines))
         if len(filtered_output):
             changed = filtered_output
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
django_manage

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Filter in Python3 return iterator, not list.  So, we can not get len of iterator.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
Before
```
TASK [web : Run Django database migrations] ************************************
task path: /www/destination_lighting/statbid/statbid_reports/provision/roles/web/tasks/setup_django_app.yaml:17
Using module file /usr/local/lib/python3.5/site-packages/ansible/modules/core/web_infrastructure/django_manage.py
<52.23.172.64> ESTABLISH SSH CONNECTION FOR USER: ubuntu
<52.23.172.64> SSH: EXEC ssh -vvv -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=ubuntu -o ConnectTimeout=10 -o ControlPath=/Users/s_mart/.ansible/cp/ansible-ssh-%h-%p-%r 52.23.172.64 '/bin/sh -c '"'"'( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1481417097.078755-197789425370261 `" && echo ansible-tmp-1481417097.078755-197789425370261="` echo $HOME/.ansible/tmp/ansible-tmp-1481417097.078755-197789425370261 `" ) && sleep 0'"'"''
<52.23.172.64> PUT /var/folders/56/5bxrcpk151lcfnmhmkrw8hhr0000gn/T/tmp7jarn1ax TO /home/ubuntu/.ansible/tmp/ansible-tmp-1481417097.078755-197789425370261/django_manage.py
<52.23.172.64> SSH: EXEC sftp -b - -vvv -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=ubuntu -o ConnectTimeout=10 -o ControlPath=/Users/s_mart/.ansible/cp/ansible-ssh-%h-%p-%r '[52.23.172.64]'
<52.23.172.64> ESTABLISH SSH CONNECTION FOR USER: ubuntu
<52.23.172.64> SSH: EXEC ssh -vvv -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=ubuntu -o ConnectTimeout=10 -o ControlPath=/Users/s_mart/.ansible/cp/ansible-ssh-%h-%p-%r 52.23.172.64 '/bin/sh -c '"'"'chmod u+x /home/ubuntu/.ansible/tmp/ansible-tmp-1481417097.078755-197789425370261/ /home/ubuntu/.ansible/tmp/ansible-tmp-1481417097.078755-197789425370261/django_manage.py && sleep 0'"'"''
<52.23.172.64> ESTABLISH SSH CONNECTION FOR USER: ubuntu
<52.23.172.64> SSH: EXEC ssh -vvv -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=ubuntu -o ConnectTimeout=10 -o ControlPath=/Users/s_mart/.ansible/cp/ansible-ssh-%h-%p-%r -tt 52.23.172.64 '/bin/sh -c '"'"'sudo -H -S -n -u root /bin/sh -c '"'"'"'"'"'"'"'"'echo BECOME-SUCCESS-nrzkwtmwdsqullygmnrvdeiolkuemuln; DATABASE_NAME=statbid_report STATIC_ROOT=/webapps/statbid_report/static/ DATABASE_USER=statbid_report DATABASE_PORT=5432 DJANGO_SECRET_KEY='"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'akr2icmg1n8%z^3fe3c+)5d0(t^cy-2_25rrl35a7@!scna^1#'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"'"' MEDIA_ROOT=/webapps/statbid_report/media/ DJANGO_SETTINGS_MODULE=reports_app.settings DATABASE_PASSWORD=Slngv5riYqKe DATABASE_HOST=localhost /usr/bin/python3.5 /home/ubuntu/.ansible/tmp/ansible-tmp-1481417097.078755-197789425370261/django_manage.py; rm -rf "/home/ubuntu/.ansible/tmp/ansible-tmp-1481417097.078755-197789425370261/" > /dev/null 2>&1'"'"'"'"'"'"'"'"' && sleep 0'"'"''
fatal: [52.23.172.64]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_name": "django_manage"
    },
    "module_stderr": "OpenSSH_7.2p2, LibreSSL 2.4.1\r\ndebug1: Reading configuration data /etc/ssh/ssh_config\r\ndebug1: /etc/ssh/ssh_config line 20: Applying options for *\r\ndebug1: auto-mux: Trying existing master\r\ndebug2: fd 3 setting O_NONBLOCK\r\ndebug2: mux_client_hello_exchange: master version 4\r\ndebug3: mux_client_forwards: request forwardings: 0 local, 0 remote\r\ndebug3: mux_client_request_session: entering\r\ndebug3: mux_client_request_alive: entering\r\ndebug3: mux_client_request_alive: done pid = 13037\r\ndebug3: mux_client_request_session: session request sent\r\ndebug1: mux_client_request_session: master session id: 2\r\ndebug3: mux_client_read_packet: read header failed: Broken pipe\r\ndebug2: Received exit status from master 0\r\nShared connection to 52.23.172.64 closed.\r\n",
    "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_0a7fqdpo/ansible_module_django_manage.py\", line 287, in <module>\r\n    main()\r\n  File \"/tmp/ansible_0a7fqdpo/ansible_module_django_manage.py\", line 278, in main\r\n    if len(filtered_output):\r\nTypeError: object of type 'filter' has no len()\r\n",
    "msg": "MODULE FAILURE"
}
```

AFTER

```
TASK [web : Run Django database migrations] ************************************************************************************************************************************
ok: 
```

… of list