### PR TITLE
add option for path to pear executable

### DIFF
--- a/lib/ansible/modules/packaging/language/pear.py
+++ b/lib/ansible/modules/packaging/language/pear.py
@@ -45,6 +45,12 @@ options:
         required: false
         default: "present"
         choices: ["present", "absent", "latest"]
+    executable:
+      description:
+        - The explicit executable or path to find the pear executable
+      required: false
+      default: null
+      version_added: "2.3"
 '''
 
 EXAMPLES = '''
@@ -81,6 +87,12 @@ def get_local_version(pear_output):
             return installed
     return None
 
+def _get_pear_path(module):
+    if module.params['executable'] and os.path.isfile(module.params['executable']):
+        return module.params['executable']
+    else:
+        return module.get_bin_path('pear', True, [module.params['executable']])
+
 def get_repository_version(pear_output):
     """Take pear remote-info output and get the latest version"""
     lines = pear_output.split('\n')
@@ -94,13 +106,13 @@ def query_package(module, name, state="present"):
     Returns a boolean to indicate if the package is installed,
     and a second boolean to indicate if the package is up-to-date."""
     if state == "present":
-        lcmd = "pear info %s" % (name)
+        lcmd = "%s info %s" % (_get_pear_path(module), name)
         lrc, lstdout, lstderr = module.run_command(lcmd, check_rc=False)
         if lrc != 0:
             # package is not installed locally
             return False, False
 
-        rcmd = "pear remote-info %s" % (name)
+        rcmd = "%s remote-info %s" % (_get_pear_path(module), name)
         rrc, rstdout, rstderr = module.run_command(rcmd, check_rc=False)
 
         # get the version installed locally (if any)
@@ -127,7 +139,7 @@ def remove_packages(module, packages):
         if not installed:
             continue
 
-        cmd = "pear uninstall %s" % (package)
+        cmd = "%s uninstall %s" % (_get_pear_path(module), package)
         rc, stdout, stderr = module.run_command(cmd, check_rc=False)
 
         if rc != 0:
@@ -158,7 +170,7 @@ def install_packages(module, state, packages):
         if state == 'latest':
             command = 'upgrade'
 
-        cmd = "pear %s %s" % (command, package)
+        cmd = "%s %s %s" % (_get_pear_path(module), command, package)
         rc, stdout, stderr = module.run_command(cmd, check_rc=False)
 
         if rc != 0:
@@ -189,26 +201,18 @@ def check_packages(module, packages, state):
         module.exit_json(change=False, msg="package(s) already %s" % state)
 
 
-def exe_exists(program):
-    for path in os.environ["PATH"].split(os.pathsep):
-        path = path.strip('"')
-        exe_file = os.path.join(path, program)
-        if os.path.isfile(exe_file) and os.access(exe_file, os.X_OK):
-            return True
-
-    return False
 
 
 def main():
     module = AnsibleModule(
         argument_spec    = dict(
             name         = dict(aliases=['pkg']),
-            state        = dict(default='present', choices=['present', 'installed', "latest", 'absent', 'removed'])),
+            state        = dict(default='present', choices=['present', 'installed', "latest", 'absent', 'removed']),
+            executable   = dict(default=None, required=False, type='path')),
         required_one_of = [['name']],
         supports_check_mode = True)
 
-    if not exe_exists("pear"):
-        module.fail_json(msg="cannot find pear executable in PATH")
+
 
     p = module.params
 

--- a/lib/ansible/modules/packaging/language/pear.py
+++ b/lib/ansible/modules/packaging/language/pear.py
@@ -47,7 +47,7 @@ options:
         choices: ["present", "absent", "latest"]
     executable:
       description:
-        - The explicit executable or path to find the pear executable
+        - Path to the pear executable
       required: false
       default: null
       version_added: "2.4"

--- a/lib/ansible/modules/packaging/language/pear.py
+++ b/lib/ansible/modules/packaging/language/pear.py
@@ -50,7 +50,7 @@ options:
         - The explicit executable or path to find the pear executable
       required: false
       default: null
-      version_added: "2.3"
+      version_added: "2.4"
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
ref https://github.com/ansible/ansible-modules-extras/pull/3365

this PR adds the feature @resmo suggested at https://github.com/ansible/ansible-modules-extras/pull/3365#issuecomment-262194091

---

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME
pear

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
This allows you to specify a path to the pear executable or a directory where the pear executable is located. This is useful if you have multiple versions of PHP installed at once and need to install pecl modules for them. I've included a playbook showing its usefulness on a CentOS 7 machine using SCL RPMs but there are other methods.

```yaml
- hosts: localhost
  tasks:
    - name: install prereqs
      package: name={{ item }}
      with_items:
        - epel-release
        - centos-release-scl
        - centos-release-scl-rh
    - name: install packages 
      package: name={{ item }}
      with_items:
        - gcc-c++
        - libssh2-devel
        - php-pear
        - php-devel
        - php55-php-devel
        - php55-php-pear
        - rh-php56-php-pear
        - rh-php56-php-devel
    - name: create symlink to give non-standard name for SCL php55 pear
      file:
        state: link
        src: /opt/rh/php55/root/usr/bin/pear
        dest: /usr/bin/php55-pear
    - name: install pecl-ssh2 for default PHP
      pear:
        name: pecl/ssh2
    - name: install pecl-ssh2 for SCL php55 using explicit path
      pear:
        name: pecl/ssh2
        executable: /usr/bin/php55-pear
    - name: install pecl-ssh2 for SCL php56 using directory where pear executable is located
      pear:
        name: pecl/ssh2
        executable: /opt/rh/rh-php56/root/usr/bin/
```