### PR TITLE
Add get_ifaces command to virt module

### DIFF
--- a/lib/ansible/modules/cloud/misc/virt.py
+++ b/lib/ansible/modules/cloud/misc/virt.py
@@ -47,7 +47,7 @@ options:
       - in addition to state management, various non-idempotent commands are available. See examples
     required: false
     choices: ["create","status", "start", "stop", "pause", "unpause",
-              "shutdown", "undefine", "destroy", "get_xml", "autostart",
+              "shutdown", "undefine", "destroy", "get_xml", "autostart", "get_ifaces",
               "freemem", "list_vms", "info", "nodeinfo", "virttype", "define"]
   uri:
     description:
@@ -125,8 +125,8 @@ else:
     HAS_VIRT = True
 
 ALL_COMMANDS = []
-VM_COMMANDS = ['create','status', 'start', 'stop', 'pause', 'unpause',
-                'shutdown', 'undefine', 'destroy', 'get_xml', 'autostart', 'define']
+VM_COMMANDS = ['create', 'status', 'start', 'stop', 'pause', 'unpause', 'shutdown',
+               'undefine', 'destroy', 'get_xml', 'autostart', 'get_ifaces', 'define']
 HOST_COMMANDS = ['freemem', 'list_vms', 'info', 'nodeinfo', 'virttype']
 ALL_COMMANDS.extend(VM_COMMANDS)
 ALL_COMMANDS.extend(HOST_COMMANDS)
@@ -259,6 +259,9 @@ class LibvirtConnection(object):
     def define_from_xml(self, xml):
         return self.conn.defineXML(xml)
 
+    def get_ifaces(self, vmid):
+        vm = self.conn.lookupByName(vmid)
+        return vm.interfaceAddresses(libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_LEASE)
 
 class Virt(object):
 
@@ -426,6 +429,14 @@ class Virt(object):
         """
         self.__get_conn()
         return self.conn.define_from_xml(xml)
+
+    def get_ifaces(self, vmid):
+        """
+        Gets the interfaces on a guest
+        """
+
+        self.__get_conn()
+        return self.conn.get_ifaces(vmid)
 
 def core(module):
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
virt

##### ANSIBLE VERSION
```
ansible 2.3.0 (virt/domifaddr e503c4d440) last updated 2016/12/11 19:22:29 (GMT +000)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Part of my libvirt provisioning process is to retrieve the IP address that was leased by libvirt's dnsmasq. This was not yet available in the virt module so I've added this functionality.

This is my first pull request for Ansible, so please inform me if I forgot anything.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
PARSED OUTPUT
{
    "changed": false, 
    "invocation": {
        "module_args": {
            "command": "get_ifaces", 
            "name": "coreos-2.guests.internal.siwyd.com", 
            "state": null, 
            "uri": "qemu+ssh://hb@batou/system", 
            "xml": null
        }
    }, 
    "vnet1": {
        "addrs": [
            {
                "addr": "10.200.2.5", 
                "prefix": 24, 
                "type": 0
            }
        ], 
        "hwaddr": "52:54:00:51:9a:52"
    }
}
```