### PR TITLE
Added 'suspended' as desired state for VM

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vsphere_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vsphere_guest.py
@@ -1518,13 +1518,13 @@ def power_state(vm, state, force):
 
     check_status = ' '.join(state.split("_")).upper()
 
-    # Need Force
-    if not force and power_status in [
-        'SUSPENDED', 'POWERING ON',
-        'RESETTING', 'BLOCKED ON MSG'
-    ]:
-
-        return "VM is in %s power state. Force is required!" % power_status
+    # Need Force - skip check for suspended if already true
+    if not (state == 'suspended' and power_status == check_status):
+        if not force and power_status in [
+            'SUSPENDED', 'POWERING ON',
+            'RESETTING', 'BLOCKED ON MSG'
+        ]:
+            return "VM is in %s power state. Force is required!" % power_status
 
     # State is already true
     if power_status == check_status:
@@ -1543,6 +1543,12 @@ def power_state(vm, state, force):
                     vm.reset(sync_run=False)
                 else:
                     return "Cannot restart VM in the current state %s" \
+                        % power_status
+            elif state == 'suspended':
+                if power_status == 'POWERED_ON':
+                    vm.suspend(sync_run=False)
+                else:
+                    return "Cannot suspend VM in the current state %s" \
                         % power_status
             return True
 
@@ -1711,7 +1717,8 @@ def main():
                     'present',
                     'absent',
                     'restarted',
-                    'reconfigured'
+                    'reconfigured',
+                    'suspended'
                 ],
                 default='present'),
             vmware_guest_facts=dict(required=False, type='bool'),

--- a/lib/ansible/modules/cloud/vmware/vsphere_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vsphere_guest.py
@@ -1818,7 +1818,7 @@ def main():
                 module.fail_json(
                     msg="Fact gather failed with exception %s" % e)
         # Power Changes
-        elif state in ['powered_on', 'powered_off', 'restarted']:
+        elif state in ['powered_on', 'powered_off', 'restarted', 'suspended']:
             state_result = power_state(vm, state, force)
 
             # Failure


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

cloud/vmware/vsphere_guest
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Add 'suspended' as a desired state for a VM.
Doesn't error about force being needed if VM is already suspended.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
TASK [vsphere : Suspend vSphere Guest VM] ************************************
ok: [vcsa -> localhost] => (item=Test VM)

PLAY RECAP ******************************************************************
vcsa                                : ok=1             changed=0          unreachable=0             failed=0
```
