### PR TITLE
Add host affinity to the documentation template

### DIFF
--- a/hacking/templates/rst.j2
+++ b/hacking/templates/rst.j2
@@ -87,6 +87,15 @@ Options
 
 {% endif %}
 
+{% if host_affinity is defined %}
+Host Affinity
+-------------
+{% if host_affinity %}
+This module is designed to be run only on @{ host_affinity }@.
+{% else %}
+This module is designed to be run on every host.
+{% endif %}
+{% endif %}
 
 {% if examples or plainexamples -%}
 Examples

--- a/lib/ansible/modules/cloud/azure/azure.py
+++ b/lib/ansible/modules/cloud/azure/azure.py
@@ -25,6 +25,7 @@ short_description: create or terminate a virtual machine in azure
 description:
      - Creates or terminates azure instances. When created optionally waits for it to be 'running'.
 version_added: "1.7"
+host_affinity: localhost
 options:
   name:
     description:

--- a/lib/ansible/modules/monitoring/logicmonitor.py
+++ b/lib/ansible/modules/monitoring/logicmonitor.py
@@ -80,6 +80,7 @@ version_added: "2.2"
 author: [Ethan Culler-Mayeno (@ethanculler), Jeff Wozniak (@woz5999)]
 notes:
   - You must have an existing LogicMonitor account for this module to function.
+host_affinity: localhost
 requirements: ["An existing LogicMonitor account", "Linux"]
 options:
   target:

--- a/lib/ansible/modules/monitoring/logicmonitor_facts.py
+++ b/lib/ansible/modules/monitoring/logicmonitor_facts.py
@@ -67,6 +67,7 @@ version_added: "2.2"
 author: [Ethan Culler-Mayeno (@ethanculler), Jeff Wozniak (@woz5999)]
 notes:
   - You must have an existing LogicMonitor account for this module to function.
+host_affinity: localhost
 requirements: ["An existing LogicMonitor account", "Linux"]
 options:
     target:

--- a/lib/ansible/modules/network/dnsimple.py
+++ b/lib/ansible/modules/network/dnsimple.py
@@ -25,6 +25,7 @@ version_added: "1.6"
 short_description: Interface with dnsimple.com (a DNS hosting service).
 description:
    - "Manages domains and records via the DNSimple API, see the docs: U(http://developer.dnsimple.com/)"
+host_affinity: localhost
 options:
   account_email:
     description:


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Many

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.2
```

##### SUMMARY
Add a field to document host affinity and start to use it. ATM we have many modules that declare this kind of stuff in the examples, but imho is better to have a section about it (people might not read the examples)