### PR TITLE
datadog_monitor: Idempotence fix

### DIFF
--- a/lib/ansible/modules/monitoring/datadog_monitor.py
+++ b/lib/ansible/modules/monitoring/datadog_monitor.py
@@ -258,7 +258,7 @@ def _update_monitor(module, monitor, options):
 
         if 'errors' in msg:
             module.fail_json(msg=str(msg['errors']))
-        elif _equal_dicts(msg, monitor, ['creator', 'overall_state', 'modified']):
+        elif _equal_dicts(msg, monitor, ['creator', 'overall_state', 'modified', 'matching_downtimes']):
             module.exit_json(changed=False, msg=msg)
         else:
             module.exit_json(changed=True, msg=msg)

--- a/lib/ansible/modules/monitoring/datadog_monitor.py
+++ b/lib/ansible/modules/monitoring/datadog_monitor.py
@@ -258,7 +258,7 @@ def _update_monitor(module, monitor, options):
 
         if 'errors' in msg:
             module.fail_json(msg=str(msg['errors']))
-        elif _equal_dicts(msg, monitor, ['creator', 'overall_state', 'modified', 'matching_downtimes']):
+        elif _equal_dicts(msg, monitor, ['creator', 'overall_state', 'modified', 'matching_downtimes', 'overall_state_modified']):
             module.exit_json(changed=False, msg=msg)
         else:
             module.exit_json(changed=True, msg=msg)


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
datadog_monitor

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel 5d05b9b4da) last updated 2016/12/12 10:55:25 (GMT +200)
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Excluded the field "matching_downtimes" from the equality check, it is only set on the existing JSON, not the one which is build by the module.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
TASK [ansible-galaxy-datadog-basic-monitors : Basic Datadog monitors] **********
changed: [testserver] => (item={u'query': u'avg(last_5m):max:system.load.5', u'message': u'System load too high', u'name': u'[load.5]', u'condition': u'>6'})
```
After:
```
TASK [ansible-galaxy-datadog-basic-monitors : Basic Datadog monitors] **********
ok: [testserver] => (item={u'query': u'avg(last_5m):max:system.load.5', u'message': u'System load too high', u'name': u'[load.5]', u'condition': u'>6'})
```

Fixes: #19216