### PR TITLE
ec2_asg: various fixes

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -641,10 +641,17 @@ def replace(connection, module):
     as_group = connection.get_all_groups(names=[group_name])[0]
     wait_for_new_inst(module, connection, group_name, wait_timeout, as_group.min_size, 'viable_instances')
     props = get_properties(as_group)
-    instances = props['instances']
+    instances = []
     if replace_instances:
         instances = replace_instances
-        
+    elif 'instances' in props:
+        instances = props['instances']
+
+    # No instances to be replaced (initial configuration or currently 0 sized)
+    if not instances:
+        changed = False
+        return(changed, props)
+
     #check if min_size/max_size/desired capacity have been specified and if not use ASG values
     if min_size is None:
         min_size = as_group.min_size
@@ -674,7 +681,7 @@ def replace(connection, module):
     if not old_instances:
         changed = False
         return(changed, props)
-      
+
     # set temporary settings and wait for them to be reached
     # This should get overwritten if the number of instances left is less than the batch size.
 

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -302,9 +302,9 @@ def get_properties(autoscaling_group):
                 properties['unhealthy_instances'] += 1
             if i.lifecycle_state == 'InService':
                 properties['in_service_instances'] += 1
-            if i.lifecycle_state == 'Terminating':
+            if i.lifecycle_state in ['Terminating','Terminating:Wait','Terminating:Proceed']:
                 properties['terminating_instances'] += 1
-            if i.lifecycle_state == 'Pending':
+            if i.lifecycle_state in ['Pending','Pending:Wait','Pending:Proceed']:
                 properties['pending_instances'] += 1
     properties['instance_facts'] = instance_facts
     properties['load_balancers'] = autoscaling_group.load_balancers
@@ -837,7 +837,7 @@ def wait_for_term_inst(connection, module, term_instances):
             lifecycle = instance_facts[i]['lifecycle_state']
             health = instance_facts[i]['health_status']
             log.debug("Instance {0} has state of {1},{2}".format(i,lifecycle,health ))
-            if  lifecycle == 'Terminating' or health == 'Unhealthy':
+            if  lifecycle in ['Terminating','Terminating:Wait','Terminating:Proceed'] or health == 'Unhealthy':
                 count += 1
         time.sleep(10)
 

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -654,7 +654,7 @@ def replace(connection, module):
 
     #check if min_size/max_size/desired capacity have been specified and if not use ASG values
     if min_size is None:
-        min_size = as_group.min_size
+        min_size = as_group.min_size or 0
     if max_size is None:
         max_size = as_group.max_size
     if desired_capacity is None:
@@ -765,7 +765,10 @@ def terminate_batch(connection, module, replace_instances, initial_instances, le
 
     as_group = connection.get_all_groups(names=[group_name])[0]
     props = get_properties(as_group)
-    desired_size = as_group.min_size
+    # as_group.min_size can return None rather than 0 :/
+    desired_size = as_group.min_size or 0
+    if min_size is None:
+        min_size = as_group.min_size or 0
 
     new_instances, old_instances = get_instances_by_lc(props, lc_check, initial_instances)
     num_new_inst_needed = desired_capacity - len(new_instances)

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -692,10 +692,11 @@ def replace(connection, module):
     as_group = connection.get_all_groups(names=[group_name])[0]
     props = get_properties(as_group)
     instances = props['instances']
+    new_instances, old_instances = get_instances_by_lc(props, lc_check, instances)
     if replace_instances:
         instances = replace_instances
     log.debug("beginning main loop")
-    for i in get_chunks(instances, batch_size):
+    for i in get_chunks(old_instances, batch_size):
         # break out of this loop if we have enough new instances
         break_early, desired_size, term_instances = terminate_batch(connection, module, i, instances, desired_capacity, False)
         wait_for_term_inst(connection, module, term_instances)

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -687,7 +687,7 @@ def replace(connection, module):
 
     as_group = connection.get_all_groups(names=[group_name])[0]
     update_size(as_group, max_size + batch_size, min_size + batch_size, desired_capacity + batch_size)
-    wait_for_new_inst(module, connection, group_name, wait_timeout, as_group.min_size, 'viable_instances')
+    wait_for_new_inst(module, connection, group_name, wait_timeout, desired_capacity + batch_size, 'viable_instances')
     wait_for_elb(connection, module, group_name)
     as_group = connection.get_all_groups(names=[group_name])[0]
     props = get_properties(as_group)

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -667,7 +667,7 @@ def replace(connection, module):
     if lc_check:
         if num_new_inst_needed == 0 and old_instances:
             log.debug("No new instances needed, but old instances are present. Removing old instances")
-            terminate_batch(connection, module, old_instances, instances, True)
+            terminate_batch(connection, module, old_instances, instances, desired_capacity, True)
             as_group = connection.get_all_groups(names=[group_name])[0]
             props = get_properties(as_group)
             changed = True
@@ -697,7 +697,7 @@ def replace(connection, module):
     log.debug("beginning main loop")
     for i in get_chunks(instances, batch_size):
         # break out of this loop if we have enough new instances
-        break_early, desired_size, term_instances = terminate_batch(connection, module, i, instances, False)
+        break_early, desired_size, term_instances = terminate_batch(connection, module, i, instances, desired_capacity, False)
         wait_for_term_inst(connection, module, term_instances)
         wait_for_new_inst(module, connection, group_name, wait_timeout, desired_size, 'viable_instances')
         wait_for_elb(connection, module, group_name)
@@ -753,10 +753,9 @@ def list_purgeable_instances(props, lc_check, replace_instances, initial_instanc
                 instances_to_terminate.append(i)
     return instances_to_terminate
 
-def terminate_batch(connection, module, replace_instances, initial_instances, leftovers=False):
+def terminate_batch(connection, module, replace_instances, initial_instances, desired_capacity, leftovers=False):
     batch_size = module.params.get('replace_batch_size')
     min_size =  module.params.get('min_size')
-    desired_capacity =  module.params.get('desired_capacity')
     group_name = module.params.get('name')
     wait_timeout = int(module.params.get('wait_timeout'))
     lc_check = module.params.get('lc_check')


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ec2_asg

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
```
props doesn't always have an instances key

during 'replace' return changed=False when there are no instances to change.

This primarily occurs when spinning up a new ASG, and avoids people needing
separate plays for creating the ASG and updating the ASG to make changes
```