### PR TITLE
Close open file handles

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -575,19 +575,10 @@ class JenkinsPlugin(object):
 
             # Write the updates file
             update_fd, updates_file = tempfile.mkstemp()
+            os.write(update_fd, r.read())
 
             try:
-                fd = open(updates_file, 'wb')
-            except IOError:
-                e = get_exception()
-                self.module.fail_json(
-                    msg="Cannot open the tmp updates file %s." % updates_file,
-                    details=str(e))
-
-            fd.write(r.read())
-
-            try:
-                fd.close()
+                os.close(update_fd)
             except IOError:
                 e = get_exception()
                 self.module.fail_json(
@@ -651,25 +642,15 @@ class JenkinsPlugin(object):
 
     def _write_file(self, f, data):
         # Store the plugin into a temp file and then move it
-        tmp_f_tuple, tmp_f = tempfile.mkstemp()
-
-        try:
-            fd = open(tmp_f, 'wb')
-        except IOError:
-            e = get_exception()
-            self.module.fail_json(
-                msg='Cannot open the temporal plugin file %s.' % tmp_f,
-                details=str(e))
+        tmp_f_fd, tmp_f = tempfile.mkstemp()
 
         if isinstance(data, str):
-            d = data
+            os.write(tmp_f_fd, data)
         else:
-            d = data.read()
-
-        fd.write(d)
+            os.write(tmp_f_fd, data.read())
 
         try:
-            fd.close()
+            os.close(tmp_f_fd)
         except IOError:
             e = get_exception()
             self.module.fail_json(


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Jenkins Plugins
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

`mkstemp()` returns a tuple containing an OS-level handle to an open file
(as would be returned by `os.open()`) and the absolute pathname of that
file, in that order.

This patch makes sure that the `fd` opened by `tempfile.mkstemp()` is
re-used and `close()`d properly.