### PR TITLE
Fix cronvar fail when run without user

### DIFF
--- a/lib/ansible/modules/system/cronvar.py
+++ b/lib/ansible/modules/system/cronvar.py
@@ -135,8 +135,6 @@ class CronVar(object):
     def __init__(self, module, user=None, cron_file=None):
         self.module = module
         self.user = user
-        if self.user is None:
-            self.user = 'root'
         self.lines = None
         self.wordchars = ''.join(chr(x) for x in range(128) if chr(x) not in ('=', "'", '"', ))
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- cronvar

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file = /home/michael/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Got bug in case when module is run as uprivileged user: it always fails because cron requires sudo when `-u` option is specified.
When `user:` parameter is not set, cronvar tries to make changes for root.

So I made it behaves exactly like cron module when handling self.user.

<!--- Paste verbatim command output below, e.g. before and after your change -->
playbook:
```
$ cat a.yml
---
- hosts: ansible
  tasks:
    - name: Add var to crontab
      cronvar:
        name: "TEST"
        value: "Test"
```
before:
```
Using /home/michael/.ansible.cfg as config file

PLAYBOOK: a.yml ****************************************************************
1 plays in a.yml

PLAY [ansible] *****************************************************************

TASK [setup] *******************************************************************
...
ok: [localhost]

TASK [Add var to crontab] ******************************************************
task path: /home/michael/repos/ansible/a.yml:4
...
fatal: [localhost]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_args": {
            "backup": false,
            "cron_file": null,
            "insertafter": null,
            "insertbefore": null,
            "name": "TEST",
            "state": "present",
            "user": null,
            "value": "Test"
        },
        "module_name": "cronvar"
    },
    "msg": "must be privileged to use -u\n"
}
        to retry, use: --limit @/home/michael/repos/ansible/a.retry

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1
```
after:
```
PLAY [ansible] ******************************************************************************************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************************************************************************************
ok: [localhost]

TASK [Add var to crontab] *******************************************************************************************************************************************************************
changed: [localhost]

PLAY RECAP **********************************************************************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0
```