### PR TITLE
Support for simpleinit-msb init system

### DIFF
--- a/lib/ansible/module_utils/facts/system/service_mgr.py
+++ b/lib/ansible/module_utils/facts/system/service_mgr.py
@@ -124,6 +124,8 @@ class ServiceMgrFactCollector(BaseFactCollector):
             # FIXME: mv is_systemd_managed
             if self.is_systemd_managed(module=module):
                 service_mgr_name = 'systemd'
+            elif module.get_bin_path('telinit') and os.path.exists("/etc/init.d/smgl_init"):
+                service_mgr_name = 'simpleinit'
             elif module.get_bin_path('initctl') and os.path.exists("/etc/init/"):
                 service_mgr_name = 'upstart'
             elif os.path.exists('/sbin/openrc'):

--- a/lib/ansible/modules/system/service.py
+++ b/lib/ansible/modules/system/service.py
@@ -433,7 +433,8 @@ class LinuxService(Service):
     def get_service_tools(self):
 
         paths = [ '/sbin', '/usr/sbin', '/bin', '/usr/bin' ]
-        binaries = [ 'service', 'chkconfig', 'update-rc.d', 'rc-service', 'rc-update', 'initctl', 'telinit', 'systemctl', 'start', 'stop', 'restart', 'insserv' ]
+        binaries = [ 'service', 'chkconfig', 'update-rc.d', 'rc-service', 'rc-update', 'initctl', 'telinit', 'systemctl', 'start', 'stop', 'restart',
+                     'insserv' ]
         initpaths = [ '/etc/init.d' ]
         location = dict()
 

--- a/lib/ansible/modules/system/service.py
+++ b/lib/ansible/modules/system/service.py
@@ -974,6 +974,7 @@ class LinuxService(Service):
 
                     if not service_exists:
                         self.module.fail_json(msg='telinit could not find the requested service: %s' % self.name)
+
                     svc_cmd = "%s run %s" % (self.svc_cmd, self.name)
                 else:
                     # SysV and OpenRC take the form <cmd> <name> <action>

--- a/lib/ansible/modules/system/service.py
+++ b/lib/ansible/modules/system/service.py
@@ -884,7 +884,7 @@ class LinuxService(Service):
                 return (rc, out, err)
 
         #
-        # telinit (Source Mage GNU/Linux)
+        # simpleinit-msb (Source Mage GNU/Linux)
         #
         if self.enable_cmd.endswith("telinit"):
             (rc, out, err) = self.execute_command("%s list" % self.enable_cmd)

--- a/lib/ansible/modules/system/service.py
+++ b/lib/ansible/modules/system/service.py
@@ -959,7 +959,7 @@ class LinuxService(Service):
                     # initctl commands take the form <cmd> <action> <name>
                     svc_cmd = self.svc_cmd
                     arguments = "%s %s" % (self.name, arguments)
-                # telinit
+                # telinit takes the form <cmd> run <name> <action>
                 elif self.svc_cmd.endswith("telinit"):
                     (rc, out, err) = self.execute_command("%s list" % self.enable_cmd)
 


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

`lib/ansible/modules/system/service.py `

##### ANSIBLE VERSION

`2.2.0.0`

##### SUMMARY

After [package management](https://github.com/ansible/ansible/pull/19072) it's the last of 2 main parts of any distro -- an init system.

This adds full support for `simpleinit-msb` used in [Source Mage](http://sourcemage.org).

[The init](http://sourcemage.org/Init) system is very simple and unique to Source Mage, based on the [Linux Boot Scripts](http://www.safe-mbox.com/~rgooch/linux/boot-scripts/) design pattern.

It uses `telinit` binary to manage init scripts in the system, move them between runlevels, enable/disable, and even install and remove them:

```text
telinit run <script> [<args>]        run init <script> with arguments <args>
telinit switch <rlvl>                switch to runlevel <rlvl>
telinit enable [<script> ... ]       enable and start <script> if not enabled
telinit disable [<script> ... ]      stop and disable <script> if not disabled
telinit bootenable [<script> ... ]   enable <script> if not enabled
telinit bootdisable [<script> ... ]  disable <script> if not disabled
telinit delete [<script> ... ]       delete <script> if disabled
telinit enabled                      list enabled startup scripts
telinit disabled                     list disabled startup scripts
telinit list                         list startup scripts and their runlevels
telinit runlevels                    list all runlevels
telinit runlevel                     print the highest completed runlevel
telinit move <script> <rlvl>         move <script> to runlevel <rlvl>
telinit install <file> <rlvl>        install <file> into runlevel <rlvl>
telinit spellinstall <spell>         install <spell>'s init or xinetd scripts
```

I've also managed to add some protection for non-existing scripts inside Ansible code.