### PR TITLE
Fix `TgzArchive.is_unarchived` when `keep_newer: yes`

### DIFF
--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -677,7 +677,7 @@ class TgzArchive(object):
                 out += line + '\n'
             if not self.file_args['mode'] and MODE_DIFF_RE.search(line):
                 out += line + '\n'
-            if MOD_TIME_DIFF_RE.search(line):
+            if not self.module.params['keep_newer'] and MOD_TIME_DIFF_RE.search(line):
                 out += line + '\n'
             if MISSING_FILE_RE.search(line):
                 out += line + '\n'


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Module unarchive.

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /home/vagrant/ansibox/ansible.cfg
  configured module search path = ['library']
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

PR ansible/ansible-modules-core#3926 added check of "Mod time differs" in tarballs to fix ansible/ansible-modules-core#3901, but it breaks the idempotence when module parameter `keep_newer` by always launching an unarchive action which does nothing.

##### STEPS TO REPRODUCE ISSUE

1. prepare tar file from folder, make it demo.tar
2. run this command in playbook
```
unarchive:
  src: /opt/packages/demo.tar
  dest: /opt/app/
  keep_newer: yes
```
3. update content of any file, make newer demo.tar
4. run the same playbook

EXPECTED RESULTS

The task should be idempotent,

ACTUAL RESULTS

The task is reported as `changed`.