### PR TITLE
Fix changed event for docker_image in force mode

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -342,6 +342,8 @@ class ImageManager(DockerBaseClass):
                 self.results['changed'] = True
                 if not self.check_mode:
                     self.results['image'] = self.client.pull_image(self.name, tag=self.tag)
+                    if image and image == self.results['image']:
+                        self.results['changed'] = False
 
         if self.archive_path:
             self.archive_image(self.name, self.tag)


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
`docker_image.py`

##### ANSIBLE VERSION

```
devel
```

##### SUMMARY

This fixes the changed event for docker_image in force mode to not always be True.

This is a take over from ansible/ansible-modules-core/pull/4623
