### PR TITLE
Add support for --list-modules

### DIFF
--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -53,7 +53,7 @@ class PlaybookExecutor:
         self.passwords         = passwords
         self._unreachable_hosts = dict()
 
-        if options.listhosts or options.listtasks or options.listtags or options.syntax:
+        if options.listhosts or options.listtasks or options.listtags or options.syntax or options.listmodules:
             self._tqm = None
         else:
             self._tqm = TaskQueueManager(inventory=inventory, variable_manager=variable_manager, loader=loader, options=options, passwords=self.passwords)


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
* `lib/ansible/cli/playbook.py`
* `lib/ansible/executor/playbook_executor.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (list_modules 245503f3ba) last updated 2016/12/12 11:39:16 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Add a ansible-playbook --list-modules parameter to allow playbook
authors to audit the modules used by their playbook.  Similar to
`--list-tasks`, the modules are listed per play, in addition to
a playbook summary.  The lists of modules are ordered by frequency.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
$ ansible-playbook -i inventory install.yml --list-modules  

playbook: install.yml

  play #1 (tower:database): tower:database	TAGS: []
    modules:
      fail: 9
      set_fact: 2
      debug: 1
      setup: 1

  play #2 (all): Group nodes by OS distribution	TAGS: []
    modules:
      group_by: 1

  play #3 (RedHat-7*:CentOS-7*:Ubuntu-14.04:Ubuntu-16.04:OracleLinux-7*): Group supported distributions	TAGS: []
    modules:
      group_by: 1

  play #4 (!supported): Ensure all node OS distributions are supported	TAGS: []
    modules:
      fail: 1

  play #5 (tower:database): Define role discovered variables, usable throughout the playbook	TAGS: []
    modules:
      command: 16
      file: 15
      template: 10
      service: 7
      stat: 5
      include_vars: 5
      wait_for: 3
      set_fact: 3
      copy: 2
      postgresql_user: 1
      slurp: 1
      seboolean: 1
      postgresql_db: 1

  play #6 (tower): Sanity check and prep Tower node(s)	TAGS: []
    modules:
      fail: 9
      command: 5
      service: 3
      slurp: 1
      stat: 1

  play #7 (database): Install postgres database node	TAGS: []
    modules:
      stat: 11
      command: 9
      apt: 6
      template: 6
      file: 5
      yum: 5
      firewalld: 4
      copy: 4
      include_vars: 3
      service: 3
      ini_file: 3
      wait_for: 2
      set_fact: 2
      postgresql_user: 1
      slurp: 1
      apt_key: 1
      apt_repository: 1
      postgresql_db: 1

  play #8 (tower): Install Tower node(s)	TAGS: []
    modules:
      command: 33
      file: 18
      template: 17
      stat: 15
      service: 10
      include_vars: 7
      apt: 6
      copy: 6
      set_fact: 5
      yum: 5
      lineinfile: 4
      wait_for: 4
      firewalld: 4
      ini_file: 3
      slurp: 2
      rabbitmq_vhost: 1
      rabbitmq_plugin: 1
      apt_repository: 1
      seboolean: 1
      rabbitmq_user: 1
      apt_key: 1
      postgresql_user: 1
      postgresql_db: 1

  module summary:
      command: 63
      file: 38
      template: 33
      stat: 32
      service: 23
      fail: 19
      include_vars: 15
      apt: 12
      copy: 12
      set_fact: 12
      yum: 10
      wait_for: 9
      firewalld: 8
      ini_file: 6
      slurp: 5
      lineinfile: 4
      postgresql_user: 3
      postgresql_db: 3
      apt_repository: 2
      seboolean: 2
      group_by: 2
      apt_key: 2
      rabbitmq_vhost: 1
      rabbitmq_plugin: 1
      rabbitmq_user: 1
      setup: 1
      debug: 1
```

