### PR TITLE
ec2_ami_find: set is_public to 'true' or 'false'

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_ami_find.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami_find.py
@@ -356,8 +356,8 @@ def main():
         filter['architecture'] = architecture
     if hypervisor:
         filter['hypervisor'] = hypervisor
-    if is_public:
-        filter['is_public'] = is_public
+    if is_public is not None:
+        filter['is_public'] = 'true' if is_public else 'false'
     if name:
         filter['name'] = name
     if platform:

--- a/lib/ansible/modules/cloud/amazon/ec2_ami_find.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami_find.py
@@ -356,8 +356,8 @@ def main():
         filter['architecture'] = architecture
     if hypervisor:
         filter['hypervisor'] = hypervisor
-    if is_public is not None:
-        filter['is_public'] = 'true' if is_public else 'false'
+    if is_public:
+        filter['is_public'] = 'true'
     if name:
         filter['name'] = name
     if platform:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_ami_find

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/etc/ansible/library']
```
##### SUMMARY
Allow documented is_public yaml values to work with boto, as per https://github.com/melta/boto/blob/master/boto/ec2/image.py#L60:L71.

This is a workaround for a coding error in boto2, where a parameter is documented as a boolean, but treated as a string.

See #5600 for expected output.

fixes https://github.com/ansible/ansible-modules-core/issues/5600
---
Despite being a boolean property, https://github.com/melta/boto/blob/master/boto/ec2/image.py#L63:L64 sets is_public = True only if the argument is passed in as the string 'true'. Likewise for False/'false'.

This is a workaround for that bug in boto2, to allow the documented parameter to work with valid yaml values.

fixes https://github.com/ansible/ansible-modules-core/issues/5600