### PR TITLE
Check for removal not allowed errors

### DIFF
--- a/lib/ansible/module_utils/asa.py
+++ b/lib/ansible/module_utils/asa.py
@@ -47,6 +47,7 @@ class Cli(CliBase):
 
     CLI_ERRORS_RE = [
         re.compile(r"error:", re.I),
+        re.compile(r"^Removing.* not allowed")
     ]
 
     NET_PASSWD_RE = re.compile(r"[\r\n]?password: $", re.I)

--- a/test/integration/targets/asa_config/tests/cli/removal_error.yaml
+++ b/test/integration/targets/asa_config/tests/cli/removal_error.yaml
@@ -1,0 +1,46 @@
+---
+- debug: msg="START cli/removal_error.yaml"
+
+- name: setup
+  asa_config:
+    commands:
+      - clear configure access-list ANSIBLE-DNS
+      - no object-group network OGA-GOOGLE-DNS
+    provider: "{{ cli }}"
+  ignore_errors: yes
+
+- name: configure test object-group
+  asa_config:
+    parents: object-group network OGA-GOOGLE-DNS
+    lines: network-object host 8.8.8.8
+    provider: "{{ cli }}"
+  register: result
+
+
+- name: configure test access-list
+  asa_config:
+    lines: access-list ANSIBLE-DNS extended permit udp any object-group OGA-GOOGLE-DNS eq domain
+    provider: "{{ cli }}"
+
+- name: try to remove object-group (should fail)
+  asa_config:
+    commands:
+      - no object-group network OGA-GOOGLE-DNS
+    provider: "{{ cli }}"
+  ignore_errors: yes
+  register: result
+
+
+- name: Last command should fail
+  assert:
+    that:
+      - "result.failed == true"
+
+- name: teardown
+  asa_config:
+    commands:
+      - clear configure access-list ANSIBLE-DNS
+      - no object-group network OGA-GOOGLE-DNS
+    provider: "{{ cli }}"
+
+- debug: msg="END cli/removal_error.yaml"


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

* asa_config

##### ANSIBLE VERSION
```
$ ansible --version
ansible 2.3.0 (asa_removal e7d6592dd3) last updated 2016/12/12 20:27:41 (GMT +200)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Cisco ASA reports errors when trying to remove an object used by another item.

```
object-group network OGA-GOOGLE-DNS
 network-object host 8.8.8.8
access-list ANSIBLE-DNS extended permit udp any object-group OGA-GOOGLE-DNS eq domain

ns2903-asa-02(config)#
ns2903-asa-02(config)# no object-group network OGA-GOOGLE-DNS
Removing object-group (OGA-GOOGLE-DNS) not allowed, it is being used.
ns2903-asa-02(config)#
```
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

This patch looks for the "^Removing ... not allowed" string and reports this as an error. The included test will check for this in the future.

Fixes #18947

