### PR TITLE
Remove core/extras dirs from old PRs during CI.

### DIFF
--- a/test/utils/shippable/shippable.sh
+++ b/test/utils/shippable/shippable.sh
@@ -24,6 +24,9 @@ pip list --disable-pip-version-check
 export PATH="test/runner:${PATH}"
 reorganize-tests.sh # temporary solution until repositories are merged
 
+# remove empty core/extras module directories from PRs created prior to the repo-merge
+find lib/ansible/modules -type d -empty -print -delete
+
 function cleanup
 {
     if [ "$(ls test/results/coverage/)" ]; then


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

CI

##### ANSIBLE VERSION

```
ansible 2.3.0 (pre-merge-ci 59dcd660ad) last updated 2016/12/12 12:06:00 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Remove core/extras dirs from old PRs during CI.