### PR TITLE
cloudstack: cs_securitygroup_rule: fix impossible to set icmp_code and icmp_type to 0

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_securitygroup_rule.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_securitygroup_rule.py
@@ -243,10 +243,10 @@ class AnsibleCloudStackSecurityGroupRule(AnsibleCloudStack):
         icmp_code                = self.module.params.get('icmp_code')
         icmp_type                = self.module.params.get('icmp_type')
 
-        if protocol in ['tcp', 'udp'] and not (start_port and end_port):
+        if protocol in ['tcp', 'udp'] and (start_port is None or end_port is None):
             self.module.fail_json(msg="no start_port or end_port set for protocol '%s'" % protocol)
 
-        if protocol == 'icmp' and not (icmp_type and icmp_code):
+        if protocol == 'icmp' and (icmp_type is None or icmp_code is None):
             self.module.fail_json(msg="no icmp_type or icmp_code set for protocol '%s'" % protocol)
 
         for rule in rules:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cs_securitygroup_rule

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.0, 2.1, 2.2, 2.3
```

##### SUMMARY
icmp code and type as well as ports can not be 0 although 0 is valid, fixes #19175 
