### PR TITLE
fixes #19259: ec2_facts - Add support for ca-central-1

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_facts.py
@@ -70,6 +70,7 @@ class Ec2Metadata(object):
                    'ap-southeast-1',
                    'ap-southeast-2',
                    'ap-south-1',
+                   'ca-central-1',
                    'eu-central-1',
                    'eu-west-1',
                    'sa-east-1',


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #19259

Add support for ca-central-1 to ec2_facts
