### PR TITLE
Allow CPU and Memory to be templatable

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -323,6 +323,9 @@ def main():
         else:
             if not module.check_mode:
                 # Doesn't exist. create it.
+                for container in module.params['containers']:
+                    container['cpu'] = int(container['cpu'])
+                    container['memory'] = int(container['memory'])
                 volumes = module.params.get('volumes', []) or []
                 results['taskdefinition'] = task_mgr.register_task(module.params['family'],
                                                                    module.params['containers'], volumes)


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

ecs_taskdefinition
##### Ansible Version:

```
ansible 2.0.0.2
```
##### Summary:

Currently, the module does not allow the CPU and Memory parameters to be templatable. They must be integer/long. This makes the module unusable with variables. In other words, we would need to call the module for every task definition.
This change will allow the CPU and Memory to be templatable like so,

```
    containers:
      - name: "nikhil-test"
        image: "nikhil-test-nginx:{{deploy_tag}}"
        memory: "{{mycontainers.nginx.memory}}"
        cpu: "{{mycontainers.nginx.cpu}}"
```
##### Example output:

Error before change: 

```
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter containerDefinitions[0].memory, value: 1920, type: <type 'str'>, valid types: <type 'int'>, <type 'long'>
Invalid type for parameter containerDefinitions[0].cpu, value: 2560, type: <type 'str'>, valid types: <type 'int'>, <type 'long'>
```

This error is not seen with suggested change

##### Note
This is a clone of https://github.com/ansible/ansible-modules-extras/pull/1715
I could not rebase the original PR due to losing access to the repo I originally contributed from