### PR TITLE
Fix for #19265

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -597,7 +597,7 @@ class SSLValidationHandler(urllib_request.BaseHandler):
 
         # Write the dummy ca cert if we are running on Mac OS X
         if system == 'Darwin':
-            os.write(tmp_fd, DUMMY_CA_CERT)
+            os.write(tmp_fd, DUMMY_CA_CERT.encode())
             # Default Homebrew path for OpenSSL certs
             paths_checked.append('/usr/local/etc/openssl')
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/urls.py
##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /Users/regs/work/pantsibot/ansible.cfg
  configured module search path = ['./library']
```

##### SUMMARY
Renders string output to UTF-8 encoded bytes, appropriate for passing to `os.write()` in Python 3.5.


