### PR TITLE
Code smell test for iteritems and itervalues

### DIFF
--- a/lib/ansible/modules/system/authorized_key.py
+++ b/lib/ansible/modules/system/authorized_key.py
@@ -233,16 +233,16 @@ class keydict(dict):
             yield key, self[key][indexes[key]]
 
     def iteritems(self):
-        return self._item_generator()
+        raise NotImplementedError("Do not use this as it's not available on py3")
 
     def items(self):
-        return list(self.iteritems())
+        return list(self._item_generator())
 
     def itervalues(self):
-        return (item[1] for item in self.iteritems())
+        raise NotImplementedError("Do not use this as it's not available on py3")
 
     def values(self):
-        return list(self.itervalues())
+        return [item[1] for item in self.items()]
 
 
 def keyfile(module, user, write=False, path=None, manage_dir=True):

--- a/packaging/release/templates/RELEASES.tmpl
+++ b/packaging/release/templates/RELEASES.tmpl
@@ -5,9 +5,9 @@ VERSION  RELEASE     CODE NAME
 ++++++++++++++++++++++++++++++
 
 {% for version in versions %}
-{% for vkey, vdata in version.iteritems() %}
+{% for vkey, vdata in version.items() %}
 {% for release in vdata.releases %}
-{% for rkey, rdata in release.iteritems() %}
+{% for rkey, rdata in release.items() %}
 {% set major_minor = vkey + "." + rkey %}
 {{"%-8s"|format(major_minor)}} {{"%-10s"|format(rdata)}}  "{{vdata.code_name}}"
 {% endfor %}

--- a/test/sanity/code-smell/no-dict-iteritems.sh
+++ b/test/sanity/code-smell/no-dict-iteritems.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+ITERITEMS_USERS=$(grep -rI '\.iteritems' . \
+    --exclude-dir .git \
+    --exclude-dir .tox \
+    --exclude-dir docsite \
+    | grep -v \
+    -e 'six\.iteritems' \
+    -e lib/ansible/compat/six/_six.py \
+    -e lib/ansible/module_utils/six.py \
+    -e test/sanity/code-smell/no-dict-iteritems.sh \
+    )
+
+if [ "${ITERITEMS_USERS}" ]; then
+    echo 'iteritems has been removed in python3.  Alternatives:'
+    echo '    for KEY, VALUE in DICT.items():'
+    echo '    from ansible.module_utils.six import iteritems ; for KEY, VALUE in iteritems(DICT):'
+    echo '    from ansible.compat.six import iteritems ; for KEY, VALUE in iteritems(DICT):'
+    echo "${ITERITEMS_USERS}"
+    exit 1
+fi

--- a/test/sanity/code-smell/no-dict-itervalues.sh
+++ b/test/sanity/code-smell/no-dict-itervalues.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+ITERVALUES_USERS=$(grep -rI '\.itervalues' . \
+    --exclude-dir .git \
+    --exclude-dir .tox \
+    --exclude-dir docsite \
+    | grep -v \
+    -e 'six\.itervalues' \
+    -e lib/ansible/compat/six/_six.py \
+    -e lib/ansible/module_utils/six.py \
+    -e test/sanity/code-smell/no-dict-itervalues.sh \
+    )
+
+if [ "${ITERVALUES_USERS}" ]; then
+    echo 'itervalues has been removed in python3.  Alternatives:'
+    echo '    for VALUE in DICT.values():'
+    echo '    from ansible.module_utils.six import itervalues ; for VALUE in itervalues(DICT):'
+    echo '    from ansible.compat.six import itervalues ; for VALUE in itervalues(DICT):'
+    echo "${ITERVALUES_USERS}"
+    exit 1
+fi


### PR DESCRIPTION
##### ISSUE TYPE

 - Test Pull Request

##### COMPONENT NAME
test/sanity/code-smell

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

##### SUMMARY
iteritems and itervalues aren't available in python3.  Write code-smell tests to make sure we don't add those into the code.