### PR TITLE
Remove itervalues (not available on py3)

### DIFF
--- a/contrib/inventory/nova.py
+++ b/contrib/inventory/nova.py
@@ -26,7 +26,7 @@ import re
 import os
 import ConfigParser
 from novaclient import client as nova_client
-from six import iteritems
+from six import iteritems, itervalues
 
 try:
     import json
@@ -105,7 +105,7 @@ def get_ips(server, access_ip=True):
     # Iterate through each servers network(s), get addresses and get type
     addresses = getattr(server, 'addresses', {})
     if len(addresses) > 0:
-        for network in addresses.itervalues():
+        for network in itervalues(addresses):
             for address in network:
                 if address.get('OS-EXT-IPS:type', False) == 'fixed':
                     private.append(address['addr'])

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -379,7 +379,7 @@ def main():
 
         # Finally, remove anything left in the groupRules -- these will be defunct rules
         if purge_rules:
-            for (rule, grant) in groupRules.itervalues() :
+            for (rule, grant) in groupRules.values():
                 grantGroup = None
                 if grant.group_id:
                     if grant.owner_id != group.owner_id:
@@ -456,7 +456,7 @@ def main():
 
         # Finally, remove anything left in the groupRules -- these will be defunct rules
         if purge_rules_egress:
-            for (rule, grant) in groupRules.itervalues():
+            for (rule, grant) in groupRules.values():
                 grantGroup = None
                 if grant.group_id:
                     grantGroup = groups[grant.group_id].id

--- a/lib/ansible/modules/cloud/lxd/lxd_container.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_container.py
@@ -388,7 +388,7 @@ class LXDContainerManagement(object):
 
     @staticmethod
     def _has_all_ipv4_addresses(addresses):
-        return len(addresses) > 0 and all([len(v) > 0 for v in addresses.itervalues()])
+        return len(addresses) > 0 and all([len(v) > 0 for v in addresses.values()])
 
     def _get_addresses(self):
         try:

--- a/lib/ansible/modules/cloud/misc/xenserver_facts.py
+++ b/lib/ansible/modules/cloud/misc/xenserver_facts.py
@@ -94,7 +94,7 @@ def get_networks(session):
     recs = session.xenapi.network.get_all_records()
     xs_networks = {}
     networks = change_keys(recs, key='uuid')
-    for network in networks.itervalues():
+    for network in networks.values():
         xs_networks[network['name_label']] = network
     return xs_networks
 
@@ -104,7 +104,7 @@ def get_pifs(session):
     pifs = change_keys(recs, key='uuid')
     xs_pifs = {}
     devicenums = range(0, 7)
-    for pif in pifs.itervalues():
+    for pif in pifs.values():
         for eth in devicenums:
             interface_name = "eth%s" % (eth)
             bond_name = interface_name.replace('eth', 'bond')
@@ -151,7 +151,7 @@ def get_vms(session):
         return None
 
     vms = change_keys(recs, key='uuid')
-    for vm in vms.itervalues():
+    for vm in vms.values():
        xs_vms[vm['name_label']] = vm
     return xs_vms
 
@@ -162,7 +162,7 @@ def get_srs(session):
     if not recs:
         return None
     srs = change_keys(recs, key='uuid')
-    for sr in srs.itervalues():
+    for sr in srs.values():
        xs_srs[sr['name_label']] = sr
     return xs_srs
 


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Various.  Needed to fix modules on python3

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel, stable-2.2
```

##### SUMMARY
Remove itervalues.  Unless the data is very large, we can just use dict.values() instead.