### PR TITLE
Add thin pool / volume managment to lvol

### DIFF
--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -381,7 +381,7 @@ def main():
     lvs = parse_lvs(current_lvs)
 
     if snapshot:
-        ### check snapshot pre-conditions
+        # Check snapshot pre-conditions
         for test_lv in lvs:
             if test_lv['name'] == lv or test_lv['name'] == thinpool:
                 if not test_lv['thinpool'] and not thinpool:
@@ -394,7 +394,7 @@ def main():
 
     elif thinpool:
         if lv:
-            ### check thin volume pre-conditions
+            # Check thin volume pre-conditions
             for test_lv in lvs:
                 if test_lv['name'] == thinpool:
                     break
@@ -416,7 +416,7 @@ def main():
     msg = ''
     if this_lv is None:
         if state == 'present':
-            ### require size argument except for snapshot of thin volumes
+            # Require size argument except for snapshot of thin volumes
             if (lv or thinpool) and not size:
                 for test_lv in lvs:
                     if test_lv['name'] == lv and test_lv['thinvol'] and snapshot:
@@ -424,7 +424,7 @@ def main():
                 else:
                     module.fail_json(msg="No size given.")
 
-            ### create LV
+            # create LV
             lvcreate_cmd = module.get_bin_path("lvcreate", required=True)
             if snapshot is not None:
                 if size:

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -422,7 +422,7 @@ def main():
             lvcreate_cmd = module.get_bin_path("lvcreate", required=True)
             if snapshot is not None:
                 cmd = "%s %s %s -%s %s%s -s -n %s %s %s/%s" % (lvcreate_cmd, test_opt, yesopt, size_opt, size, size_unit, snapshot, opts, vg, lv)
-            if thinpool and lv:
+            elif thinpool and lv:
                 if size_opt == 'l':
                     module.fail_json(changed=False, msg="Thin volume sizing with percentage not supported.")
                 size_opt = 'V'

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -197,10 +197,17 @@ EXAMPLES = '''
     active: false
 
 # Create a thin pool of 512g.
-- lvol: vg=firefly thinpool=testpool size=512g
+- lvol:
+    vg: firefly
+    thinpool: testpool
+    size: 512g
 
 # Create a thin volume of 128g.
-- lvol: vg=firefly lv=test thinpool=testpool size=128g
+- lvol:
+    vg: firefly
+    lv: test
+    thinpool: testpool
+    size: 128g
 '''
 
 import re

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -68,6 +68,11 @@ options:
     description:
     - Comma separated list of physical volumes (e.g. /dev/sda,/dev/sdb).
     version_added: "2.2"
+  thinpool:
+    description:
+    - The thin pool volume name. When you want to create thinprovisioning volume, specify thin pool volume name.
+    required: false
+    version_added: "2.5"
   shrink:
     description:
     - Shrink if current size is higher than size requested.
@@ -188,6 +193,12 @@ EXAMPLES = '''
     lv: test
     size: 512g
     active: false
+
+# Create a thin pool of 512g.
+- lvol: vg=firefly thinpool=testpool size=512g
+
+# Create a thin volume of 128g.
+- lvol: vg=firefly lv=test thinpool=testpool size=128g
 '''
 
 import re
@@ -251,6 +262,7 @@ def main():
             snapshot=dict(type='str'),
             pvs=dict(type='str'),
             resizefs=dict(type='bool', default=False),
+            thinpool=dict(type='str'),
         ),
         supports_check_mode=True,
     )
@@ -274,6 +286,7 @@ def main():
     shrink = module.boolean(module.params['shrink'])
     active = module.boolean(module.params['active'])
     resizefs = module.boolean(module.params['resizefs'])
+    thinpool = module.params['thinpool']
     size_opt = 'L'
     size_unit = 'm'
     snapshot = module.params['snapshot']
@@ -362,6 +375,23 @@ def main():
         check_lv = snapshot
     for test_lv in lvs:
         if test_lv['name'] in (check_lv, check_lv.rsplit('/', 1)[-1]):
+
+    if thinpool and lv:
+        for test_lv in lvs:
+            if test_lv['name'] == thinpool:
+                break
+        else:
+            module.fail_json(msg="Thin poll %s does not exist." % thinpool)
+
+    if thinpool and not lv:
+        target = thinpool
+    elif lv:
+        target = lv
+    else:
+        module.fail_json(msg="lv param is required unless thinpool param is specified.")
+
+    for test_lv in lvs:
+        if test_lv['name'] == target:
             this_lv = test_lv
             break
     else:
@@ -384,7 +414,26 @@ def main():
             if rc == 0:
                 changed = True
             else:
-                module.fail_json(msg="Creating logical volume '%s' failed" % lv, rc=rc, err=err)
+                lvcreate_cmd = module.get_bin_path("lvcreate", required=True)
+                if snapshot is not None:
+                    cmd = "%s %s -%s %s%s -s -n %s %s %s/%s" % (lvcreate_cmd, yesopt, size_opt, size, size_unit, snapshot, opts, vg, lv)
+                else:
+                    cmd = "%s %s -n %s -%s %s%s %s %s %s" % (lvcreate_cmd, yesopt, lv, size_opt, size, size_unit, opts, vg, pvs)
+                if thinpool and lv:
+                    if size_opt == 'l':
+                       module.fail_json(changed=False, msg="Thin volume sizing with percentage not supported.")
+                    size_opt = 'V'
+
+                    cmd = "%s %s -n %s -%s %s%s %s -T %s/%s" % (lvcreate_cmd, yesopt, lv, size_opt, size, size_unit, opts, vg, thinpool)
+                elif thinpool and not lv:
+                    cmd = "%s %s -%s %s%s %s -T %s/%s" % (lvcreate_cmd, yesopt, size_opt, size, size_unit, opts, vg, thinpool)
+                else:
+                    cmd = "%s %s -n %s -%s %s%s %s %s" % (lvcreate_cmd, yesopt, lv, size_opt, size, size_unit, opts, vg)
+                rc, _, err = module.run_command(cmd)
+                if rc == 0:
+                    changed = True
+                else:
+                    module.fail_json(msg="Creating logical volume '%s' failed" % lv, rc=rc, err=err)
     else:
         if state == 'absent':
             # remove LV

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -374,29 +374,31 @@ def main():
 
     lvs = parse_lvs(current_lvs)
 
-    if snapshot is None:
-        check_lv = lv
-    else:
-        check_lv = snapshot
+    if lv:
+        if snapshot:
+            for test_lv in lvs:
+                if test_lv['name'] == lv:
+                    break
+            else:
+                module.fail_json(msg="Snapshot origin LV %s does not exist in volume group %s." % (lv, vg))
+            check_lv = snapshot
+
+        elif thinpool:
+            for test_lv in lvs:
+                if test_lv['name'] == thinpool:
+                    break
+            else:
+                module.fail_json(msg="Thin pool LV %s does not exist in volume group %s." % (thinpool, vg))
+            check_lv = lv
+
+        else:
+            check_lv = lv
+
+    elif thinpool:
+        check_lv = thinpool
+
     for test_lv in lvs:
         if test_lv['name'] in (check_lv, check_lv.rsplit('/', 1)[-1]):
-
-    if thinpool and lv:
-        for test_lv in lvs:
-            if test_lv['name'] == thinpool:
-                break
-        else:
-            module.fail_json(msg="Thin pool %s does not exist." % thinpool)
-
-    if thinpool and not lv:
-        target = thinpool
-    elif snapshot:
-        target = snapshot
-    elif lv:
-        target = lv
-
-    for test_lv in lvs:
-        if test_lv['name'] == target:
             this_lv = test_lv
             break
     else:

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -25,11 +25,9 @@ options:
   vg:
     description:
     - The volume group this logical volume is part of.
-    required: true
   lv:
     description:
     - The name of the logical volume.
-    required: false
   size:
     description:
     - The size of the logical volume, according to lvcreate(8) --size, by
@@ -71,7 +69,6 @@ options:
   thinpool:
     description:
     - The thin pool volume name. When you want to create a thin provisioned volume, specify a thin pool volume name.
-    required: false
     version_added: "2.5"
   shrink:
     description:
@@ -263,7 +260,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             vg=dict(type='str', required=True),
-            lv=dict(type='str', required=True),
+            lv=dict(type='str'),
             size=dict(type='str'),
             opts=dict(type='str'),
             state=dict(type='str', default='present', choices=['absent', 'present']),

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -29,7 +29,7 @@ options:
   lv:
     description:
     - The name of the logical volume.
-    required: true
+    required: false
   size:
     description:
     - The size of the logical volume, according to lvcreate(8) --size, by
@@ -70,7 +70,7 @@ options:
     version_added: "2.2"
   thinpool:
     description:
-    - The thin pool volume name. When you want to create thinprovisioning volume, specify thin pool volume name.
+    - The thin pool volume name. When you want to create a thin provisioned volume, specify a thin pool volume name.
     required: false
     version_added: "2.5"
   shrink:
@@ -85,6 +85,8 @@ options:
     type: bool
     default: 'yes'
     version_added: "2.5"
+notes:
+  - You must specify lv (when managing the state of logical volumes) or thinpool (when managing a thin provisisoned volume).
 '''
 
 EXAMPLES = '''
@@ -265,6 +267,9 @@ def main():
             thinpool=dict(type='str'),
         ),
         supports_check_mode=True,
+        required_one_of=(
+            ['lv', 'thinpool'],
+        ),
     )
 
     # Determine if the "--yes" option should be used
@@ -381,14 +386,14 @@ def main():
             if test_lv['name'] == thinpool:
                 break
         else:
-            module.fail_json(msg="Thin poll %s does not exist." % thinpool)
+            module.fail_json(msg="Thin pool %s does not exist." % thinpool)
 
     if thinpool and not lv:
         target = thinpool
+    elif snapshot:
+        target = snapshot
     elif lv:
         target = lv
-    else:
-        module.fail_json(msg="lv param is required unless thinpool param is specified.")
 
     for test_lv in lvs:
         if test_lv['name'] == target:
@@ -417,8 +422,6 @@ def main():
                 lvcreate_cmd = module.get_bin_path("lvcreate", required=True)
                 if snapshot is not None:
                     cmd = "%s %s -%s %s%s -s -n %s %s %s/%s" % (lvcreate_cmd, yesopt, size_opt, size, size_unit, snapshot, opts, vg, lv)
-                else:
-                    cmd = "%s %s -n %s -%s %s%s %s %s %s" % (lvcreate_cmd, yesopt, lv, size_opt, size, size_unit, opts, vg, pvs)
                 if thinpool and lv:
                     if size_opt == 'l':
                        module.fail_json(changed=False, msg="Thin volume sizing with percentage not supported.")
@@ -428,7 +431,7 @@ def main():
                 elif thinpool and not lv:
                     cmd = "%s %s -%s %s%s %s -T %s/%s" % (lvcreate_cmd, yesopt, size_opt, size, size_unit, opts, vg, thinpool)
                 else:
-                    cmd = "%s %s -n %s -%s %s%s %s %s" % (lvcreate_cmd, yesopt, lv, size_opt, size, size_unit, opts, vg)
+                    cmd = "%s %s -n %s -%s %s%s %s %s %s" % (lvcreate_cmd, yesopt, lv, size_opt, size, size_unit, opts, vg, pvs)
                 rc, _, err = module.run_command(cmd)
                 if rc == 0:
                     changed = True

--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -86,7 +86,7 @@ options:
     default: 'yes'
     version_added: "2.5"
 notes:
-  - You must specify lv (when managing the state of logical volumes) or thinpool (when managing a thin provisisoned volume).
+  - You must specify lv (when managing the state of logical volumes) or thinpool (when managing a thin provisioned volume).
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

lvol
##### ANSIBLE VERSION

```
ansible 2.3.0
```
##### SUMMARY

I have taken the stale PR ansible/ansible-modules-extras#2216, by @mvdbeek (and originally @KlabKatsumi ansible/ansible-modules-extras#1422) and rebased the two patches onto current `devel` HEAD. Unfortunately the logic got a bit shaken up by the recent check-mode update, which I tried to fix with my commits. I also rewrote the logical volume check logic.

If it matters, I could also try to rebase a bit "nicer" so that 89b0c1c wouldn't be necessary. Please let me know.
