### PR TITLE
Fixes for uri under python3 and local (non-httptester) testing

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -512,9 +512,15 @@ def RedirectHandlerFactory(follow_redirects=None, validate_certs=True):
                 newheaders = dict((k,v) for k,v in req.headers.items()
                                   if k.lower() not in ("content-length", "content-type")
                                  )
+                try:
+                    # Python 2-3.3
+                    origin_req_host = req.get_origin_req_host()
+                except AttributeError:
+                    # Python 3.4+
+                    origin_req_host = req.origin_req_host
                 return urllib_request.Request(newurl,
                                headers=newheaders,
-                               origin_req_host=req.get_origin_req_host(),
+                               origin_req_host=origin_req_host,
                                unverifiable=True)
             else:
                 raise urllib_error.HTTPError(req.get_full_url(), code, msg, hdrs, fp)
@@ -862,6 +868,7 @@ def open_url(url, data=None, headers=None, method=None, use_proxy=True,
     opener = urllib_request.build_opener(*handlers)
     urllib_request.install_opener(opener)
 
+    data = to_bytes(data, nonstring='passthru')
     if method:
         if method.upper() not in ('OPTIONS','GET','HEAD','POST','PUT','DELETE','TRACE','CONNECT','PATCH'):
             raise ConnectionError('invalid HTTP request method; %s' % method.upper())

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -198,10 +198,6 @@
   set_fact:
     is_ubuntu_precise: "{{ ansible_distribution == 'Ubuntu' and ansible_distribution_release == 'precise' }}"
 
-# These tests are just side effects of how the site is hosted.  It's not
-# specifically a test site.  So the tests may break due to the hosting
-# changing.  Eventually we need to standup a webserver with SNI as part of the
-# test run.
 - name: Test that SNI succeeds on python versions that have SNI
   uri:
     url: 'https://{{ sni_host }}/'
@@ -213,7 +209,7 @@
   assert:
     that:
       - result|success
-      - 'sni_host == result.content'
+      - 'sni_host in result.content'
   when: ansible_python.has_sslcontext
 
 - name: Verify SNI verification fails on old python without urllib3 contrib
@@ -253,7 +249,7 @@
   assert:
     that:
       - result|success
-      - 'sni_host == result.content'
+      - 'sni_host in result.content'
   when: not ansible_python.has_sslcontext and not is_ubuntu_precise|bool
 
 - name: Uninstall ndg-httpsclient and urllib3

--- a/test/utils/shippable/python3-test-tag-blacklist.txt
+++ b/test/utils/shippable/python3-test-tag-blacklist.txt
@@ -1,3 +1,2 @@
 test_hg
 test_service
-test_uri


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
modules/network/basic/uri.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.2
```

##### SUMMARY
Tests for uri were still failing on python3 after the fix to safe_eval.  These additional fixes make it pass.
