### PR TITLE
Set os_server metadata on existing instances

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -434,6 +434,8 @@ def _parse_meta(meta):
             k, v = kv_str.split("=")
             metas[k] = v
         return metas
+    if not meta:
+        return {}
     return meta
 
 

--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -427,6 +427,16 @@ def _network_args(module, cloud):
     return args
 
 
+def _parse_meta(meta):
+    if isinstance(meta, str):
+        metas = {}
+        for kv_str in meta.split(","):
+            k, v = kv_str.split("=")
+            metas[k] = v
+        return metas
+    return meta
+
+
 def _delete_server(module, cloud):
     try:
         cloud.delete_server(
@@ -459,12 +469,7 @@ def _create_server(module, cloud):
 
     nics = _network_args(module, cloud)
 
-    if isinstance(module.params['meta'], str):
-        metas = {}
-        for kv_str in module.params['meta'].split(","):
-            k, v = kv_str.split("=")
-            metas[k] = v
-        module.params['meta'] = metas
+    module.params['meta'] = _parse_meta(module.params['meta'])
 
     bootkwargs = dict(
         name=module.params['name'],
@@ -500,12 +505,7 @@ def _create_server(module, cloud):
 def _update_server(module, cloud, server):
     changed = False
 
-    if type(module.params['meta']) is str:
-        metas = {}
-        for kv_str in module.params['meta'].split(","):
-            k, v = kv_str.split("=")
-            metas[k] = v
-        module.params['meta'] = metas
+    module.params['meta'] = _parse_meta(module.params['meta'])
 
     # cloud.set_server_metadata only updates the key=value pairs, it doesn't
     # touch existing ones


### PR DESCRIPTION
##### ISSUE TYPE: Feature Pull Request

##### COMPONENT NAME: cloud/openstack/os_server.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

At present `os_server` can modify the floating IP on an existing instance, but most other properties are unchanged since they may require a rebuild of the instance. However user properties (the `os_server` `meta` arg) can be updated easily.

New or existing metadata keys/values will be added/updated on an existing instance, no keys will be deleted. This follows the behaviour of `shade.openstackcloud.OpenStackCloud.set_server_metadata`.

Fixes ~~#5500~~https://github.com/ansible/ansible-modules-core/issues/5500.

`test.yml`:
```
- hosts: localhost

  tasks:

  - os_server:
      flavor_ram: 1024
      image: CentOS7
      key: test-key
      name: test-1
    register: instance

  - debug: msg={{ instance.openstack.metadata }}
```
`ansible-playbook test.yml`
```
 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [os_server] ***************************************************************
changed: [localhost]

TASK [debug] *******************************************************************
ok: [localhost] => {
    "msg": {}
}

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=1    unreachable=0    failed=0   
```

Add some metadata:
```
  - os_server:
      flavor_ram: 1024
      image: CentOS7
      key: test-key
      meta:
        groups: 'test-group'
      name: test-1
    register: instance
```

Rerun without this PR:
```
TASK [os_server] ***************************************************************
ok: [localhost]

TASK [debug] *******************************************************************
ok: [localhost] => {
    "msg": {}
}

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0   
```
Rerun with this PR:
```
TASK [os_server] ***************************************************************
changed: [localhost]

TASK [debug] *******************************************************************
ok: [localhost] => {
    "msg": {
        "groups": "test-group"
    }
}

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=1    unreachable=0    failed=0   
```