### PR TITLE
Add private fork CI support to ansible-test.

### DIFF
--- a/test/runner/lib/changes.py
+++ b/test/runner/lib/changes.py
@@ -10,6 +10,7 @@ from lib.util import (
     SubprocessError,
     MissingEnvironmentVariable,
     CommonConfig,
+    display,
 )
 
 from lib.http import (
@@ -97,9 +98,13 @@ class ShippableChanges(object):
     @staticmethod
     def get_last_successful_commit(merge_runs):
         """
-        :type merge_runs: list[dict]
+        :type merge_runs: dict | list[dict]
         :rtype: str
         """
+        if 'id' in merge_runs and merge_runs['id'] == 4004:
+            display.warning('Unable to find project. Cannot determine changes. All tests will be executed.')
+            return None
+
         merge_runs = sorted(merge_runs, key=lambda r: r['createdAt'])
         known_commits = set()
         last_successful_commit = None


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (devel dab2bf7e13) last updated 2016/12/13 15:22:00 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Add private fork CI support to ansible-test.

When running CI on a private fork, ansible-test cannot determine changes for commits without an API key. This change provides a fallback to running all tests in this scenario.

PR change detection still works as expected.