### PR TITLE
Allow creation of Openstack volumes from an existing volume

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_volume.py
+++ b/lib/ansible/modules/cloud/openstack/os_volume.py
@@ -116,6 +116,8 @@ def _present_volume(module, cloud):
 
     if module.params['volume_src']:
         volume_id = cloud.get_volume_id(module.params['volume_src'])
+        if not volume_id:
+            module.fail_json(msg="Failed to find volume source '%s'" % module.params['volume_src'])
         volume_args['source_volid'] = volume_id
 
     volume = cloud.create_volume(

--- a/lib/ansible/modules/cloud/openstack/os_volume.py
+++ b/lib/ansible/modules/cloud/openstack/os_volume.py
@@ -67,9 +67,9 @@ options:
        - Volume snapshot id to create from
      required: false
      default: None
-   volume_src:
+   volume:
      description:
-       - Volume source to create from
+       - Volume name or id to create from
      required: false
      default: None
      version_added: "2.3"
@@ -115,10 +115,10 @@ def _present_volume(module, cloud):
         image_id = cloud.get_image_id(module.params['image'])
         volume_args['imageRef'] = image_id
 
-    if module.params['volume_src']:
-        volume_id = cloud.get_volume_id(module.params['volume_src'])
+    if module.params['volume']:
+        volume_id = cloud.get_volume_id(module.params['volume'])
         if not volume_id:
-            module.fail_json(msg="Failed to find volume source '%s'" % module.params['volume_src'])
+            module.fail_json(msg="Failed to find volume '%s'" % module.params['volume'])
         volume_args['source_volid'] = volume_id
 
     volume = cloud.create_volume(
@@ -146,12 +146,12 @@ def main():
         display_description=dict(default=None, aliases=['description']),
         image=dict(default=None),
         snapshot_id=dict(default=None),
-        volume_src=dict(default=None),
+        volume=dict(default=None),
         state=dict(default='present', choices=['absent', 'present']),
     )
     module_kwargs = openstack_module_kwargs(
         mutually_exclusive=[
-            ['image', 'snapshot_id', 'volume_src'],
+            ['image', 'snapshot_id', 'volume'],
         ],
     )
     module = AnsibleModule(argument_spec=argument_spec, **module_kwargs)

--- a/lib/ansible/modules/cloud/openstack/os_volume.py
+++ b/lib/ansible/modules/cloud/openstack/os_volume.py
@@ -67,6 +67,11 @@ options:
        - Volume snapshot id to create from
      required: false
      default: None
+   volume_src:
+     description:
+       - Volume source to create from
+     required: false
+     default: None
    state:
      description:
        - Should the resource be present or absent.
@@ -109,6 +114,10 @@ def _present_volume(module, cloud):
         image_id = cloud.get_image_id(module.params['image'])
         volume_args['imageRef'] = image_id
 
+    if module.params['volume_src']:
+        volume_id = cloud.get_volume_id(module.params['volume_src'])
+        volume_args['source_volid'] = volume_id
+
     volume = cloud.create_volume(
         wait=module.params['wait'], timeout=module.params['timeout'],
         **volume_args)
@@ -134,11 +143,12 @@ def main():
         display_description=dict(default=None, aliases=['description']),
         image=dict(default=None),
         snapshot_id=dict(default=None),
+        volume_src=dict(default=None),
         state=dict(default='present', choices=['absent', 'present']),
     )
     module_kwargs = openstack_module_kwargs(
         mutually_exclusive=[
-            ['image', 'snapshot_id'],
+            ['image', 'snapshot_id', 'volume_src'],
         ],
     )
     module = AnsibleModule(argument_spec=argument_spec, **module_kwargs)

--- a/lib/ansible/modules/cloud/openstack/os_volume.py
+++ b/lib/ansible/modules/cloud/openstack/os_volume.py
@@ -72,6 +72,7 @@ options:
        - Volume source to create from
      required: false
      default: None
+     version_added: "2.3"
    state:
      description:
        - Should the resource be present or absent.


### PR DESCRIPTION
##### ISSUE TYPE: Feature Pull Request
##### COMPONENT NAME: cloud/os_volume
##### ANSIBLE VERSION

```
ansible 2.1.2.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Adds support to `os_volume` for creating volumes by cloning an existing volume.

`os_volume` supports creating Openstack volumes from scratch, or based on an existing image or snapshot, but not from an existing volume.
Depending on the storage implementation on the Openstack cloud in some cases creating a volume from an existing volume can be a very quick copy-on-write operation, compared to a time-consuming full copy when using an image or snapshot.

This PR adds a new parameter `volume_src` to the `os_volume` module, which behaves similarly to the existing `image` parameter in taking either the name or the ID of a volume.

For example:

```
- hosts: localhost
  tasks:
  - os_volume:
      state: present
      size: "500"
      display_name: "new-volume"
      volume_src: "existing-volume"
```

```
PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [os_volume] ***************************************************************
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0
```

If an invalid volume is set this returns an error:

```
PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [os_volume] ***************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to find volume source 'non-existent-volume'"}

NO MORE HOSTS LEFT *************************************************************

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1
```

If you have the `openstack` command line client installed then the output of `openstack volume show new-volume` should include a `source_volid`:

```
| source_volid                         | f383e3b3-3382-4573-9526-aa8b32a28aff  |
```

An unrelated issue: I've noticed that if a non-existent `image` parameter is passed to `os_volume` it silently creates a new volume. If you want I can add another commit along the lines of f1222f3.
