### PR TITLE
Fixes map call usage

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_virtual_server.py
+++ b/lib/ansible/modules/network/f5/bigip_virtual_server.py
@@ -250,7 +250,7 @@ def set_rules(api, name, rules_list):
         return False
     rules_list = list(enumerate(rules_list))
     try:
-        current_rules = map(lambda x: (x['priority'], x['rule_name']), get_rules(api, name))
+        current_rules = [(x['priority'], x['rule_name']) for x in get_rules(api, name)]
         to_add_rules = []
         for i, x in rules_list:
             if (i, x) not in current_rules:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bigip_virtual_server.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
config file =   
configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```

For the comparisions that need to be done, this map call needs
to convert to a list because the six import in ansible changes
the behavior of map to return an iterator instead of a list