### PR TITLE
Add --tox-sitepackages option to ansible-test.

### DIFF
--- a/test/runner/lib/delegation.py
+++ b/test/runner/lib/delegation.py
@@ -70,10 +70,17 @@ def delegate_tox(args, exclude, require):
 
     options = {
         '--tox': args.tox_args,
+        '--tox-sitepackages': 0,
     }
 
     for version in versions:
-        tox = ['tox', '-c', 'test/runner/tox.ini', '-e', 'py' + version.replace('.', ''), '--']
+        tox = ['tox', '-c', 'test/runner/tox.ini', '-e', 'py' + version.replace('.', '')]
+
+        if args.tox_sitepackages:
+            tox.append('--sitepackages')
+
+        tox.append('--')
+
         cmd = generate_command(args, os.path.abspath('test/runner/test.py'), options, exclude, require)
 
         if not args.python:

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -1104,6 +1104,8 @@ class EnvironmentConfig(CommonConfig):
         self.docker_privileged = args.docker_privileged if 'docker_privileged' in args else False  # type: bool
         self.docker_util = docker_qualify_image(args.docker_util if 'docker_util' in args else None)  # type: str | None
 
+        self.tox_sitepackages = args.tox_sitepackages  # type: bool
+
         self.remote_stage = args.remote_stage  # type: str
 
         self.requirements = args.requirements  # type: bool

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -387,6 +387,12 @@ def add_environments(parser, tox_version=False, tox_only=False):
                                   action='store_true',
                                   help='run from a tox virtualenv')
 
+    tox = parser.add_argument_group(title='tox arguments')
+
+    tox.add_argument('--tox-sitepackages',
+                     action='store_true',
+                     help='allow access to globally installed packages')
+
     if tox_only:
         environments.set_defaults(
             docker=None,


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (tox-sitepackages 2b8f69cf66) last updated 2016/12/13 16:25:23 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Add --tox-sitepackages option to ansible-test.