### PR TITLE
Fixed expiredate parameter in user module

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -396,7 +396,7 @@ class User(object):
             cmd.append(self.shell)
 
         if self.expires:
-            cmd.append('--expiredate')
+            cmd.append('-e')
             cmd.append(time.strftime(self.DATE_FORMAT, self.expires))
 
         if self.password is not None:
@@ -509,7 +509,7 @@ class User(object):
             cmd.append(self.shell)
 
         if self.expires:
-            cmd.append('--expiredate')
+            cmd.append('-e')
             cmd.append(time.strftime(self.DATE_FORMAT, self.expires))
 
         if self.update_password == 'always' and self.password is not None and info[1] != self.password:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
user module

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Problem:
```
failed: [192.168.190.18] (item={u'groups': u'...', u'password': u'...', u'name': u'...', u'expires': ...}) => {"failed": true, "item": {"expires": ..., "groups": "...", "name": "...", "password": "..."}, "msg": "/usr/sbin/useradd: unrecognized option '--expiredate'\n`useradd --help' lub `useradd --usage' poda więcej informacji.\n", "name": "...", "rc": 2}
```
On older systems (I have this issue on OpenSuSE 11.1, pwdutils-3.2.2-2.10), "--expiredate" used to be "--expire". Changing it to "-e" solves the problem. I tested it on Debian (from 6 to 9), CentOS 6 and OpenSuSE 11.