### PR TITLE
cloudstack: utils: fail friendlier if no zones available

### DIFF
--- a/lib/ansible/module_utils/cloudstack.py
+++ b/lib/ansible/module_utils/cloudstack.py
@@ -407,6 +407,9 @@ class AnsibleCloudStack(object):
             zone = os.environ.get('CLOUDSTACK_ZONE')
         zones = self.cs.listZones()
 
+        if not zones:
+            self.module.fail_json(msg="No zones available. Please create a zone first")
+
         # use the first zone if no zone param given
         if not zone:
             self.zone = zones['zone'][0]


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
cloudstack

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.0, 2.1, 2.2, devel
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
Traceback (most recent call last):
  File "/home/resmo/debug_dir/ansible_module_cs_host.py", line 541, in <module>
    main()
  File "/home/resmo/debug_dir/ansible_module_cs_host.py", line 531, in main
    host = acs_host.present_host()
  File "/home/resmo/debug_dir/ansible_module_cs_host.py", line 438, in present_host
    host = self.get_host()
  File "/home/resmo/debug_dir/ansible_module_cs_host.py", line 429, in get_host
    'zoneid': self.get_zone(key='id'),
  File "/home/resmo/debug_dir/ansible/module_utils/cloudstack.py", line 412, in get_zone
    self.zone = zones['zone'][0]
KeyError: 'zone'

```

