### PR TITLE
Added: eu-west-2 region to AWS_REGIONS

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -39,6 +39,7 @@ AWS_REGIONS = [
     'cn-north-1',
     'eu-central-1',
     'eu-west-1',
+    'eu-west-2',
     'sa-east-1',
     'us-east-1',
     'us-west-1',


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
lib/ansible/module_utils/ec2.py

##### ANSIBLE VERSION
development

##### SUMMARY
Amazon have added a new region, eu-west-2.
For Ansible users to use the new region, it needs to be added to the AWS_REGIONS list 


