### PR TITLE
Add a new module for Cisco Spark notifications

### DIFF
--- a/lib/ansible/modules/notification/cisco_spark.py
+++ b/lib/ansible/modules/notification/cisco_spark.py
@@ -1,0 +1,214 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {
+    'status': ['stableinterface'],
+    'supported_by': 'community',
+    'version': '1.0'
+}
+
+DOCUMENTATION = '''
+---
+module: cisco_spark
+short_description: Send a message to a Cisco Spark Room or Individual
+version_added: "1.0"
+author: Drew Rusell (@drusse11)
+notes:
+  - The receipient_id type must be valid for the supplied recipient_type.
+  - Full API documentation can be found at https://developer.ciscospark.com/endpoint-messages-post.html
+
+options:
+
+  recipient_type:
+    description:
+       - The request parametmer you would like to send the message to.
+       - Messages can be sent to either a room or individual (by ID or E-Mail).
+    required: True
+    choices: ['roomId', 'toPersonEmail', 'toPersonId']
+
+  recipient_id:
+    description:
+      - The unique identifier associated with the supplied recipient_type
+    required: true
+
+  message_type:
+    description:
+       - Specifies how you would like the message formatted.
+    required: False
+    default: text
+    choices: ['text', 'markdown']
+
+  personal_token:
+    description:
+      - Your personal access token required to validate the Spark API
+    require: true
+    aliases: ['token']
+
+  message:
+    description:
+      - The message you would like to send.
+    required: True
+'''
+
+EXAMPLES = """
+# Note: The follow examples assume a variable file has been imported
+# that contains the appropriate information.
+
+- name: Cisco Spark - Markdown Message to a Room
+  cisco_spark:
+    recipient_type: roomId
+    recipient_id: "{{ room_id }}"
+    message_type: markdown
+    personal_token: "{{ token }}"
+    message: "**Cisco Spark Ansible Module - Room Message in Markdown**"
+
+- name: Cisco Spark - Text Message to a Room
+  cisco_spark:
+    recipient_type: roomId
+    recipient_id: "{{ room_id }}"
+    message_type: text
+    personal_token: "{{ token }}"
+    message: "Cisco Spark Ansible Module - Room Message in Text"
+
+- name: Cisco Spark - Text Message by an Individuals ID
+  cisco_spark:
+    recipient_type: toPersonId
+    recipient_id: "{{ person_id}}"
+    message_type: text
+    personal_token: "{{ token }}"
+    message: "Cisco Spark Ansible Module - Text Message to Individual by ID"
+
+- name: Cisco Spark - Text Message by an Individuals E-Mail Address
+  cisco_spark:
+    recipient_type: toPersonEmail
+    recipient_id: "{{ person_email }}"
+    message_type: text
+    personal_token: "{{ token }}"
+    message: "Cisco Spark Ansible Module - Text Message to Individual by E-Mail"
+
+"""
+
+RETURN = """
+status_code:
+  description:
+    - The Response Code returned by the Spark API
+    - Full Responsde Code explanations can be found at https://developer.ciscospark.com/endpoint-messages-post.html
+  returned: always
+  type: string
+  sample: 200
+
+requests_error:
+  description: The error message provided by the Python Requests module
+  returned: failed
+  type: sting
+  sample: 404 Client Error
+
+api_error:
+  description: An error message related to the Cisco Spark API
+  returned: failed
+  type: sting
+  sample: Expect base64 ID or UUID.
+"""
+
+import json
+import requests
+
+
+def spark_message(module):
+    """ Send a message to a Cisco Spark Room or Individual """
+
+    # Ansible Specific Variables
+    results = {}
+    ansible = module.params
+
+    # Cisco Spark API Variables
+    url = "https://api.ciscospark.com/v1/messages"
+
+    headers = {
+        'Authorization': 'Bearer {}'.format(ansible['personal_token']),
+        'content-type': 'application/json'
+    }
+
+    # By Room ID
+    payload = {
+        ansible['recipient_type']: ansible['recipient_id'],
+        ansible['message_type']: ansible['message']
+    }
+
+    try:
+        message = requests.request("POST", url, json=payload, headers=headers)
+    except requests.exceptions.RequestException as request_error:
+        results['failed'] = True
+        results['changed'] = False
+        results['requests_error'] = request_error
+
+    # Return an error message if there is no response
+    if message.text == "":
+        results['failed'] = True
+        results['changed'] = False
+        results['api_error'] = 'No response received. Verify your Spark personal access token'
+
+    status_code = str(message.status_code)
+
+    # Return an error message if there is no response
+    if status_code != '200':
+        # Convert the message response to JSON for processing
+        error_message = json.loads(message.text)
+
+        # Iterate through the JSON response and pull out the message field
+        for key, value in error_message.iteritems():
+            if key == 'message':
+                results['api_error'] = value
+
+        results['failed'] = True
+        results['status_code'] = status_code
+    else:
+        results['failed'] = False
+        results['status_code'] = status_code
+
+    return results
+
+
+def main():
+    '''Ansible main. '''
+    module = AnsibleModule(
+        argument_spec=dict(
+            recipient_type=dict(required=True, choices=[
+                'roomId', 'toPersonEmail', 'toPersonId']),
+            recipient_id=dict(required=True, no_log=True),
+            message_type=dict(required=False, default=['text'], aliases=[
+                              'type'], choices=['text', 'markdown']),
+            personal_token=dict(required=True, no_log=True, aliases=['token']),
+            message=dict(required=True)
+
+        ),
+
+        supports_check_mode=True
+    )
+
+    # Add Check Mode Support
+    if module.check_mode:
+        module.exit_json(changed=False)
+
+    results = spark_message(module)
+
+    module.exit_json(**results)
+
+
+from ansible.module_utils.basic import *
+main()

--- a/lib/ansible/modules/notification/cisco_spark.py
+++ b/lib/ansible/modules/notification/cisco_spark.py
@@ -29,7 +29,7 @@ module: cisco_spark
 short_description: Send a message to a Cisco Spark Room or Individual.
 description:
     - Send a message to a Cisco Spark Room or Individual with options to control the formatting.
-version_added: "1.0"
+version_added: "2.3"
 author: Drew Rusell (@drusse11)
 notes:
   - The C(recipient_id) type must be valid for the supplied C(recipient_id).

--- a/lib/ansible/modules/notification/cisco_spark.py
+++ b/lib/ansible/modules/notification/cisco_spark.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=E0401, E0602, W0401, W0212, W0614, W0622, W0401, C0413, C0330, W0612,
-# C0330, E1101, W0212
 
 ANSIBLE_METADATA = {
     'status': ['stableinterface'],
@@ -29,6 +27,8 @@ DOCUMENTATION = '''
 ---
 module: cisco_spark
 short_description: Send a message to a Cisco Spark Room or Individual
+description:
+    - Send a message to a Cisco Spark Room or Individual, with options to control the formatting.
 version_added: "1.0"
 author: Drew Rusell (@drusse11)
 notes:

--- a/lib/ansible/modules/notification/cisco_spark.py
+++ b/lib/ansible/modules/notification/cisco_spark.py
@@ -28,11 +28,11 @@ DOCUMENTATION = '''
 module: cisco_spark
 short_description: Send a message to a Cisco Spark Room or Individual.
 description:
-    - Send a message to a Cisco Spark Room or Individual, with options to control the formatting.
+    - Send a message to a Cisco Spark Room or Individual with options to control the formatting.
 version_added: "1.0"
 author: Drew Rusell (@drusse11)
 notes:
-  - The receipient_id type must be valid for the supplied recipient_type.
+  - The C(recipient_id) type must be valid for the supplied C(recipient_id).
   - Full API documentation can be found at U(https://developer.ciscospark.com/endpoint-messages-post.html).
 
 options:
@@ -46,7 +46,7 @@ options:
 
   recipient_id:
     description:
-      - The unique identifier associated with the supplied recipient_type.
+      - The unique identifier associated with the supplied C(recipient_type).
     required: true
 
   message_type:

--- a/lib/ansible/modules/notification/cisco_spark.py
+++ b/lib/ansible/modules/notification/cisco_spark.py
@@ -26,14 +26,14 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: cisco_spark
-short_description: Send a message to a Cisco Spark Room or Individual
+short_description: Send a message to a Cisco Spark Room or Individual.
 description:
     - Send a message to a Cisco Spark Room or Individual, with options to control the formatting.
 version_added: "1.0"
 author: Drew Rusell (@drusse11)
 notes:
   - The receipient_id type must be valid for the supplied recipient_type.
-  - Full API documentation can be found at https://developer.ciscospark.com/endpoint-messages-post.html
+  - Full API documentation can be found at U(https://developer.ciscospark.com/endpoint-messages-post.html).
 
 options:
 
@@ -46,7 +46,7 @@ options:
 
   recipient_id:
     description:
-      - The unique identifier associated with the supplied recipient_type
+      - The unique identifier associated with the supplied recipient_type.
     required: true
 
   message_type:
@@ -58,7 +58,7 @@ options:
 
   personal_token:
     description:
-      - Your personal access token required to validate the Spark API
+      - Your personal access token required to validate the Spark API.
     require: true
     aliases: ['token']
 
@@ -109,16 +109,16 @@ EXAMPLES = """
 RETURN = """
 status_code:
   description:
-    - The Response Code returned by the Spark API
-    - Full Responsde Code explanations can be found at https://developer.ciscospark.com/endpoint-messages-post.html
+    - The Response Code returned by the Spark API.
+    - Full Responsde Code explanations can be found at U(https://developer.ciscospark.com/endpoint-messages-post.html).
   returned: always
   type: int
   sample: 200
 
 message:
     description:
-      - The Response Message returned by the Spark API
-      - Full Responsde Code explanations can be found at https://developer.ciscospark.com/endpoint-messages-post.html
+      - The Response Message returned by the Spark API.
+      - Full Responsde Code explanations can be found at U(https://developer.ciscospark.com/endpoint-messages-post.html.
     returned: always
     type: string
     sample: OK (585 bytes)
@@ -198,4 +198,5 @@ def main():
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
-main()
+if __name__ == "__main__":
+    main()

--- a/lib/ansible/modules/notification/cisco_spark.py
+++ b/lib/ansible/modules/notification/cisco_spark.py
@@ -139,16 +139,12 @@ def spark_message(module):
     }
 
     if module.check_mode:
-
         url = "https://api.ciscospark.com/v1/people/me"
-
-        response, info = fetch_url(module, url, headers=headers)
+        payload = None
 
     else:
-
         url = "https://api.ciscospark.com/v1/messages"
 
-        # By Room ID
         payload = {
             ansible['recipient_type']: ansible['recipient_id'],
             ansible['message_type']: ansible['message']
@@ -156,7 +152,7 @@ def spark_message(module):
 
         payload = module.jsonify(payload)
 
-        response, info = fetch_url(module, url, data=payload, headers=headers)
+    response, info = fetch_url(module, url, data=payload, headers=headers)
 
     status_code = info['status']
     message = info['msg']


### PR DESCRIPTION
##### ISSUE TYPE
 - New Module Pull Request


##### COMPONENT NAME
cisco_spark

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### SUMMARY

This PR adds a new module that allows for messages to be sent to a Cisco Spark Room or individual using either standard text or markdown formatting. 

##### Test Playbook

```
---

- name: Cisco Spark Module Validation
  hosts: localhost
  connection: local
  vars_files:
    - ./vars.yml

  tasks:

    - name: Cisco Spark - Markdown Message to a Room
      cisco_spark:
        recipient_type: roomId
        recipient_id: "{{ room_id }}"
        message_type: markdown
        personal_token: "{{ token }}"
        message: "**Cisco Spark Ansible Module - Room Message in Markdown**"

    - name: Cisco Spark - Text Message to a Room
      cisco_spark:
        recipient_type: roomId
        recipient_id: "{{ room_id }}"
        message_type: text
        personal_token: "{{ token }}"
        message: "Cisco Spark Ansible Module - Room Message in Text"
    
    - name: Cisco Spark - Text Message by an Individuals ID
      cisco_spark:
        recipient_type: toPersonId
        recipient_id: "{{ person_id}}"
        message_type: text
        personal_token: "{{ token }}"
        message: "Cisco Spark Ansible Module - Text Message to Individual by ID"
    
    - name: Cisco Spark - Text Message by an Individuals E-Mail Address
      cisco_spark:
        recipient_type: toPersonEmail
        recipient_id: "{{ person_email }}"
        message_type: text
        personal_token: "{{ token }}"
        message: "Cisco Spark Ansible Module - Text Message to Individual by E-Mail"
```

