### PR TITLE
Add ciscospark.py to the exception list

### DIFF
--- a/test/compile/python2.4-skip.txt
+++ b/test/compile/python2.4-skip.txt
@@ -20,6 +20,7 @@
 /lib/ansible/modules/network/f5/
 /lib/ansible/modules/network/nmcli.py
 /lib/ansible/modules/notification/pushbullet.py
+/lib/ansible/modules/notification/ciscospark.py
 /lib/ansible/modules/packaging/language/maven_artifact.py
 /lib/ansible/modules/packaging/os/dnf.py
 /lib/ansible/modules/packaging/os/layman.py
@@ -38,7 +39,7 @@
 /lib/ansible/module_utils/openstack.py
 /lib/ansible/module_utils/rax.py
 /lib/ansible/module_utils/vca.py
-/lib/ansible/module_utils/vmware.py
+/lib/ansible/module_utils/VMware.py
 /lib/ansible/parsing/
 /lib/ansible/playbook/
 /lib/ansible/plugins/


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request


##### COMPONENT NAME
ciscospark.py

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### SUMMARY
- PR: https://github.com/ansible/ansible/pull/19348
- Reason: the module requires access to the Python json library which is not available on 2.4

Python 2.4.6 (#2, Jan 24 2014, 23:57:03)
[GCC 4.8.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import json
Traceback (most recent call last):
  File "<stdin>", line 1, in ?
ImportError: No module named json
>>>

```

