### PR TITLE
Fix error message to be more accurate and include more debugging info

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -637,7 +637,7 @@ def _load_params():
     inside it as a copy in your own code.
     '''
     global _ANSIBLE_ARGS
-    json_source = None
+    json_source = 'stdin'
     if _ANSIBLE_ARGS is not None:
         buffer = _ANSIBLE_ARGS
     else:
@@ -658,7 +658,6 @@ def _load_params():
                 json_source = 'argument'
         # default case, read from stdin
         else:
-            json_source = 'stdin'
             if PY2:
                 buffer = sys.stdin.read()
             else:
@@ -669,8 +668,9 @@ def _load_params():
         params = json.loads(buffer.decode('utf-8'))
     except ValueError:
         # This helper used too early for fail_json to work.
-        message = '\n{{"msg": "Error: Module unable to decode valid JSON.  Unable to figure out what parameters were passed", "failed": true, "json_source": "{}", "json_file":"{}", "buffer_contents":"{}"}}'.format(json_source, sys.argv[1], buffer)
-        print(message)
+        msg = '\n{{"msg": "Error: Module unable to decode valid JSON.  Unable to figure out what parameters were passed",' \
+                  ' "failed": true, "json_source": "{}", "json_file":"{}", "buffer_contents":"{}"}}'.format(json_source, sys.argv[1], buffer)
+        print(msg)
         sys.exit(1)
 
     if PY2:
@@ -681,8 +681,8 @@ def _load_params():
     except KeyError:
         # This helper does not have access to fail_json so we have to print
         # json output on our own.
-        print('\n{"msg": "Error: Module unable to locate ANSIBLE_MODULE_ARGS in json data from stdin.  Unable to figure out what parameters were passed", '
-              '"failed": true}')
+        print('\n{"msg": "Error: Module unable to locate ANSIBLE_MODULE_ARGS in json data from {}.  Unable to figure out what parameters were passed", '
+              '"failed": true}'.format(json_source))
         sys.exit(1)
 
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -681,8 +681,8 @@ def _load_params():
     except KeyError:
         # This helper does not have access to fail_json so we have to print
         # json output on our own.
-        print('\n{"msg": "Error: Module unable to locate ANSIBLE_MODULE_ARGS in json data from {0}.  Unable to figure out what parameters were passed", '
-              '"failed": true}'.format(json_source))
+        print('\n{"msg": "Error: Module unable to locate ANSIBLE_MODULE_ARGS in json data from %s.  Unable to figure out what parameters were passed", '
+              '"failed": true}' % json_source)
         sys.exit(1)
 
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -669,7 +669,7 @@ def _load_params():
     except ValueError:
         # This helper used too early for fail_json to work.
         msg = '\n{{"msg": "Error: Module unable to decode valid JSON.  Unable to figure out what parameters were passed",' \
-                  ' "failed": true, "json_source": "{}", "json_file":"{}", "buffer_contents":"{}"}}'.format(json_source, sys.argv[1], buffer)
+              ' "failed": true, "json_source": "{}", "json_file":"{}", "buffer_contents":"{}"}}'.format(json_source, sys.argv[1], buffer)
         print(msg)
         sys.exit(1)
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -637,6 +637,7 @@ def _load_params():
     inside it as a copy in your own code.
     '''
     global _ANSIBLE_ARGS
+    json_source = None
     if _ANSIBLE_ARGS is not None:
         buffer = _ANSIBLE_ARGS
     else:
@@ -649,12 +650,15 @@ def _load_params():
                 fd = open(sys.argv[1], 'rb')
                 buffer = fd.read()
                 fd.close()
+                json_source = 'file'
             else:
                 buffer = sys.argv[1]
                 if PY3:
                     buffer = buffer.encode('utf-8', errors='surrogateescape')
+                json_source = 'argument'
         # default case, read from stdin
         else:
+            json_source = 'stdin'
             if PY2:
                 buffer = sys.stdin.read()
             else:
@@ -664,8 +668,8 @@ def _load_params():
     try:
         params = json.loads(buffer.decode('utf-8'))
     except ValueError:
-        # This helper used too early for fail_json to work.
-        print('\n{"msg": "Error: Module unable to decode valid JSON on stdin.  Unable to figure out what parameters were passed", "failed": true}')
+        message = '\n{{"msg": "Error: Module unable to decode valid JSON.  Unable to figure out what parameters were passed", "failed": true, "json_source": "{}", "json_file":"{}", "buffer_contents":"{}"}}'.format(json_source, sys.argv[1], buffer)
+        print(message)
         sys.exit(1)
 
     if PY2:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -669,7 +669,7 @@ def _load_params():
     except ValueError:
         # This helper used too early for fail_json to work.
         msg = '\n{{"msg": "Error: Module unable to decode valid JSON.  Unable to figure out what parameters were passed",' \
-              ' "failed": true, "json_source": "{}", "json_file":"{}", "buffer_contents":"{}"}}'.format(json_source, sys.argv[1], buffer)
+              ' "failed": true, "json_source": "{0}", "json_file":"{1}", "buffer_contents":"{2}"}}'.format(json_source, sys.argv[1], buffer)
         print(msg)
         sys.exit(1)
 
@@ -681,7 +681,7 @@ def _load_params():
     except KeyError:
         # This helper does not have access to fail_json so we have to print
         # json output on our own.
-        print('\n{"msg": "Error: Module unable to locate ANSIBLE_MODULE_ARGS in json data from {}.  Unable to figure out what parameters were passed", '
+        print('\n{"msg": "Error: Module unable to locate ANSIBLE_MODULE_ARGS in json data from {0}.  Unable to figure out what parameters were passed", '
               '"failed": true}'.format(json_source))
         sys.exit(1)
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -668,6 +668,7 @@ def _load_params():
     try:
         params = json.loads(buffer.decode('utf-8'))
     except ValueError:
+        # This helper used too early for fail_json to work.
         message = '\n{{"msg": "Error: Module unable to decode valid JSON.  Unable to figure out what parameters were passed", "failed": true, "json_source": "{}", "json_file":"{}", "buffer_contents":"{}"}}'.format(json_source, sys.argv[1], buffer)
         print(message)
         sys.exit(1)


### PR DESCRIPTION
##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py

##### ANSIBLE VERSION
2.3

##### SUMMARY

I ran into an issue where my module wasn't getting passed valid JSON. I'm still not sure why that is, but I was derailed for hours by this message which inaccurately claims it tried to pull arguments from stdin. 

Below is a slightly redacted version (removed argument names/values I don't want to share) of the error message. You can see it looks like the args file is being created with invalid JSON (it looks like the buffer read in is missing an opening brace and possibly a key). Beyond this pull request, I'd appreciate ideas on why that might be.

```
"module_stdout": "\n{\"msg\": \"Error: Module unable to decode valid JSON.  Unable to figure out what parameters were passed\", \"failed\": true, \"json_source\": \"file\", \"json_file\":\"/home/myusername/.ansible/tmp/ansible-tmp-1481760801.8551576-394256050499/args\", \"buffer_contents\":\"_ansible_no_log=False  _ansible_verbosity=3 _ansible_module_name=my_module   _ansible_syslog_facility=LOG_USER _ansible_version=2.3.0 _ansible_selinux_special_fs='['\"'\"'fuse'\"'\"', '\"'\"'nfs'\"'\"', '\"'\"'vboxsf'\"'\"', '\"'\"'ramfs'\"'\"']'  _ansible_check_mode=False _ansible_diff=False _ansible_debug=False  \"}\n",
```
