### PR TITLE
Update `aliases` file for `uri` integration test.

### DIFF
--- a/test/integration/targets/uri/aliases
+++ b/test/integration/targets/uri/aliases
@@ -2,4 +2,3 @@ destructive
 posix/ci/group1
 skip/freebsd
 skip/osx
-skip/python3


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Integration Tests: uri

##### ANSIBLE VERSION

```
ansible 2.3.0 (uri-aliases 98277939ee) last updated 2016/12/14 17:40:38 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Update `aliases` file for `uri` integration test. The file was out of sync with the legacy test playbooks, which was causing CI change detection to always trigger the `uri` test.