### PR TITLE
[timezone module] Check if timedatectl command is actually available

### DIFF
--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -92,13 +92,14 @@ class Timezone(object):
         """Return the platform-specific subclass.
 
         It does not use load_platform_subclass() because it need to judge based
-        on whether the `timedatectl` command exists.
+        on whether the `timedatectl` command exists and available.
 
         Args:
             module: The AnsibleModule.
         """
         if get_platform() == 'Linux':
-            if module.get_bin_path('timedatectl') is not None:
+            timedatectl = module.get_bin_path('timedatectl')
+            if timedatectl is not None and module.run_command(timedatectl)[0] == 0:
                 return super(Timezone, SystemdTimezone).__new__(SystemdTimezone)
             else:
                 return super(Timezone, NosystemdTimezone).__new__(NosystemdTimezone)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`timezone` module

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### SUMMARY
Fixes #19280.

According to the bug report in the issue above, there are some environments such that:
- `timedatectl` command **_exists_**,
- but it's actually **_unavailable_**.

To support these environments, now it started to check if the found `timedatectl` command is truly available.