### PR TITLE
Use `docker pull` by default in ansible-test.

### DIFF
--- a/test/runner/lib/delegation.py
+++ b/test/runner/lib/delegation.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, print_function
 
 import os
 import sys
+import time
 
 import lib.pytar
 import lib.thread
@@ -12,6 +13,7 @@ from lib.executor import (
     SUPPORTED_PYTHON_VERSIONS,
     EnvironmentConfig,
     IntegrationConfig,
+    SubprocessError,
     ShellConfig,
     TestConfig,
     create_shell_command,
@@ -28,6 +30,7 @@ from lib.manage_ci import (
 from lib.util import (
     ApplicationError,
     run_command,
+    display,
 )
 
 BUFFER_SIZE = 256 * 256
@@ -98,6 +101,11 @@ def delegate_docker(args, exclude, require):
     util_image = args.docker_util
     test_image = args.docker
     privileged = args.docker_privileged
+
+    if util_image:
+        docker_pull(args, util_image)
+
+    docker_pull(args, test_image)
 
     util_id = None
     test_id = None
@@ -193,6 +201,26 @@ def delegate_docker(args, exclude, require):
             run_command(args,
                         ['docker', 'rm', '-f', test_id],
                         capture=True)
+
+
+def docker_pull(args, image):
+    """
+    :type args: EnvironmentConfig
+    :type image: str
+    """
+    if not args.docker_pull:
+        display.warning('Skipping docker pull for "%s". Image may be out-of-date.' % image)
+        return
+
+    for _ in range(1, 10):
+        try:
+            run_command(args, ['docker', 'pull', image])
+            return
+        except SubprocessError:
+            display.warning('Failed to pull docker image "%s". Waiting a few seconds before trying again.' % image)
+            time.sleep(3)
+
+    raise ApplicationError('Failed to pull docker image "%s".' % image)
 
 
 def docker_put(args, container_id, src, dst):

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -1103,6 +1103,7 @@ class EnvironmentConfig(CommonConfig):
 
         self.docker_privileged = args.docker_privileged if 'docker_privileged' in args else False  # type: bool
         self.docker_util = docker_qualify_image(args.docker_util if 'docker_util' in args else None)  # type: str | None
+        self.docker_pull = args.docker_pull if 'docker_pull' in args else False  # type: bool
 
         self.tox_sitepackages = args.tox_sitepackages  # type: bool
 

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -224,6 +224,8 @@ def parse_args():
                        action='store_true',
                        help='collect tests but do not execute them')
 
+    add_extra_docker_options(units, integration=False)
+
     compiler = subparsers.add_parser('compile',
                                      parents=[test],
                                      help='compile tests')
@@ -236,6 +238,8 @@ def parse_args():
                           metavar='VERSION',
                           choices=COMPILE_PYTHON_VERSIONS,
                           help='python version: %s' % ', '.join(COMPILE_PYTHON_VERSIONS))
+
+    add_extra_docker_options(compiler, integration=False)
 
     sanity = subparsers.add_parser('sanity',
                                    parents=[test],
@@ -265,6 +269,8 @@ def parse_args():
                         metavar='VERSION',
                         choices=SUPPORTED_PYTHON_VERSIONS,
                         help='python version: %s' % ', '.join(SUPPORTED_PYTHON_VERSIONS))
+
+    add_extra_docker_options(sanity, integration=False)
 
     shell = subparsers.add_parser('shell',
                                   parents=[common],
@@ -423,11 +429,20 @@ def add_environments(parser, tox_version=False, tox_only=False):
                         default='prod')
 
 
-def add_extra_docker_options(parser):
+def add_extra_docker_options(parser, integration=True):
     """
     :type parser: argparse.ArgumentParser
+    :type integration: bool
     """
     docker = parser.add_argument_group(title='docker arguments')
+
+    docker.add_argument('--docker-no-pull',
+                        action='store_false',
+                        dest='docker_pull',
+                        help='do not explicitly pull the latest docker images')
+
+    if not integration:
+        return
 
     docker.add_argument('--docker-util',
                         metavar='IMAGE',


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (at-docker 0065993965) last updated 2016/12/14 19:48:46 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Use `docker pull` by default in ansible-test.