### PR TITLE
Datadog monitor: add monitor name template variables support

### DIFF
--- a/lib/ansible/modules/monitoring/datadog_monitor.py
+++ b/lib/ansible/modules/monitoring/datadog_monitor.py
@@ -61,7 +61,7 @@ options:
         required: false
         default: null
     name:
-        description: ["The name of the alert."]
+        description: ["The name of the alert. Monitor name template variables can be accessed by using double square brackets, i.e '[[' and ']]'."]
         required: true
     message:
         description: ["A message to include with notifications for this monitor. Email notifications can be sent to specific users by using the same '@username' notation as events. Monitor message template variables can be accessed by using double square brackets, i.e '[[' and ']]'."]
@@ -120,7 +120,7 @@ EXAMPLES = '''
 # Create a metric monitor
 datadog_monitor:
   type: "metric alert"
-  name: "Test monitor"
+  name: "Test monitor [[host.name]]"
   state: "present"
   query: "datadog.agent.up".over("host:host1").last(2).count_by_status()"
   message: "Host [[host.name]] with IP [[host.ip]] is failing to report to datadog."
@@ -129,14 +129,14 @@ datadog_monitor:
 
 # Deletes a monitor
 datadog_monitor:
-  name: "Test monitor"
+  name: "Test monitor [[host.name]]"
   state: "absent"
   api_key: "9775a026f1ca7d1c6c5af9d94d9595a4"
   app_key: "87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"
 
 # Mutes a monitor
 datadog_monitor:
-  name: "Test monitor"
+  name: "Test monitor [[host.name]]"
   state: "mute"
   silenced: '{"*":None}'
   api_key: "9775a026f1ca7d1c6c5af9d94d9595a4"
@@ -144,7 +144,7 @@ datadog_monitor:
 
 # Unmutes a monitor
 datadog_monitor:
-  name: "Test monitor"
+  name: "Test monitor [[host.name]]"
   state: "unmute"
   api_key: "9775a026f1ca7d1c6c5af9d94d9595a4"
   app_key: "87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"
@@ -221,7 +221,7 @@ def _get_monitor(module):
     else:
         monitors = api.Monitor.get_all()
         for monitor in monitors:
-            if monitor['name'] == module.params['name']:
+            if monitor['name'] == _fix_template_vars(module.params['name']):
                 return monitor
     return {}
 
@@ -229,7 +229,7 @@ def _get_monitor(module):
 def _post_monitor(module, options):
     try:
         kwargs = dict(type=module.params['type'], query=module.params['query'],
-                      name=module.params['name'], message=_fix_template_vars(module.params['message']),
+                      name=_fix_template_vars(module.params['name']), message=_fix_template_vars(module.params['message']),
                       options=options)
         if module.params['tags'] is not None:
             kwargs['tags'] = module.params['tags']
@@ -250,7 +250,7 @@ def _equal_dicts(a, b, ignore_keys):
 def _update_monitor(module, monitor, options):
     try:
         kwargs = dict(id=monitor['id'], query=module.params['query'],
-                      name=module.params['name'], message=_fix_template_vars(module.params['message']),
+                      name=_fix_template_vars(module.params['name']), message=_fix_template_vars(module.params['message']),
                       options=options)
         if module.params['tags'] is not None:
             kwargs['tags'] = module.params['tags']


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
datadog_monitor module
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Datadog monitors support name template variable. Previous version of module did not allow to add template variable in monitor name. After this fix datadog templates variable will be correctly set in monitor name. This commit change square bracket '[[' and ']]' to '{{' and '}}', previously this was done only in the message input. 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->



