### PR TITLE
cloud: ovirt: add possibility specify auth params in env vars

### DIFF
--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -19,6 +19,7 @@
 #
 
 import inspect
+import os
 import time
 
 from abc import ABCMeta, abstractmethod
@@ -279,6 +280,32 @@ def wait(
             time.sleep(float(poll_interval))
 
 
+def __get_auth_dict():
+    OVIRT_URL = os.environ.get('OVIRT_URL')
+    OVIRT_USERNAME = os.environ.get('OVIRT_USERNAME')
+    OVIRT_PASSWORD = os.environ.get('OVIRT_PASSWORD')
+    OVIRT_TOKEN = os.environ.get('OVIRT_TOKEN')
+    OVIRT_CAFILE = os.environ.get('OVIRT_CAFILE')
+    OVIRT_INSECURE = OVIRT_CAFILE is None
+
+    env_vars = None
+    if OVIRT_URL and ((OVIRT_USERNAME and OVIRT_PASSWORD) or OVIRT_TOKEN):
+        env_vars = {
+            'url': OVIRT_URL,
+            'username': OVIRT_USERNAME,
+            'password': OVIRT_PASSWORD,
+            'insecure': OVIRT_INSECURE,
+            'token': OVIRT_TOKEN,
+            'ca_file': OVIRT_CAFILE,
+        }
+    if env_vars is not None:
+        auth = dict(default=env_vars, type='dict')
+    else:
+        auth = dict(required=True, type='dict')
+
+    return auth
+
+
 def ovirt_facts_full_argument_spec(**kwargs):
     """
     Extend parameters of facts module with parameters which are common to all
@@ -288,7 +315,7 @@ def ovirt_facts_full_argument_spec(**kwargs):
     :return: extended dictionary with common parameters
     """
     spec = dict(
-        auth=dict(required=True, type='dict'),
+        auth=__get_auth_dict(),
         fetch_nested=dict(default=False, type='bool'),
         nested_attributes=dict(type='list'),
     )
@@ -304,7 +331,7 @@ def ovirt_full_argument_spec(**kwargs):
     :return: extended dictionary with common parameters
     """
     spec = dict(
-        auth=dict(required=True, type='dict'),
+        auth=__get_auth_dict(),
         timeout=dict(default=180, type='int'),
         wait=dict(default=True, type='bool'),
         poll_interval=dict(default=3, type='int'),

--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -29,7 +29,6 @@ from enum import Enum
 
 try:
     import ovirtsdk4 as sdk
-    import ovirtsdk4.types as otypes
     import ovirtsdk4.version as sdk_version
     HAS_SDK = LooseVersion(sdk_version.VERSION) >= LooseVersion('4.0.0')
 except ImportError:
@@ -127,6 +126,7 @@ def create_connection(auth):
         kerberos=auth.get('kerberos', None),
     )
 
+
 def convert_to_bytes(param):
     """
     This method convert units to bytes, which follow IEC standard.
@@ -210,7 +210,7 @@ def search_by_attributes(service, **kwargs):
     else:
         res = [
             e for e in service.list() if len([
-                 k for k, v in kwargs.items() if getattr(e, k, None) == v
+                k for k, v in kwargs.items() if getattr(e, k, None) == v
             ]) == len(kwargs)
         ]
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
@@ -719,7 +719,7 @@ def control_state(vm, vms_service, module):
         vm.status == otypes.VmStatus.UNKNOWN
     ):
         # Invalid states:
-        module.fail_json("Not possible to control VM, if it's in '{}' status".format(vm.status))
+        module.fail_json(msg="Not possible to control VM, if it's in '{}' status".format(vm.status))
     elif vm.status == otypes.VmStatus.POWERING_DOWN:
         if (force and state == 'stopped') or state == 'absent':
             vm_service.stop()

--- a/lib/ansible/utils/module_docs_fragments/ovirt.py
+++ b/lib/ansible/utils/module_docs_fragments/ovirt.py
@@ -41,17 +41,17 @@ options:
         required: True
         description:
             - "Dictionary with values needed to create HTTP/HTTPS connection to oVirt:"
-            - "C(username)[I(required)] - The name of the user, something like `I(admin@internal)`."
-            - "C(password)[I(required)] - The password of the user."
+            - "C(username)[I(required)] - The name of the user, something like `I(admin@internal)`. Default value is set by I(OVIRT_USERNAME) environment variable."
+            - "C(password)[I(required)] - The password of the user. Default value is set by I(OVIRT_PASSWORD) environment variable."
             - "C(url)[I(required)] - A string containing the base URL of the server, usually
-            something like `I(https://server.example.com/ovirt-engine/api)`."
-            - "C(token) - Token to be used instead of login with username/password."
+            something like `I(https://server.example.com/ovirt-engine/api)`. Default value is set by I(OVIRT_URL) environment variable."
+            - "C(token) - Token to be used instead of login with username/password. Default value is set by I(OVIRT_TOKEN) environment variable."
             - "C(insecure) - A boolean flag that indicates if the server TLS
             certificate and host name should be checked."
             - "C(ca_file) - A PEM file containing the trusted CA certificates. The
             certificate presented by the server will be verified using these CA
             certificates. If `C(ca_file)` parameter is not set, system wide
-            CA certificate store is used."
+            CA certificate store is used. Default value is set by I(OVIRT_CAFILE) environment variable."
             - "C(kerberos) - A boolean flag indicating if Kerberos authentication
             should be used instead of the default basic authentication."
     timeout:

--- a/lib/ansible/utils/module_docs_fragments/ovirt_facts.py
+++ b/lib/ansible/utils/module_docs_fragments/ovirt_facts.py
@@ -38,17 +38,17 @@ options:
         required: True
         description:
             - "Dictionary with values needed to create HTTP/HTTPS connection to oVirt:"
-            - "C(username)[I(required)] - The name of the user, something like `I(admin@internal)`."
-            - "C(password)[I(required)] - The password of the user."
+            - "C(username)[I(required)] - The name of the user, something like `I(admin@internal)`. Default value is set by I(OVIRT_USERNAME) environment variable."
+            - "C(password)[I(required)] - The password of the user. Default value is set by I(OVIRT_PASSWORD) environment variable."
             - "C(url)[I(required)] - A string containing the base URL of the server, usually
-            something like `I(https://server.example.com/ovirt-engine/api)`."
-            - "C(token) - Token to be used instead of login with username/password."
+            something like `I(https://server.example.com/ovirt-engine/api)`. Default value is set by I(OVIRT_URL) environment variable."
+            - "C(token) - Token to be used instead of login with username/password. Default value is set by I(OVIRT_TOKEN) environment variable."
             - "C(insecure) - A boolean flag that indicates if the server TLS
             certificate and host name should be checked."
             - "C(ca_file) - A PEM file containing the trusted CA certificates. The
             certificate presented by the server will be verified using these CA
             certificates. If `C(ca_file)` parameter is not set, system wide
-            CA certificate store is used."
+            CA certificate store is used. Default value is set by I(OVIRT_CAFILE) environment variable."
             - "C(kerberos) - A boolean flag indicating if Kerberos authentication
             should be used instead of the default basic authentication."
 requirements:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/module_utils/ovirt.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This patch adds support to enter authentication parameters via environment variables,
instead of passing it via module parameters.