### PR TITLE
Fixes #19387 : docker_login.py raises NameError

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_login.py
+++ b/lib/ansible/modules/cloud/docker/docker_login.py
@@ -318,8 +318,8 @@ def main():
         login_result={}
     )
 
-    if module.params['state'] == 'present' and module.params['registry_url'] == DEFAULT_DOCKER_REGISTRY and not module.params['email']:
-        module.fail_json(msg="'email' is required when loging into DockerHub")
+    if client.module.params['state'] == 'present' and client.module.params['registry_url'] == DEFAULT_DOCKER_REGISTRY and not client.module.params['email']:
+        client.module.fail_json(msg="'email' is required when loging into DockerHub")
 
     LoginManager(client, results)
     if 'actions' in results:


### PR DESCRIPTION
Fixes: #19387 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

docker_login

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
docker-py 1.10.6
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Fixing what appears to be a typo in the docker_login.py module. Someone was attempting to reference the variable name 'module', which doesn't exist in that scope. Instead it appears that 'client.module' is  the correct reference to use which is what I amended line 318 to use. 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
fatal: [default]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "invocation": {
        "module_name": "docker_login"
    }, 
    "module_stderr": "Shared connection to localhost closed.\r\n", 
    "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible__EyB0w/ansible_module_docker_login.py\", line 333, in <module>\r\n    main()\r\n  File \"/tmp/ansible__EyB0w/ansible_module_docker_login.py\", line 321, in main\r\n    if module.params['state'] == 'present' and module.params['registry_url'] == DEFAULT_DOCKER_REGISTRY and not module.params['email']:\r\nNameError: global name 'module' is not defined\r\n", 
    "msg": "MODULE FAILURE"
}

tmp-1481822645.7-32880948701345/ > /dev/null 2>&1 && sleep 0'"'"''
ok: [default] => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "api_version": null, 
            "cacert_path": null, 
            "cert_path": null, 
            "config_path": "~/.docker/config.json", 
            "debug": false, 
            "docker_host": null, 
            "email": "<sensitive info removed>", 
            "filter_logger": false, 
            "key_path": null, 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "reauthorize": false, 
            "registry": "<sensitive info removed>", 
            "registry_url": "<sensitive info removed>", 
            "ssl_version": null, 
            "state": "present", 
            "timeout": null, 
            "tls": null, 
            "tls_hostname": null, 
            "tls_verify": null, 
            "username": "<sensitive info removed>"
        }, 
        "module_name": "docker_login"
    }, 
    "login_result": {
        "email": "<sensitive info removed>", 
        "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
        "serveraddress": "<sensitive info removed>", 
        "username": "<sensitive info removed>"
    }
}

```