### PR TITLE
Fix error on 'help module' in ansible-console

### DIFF
--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -356,7 +356,7 @@ class ConsoleCLI(CLI, cmd.Cmd):
         if module_name in self.modules:
             in_path = module_loader.find_plugin(module_name)
             if in_path:
-                oc, a, _ = module_docs.get_docstring(in_path)
+                oc, a, _, _ = module_docs.get_docstring(in_path)
                 if oc:
                     display.display(oc['short_description'])
                     display.display('Parameters:')
@@ -388,8 +388,8 @@ class ConsoleCLI(CLI, cmd.Cmd):
 
     def module_args(self, module_name):
         in_path = module_loader.find_plugin(module_name)
-        oc, a, _ = module_docs.get_docstring(in_path)
-        return oc['options'].keys()
+        oc, a, _, _ = module_docs.get_docstring(in_path)
+        return list(oc['options'].keys())
 
     def run(self):
 

--- a/test/units/cli/test_console.py
+++ b/test/units/cli/test_console.py
@@ -20,6 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import patch
 
 from ansible.cli.console import ConsoleCLI
 
@@ -30,3 +31,21 @@ class TestConsoleCLI(unittest.TestCase):
         cli.parse()
         self.assertTrue(cli.parser is not None)
 
+    def test_module_args(self):
+        cli = ConsoleCLI([])
+        cli.parse()
+        res = cli.module_args('copy')
+        self.assertTrue(cli.parser is not None)
+        self.assertIn('src', res)
+        self.assertIn('backup', res)
+        self.assertIsInstance(res, list)
+
+    @patch('ansible.utils.display.Display.display')
+    def test_helpdefault(self, mock_display):
+        cli = ConsoleCLI([])
+        cli.parse()
+        cli.modules = set(['copy'])
+        cli.helpdefault('copy')
+        self.assertTrue(cli.parser is not None)
+        self.assertTrue(len(mock_display.call_args_list) > 0,
+                        "display.display should have been called but was not")


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
ansible-console

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (console_module_docs fabdb6df3e) last updated 2016/12/15 13:38:20 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides


```

##### SUMMARY


If 'help xattr' for example, ansible-console would
traceback because module_docs.get_docstring() now
returns 4 values (module metadata was added)