### PR TITLE
Add modules for managing illumos networking

### DIFF
--- a/lib/ansible/modules/network/illumos/a
+++ b/lib/ansible/modules/network/illumos/a
@@ -1,0 +1,6 @@
+:000000 100644 000000000... 0263399fe... A      lib/ansible/modules/network/illumos/dladm_iptun.py
+:000000 100644 000000000... 4a708de23... A      lib/ansible/modules/network/illumos/dladm_linkprop.py
+:000000 100644 000000000... 9122d126d... A      lib/ansible/modules/network/illumos/dladm_vlan.py
+:000000 100644 000000000... ddfacf7d8... A      lib/ansible/modules/network/illumos/ipadm_addr.py
+:000000 100644 000000000... 0dd5a50aa... A      lib/ansible/modules/network/illumos/ipadm_addrprop.py
+:000000 100644 000000000... 8ca1dc882... A      lib/ansible/modules/network/illumos/ipadm_ifprop.py

--- a/lib/ansible/modules/network/illumos/dladm_iptun.py
+++ b/lib/ansible/modules/network/illumos/dladm_iptun.py
@@ -1,0 +1,247 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2016, Adam Števko <adam.stevko@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+#
+
+DOCUMENTATION = '''
+---
+module: dladm_iptun
+short_description: Manage IP tunnel interfaces on Solaris/illumos systems.
+description:
+    - Manage IP tunnel interfaces on Solaris/illumos systems.
+version_added: "2.3"
+author: Adam Števko (@xen0l)
+options:
+    name:
+        description:
+            - IP tunnel interface name.
+        required: true
+        aliases: [ "tunnel", "link" ]
+    temporary:
+        description:
+            - Specifies that the IP tunnel interface is temporary. Temporary IP tunnel
+              interfaces do not persist across reboots.
+        required: false
+        default: false
+    type:
+        description:
+            - Specifies the type of tunnel to be created.
+        required: false
+        default: "ipv4"
+        choices: [ "ipv4", "ipv6", "6to4" ]
+    local_address:
+        description:
+            - Literat IP address or hostname corresponding to the tunnel source.
+        required: false
+        aliases: [ "local" ]
+    remote_address:
+        description:
+            - Literal IP address or hostname corresponding to the tunnel destination.
+        required: false
+        aliases: [ "remote" ]
+    state:
+        description:
+            - Create or delete Solaris/illumos VNIC.
+        required: false
+        default: "present"
+        choices: [ "present", "absent" ]
+'''
+
+EXAMPLES = '''
+# Create IPv4 tunnel interface 'iptun0'
+dladm_iptun: name=iptun0 local_address=192.0.2.23 remote_address=203.0.113.10 state=present
+
+# Change IPv4 tunnel remote address
+dladm_iptun: name=iptun0 type=ipv4 local_address=192.0.2.23 remote_address=203.0.113.11
+
+# Create IPv6 tunnel interface 'tun0'
+dladm_iptun: name=tun0 type=ipv6 local_address=192.0.2.23 remote_address=203.0.113.42
+
+# Remove 'iptun0' tunnel interface
+dladm_iptun: name=iptun0 state=absent
+'''
+
+SUPPORTED_TYPES = ['ipv4', 'ipv6', '6to4']
+
+
+class IPTun(object):
+
+    def __init__(self, module):
+        self.module = module
+
+        self.name = module.params['name']
+        self.type = module.params['type']
+        self.local_address = module.params['local_address']
+        self.remote_address = module.params['remote_address']
+        self.temporary = module.params['temporary']
+        self.state = module.params['state']
+
+        self.dladm_bin = self.module.get_bin_path('dladm', True)
+
+    def iptun_exists(self):
+        cmd = [self.dladm_bin]
+
+        cmd.append('show-iptun')
+        cmd.append(self.name)
+
+        (rc, _, _) = self.module.run_command(cmd)
+
+        if rc == 0:
+            return True
+        else:
+            return False
+
+    def create_iptun(self):
+        cmd = [self.dladm_bin]
+
+        cmd.append('create-iptun')
+
+        if self.temporary:
+            cmd.append('-t')
+
+        cmd.append('-T')
+        cmd.append(self.type)
+        cmd.append('-a')
+        cmd.append('local=' + self.local_address + ',remote=' + self.remote_address)
+        cmd.append(self.name)
+
+        return self.module.run_command(cmd)
+
+    def delete_iptun(self):
+        cmd = [self.dladm_bin]
+
+        cmd.append('delete-iptun')
+
+        if self.temporary:
+            cmd.append('-t')
+        cmd.append(self.name)
+
+        return self.module.run_command(cmd)
+
+    def update_iptun(self):
+        cmd = [self.dladm_bin]
+
+        cmd.append('modify-iptun')
+
+        if self.temporary:
+            cmd.append('-t')
+        cmd.append('-a')
+        cmd.append('local=' + self.local_address + ',remote=' + self.remote_address)
+        cmd.append(self.name)
+
+        return self.module.run_command(cmd)
+
+    def _query_iptun_props(self):
+        cmd = [self.dladm_bin]
+
+        cmd.append('show-iptun')
+        cmd.append('-p')
+        cmd.append('-c')
+        cmd.append('link,type,flags,local,remote')
+        cmd.append(self.name)
+
+        return self.module.run_command(cmd)
+
+    def iptun_needs_updating(self):
+        (rc, out, err) = self._query_iptun_props()
+
+        NEEDS_UPDATING = False
+
+        if rc == 0:
+            configured_local, configured_remote = out.split(':')[3:]
+
+            if self.local_address != configured_local or self.remote_address != configured_remote:
+                NEEDS_UPDATING = True
+
+            return NEEDS_UPDATING
+        else:
+            self.module.fail_json(msg='Failed to query tunnel interface %s properties' % self.name,
+                                  err=err,
+                                  rc=rc)
+
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(required=True, type='str'),
+            type=dict(default='ipv4', type='str', aliases=['tunnel_type'],
+                      choices=SUPPORTED_TYPES),
+            local_address=dict(type='str', aliases=['local']),
+            remote_address=dict(type='str', aliases=['remote']),
+            temporary=dict(default=False, type='bool'),
+            state=dict(default='present', choices=['absent', 'present']),
+        ),
+        required_if=[
+            ['state', 'present', ['local_address', 'remote_address']],
+        ],
+        supports_check_mode=True
+    )
+
+    iptun = IPTun(module)
+
+    rc = None
+    out = ''
+    err = ''
+    result = {}
+    result['name'] = iptun.name
+    result['type'] = iptun.type
+    result['local_address'] = iptun.local_address
+    result['remote_address'] = iptun.remote_address
+    result['state'] = iptun.state
+    result['temporary'] = iptun.temporary
+
+    if iptun.state == 'absent':
+        if iptun.iptun_exists():
+            if module.check_mode:
+                module.exit_json(changed=True)
+            (rc, out, err) = iptun.delete_iptun()
+            if rc != 0:
+                module.fail_json(name=iptun.name, msg=err, rc=rc)
+    elif iptun.state == 'present':
+        if not iptun.iptun_exists():
+            if module.check_mode:
+                module.exit_json(changed=True)
+            (rc, out, err) = iptun.create_iptun()
+
+            if rc is not None and rc != 0:
+                module.fail_json(name=iptun.name, msg=err, rc=rc)
+        else:
+            if iptun.iptun_needs_updating():
+                (rc, out, err) = ipyim.update_iptun()
+                if rc != 0:
+                    module.fail_json(msg='Error while updating tunnel interface: "%s"' % err,
+                                     name=iptun.name,
+                                     stderr=err,
+                                     rc=rc)
+
+    if rc is None:
+        result['changed'] = False
+    else:
+        result['changed'] = True
+
+    if out:
+        result['stdout'] = out
+    if err:
+        result['stderr'] = err
+
+    module.exit_json(**result)
+
+from ansible.module_utils.basic import *
+main()

--- a/lib/ansible/modules/network/illumos/dladm_linkprop.py
+++ b/lib/ansible/modules/network/illumos/dladm_linkprop.py
@@ -1,0 +1,272 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2016, Adam Števko <adam.stevko@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+#
+
+DOCUMENTATION = '''
+---
+module: dladm_linkprop
+short_description: Manage link properties on Solaris/illumos systems.
+description:
+    - Set / reset link properties on Solaris/illumos systems.
+version_added: "2.3"
+author: Adam Števko (@xen0l)
+options:
+    link:
+        description:
+            - Link interface name.
+        type: str
+        required: true
+        aliases: [ "nic", "interface" ]
+    property:
+        description:
+            - Specifies the name of the property we want to manage.
+        type: str
+        required: true
+        aliases: [ "name" ]
+    value:
+        description:
+            - Specifies the value we want to set for the link property.
+        type: str
+        required: false
+    temporary:
+        description:
+            - Specifies that lin property configuration is temporary. Temporary
+              link property configuration does not persist across reboots.
+        required: false
+        type: boolean
+        default: false
+    state:
+        description:
+            - Set or reset the property value.
+        required: false
+        type: str
+        default: "present"
+        choices: [ "present", "absent", "reset" ]
+'''
+
+EXAMPLES = '''
+# Set 'maxbw' to 100M on e1000g1
+dladm_linkprop: name=e1000g1 property=maxbw value=100M state=present
+
+# Set 'mtu' to 9000 on e1000g1
+dladm_linkprop: name=e1000g1 property=mtu value=9000
+
+# Reset 'mtu' property on e1000g1
+dladm_linkprop: name=e1000g1 property=mtu state=reset
+'''
+
+RETURN = '''
+'''
+
+class LinkProp(object):
+
+    def __init__(self, module):
+        self.module = module
+
+        self.link = module.params['link']
+        self.property = module.params['property']
+        self.value = module.params['value']
+        self.temporary = module.params['temporary']
+        self.state = module.params['state']
+
+        self.dladm_bin = self.module.get_bin_path('dladm', True)
+
+    def property_exists(self):
+        cmd = [self.dladm_bin]
+
+        cmd.append('show-linkprop')
+        cmd.append('-p')
+        cmd.append(self.property)
+        cmd.append(self.link)
+
+        (rc, _, _) = self.module.run_command(cmd)
+
+        if rc == 0:
+            return True
+        else:
+            self.module.fail_json(msg='Unknown property "%s" on link %s' %
+                                  (self.property, self.link),
+                                  property=self.property,
+                                  link=self.link)
+
+    def property_is_modified(self):
+        cmd = [self.dladm_bin]
+
+        cmd.append('show-linkprop')
+        cmd.append('-c')
+        cmd.append('-o')
+        cmd.append('value,default')
+        cmd.append('-p')
+        cmd.append(self.property)
+        cmd.append(self.link)
+
+        (rc, out, _) = self.module.run_command(cmd)
+
+        out = out.rstrip()
+        (value, default) = out.split(':')
+
+        if rc == 0 and value == default:
+            return True
+        else:
+            return False
+
+    def property_is_readonly(self):
+        cmd = [self.dladm_bin]
+
+        cmd.append('show-linkprop')
+        cmd.append('-c')
+        cmd.append('-o')
+        cmd.append('perm')
+        cmd.append('-p')
+        cmd.append(self.property)
+        cmd.append(self.link)
+
+        (rc, out, _) = self.module.run_command(cmd)
+
+        out = out.rstrip()
+
+        if rc == 0 and out == 'r-':
+            return True
+        else:
+            return False
+
+    def property_is_set(self):
+        cmd = [self.dladm_bin]
+
+        cmd.append('show-linkprop')
+        cmd.append('-c')
+        cmd.append('-o')
+        cmd.append('value')
+        cmd.append('-p')
+        cmd.append(self.property)
+        cmd.append(self.link)
+
+        (rc, out, _) = self.module.run_command(cmd)
+
+        out = out.rstrip()
+
+        if rc == 0 and self.value == out:
+            return True
+        else:
+            return False
+
+    def set_property(self):
+        cmd = [self.dladm_bin]
+
+        cmd.append('set-linkprop')
+
+        if self.temporary:
+            cmd.append('-t')
+
+        cmd.append('-p')
+        cmd.append(self.property + '=' + self.value)
+        cmd.append(self.link)
+
+        return self.module.run_command(cmd)
+
+    def reset_property(self):
+        cmd = [self.dladm_bin]
+
+        cmd.append('reset-linkprop')
+
+        if self.temporary:
+            cmd.append('-t')
+
+        cmd.append('-p')
+        cmd.append(self.property)
+        cmd.append(self.link)
+
+        return self.module.run_command(cmd)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            link=dict(required=True, default=None, type='str', aliases=['nic', 'interface']),
+            property=dict(required=True, type='str', aliases=['name']),
+            value=dict(required=False, type='str'),
+            temporary=dict(default=False, type='bool', choices=BOOLEANS),
+            state=dict(
+                default='present', choices=['absent', 'present', 'reset']),
+        ),
+        required_if=[
+            ['state', 'present', ['value']],
+        ],
+
+        supports_check_mode=True
+    )
+
+
+    linkprop = LinkProp(module)
+
+    rc = None
+    out = ''
+    err = ''
+    result = {}
+    result['property'] = linkprop.property
+    result['link'] = linkprop.link
+    result['state'] = linkprop.state
+    if linkprop.value:
+        result['value'] = linkprop.value
+
+    if linkprop.state == 'absent' or linkprop.state == 'reset':
+        if linkprop.property_exists():
+            if not linkprop.property_is_modified():
+                if module.check_mode:
+                    module.exit_json(changed=True)
+                (rc, out, err) = linkprop.reset_property()
+                if rc != 0:
+                    module.fail_json(property=linkprop.property,
+                                     link=linkprop.link,
+                                     msg=err,
+                                     rc=rc)
+
+    elif linkprop.state == 'present':
+        if linkprop.property_exists():
+            if not linkprop.property_is_readonly():
+                if not linkprop.property_is_set():
+                    if module.check_mode:
+                        module.exit_json(changed=True)
+
+                    (rc, out, err) = linkprop.set_property()
+                    if rc != 0:
+                        module.fail_json(property=linkprop.property,
+                                         link=linkprop.link,
+                                         msg=err,
+                                         rc=rc)
+            else:
+                module.fail_json(msg='Property "%s" is read-only!' % (linkprop.property),
+                                 property=linkprop.property,
+                                 link=linkprop.link)
+
+    if rc is None:
+        result['changed'] = False
+    else:
+        result['changed'] = True
+
+    if out:
+        result['stdout'] = out
+    if err:
+        result['stderr'] = err
+
+    module.exit_json(**result)
+
+from ansible.module_utils.basic import *
+main()

--- a/lib/ansible/modules/network/illumos/dladm_vlan.py
+++ b/lib/ansible/modules/network/illumos/dladm_vlan.py
@@ -1,0 +1,188 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2015, Adam Števko <adam.stevko@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+#
+
+DOCUMENTATION = '''
+---
+module: dladm_vlan
+short_description: Manage VLAN interfaces on Solaris/illumos systems.
+description:
+    - Create or delete VLAN interfaces on Solaris/illumos systems.
+version_added: "2.3"
+author: Adam Števko (@xen0l)
+options:
+    name:
+        description:
+            - VLAN interface name.
+        required: true
+    link:
+        description:
+            - VLAN underlying link name.
+        required: true
+    temporary:
+        description:
+            - Specifies that the VLAN interface is temporary. Temporary VLANs
+              do not persist across reboots.
+        required: false
+        default: false
+    vlan_id:
+        description:
+            - VLAN ID value for VLAN interface.
+        required: false
+        default: false
+        aliases: [ "vid" ]
+    state:
+        description:
+            - Create or delete Solaris/illumos VNIC.
+        required: false
+        default: "present"
+        choices: [ "present", "absent" ]
+'''
+
+EXAMPLES = '''
+# Create 'vlan42' VLAN over 'bnx0' link
+dladm_vlan: name=vlan42 link=bnx0 vlan_id=42 state=present
+
+# Remove 'vlan1337' VLAN interface
+dladm_vlan: name=vlan1337 state=absent
+'''
+
+
+class VLAN(object):
+
+    def __init__(self, module):
+        self.module = module
+
+        self.name = module.params['name']
+        self.link = module.params['link']
+        self.vlan_id = module.params['vlan_id']
+        self.temporary = module.params['temporary']
+        self.state = module.params['state']
+
+    def vlan_exists(self):
+        cmd = [self.module.get_bin_path('dladm', True)]
+
+        cmd.append('show-vlan')
+        cmd.append(self.name)
+
+        (rc, _, _) = self.module.run_command(cmd)
+
+        if rc == 0:
+            return True
+        else:
+            return False
+
+    def create_vlan(self):
+        cmd = [self.module.get_bin_path('dladm', True)]
+
+        cmd.append('create-vlan')
+
+        if self.temporary:
+            cmd.append('-t')
+
+        cmd.append('-l')
+        cmd.append(self.link)
+        cmd.append('-v')
+        cmd.append(self.vlan_id)
+        cmd.append(self.name)
+
+        return self.module.run_command(cmd)
+
+    def delete_vlan(self):
+        cmd = [self.module.get_bin_path('dladm', True)]
+
+        cmd.append('delete-vlan')
+
+        if self.temporary:
+            cmd.append('-t')
+        cmd.append(self.name)
+
+        return self.module.run_command(cmd)
+
+    def is_valid_vlan_id(self):
+
+        return 0 <= int(self.vlan_id) <= 4095
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(required=True, type='str'),
+            link=dict(default=None, type='str'),
+            vlan_id=dict(default=0, aliases=['vid']),
+            temporary=dict(default=False, type='bool'),
+            state=dict(default='present', choices=['absent', 'present']),
+        ),
+        required_if=[
+            ['state', 'present', ['vlan_id', 'link', 'name']],
+        ],
+        supports_check_mode=True
+    )
+
+    vlan = VLAN(module)
+
+    rc = None
+    out = ''
+    err = ''
+    result = {}
+    result['name'] = vlan.name
+    result['link'] = vlan.link
+    result['state'] = vlan.state
+    result['temporary'] = vlan.temporary
+
+    if int(vlan.vlan_id) != 0:
+        if not vlan.is_valid_vlan_id():
+            module.fail_json(msg='Invalid VLAN id value',
+                             name=vlan.name,
+                             state=vlan.state,
+                             link=vlan.link,
+                             vlan_id=vlan.vlan_id)
+        result['vlan_id'] = vlan.vlan_id
+
+    if vlan.state == 'absent':
+        if vlan.vlan_exists():
+            if module.check_mode:
+                module.exit_json(changed=True)
+            (rc, out, err) = vlan.delete_vlan()
+            if rc != 0:
+                module.fail_json(name=vlan.name, msg=err, rc=rc)
+    elif vlan.state == 'present':
+        if not vlan.vlan_exists():
+            if module.check_mode:
+                module.exit_json(changed=True)
+            (rc, out, err) = vlan.create_vlan()
+
+        if rc is not None and rc != 0:
+            module.fail_json(name=vlan.name, msg=err, rc=rc)
+
+    if rc is None:
+        result['changed'] = False
+    else:
+        result['changed'] = True
+
+    if out:
+        result['stdout'] = out
+    if err:
+        result['stderr'] = err
+
+    module.exit_json(**result)
+
+from ansible.module_utils.basic import *
+main()

--- a/lib/ansible/modules/network/illumos/ipadm_addr.py
+++ b/lib/ansible/modules/network/illumos/ipadm_addr.py
@@ -1,0 +1,373 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2015, Adam Števko <adam.stevko@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+#
+
+DOCUMENTATION = '''
+---
+module: ipadm_addr
+short_description: Manage IP addresses on an interface.
+description:
+    - Create/delete static/dynamic IP addresses on network interfaces on Solaris/illumos systems.
+    - Up/down static/dynamic IP addresses on network interfaces on Solaris/illumos systems.
+    - Manage IPv6 link-local addresses on network interfaces on Solaris/illumos systems.
+version_added: "2.1"
+author: Adam Števko (@xen0l)
+options:
+    address:
+        description:
+            - Specifiies an IP address to configure in CIDR notation.
+        required: false
+        aliases: [ "addr" ]
+    addrtype:
+        description:
+            - Specifiies a type of IP address to configure.
+        required: false
+        default: static
+        choices: [ 'static', 'dhcp', 'addrconf' ]
+    addrobj:
+        description:
+            - Specifies an unique IP address on the system.
+        required: true
+    temporary:
+        description:
+            - Specifies that the configured IP address is temporary. Temporary
+              IP addresses do not persist across reboots.
+        required: false
+        default: false
+    wait:
+        description:
+            - Specifies the time in seconds we wait for obtaining address via DHCP.
+        required: false
+        default: 60
+    state:
+        description:
+            - Create/delete/enable/disable an IP address on the network interface.
+        required: false
+        default: present
+        choices: [ 'absent', 'present', 'up', 'down', 'enabled', 'disabled', 'refreshed' ]
+'''
+
+EXAMPLES = '''
+# Configure IP address 10.0.0.1 on e1000g0
+ipadm_addr: addr=10.0.0.1/32 addrobj=e1000g0/v4 state=present
+
+# Delete addrobj
+ipadm_addr: addrobj=e1000g0/v4 state=absent
+
+# Configure link-local IPv6 address
+ipadm_addr: addtype=addrconf addrobj=vnic0/v6
+
+# Configure address via DHCP and wait 180 seconds for address obtaining
+ipadm_addr: addrobj=vnic0/dhcp addrtype=dhcp wait=180
+'''
+
+import socket
+
+SUPPORTED_TYPES = ['static', 'addrconf', 'dhcp']
+
+
+class Addr(object):
+
+    def __init__(self, module):
+        self.module = module
+
+        self.address = module.params['address']
+        self.addrtype = module.params['addrtype']
+        self.addrobj = module.params['addrobj']
+        self.temporary = module.params['temporary']
+        self.state = module.params['state']
+        self.wait = module.params['wait']
+
+    def is_cidr_notation(self):
+
+        return self.address.count('/') == 1
+
+    def is_valid_address(self):
+
+        ip_address = self.address.split('/')[0]
+
+        try:
+            if len(ip_address.split('.')) == 4:
+                socket.inet_pton(socket.AF_INET, ip_address)
+            else:
+                socket.inet_pton(socket.AF_INET6, ip_address)
+        except socket.error:
+            return False
+
+        return True
+
+    def is_dhcp(self):
+        cmd = [self.module.get_bin_path('ipadm')]
+
+        cmd.append('show-addr')
+        cmd.append('-p')
+        cmd.append('-o')
+        cmd.append('type')
+        cmd.append(self.addrobj)
+
+        (rc, out, err) = self.module.run_command(cmd)
+
+        if rc == 0:
+            if out.rstrip() != 'dhcp':
+                return False
+
+            return True
+        else:
+            self.module.fail_json(msg='Wrong addrtype %s for addrobj "%s": %s' % (out, self.addrobj, err),
+                                  rc=rc,
+                                  stderr=err)
+
+    def addrobj_exists(self):
+        cmd = [self.module.get_bin_path('ipadm')]
+
+        cmd.append('show-addr')
+        cmd.append(self.addrobj)
+
+        (rc, _, _) = self.module.run_command(cmd)
+
+        if rc == 0:
+            return True
+        else:
+            return False
+
+    def delete_addr(self):
+        cmd = [self.module.get_bin_path('ipadm')]
+
+        cmd.append('delete-addr')
+        cmd.append(self.addrobj)
+
+        return self.module.run_command(cmd)
+
+    def create_addr(self):
+        cmd = [self.module.get_bin_path('ipadm')]
+
+        cmd.append('create-addr')
+        cmd.append('-T')
+        cmd.append(self.addrtype)
+
+        if self.temporary:
+            cmd.append('-t')
+
+        if self.addrtype == 'static':
+            cmd.append('-a')
+            cmd.append(self.address)
+
+        if self.addrtype == 'dhcp' and self.wait:
+            cmd.append('-w')
+            cmd.append(self.wait)
+
+        cmd.append(self.addrobj)
+
+        return self.module.run_command(cmd)
+
+    def up_addr(self):
+        cmd = [self.module.get_bin_path('ipadm')]
+
+        cmd.append('up-addr')
+
+        if self.temporary:
+            cmd.append('-t')
+
+        cmd.append(self.addrobj)
+
+        return self.module.run_command(cmd)
+
+    def down_addr(self):
+        cmd = [self.module.get_bin_path('ipadm')]
+
+        cmd.append('down-addr')
+
+        if self.temporary:
+            cmd.append('-t')
+
+        cmd.append(self.addrobj)
+
+        return self.module.run_command(cmd)
+
+    def enable_addr(self):
+        cmd = [self.module.get_bin_path('ipadm')]
+
+        cmd.append('enable-addr')
+        cmd.append('-t')
+        cmd.append(self.addrobj)
+
+        return self.module.run_command(cmd)
+
+    def disable_addr(self):
+        cmd = [self.module.get_bin_path('ipadm')]
+
+        cmd.append('disable-addr')
+        cmd.append('-t')
+        cmd.append(self.addrobj)
+
+        return self.module.run_command(cmd)
+
+    def refresh_addr(self):
+        cmd = [self.module.get_bin_path('ipadm')]
+
+        cmd.append('refresh-addr')
+        cmd.append(self.addrobj)
+
+        return self.module.run_command(cmd)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            address=dict(aliases=['addr']),
+            addrtype=dict(default='static', choices=SUPPORTED_TYPES),
+            addrobj=dict(required=True),
+            temporary=dict(default=False, type='bool'),
+            state=dict(
+                default='present', choices=['absent', 'present', 'up', 'down', 'enabled', 'disabled', 'refreshed']),
+            wait=dict(default=60),
+        ),
+        mutually_exclusive=[
+            ('address', 'wait'),
+        ],
+        supports_check_mode=True
+    )
+
+    addr = Addr(module)
+
+    rc = None
+    out = ''
+    err = ''
+    result = {}
+    result['addrobj'] = addr.addrobj
+    result['state'] = addr.state
+    result['temporary'] = addr.temporary
+    result['addrtype'] = addr.addrtype
+
+    if addr.addrtype == 'static' and addr.address:
+        if addr.is_cidr_notation() and addr.is_valid_address():
+            result['address'] = addr.address
+        else:
+            module.fail_json(msg='Invalid IP address: %s' % addr.address)
+
+    if addr.addrtype == 'dhcp' and addr.wait:
+        result['wait'] = addr.wait
+
+    if addr.state == 'absent':
+        if addr.addrobj_exists():
+            if module.check_mode:
+                module.exit_json(changed=True)
+
+            (rc, out, err) = addr.delete_addr()
+            if rc != 0:
+                module.fail_json(msg='Error while deleting addrobj: "%s"' % err,
+                                 addrobj=addr.addrobj,
+                                 stderr=err,
+                                 rc=rc)
+
+    elif addr.state == 'present':
+        if not addr.addrobj_exists():
+            if module.check_mode:
+                module.exit_json(changed=True)
+
+            (rc, out, err) = addr.create_addr()
+            if rc != 0:
+                module.fail_json(msg='Error while configuring IP address: "%s"' % err,
+                                 addrobj=addr.addrobj,
+                                 addr=addr.address,
+                                 stderr=err,
+                                 rc=rc)
+
+    elif addr.state == 'up':
+        if addr.addrobj_exists():
+            if module.check_mode:
+                module.exit_json(changed=True)
+
+            (rc, out, err) = addr.up_addr()
+            if rc != 0:
+                module.fail_json(msg='Error while bringing IP address up: "%s"' % err,
+                                 addrobj=addr.addrobj,
+                                 stderr=err,
+                                 rc=rc)
+
+    elif addr.state == 'down':
+        if addr.addrobj_exists():
+            if module.check_mode:
+                module.exit_json(changed=True)
+
+            (rc, out, err) = addr.down_addr()
+            if rc != 0:
+                module.fail_json(msg='Error while bringing IP address down: "%s"' % err,
+                                 addrobj=addr.addrobj,
+                                 stderr=err,
+                                 rc=rc)
+
+    elif addr.state == 'refreshed':
+        if addr.addrobj_exists():
+            if addr.is_dhcp():
+                if module.check_mode:
+                    module.exit_json(changed=True)
+
+                (rc, out, err) = addr.refresh_addr()
+                if rc != 0:
+                    module.fail_json(msg='Error while refreshing IP address: "%s"' % err,
+                                     addrobj=addr.addrobj,
+                                     stderr=err,
+                                     rc=rc)
+            else:
+                module.fail_json(msg='state "refreshed" cannot be used with "%s" addrtype' % addr.addrtype,
+                                 addrobj=addr.addrobj,
+                                 stderr=err,
+                                 rc=1)
+
+    elif addr.state == 'enabled':
+        if addr.addrobj_exists():
+            if module.check_mode:
+                module.exit_json(changed=True)
+
+            (rc, out, err) = addr.enable_addr()
+            if rc != 0:
+                module.fail_json(msg='Error while enabling IP address: "%s"' % err,
+                                 addrobj=addr.addrobj,
+                                 stderr=err,
+                                 rc=rc)
+
+    elif addr.state == 'disabled':
+        if addr.addrobj_exists():
+            if module.check_mode:
+                module.exit_json(changed=True)
+
+            (rc, out, err) = addr.disable_addr()
+            if rc != 0:
+                module.fail_json(msg='Error while disabling IP address: "%s"' % err,
+                                 addrobj=addr.addrobj,
+                                 stderr=err,
+                                 rc=rc)
+
+    if rc is None:
+        result['changed'] = False
+    else:
+        result['changed'] = True
+
+    if out:
+        result['stdout'] = out
+    if err:
+        result['stderr'] = err
+
+    module.exit_json(**result)
+
+
+from ansible.module_utils.basic import *
+main()

--- a/lib/ansible/modules/network/illumos/ipadm_addrprop.py
+++ b/lib/ansible/modules/network/illumos/ipadm_addrprop.py
@@ -1,0 +1,237 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2015, Adam Števko <adam.stevko@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+#
+
+DOCUMENTATION = '''
+---
+module: ipadm_addrprop
+short_description: Manage IP address properties on Solaris/illumos systems.
+description:
+    - Modify IP address properties on Solaris/illumos systems.
+version_added: "2.3"
+author: Adam Števko (@xen0l)
+options:
+    addrobj:
+        description:
+            - Specifies the address object we want to manage.
+        required: true
+        aliases: [nic, interface]
+    property:
+        description:
+            - Specifies the name of the address property we want to manage.
+        required: true
+        aliases: [name]
+    value:
+        description:
+            - Specifies the value we want to set for the address property.
+        required: false
+    temporary:
+        description:
+            - Specifies that the address property value is temporary.
+              Temporary values do not persist across reboots.
+        required: false
+        default: false
+    state:
+        description:
+            - Set or reset the property value.
+        required: false
+        default: present
+        choices: [ "present", "absent", "reset" ]
+'''
+
+EXAMPLES = '''
+# Mark address on addrobj as deprecated
+ipadm_addrprop: property=deprecated value=on addrobj=e1000g0/v6
+
+# Set network prefix length for addrobj
+ipadm_addrprop: addrobj=bge0/v4 name=prefixlen value=26
+'''
+
+RETURN = '''
+'''
+
+
+class AddrProp(object):
+
+    def __init__(self, module):
+        self.module = module
+
+        self.addrobj = module.params['addrobj']
+        self.property = module.params['property']
+        self.value = module.params['value']
+        self.temporary = module.params['temporary']
+        self.state = module.params['state']
+
+    def property_exists(self):
+        cmd = [self.module.get_bin_path('ipadm')]
+
+        cmd.append('show-addrprop')
+        cmd.append('-p')
+        cmd.append(self.property)
+        cmd.append(self.addrobj)
+
+        (rc, _, _) = self.module.run_command(cmd)
+
+        if rc == 0:
+            return True
+        else:
+            self.module.fail_json(msg='Unknown property "%s" on addrobj %s' %
+                                  (self.property, self.addrobj),
+                                  property=self.property,
+                                  addrobj=self.addrobj)
+
+    def property_is_modified(self):
+        cmd = [self.module.get_bin_path('ipadm')]
+
+        cmd.append('show-addrprop')
+        cmd.append('-c')
+        cmd.append('-o')
+        cmd.append('current,default')
+        cmd.append('-p')
+        cmd.append(self.property)
+        cmd.append(self.addrobj)
+
+        (rc, out, _) = self.module.run_command(cmd)
+
+        out = out.rstrip()
+        (value, default) = out.split(':')
+
+        if rc == 0 and value == default:
+            return True
+        else:
+            return False
+
+    def property_is_set(self):
+        cmd = [self.module.get_bin_path('ipadm')]
+
+        cmd.append('show-addrprop')
+        cmd.append('-c')
+        cmd.append('-o')
+        cmd.append('current')
+        cmd.append('-p')
+        cmd.append(self.property)
+        cmd.append(self.addrobj)
+
+        (rc, out, _) = self.module.run_command(cmd)
+
+        out = out.rstrip()
+
+        if rc == 0 and self.value == out:
+            return True
+        else:
+            return False
+
+    def set_property(self):
+        cmd = [self.module.get_bin_path('ipadm')]
+
+        cmd.append('set-addrprop')
+
+        if self.temporary:
+            cmd.append('-t')
+
+        cmd.append('-p')
+        cmd.append(self.property + '=' + self.value)
+        cmd.append(self.addrobj)
+
+        return self.module.run_command(cmd)
+
+    def reset_property(self):
+        cmd = [self.module.get_bin_path('ipadm')]
+
+        cmd.append('reset-addrprop')
+
+        if self.temporary:
+            cmd.append('-t')
+
+        cmd.append('-p')
+        cmd.append(self.property)
+        cmd.append(self.addrobj)
+
+        return self.module.run_command(cmd)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            addrobj=dict(required=True, default=None, aliases=['nic, interface']),
+            property=dict(required=True, aliases=['name']),
+            value=dict(required=False),
+            temporary=dict(default=False, type='bool'),
+            state=dict(
+                default='present', choices=['absent', 'present', 'reset']),
+        ),
+        supports_check_mode=True
+    )
+
+    addrprop = AddrProp(module)
+
+    rc = None
+    out = ''
+    err = ''
+    result = {}
+    result['property'] = addrprop.property
+    result['addrobj'] = addrprop.addrobj
+    result['state'] = addrprop.state
+    if addrprop.value:
+        result['value'] = addrprop.value
+
+    if addrprop.state == 'absent' or addrprop.state == 'reset':
+        if addrprop.property_exists():
+            if not addrprop.property_is_modified():
+                if module.check_mode:
+                    module.exit_json(changed=True)
+                (rc, out, err) = addrprop.reset_property()
+                if rc != 0:
+                    module.fail_json(property=addrprop.property,
+                                     addrobj=addrprop.addrobj,
+                                     msg=err,
+                                     rc=rc)
+
+    elif addrprop.state == 'present':
+        if addrprop.value is None:
+            module.fail_json(msg='Value is mandatory with state "present"')
+
+        if addrprop.property_exists():
+            if not addrprop.property_is_set():
+                if module.check_mode:
+                    module.exit_json(changed=True)
+
+                (rc, out, err) = addrprop.set_property()
+                if rc != 0:
+                    module.fail_json(property=addrprop.property,
+                                     addrobj=addrprop.addrobj,
+                                     msg=err,
+                                     rc=rc)
+
+    if rc is None:
+        result['changed'] = False
+    else:
+        result['changed'] = True
+
+    if out:
+        result['stdout'] = out
+    if err:
+        result['stderr'] = err
+
+    module.exit_json(**result)
+
+
+from ansible.module_utils.basic import *
+main()

--- a/lib/ansible/modules/network/illumos/ipadm_ifprop.py
+++ b/lib/ansible/modules/network/illumos/ipadm_ifprop.py
@@ -1,0 +1,265 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2015, Adam Števko <adam.stevko@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+#
+
+DOCUMENTATION = '''
+---
+module: ipadm_ifprop
+short_description: Manage IP interface properties on Solaris/illumos systems.
+description:
+    - Modify IP interface properties on Solaris/illumos systems.
+version_added: "2.3"
+author: Adam Števko (@xen0l)
+options:
+    interface:
+        description:
+            - Specifies the IP interface we want to manage.
+        required: true
+        aliases: [nic]
+    protocol:
+        description:
+            - Specifies the procotol for which we want to manage properties.
+        required: true
+    property:
+        description:
+            - Specifies the name of the property we want to manage.
+        required: true
+        aliases: [name]
+    value:
+        description:
+            - Specifies the value we want to set for the property.
+        required: false
+    temporary:
+        description:
+            - Specifies that the property value is temporary. Temporary
+              property values do not persist across reboots.
+        required: false
+        default: false
+    state:
+        description:
+            - Set or reset the property value.
+        required: false
+        default: present
+        choices: [ "present", "absent", "reset" ]
+'''
+
+EXAMPLES = '''
+# Allow forwarding of IPv4 packets on network interface e1000g0
+ipadm_ifprop: protocol=ipv4 property=forwarding value=on interface=e1000g0
+
+# Temporarily reset IPv4 forwarding property on network interface e1000g0
+ipadm_ifprop: protocol=ipv4 interface=e1000g0  temporary=true property=forwarding state=reset
+
+# Configure IPv6 metric on network interface e1000g0
+ipadm_ifprop: protocol=ipv6 nic=e1000g0 name=metric value=100
+
+# Set IPv6 MTU on network interface bge0
+ipadm_ifprop: interface=bge0 name=mtu value=1280 protocol=ipv6
+'''
+
+RETURN = '''
+'''
+
+SUPPORTED_PROTOCOLS = ['ipv4', 'ipv6']
+
+
+class IfProp(object):
+
+    def __init__(self, module):
+        self.module = module
+
+        self.interface = module.params['interface']
+        self.protocol = module.params['protocol']
+        self.property = module.params['property']
+        self.value = module.params['value']
+        self.temporary = module.params['temporary']
+        self.state = module.params['state']
+
+    def property_exists(self):
+        cmd = [self.module.get_bin_path('ipadm')]
+
+        cmd.append('show-ifprop')
+        cmd.append('-p')
+        cmd.append(self.property)
+        cmd.append('-m')
+        cmd.append(self.protocol)
+        cmd.append(self.interface)
+
+        (rc, _, _) = self.module.run_command(cmd)
+
+        if rc == 0:
+            return True
+        else:
+            self.module.fail_json(msg='Unknown %s property "%s" on IP interface %s' %
+                                  (self.protocol, self.property, self.interface),
+                                  protocol=self.protocol,
+                                  property=self.property,
+                                  interface=self.interface)
+
+    def property_is_modified(self):
+        cmd = [self.module.get_bin_path('ipadm')]
+
+        cmd.append('show-ifprop')
+        cmd.append('-c')
+        cmd.append('-o')
+        cmd.append('current,default')
+        cmd.append('-p')
+        cmd.append(self.property)
+        cmd.append('-m')
+        cmd.append(self.protocol)
+        cmd.append(self.interface)
+
+        (rc, out, _) = self.module.run_command(cmd)
+
+        out = out.rstrip()
+        (value, default) = out.split(':')
+
+        if rc == 0 and value == default:
+            return True
+        else:
+            return False
+
+    def property_is_set(self):
+        cmd = [self.module.get_bin_path('ipadm')]
+
+        cmd.append('show-ifprop')
+        cmd.append('-c')
+        cmd.append('-o')
+        cmd.append('current')
+        cmd.append('-p')
+        cmd.append(self.property)
+        cmd.append('-m')
+        cmd.append(self.protocol)
+        cmd.append(self.interface)
+
+        (rc, out, _) = self.module.run_command(cmd)
+
+        out = out.rstrip()
+
+        if rc == 0 and self.value == out:
+            return True
+        else:
+            return False
+
+    def set_property(self):
+        cmd = [self.module.get_bin_path('ipadm')]
+
+        cmd.append('set-ifprop')
+
+        if self.temporary:
+            cmd.append('-t')
+
+        cmd.append('-p')
+        cmd.append(self.property + "=" + self.value)
+        cmd.append('-m')
+        cmd.append(self.protocol)
+        cmd.append(self.interface)
+
+        return self.module.run_command(cmd)
+
+    def reset_property(self):
+        cmd = [self.module.get_bin_path('ipadm')]
+
+        cmd.append('reset-ifprop')
+
+        if self.temporary:
+            cmd.append('-t')
+
+        cmd.append('-p')
+        cmd.append(self.property)
+        cmd.append('-m')
+        cmd.append(self.protocol)
+        cmd.append(self.interface)
+
+        return self.module.run_command(cmd)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            protocol=dict(required=True, choices=SUPPORTED_PROTOCOLS),
+            property=dict(required=True, aliases=['name']),
+            value=dict(required=False),
+            temporary=dict(default=False, type='bool'),
+            interface=dict(required=True, default=None, aliases=['nic']),
+            state=dict(
+                default='present', choices=['absent', 'present', 'reset']),
+        ),
+        supports_check_mode=True
+    )
+
+    ifprop = IfProp(module)
+
+    rc = None
+    out = ''
+    err = ''
+    result = {}
+    result['protocol'] = ifprop.protocol
+    result['property'] = ifprop.property
+    result['interface'] = ifprop.interface
+    result['state'] = ifprop.state
+    if ifprop.value:
+        result['value'] = ifprop.value
+
+    if ifprop.state == 'absent' or ifprop.state == 'reset':
+        if ifprop.property_exists():
+            if not ifprop.property_is_modified():
+                if module.check_mode:
+                    module.exit_json(changed=True)
+                (rc, out, err) = ifprop.reset_property()
+                if rc != 0:
+                    module.fail_json(protocol=ifprop.protocol,
+                                     property=ifprop.property,
+                                     interface=ifprop.interface,
+                                     msg=err,
+                                     rc=rc)
+
+    elif ifprop.state == 'present':
+        if ifprop.value is None:
+            module.fail_json(msg='Value is mandatory with state "present"')
+
+        if ifprop.property_exists():
+            if not ifprop.property_is_set():
+                if module.check_mode:
+                    module.exit_json(changed=True)
+
+                (rc, out, err) = ifprop.set_property()
+                if rc != 0:
+                    module.fail_json(protocol=ifprop.protocol,
+                                     property=ifprop.property,
+                                     interface=ifprop.interface,
+                                     msg=err,
+                                     rc=rc)
+
+    if rc is None:
+        result['changed'] = False
+    else:
+        result['changed'] = True
+
+    if out:
+        result['stdout'] = out
+    if err:
+        result['stderr'] = err
+
+    module.exit_json(**result)
+
+
+from ansible.module_utils.basic import *
+main()


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request


##### COMPONENT NAME
dladm_iptun
dladm_linkprop
dladm_vlan
ipadm_addr
ipadm_addrprop
ipadm_ifprop

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
latest
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

These modules extend Ansible's support for configuring networking on Solaris/illumos systems.
With these modules the 90% of networking configuration use cases on Solaris/illumos systems are covered.
