### PR TITLE
Ansible doesn't require paramiko anymore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,5 @@
 # be suitable)
 jinja2
 PyYAML
-paramiko
 pycrypto >= 2.6
 setuptools


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request
##### COMPONENT NAME
install
##### ANSIBLE VERSION
```
ansible 2.3.0 (remove_host b2346c2525) last updated 2016/12/15 14:43:56 (GMT +200)
  config file = /home/jpic/.ansible.cfg
  configured module search path = ['/home/jpic/ansible/library', '/usr/share/ansible']
```

##### SUMMARY

This commit prevents setuptools from blowing up when ansible is installed and paramiko is not. 