### PR TITLE
Fix assembling unicode-named files.

### DIFF
--- a/lib/ansible/modules/files/assemble.py
+++ b/lib/ansible/modules/files/assemble.py
@@ -137,7 +137,7 @@ def assemble_from_fragments(src_path, delimiter=None, compiled_regexp=None, igno
     delimit_me = False
     add_newline = False
 
-    for f in sorted(os.listdir(src_path)):
+    for f in sorted(os.listdir(u"%s" % src_path)):
         if compiled_regexp and not compiled_regexp.search(f):
             continue
         fragment = u"%s/%s" % (src_path, f)


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ansible_module_assemble
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes https://github.com/ansible/ansible/issues/19437

`os.listdir()` returns unicode strings only if its argument is also unicode.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```

