### PR TITLE
removed unused 'static' option

### DIFF
--- a/lib/ansible/modules/utilities/logic/include_role.py
+++ b/lib/ansible/modules/utilities/logic/include_role.py
@@ -41,11 +41,6 @@ options:
       - "File to load from a Role's defaults/ directory."
     required: False
     default: 'main'
-  static:
-    description:
-      - Gives Ansible a hint if this is a 'static' include or not. If static it implies that it won't need templating nor loops nor conditionals and will show included tasks in the --list options.
-    required: False
-    default: None
   allow_duplicates:
     description:
       - Overrides the role's metadata setting to allow using a role more than once with the same parameters.
@@ -56,10 +51,9 @@ options:
       - If True the variables from defaults/ and vars/ in a role will not be made available to the rest of the play.
     default: None
 notes:
-    - THIS IS EARLY PREVIEW, THINGS MAY CHANGE
     - Handlers are made available to the whole play.
     - simple dependencies seem to work fine.
-    - "Things not tested (yet): plugin overrides, nesting includes, used as handler, other stuff I did not think of when I wrote this."
+    - As with C(include) this task can be static or dynamic, If static it implies that it won't need templating nor loops nor conditionals and will show included tasks in the --list options. Ansible will try to autodetect what is needed, but you can set `static: yes|no` at task level to control this.
 '''
 
 EXAMPLES = """

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -48,7 +48,6 @@ class IncludeRole(Task):
 
     # private as this is a 'module options' vs a task property
     _allow_duplicates = FieldAttribute(isa='bool', default=True, private=True)
-    _static = FieldAttribute(isa='bool', default=None, private=True)
     _private = FieldAttribute(isa='bool', default=None, private=True)
 
     def __init__(self, block=None, role=None, task_include=None):
@@ -113,7 +112,7 @@ class IncludeRole(Task):
 
         #FIXME: find a way to make this list come from object ( attributes does not work as per below)
         # manual list as otherwise the options would set other task parameters we don't want.
-        for option in ['static', 'private', 'allow_duplicates']:
+        for option in ['private', 'allow_duplicates']:
             if option in ir.args:
                 setattr(ir, option, ir.args.get(option))
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.2/2.3
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

the task level directive is what actually controls this, this option was never used
fixes #19438