### PR TITLE
Remove the `ignore` rules from MANIFEST.in for modules-core/extras repos

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -18,7 +18,3 @@ include MANIFEST.in
 include CHANGELOG.md
 include contrib/README.md
 recursive-include contrib/inventory *
-exclude lib/ansible/modules/core/.git*
-exclude lib/ansible/modules/extras/.git*
-prune lib/ansible/modules/core/.git
-prune lib/ansible/modules/extras/.git


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request
 
##### COMPONENT NAME
packaging

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Remove ignores for the submodules from the MANIFEST.in because that's no longer necessary. 
