### PR TITLE
user: make system=yes work on Darwin systems.

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -1539,7 +1539,7 @@ class DarwinUser(User):
         Return the next available uid. If system=True, then
         uid should be below of 500, if possible.
         '''
-        system = True if system == True else False
+        system = (system == True)
         cmd = self._get_dscl()
         cmd += ['-list', '/Users', 'UniqueID']
         (rc, out, err) = self.execute_command(cmd, obey_checkmode=False)

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -1539,7 +1539,6 @@ class DarwinUser(User):
         Return the next available uid. If system=True, then
         uid should be below of 500, if possible.
         '''
-        system = (system == True)
         cmd = self._get_dscl()
         cmd += ['-list', '/Users', 'UniqueID']
         (rc, out, err) = self.execute_command(cmd, obey_checkmode=False)


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
system/user.py module

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 4981feee99) last updated 2016/11/15 14:27:13 (GMT +200)
  lib/ansible/modules/core: (detached HEAD a4cddac368) last updated 2016/11/15 14:29:56 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 19c7d5b31b) last updated 2016/11/15 14:28:34 (GMT +200)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Extend user module for Darwin operating systems such that the `system` option of the user module now generates a system uid (< 500) if possible. If all system uids are taken, normal uid will be generated.

Extend `_get_next_uid` method of `DarwinUser` class  to take an extra argument `system` so the method knows, that the user wants a system uid. Change logic to prefer next free id below of 500.

Commit message: Add ability to add real system users with next free system uid (< 500) on macOS.