### PR TITLE
removes network os guess static method

### DIFF
--- a/lib/ansible/plugins/terminal/ios.py
+++ b/lib/ansible/plugins/terminal/ios.py
@@ -80,9 +80,3 @@ class TerminalModule(TerminalBase):
             self._exec_cli_command('disable')
 
 
-    @staticmethod
-    def guess_network_os(conn):
-        stdin, stdout, stderr = conn.exec_command('show version')
-        if 'Cisco IOS Software' in stdout.read():
-            return 'ios'
-

--- a/lib/ansible/plugins/terminal/iosxr.py
+++ b/lib/ansible/plugins/terminal/iosxr.py
@@ -30,7 +30,8 @@ class TerminalModule(TerminalBase):
 
     terminal_prompts_re = [
         re.compile(r"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
-        re.compile(r"\[\w+\@[\w\-\.]+(?: [^\]])\] ?[>#\$] ?$")
+        re.compile(r"\[\w+\@[\w\-\.]+(?: [^\]])\] ?[>#\$] ?$"),
+        re.compile(r']]>]]>[\r\n]?')
     ]
 
     terminal_errors_re = [
@@ -51,11 +52,3 @@ class TerminalModule(TerminalBase):
                 self._connection.exec_command(cmd)
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')
-
-    @staticmethod
-    def guess_network_os(conn):
-        stdin, stdout, stderr = conn.exec_command('show version')
-        if 'Cisco IOS XR' in stdout.read():
-            return 'iosxr'
-
-


### PR DESCRIPTION
For devices that do not support multiplexing, we cannot automatically
determine the network os.  This removes the os guess static method
from the terminal plugin.  For this devices, the network_os
value must be configured