### PR TITLE
Allow setting ipv4.dhcp-client-id parameter

### DIFF
--- a/lib/ansible/modules/network/nmcli.py
+++ b/lib/ansible/modules/network/nmcli.py
@@ -107,6 +107,12 @@ options:
         description:
             - The connection MTU, e.g. 9000. This can't be applied when creating the interface and is done once the interface has been created.
             - Can be used when modifying Team, VLAN, Ethernet (Future plans to implement wifi, pppoe, infiniband)
+    dhcp_client_id:
+        required: False
+        default: None
+        description:
+            - DHCP Client Identifier sent to the DHCP server
+        version_added: "2.3"
     primary:
         required: False
         default: None
@@ -567,6 +573,7 @@ class Nmcli(object):
         self.type=module.params['type']
         self.ip4=module.params['ip4']
         self.gw4=module.params['gw4']
+        self.dhcp_client_id=module.params['dhcp_client_id']
         self.dns4=module.params['dns4']
         self.ip6=module.params['ip6']
         self.gw6=module.params['gw6']
@@ -725,6 +732,9 @@ class Nmcli(object):
         if self.gw4 is not None:
             cmd.append('gw4')
             cmd.append(self.gw4)
+        if self.dhcp_client_id is not None:
+            cmd.append('ipv4.dhcp-client-id')
+            cmd.append(self.dhcp_client_id)
         if self.ip6 is not None:
             cmd.append('ip6')
             cmd.append(self.ip6)
@@ -748,6 +758,9 @@ class Nmcli(object):
         if self.gw4 is not None:
             cmd.append('ipv4.gateway')
             cmd.append(self.gw4)
+        if self.dhcp_client_id is not None:
+            cmd.append('ipv4.dhcp-client-id')
+            cmd.append(self.dhcp_client_id)
         if self.dns4 is not None:
             cmd.append('ipv4.dns')
             cmd.append(self.dns4)
@@ -827,6 +840,9 @@ class Nmcli(object):
         if self.gw4 is not None:
             cmd.append('gw4')
             cmd.append(self.gw4)
+        if self.dhcp_client_id is not None:
+            cmd.append('ipv4.dhcp-client-id')
+            cmd.append(self.dhcp_client_id)
         if self.ip6 is not None:
             cmd.append('ip6')
             cmd.append(self.ip6)
@@ -868,6 +884,9 @@ class Nmcli(object):
         if self.gw4 is not None:
             cmd.append('ipv4.gateway')
             cmd.append(self.gw4)
+        if self.dhcp_client_id is not None:
+            cmd.append('ipv4.dhcp-client-id')
+            cmd.append(self.dhcp_client_id)
         if self.dns4 is not None:
             cmd.append('ipv4.dns')
             cmd.append(self.dns4)
@@ -943,6 +962,9 @@ class Nmcli(object):
         if self.gw4 is not None:
             cmd.append('gw4')
             cmd.append(self.gw4)
+        if self.dhcp_client_id is not None:
+            cmd.append('ipv4.dhcp-client-id')
+            cmd.append(self.dhcp_client_id)
         if self.ip6 is not None:
             cmd.append('ip6')
             cmd.append(self.ip6)
@@ -969,6 +991,9 @@ class Nmcli(object):
         if self.gw4 is not None:
             cmd.append('ipv4.gateway')
             cmd.append(self.gw4)
+        if self.dhcp_client_id is not None:
+            cmd.append('ipv4.dhcp-client-id')
+            cmd.append(self.dhcp_client_id)
         if self.dns4 is not None:
             cmd.append('ipv4.dns')
             cmd.append(self.dns4)
@@ -1103,6 +1128,7 @@ def main():
             type=dict(required=False, default=None, choices=['ethernet', 'team', 'team-slave', 'bond', 'bond-slave', 'bridge', 'vlan'], type='str'),
             ip4=dict(required=False, default=None, type='str'),
             gw4=dict(required=False, default=None, type='str'),
+            dhcp_client_id=dict(required=False, default=None, type='str'),
             dns4=dict(required=False, default=None, type='str'),
             ip6=dict(required=False, default=None, type='str'),
             gw6=dict(required=False, default=None, type='str'),


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Plugin Name:

nmcli
##### Summary:

Allow setting ipv4.dhcp-client-id parameter for an interface.  Fixes #1523
##### Example:

```
- name: Configure dhcp-client-id for CORA network
  nmcli: state=present type=ethernet conn_name=CORA dhcp_client_id={{ ansible_fqdn }}
  tags: network
```
