### PR TITLE
Added listen_ports_facts module

### DIFF
--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -30,10 +30,12 @@ options:
   whitelist_tcp:
     description:
       - A list of TCP port numbers that are expected to have processes listening.
+    type: list
     default: []
   whitelist_udp:
     description:
       - A list of UDP port numbers that are expected to have processes listening.
+    type: list
     default: []
 '''
 

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
-# (c) 2017, Nathan Davison <ndavison85@gmail.com>
-#
 # -*- coding: utf-8 -*-
+#
 # (c) 2017, Nathan Davison <ndavison85@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -274,6 +274,28 @@ def applyWhitelist(portspids, whitelist=None):
     return processes
 
 
+def getPidSTime(pid):
+    ps_cmd = module.get_bin_path('ps', True)
+    rc, ps_output, stderr = module.run_command([ps_cmd, '-o', 'lstart', '-p', str(pid)])
+    stime = ''
+    if rc == 0:
+        for line in ps_output.splitlines():
+            if 'started' not in line:
+                stime = line
+    return stime
+
+
+def getPidUser(pid):
+    ps_cmd = module.get_bin_path('ps', True)
+    rc, ps_output, stderr = module.run_command([ps_cmd, '-o', 'user', '-p', str(pid)])
+    user = ''
+    if rc == 0:
+        for line in ps_output.splitlines():
+            if line != 'USER':
+                user = line
+    return user
+
+
 def main():
 
     module = AnsibleModule(
@@ -286,26 +308,6 @@ def main():
 
     if platform.system() != 'Linux':
         module.fail_json(msg='This module requires Linux.')
-
-    def getPidSTime(pid):
-        ps_cmd = module.get_bin_path('ps', True)
-        rc, ps_output, stderr = module.run_command([ps_cmd, '-o', 'lstart', '-p', pid])
-        stime = ''
-        if rc == 0:
-            for line in ps_output.splitlines():
-                if 'started' not in line:
-                    stime = line
-        return stime
-
-    def getPidUser(pid):
-        ps_cmd = module.get_bin_path('ps', True)
-        rc, ps_output, stderr = module.run_command([ps_cmd, '-o', 'user', '-p', pid])
-        user = ''
-        if rc == 0:
-            for line in ps_output.splitlines():
-                if line != 'USER':
-                    user = line
-        return user
 
     result = dict(
         changed=False,

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -260,5 +260,6 @@ def main():
 
     module.exit_json(**result)
 
+
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -289,20 +289,20 @@ def main():
 
     def getPidSTime(pid):
         ps_cmd = module.get_bin_path('ps', True)
-        rc, ps_output, stderr = module.run_command([ps_cmd, '-o', 'lstart', '-p', pid])
+        rc, ps_output, stderr = module.run_command([ps_cmd, '-o', 'lstart', '-p', str(pid)])
         stime = ''
         if rc == 0:
-            for line in ps_output.splitlines():
+            for line in iter(ps_output.splitlines()):
                 if 'started' not in line:
                     stime = line
         return stime
 
     def getPidUser(pid):
         ps_cmd = module.get_bin_path('ps', True)
-        rc, ps_output, stderr = module.run_command([ps_cmd, '-o', 'user', '-p', pid])
+        rc, ps_output, stderr = module.run_command([ps_cmd, '-o', 'user', '-p', str(pid)])
         user = ''
         if rc == 0:
-            for line in ps_output.splitlines():
+            for line in iter(ps_output.splitlines()):
                 if line != 'USER':
                     user = line
         return user

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -292,7 +292,7 @@ def main():
         rc, ps_output, stderr = module.run_command([ps_cmd, '-o', 'lstart', '-p', str(pid)])
         stime = ''
         if rc == 0:
-            for line in iter(ps_output.splitlines()):
+            for line in ps_output.splitlines():
                 if 'started' not in line:
                     stime = line
         return stime
@@ -302,7 +302,7 @@ def main():
         rc, ps_output, stderr = module.run_command([ps_cmd, '-o', 'user', '-p', str(pid)])
         user = ''
         if rc == 0:
-            for line in iter(ps_output.splitlines()):
+            for line in ps_output.splitlines():
                 if line != 'USER':
                     user = line
         return user

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -1,4 +1,6 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
 # (c) 2017, Nathan Davison <ndavison85@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -16,10 +18,11 @@ module: listen_ports_facts
 author:
     - Nathan Davison (@ndavison)
 
-version_added: "2.6"
+version_added: "2.8"
 
 description:
-    - Gather facts on processes listening on TCP and UDP ports. Optionally provide whitelists to gather facts on violations of the whitelist.
+    - Gather facts on processes listening on TCP and UDP ports.
+    - Optionally provide whitelists to gather facts on violations of the whitelist.
 
 short_description: Gather facts on processes listening on TCP and UDP ports.
 
@@ -35,7 +38,7 @@ options:
 '''
 
 EXAMPLES = '''
-- name: gather facts on listening ports, and populate the tcp_listen_violations fact with processes listening on TCP ports that are not 22, 80, or 443.
+- name: Gather facts on listening ports, and populate the tcp_listen_violations fact with processes listening on TCP ports that are not 22, 80, or 443.
   listen_ports_facts:
     whitelist_tcp:
       - 22
@@ -44,7 +47,7 @@ EXAMPLES = '''
 
 - name: TCP whitelist violation
   debug:
-    msg: "TCP port {{item.port}} by pid {{item.pid}} violates the whitelist"
+    msg: TCP port {{ item.port }} by pid {{ item.pid }} violates the whitelist
   with_items: "{{ tcp_listen_violations }}"
   when: tcp_listen_violations
 '''
@@ -186,10 +189,10 @@ def main():
 
     module = AnsibleModule(
         argument_spec=dict(
-            whitelist_tcp=dict(required=False, type='list', default=list()),
-            whitelist_udp=dict(required=False, type='list', default=list())
+            whitelist_tcp=dict(type='list', default=list()),
+            whitelist_udp=dict(type='list', default=list()),
         ),
-        supports_check_mode=True
+        supports_check_mode=True,
     )
 
     if platform.system() != 'Linux':
@@ -215,9 +218,15 @@ def main():
                     user = line
         return user
 
-    result = {}
-    result['changed'] = False
-    result['ansible_facts'] = dict(tcp_listen_violations=list(), udp_listen_violations=list(), tcp_listen=list(), udp_listen=list())
+    result = dict(
+        changed=False,
+        ansible_facts=dict(
+            tcp_listen_violations=list(),
+            udp_listen_violations=list(),
+            tcp_listen=list(),
+            udp_listen=list(),
+        )
+    )
 
     try:
         netstat_cmd = module.get_bin_path('netstat', True)

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
+# (c) 2017, Nathan Davison <ndavison85@gmail.com>
 #
+# -*- coding: utf-8 -*-
 # (c) 2017, Nathan Davison <ndavison85@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -289,20 +289,20 @@ def main():
 
     def getPidSTime(pid):
         ps_cmd = module.get_bin_path('ps', True)
-        rc, ps_output, stderr = module.run_command([ps_cmd, '-o', 'lstart', '-p', str(pid)])
+        rc, ps_output, stderr = module.run_command([ps_cmd, '-o', 'lstart', '-p', pid])
         stime = ''
         if rc == 0:
-            for line in iter(ps_output.splitlines()):
+            for line in ps_output.splitlines():
                 if 'started' not in line:
                     stime = line
         return stime
 
     def getPidUser(pid):
         ps_cmd = module.get_bin_path('ps', True)
-        rc, ps_output, stderr = module.run_command([ps_cmd, '-o', 'user', '-p', str(pid)])
+        rc, ps_output, stderr = module.run_command([ps_cmd, '-o', 'user', '-p', pid])
         user = ''
         if rc == 0:
-            for line in iter(ps_output.splitlines()):
+            for line in ps_output.splitlines():
                 if line != 'USER':
                     user = line
         return user

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -55,85 +55,171 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-tcp_listen:
-  description: A list of processes that are listening on a TCP port.
-  returned: when at least one process is listening on a TCP port.
-  type: list
-  sample:
-    - address: '0.0.0.0'
-      name: 'mysqld'
-      pid: 1223
-      port: 3306
-      protocol: 'tcp'
-      stime: 'Thu Feb  2 13:29:45 2017'
-      user: 'mysql'
-    - address: '0.0.0.0'
-      name: 'httpd'
-      pid: 905
-      port: 443
-      protocol: 'tcp'
-      stime: 'Thu Feb  2 13:29:45 2017'
-      user: 'apache'
-
-udp_listen:
-  description: A list of processes that are listening on a UDP port.
-  returned: when at least one process is listening on a UDP port.
-  type: list
-  sample:
-    - address: '0.0.0.0'
-      name: 'rsyslogd'
-      pid: 609
-      port: 514
-      protocol: 'udp'
-      stime: 'Thu Feb  2 13:29:45 2017'
-      user: 'root'
-    - address: '0.0.0.0'
-      name: 'chrome'
-      pid: 4551
-      port: 5353
-      protocol: 'udp'
-      stime: 'Thu Feb  2 13:29:45 2017'
-      user: 'root'
-
-tcp_listen_violations:
-  description: A list of processes that are listening on a TCP port that violated the whitelist_tcp argument.
-  returned: when at least one process that is listening on a TCP port isn't included in the supplied TCP whitelist.
-  type: list
-  sample:
-    - address: '0.0.0.0'
-      name: 'mysqld'
-      pid: 1223
-      port: 3306
-      protocol: 'tcp'
-      stime: 'Thu Feb  2 13:29:45 2017'
-      user: 'mysql'
-    - address: '0.0.0.0'
-      name: 'httpd'
-      pid: 905
-      port: 443
-      protocol: 'tcp'
-      stime: 'Thu Feb  2 13:29:45 2017'
-      user: 'apache'
-
-udp_listen_violations:
-  description: A list of processes that are listening on a UDP port that violated the whitelist_udp argument.
-  returned: when at least one process that is listening on a UDP port isn't included in the supplied UDP whitelist.
-  type: list
-  sample:
-    - address: '0.0.0.0'
-      name: 'rsyslogd'
-      pid: 609
-      port: 514
-      protocol: 'udp'
-      stime: 'Thu Feb  2 13:29:45 2017'
-      user: 'root'
-    - address: '0.0.0.0'
-      name: 'chrome'
-      pid: 4551
-      port: 5353
-      protocol: 'udp'
-      stime: 'Thu Feb  2 13:29:45 2017'
-      user: 'root'
+ansible_facts:
+  description: Dictionary containing details of TCP and UDP ports with listening servers and any violations not found in the optional whitelists
+  returned: always
+  type: complex
+  contains:
+    tcp_listen:
+      description: A list of processes that are listening on a TCP port.
+      returned: if TCP servers were found
+      type: list
+      contains:
+        address:
+          description: The address the server is listening on.
+          returned: always
+          type: str
+          sample: "0.0.0.0"
+        name:
+          description: The name of the listening process.
+          returned: if user permissions allow
+          type: str
+          sample: "mysqld"
+        pid:
+          description: The pid of the listening process.
+          returned: always
+          type: int
+          sample: 1223
+        port:
+          description: The port the server is listening on.
+          returned: always
+          type: int
+          sample: 3306
+        protocol:
+          description: The network protocol of the server.
+          returned: always
+          type: str
+          sample: "tcp"
+        stime:
+          description: The start time of the listening process.
+          returned: always
+          type: str
+          sample: "Thu Feb  2 13:29:45 2017"
+        user:
+          description: The user who is running the listening process.
+          returned: always
+          type: str
+          sample: "mysql"
+    udp_listen:
+      description: A list of processes that are listening on a UDP port.
+      returned: if UDP servers were found
+      type: list
+      contains:
+        address:
+          description: The address the server is listening on.
+          returned: always
+          type: str
+          sample: "0.0.0.0"
+        name:
+          description: The name of the listening process.
+          returned: if user permissions allow
+          type: str
+          sample: "rsyslogd"
+        pid:
+          description: The pid of the listening process.
+          returned: always
+          type: int
+          sample: 609
+        port:
+          description: The port the server is listening on.
+          returned: always
+          type: int
+          sample: 514
+        protocol:
+          description: The network protocol of the server.
+          returned: always
+          type: str
+          sample: "udp"
+        stime:
+          description: The start time of the listening process.
+          returned: always
+          type: str
+          sample: "Thu Feb  2 13:29:45 2017"
+        user:
+          description: The user who is running the listening process.
+          returned: always
+          type: str
+          sample: "root"
+    tcp_listen_violations:
+      description: A list of processes that are listening on a TCP port that was not in the whitelist_tcp argument.
+      returned: if a TCP whitelist was supplied and violations were found
+      type: list
+      contains:
+        address:
+          description: The address the server is listening on.
+          returned: always
+          type: str
+          sample: "0.0.0.0"
+        name:
+          description: The name of the listening process.
+          returned: if user permissions allow
+          type: str
+          sample: "mysqld"
+        pid:
+          description: The pid of the listening process.
+          returned: always
+          type: int
+          sample: 1223
+        port:
+          description: The port the server is listening on.
+          returned: always
+          type: int
+          sample: 3306
+        protocol:
+          description: The network protocol of the server.
+          returned: always
+          type: str
+          sample: "tcp"
+        stime:
+          description: The start time of the listening process.
+          returned: always
+          type: str
+          sample: "Thu Feb  2 13:29:45 2017"
+        user:
+          description: The user who is running the listening process.
+          returned: always
+          type: str
+          sample: "mysql"
+    udp_listen_violations:
+      description: A list of processes that are listening on a UDP port that was not in the whitelist_udp argument.
+      returned: if a UDP whitelist was supplied and violations were found
+      type: list
+      contains:
+        address:
+          description: The address the server is listening on.
+          returned: always
+          type: str
+          sample: "0.0.0.0"
+        name:
+          description: The name of the listening process.
+          returned: if user permissions allow
+          type: str
+          sample: "rsyslogd"
+        pid:
+          description: The pid of the listening process.
+          returned: always
+          type: int
+          sample: 609
+        port:
+          description: The port the server is listening on.
+          returned: always
+          type: int
+          sample: 514
+        protocol:
+          description: The network protocol of the server.
+          returned: always
+          type: str
+          sample: "udp"
+        stime:
+          description: The start time of the listening process.
+          returned: always
+          type: str
+          sample: "Thu Feb  2 13:29:45 2017"
+        user:
+          description: The user who is running the listening process.
+          returned: always
+          type: str
+          sample: "root"
 '''
 
 import re

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -274,28 +274,6 @@ def applyWhitelist(portspids, whitelist=None):
     return processes
 
 
-def getPidSTime(pid):
-    ps_cmd = module.get_bin_path('ps', True)
-    rc, ps_output, stderr = module.run_command([ps_cmd, '-o', 'lstart', '-p', str(pid)])
-    stime = ''
-    if rc == 0:
-        for line in ps_output.splitlines():
-            if 'started' not in line:
-                stime = line
-    return stime
-
-
-def getPidUser(pid):
-    ps_cmd = module.get_bin_path('ps', True)
-    rc, ps_output, stderr = module.run_command([ps_cmd, '-o', 'user', '-p', str(pid)])
-    user = ''
-    if rc == 0:
-        for line in ps_output.splitlines():
-            if line != 'USER':
-                user = line
-    return user
-
-
 def main():
 
     module = AnsibleModule(
@@ -308,6 +286,26 @@ def main():
 
     if platform.system() != 'Linux':
         module.fail_json(msg='This module requires Linux.')
+
+    def getPidSTime(pid):
+        ps_cmd = module.get_bin_path('ps', True)
+        rc, ps_output, stderr = module.run_command([ps_cmd, '-o', 'lstart', '-p', pid])
+        stime = ''
+        if rc == 0:
+            for line in ps_output.splitlines():
+                if 'started' not in line:
+                    stime = line
+        return stime
+
+    def getPidUser(pid):
+        ps_cmd = module.get_bin_path('ps', True)
+        rc, ps_output, stderr = module.run_command([ps_cmd, '-o', 'user', '-p', pid])
+        user = ''
+        if rc == 0:
+            for line in ps_output.splitlines():
+                if line != 'USER':
+                    user = line
+        return user
 
     result = dict(
         changed=False,

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -11,7 +11,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: listen_ports_facts
 
@@ -39,7 +39,7 @@ options:
     default: []
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Gather facts on listening ports, and populate the tcp_listen_violations fact with processes listening on TCP ports that are not 22, 80, or 443.
   listen_ports_facts:
     whitelist_tcp:
@@ -54,7 +54,7 @@ EXAMPLES = '''
   when: tcp_listen_violations
 '''
 
-RETURN = '''
+RETURN = r'''
 tcp_listen:
   description: A list of processes that are listening on a TCP port.
   returned: when at least one process is listening on a TCP port.

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -23,7 +23,7 @@ DOCUMENTATION = '''
 module: listen_ports_facts
 author:
     - '"Nathan Davison (@ndavison)" <ndavison85@gmail.com>'
-version_added: "2.3"
+version_added: "2.4"
 description:
     - Gather facts on processes listening on TCP and UDP ports. Optionally provide whitelists to gather facts on violations ofthe whitelist.
 short_description: Gather facts on processes listening on TCP and UDP ports.

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -23,11 +23,11 @@ options:
   whitelist_tcp:
     description:
       - A list of TCP port numbers that are expected to have processes listening.
-    default: list()
+    default: list
   whitelist_udp:
     description:
       - A list of UDP port numbers that are expected to have processes listening.
-    default: list()
+    default: list
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -38,135 +38,83 @@ EXAMPLES = '''
 RETURN = '''
 tcp_listen:
   description: A list of processes that are listening on a TCP port.
+  returned: success
   type: list
-  contains:
-    address:
-      description: The address (IPv4 or IPv6) of the process.
-      type: string
-      sample: '0.0.0.0'
-    name:
-      description: The name of the process.
-      type: string
-      sample: 'mysqld'
-    pid:
-      description: The pid of the process.
-      type: int
-      sample: 1223
-    port:
-      description: The port the pid was listening on.
-      type: int
-      sample: 3306
-    protocol:
-      description: The protocol, TCP or UDP, of the listening connection.
-      type: string
-      sample: 'tcp'
-    stime:
-      description: The start time of the process.
-      type: string
-      sample: 'Thu Feb  2 13:29:45 2017'
-    user:
-      description: The user running the process.
-      type: string
-      sample: 'mysql'
+  sample:
+    - address: '0.0.0.0'
+      name: 'mysqld'
+      pid: 1223
+      port: 3306
+      protocol: 'tcp'
+      stime: 'Thu Feb  2 13:29:45 2017'
+      user: 'mysql'
+    - address: '0.0.0.0'
+      name: 'httpd'
+      pid: 905
+      port: 443
+      protocol: 'tcp'
+      stime: 'Thu Feb  2 13:29:45 2017'
+      user: 'apache'
 
 udp_listen:
   description: A list of processes that are listening on a UDP port.
+  returned: success
   type: list
-  contains:
-    address:
-      description: The address (IPv4 or IPv6) of the process.
-      type: string
-      sample: '0.0.0.0'
-    name:
-      description: The name of the process.
-      type: string
-      sample: 'rsyslogd'
-    pid:
-      description: The pid of the process.
-      type: int
-      sample: 609
-    port:
-      description: The port the pid was listening on.
-      type: int
-      sample: 514
-    protocol:
-      description: The protocol, TCP or UDP, of the listening connection.
-      type: string
-      sample: 'udp'
-    stime:
-      description: The start time of the process.
-      type: string
-      sample: 'Thu Feb  2 13:29:45 2017'
-    user:
-      description: The user running the process.
-      type: string
-      sample: 'root'
+  sample:
+    - address: '0.0.0.0'
+      name: 'rsyslogd'
+      pid: 609
+      port: 514
+      protocol: 'udp'
+      stime: 'Thu Feb  2 13:29:45 2017'
+      user: 'root'
+    - address: '0.0.0.0'
+      name: 'chrome'
+      pid: 4551
+      port: 5353
+      protocol: 'udp'
+      stime: 'Thu Feb  2 13:29:45 2017'
+      user: 'root'
 
 tcp_listen_violations:
   description: A list of processes that are listening on a TCP port that violated the whitelist_tcp argument.
+  returned: success
   type: list
-  contains:
-    address:
-      description: The address (IPv4 or IPv6) of the process.
-      type: string
-      sample: '0.0.0.0'
-    name:
-      description: The name of the process.
-      type: string
-      sample: 'mysqld'
-    pid:
-      description: The pid of the process.
-      type: int
-      sample: 1223
-    port:
-      description: The port the pid was listening on.
-      type: int
-      sample: 3306
-    protocol:
-      description: The protocol, TCP or UDP, of the listening connection.
-      type: string
-      sample: 'tcp'
-    stime:
-      description: The start time of the process.
-      type: string
-      sample: 'Thu Feb  2 13:29:45 2017'
-    user:
-      description: The user running the process.
-      type: string
-      sample: 'mysql'
+  sample:
+    - address: '0.0.0.0'
+      name: 'mysqld'
+      pid: 1223
+      port: 3306
+      protocol: 'tcp'
+      stime: 'Thu Feb  2 13:29:45 2017'
+      user: 'mysql'
+    - address: '0.0.0.0'
+      name: 'httpd'
+      pid: 905
+      port: 443
+      protocol: 'tcp'
+      stime: 'Thu Feb  2 13:29:45 2017'
+      user: 'apache'
 
 udp_listen_violations:
   description: A list of processes that are listening on a UDP port that violated the whitelist_udp argument.
+  returned: success
   type: list
-  contains:
-    address:
-      description: The address (IPv4 or IPv6) of the process.
-      type: string
-      sample: '0.0.0.0'
-    name:
-      description: The name of the process.
-      type: string
-      sample: 'rsyslogd'
-    pid:
-      description: The pid of the process.
-      type: int
-      sample: 609
-    port:
-      description: The port the pid was listening on.
-      type: int
-      sample: 514
-    protocol:
-      description: The protocol, TCP or UDP, of the listening connection.
-      type: string
-      sample: 'udp'
-    stime:
-      description: The start time of the process.
-      type: string
-      sample: 'Thu Feb  2 13:29:45 2017'
-    user:
-      description: The user running the process.
-      type: string
-      sample: 'root'
+  sample:
+    - address: '0.0.0.0'
+      name: 'rsyslogd'
+      pid: 609
+      port: 514
+      protocol: 'udp'
+      stime: 'Thu Feb  2 13:29:45 2017'
+      user: 'root'
+    - address: '0.0.0.0'
+      name: 'chrome'
+      pid: 4551
+      port: 5353
+      protocol: 'udp'
+      stime: 'Thu Feb  2 13:29:45 2017'
+      user: 'root'
 '''
 
 ANSIBLE_METADATA = {'status': ['preview'],

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -168,7 +168,7 @@ def main():
         tcp_violations = applyWhitelist(tcp_ports, module.params['whitelist_tcp'])
         if tcp_violations:
             result['ansible_facts']['tcp_listen_violations'] = tcp_violations
-    
+
     # if a UDP whitelist was supplied, determine which if any pids violate it
     if module.params['whitelist_udp'] and udp_ports:
         udp_violations = applyWhitelist(udp_ports, module.params['whitelist_udp'])

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -23,11 +23,11 @@ options:
   whitelist_tcp:
     description:
       - A list of TCP port numbers that are expected to have processes listening.
-    default: list
+    default: []
   whitelist_udp:
     description:
       - A list of UDP port numbers that are expected to have processes listening.
-    default: list
+    default: []
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -253,18 +253,20 @@ def main():
         ps_cmd = module.get_bin_path('ps', True)
         rc, ps_output, stderr = module.run_command([ps_cmd, '-o', 'lstart', '-p', str(pid)])
         stime = ''
-        for line in iter(ps_output.splitlines()):
-            if 'started' not in line:
-                stime = line
+        if rc == 0:
+            for line in iter(ps_output.splitlines()):
+                if 'started' not in line:
+                    stime = line
         return stime
 
     def getPidUser(pid):
         ps_cmd = module.get_bin_path('ps', True)
         rc, ps_output, stderr = module.run_command([ps_cmd, '-o', 'user', '-p', str(pid)])
         user = ''
-        for line in iter(ps_output.splitlines()):
-            if line != 'USER':
-                user = line
+        if rc == 0:
+            for line in iter(ps_output.splitlines()):
+                if line != 'USER':
+                    user = line
         return user
 
     result = {}
@@ -276,23 +278,25 @@ def main():
 
         # which TCP ports are listening for connections?
         rc, output_tcp, stderr = module.run_command([netstat_cmd, '-plnt'])
-        tcp_ports = netStatParse(output_tcp)
-        for i, p in enumerate(tcp_ports):
-            p['stime'] = getPidSTime(p['pid'])
-            p['user'] = getPidUser(p['pid'])
-            tcp_ports[i] = p
-        if tcp_ports:
-            result['ansible_facts']['tcp_listen'] = tcp_ports
+        if rc == 0:
+            tcp_ports = netStatParse(output_tcp)
+            for i, p in enumerate(tcp_ports):
+                p['stime'] = getPidSTime(p['pid'])
+                p['user'] = getPidUser(p['pid'])
+                tcp_ports[i] = p
+            if tcp_ports:
+                result['ansible_facts']['tcp_listen'] = tcp_ports
 
         # which UDP ports are listening for connections?
         rc, output_udp, stderr = module.run_command([netstat_cmd, '-plnu'])
-        udp_ports = netStatParse(output_udp)
-        for i, p in enumerate(udp_ports):
-            p['stime'] = getPidSTime(p['pid'])
-            p['user'] = getPidUser(p['pid'])
-            udp_ports[i] = p
-        if udp_ports:
-            result['ansible_facts']['udp_listen'] = udp_ports
+        if rc == 0:
+            udp_ports = netStatParse(output_udp)
+            for i, p in enumerate(udp_ports):
+                p['stime'] = getPidSTime(p['pid'])
+                p['user'] = getPidUser(p['pid'])
+                udp_ports[i] = p
+            if udp_ports:
+                result['ansible_facts']['udp_listen'] = udp_ports
 
     except EnvironmentError:
         err = get_exception()

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -1,22 +1,6 @@
 #!/usr/bin/python
-# encoding: utf-8
-
-# (c) 2016, Nathan Davison <ndavison85@gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# (c) 2017, Nathan Davison <ndavison85@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 DOCUMENTATION = '''
 ---

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -117,9 +117,9 @@ udp_listen_violations:
       user: 'root'
 '''
 
-ANSIBLE_METADATA = {'status': ['preview'],
-                    'supported_by': 'community',
-                    'metadata_version': '1.0'}
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
 
 import re
 import platform

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -25,7 +25,7 @@ author:
     - '"Nathan Davison (@ndavison)" <ndavison85@gmail.com>'
 version_added: "2.3"
 description:
-    - | 
+    - |
       Gather facts on processes listening on TCP and UDP ports. Optionally provide a whitelist of TCP and/or UDP ports to gather facts on processes
        that violate the whitelists.
 short_description: Gather facts on processes listening on TCP and UDP ports.

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -287,10 +287,10 @@ def main():
                     result['ansible_facts']['tcp_listen'].append(p)
                 elif p['protocol'] == 'udp':
                     result['ansible_facts']['udp_listen'].append(p)
-
-    except EnvironmentError:
-        err = get_exception()
-        module.fail_json(msg=str(err))
+                    
+    except:
+        e = get_exception()
+        module.fail_json(msg=str(e))
 
     # if a TCP whitelist was supplied, determine which if any pids violate it
     if module.params['whitelist_tcp'] and result['ansible_facts']['tcp_listen']:

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -186,8 +186,8 @@ udp_listen_violations:
 '''
 
 ANSIBLE_METADATA = {'status': ['preview'],
-                    'supported_by': 'committer',
-                    'version': '1.0'}
+                    'supported_by': 'community',
+                    'metadata_version': '1.0'}
 
 import re
 import platform

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -5,6 +5,10 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
 DOCUMENTATION = '''
 ---
 module: listen_ports_facts
@@ -126,10 +130,6 @@ udp_listen_violations:
       stime: 'Thu Feb  2 13:29:45 2017'
       user: 'root'
 '''
-
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
 
 import re
 import platform

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -7,7 +7,7 @@ DOCUMENTATION = '''
 module: listen_ports_facts
 author:
     - Nathan Davison (@ndavison)
-version_added: "2.5"
+version_added: "2.4"
 description:
     - Gather facts on processes listening on TCP and UDP ports. Optionally provide whitelists to gather facts on violations of the whitelist.
 short_description: Gather facts on processes listening on TCP and UDP ports.

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -287,7 +287,7 @@ def main():
                     result['ansible_facts']['tcp_listen'].append(p)
                 elif p['protocol'] == 'udp':
                     result['ansible_facts']['udp_listen'].append(p)
-                    
+
     except:
         e = get_exception()
         module.fail_json(msg=str(e))

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -25,9 +25,7 @@ author:
     - '"Nathan Davison (@ndavison)" <ndavison85@gmail.com>'
 version_added: "2.3"
 description:
-    - |
-      Gather facts on processes listening on TCP and UDP ports. Optionally provide a whitelist of TCP and/or UDP ports to gather facts on processes
-       that violate the whitelists.
+    - Gather facts on processes listening on TCP and UDP ports. Optionally provide whitelists to gather facts on violations ofthe whitelist.
 short_description: Gather facts on processes listening on TCP and UDP ports.
 options:
   whitelist_tcp:

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -243,7 +243,7 @@ def main():
             whitelist_tcp = dict(required=False, type='list', default=list()),
             whitelist_udp = dict(required=False, type='list', default=list())
         ),
-        supports_check_mode=False
+        supports_check_mode=True
     )
 
     if platform.system() != 'Linux':

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -194,6 +194,7 @@ import platform
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
 
+
 def netStatParse(raw):
     results = list()
     for line in iter(raw.splitlines()):
@@ -227,6 +228,7 @@ def netStatParse(raw):
                 raise EnvironmentError('Could not get process information for the listening ports.')
     return results
 
+
 def applyWhitelist(portspids, whitelist=list()):
     processes = list()
     for p in portspids:
@@ -236,12 +238,13 @@ def applyWhitelist(portspids, whitelist=list()):
                 processes.append(process)
     return processes
 
+
 def main():
 
     module = AnsibleModule(
-        argument_spec = dict(
-            whitelist_tcp = dict(required=False, type='list', default=list()),
-            whitelist_udp = dict(required=False, type='list', default=list())
+        argument_spec=dict(
+            whitelist_tcp=dict(required=False, type='list', default=list()),
+            whitelist_udp=dict(required=False, type='list', default=list())
         ),
         supports_check_mode=True
     )

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -164,7 +164,9 @@ def netStatParse(raw):
     return results
 
 
-def applyWhitelist(portspids, whitelist=list()):
+def applyWhitelist(portspids, whitelist=None):
+    if whitelist is None:
+        whitelist = list()
     processes = list()
     for p in portspids:
         if int(p['port']) not in whitelist and str(p['port']) not in whitelist:

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -126,6 +126,7 @@ import platform
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
 
+
 def netStatParse(raw):
     results = list()
     for line in iter(raw.splitlines()):

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -2,6 +2,9 @@
 # (c) 2017, Nathan Davison <ndavison85@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 DOCUMENTATION = '''
 ---
 module: listen_ports_facts

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -214,8 +214,14 @@ def netStatParse(raw):
             if conns and pids:
                 address = conns.group(1)
                 port = conns.group(2)
-                pid = pids.group(2) if pids.group(2) else 0
-                name = pids.group(3) if pids.group(3) else ''
+                if (pids.group(2)):
+                    pid = pids.group(2)
+                else:
+                    pid = 0
+                if (pids.group(3)):
+                    name = pids.group(3)
+                else:
+                    name = ''
                 result = dict(pid=int(pid), address=address, port=int(port), protocol=protocol, name=name)
                 if result not in results:
                     results.append(result)

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -7,7 +7,7 @@ DOCUMENTATION = '''
 module: listen_ports_facts
 author:
     - Nathan Davison (@ndavison)
-version_added: "2.4"
+version_added: "2.5"
 description:
     - Gather facts on processes listening on TCP and UDP ports. Optionally provide whitelists to gather facts on violations of the whitelist.
 short_description: Gather facts on processes listening on TCP and UDP ports.
@@ -38,7 +38,7 @@ EXAMPLES = '''
 RETURN = '''
 tcp_listen:
   description: A list of processes that are listening on a TCP port.
-  returned: success
+  returned: when at least one process is listening on a TCP port.
   type: list
   sample:
     - address: '0.0.0.0'
@@ -58,7 +58,7 @@ tcp_listen:
 
 udp_listen:
   description: A list of processes that are listening on a UDP port.
-  returned: success
+  returned: when at least one process is listening on a UDP port.
   type: list
   sample:
     - address: '0.0.0.0'
@@ -78,7 +78,7 @@ udp_listen:
 
 tcp_listen_violations:
   description: A list of processes that are listening on a TCP port that violated the whitelist_tcp argument.
-  returned: success
+  returned: when at least one process that is listening on a TCP port isn't included in the supplied TCP whitelist.
   type: list
   sample:
     - address: '0.0.0.0'
@@ -98,7 +98,7 @@ tcp_listen_violations:
 
 udp_listen_violations:
   description: A list of processes that are listening on a UDP port that violated the whitelist_udp argument.
-  returned: success
+  returned: when at least one process that is listening on a UDP port isn't included in the supplied UDP whitelist.
   type: list
   sample:
     - address: '0.0.0.0'
@@ -117,7 +117,7 @@ udp_listen_violations:
       user: 'root'
 '''
 
-ANSIBLE_METADATA = {'metadata_version': '1.0',
+ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -197,7 +197,6 @@ ANSIBLE_METADATA = {'status': ['preview'],
 
 import re
 import platform
-from subprocess import Popen, PIPE
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
 
@@ -252,8 +251,7 @@ def main():
 
     def getPidSTime(pid):
         ps_cmd = module.get_bin_path('ps', True)
-        p1 = Popen([ps_cmd, '-o', 'lstart', '-p', str(pid)], stdout=PIPE, stderr=PIPE)
-        ps_output = p1.communicate()[0]
+        rc, ps_output, stderr = module.run_command([ps_cmd, '-o', 'lstart', '-p', str(pid)])
         stime = ''
         for line in iter(ps_output.splitlines()):
             if 'started' not in line:
@@ -262,8 +260,7 @@ def main():
 
     def getPidUser(pid):
         ps_cmd = module.get_bin_path('ps', True)
-        p1 = Popen([ps_cmd, '-o', 'user', '-p', str(pid)], stdout=PIPE, stderr=PIPE)
-        ps_output = p1.communicate()[0]
+        rc, ps_output, stderr = module.run_command([ps_cmd, '-o', 'user', '-p', str(pid)])
         user = ''
         for line in iter(ps_output.splitlines()):
             if line != 'USER':
@@ -278,8 +275,7 @@ def main():
         netstat_cmd = module.get_bin_path('netstat', True)
 
         # which TCP ports are listening for connections?
-        p1 = Popen([netstat_cmd, '-plnt'], stdout=PIPE, stderr=PIPE)
-        output_tcp = p1.communicate()[0]
+        rc, output_tcp, stderr = module.run_command([netstat_cmd, '-plnt'])
         tcp_ports = netStatParse(output_tcp)
         for i, p in enumerate(tcp_ports):
             p['stime'] = getPidSTime(p['pid'])
@@ -289,8 +285,7 @@ def main():
             result['ansible_facts']['tcp_listen'] = tcp_ports
 
         # which UDP ports are listening for connections?
-        p1 = Popen([netstat_cmd, '-plnu'], stdout=PIPE, stderr=PIPE)
-        output_udp = p1.communicate()[0]
+        rc, output_udp, stderr = module.run_command([netstat_cmd, '-plnu'])
         udp_ports = netStatParse(output_udp)
         for i, p in enumerate(udp_ports):
             p['stime'] = getPidSTime(p['pid'])

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -10,7 +10,7 @@ DOCUMENTATION = '''
 module: listen_ports_facts
 author:
     - Nathan Davison (@ndavison)
-version_added: "2.5"
+version_added: "2.6"
 description:
     - Gather facts on processes listening on TCP and UDP ports. Optionally provide whitelists to gather facts on violations of the whitelist.
 short_description: Gather facts on processes listening on TCP and UDP ports.

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -31,11 +31,9 @@ options:
   whitelist_tcp:
     description:
       - A list of TCP port numbers that are expected to have processes listening.
-    required: false
   whitelist_udp:
     description:
       - A list of UDP port numbers that are expected to have processes listening.
-    required: false
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -67,7 +67,7 @@ def netStatParse(raw):
         listening_search = re.search('[^ ]+:[0-9]+', line)
         if listening_search:
             splitted = line.split()
-            conns = re.search('[^ ]+:([0-9]+)', splitted[3])
+            conns = re.search('([^ ]+):([0-9]+)', splitted[3])
             pidstr = ''
             if 'tcp' in splitted[0]:
                 protocol = 'tcp'
@@ -77,10 +77,11 @@ def netStatParse(raw):
                 pidstr = splitted[5]
             pids = re.search('([0-9]+)/(.*)', pidstr)
             if conns and pids:
-                port = conns.group(1)
+                address = conns.group(1)
+                port = conns.group(2)
                 pid = pids.group(1)
                 name = pids.group(2)
-                result = dict(pid=int(pid), port=int(port), protocol=protocol, name=name)
+                result = dict(pid=int(pid), address=address, port=int(port), protocol=protocol, name=name)
                 if result not in results:
                     results.append(result)
             elif not pids:
@@ -91,7 +92,7 @@ def applyWhitelist(portspids, whitelist=list()):
     processes = list()
     for p in portspids:
         if int(p['port']) not in whitelist and str(p['port']) not in whitelist:
-            process = dict(pid=p['pid'], port=p['port'], protocol=p['protocol'], name=p['name'], stime=p['stime'], user=p['user'])
+            process = dict(pid=p['pid'], address=p['address'], port=p['port'], protocol=p['protocol'], name=p['name'], stime=p['stime'], user=p['user'])
             if process not in processes:
                 processes.append(process)
     return processes

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -210,17 +210,17 @@ def netStatParse(raw):
             elif 'udp' in splitted[0]:
                 protocol = 'udp'
                 pidstr = splitted[5]
-            pids = re.search('([0-9]+)/(.*)', pidstr)
+            pids = re.search('(([0-9]+)/(.*)|-)', pidstr)
             if conns and pids:
                 address = conns.group(1)
                 port = conns.group(2)
-                pid = pids.group(1)
-                name = pids.group(2)
+                pid = pids.group(2) if pids.group(2) else 0
+                name = pids.group(3) if pids.group(3) else ''
                 result = dict(pid=int(pid), address=address, port=int(port), protocol=protocol, name=name)
                 if result not in results:
                     results.append(result)
-            elif not pids:
-                raise EnvironmentError('Could not get the pids for the listening ports - possibly a permission issue')
+            else:
+                raise EnvironmentError('Could not get process information for the listening ports.')
     return results
 
 def applyWhitelist(portspids, whitelist=list()):

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -232,7 +232,7 @@ def main():
                 if p['protocol'] == 'tcp':
                     result['ansible_facts']['tcp_listen'].append(p)
                 elif p['protocol'] == 'udp':
-    except Exception, e:
+    except Exception as e:
         module.fail_json(msg=str(e))
 
     # if a TCP whitelist was supplied, determine which if any pids violate it

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -9,7 +9,7 @@ author:
     - '"Nathan Davison (@ndavison)" <ndavison85@gmail.com>'
 version_added: "2.4"
 description:
-    - Gather facts on processes listening on TCP and UDP ports. Optionally provide whitelists to gather facts on violations ofthe whitelist.
+    - Gather facts on processes listening on TCP and UDP ports. Optionally provide whitelists to gather facts on violations of the whitelist.
 short_description: Gather facts on processes listening on TCP and UDP ports.
 options:
   whitelist_tcp:

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -57,6 +57,140 @@ EXAMPLES = '''
   when: tcp_listen_violations
 '''
 
+RETURN = '''
+tcp_listen:
+  description: A list of processes that are listening on a TCP port.
+  type: list
+  contains:
+    address:
+      description: The address (IPv4 or IPv6) of the process.
+      type: string
+      sample: '0.0.0.0'
+    name:
+      description: The name of the process.
+      type: string
+      sample: 'mysqld'
+    pid:
+      description: The pid of the process.
+      type: int
+      sample: 1223
+    port:
+      description: The port the pid was listening on.
+      type: int
+      sample: 3306
+    protocol:
+      description: The protocol, TCP or UDP, of the listening connection.
+      type: string
+      sample: 'tcp'
+    stime:
+      description: The start time of the process.
+      type: string
+      sample: 'Thu Feb  2 13:29:45 2017'
+    user:
+      description: The user running the process.
+      type: string
+      sample: 'mysql'
+
+udp_listen:
+  description: A list of processes that are listening on a UDP port.
+  type: list
+  contains:
+    address:
+      description: The address (IPv4 or IPv6) of the process.
+      type: string
+      sample: '0.0.0.0'
+    name:
+      description: The name of the process.
+      type: string
+      sample: 'rsyslogd'
+    pid:
+      description: The pid of the process.
+      type: int
+      sample: 609
+    port:
+      description: The port the pid was listening on.
+      type: int
+      sample: 514
+    protocol:
+      description: The protocol, TCP or UDP, of the listening connection.
+      type: string
+      sample: 'udp'
+    stime:
+      description: The start time of the process.
+      type: string
+      sample: 'Thu Feb  2 13:29:45 2017'
+    user:
+      description: The user running the process.
+      type: string
+      sample: 'root'
+
+tcp_listen_violations:
+  description: A list of processes that are listening on a TCP port that violated the whitelist_tcp argument.
+  type: list
+  contains:
+    address:
+      description: The address (IPv4 or IPv6) of the process.
+      type: string
+      sample: '0.0.0.0'
+    name:
+      description: The name of the process.
+      type: string
+      sample: 'mysqld'
+    pid:
+      description: The pid of the process.
+      type: int
+      sample: 1223
+    port:
+      description: The port the pid was listening on.
+      type: int
+      sample: 3306
+    protocol:
+      description: The protocol, TCP or UDP, of the listening connection.
+      type: string
+      sample: 'tcp'
+    stime:
+      description: The start time of the process.
+      type: string
+      sample: 'Thu Feb  2 13:29:45 2017'
+    user:
+      description: The user running the process.
+      type: string
+      sample: 'mysql'
+
+udp_listen_violations:
+  description: A list of processes that are listening on a UDP port that violated the whitelist_udp argument.
+  type: list
+  contains:
+    address:
+      description: The address (IPv4 or IPv6) of the process.
+      type: string
+      sample: '0.0.0.0'
+    name:
+      description: The name of the process.
+      type: string
+      sample: 'rsyslogd'
+    pid:
+      description: The pid of the process.
+      type: int
+      sample: 609
+    port:
+      description: The port the pid was listening on.
+      type: int
+      sample: 514
+    protocol:
+      description: The protocol, TCP or UDP, of the listening connection.
+      type: string
+      sample: 'udp'
+    stime:
+      description: The start time of the process.
+      type: string
+      sample: 'Thu Feb  2 13:29:45 2017'
+    user:
+      description: The user running the process.
+      type: string
+      sample: 'root'
+'''
+
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'committer',
                     'version': '1.0'}

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -10,7 +10,7 @@ DOCUMENTATION = '''
 module: listen_ports_facts
 author:
     - Nathan Davison (@ndavison)
-version_added: "2.4"
+version_added: "2.5"
 description:
     - Gather facts on processes listening on TCP and UDP ports. Optionally provide whitelists to gather facts on violations of the whitelist.
 short_description: Gather facts on processes listening on TCP and UDP ports.

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -25,7 +25,8 @@ author:
     - '"Nathan Davison (@ndavison)" <ndavison85@gmail.com>'
 version_added: "2.3"
 description:
-    - Gather facts on processes listening on TCP and UDP ports. Optionally provide a whitelist of TCP and/or UDP ports to gather facts on processes that violate the whitelists.
+    - Gather facts on processes listening on TCP and UDP ports. Optionally provide a whitelist of TCP and/or UDP ports to gather facts on processes that
+    violate the whitelists.
 short_description: Gather facts on processes listening on TCP and UDP ports.
 options:
   whitelist_tcp:

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -232,6 +232,7 @@ def main():
                 if p['protocol'] == 'tcp':
                     result['ansible_facts']['tcp_listen'].append(p)
                 elif p['protocol'] == 'udp':
+                    result['ansible_facts']['udp_listen'].append(p)
     except Exception as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -25,9 +25,7 @@ author:
     - '"Nathan Davison (@ndavison)" <ndavison85@gmail.com>'
 version_added: "2.3"
 description:
-    - Gather facts on processes listening on TCP and UDP ports. Optionally provide 
-    a whitelist of TCP and/or UDP ports to gather facts on processes that violate 
-    the whitelists.
+    - Gather facts on processes listening on TCP and UDP ports. Optionally provide a whitelist of TCP and/or UDP ports to gather facts on processes that violate the whitelists.
 short_description: Gather facts on processes listening on TCP and UDP ports.
 options:
   whitelist_tcp:

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -48,6 +48,12 @@ EXAMPLES = '''
       - 22
       - 80
       - 443
+
+- name: TCP whitelist violation
+  debug:
+    msg: "TCP port {{item.port}} by pid {{item.pid}} violates the whitelist"
+  with_items: "{{ tcp_listen_violations }}"
+  when: tcp_listen_violations
 '''
 
 ANSIBLE_METADATA = {'status': ['preview'],

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -24,9 +24,9 @@ module: listen_ports_facts
 author:
     - '"Nathan Davison (@ndavison)" <ndavison85@gmail.com>'
 version_added: "2.3"
-description:
-    - Gather facts on processes listening on TCP and UDP ports. Optionally provide a whitelist of TCP and/or UDP ports to gather facts on processes that
-    violate the whitelists.
+description: |
+    - Gather facts on processes listening on TCP and UDP ports. Optionally provide a whitelist of TCP and/or UDP ports to gather facts on processes
+     that violate the whitelists.
 short_description: Gather facts on processes listening on TCP and UDP ports.
 options:
   whitelist_tcp:

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -6,7 +6,7 @@ DOCUMENTATION = '''
 ---
 module: listen_ports_facts
 author:
-    - '"Nathan Davison (@ndavison)" <ndavison85@gmail.com>'
+    - Nathan Davison (@ndavison)
 version_added: "2.4"
 description:
     - Gather facts on processes listening on TCP and UDP ports. Optionally provide whitelists to gather facts on violations of the whitelist.

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -8,19 +8,26 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: listen_ports_facts
+
 author:
     - Nathan Davison (@ndavison)
+
 version_added: "2.6"
+
 description:
     - Gather facts on processes listening on TCP and UDP ports. Optionally provide whitelists to gather facts on violations of the whitelist.
+
 short_description: Gather facts on processes listening on TCP and UDP ports.
+
 options:
   whitelist_tcp:
     description:
       - A list of TCP port numbers that are expected to have processes listening.
+    default: list()
   whitelist_udp:
     description:
       - A list of UDP port numbers that are expected to have processes listening.
+    default: list()
 '''
 
 EXAMPLES = '''
@@ -127,7 +134,6 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 import re
 import platform
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
 
 
 def netStatParse(raw):
@@ -226,10 +232,7 @@ def main():
                 if p['protocol'] == 'tcp':
                     result['ansible_facts']['tcp_listen'].append(p)
                 elif p['protocol'] == 'udp':
-                    result['ansible_facts']['udp_listen'].append(p)
-
-    except:
-        e = get_exception()
+    except Exception, e:
         module.fail_json(msg=str(e))
 
     # if a TCP whitelist was supplied, determine which if any pids violate it

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -126,7 +126,6 @@ import platform
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
 
-
 def netStatParse(raw):
     results = list()
     for line in iter(raw.splitlines()):

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -34,12 +34,10 @@ options:
     description:
       - A list of TCP port numbers that are expected to have processes listening.
     required: false
-    type: "list"
   whitelist_udp:
     description:
       - A list of UDP port numbers that are expected to have processes listening.
     required: false
-    type: "list"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/system/listen_ports_facts.py
+++ b/lib/ansible/modules/system/listen_ports_facts.py
@@ -24,9 +24,10 @@ module: listen_ports_facts
 author:
     - '"Nathan Davison (@ndavison)" <ndavison85@gmail.com>'
 version_added: "2.3"
-description: |
-    - Gather facts on processes listening on TCP and UDP ports. Optionally provide a whitelist of TCP and/or UDP ports to gather facts on processes
-     that violate the whitelists.
+description:
+    - | 
+      Gather facts on processes listening on TCP and UDP ports. Optionally provide a whitelist of TCP and/or UDP ports to gather facts on processes
+       that violate the whitelists.
 short_description: Gather facts on processes listening on TCP and UDP ports.
 options:
   whitelist_tcp:

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -78,10 +78,11 @@ def netStatParse(raw):
         if listening_search:
             splitted = line.split()
             conns = re.search('[^ ]+:([^ ]+)', splitted[3])
+            pidstr = ''
             if 'tcp' in splitted[0]:
                 proto = 'tcp'
                 pidstr = splitted[6]
-            else:
+            elif 'udp' in splitted[0]:
                 proto = 'udp'
                 pidstr = splitted[5]
             pids = re.search('([0-9]+)/', pidstr)

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -140,8 +140,8 @@ def main():
     # get just the pids to avoid duplicates across protocols
     pids = list()
     for p in killed:
-    	if p['pid'] not in pids:
-    		pids.append(p['pid'])
+        if p['pid'] not in pids:
+            pids.append(p['pid'])
 
     # kill! kill!
     if not module.check_mode:

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -112,11 +112,11 @@ def applyWhitelist(portspids, whitelist=list()):
 
 def getPidSTime(pid):
     p1 = Popen(['ps', '-o', 'lstart', '-p', str(pid)], stdout=PIPE, stderr=PIPE)
-    p2 = Popen(['grep', '^[^ ]'], stdin=p1.stdout, stdout=PIPE, stderr=PIPE)
-    p1.stdout.close()
-    p3 = Popen(['tr', '-d', '"\n"'], stdin=p2.stdout, stdout=PIPE, stderr=PIPE)
-    p2.stdout.close()
-    stime = p3.communicate()[0]
+    ps_output = p1.communicate()[0]
+    stime = ''
+    for line in iter(ps_output.splitlines()):
+        if 'started' not in line:
+            stime = line
     return stime
 
 def main():

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -1,0 +1,149 @@
+#!/usr/bin/python
+# encoding: utf-8
+
+# (c) 2016, Nathan Davison <ndavison85@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: portenforce
+author:
+    - '"Nathan Davison (@ndavison)" <ndavison85@gmail.com>'
+version_added: "2.1"
+description:
+    - Kill processes listening on TCP and UDP ports not defined in the whitelists.
+short_description: Kill processes listening on TCP and UDP ports not defined in the whitelists.
+options:
+  whitelist_tcp:
+    description:
+      - A list of TCP ports to allow.
+    required: false
+    type: "list"
+  whitelist_udp:
+    description:
+      - A list of UDP ports to allow.
+    required: false
+    type: "list"
+'''
+
+EXAMPLES = '''
+- name: only allow TCP 80, 443, and 22
+  portenforce:
+    whitelist_tcp:
+      - 22
+      - 80
+      - 443
+'''
+
+RETURN = '''
+killed:
+  description: A list of pids that were killed.
+  type: list
+  contains:
+    pid:
+      description: The pid of a killed process.
+      type: int
+      sample: 1223
+    port:
+      description: The port the killed pid was listening on.
+      type: int
+      sample: 443
+    proto:
+      description: The protocol, TCP or UDP, of the listening connection.
+      type: string
+      sample: 'tcp'
+'''
+
+import re
+from subprocess import Popen, PIPE
+
+def netStatParse(raw):
+	results = list()
+	for line in iter(raw.splitlines()):
+		listening_search = re.search('[^ ]+:[^ ]+', line)
+		if listening_search:
+			splitted = line.split()
+			conns = re.search('[^ ]+:([^ ]+)', splitted[3])
+			proto = 'tcp' if 'tcp' in splitted[0] else 'udp'
+			pidstr = splitted[6] if proto == 'tcp' else splitted[5]
+			pids = re.search('([0-9]+)/', pidstr)
+			if conns and pids:
+				port = conns.group(1)
+				pid = pids.group(1)
+				result = dict(pid=int(pid), port=int(port), proto=proto)
+				if result not in results:
+					results.append(result)
+			elif not pids:
+				raise EnvironmentError('Could not get the pids for the listening ports - possibly a permission issue')
+	return results
+
+def applyWhitelist(portspids, whitelist=list()):
+	kill_pids = list()
+	for p in portspids:
+		if int(p['port']) not in whitelist and str(p['port']) not in whitelist:
+			if dict(pid=p['pid'], port=p['port'], proto=p['proto']) not in kill_pids:
+				kill_pids.append(dict(pid=p['pid'], port=p['port'], proto=p['proto']))
+	return kill_pids
+
+def main():
+
+	module = AnsibleModule(
+		argument_spec = dict(
+			whitelist_tcp = dict(required=False, type='list', default=list()),
+			whitelist_udp = dict(required=False, type='list', default=list())
+		),
+		supports_check_mode=True
+	)
+
+	result = {}
+	result['changed'] = False
+	result['killed'] = list()
+
+	try:
+		# which TCP ports are listening for connections?
+		p1 = Popen(['netstat', '-plnt'], stdout=PIPE, stderr=PIPE)
+		output_tcp = p1.communicate()[0]
+		kill_tcp = netStatParse(output_tcp)
+
+		# which UDP ports are listening for connections?
+		p1 = Popen(['netstat', '-plnu'], stdout=PIPE, stderr=PIPE)
+		output_udp = p1.communicate()[0]
+		kill_udp = netStatParse(output_udp)
+	except EnvironmentError as err:
+		module.fail_json(msg=str(err))
+
+	# gather all the pids to kill
+	kill_pids_tcp = applyWhitelist(kill_tcp, module.params['whitelist_tcp'])
+	kill_pids_udp = applyWhitelist(kill_udp, module.params['whitelist_udp'])
+	killed = list(kill_pids_tcp)
+	killed.extend(x for x in kill_pids_udp if x not in kill_pids_tcp)
+
+	# kill! kill!
+	if not module.check_mode:
+		for p in killed:
+			p1 = Popen(['kill', str(p['pid'])], stdout=PIPE)
+
+	if killed:
+		result['changed'] = True
+		result['killed'] = killed
+
+	module.exit_json(**result)
+
+# import module snippets
+from ansible.module_utils.basic import *
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -73,6 +73,7 @@ killed:
 '''
 
 import re
+import os
 from subprocess import Popen, PIPE
 
 def netStatParse(raw):
@@ -168,7 +169,7 @@ def main():
     if not module.check_mode:
         for p in kill_unique:
             if p['stime'] == getPidSTime(p['pid']):
-                p1 = Popen(['kill', str(p['pid'])], stdout=PIPE)
+                os.kill(p['pid'], 15)
 
     if kill_all:
         result['changed'] = True

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -131,16 +131,22 @@ def main():
     except EnvironmentError, err:
         module.fail_json(msg=str(err))
 
-    # gather all the pids to kill
+    # gather details of the pids to kill
     kill_pids_tcp = applyWhitelist(kill_tcp, module.params['whitelist_tcp'])
     kill_pids_udp = applyWhitelist(kill_udp, module.params['whitelist_udp'])
     killed = list(kill_pids_tcp)
     killed.extend(x for x in kill_pids_udp if x not in kill_pids_tcp)
 
+    # get just the pids to avoid duplicates across protocols
+    pids = list()
+    for p in killed:
+    	if p['pid'] not in pids:
+    		pids.append(p['pid'])
+
     # kill! kill!
     if not module.check_mode:
-        for p in killed:
-            p1 = Popen(['kill', str(p['pid'])], stdout=PIPE)
+        for pid in pids:
+            p1 = Popen(['kill', str(pid)], stdout=PIPE)
 
     if killed:
         result['changed'] = True

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -80,9 +80,10 @@ def netStatParse(raw):
 			conns = re.search('[^ ]+:([^ ]+)', splitted[3])
 			if 'tcp' in splitted[0]:
 				proto = 'tcp'
+				pidstr = splitted[6]
 			else:
 				proto = 'udp'
-			pidstr = splitted[6] if proto == 'tcp' else splitted[5]
+				pidstr = splitted[5]
 			pids = re.search('([0-9]+)/', pidstr)
 			if conns and pids:
 				port = conns.group(1)

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -74,6 +74,7 @@ killed:
 
 import re
 import os
+import platform
 from subprocess import Popen, PIPE
 
 def netStatParse(raw):
@@ -120,6 +121,9 @@ def main():
         ),
         supports_check_mode=True
     )
+
+    if platform.system() != 'Linux':
+        module.fail_json(msg='This module requires Linux.')
 
     def getPidSTime(pid):
         ps_cmd = module.get_bin_path('ps', True)

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -23,7 +23,7 @@ DOCUMENTATION = '''
 module: portenforce
 author:
     - '"Nathan Davison (@ndavison)" <ndavison85@gmail.com>'
-version_added: "2.1"
+version_added: "2.2"
 description:
     - Kill processes listening on TCP and UDP ports not defined in the whitelists.
 short_description: Kill processes listening on TCP and UDP ports not defined in the whitelists.

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -66,6 +66,10 @@ killed:
       description: The protocol, TCP or UDP, of the listening connection.
       type: string
       sample: 'tcp'
+    stime:
+      description: The start time of the killed process.
+      type: string
+      sample: Thu Apr 21 17:30:16 2016
 '''
 
 import re
@@ -85,11 +89,12 @@ def netStatParse(raw):
             elif 'udp' in splitted[0]:
                 proto = 'udp'
                 pidstr = splitted[5]
-            pids = re.search('([0-9]+)/', pidstr)
+            pids = re.search('([0-9]+)/(.*)', pidstr)
             if conns and pids:
                 port = conns.group(1)
                 pid = pids.group(1)
-                result = dict(pid=int(pid), port=int(port), proto=proto)
+                name = pids.group(2)
+                result = dict(pid=int(pid), port=int(port), proto=proto, name=name)
                 if result not in results:
                     results.append(result)
             elif not pids:
@@ -100,9 +105,18 @@ def applyWhitelist(portspids, whitelist=list()):
     kill_pids = list()
     for p in portspids:
         if int(p['port']) not in whitelist and str(p['port']) not in whitelist:
-            if dict(pid=p['pid'], port=p['port'], proto=p['proto']) not in kill_pids:
-                kill_pids.append(dict(pid=p['pid'], port=p['port'], proto=p['proto']))
+            if dict(pid=p['pid'], port=p['port'], proto=p['proto'], name=p['name'], stime=p['stime']) not in kill_pids:
+                kill_pids.append(dict(pid=p['pid'], port=p['port'], proto=p['proto'], name=p['name'], stime=p['stime']))
     return kill_pids
+
+def getPidSTime(pid):
+    p1 = Popen(['ps', '-o', 'lstart', '-p', str(pid)], stdout=PIPE, stderr=PIPE)
+    p2 = Popen(['grep', '^[^ ]'], stdin=p1.stdout, stdout=PIPE, stderr=PIPE)
+    p1.stdout.close()
+    p3 = Popen(['tr', '-d', '"\n"'], stdin=p2.stdout, stdout=PIPE, stderr=PIPE)
+    p2.stdout.close()
+    stime = p3.communicate()[0]
+    return stime
 
 def main():
 
@@ -123,34 +137,42 @@ def main():
         p1 = Popen(['netstat', '-plnt'], stdout=PIPE, stderr=PIPE)
         output_tcp = p1.communicate()[0]
         kill_tcp = netStatParse(output_tcp)
+        for i, p in enumerate(kill_tcp):
+            p['stime'] = getPidSTime(p['pid']) 
+            kill_tcp[i] = p
 
         # which UDP ports are listening for connections?
         p1 = Popen(['netstat', '-plnu'], stdout=PIPE, stderr=PIPE)
         output_udp = p1.communicate()[0]
         kill_udp = netStatParse(output_udp)
+        for i, p in enumerate(kill_udp):
+            p['stime'] = getPidSTime(p['pid']) 
+            kill_udp[i] = p
+
     except EnvironmentError, err:
         module.fail_json(msg=str(err))
 
     # gather details of the pids to kill
     kill_pids_tcp = applyWhitelist(kill_tcp, module.params['whitelist_tcp'])
     kill_pids_udp = applyWhitelist(kill_udp, module.params['whitelist_udp'])
-    killed = list(kill_pids_tcp)
-    killed.extend(x for x in kill_pids_udp if x not in kill_pids_tcp)
+    kill_all = list(kill_pids_tcp)
+    kill_all.extend(x for x in kill_pids_udp if x not in kill_pids_tcp)
 
     # get just the pids to avoid duplicates across protocols
-    pids = list()
-    for p in killed:
-        if p['pid'] not in pids:
-            pids.append(p['pid'])
+    kill_unique = list()
+    for p in kill_all:
+        if p['pid'] not in kill_unique:
+            kill_unique.append(p)
 
     # kill! kill!
     if not module.check_mode:
-        for pid in pids:
-            p1 = Popen(['kill', str(pid)], stdout=PIPE)
+        for p in kill_unique:
+            if p['stime'] == getPidSTime(p['pid']):
+                p1 = Popen(['kill', str(p['pid'])], stdout=PIPE)
 
-    if killed:
+    if kill_all:
         result['changed'] = True
-        result['killed'] = killed
+        result['killed'] = kill_all
 
     module.exit_json(**result)
 

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -78,7 +78,10 @@ def netStatParse(raw):
 		if listening_search:
 			splitted = line.split()
 			conns = re.search('[^ ]+:([^ ]+)', splitted[3])
-			proto = 'tcp' if 'tcp' in splitted[0] else 'udp'
+			if 'tcp' in splitted[0]:
+				proto = 'tcp'
+			else:
+				proto = 'udp'
 			pidstr = splitted[6] if proto == 'tcp' else splitted[5]
 			pids = re.search('([0-9]+)/', pidstr)
 			if conns and pids:

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -127,7 +127,7 @@ def main():
 		p1 = Popen(['netstat', '-plnu'], stdout=PIPE, stderr=PIPE)
 		output_udp = p1.communicate()[0]
 		kill_udp = netStatParse(output_udp)
-	except EnvironmentError as err:
+	except EnvironmentError, err:
 		module.fail_json(msg=str(err))
 
 	# gather all the pids to kill

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -106,8 +106,9 @@ def applyWhitelist(portspids, whitelist=list()):
     kill_pids = list()
     for p in portspids:
         if int(p['port']) not in whitelist and str(p['port']) not in whitelist:
-            if dict(pid=p['pid'], port=p['port'], proto=p['proto'], name=p['name'], stime=p['stime']) not in kill_pids:
-                kill_pids.append(dict(pid=p['pid'], port=p['port'], proto=p['proto'], name=p['name'], stime=p['stime']))
+            to_kill = dict(pid=p['pid'], port=p['port'], proto=p['proto'], name=p['name'], stime=p['stime'])
+            if to_kill not in kill_pids:
+                kill_pids.append(to_kill)
     return kill_pids
 
 def main():

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -187,6 +187,6 @@ def main():
     module.exit_json(**result)
 
 # import module snippets
-from ansible.module_utils.basic import *
+from ansible.module_utils.basic import AnsibleModule
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -173,8 +173,10 @@ def main():
 
     # get just the pids to avoid duplicates across protocols
     kill_unique = list()
+    pids_seen = list()
     for p in kill_all:
-        if p['pid'] not in kill_unique:
+        if p['pid'] not in pids_seen:
+            pids_seen.append(p['pid'])
             kill_unique.append(p)
 
     # kill! kill!

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -150,7 +150,7 @@ def main():
         output_tcp = p1.communicate()[0]
         kill_tcp = netStatParse(output_tcp)
         for i, p in enumerate(kill_tcp):
-            p['stime'] = getPidSTime(p['pid']) 
+            p['stime'] = getPidSTime(p['pid'])
             kill_tcp[i] = p
 
         # which UDP ports are listening for connections?
@@ -158,7 +158,7 @@ def main():
         output_udp = p1.communicate()[0]
         kill_udp = netStatParse(output_udp)
         for i, p in enumerate(kill_udp):
-            p['stime'] = getPidSTime(p['pid']) 
+            p['stime'] = getPidSTime(p['pid'])
             kill_udp[i] = p
 
     except EnvironmentError:

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -23,7 +23,7 @@ DOCUMENTATION = '''
 module: portenforce
 author:
     - '"Nathan Davison (@ndavison)" <ndavison85@gmail.com>'
-version_added: "2.2"
+version_added: "2.3"
 description:
     - Kill processes listening on TCP and UDP ports not defined in the whitelists.
 short_description: Kill processes listening on TCP and UDP ports not defined in the whitelists.

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -125,6 +125,9 @@ def main():
     if platform.system() != 'Linux':
         module.fail_json(msg='This module requires Linux.')
 
+    if not module.params['whitelist_tcp'] and not module.params['whitelist_udp']:
+        module.fail_json(msg="You must supply either a 'whitelist_tcp' or 'whitelist_udp' argument.")
+
     def getPidSTime(pid):
         ps_cmd = module.get_bin_path('ps', True)
         p1 = Popen([ps_cmd, '-o', 'lstart', '-p', str(pid)], stdout=PIPE, stderr=PIPE)

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -80,6 +80,8 @@ import re
 import os
 import platform
 from subprocess import Popen, PIPE
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.pycompat24 import get_exception
 
 def netStatParse(raw):
     results = list()
@@ -196,7 +198,5 @@ def main():
     module.exit_json(**result)
 
 # import module snippets
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -72,6 +72,10 @@ killed:
       sample: Thu Apr 21 17:30:16 2016
 '''
 
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'committer',
+                    'version': '1.0'}
+
 import re
 import os
 import platform

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -80,10 +80,10 @@ from subprocess import Popen, PIPE
 def netStatParse(raw):
     results = list()
     for line in iter(raw.splitlines()):
-        listening_search = re.search('[^ ]+:[^ ]+', line)
+        listening_search = re.search('[^ ]+:[0-9]+', line)
         if listening_search:
             splitted = line.split()
-            conns = re.search('[^ ]+:([^ ]+)', splitted[3])
+            conns = re.search('[^ ]+:([0-9]+)', splitted[3])
             pidstr = ''
             if 'tcp' in splitted[0]:
                 proto = 'tcp'

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -188,5 +188,6 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.pycompat24 import get_exception
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/system/portenforce.py
+++ b/lib/ansible/modules/system/portenforce.py
@@ -158,7 +158,8 @@ def main():
             p['stime'] = getPidSTime(p['pid']) 
             kill_udp[i] = p
 
-    except EnvironmentError, err:
+    except EnvironmentError:
+        err = get_exception()
         module.fail_json(msg=str(err))
 
     # gather details of the pids to kill

--- a/test/integration/targets/listen_ports_facts/aliases
+++ b/test/integration/targets/listen_ports_facts/aliases
@@ -1,0 +1,2 @@
+posix/ci/group2
+destructive

--- a/test/integration/targets/listen_ports_facts/aliases
+++ b/test/integration/targets/listen_ports_facts/aliases
@@ -1,5 +1,4 @@
 shippable/posix/group1
-posix/ci/group2
 destructive
 skip/osx
 skip/freebsd

--- a/test/integration/targets/listen_ports_facts/aliases
+++ b/test/integration/targets/listen_ports_facts/aliases
@@ -3,4 +3,3 @@ posix/ci/group2
 destructive
 skip/osx
 skip/freebsd
-skip/suse

--- a/test/integration/targets/listen_ports_facts/aliases
+++ b/test/integration/targets/listen_ports_facts/aliases
@@ -1,3 +1,6 @@
 shippable/posix/group1
 posix/ci/group2
 destructive
+skip/osx
+skip/freebsd
+skip/opensuse

--- a/test/integration/targets/listen_ports_facts/aliases
+++ b/test/integration/targets/listen_ports_facts/aliases
@@ -1,2 +1,3 @@
+shippable/posix/group1
 posix/ci/group2
 destructive

--- a/test/integration/targets/listen_ports_facts/aliases
+++ b/test/integration/targets/listen_ports_facts/aliases
@@ -3,4 +3,4 @@ posix/ci/group2
 destructive
 skip/osx
 skip/freebsd
-skip/opensuse
+skip/suse

--- a/test/integration/targets/listen_ports_facts/tasks/main.yml
+++ b/test/integration/targets/listen_ports_facts/tasks/main.yml
@@ -10,7 +10,7 @@
   with_items:
     - net-tools
     - netcat
-  when: ansible_os_family == 'Debian'
+  when: ansible_os_family == "Debian"
 
 - name: install netstat and netcat on rh < 7
   yum:
@@ -34,19 +34,19 @@
   command: nc -u -l 5555
   async: 45
   poll: 0
-  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
 
 - name: start UDP server on port 5556
   command: nc -u -l 5556
   async: 45
   poll: 0
-  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
 
 - name: start TCP server on port 5557
   command: nc -l 5557
   async: 45
   poll: 0
-  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
 
 - name: Gather listening ports facts with whitelists
   listen_ports_facts:
@@ -54,44 +54,44 @@
       - 22
     whitelist_udp:
       - 55556
-  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
 
 - name: check for ansible_facts.tcp_listen_violations exists
   assert:
     that: ansible_facts.tcp_listen_violations is defined
-  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
 
 - name: check for ansible_facts.udp_listen_violations exists
   assert:
     that: ansible_facts.udp_listen_violations is defined
-  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
 
 - name: check for ansible_facts.udp_listen exists
   assert:
     that: ansible_facts.udp_listen is defined
-  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
 
 - name: check for ansible_facts.tcp_listen exists
   assert:
     that: ansible_facts.tcp_listen is defined
-  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
 
 - name: check TCP violations
   assert:
     that: ansible_facts.tcp_listen_violations|length > 0
-  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
 
 - name: check UDP violations
   assert:
     that: ansible_facts.udp_listen_violations|length > 0
-  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
 
 - name: check TCP listening ports
   assert:
     that: ansible_facts.tcp_listen|length > 0
-  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
 
 - name: check UDP listening ports
   assert:
     that: ansible_facts.udp_listen|length > 0
-  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
+  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"

--- a/test/integration/targets/listen_ports_facts/tasks/main.yml
+++ b/test/integration/targets/listen_ports_facts/tasks/main.yml
@@ -16,19 +16,41 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-- name: install netcat
-  package:
-    name: netcat
-    state: present
+- name: install netstat and netcat on deb
+  apt:
+    name: "{{ item }}"
+    state: latest
+  with_items:
+    - net-tools
+    - netcat
+  when: ansible_os_family == 'Debian'
 
-- name: start UDP server on port 55555
-  shell: nc -u -l 55555 &
+- name: install netstat and netcat on rh < 7
+  yum:
+    name: "{{ item }}"
+    state: latest
+  with_items:
+    - net-tools
+    - nc.x86_64
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int < 7
 
-- name: start UDP server on port 55556
-  shell: nc -u -l 55556 &
+- name: install netstat and netcat on rh >= 7
+  yum:
+    name: "{{ item }}"
+    state: latest
+  with_items:
+    - net-tools
+    - nmap-ncat
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7
 
-- name: start TCP server on port 55557
-  shell: nc -l 55557 &
+- name: start UDP server on port 5555
+  shell: nc -u -l 5555 &
+
+- name: start UDP server on port 5556
+  shell: nc -u -l 5556 &
+
+- name: start TCP server on port 5557
+  shell: nc -l 5557 &
 
 - name: Gather listening ports facts with whitelists
   listen_ports_facts:
@@ -59,7 +81,7 @@
 
 - name: check UDP violations
   assert:
-    that: ansible_facts.udp_listen_violations|length == 1
+    that: ansible_facts.udp_listen_violations|length > 0
 
 - name: check TCP listening ports
   assert:
@@ -67,4 +89,4 @@
 
 - name: check UDP listening ports
   assert:
-    that: ansible_facts.udp_listen|length == 2
+    that: ansible_facts.udp_listen|length > 0

--- a/test/integration/targets/listen_ports_facts/tasks/main.yml
+++ b/test/integration/targets/listen_ports_facts/tasks/main.yml
@@ -1,20 +1,7 @@
 # Test playbook for the listen_ports_facts module
-# (c) 2019, Nathan Davison <ndavison85@gmail.com>
+# Copyright: (c) 2019, Nathan Davison <ndavison85@gmail.com>
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 - name: install netstat and netcat on deb
   apt:
@@ -44,13 +31,19 @@
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7
 
 - name: start UDP server on port 5555
-  shell: nc -u -l 5555 &
+  command: nc -u -l 5555
+  async: 45
+  poll: 0
 
 - name: start UDP server on port 5556
-  shell: nc -u -l 5556 &
+  command: nc -u -l 5556
+  async: 45
+  poll: 0
 
 - name: start TCP server on port 5557
-  shell: nc -l 5557 &
+  command: nc -l 5557
+  async: 45
+  poll: 0
 
 - name: Gather listening ports facts with whitelists
   listen_ports_facts:

--- a/test/integration/targets/listen_ports_facts/tasks/main.yml
+++ b/test/integration/targets/listen_ports_facts/tasks/main.yml
@@ -34,16 +34,19 @@
   command: nc -u -l 5555
   async: 45
   poll: 0
+  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
 
 - name: start UDP server on port 5556
   command: nc -u -l 5556
   async: 45
   poll: 0
+  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
 
 - name: start TCP server on port 5557
   command: nc -l 5557
   async: 45
   poll: 0
+  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
 
 - name: Gather listening ports facts with whitelists
   listen_ports_facts:
@@ -51,35 +54,44 @@
       - 22
     whitelist_udp:
       - 55556
+  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
 
 - name: check for ansible_facts.tcp_listen_violations exists
   assert:
     that: ansible_facts.tcp_listen_violations is defined
+  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
 
 - name: check for ansible_facts.udp_listen_violations exists
   assert:
     that: ansible_facts.udp_listen_violations is defined
+  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
 
 - name: check for ansible_facts.udp_listen exists
   assert:
     that: ansible_facts.udp_listen is defined
+  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
 
 - name: check for ansible_facts.tcp_listen exists
   assert:
     that: ansible_facts.tcp_listen is defined
+  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
 
 - name: check TCP violations
   assert:
     that: ansible_facts.tcp_listen_violations|length > 0
+  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
 
 - name: check UDP violations
   assert:
     that: ansible_facts.udp_listen_violations|length > 0
+  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
 
 - name: check TCP listening ports
   assert:
     that: ansible_facts.tcp_listen|length > 0
+  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'
 
 - name: check UDP listening ports
   assert:
     that: ansible_facts.udp_listen|length > 0
+  when: ansible_os_family == "RedHat" or ansible_os_family == 'Debian'

--- a/test/integration/targets/listen_ports_facts/tasks/main.yml
+++ b/test/integration/targets/listen_ports_facts/tasks/main.yml
@@ -1,0 +1,70 @@
+# Test playbook for the listen_ports_facts module
+# (c) 2019, Nathan Davison <ndavison85@gmail.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- name: install netcat
+  package:
+    name: netcat
+    state: present
+
+- name: start UDP server on port 55555
+  shell: nc -u -l 55555 &
+
+- name: start UDP server on port 55556
+  shell: nc -u -l 55556 &
+
+- name: start TCP server on port 55557
+  shell: nc -l 55557 &
+
+- name: Gather listening ports facts with whitelists
+  listen_ports_facts:
+    whitelist_tcp:
+      - 22
+    whitelist_udp:
+      - 55556
+
+- name: check for ansible_facts.tcp_listen_violations exists
+  assert:
+    that: ansible_facts.tcp_listen_violations is defined
+
+- name: check for ansible_facts.udp_listen_violations exists
+  assert:
+    that: ansible_facts.udp_listen_violations is defined
+
+- name: check for ansible_facts.udp_listen exists
+  assert:
+    that: ansible_facts.udp_listen is defined
+
+- name: check for ansible_facts.tcp_listen exists
+  assert:
+    that: ansible_facts.tcp_listen is defined
+
+- name: check TCP violations
+  assert:
+    that: ansible_facts.tcp_listen_violations|length > 0
+
+- name: check UDP violations
+  assert:
+    that: ansible_facts.udp_listen_violations|length == 1
+
+- name: check TCP listening ports
+  assert:
+    that: ansible_facts.tcp_listen|length > 0
+
+- name: check UDP listening ports
+  assert:
+    that: ansible_facts.udp_listen|length == 2

--- a/test/integration/targets/listen_ports_facts/tasks/main.yml
+++ b/test/integration/targets/listen_ports_facts/tasks/main.yml
@@ -31,22 +31,40 @@
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7
 
 - name: start UDP server on port 5555
-  command: nc -u -l 5555
-  async: 45
+  command: nc -u -l -p 5555
+  async: 1000
   poll: 0
-  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
+  when: (ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7) or ansible_os_family == "Debian"
+
+- name: start UDP server on port 5555
+  command: nc -u -l 5555
+  async: 1000
+  poll: 0
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int < 7
 
 - name: start UDP server on port 5556
-  command: nc -u -l 5556
-  async: 45
+  command: "nc -u -l -p 5556"
+  async: 1000
   poll: 0
-  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
+  when: (ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7) or ansible_os_family == "Debian"
+
+- name: start UDP server on port 5556
+  command: "nc -u -l 5556"
+  async: 1000
+  poll: 0
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int < 7
 
 - name: start TCP server on port 5557
-  command: nc -l 5557
-  async: 45
+  command: "nc -l -p 5557"
+  async: 1000
   poll: 0
-  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
+  when: (ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7) or ansible_os_family == "Debian"
+
+- name: start TCP server on port 5557
+  command: "nc -l 5557"
+  async: 1000
+  poll: 0
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int < 7
 
 - name: Gather listening ports facts with whitelists
   listen_ports_facts:

--- a/test/integration/targets/listen_ports_facts/tasks/main.yml
+++ b/test/integration/targets/listen_ports_facts/tasks/main.yml
@@ -42,46 +42,20 @@
   poll: 0
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int < 7
 
-- name: start UDP server on port 5556
-  command: "nc -u -l -p 5556"
+- name: start TCP server on port 5556
+  command: "nc -l -p 5556"
   async: 1000
   poll: 0
   when: (ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7) or ansible_os_family == "Debian"
 
-- name: start UDP server on port 5556
-  command: "nc -u -l 5556"
+- name: start TCP server on port 5556
+  command: "nc -l 5556"
   async: 1000
   poll: 0
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int < 7
 
-- name: start TCP server on port 5557
-  command: "nc -l -p 5557"
-  async: 1000
-  poll: 0
-  when: (ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7) or ansible_os_family == "Debian"
-
-- name: start TCP server on port 5557
-  command: "nc -l 5557"
-  async: 1000
-  poll: 0
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int < 7
-
-- name: Gather listening ports facts with whitelists
+- name: Gather listening ports facts
   listen_ports_facts:
-    whitelist_tcp:
-      - 22
-    whitelist_udp:
-      - 55556
-  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
-
-- name: check for ansible_facts.tcp_listen_violations exists
-  assert:
-    that: ansible_facts.tcp_listen_violations is defined
-  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
-
-- name: check for ansible_facts.udp_listen_violations exists
-  assert:
-    that: ansible_facts.udp_listen_violations is defined
   when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
 
 - name: check for ansible_facts.udp_listen exists
@@ -94,22 +68,12 @@
     that: ansible_facts.tcp_listen is defined
   when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
 
-- name: check TCP violations
+- name: check TCP 5556 is in listening ports
   assert:
-    that: ansible_facts.tcp_listen_violations|length > 0
-  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
+    that: 5556 in ansible_facts.tcp_listen | map(attribute='port') | sort | list
+  when: (ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7) or ansible_os_family == "Debian"
 
-- name: check UDP violations
+- name: check UDP 5555 is in listening ports
   assert:
-    that: ansible_facts.udp_listen_violations|length > 0
-  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
-
-- name: check TCP listening ports
-  assert:
-    that: ansible_facts.tcp_listen|length > 0
-  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
-
-- name: check UDP listening ports
-  assert:
-    that: ansible_facts.udp_listen|length > 0
-  when: ansible_os_family == "RedHat" or ansible_os_family == "Debian"
+    that: 5555 in ansible_facts.udp_listen | map(attribute='port') | sort | list
+  when: (ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 7) or ansible_os_family == "Debian"


### PR DESCRIPTION
##### ISSUE TYPE
- New Module Pull Request
##### COMPONENT NAME

listen_ports_facts
##### ANSIBLE VERSION

```
ansible 2.4.0 (ansible-modules-extras/pull/2069 0f24cd1b2a) last updated 2017/03/29 18:34:39 (GMT +1100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  python version = 2.7.5 (default, Nov 20 2015, 02:00:19) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```
##### SUMMARY

This module allows the user gather facts on which TCP and UDP ports have processes listening, and optionally provide a whitelist for either protocol and gather facts of violations.
