### PR TITLE
Minor sts_session_token fixes aligning more closely to boto3 api

### DIFF
--- a/lib/ansible/modules/cloud/amazon/sts_session_token.py
+++ b/lib/ansible/modules/cloud/amazon/sts_session_token.py
@@ -128,7 +128,7 @@ def get_session_token(connection, module):
     try:
         response = connection.get_session_token(**args)
         changed = True
-    except ClientError, e:
+    except ClientError as e:
         module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
 
     module.exit_json(changed=changed, **camel_dict_to_snake_dict(response))


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

sts_session_token
##### ANSIBLE VERSION

2.2
##### SUMMARY

This module was merged quickly before I could review.

This PR just changes the return values to match boto3 as we want to keep values closely aligned to the API.  It also uses the helper function camel_dict_to_snake_dict to keep code DRY.

Also fixed the exception handling for AWS ClientError
