### PR TITLE
Update assemble to allow alternate source of files

### DIFF
--- a/lib/ansible/modules/files/assemble.py
+++ b/lib/ansible/modules/files/assemble.py
@@ -175,7 +175,7 @@ def assemble_from_fragments(src_path, delimiter=None, compiled_regexp=None, igno
         
 
     for fragment in sorted_files:
-        if compiled_regexp and not compiled_regexp.search(fragment) and not src_files:
+        if compiled_regexp and not compiled_regexp.search(os.path.basename(fragment)) and not src_files:
             continue
         #fragment = u"%s/%s" % (src_path, f)
         if not os.path.isfile(fragment) or (ignore_hidden and os.path.basename(fragment).startswith('.')):

--- a/lib/ansible/modules/files/assemble.py
+++ b/lib/ansible/modules/files/assemble.py
@@ -41,14 +41,14 @@ options:
   src:
     description:
       - An already existing directory full of source files.
-    required: flase
+    required: false
     default: null
     aliases: []
   src_files:
     description:
       - A list of files sorted by user. 
     version_added: "2.3"
-    required: flase
+    required: false
     default: null
     aliases: []
   dest:

--- a/lib/ansible/modules/files/assemble.py
+++ b/lib/ansible/modules/files/assemble.py
@@ -171,6 +171,7 @@ def assemble_from_fragments(src_path, delimiter=None, compiled_regexp=None, igno
             sorted_files.append(str(src_path) + '/' + str(current_file))
     else:
         for current_file in src_files:
+            current_file = os.path.expanduser(current_file)
             sorted_files.append(current_file)
         
 

--- a/lib/ansible/modules/files/assemble.py
+++ b/lib/ansible/modules/files/assemble.py
@@ -178,7 +178,6 @@ def assemble_from_fragments(src_path, delimiter=None, compiled_regexp=None, igno
     for fragment in sorted_files:
         if compiled_regexp and not compiled_regexp.search(os.path.basename(fragment)) and not src_files:
             continue
-        #fragment = u"%s/%s" % (src_path, f)
         if not os.path.isfile(fragment) or (ignore_hidden and os.path.basename(fragment).startswith('.')):
             continue
         fragment_content = open(fragment, 'rb').read()

--- a/lib/ansible/modules/files/assemble.py
+++ b/lib/ansible/modules/files/assemble.py
@@ -192,6 +192,7 @@ def assemble_from_fragments(src_path, delimiter=None, compiled_regexp=None, igno
                 # un-escape anything like newlines
                 delimiter = codecs.escape_decode(delimiter)[0]
                 tmp.write(delimiter)
+
                 # always make sure there's a newline after the
                 # delimiter, so lines don't run together
                 if delimiter[-1] != b('\n'):

--- a/lib/ansible/modules/files/assemble.py
+++ b/lib/ansible/modules/files/assemble.py
@@ -41,14 +41,12 @@ options:
   src:
     description:
       - An already existing directory full of source files.
-    required: false
     default: null
     aliases: []
   src_files:
     description:
       - A list of files sorted by user. 
     version_added: "2.3"
-    required: false
     default: null
     aliases: []
   dest:

--- a/lib/ansible/plugins/action/assemble.py
+++ b/lib/ansible/plugins/action/assemble.py
@@ -90,6 +90,7 @@ class ActionModule(ActionBase):
             return result
 
         src        = self._task.args.get('src', None)
+        src_files  = self._task.args.get('src_files', None)
         dest       = self._task.args.get('dest', None)
         delimiter  = self._task.args.get('delimiter', None)
         remote_src = self._task.args.get('remote_src', 'yes')
@@ -97,9 +98,14 @@ class ActionModule(ActionBase):
         follow     = self._task.args.get('follow', False)
         ignore_hidden = self._task.args.get('ignore_hidden', False)
 
-        if src is None or dest is None:
+        if src is None and src_files is None:
             result['failed'] = True
-            result['msg'] = "src and dest are required"
+            result['msg'] = "src or src_files is required"
+            return result
+
+        if dest is None:
+            result['failed'] = True
+            result['msg'] = "dest is required"
             return result
 
         remote_user = task_vars.get('ansible_ssh_user') or self._play_context.remote_user
@@ -119,7 +125,7 @@ class ActionModule(ActionBase):
                 result['msg'] = to_native(e)
                 return result
 
-        if not os.path.isdir(src):
+        if not os.path.isdir(src) and src:
             result['failed'] = True
             result['msg'] = u"Source (%s) is not a directory" % src
             return result

--- a/test/integration/targets/assemble/tasks/main.yml
+++ b/test/integration/targets/assemble/tasks/main.yml
@@ -93,7 +93,7 @@
 
 - name: test assemble with src_files and reordered
   assemble:
-    src: "./"
+    src: "{{output_dir}}/src"
     dest: "{{output_dir}}/assembled6"
     src_files:
       - 'fragment2'
@@ -110,8 +110,8 @@
   assemble:
     dest: "{{output_dir}}/assembled7"
     src_files:
-      - './fragment4'
-      - './fragment3'
+      - '{{output_dir}}/src/fragment4'
+      - '{{output_dir}}/src/fragment3'
   register: result
 
 - name: assert the fragments were assembled in correct order

--- a/test/integration/targets/assemble/tasks/main.yml
+++ b/test/integration/targets/assemble/tasks/main.yml
@@ -90,3 +90,32 @@
     that:
     - "result.state == 'file'"
     - "result.checksum == '505359f48c65b3904127cf62b912991d4da7ed6d'"
+
+- name: test assemble with src_files and reordered
+  assemble:
+    src: "./"
+    dest: "{{output_dir}}/assembled6"
+    src_files:
+      - 'fragment2'
+      - 'fragment1'
+  register: result
+
+- name: assert the fragments were assembled in correct order
+  assert:
+    that:
+    - "result.state == 'file'"
+    - "result.checksum == '552138093d792c8153b6fa45b9a6247d644ab12d'"
+
+- name: test assemble with src_files and reordered and no src
+  assemble:
+    dest: "{{output_dir}}/assembled7"
+    src_files:
+      - './fragment4'
+      - './fragment3'
+  register: result
+
+- name: assert the fragments were assembled in correct order
+  assert:
+    that:
+    - "result.state == 'file'"
+    - "result.checksum == '194105ee299c3b4985dc858837a3c6a8ac10a52c'"

--- a/test/integration/targets/assemble/tasks/main.yml
+++ b/test/integration/targets/assemble/tasks/main.yml
@@ -91,7 +91,6 @@
     - "result.state == 'file'"
     - "result.checksum == '505359f48c65b3904127cf62b912991d4da7ed6d'"
 
-
 - name: test assemble with src_files and reordered
   assemble:
     src: "{{output_dir}}/src"
@@ -106,7 +105,6 @@
     that:
     - "result.state == 'file'"
     - "result.checksum == '847b7a99700590b671ddfc22fed082be2dcea909'"
-
 
 - name: test assemble with src_files and reordered using diff order
   assemble:
@@ -181,4 +179,3 @@
     - "result.state == 'file'"
     - "result.changed == False"
     - "result.checksum == '194105ee299c3b4985dc858837a3c6a8ac10a52c'"
-

--- a/test/integration/targets/assemble/tasks/main.yml
+++ b/test/integration/targets/assemble/tasks/main.yml
@@ -91,7 +91,24 @@
     - "result.state == 'file'"
     - "result.checksum == '505359f48c65b3904127cf62b912991d4da7ed6d'"
 
+
 - name: test assemble with src_files and reordered
+  assemble:
+    src: "{{output_dir}}/src"
+    dest: "{{output_dir}}/assembled6"
+    src_files:
+      - 'fragment3'
+      - 'fragment1'
+  register: result
+
+- name: assert the fragments were assembled in correct order
+  assert:
+    that:
+    - "result.state == 'file'"
+    - "result.checksum == '847b7a99700590b671ddfc22fed082be2dcea909'"
+
+
+- name: test assemble with src_files and reordered using diff order
   assemble:
     src: "{{output_dir}}/src"
     dest: "{{output_dir}}/assembled6"
@@ -106,7 +123,37 @@
     - "result.state == 'file'"
     - "result.checksum == '552138093d792c8153b6fa45b9a6247d644ab12d'"
 
+- name: test again for idempotency
+  assemble:
+    src: "{{output_dir}}/src"
+    dest: "{{output_dir}}/assembled6"
+    src_files:
+      - 'fragment2'
+      - 'fragment1'
+  register: result
+
+- name: assert that the same assemble made no changes
+  assert:
+    that:
+    - "result.state == 'file'"
+    - "result.changed == False"
+    - "result.checksum == '552138093d792c8153b6fa45b9a6247d644ab12d'"
+
 - name: test assemble with src_files and reordered and no src
+  assemble:
+    dest: "{{output_dir}}/assembled7"
+    src_files:
+      - '{{output_dir}}/src/fragment2'
+      - '{{output_dir}}/src/fragment3'
+  register: result
+
+- name: assert the fragments were assembled in correct order
+  assert:
+    that:
+    - "result.state == 'file'"
+    - "result.checksum == '3d18e2636c9e275fec2a999c4a53f6b7eb698aff'"
+
+- name: test assemble with src_files and reordered and no src using diff order
   assemble:
     dest: "{{output_dir}}/assembled7"
     src_files:
@@ -119,3 +166,19 @@
     that:
     - "result.state == 'file'"
     - "result.checksum == '194105ee299c3b4985dc858837a3c6a8ac10a52c'"
+
+- name: test again for idempotency
+  assemble:
+    dest: "{{output_dir}}/assembled7"
+    src_files:
+      - '{{output_dir}}/src/fragment4'
+      - '{{output_dir}}/src/fragment3'
+  register: result
+
+- name: assert that the same assemble made no changes
+  assert:
+    that:
+    - "result.state == 'file'"
+    - "result.changed == False"
+    - "result.checksum == '194105ee299c3b4985dc858837a3c6a8ac10a52c'"
+


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Assemble module

##### ANSIBLE VERSION

```
ansible 2.3.0 (assemble-sort 1c9218785b) last updated 2016/12/18 20:50:59 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Allow alternate to sort in the assemble module. 
Refer to: https://github.com/ansible/ansible/issues/19442
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
