### PR TITLE
Improve error message for module validation

### DIFF
--- a/test/sanity/validate-modules/validate-modules
+++ b/test/sanity/validate-modules/validate-modules
@@ -39,6 +39,7 @@ from module_args import get_argument_spec
 from schema import doc_schema, option_schema
 
 from utils import CaptureStd
+from voluptuous.humanize import humanize_error
 
 import yaml
 import yaml.reader
@@ -373,6 +374,8 @@ class ModuleValidator(Validator):
         try:
             doc_schema(doc)
         except Exception as e:
+            for error in e.errors:
+                error.data = doc
             errors.extend(e.errors)
 
         options = doc.get('options', {})
@@ -382,12 +385,13 @@ class ModuleValidator(Validator):
             except Exception as e:
                 for error in e.errors:
                     error.path[:0] = ['options', key]
+                    error.data = option
                 errors.extend(e.errors)
 
         for error in errors:
             path = [str(p) for p in error.path]
             self.errors.append('DOCUMENTATION.%s: %s' %
-                               ('.'.join(path), error.error_message))
+                               ('.'.join(path), humanize_error(error.data, error)))
 
     def _validate_docs(self):
         doc_info = self._get_docs()


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
validate-modules

##### ANSIBLE VERSION
```
ansible 2.3.0 (improve_validate_modules_message af530a1331) last updated 2016/12/19 14:46:30 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Print out the data that fails to validate when doing
schema checking on modules

This allows easier interpretation of error messages.

From:

```
ERROR: DOCUMENTATION.notes.2: expected basestring
```

To:

```
ERROR: DOCUMENTATION.notes.2: expected basestring @ data['notes'][2].
Got {"As with C(include) this task can be static or dynamic, If static
it implies that it won't need templating nor loops nor conditionals and
will show included tasks in the --list options. Ansible will try to
autodetect what is needed, but you can set `static": 'yes|no` at task
level to control this.'}
```

See e.g. [shippable failure](https://app.shippable.com/runs/58568ebc8171491100ba8005/1/console) from #19429