### PR TITLE
Support pacman packages using different types of compression

### DIFF
--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -348,7 +348,7 @@ def main():
 
         pkg_files = []
         for i, pkg in enumerate(pkgs):
-            if pkg.endswith('.pkg.tar.xz'):
+            if re.match(".*\.pkg\.tar(\.(gz|bz2|xz|lrz|lzo|Z))?$", pkg):
                 # The package given is a filename, extract the raw pkg name from
                 # it and store the filename
                 pkg_files.append(pkg)


### PR DESCRIPTION
It's possible to compress packages using several different compression
methods, or not compressed at all. Previously, the pacman module only
supported files compressed using xz. This update ensures that all
compression types currently supported by pacman are supported by the
ansible pacman module.

The list of supported compression methods at the time of writing can be
found here:
https://git.archlinux.org/pacman.git/tree/scripts/makepkg.sh.in#n747