### PR TITLE
Fix include_role docs to be valid YAML

### DIFF
--- a/lib/ansible/modules/utilities/logic/include_role.py
+++ b/lib/ansible/modules/utilities/logic/include_role.py
@@ -53,7 +53,7 @@ options:
 notes:
     - Handlers are made available to the whole play.
     - simple dependencies seem to work fine.
-    - As with C(include) this task can be static or dynamic, If static it implies that it won't need templating nor loops nor conditionals and will show included tasks in the --list options. Ansible will try to autodetect what is needed, but you can set `static: yes|no` at task level to control this.
+    - As with C(include) this task can be static or dynamic, If static it implies that it won't need templating nor loops nor conditionals and will show included tasks in the --list options. Ansible will try to autodetect what is needed, but you can set `static` to `yes` or `no` at task level to control this.
 '''
 
 EXAMPLES = """


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
include_role module

##### ANSIBLE VERSION
```
ansible 2.3.0 (include_role_docs 3244eb4453) last updated 2016/12/19 19:32:21 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Remove the colon from one of the documentation notes, which is causing documentation schema validation to fail. The YAML validation error is currently causing all new PRs based upon 884b52919 or later to fail