### PR TITLE
Azure dynamic inventory: make host name in inventory configurable

### DIFF
--- a/contrib/inventory/azure_rm.ini
+++ b/contrib/inventory/azure_rm.ini
@@ -20,3 +20,7 @@ group_by_resource_group=yes
 group_by_location=yes
 group_by_security_group=yes
 group_by_tag=yes
+
+# Python format expression to use as host ID in inventory. 
+# May use all fields provided by the inventory script, including 'name' (i.e. resource name), 'resource_group', 'computer_name', 'fqdn'
+id_format={name}

--- a/contrib/inventory/azure_rm.ini
+++ b/contrib/inventory/azure_rm.ini
@@ -21,6 +21,6 @@ group_by_location=yes
 group_by_security_group=yes
 group_by_tag=yes
 
-# Python format expression to use as host ID in inventory. 
+# Python format expression to use as name of host in inventory. 
 # May use all fields provided by the inventory script, including 'name' (i.e. resource name), 'resource_group', 'computer_name', 'fqdn'
-id_format={name}
+inventory_name_format={name}

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -684,26 +684,16 @@ class AzureInventory(object):
     def _get_settings(self):
         # Load settings from the .ini, if it exists. Otherwise,
         # look for environment values.
-        file_settings = self._load_settings()
-        if file_settings:
-            for key in AZURE_CONFIG_SETTINGS:
-                if key in ('resource_groups', 'tags', 'locations') and file_settings.get(key):
-                    values = file_settings.get(key).split(',')
-                    if len(values) > 0:
-                        setattr(self, key, values)
-                elif file_settings.get(key):
-                    val = self._to_boolean(file_settings[key])
-                    setattr(self, key, val)
-        else:
-            env_settings = self._get_env_settings()
-            for key in AZURE_CONFIG_SETTINGS:
-                if key in('resource_groups', 'tags', 'locations') and env_settings.get(key):
-                    values = env_settings.get(key).split(',')
-                    if len(values) > 0:
-                        setattr(self, key, values)
-                elif env_settings.get(key, None) is not None:
-                    val = self._to_boolean(env_settings[key])
-                    setattr(self, key, val)
+        settings = self._load_settings() or self._get_env_settings()
+
+        for key in AZURE_CONFIG_SETTINGS:
+            if key in ('resource_groups', 'tags', 'locations') and settings.get(key):
+                values = settings.get(key).split(',')
+                if len(values) > 0:
+                    setattr(self, key, values)
+            elif settings.get(key, None) is not None:
+                val = self._to_boolean(settings[key])
+                setattr(self, key, val)
 
     def _parse_ref_id(self, reference):
         response = {}

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -148,11 +148,11 @@ By default hosts are named by their unqualified resource name in Azure. You may 
 if it leads to name collisions - because you use the same resource name in multiple resource groups -  
 or if you find other names more convenient. 
 
-To use the private computer name of a VM as ID:
-AZURE_ID_FORMAT={computer_name}
+To use the private computer name of a VM as inventory host name:
+AZURE_INVENTORY_NAME_FORMAT={computer_name}
 
 To use a qualified name that is guaranteed to be unique in the subscription:
-AZURE_ID_FORMAT={resource_group}_{name}
+AZURE_INVENTORY_NAME_FORMAT={resource_group}_{name}
 
 Specify any Python format string containing host variables provided by this inventory.
 
@@ -245,7 +245,7 @@ AZURE_CONFIG_SETTINGS = dict(
     group_by_location='AZURE_GROUP_BY_LOCATION',
     group_by_security_group='AZURE_GROUP_BY_SECURITY_GROUP',
     group_by_tag='AZURE_GROUP_BY_TAG',
-    id_format='AZURE_ID_FORMAT'
+    id_format='AZURE_INVENTORY_NAME_FORMAT'
 )
 
 AZURE_MIN_VERSION = "0.30.0rc5"


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ansible/contrib/inventory/azure_rm.py

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### SUMMARY
Currently Azure dynamic inventory uses the unqualified resource name of the VMs as inventory name. (`inventory_hostname`, not `ansible_hostname`.) 

For the sake of convention we use the same resource name (e.g. 'appserver') for different VMs in multiple resource groups (e.g 'resourceGroups/production/appserver' and 'resourceGroups/qa/appserver'). In this case the dynamic inventory will only yield one of the two VMs as inventory host by the name 'appserver'.

This pull request makes the inventory name configurable by allowing to specify a Python format string. The user can then specify any naming based on the host variables already provided by the script, including 'name' (i.e. resource name), 'resource_group', 'computer_name', 'fqdn'.

This way the user can disambiguate hosts, but also choose more convenient names.

The default behavior is unchanged.

```
$ ansible -i azure_rm.py --list-hosts all
  hosts (1):
    appserver
$ AZURE_ID_FORMAT="{resource_group}_{name}" ansible -i azure_rm.py --list-hosts all
  hosts (2):
    production_appserver
    qa_appserver
$ AZURE_ID_FORMAT="{fqdn}" ansible -i azure_rm.py --list-hosts all
  hosts (2):
    appserver.production.company.com
    appserver.qa.company.com
```

##### OPEN QUESTIONS/DOUBTS
1. Is it good practice to expose a Python format string as configuration? (Security concerns?)
2. Should we come up with a better name for the environment variable/setting than  `AZURE_ID_FORMAT`/`id_format`. Unfortunately inventory/host name is pretty ambiguous in meaning - `inventory_hostname` and `ansible_hostname` are not very descriptive either.
