### PR TITLE
Better error msg for basic.get_bin_path()

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1839,7 +1839,7 @@ class AnsibleModule(object):
                 bin_path = path
                 break
         if required and bin_path is None:
-            self.fail_json(msg='Failed to find required executable %s' % arg)
+            self.fail_json(msg='Failed to find required executable %s in paths: %s' % (arg, os.pathsep.join(paths)))
         return bin_path
 
     def boolean(self, arg):


### PR DESCRIPTION
Include the searched paths in the error message.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/module_utils/basic.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (basic_get_bin_path_errors b0b26ea41f) last updated 2016/12/19 18:14:40 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides


```

##### SUMMARY
Show a more descriptive error message if get_bin_path('some_cmd', required=True) fails.

Before:
```
[fedora-23:ansible (devel % u=)]$ ansible -i hosts localhost -m git -a 'dest=/tmp/test_repo repo=https://github.com/ansible/ansible-examples.git'
localhost | FAILED! => {
    "changed": false, 
    "failed": true, 
    "msg": "Failed to find required executable supergit"
}
```

After:

```
[fedora-23:ansible (devel % u=)]$ ansible -i hosts localhost -m git -a 'dest=/tmp/test_repo repo=https://github.com/ansible/ansible-examples.git'
localhost | FAILED! => {
    "changed": false, 
    "failed": true, 
    "msg": "Failed to find required executable supergit in paths: /home/adrian/src/ansible/bin:/home/adrian/bin:/home/adrian/.local/bin:/home/adrian/pythons/bin:/usr/lib64/qt-3.3/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/home/adrian/.rvm/bin:/home/adrian/.cabal/bin:/home/adrian/gopath/bin:/sbin"
}
```
