### PR TITLE
nxos_file_copy: Fix md5 sums check

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -277,6 +277,8 @@ def execute_show(cmds, module, command_type=None):
 
 def execute_show_command(command, module, command_type='cli_show'):
     if module.params['transport'] == 'cli':
+        if 'md5sum' in command:
+            command += ' | json'
         cmds = [command]
         body = execute_show(cmds, module)
     elif module.params['transport'] == 'nxapi':
@@ -328,11 +330,12 @@ def get_remote_md5(module, dst):
 
 def get_local_md5(module, blocksize=2**20):
     md5 = hashlib.md5()
-    with open(module.params['local_file'], 'rb') as f:
-        buf = f.read(blocksize)
-        while buf:
-            md5.update(buf)
-            buf = f.read(blocksize)
+    local_file = open(module.params['local_file'], 'rb')
+    buf = local_file.read(blocksize)
+    while buf:
+        md5.update(buf)
+        buf = local_file.read(blocksize)
+    local_file.close()
     return md5.hexdigest()
 
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_file_copy

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Fix md5 sums check