### PR TITLE
nxos_snmp_community: Use running config for module operations instead of cli commands. 

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_snmp_community.py
+++ b/lib/ansible/modules/network/nxos/nxos_snmp_community.py
@@ -58,6 +58,26 @@ options:
         required: true
         default: present
         choices: ['present','absent']
+    include_defaults:
+        description:
+            - Specify to use or not the complete runnning configuration
+              for module operations.
+        required: false
+        default: false
+        choices: ['true','false']
+    config:
+        description:
+            - Configuration string to be used for module operations. If not
+              specified, the module will use the current running configuration.
+        required: false
+        default: null
+    save:
+        description:
+            - Specify to save the running configuration after
+              module operations.
+        required: false
+        default: false
+        choices: ['true','false']
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/network/nxos/nxos_snmp_community.py
+++ b/lib/ansible/modules/network/nxos/nxos_snmp_community.py
@@ -65,14 +65,14 @@ options:
         required: false
         default: false
         choices: ['true','false']
-        version_added: 2.2
+        version_added: 2.3
     config:
         description:
             - Configuration string to be used for module operations. If not
               specified, the module will use the current running configuration.
         required: false
         default: null
-        version_added: 2.2
+        version_added: 2.3
     save:
         description:
             - Specify to save the running configuration after
@@ -80,7 +80,7 @@ options:
         required: false
         default: false
         choices: ['true','false']
-        version_added: 2.2
+        version_added: 2.3
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/network/nxos/nxos_snmp_community.py
+++ b/lib/ansible/modules/network/nxos/nxos_snmp_community.py
@@ -352,13 +352,17 @@ def main():
             save=dict(type='bool', default=False)
     )
     module = get_network_module(argument_spec=argument_spec,
-                                required_one_of=[['access', 'group']],
                                 mutually_exclusive=[['access', 'group']],
                                 supports_check_mode=True)
 
     access = module.params['access']
     group = module.params['group']
     state = module.params['state']
+
+    if state == 'present':
+        if not group and not access:
+            module.fail_json(msg='group or access param must be '
+                                 'used when state=present')
 
     if access:
         if access == 'ro':

--- a/lib/ansible/modules/network/nxos/nxos_snmp_community.py
+++ b/lib/ansible/modules/network/nxos/nxos_snmp_community.py
@@ -65,12 +65,14 @@ options:
         required: false
         default: false
         choices: ['true','false']
+        version_added: 2.2
     config:
         description:
             - Configuration string to be used for module operations. If not
               specified, the module will use the current running configuration.
         required: false
         default: null
+        version_added: 2.2
     save:
         description:
             - Specify to save the running configuration after
@@ -78,6 +80,7 @@ options:
         required: false
         default: false
         choices: ['true','false']
+        version_added: 2.2
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_snmp_community

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Changed how module work to make it use running config for module operations instead of cli commands. Referring to #5214
