### PR TITLE
Update vca_vapp.py

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vca_vapp.py
+++ b/lib/ansible/modules/cloud/vmware/vca_vapp.py
@@ -189,6 +189,9 @@ def create(module):
                                   catalog_name, network_name, network_mode,
                                   vm_name, vm_cpus, vm_memory, deploy, poweron)
 
+    if task is False:
+        module.fail('Failed to create vapp: ' + vapp_name)
+        
     module.vca.block_until_completed(task)
 
 def delete(module):


### PR DESCRIPTION
Check result of vApp creation and return module failure if creation task not present

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/cloud/vmware/vca_vapp.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Added check of the value returned from create_vapp and fail module if task is False.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #19539 
<!-- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [vcd : Create VM] *********************************************************
fatal: [elk0-dev3]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to create vapp"}
fatal: [elk0-dev4]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to create vapp"}
fatal: [elk0-dev2]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to create vapp"}
fatal: [elk0-dev5]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to create vapp"}
fatal: [elk0-dev1]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to create vapp"}

```