### PR TITLE
Fix missing imports from sysctl module

### DIFF
--- a/lib/ansible/modules/system/sysctl.py
+++ b/lib/ansible/modules/system/sysctl.py
@@ -117,8 +117,8 @@ EXAMPLES = '''
 
 import os
 import tempfile
-import re
-from ansible.module_utils.basic import get_platform, AnsibleModule, BOOLEANS_TRUE, BOOLEANS_FALSE
+from ansible.module_utils.basic import get_platform, get_exception, AnsibleModule, BOOLEANS_TRUE, BOOLEANS_FALSE
+
 
 class SysctlModule(object):
 


### PR DESCRIPTION
This module was missing an import of get_exception()
and had an unused import of 're'

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/modules/system/sysctl.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (sysctl_19388 412c19cc08) last updated 2016/12/15 14:56:49 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides


```

##### SUMMARY

This module was missing an import of get_exception()
and had an unused import of 're'
