### PR TITLE
Show valid bool symbols in error for invalid bool symbol

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1665,7 +1665,8 @@ class AnsibleModule(object):
             try:
                 self.params[k] = type_checker(value)
             except (TypeError, ValueError):
-                self.fail_json(msg="argument %s is of type %s and we were unable to convert to %s" % (k, type(value), wanted))
+                e = get_exception()
+                self.fail_json(msg="argument %s is of type %s and we were unable to convert to %s: %s" % (k, type(value), wanted, e))
 
     def _set_defaults(self, pre=True):
         for (k,v) in self.argument_spec.items():
@@ -1857,7 +1858,7 @@ class AnsibleModule(object):
         elif arg in BOOLEANS_FALSE:
             return False
         else:
-            self.fail_json(msg='Boolean %s not in either boolean list' % arg)
+            self.fail_json(msg='%s is not a valid boolean. Valid booleans include: %s' % (to_text(arg), ','.join(['%s' % x for x in BOOLEANS])))
 
     def jsonify(self, data):
         for encoding in ("utf-8", "latin-1"):


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/module_utils/basic.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (valid_bool_error e04933113d) last updated 2016/12/20 10:40:29 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
If we throw an error about a value not being a valid boolean, also include the list of valid booleans.

Before:
```
[fedora-23:ansible (devel % u=)]$ ansible -i hosts localhost -m copy -a 'src=README.md dest=/tmp/readme.txt unsafe_writes=4xrtvdvr'
localhost | FAILED! => {
    "changed": false, 
    "checksum": "e400e0d41a48a66433478d2c9b0f21269febe06b", 
    "failed": true, 
    "msg": "Boolean 4xrtvdvr not in either boolean list"
}
```

After:
```
[fedora-23:ansible (valid_bool_error %)]$ ansible -i hosts localhost -m copy -a 'src=README.md dest=/tmp/readme.txt unsafe_writes=4xrtvdvr'
localhost | FAILED! => {
    "changed": false, 
    "checksum": "e400e0d41a48a66433478d2c9b0f21269febe06b", 
    "failed": true, 
    "msg": "4xrtvdvr is not a valid boolean. Valid booleans include: y,yes,on,1,true,1,True,n,no,off,0,false,0,False"
}
```

