### PR TITLE
ops_command tests: Make tests pass on fresh install

### DIFF
--- a/test/integration/targets/ops_command/tests/cli/contains.yaml
+++ b/test/integration/targets/ops_command/tests/cli/contains.yaml
@@ -5,10 +5,10 @@
   ops_command:
     commands:
       - show version
-      - show interface GigabitEthernet0/0
+      - show interface eth1
     wait_for:
-      - "result[0] contains 15.6"
-      - "result[1] contains GigabitEthernet0/0"
+      - "result[0] contains OpenSwitch"
+      - "result[1] contains 'Interface eth1'"
     provider: "{{ cli }}"
   register: result
 

--- a/test/integration/targets/ops_command/tests/cli/output.yaml
+++ b/test/integration/targets/ops_command/tests/cli/output.yaml
@@ -16,7 +16,7 @@
   ops_command:
     commands:
       - show version
-      - show interfaces
+      - show interface
     provider: "{{ cli }}"
   register: result
 


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
ops_command

##### ANSIBLE VERSION

##### SUMMARY
Looks like `ops01` got reinstalled recently, which is causing the tests to fail

* `GigabitEthernet0/0` doesn't exist, so changed to 1eth11
* I'm assuming the `15.6` was part of the version, changed to be more generic
* `show interfaces` was returning invalid command, changed to `show interface` - This change confuses me

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/19566)
<!-- Reviewable:end -->
