### PR TITLE
ec2_vol: Add key selection support for EBS volume encryption.

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vol.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vol.py
@@ -74,7 +74,6 @@ options:
     description:
       - device id to override device mapping. Assumes /dev/sdf for Linux/UNIX and /dev/xvdf for Windows.
     required: false
-    default: null
   delete_on_termination:
     description:
       - When set to "yes", the volume will be deleted upon instance termination.

--- a/lib/ansible/modules/cloud/amazon/ec2_vol.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vol.py
@@ -74,6 +74,7 @@ options:
     description:
       - device id to override device mapping. Assumes /dev/sdf for Linux/UNIX and /dev/xvdf for Windows.
     required: false
+    default: null
   delete_on_termination:
     description:
       - When set to "yes", the volume will be deleted upon instance termination.
@@ -322,6 +323,15 @@ def boto_supports_volume_encryption():
     """
     return hasattr(boto, 'Version') and LooseVersion(boto.Version) >= LooseVersion('2.29.0')
 
+def boto_supports_kms_key_id():
+    """
+    Check if Boto library supports kms_key_ids (added in 2.39.0)
+
+    Returns:
+        True if version is equal to or higher then the version needed, else False
+    """
+    return hasattr(boto, 'Version') and LooseVersion(boto.Version) >= LooseVersion('2.39.0')
+
 
 def create_volume(module, ec2, zone):
     changed = False
@@ -555,6 +565,9 @@ def main():
 
     if encrypted and not boto_supports_volume_encryption():
         module.fail_json(msg="You must use boto >= v2.29.0 to use encrypted volumes")
+
+    if kms_key_id and not boto_supports_kms_key_id():
+        module.fail_json(msg="You must use boto >= v2.39.0 to use kms_key_id")
 
     # Here we need to get the zone info for the instance. This covers situation where
     # instance is specified but zone isn't.

--- a/lib/ansible/modules/cloud/amazon/ec2_vol.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vol.py
@@ -65,6 +65,11 @@ options:
       - Enable encryption at rest for this volume.
     default: false
     version_added: "1.8"
+  kms_key_id:
+    description:
+      - Specify the id of the KMS key to use.
+    default: null
+    version_added: "2.1"
   device_name:
     description:
       - device id to override device mapping. Assumes /dev/sdf for Linux/UNIX and /dev/xvdf for Windows.
@@ -324,6 +329,7 @@ def create_volume(module, ec2, zone):
     name = module.params.get('name')
     iops = module.params.get('iops')
     encrypted = module.params.get('encrypted')
+    kms_key_id = module.params.get('kms_key_id')
     volume_size = module.params.get('volume_size')
     volume_type = module.params.get('volume_type')
     snapshot = module.params.get('snapshot')
@@ -335,7 +341,10 @@ def create_volume(module, ec2, zone):
     if volume is None:
         try:
             if boto_supports_volume_encryption():
-                volume = ec2.create_volume(volume_size, zone, snapshot, volume_type, iops, encrypted)
+                if kms_key_id:
+                    volume = ec2.create_volume(volume_size, zone, snapshot, volume_type, iops, encrypted, kms_key_id)
+                else:
+                    volume = ec2.create_volume(volume_size, zone, snapshot, volume_type, iops, encrypted)
                 changed = True
             else:
                 volume = ec2.create_volume(volume_size, zone, snapshot, volume_type, iops)
@@ -409,7 +418,7 @@ def modify_dot_attribute(module, ec2, instance, device_name):
         dot = instance.block_device_mapping[device_name].delete_on_termination
     except boto.exception.BotoServerError as e:
         module.fail_json(msg = "%s: %s" % (e.error_code, e.error_message))
-
+  
     if delete_on_termination != dot:
         try:
             bdt = BlockDeviceType(delete_on_termination=delete_on_termination)
@@ -418,7 +427,7 @@ def modify_dot_attribute(module, ec2, instance, device_name):
 
             ec2.modify_instance_attribute(instance_id=instance.id, attribute='blockDeviceMapping', value=bdm)
 
-            while instance.block_device_mapping[device_name].delete_on_termination != delete_on_termination:
+	    while instance.block_device_mapping[device_name].delete_on_termination != delete_on_termination:
                 time.sleep(3)
                 instance.update()
             changed = True
@@ -486,6 +495,7 @@ def main():
             volume_type = dict(choices=['standard', 'gp2', 'io1', 'st1', 'sc1'], default='standard'),
             iops = dict(),
             encrypted = dict(type='bool', default=False),
+            kms_key_id = dict(),
             device_name = dict(),
             delete_on_termination = dict(type='bool', default=False),
             zone = dict(aliases=['availability_zone', 'aws_zone', 'ec2_zone']),
@@ -503,6 +513,7 @@ def main():
     instance = module.params.get('instance')
     volume_size = module.params.get('volume_size')
     encrypted = module.params.get('encrypted')
+    kms_key_id = module.params.get('kms_key_id')
     device_name = module.params.get('device_name')
     zone = module.params.get('zone')
     snapshot = module.params.get('snapshot')


### PR DESCRIPTION
Original-code-by: https://github.com/nonshankus
More or less a rebase of PR onto master: https://github.com/ansible/ansible-modules-core/issues/3217

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ec2_vol

##### ANSIBLE VERSION
```
ansible 2.1.1.0
```

##### SUMMARY
Add support to specify the encryption key for encrypted EBS volumes.

It adds an additional config `kms_key_id` that can be used to use a key other than the default.
