### PR TITLE
support configuration option ansible_ssh_host

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -29,6 +29,24 @@ regions_exclude = us-gov-west-1,cn-north-1
 # in the event of a collision.
 destination_variable = public_dns_name
 
+# This allows you to override the ansible_ssh_host with an ec2 variable.
+# Ansible uses the value of ansible_ssh_host to ssh into a host.
+# If ansible_ssh_host isn't explicitly configured, it is implicitly set to the
+# hosts destination address.
+#
+# Example:
+#   # use private EC2 ip address as destination variable, for instance to include
+#   # stopped instances in the repository listing
+#   vpc_destination_variable = private_ip
+#   # but ssh to the public ip address when connecting to running instances
+#   ansible_ssh_host = ip_address
+#
+# Typically, ansible_ssh_host is either set to the ec2 variable 'ip_address'
+# or 'public_dns_name'.
+#
+#ansible_ssh_host=ip_address
+#ansible_ssh_host=public_dns_name
+
 # This allows you to override the inventory_name with an ec2 variable, instead
 # of using the destination_variable above. Addressing (aka ansible_ssh_host)
 # will still use destination_variable. Tags should be written as 'tag_TAGNAME'.

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -263,6 +263,12 @@ class Ec2Inventory(object):
             self.destination_format = None
             self.destination_format_tags = None
 
+        # ansbile_ssh_host
+        if config.has_option('ec2', 'ansible_ssh_host'):
+            self.ansible_ssh_host = config.get('ec2', 'ansible_ssh_host')
+        else:
+            self.ansible_ssh_host = None
+
         # Route53
         self.route53_enabled = config.getboolean('ec2', 'route53')
         self.route53_excluded_zones = []
@@ -900,7 +906,12 @@ class Ec2Inventory(object):
         self.push(self.inventory, 'ec2', hostname)
 
         self.inventory["_meta"]["hostvars"][hostname] = self.get_host_info_dict_from_instance(instance)
-        self.inventory["_meta"]["hostvars"][hostname]['ansible_ssh_host'] = dest
+
+        if self.ansible_ssh_host:
+            ansible_ssh_host = dest = getattr(instance, self.ansible_ssh_host, None)
+        else:
+            ansible_ssh_host = dest
+        self.inventory["_meta"]["hostvars"][hostname]['ansible_ssh_host'] = ansible_ssh_host
 
 
     def add_rds_instance(self, instance, region):


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - ec2.py

##### ANSIBLE VERSION
ansible 2.2.0.0

##### SUMMARY
From the extended `ec2.ini' 
```
# This allows you to override the ansible_ssh_host with an ec2 variable.
# Ansible uses the value of ansible_ssh_host to ssh into a host.
# If ansible_ssh_host isn't explicitly configured, it is implicitly set to the
# hosts destination address.
#
# Example:
#   # use private EC2 ip address as destination variable, for instance to include
#   # stopped instances in the repository listing
#   vpc_destination_variable = private_ip
#   # but ssh to the public ip address when connecting to running instances
#   ansible_ssh_host = ip_address
#
# Typically, ansible_ssh_host is either set to the ec2 variable 'ip_address'
# or 'public_dns_name'.
#
#ansible_ssh_host=ip_address
#ansible_ssh_host=public_dns_name
```
