### PR TITLE
Issue #19575: Adding Dest Param to win_uri

### DIFF
--- a/lib/ansible/modules/windows/win_uri.ps1
+++ b/lib/ansible/modules/windows/win_uri.ps1
@@ -73,7 +73,7 @@ if ($body -ne $null) {
 
 if ($dest -ne $null) {
     $webrequest_opts.OutFile = $dest
-    Set-Attr $result.dest "dest" $dest
+    Set-Attr $result.win_uri "dest" $dest
 }
 
 try {

--- a/lib/ansible/modules/windows/win_uri.ps1
+++ b/lib/ansible/modules/windows/win_uri.ps1
@@ -42,6 +42,7 @@ $method = Get-AnsibleParam -obj $params "method" -default "GET"
 $content_type = Get-AnsibleParam -obj $params -name "content_type"
 $headers = Get-AnsibleParam -obj $params -name "headers"
 $body = Get-AnsibleParam -obj $params -name "body"
+$dest = Get-AnsibleParam -obj $params -name "dest" -default $null
 $use_basic_parsing = ConvertTo-Bool (Get-AnsibleParam -obj $params -name "use_basic_parsing" -default $true)
 
 $webrequest_opts.Uri = $url
@@ -68,6 +69,11 @@ if ($headers -ne $null) {
 if ($body -ne $null) {
     $webrequest_opts.Body = $body
     Set-Attr $result.win_uri "body" $body
+}
+
+if ($dest -ne $null) {
+    $webrequest_opts.OutFile = $dest
+    Set-Attr $result.dest "dest" $dest
 }
 
 try {

--- a/lib/ansible/modules/windows/win_uri.py
+++ b/lib/ansible/modules/windows/win_uri.py
@@ -57,6 +57,11 @@ options:
   body:
     description:
       - The body of the HTTP request/response to the web service.
+  dest:
+    version_added: "2.3"
+    description:
+      - Output the response body to a file.
+    default: None
   headers:
     description:
       - 'Key Value pairs for headers. Example "Host: www.somesite.com"'


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
win_uri

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Added `dest` parameter. This will output the response body to a specified file.

Addresses Issue #19575 
