### PR TITLE
[win_chocolatey]Support for Side by side installs

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -176,8 +176,6 @@ Function Choco-Upgrade
         [Parameter(Mandatory=$false, Position=9)]
         [bool]$ignoredependencies,
         [Parameter(Mandatory=$false, Position=10)]
-        [Parameter(Mandatory=$false, Position=11)]
-        [bool]$allowmultipleversions
         [int]$timeout,
         [Parameter(Mandatory=$false, Position=12)]
         [bool]$skipscripts
@@ -287,10 +285,12 @@ Function Choco-Install
         [Parameter(Mandatory=$false, Position=11)]
         [int]$timeout,
         [Parameter(Mandatory=$false, Position=12)]
+        [bool]$allowmultipleversions,
+        [Parameter(Mandatory=$false, Position=13)]
         [bool]$skipscripts
     )
 
-    if (Choco-IsInstalled $package) -and (-not $allowmultipleversions))
+    if (Choco-IsInstalled $package)
     {
         if ($state -eq "latest")
         {
@@ -354,6 +354,11 @@ Function Choco-Install
         $cmd += " -ignoredependencies"
     }
 
+    if ($allowmultipleversions)
+    {
+        $cmd += " -m"
+    }
+
     if ($skipscripts)
     {
         $cmd += " --skip-scripts"
@@ -386,6 +391,8 @@ Function Choco-Uninstall
         [Parameter(Mandatory=$false, Position=4)]
         [int]$timeout,
         [Parameter(Mandatory=$false, Position=5)]
+        [bool]$allowmultipleversions,
+        [Parameter(Mandatory=$false, Position=6)]
         [bool]$skipscripts
 
     )
@@ -417,6 +424,11 @@ Function Choco-Uninstall
         $cmd += " -params '$packageparams'"
     }
 
+    if ($allowmultipleversions)
+    {
+        $cmd += " -m"
+    }
+
     if ($skipscripts)
     {
         $cmd += " --skip-scripts"
@@ -444,12 +456,13 @@ Try
         Choco-Install -package $package -version $version -source $source -force $force `
             -installargs $installargs -packageparams $packageparams `
             -allowemptychecksums $allowemptychecksums -ignorechecksums $ignorechecksums `
-            -ignoredependencies $ignoredependencies -timeout $timeout -skipscripts $skipscripts
+            -ignoredependencies $ignoredependencies -timeout $timeout `
+            -allowmultipleversions $allowmultipleversions -skipscripts $skipscripts
     }
     elseif ($state -eq "absent")
     {
         Choco-Uninstall -package $package -version $version -force $force -timeout $timeout `
-            -skipscripts $skipscripts
+            -allowmultipleversions $allowmultipleversions -skipscripts $skipscripts
     }
     elseif ($state -eq "reinstalled")
     {

--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -177,7 +177,7 @@ Function Choco-Upgrade
         [bool]$ignoredependencies,
         [Parameter(Mandatory=$false, Position=10)]
         [int]$timeout,
-        [Parameter(Mandatory=$false, Position=12)]
+        [Parameter(Mandatory=$false, Position=11)]
         [bool]$skipscripts
     )
 

--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -36,6 +36,7 @@ $packageparams = Get-AnsibleParam -obj $params -name "params" -type "str"
 $allowemptychecksums = Get-AnsibleParam -obj $params -name "allow_empty_checksums" -type "bool" -default $false
 $ignorechecksums = Get-AnsibleParam -obj $params -name "ignore_checksums" -type "bool" -default $false
 $ignoredependencies = Get-AnsibleParam -obj $params -name "ignore_dependencies" -type "bool" -default $false
+$allowmultipleversions = Get-AnsibleParam -obj $params -name "allow_multiple_version" -type "bool" -default $false
 $skipscripts = Get-AnsibleParam -obj $params -name "skip_scripts" -type "bool" -default $false
 
 $result = @{
@@ -175,8 +176,10 @@ Function Choco-Upgrade
         [Parameter(Mandatory=$false, Position=9)]
         [bool]$ignoredependencies,
         [Parameter(Mandatory=$false, Position=10)]
-        [int]$timeout,
         [Parameter(Mandatory=$false, Position=11)]
+        [bool]$allowmultipleversions
+        [int]$timeout,
+        [Parameter(Mandatory=$false, Position=12)]
         [bool]$skipscripts
     )
 
@@ -287,7 +290,7 @@ Function Choco-Install
         [bool]$skipscripts
     )
 
-    if (Choco-IsInstalled $package)
+    if (Choco-IsInstalled $package) -and (-not $allowmultipleversions))
     {
         if ($state -eq "latest")
         {

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -94,6 +94,12 @@ options:
     type: bool
     default: 'no'
     version_added: '2.1'
+  allow_multiple_versions:
+    description:
+      - Allow multiple versions of the same package to be installed
+    type: bool
+    default: 'no'
+    version_added: '2.4'
   timeout:
     description:
       - The time to allow chocolatey to finish before timing out.


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
win_chocolatey

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
This commit adds support for side by side installations of the different
versions of the same Chocolatey package in Ansible.

Internally the -m flag will be set when running the choco.exe install *
command. This will make Chocolatey disregard the currently installed
version and thus not upgrade, but install it side-by-side.

This change will probably be unsupported by some packages and maybe there
will be a need to provide a path to Ansible's win_chocolatey module, so it
is easier to manage multiple side-by-side installations of the same
package.
