### PR TITLE
os_recordset fix for names with multiple DNS record types

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_recordset.py
+++ b/lib/ansible/modules/cloud/openstack/os_recordset.py
@@ -197,7 +197,6 @@ def main():
             recordset = None
 
         if state == 'present':
-            recordset_type = module.params.get('recordset_type')
             records = module.params.get('records')
             description = module.params.get('description')
             ttl = module.params.get('ttl')

--- a/lib/ansible/modules/cloud/openstack/os_recordset.py
+++ b/lib/ansible/modules/cloud/openstack/os_recordset.py
@@ -192,6 +192,7 @@ def main():
 
         if len(recordsets) == 1:
             recordset = recordsets[0]
+            recordset_id = recordset['id']
         else:
             # recordsets is filtered by type and should never be more than 1 return
             recordset = None
@@ -222,10 +223,11 @@ def main():
                                                zone, pre_update_recordset)
                 if changed:
                     zone = cloud.update_recordset(
-                        zone, name + '.' + zone,
+                        zone, recordset_id,
                         records=records,
                         description=description,
                         ttl=ttl)
+
             module.exit_json(changed=changed, recordset=recordset)
 
         elif state == 'absent':
@@ -238,7 +240,7 @@ def main():
             if recordset is None:
                 changed=False
             else:
-                cloud.delete_recordset(zone, name + '.' + zone)
+                cloud.delete_recordset(zone, recordset_id)
                 changed=True
             module.exit_json(changed=changed)
 

--- a/lib/ansible/modules/cloud/openstack/os_recordset.py
+++ b/lib/ansible/modules/cloud/openstack/os_recordset.py
@@ -192,7 +192,10 @@ def main():
 
         if len(recordsets) == 1:
             recordset = recordsets[0]
-            recordset_id = recordset['id']
+            try:
+                recordset_id = recordset['id']
+            except KeyError as e:
+                module.fail_json(msg=str(e))
         else:
             # recordsets is filtered by type and should never be more than 1 return
             recordset = None

--- a/lib/ansible/modules/cloud/openstack/os_recordset.py
+++ b/lib/ansible/modules/cloud/openstack/os_recordset.py
@@ -185,8 +185,16 @@ def main():
 
     try:
         cloud = shade.openstack_cloud(**module.params)
-        recordset = cloud.get_recordset(zone, name + '.' + zone)
+        recordset_type = module.params.get('recordset_type')
+        recordset_filter = { 'type': recordset_type  }
 
+        recordsets = cloud.search_recordsets(zone, name_or_id=name + '.' + zone, filters=recordset_filter)
+
+        if len(recordsets) == 1:
+            recordset = recordsets[0]
+        else:
+            # recordsets is filtered by type and should never be more than 1 return
+            recordset = None
 
         if state == 'present':
             recordset_type = module.params.get('recordset_type')


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
cloud/openstack/os_recordset

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /home/ubuntu/work/playbooks/ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #19572 

Only the name of the DNS record was searched by the `shade` client (not by type too). While there can only be 1 unique entry per name + type,  it was assuming that there could only be 1 unique entry per name.  In our case, we have both A and AAAA records and thus it was getting hung up when trying to read (or write) a second record for the same DNS name.

This patch searches for the specific name + type before passing it to the rest of the module to work on. 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

Before (when both A and AAAA records already existed)
```
TASK [Setup testhost A record] ************************************************
fatal: [www.example.com -> localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Unable to create recordset www (Inner Exception: Duplicate RecordSet)"}
TASK [Setup testhost AAAA record] ************************************************
fatal: [www.example.com -> localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Unable to create recordset www (Inner Exception: Duplicate RecordSet)"}
```

BEFORE (when only an AAAA record existed)
```
TASK [Setup testhost A record] ************************************************
fatal: [www.example.com -> localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Error updating recordset www.example.com. (Inner Exception: u'10.0.0.1' is not a 'ipv6')"}
```

AFTER (when both exist):
```
TASK [Setup testhost A record] ***********************************************
ok: [www.example.com -> localhost]

TASK [Setup testhost AAAA record] ********************************************
ok: [www.example.com -> localhost]
```
AFTER (when only an AAAA record exists)
```
TASK [Setup testhost A record] ***********************************************
changed: [www.example.com -> localhost]

TASK [Setup testhost AAAA record] ********************************************
ok: [www.example.com -> localhost]
```
AFTER (when only an A record exists)
```
TASK [Setup testhost A record] ***********************************************
ok: [www.example.com -> localhost]

TASK [Setup testhost AAAA record] ********************************************
changed: [www.example.com -> localhost]
```
