### PR TITLE
Fix too-many-quote problem in setup_ec2 role

### DIFF
--- a/test/integration/roles/setup_ec2/tasks/main.yml
+++ b/test/integration/roles/setup_ec2/tasks/main.yml
@@ -17,7 +17,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 - name: generate random string
-  command: '{{ ansible_python.executable }} -c "import string,random; print ''.join(random.choice(string.ascii_lowercase) for _ in range(8));"'
+  command: '{{ ansible_python.executable }} -c "import string,random; print str().join(random.choice(string.ascii_lowercase) for _ in range(8));"'
   register: random_string
   tags:
     - prepare


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
test/integration/roles/setup_ec2

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 8c5d321a23) last updated 2016/12/21 11:33:16 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
An inner single-quote pair breaks out of the outer single-quote
pair. Rather than escaping the inner quotes to protect against
this, just use the fact that `str()` is equivalent to `""`.