### PR TITLE
docs: add minimum version for the json_query filter

### DIFF
--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -219,6 +219,7 @@ Note that jinja2 already provides some like abs() and round().
 
 JSON Query Filter
 -----------------
+.. versionadded:: 2.2
 
 Sometimes you end up with a complex data structure in JSON format and you need to extract only a small set of data within it. The **json_query** filter lets you query a complex JSON structure and iterate over it using a with_items structure.
 


### PR DESCRIPTION
The documentation did not at all specify that the `json_query` filter
was not available in earlier versions.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
jinja2 filter docs

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /Users/felix.frank/.../ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Adds a snippet of missing documentation.