### PR TITLE
Fix win_robocopy flags argument

### DIFF
--- a/lib/ansible/modules/windows/win_robocopy.ps1
+++ b/lib/ansible/modules/windows/win_robocopy.ps1
@@ -85,7 +85,9 @@ if ($flags -eq $null) {
     }
 }
 Else {
-    $robocopy_opts += $flags
+    ForEach ($f in $flags.split(" ")) {
+        $robocopy_opts += $f
+    }
 }
 
 Set-Attr $result.win_robocopy "purge" $purge


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Module win_robocopy

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
The flags actually only works with exactly one argument. When specifying more than one with spaces, robocopy cannot parse arguments.

I've updated "msg" to display robocopy output, or else it would only show `{"changed": false, "failed": true, "msg": "Fatal Error!"}`

```
$ ansible -v -i hosts sysadm -m win_robocopy -a "src=C:/test1/ dest=C:/test2/ flags='/E /PURGE /XD in /XD out'"          
Using /etc/ansible/ansible.cfg as config file
******** | FAILED! => {
    "changed": false, 
    "failed": true, 
    "msg": "-------------------------------------------------------------------------------    ROBOCOPY     ::     Robust File Copy for Windows                               -------------------------------------------------------------------------------    Started : mercredi 21 décembre 2016 15:59:49    Source - C:\\test1\\      Dest - C:\\test2\\      Files :    Options : /DCOPY:DA /COPY:DAT /R:1000000 /W:30   ------------------------------------------------------------------------------  ERROR : Invalid Parameter #3 : \"/E /PURGE /XD in /XD out\"         Simple Usage :: ROBOCOPY source destination /MIR               source :: Source Directory (drive:\\path or \\\\server\\share\\path).         destination :: Destination Dir  (drive:\\path or \\\\server\\share\\path).                /MIR :: Mirror a complete directory tree.      For more usage information run ROBOCOPY /?                                                             ****  /MIR can DELETE files as well as copy them !"
}
```

Interesting part:
`ERROR : Invalid Parameter #3 : \"/E /PURGE /XD in /XD out\"`

With this commit.
```
$ ansible -v -i hosts sysadm -m win_robocopy -a "src=C:/test1/ dest=C:/test2/ flags='/E /PURGE /XD in /XD out'"
Using /etc/ansible/ansible.cfg as config file
******** | SUCCESS => {
    "changed": false, 
    "win_robocopy": {
        "changed": true, 
        "dest": "C:/test2/", 
        "flags": "/E /PURGE /XD in /XD out", 
        "msg": "Files copied successfully!", 
        "output": [
            "", 
            "-------------------------------------------------------------------------------", 
            "   ROBOCOPY     ::     Robust File Copy for Windows                              ", 
            "-------------------------------------------------------------------------------", 
            "", 
            "  Started : mercredi 21 décembre 2016 16:00:31", 
            "   Source : C:\\test1\\", 
            "     Dest : C:\\test2\\", 
            "", 
            "    Files : *.*", 
            "\t    ", 
            " Exc Dirs : in", 
            "\t    out", 
            "\t    ", 
            "  Options : *.* /S /E /DCOPY:DA /COPY:DAT /PURGE /R:1000000 /W:30 ", 
            "", 
            "------------------------------------------------------------------------------", 
            "", 
            "\t                   1\tC:\\test1\\", 
            "\t    New File  \t\t       0\tNew Text Document.txt", 
            "100%  ", 
            "", 
            "------------------------------------------------------------------------------", 
            "", 
            "               Total    Copied   Skipped  Mismatch    FAILED    Extras", 
            "    Dirs :         1         0         0         0         0         0", 
            "   Files :         1         1         0         0         0         0", 
            "   Bytes :         0         0         0         0         0         0", 
            "   Times :   0:00:00   0:00:00                       0:00:00   0:00:00", 
            "   Ended : mercredi 21 décembre 2016 16:00:31", 
            ""
        ], 
        "purge": false, 
        "recurse": false, 
        "return_code": 1, 
        "src": "C:/test1/"
    }
}
```

Don't know if there is a better way to do this with powershell, but works for my test cases at least.