### PR TITLE
Switch from `iteritems` to `items` for py3.

### DIFF
--- a/lib/ansible/modules/network/ldap_entry.py
+++ b/lib/ansible/modules/network/ldap_entry.py
@@ -184,7 +184,7 @@ class LdapEntry(object):
         """ Turn attribute's value to array. """
         attrs = {}
 
-        for name, value in self.module.params['attributes'].iteritems():
+        for name, value in self.module.params['attributes'].items():
             if name not in attrs:
                 attrs[name] = []
 
@@ -288,7 +288,7 @@ def main():
 
     # Update module parameters with user's parameters if defined
     if 'params' in module.params and isinstance(module.params['params'], dict):
-        for key, val in module.params['params'].iteritems():
+        for key, val in module.params['params'].items():
             if key in module.argument_spec:
                 module.params[key] = val
             else:


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ldap_entry

##### ANSIBLE VERSION

```
ansible 2.3.0 (no-iteritems 9b935756cb) last updated 2016/12/21 09:00:28 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Switch from `iteritems` to `items` for py3.