### PR TITLE
Don't use netconf's discard_changes when the device has no candidate cap

### DIFF
--- a/lib/ansible/modules/network/netconf/netconf_config.py
+++ b/lib/ansible/modules/network/netconf/netconf_config.py
@@ -136,7 +136,8 @@ def netconf_edit_config(m, xml, commit, retkwargs):
         datastore = 'running'
     m.lock(target=datastore)
     try:
-        m.discard_changes()
+        if ":candidate" in m.server_capabilities:
+            m.discard_changes()
         config_before = m.get_config(source=datastore)
         m.edit_config(target=datastore, config=xml)
         config_after = m.get_config(source=datastore)


### PR DESCRIPTION
The discard_changes netconf RPC requires the candidate capability.
We were getting an exception when configuring that kind of device.

Fixes #19529

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/network/netconf/netconf_config

##### ANSIBLE VERSION
ansible 2.2.0.0

##### SUMMARY
One can see clearly from the source code of ncclient at the link below that the dicard_changes operation requires the candidate capability.
https://github.com/ncclient/ncclient/blob/master/ncclient/operations/edit.py#L172
Issue #19529 is exactly this test failing.
