### PR TITLE
Fix backward compat change - create custom required_together statement

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_eip.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eip.py
@@ -365,10 +365,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec=argument_spec,
-        supports_check_mode=True,
-        required_together=[
-            ('device_id', 'private_ip_address'),
-        ]
+        supports_check_mode=True
     )
 
     if not HAS_BOTO:
@@ -385,6 +382,10 @@ def main():
     domain = 'vpc' if in_vpc else None
     reuse_existing_ip_allowed = module.params.get('reuse_existing_ip_allowed')
     release_on_disassociation = module.params.get('release_on_disassociation')
+
+    # Parameter checks
+    if private_ip_address is not None and device_id is None:
+        module.fail_json(msg="parameters are required together: ('device_id', 'private_ip_address')")
 
     if instance_id:
         warnings = ["instance_id is no longer used, please use device_id going forward"]


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_eip

##### ANSIBLE VERSION
devel

##### SUMMARY
The required_together statement in the last PR should not apply.
Although private_ip_address is required with device_id, device_id is not required with private_ip_address so i have rewritten the check as a custom check