### PR TITLE
fix junos typo

### DIFF
--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -287,7 +287,7 @@ def load_config(module, result):
 def rollback_config(module, result):
     rollback = module.params['rollback']
 
-    kwargs = dict(comment=module.param['comment'],
+    kwargs = dict(comment=module.params['comment'],
                   commit=not module.check_mode)
 
     diff = module.connection.rollback_config(rollback, **kwargs)


### PR DESCRIPTION

##### ISSUE TYPE
 - Bugfix Pull Request
##### COMPONENT NAME
junos_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```

##### SUMMARY
fixes #19646
