### PR TITLE
Verify image exists when passed for open stack server creation

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -447,6 +447,9 @@ def _create_server(module, cloud):
     if not module.params['boot_volume']:
         image_id = cloud.get_image_id(
             module.params['image'], module.params['image_exclude'])
+        if not image_id:
+            module.fail_json(msg="Could not find image %s" %
+                             module.params['image'])
 
     if flavor:
         flavor_dict = cloud.get_flavor(flavor)


### PR DESCRIPTION
If the image doesn't exist, we should fail and raise the error clearly. Fixes #18921 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloud/openstack/os-server

##### ANSIBLE VERSION
```
ansible 2.3.0
```

##### SUMMARY
Previously, if we passed an invalid image, shade would give back a none type for the image and pass that into shade's OpenStackCloud.create_server, which would result in vague invalid number of arguments passed error. This gives a more clear error of the problem of the image not existing.

```
(ansible) ubuntu@devstack:~/ansible$ ansible-playbook ~/test/ansible/test_os_server_create.yml
 [WARNING]: Host file not found: /etc/ansible/hosts

 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [localhost] ***************************************************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] *********************************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [os_server] ***************************************************************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Could not find image fake"}
        to retry, use: --limit @/home/ubuntu/test/ansible/test_os_server_create.retry

PLAY RECAP *********************************************************************************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1

(ansible) ubuntu@devstack:~/ansible$ cat ~/test/ansible/test_os_server_create.yml
- hosts: localhost
  connection: local
  tasks:
    - os_server:
        cloud: citycloud
        state: present
        name: test
        image: fake
        region_name: Sto2
        flavor: 1C-0.5GB
        key_name: launcher
        wait: yes
```