### PR TITLE
fix multiple handler notifications

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -437,7 +437,7 @@ class StrategyBase:
                                 target_handler = search_handler_blocks_by_name(handler_name, iterator._play.handlers)
                                 if target_handler is not None:
                                     found = True
-                                    if original_host._uuid not in self._notified_handlers[target_handler._uuid]:
+                                    if original_host not in self._notified_handlers[target_handler._uuid]:
                                         self._notified_handlers[target_handler._uuid].append(original_host)
                                         # FIXME: should this be a callback?
                                         display.vv("NOTIFIED HANDLER %s" % (handler_name,))

--- a/test/integration/targets/handlers/roles/test_handlers_meta/handlers/main.yml
+++ b/test/integration/targets/handlers/roles/test_handlers_meta/handlers/main.yml
@@ -5,3 +5,6 @@
 - name: set_handler_fact_2
   set_fact:
     handler2_called: True
+
+- name: count_handler
+  shell: echo . >> {{ handler_countpath }}

--- a/test/integration/targets/handlers/roles/test_handlers_meta/tasks/main.yml
+++ b/test/integration/targets/handlers/roles/test_handlers_meta/tasks/main.yml
@@ -30,6 +30,41 @@
         - "handler1_called is defined"
         - "handler2_called is not defined"
 
+- name: make a tempfile for counting
+  shell: mktemp
+  register: mktemp_out
+
+- name: register tempfile path
+  set_fact:
+    handler_countpath: "{{ mktemp_out.stdout }}"
+
+- name: notify the counting handler
+  shell: echo
+  notify:
+    - count_handler
+
+- name: notify the counting handler again
+  shell: echo
+  notify:
+    - count_handler
+
+- name: force handler execution now
+  meta: flush_handlers
+
+- name: get handler execution count
+  shell: cat {{ handler_countpath }} | grep -o . | wc -l
+  register: exec_count_out
+
+- debug: var=exec_count_out.stdout
+
+- name: ensure single execution
+  assert:
+    that:
+    - exec_count_out.stdout | int == 1
+
+- name: cleanup tempfile
+  file: path={{ handler_countpath }} state=absent
+
 - name: reset handler1_called
   set_fact:
     handler1_called: False


### PR DESCRIPTION
Fixes #19647
Adds integration test to catch multiple handler notifications

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
StrategyBase

##### SUMMARY
Fixes erroneous multiple handler notification due to key mismatch on Host._notified_handlers.

This needs to be backported to stable-2.2 as well for 2.2.1.