### PR TITLE
Fixes invalid ip6tables option (#19656)

### DIFF
--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -403,7 +403,11 @@ def construct_rule(params):
     append_param(rule, params['uid_owner'], '--uid-owner', False)
     append_jump(rule, params['reject_with'], 'REJECT')
     append_param(rule, params['reject_with'], '--reject-with', False)
-    append_param(rule, params['icmp_type'], '--icmp-type', False)
+    append_param(
+        rule,
+        params['icmp_type'],
+        '--icmp-type' if params['ip_version'] == 'ipv4' else '--icmpv6-type',
+        False)
     return rule
 
 

--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -23,6 +23,11 @@ BINS = dict(
     ipv6='ip6tables',
 )
 
+ICMP_TYPE_OPTIONS = dict(
+    ipv4='--icmp-type',
+    ipv6='--icmpv6-type',
+)
+
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'core',
                     'version': '1.0'}
@@ -406,7 +411,7 @@ def construct_rule(params):
     append_param(
         rule,
         params['icmp_type'],
-        '--icmp-type' if params['ip_version'] == 'ipv4' else '--icmpv6-type',
+        ICMP_TYPE_OPTIONS[params['ip_version']],
         False)
     return rule
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

iptables

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel 78d4f6bbc1) last updated 2016/12/23 01:59:45 (GMT +100)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
See issue #19656 for a description of the bug. This fix simply switches the command line option depending on the `ip_version` in use.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
Before:

```
TASK [common : Allow inbound and outbound echo requests] **********************************************************************************************************************************************************
failed: [lon-1.cloud.thebrightons.co.uk] (item=INPUT) => {"cmd": "/sbin/ip6tables -t filter -A INPUT -p ipv6-icmp -j ACCEPT --icmp-type echo-request", "failed": true, "item": "INPUT", "msg": "ip6tables v1.4.21: unknown option \"--icmp-type\"\nTry `ip6tables -h' or 'ip6tables --help' for more information.", "rc": 2, "stderr": "ip6tables v1.4.21: unknown option \"--icmp-type\"\nTry `ip6tables -h' or 'ip6tables --help' for more information.\n", "stdout": "", "stdout_lines": []}
failed: [lon-1.cloud.thebrightons.co.uk] (item=OUTPUT) => {"cmd": "/sbin/ip6tables -t filter -A OUTPUT -p ipv6-icmp -j ACCEPT --icmp-type echo-request", "failed": true, "item": "OUTPUT", "msg": "ip6tables v1.4.21: unknown option \"--icmp-type\"\nTry `ip6tables -h' or 'ip6tables --help' for more information.", "rc": 2, "stderr": "ip6tables v1.4.21: unknown option \"--icmp-type\"\nTry `ip6tables -h' or 'ip6tables --help' for more information.\n", "stdout": "", "stdout_lines": []}
```

After:

````
TASK [common : Allow inbound and outbound echo requests] **********************************************************************************************************************************************************
changed: [lon-1.cloud.thebrightons.co.uk] => (item=INPUT)
changed: [lon-1.cloud.thebrightons.co.uk] => (item=OUTPUT)
````