### PR TITLE
FIX issue 18461 : docker_container fact filtered by data parser

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -608,7 +608,7 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-ansible_docker_container:
+docker_container:
     description:
       - Facts representing the current state of the container. Matches the docker inspection output.
       - Note that facts are not part of registered vars but accessible directly.
@@ -1669,7 +1669,7 @@ class ContainerManager(DockerBaseClass):
             self.results['diff'] = self.diff
 
         if self.facts:
-            self.results['ansible_facts'] = {'ansible_docker_container': self.facts}
+            self.results['ansible_facts'] = {'docker_container': self.facts}
 
     def present(self, state):
         container = self._get_container(self.parameters.name)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION

```
ansible 2.3.0
```

##### SUMMARY

Fixes #18461 : docker_container return fact is filtered by the data parser. 
So I just changed the name of the dictionnary returned by the module. 
was: ansible_docker_container 
becomes : docker_container. 

Before
```
TASK [starting container] ******************************************************
changed: [localhost] => {"ansible_facts": {}, "changed": true}

TASK [inventory addendum] ******************************************************
ok: [localhost] => {
    "docker_cont": {
        "ansible_facts": {}, 
        "changed": true
    }
}
```
After :
```
TASK [starting container] **************************************************************
changed: [localhost] => {"ansible_facts": {"docker_container": {"AppArmorProfile": "", "Args": [" 
```
[...]
