### PR TITLE
Support Jinja2 in dict keys

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -356,7 +356,8 @@ class Templar:
                 # changes sizes due to the templating, which can happen with hostvars
                 for k in variable.keys():
                     if k not in static_vars:
-                        d[k] = self.template(variable[k], preserve_trailing_newlines=preserve_trailing_newlines, fail_on_undefined=fail_on_undefined, overrides=overrides)
+                        new_k = self.template(k, preserve_trailing_newlines=preserve_trailing_newlines, fail_on_undefined=fail_on_undefined, overrides=overrides)
+                        d[new_k] = self.template(variable[k], preserve_trailing_newlines=preserve_trailing_newlines, fail_on_undefined=fail_on_undefined, overrides=overrides)
                     else:
                         d[k] = variable[k]
                 return d


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

Templar


##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
This patch allows to use Jinja2 expressions in dictionary keys. Using this patch, the output of the following play

```
---
- hosts: all
  connection: local
  gather_facts: no
  vars:
   test_var: aaa
   test_list:
     - "{{ test_var }}"
     - "{{ test_var }}": bbb
  tasks:
    - debug:
       var: test_list
```

will result into this output:

```
TASK [debug] *******************************************************************
ok: [localhost] => {
    "test_list": [
        "aaa", 
        {
            "aaa": "bbb"
        }
    ]
}
```

instead of to this:

```
TASK [debug] *******************************************************************
ok: [localhost] => {
    "test_list": [
        "aaa", 
        {
            "{{ test_var }}": "bbb"
        }
    ]
}
```

fixes #19956