### PR TITLE
cron - Apply SELinux context only if cron_file exists

### DIFF
--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -237,12 +237,6 @@ import tempfile
 import platform
 import pipes
 
-try:
-    import selinux
-    HAS_SELINUX = True
-except ImportError:
-    HAS_SELINUX = False
-
 CRONCMD = "/usr/bin/crontab"
 
 class CronTabError(Exception):
@@ -345,8 +339,8 @@ class CronTab(object):
                 self.module.fail_json(msg=err)
 
         # set SELinux permissions
-        if HAS_SELINUX:
-            selinux.selinux_lsetfilecon_default(self.cron_file)
+        if self.module.selinux_enabled() and self.cron_file:
+            self.module.set_default_selinux_context(self.cron_file, False)
 
     def do_comment(self, name):
         return "%s%s" % (self.ansible, name)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`cron` module

##### ANSIBLE VERSION
```
ansible 2.3.0 (18768-cron-oserror-selinux 5fe684da1b) last updated 2016/12/25 02:57:37 (GMT +000)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Running a task without a `cron_file` parameter against an SELinux enabled host results in attempting to set a context against a null filename...this evidently manifests as an OSError.

Added a check that `cron_file` exists before applying said context, and verified against a vagrant machine with SELinux installed.

###### Before the patch
```
TASK [test cron job] *******************************************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: OSError: [Errno 14] Bad address
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_sgtLRe/ansible_module_cron.py\", line 779, in <module>\n    main()\n  File \"/tmp/ansible_sgtLRe/ansible_module_cron.py\", line 746, in main\n    crontab.write()\n  File \"/tmp/ansible_sgtLRe/ansible_module_cron.py\", line 349, in write\n    selinux.selinux_lsetfilecon_default(self.cron_file)\nOSError: [Errno 14] Bad address\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 0}
	to retry, use: --limit @/vagrant/test.retry
```

###### After the patch
```
TASK [test cron job] *******************************************************************************************************************************************************************************************
changed: [localhost]
```

Fixes #18768