### PR TITLE
Recognise pkgin when installed in the global zone on SmartOS

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -145,6 +145,7 @@ class Facts(object):
                  { 'path' : '/bin/opkg',            'name' : 'opkg' },
                  { 'path' : '/usr/pkg/bin/pkgin',   'name' : 'pkgin' },
                  { 'path' : '/opt/local/bin/pkgin', 'name' : 'pkgin' },
+                 { 'path' : '/opt/tools/bin/pkgin', 'name' : 'pkgin' },
                  { 'path' : '/opt/local/bin/port',  'name' : 'macports' },
                  { 'path' : '/usr/local/bin/brew',  'name' : 'homebrew' },
                  { 'path' : '/sbin/apk',            'name' : 'apk' },
@@ -2247,7 +2248,7 @@ class Darwin(Hardware):
 class HurdHardware(LinuxHardware):
     """
     GNU Hurd specific subclass of Hardware. Define memory and mount facts
-    based on procfs compatibility translator mimicking the interface of 
+    based on procfs compatibility translator mimicking the interface of
     the Linux kernel.
     """
 
@@ -3016,7 +3017,7 @@ class NetBSDNetwork(GenericBsdIfconfigNetwork):
     """
     platform = 'NetBSD'
 
-    def parse_media_line(self, words, current_if, ips): 
+    def parse_media_line(self, words, current_if, ips):
         # example of line:
         # $ ifconfig
         # ne0: flags=8863<UP,BROADCAST,NOTRAILERS,RUNNING,SIMPLEX,MULTICAST> mtu 1500


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

Facts (`setup` module)

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (pkgin_gz 0b7e973dab) last updated 2016/12/25 13:43:29 (GMT +200)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Currently the `pkg_mgr` fact is not set for SmartOS global zones with pkgin installed. As documented [upstream](https://pkgsrc.joyent.com/install-on-illumos/) the prefix for the "SmartOS GZ" is `/opt/tools`. This PR teaches Ansible to look there too for the `pkgin` binary and set the fact accordingly.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
calafate-gz | SUCCESS => {
    "ansible_facts": {
        "ansible_pkg_mgr": "unknown"
    },
    "changed": false
}
```

After:
```
calafate-gz | SUCCESS => {
    "ansible_facts": {
        "ansible_pkg_mgr": "pkgin"
    },
    "changed": false
}
```
