### PR TITLE
Add 3 new Amazon AWS regions

### DIFF
--- a/lib/ansible/modules/cloud/amazon/_ec2_ami_search.py
+++ b/lib/ansible/modules/cloud/amazon/_ec2_ami_search.py
@@ -61,8 +61,9 @@ options:
     required: false
     default: us-east-1
     choices: ["ap-northeast-1", "ap-southeast-1", "ap-northeast-2",
-              "ap-southeast-2", "eu-central-1", "eu-west-1", "sa-east-1",
-              "us-east-1", "us-west-1", "us-west-2", "us-gov-west-1"]
+              "ap-southeast-2", "ca-central-1", "eu-central-1", "eu-west-1",
+              "eu-west-2", "sa-east-1", "us-east-1", "us-east-2", "us-west-1",
+              "us-west-2", "us-gov-west-1"]
   virt:
     description: virutalization type
     required: false
@@ -103,14 +104,16 @@ AWS_REGIONS = ['ap-northeast-1',
                'ap-northeast-2',
                'ap-southeast-2',
                'ap-south-1',
+               'ca-central-1',
                'eu-central-1',
                'eu-west-1',
+               'eu-west-2',
                'sa-east-1',
                'us-east-1',
+               'us-east-2',
                'us-west-1',
                'us-west-2',
                "us-gov-west-1"]
-
 
 def get_url(module, url):
     """ Get url and return response """

--- a/lib/ansible/modules/cloud/amazon/ec2_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_facts.py
@@ -70,10 +70,13 @@ class Ec2Metadata(object):
                    'ap-southeast-1',
                    'ap-southeast-2',
                    'ap-south-1',
+                   'ca-central-1',
                    'eu-central-1',
                    'eu-west-1',
+                   'eu-west-2',
                    'sa-east-1',
                    'us-east-1',
+                   'us-east-2',
                    'us-west-1',
                    'us-west-2',
                    'us-gov-west-1'


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
modules/cloud/amazon

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
AWS added 3 new regions:
- ca-central-1
- eu-west-2
- us-east-2