### PR TITLE
Fix the editable condition into pip module (#19028)

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -519,8 +519,6 @@ def main():
         if module.check_mode:
             if extra_args or requirements or state == 'latest' or not name:
                 module.exit_json(changed=True)
-            elif has_vcs:
-                module.exit_json(changed=True)
 
             pkg_cmd, out_pip, err_pip = _get_packages(module, pip, chdir)
 
@@ -549,10 +547,9 @@ def main():
                         break
             module.exit_json(changed=changed, cmd=pkg_cmd, stdout=out, stderr=err)
 
+        out_freeze_before = None
         if requirements or has_vcs:
             _, out_freeze_before, _ = _get_packages(module, pip, chdir)
-        else:
-            out_freeze_before = None
 
         rc, out_pip, err_pip = module.run_command(cmd, path_prefix=path_prefix, cwd=chdir)
         out += out_pip
@@ -569,11 +566,8 @@ def main():
             if out_freeze_before is None:
                 changed = 'Successfully installed' in out_pip
             else:
-                if out_freeze_before is None:
-                    changed = 'Successfully installed' in out_pip
-                else:
-                    _, out_freeze_after, _ = _get_packages(module, pip, chdir)
-                    changed = out_freeze_before != out_freeze_after
+                _, out_freeze_after, _ = _get_packages(module, pip, chdir)
+                changed = out_freeze_before != out_freeze_after
 
         module.exit_json(changed=changed, cmd=cmd, name=name, version=version,
                          state=state, requirements=requirements, virtualenv=env,

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -101,9 +101,9 @@ options:
     version_added: "1.0"
   editable:
     description:
-      - Pass the editable flag for versioning URLs.
+      - Pass the editable flag.
     required: false
-    default: yes
+    default: false
     version_added: "2.0"
   chdir:
     description:
@@ -158,10 +158,9 @@ EXAMPLES = '''
 - pip:
     name: svn+http://myrepo/svn/MyApp#egg=MyApp
 
-# Install MyApp using one of the remote protocols (bzr+,hg+,git+) in a non editable way.
+# Install MyApp using one of the remote protocols (bzr+,hg+,git+).
 - pip:
     name: git+http://myrepo/app/MyApp
-    editable: false
 
 # Install (MyApp) from local tarball
 - pip:
@@ -399,7 +398,7 @@ def main():
             virtualenv_python=dict(type='str'),
             use_mirrors=dict(default=True, type='bool'),
             extra_args=dict(),
-            editable=dict(default=True, type='bool'),
+            editable=dict(default=False, type='bool'),
             chdir=dict(type='path'),
             executable=dict(),
             umask=dict(),
@@ -498,7 +497,7 @@ def main():
                     has_vcs = True
                     break
 
-        if has_vcs and module.params['editable']:
+        if module.params['editable']:
             args_list = []  # used if extra_args is not used at all
             if extra_args:
                 args_list = extra_args.split(' ')

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -80,7 +80,7 @@
 
 # Test virtualenv installations
 
-- name: make sure the test env doesn't exist
+- name: "make sure the test env doesn't exist"
   file: state=absent name={{ output_dir }}/pipenv
 
 - name: create a requirement file with an vcs url
@@ -97,22 +97,24 @@
     that:
       - "req_installed.changed"
 
-- name: repeat installation to check status didn't change
+- name: "repeat installation to check status didn't change"
   pip: requirements={{ output_dir}}/pipreq.txt
     virtualenv={{ output_dir }}/pipenv
   register: req_installed
 
-- name: check that a change didn't occurr this time (bug ansible#1705)
+- name: "check that a change didn't occurr this time (bug ansible#1705)"
   assert:
     that:
       - "not req_installed.changed"
 
 - name: install the same module from url
-  pip: name="git+https://github.com/dvarrazzo/pyiso8601#egg=pyiso8601"
-    virtualenv={{ output_dir }}/pipenv
+  pip: 
+    name: "git+https://github.com/dvarrazzo/pyiso8601#egg=pyiso8601"
+    virtualenv: "{{ output_dir }}/pipenv"
+    editable: True
   register: url_installed
 
-- name: check that a change didn't occurr (bug ansible-modules-core#1645)
+- name: "check that a change didn't occurr (bug ansible-modules-core#1645)"
   assert:
     that:
       - "not url_installed.changed"


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
pip

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### SUMMARY
Related to https://github.com/ansible/ansible/issues/19028.

The pip editable flag should be added when when `editable` directive is set (not only compound condition with vcs)




