### PR TITLE
Allow version specifiers for pip install

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -247,7 +247,10 @@ def _get_full_name(name, version=None):
     if version is None:
         resp = name
     else:
-        resp = name + '==' + version
+        # prepend '==' if no constraint has been specified
+        if version and version[0].isdigit():
+            version = '==' + version
+        resp = name + version
     return resp
 
 

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -72,10 +72,40 @@
     that:
       - "absent2.changed"
 
+# Test version constraints
+
+- name: install package with version constraint
+  pip: name={{ pip_test_package }} version="<=4.2.0" state=present
+  register: version
+
+- name: assert package installed correctly
+  assert:
+    that:
+      - "version.changed"
+
+- name: ensure package is installed
+  pip: name={{ pip_test_package }} version="<=4.2.0" state=present
+  register: version2
+
+- name: assert no changes ocurred
+  assert:
+    that:
+      - "version2.changed == False"
+
+- name: run with check_mode
+  pip: name={{ pip_test_package }} version="<=4.2.0" state=present
+  check_mode: yes
+  register: version3
+
+- name: assert not changes ocurred
+  assert:
+    that:
+      - "version3.changed == False"
+
 # put the test package back
 
 - name: now put it back in case someone wanted it (like us!)
-  pip: name={{ pip_test_package }} state=present
+  pip: name={{ pip_test_package }} version="4.2.0" state=present
 
 
 # Test virtualenv installations


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
PIP module

##### ANSIBLE VERSION
````
ansible 2.2.0.0
````

##### SUMMARY
Add support for version specifiers when installing packages using `pip` module. This allows users to specify a minimum required version or a version range. It fallbacks to an exact version match if no version is specified, to maintain backward compatibility.

Example:
```
- name: upgrade pip
  pip: name=pip version=">=9.0.1"
```
