### PR TITLE
Fix a push example in docker-image.

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -215,6 +215,7 @@ EXAMPLES = '''
     path: ./sinatra
     name: registry.ansible.com/chouseknecht/sinatra
     tag: v1
+    push: yes
 
 - name: Archive image
   docker_image:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/cloud/docker/docker_image.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /home/jonathang/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Actually the below example in official document will only build image, and won't push it.
```
- name: Build an image and push it to a private repo
  docker_image:
    path: ./sinatra
    name: registry.ansible.com/chouseknecht/sinatra
    tag: v1
```
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
Without push

Yaml file:
```
- hosts: localhost
  connection: local
  name: Build and push BOM images to docker registry 
  vars:
    tag: "{{ tag }}"
  tasks:
    - name: Build BOM redis image
      docker_image:
        name: example.com/engbom_redis
        tag: "{{ tag }}"
        path: "{{ playbook_dir }}/dockerfiles/redis_bom/"
```
Output:
```
changed: [localhost] => {
    "actions": [
        "Built image example.com/engbom_redis:1.9.2 from /my/local/path/"
    ], 
    "changed": true, 
```

With push parameter, the output:
```
changed: [localhost] => {
    "actions": [
        "Built image example.com/engbom_redis:1.9.2 from /my/local/path/", 
        "Pushed image example.com/engbom_redis to example.com/engbom_redis:1.9.2"
    ], 
    "changed": true, 
```