### PR TITLE
[PATCH] [rhn_channel] Add support for setting base channels

### DIFF
--- a/lib/ansible/modules/packaging/os/rhn_channel.py
+++ b/lib/ansible/modules/packaging/os/rhn_channel.py
@@ -22,13 +22,15 @@ description:
 version_added: "1.1"
 author: "Vincent Van der Kussen (@vincentvdk)"
 notes:
-    - This module fetches the system id from RHN.
-    - This module doesn't support I(check_mode).
+    - This module fetches the system id from RHN matching on Satellite's system profile name
+    - Invalid channel errors are usually due to typos, such as using a channel
+    - from one architecture against a system registered with another.
 options:
     name:
         description:
             - Name of the software channel.
         required: true
+        aliases: ['channel']
     sysname:
         description:
             - Name of the system as it is known in RHN/Satellite.
@@ -37,6 +39,7 @@ options:
         description:
             - Whether the channel should be present or not, taking action if the state is different from what is stated.
         default: present
+        choices: ['present', 'absent']
     url:
         description:
             - The full URL to the RHN/Satellite API.
@@ -60,45 +63,179 @@ EXAMPLES = '''
     password: guessme
 '''
 
+import errno
+import operator
+import re
+import socket
+import sys
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves import xmlrpc_client
 
 
-# ------------------------------------------------------- #
+class InvalidChannel(KeyError):
+    """Raised when a given channel exists but isn't valid for the given system
 
+    Example cases:
+        - channel is from a different architecture
+        - using base1/child when system is subscribed to base2
+    """
+    def __init__(self, channelname, *args):
+        super(InvalidChannel, self).__init__(*args)
+        self.channelname = channelname
+
+    def __str__(self):
+        return 'Channel %s is not valid for this system' % self.channelname
+
+
+# ------------------------------------------------------- #
 def get_systemid(client, session, sysname):
+    """
+    Returns the Spacewalk ID matching the system name
+
+    This is an exact match on the system name according to Spacewalk.
+
+    TODO: This kind of matching can result in multiple system entries, the
+    module doesn't catch this exception. It will instead pick the latest entry
+    (by system ID).
+    """
     systems = client.system.listUserSystems(session)
-    for system in systems:
-        if system.get('name') == sysname:
-            idres = system.get('id')
+    for system in sorted(systems, key=operator.itemgetter('id'), reverse=True):
+        if system['name'] == sysname:
+            idres = system['id']
             idd = int(idres)
             return idd
+    raise KeyError('Satellite system not found: %s' % sysname)
+
 
 # ------------------------------------------------------- #
-
-def subscribe_channels(channelname, client, session, sysname, sys_id):
-    channels = base_channels(client, session, sys_id)
-    channels.append(channelname)
-    return client.system.setChildChannels(session, sys_id, channels)
-
-# ------------------------------------------------------- #
-
-def unsubscribe_channels(channelname, client, session, sysname, sys_id):
-    channels = base_channels(client, session, sys_id)
-    channels.remove(channelname)
-    return client.system.setChildChannels(session, sys_id, channels)
-
-# ------------------------------------------------------- #
-
-def base_channels(client, session, sys_id):
-    basechan = client.channel.software.listSystemChannels(session, sys_id)
+def get_channel(client, session, label):
+    """
+    Returns Spacewalk channel details
+    """
+    if label is None:
+        raise KeyError('Channel %r not found' % (label,))
     try:
-        chans = [item['label'] for item in basechan]
-    except KeyError:
-        chans = [item['channel_label'] for item in basechan]
-    return chans
+        channel = client.channel.software.getDetails(session, label)
+        return channel
+    except xmlrpc_client.Fault as e:
+        # xmlrpc_client.Fault: <Fault -210: 'redstone.xmlrpc.XmlRpcFault: No such channel: foo'>
+        if e.faultCode == -210:
+            raise KeyError('Channel %s not found' % (label,))
+        raise
+
 
 # ------------------------------------------------------- #
+def set_base_channel(client, session, channelname, sys_id, check_mode):
+    """
+    Changes a system's base channel if needed
+
+    Raises:
+        InvalidChannel: The given channel is invalid for this system
+    """
+    # get channels for system
+    base_channels, current_base = _base_channels(client, session, sys_id)
+
+    if current_base == channelname:
+        return dict(changed=False, msg="Channel %s already set" % channelname, channel_type='base')
+
+    if channelname not in base_channels:
+        raise InvalidChannel(channelname)
+
+    if not check_mode:
+        client.system.setBaseChannel(session, sys_id, channelname)
+
+    return dict(changed=True, msg="Channel %s set" % channelname, channel_type='base')
+
+
+# ------------------------------------------------------- #
+def add_child_channel(client, session, channelname, sys_id, check_mode):
+    """
+    Add a child channel to a given system, noop otherwise
+
+    Raises:
+        InvalidChannel: The given channel is invalid for this system
+    """
+    channels = _subscribed_childs(client, session, sys_id)
+    if channelname in channels:
+        return dict(changed=False, msg="Channel %s already set" % channelname, channel_type='child')
+
+    if channelname not in _subscribable_childs(client, session, sys_id):
+        raise InvalidChannel(channelname)
+
+    channels.append(channelname)
+    if not check_mode:
+        client.system.setChildChannels(session, sys_id, channels)
+
+    return dict(changed=True, msg="Channel %s set" % channelname, channel_type='child')
+
+
+# ------------------------------------------------------- #
+def remove_child_channel(client, session, channelname, sys_id, check_mode):
+    """
+    Removes a child channel from a system, noop otherwise
+
+    Raises:
+        InvalidChannel: The given channel is invalid for this system
+    """
+    # channel in subscribable is valid for this system and not subscribed.
+    # thats a successful absence check
+    if channelname in _subscribable_childs(client, session, sys_id):
+        return dict(changed=False, msg="Channel %s already removed" % channelname, channel_type='child')
+
+    # channel not in subscribable suggests it is subscribed
+    # however it could be an invalid channel for this system, raise if so
+    channels = _subscribed_childs(client, session, sys_id)
+    try:
+        channels.remove(channelname)
+    except ValueError:
+        raise InvalidChannel(channelname)
+
+    if not check_mode:
+        client.system.setChildChannels(session, sys_id, channels)
+
+    return dict(changed=True, msg="Channel %s removed" % channelname, channel_type='child')
+
+
+# ------------------------------------------------------- #
+def _subscribed_childs(client, session, sys_id):
+    """
+    List currently subscribed child channels for the system
+
+    Returns: [subscribed_channels]
+    """
+    channels = client.system.listSubscribedChildChannels(session, sys_id)
+    channels = [c['label'] for c in channels]
+    return channels
+
+
+# ------------------------------------------------------- #
+def _subscribable_childs(client, session, sys_id):
+    """
+    List available child channels fro the system
+
+    Returns: [available_channels]
+    """
+    channels = client.system.listSubscribableChildChannels(session, sys_id)
+    channels = [c['label'] for c in channels]
+    return channels
+
+
+# ------------------------------------------------------- #
+def _base_channels(client, session, sys_id):
+    """List valid base channels for the given system and the currently in-use base
+
+    Returns: ([channels], current_base_channel)
+    """
+    basechans = client.system.listSubscribableBaseChannels(session, sys_id)
+    chans = []
+    current_base = None
+    for chan in basechans:
+        chans.append(chan['label'])
+        if chan['current_base']:
+            current_base = chan['label']
+
+    return chans, current_base
 
 
 def main():
@@ -106,12 +243,13 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
             state = dict(default='present', choices=['present', 'absent']),
-            name = dict(required=True),
+            name = dict(required=True, aliases=['channel']),
             sysname = dict(required=True),
             url = dict(required=True),
             user = dict(required=True),
             password = dict(required=True, aliases=['pwd'], no_log=True),
-        )
+        ),
+        supports_check_mode=True,
     )
 
     state = module.params['state']
@@ -122,29 +260,61 @@ def main():
     password = module.params['password']
 
     # initialize connection
-    client = xmlrpc_client.Server(saturl)
-    session = client.auth.login(user, password)
-
-    # get systemid
-    sys_id = get_systemid(client, session, systname)
-
-    # get channels for system
-    chans = base_channels(client, session, sys_id)
+    client = xmlrpc_client.Server(saturl, verbose=0)
 
     try:
-        if state == 'present':
-            if channelname in chans:
-                module.exit_json(changed=False, msg="Channel %s already exists" % channelname)
-            else:
-                subscribe_channels(channelname, client, session, systname, sys_id)
-                module.exit_json(changed=True, msg="Channel %s added" % channelname)
+        session = client.auth.login(user, password)
+    except xmlrpc_client.ProtocolError as e:
+        module.fail_json(msg='Failed to connect <%s> (invalid or incorrect url?): %s' % (saturl, e))
+    except xmlrpc_client.Fault as e:
+        # <Fault 2950: 'redstone.xmlrpc.XmlRpcFault: Either the password or
+        # username is incorrect.'>
+        module.fail_json(msg='Unable to login <%s>: %s' % (saturl, e.faultString))
+    except socket.error as e:
+        if e.errno == errno.ETIMEDOUT:
+            module.fail_json(msg='Timeout error while connecting to <%s>' % (saturl,))
+        module.fail_json(msg='Failed to connect <%s>: %s' % (saturl, str(e)))
 
-        if state == 'absent':
-            if not channelname in chans:
-                module.exit_json(changed=False, msg="Not subscribed to channel %s." % channelname)
+    # get systemid
+    try:
+        sys_id = get_systemid(client, session, systname)
+    except KeyError as e:
+        module.fail_json(msg=e.message)
+
+    # check channel existence
+    try:
+        channel = get_channel(client, session, channelname)
+    except KeyError as e:
+        module.fail_json(msg=e.message)
+
+    try:
+        ret = dict()
+        # is this a base_channel? (will be '' if so)
+        is_base = not channel['parent_channel_label']
+        if state == 'present':
+            if not is_base:
+                ret = add_child_channel(client, session, channelname, sys_id, module.check_mode)
             else:
-                unsubscribe_channels(channelname, client, session, systname, sys_id)
-                module.exit_json(changed=True, msg="Channel %s removed" % channelname)
+                ret = set_base_channel(client, session, channelname, sys_id, module.check_mode)
+        elif state == 'absent':
+            if not is_base:
+                try:
+                    ret = remove_child_channel(client, session, channelname, sys_id, module.check_mode)
+                except InvalidChannel:
+                    # TODO: strict_mode? make this into an error. likely user tried to
+                    # remove a channel that isn't valid for this box. incorrect architecture
+                    # or the like
+                    ret = dict(changed=False, msg="No such channel %s available to unsubscribe" % channelname)
+            else:
+                # present/absent doesn't apply to base channels
+                ret = dict(changed=False, msg="Base channel %s is not in use" % channelname)
+                if channel['name'] == channelname:
+                    ret = dict()  # just guarding.
+                    module.fail_json(msg='absent can only verify a base channel is not in use. Use present instead to set a new base channel')
+    except InvalidChannel as e:
+        module.fail_json(msg=str(e))
+    else:
+        module.exit_json(**ret)
     finally:
         client.auth.logout(session)
 


### PR DESCRIPTION
##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
rhn_channel

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /Users/dkimsey/.ansible.cfg
  configured module search path = ['library/']
```

##### SUMMARY
The rhn_channel module lacked the ability to change a system's base
channel. This adds the functionality and improves some of its error
handling to be a bit more friendly and descriptive where possible.

For clarity on the "name" parameter, an alias is added, "channel".

While improving error message, resolve the "TypeError: cannot marshal
None unless allow_none is enabled" when the system isn't found on
RHN/Satellite.

There is one added TODO, currently the get_systemid function silently
ignores the presence of multiple systems with the same name. This is
existing functionality and perhaps should be made into an error. I've
left it in for now. I did however make it deterministic, previously it
was in whatever order Satellite returned it which is undefined.  Also,
this uses the listUserSystems API call and not search.system. Satellite
docs suggest the former is limited to systems the current user has
access to. This may be an edge case worth addressing at some later
point, but doing so might break existing uses.  It is likely for large
infrastructures listUserSystems is slow since it returns all systems and
then enumerates for exact matches.

Note: This PR is a port of [ansible-modules-core#4293](https://github.com/ansible/ansible-modules-core/pull/4293)
<!-- Paste verbatim command output below, e.g. before and after your change -->
##### Demo

_Feature: Setting a base channel_
```
$ ansible all -m rhn_channel -a 'name=dev-centos7-base-x86_64 sysname=test-foo-01.com url=https://spacewalk.com/rpc/api user=svc-ansible password=********' -i test-foo-01.com,
# Before
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: xmlrpclib.Fault: <Fault 1230: 'redstone.xmlrpc.XmlRpcFault: Unable to subscribe this system to the requested channel: "dev-centos7-base-x86_64"'>
test-foo-01.com | FAILED! => {
    "changed": false,
    "failed": true,
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_qCsyQm/ansible_module_rhn_channel.py\", line 169, in <module>\n    main()\n  File \"/tmp/ansible_qCsyQm/ansible_module_rhn_channel.py\", line 154, in main\n    subscribe_channels(channelname, client, session, systname, sys_id)\n  File \"/tmp/ansible_qCsyQm/ansible_module_rhn_channel.py\", line 96, in subscribe_channels\n    return client.system.setChildChannels(session, sys_id, channels)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1233, in __call__\n    return self.__send(self.__name, args)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1587, in __request\n    verbose=self.__verbose\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1273, in request\n    return self.single_request(host, handler, request_body, verbose)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1306, in single_request\n    return self.parse_response(response)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1482, in parse_response\n    return u.close()\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 794, in close\n    raise Fault(**self._stack[0])\nxmlrpclib.Fault: <Fault 1230: 'redstone.xmlrpc.XmlRpcFault: Unable to subscribe this system to the requested channel: \"dev-centos7-base-x86_64\"'>\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE"
}
# After
test-foo-01.com | SUCCESS => {
    "changed": true,
    "channel_type": "base",
    "msg": "Channel dev-centos7-base-x86_64 set"
}
```

_Bugfix: Missing system or invalid name dies_
```
$ ansible all -m rhn_channel -a 'name=prod-centos7-base-x86_64 sysname=no-such-host.com url=https://spacewalk.com/rpc/api user=svc-ansible password=********' -i test-foo-01.com,
# Before
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: cannot marshal None unless allow_none is enabled
test-foo-01.com | FAILED! => {
    "changed": false,
    "failed": true,
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_CUUwXB/ansible_module_rhn_channel.py\", line 169, in <module>\n    main()\n  File \"/tmp/ansible_CUUwXB/ansible_module_rhn_channel.py\", line 147, in main\n    chans = base_channels(client, session, sys_id)\n  File \"/tmp/ansible_CUUwXB/ansible_module_rhn_channel.py\", line 108, in base_channels\n    basechan = client.channel.software.listSystemChannels(session, sys_id)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1233, in __call__\n    return self.__send(self.__name, args)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1581, in __request\n    allow_none=self.__allow_none)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1086, in dumps\n    data = m.dumps(params)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 633, in dumps\n    dump(v, write)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 655, in __dump\n    f(self, value, write)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 659, in dump_nil\n    raise TypeError, \"cannot marshal None unless allow_none is enabled\"\nTypeError: cannot marshal None unless allow_none is enabled\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE"
}
# After
test-foo-01.com | FAILED! => {
    "changed": false,
    "failed": true,
    "msg": "Satellite system not found: no-such-host.com"
}
```

_Bugfix: Incorrect or invalid channel name dies_
```
$ ansible all -m rhn_channel -a 'name=no-such-channel sysname=test-foo-01.com url=https://spacewalk.com/rpc/api user=svc-ansible password=********' -i test-foo-01.com,
# Before
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: xmlrpclib.Fault: <Fault 1201: 'redstone.xmlrpc.XmlRpcFault: Invalid channel label'>
test-foo-01.com | FAILED! => {
    "changed": false,
    "failed": true,
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_e6ds3p/ansible_module_rhn_channel.py\", line 169, in <module>\n    main()\n  File \"/tmp/ansible_e6ds3p/ansible_module_rhn_channel.py\", line 154, in main\n    subscribe_channels(channelname, client, session, systname, sys_id)\n  File \"/tmp/ansible_e6ds3p/ansible_module_rhn_channel.py\", line 96, in subscribe_channels\n    return client.system.setChildChannels(session, sys_id, channels)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1233, in __call__\n    return self.__send(self.__name, args)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1587, in __request\n    verbose=self.__verbose\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1273, in request\n    return self.single_request(host, handler, request_body, verbose)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1306, in single_request\n    return self.parse_response(response)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1482, in parse_response\n    return u.close()\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 794, in close\n    raise Fault(**self._stack[0])\nxmlrpclib.Fault: <Fault 1201: 'redstone.xmlrpc.XmlRpcFault: Invalid channel label'>\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE"
}
# After
test-foo-01.com | FAILED! => {
    "changed": false,
    "failed": true,
    "msg": "Channel no-such-channel not found"
}
```

_Bugfix: Improved errors on API login failures, bad host_
```
$ ansible all -m rhn_channel -a 'name=channel-irrelevant sysname=system-irrelevant url=https://bad-host.com/rpc/api user=svc-ansible password=********' -i test-foo-01.com,
# Before
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: socket.gaierror: [Errno -2] Name or service not known
test-foo-01.com | FAILED! => {
    "changed": false,
    "failed": true,
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_EaCaLD/ansible_module_rhn_channel.py\", line 169, in <module>\n    main()\n  File \"/tmp/ansible_EaCaLD/ansible_module_rhn_channel.py\", line 141, in main\n    session = client.auth.login(user, password)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1233, in __call__\n    return self.__send(self.__name, args)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1587, in __request\n    verbose=self.__verbose\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1273, in request\n    return self.single_request(host, handler, request_body, verbose)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1301, in single_request\n    self.send_content(h, request_body)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1448, in send_content\n    connection.endheaders(request_body)\n  File \"/usr/lib64/python2.7/httplib.py\", line 975, in endheaders\n    self._send_output(message_body)\n  File \"/usr/lib64/python2.7/httplib.py\", line 835, in _send_output\n    self.send(msg)\n  File \"/usr/lib64/python2.7/httplib.py\", line 797, in send\n    self.connect()\n  File \"/usr/lib64/python2.7/httplib.py\", line 1189, in connect\n    HTTPConnection.connect(self)\n  File \"/usr/lib64/python2.7/httplib.py\", line 778, in connect\n    self.timeout, self.source_address)\n  File \"/usr/lib64/python2.7/socket.py\", line 553, in create_connection\n    for res in getaddrinfo(host, port, 0, SOCK_STREAM):\nsocket.gaierror: [Errno -2] Name or service not known\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE"
}
# After
test-foo-01.com | FAILED! => {
    "changed": false,
    "failed": true,
    "msg": "Failed to connect <https://bad-host.com/rpc/api>: [Errno -2] Name or service not known"
}
```

_Bugfix: Improved errors on API login failures, bad path_
```
$ ansible all -m rhn_channel -a 'name=channel-irrelevant sysname=system-irrelevant url=https://spacewalk.com/bad/api/path user=svc-ansible password=********' -i test-foo-01.com,
# Before
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: xmlrpclib.ProtocolError: <ProtocolError for spacewalk.com/bad-api-path/rpc/api: 404 Not Found>
test-foo-01.com | FAILED! => {
    "changed": false,
    "failed": true,
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_4o9T0M/ansible_module_rhn_channel.py\", line 169, in <module>\n    main()\n  File \"/tmp/ansible_4o9T0M/ansible_module_rhn_channel.py\", line 141, in main\n    session = client.auth.login(user, password)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1233, in __call__\n    return self.__send(self.__name, args)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1587, in __request\n    verbose=self.__verbose\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1273, in request\n    return self.single_request(host, handler, request_body, verbose)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1321, in single_request\n    response.msg,\nxmlrpclib.ProtocolError: <ProtocolError for spacewalk.com/bad-api-path/rpc/api: 404 Not Found>\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE"
}
# After
test-foo-01.com | FAILED! => {
    "changed": false,
    "failed": true,
    "msg": "Failed to connect <https://spacewalk.com/bad-api-path/rpc/api> (invalid or incorrect url?): <ProtocolError for spacewalk.com/bad-api-path/rpc/api: 404 Not Found>"
}
```

_Bugfix: Improved errors on API login failures, bad username or password_
```
$ ansible all -m rhn_channel -a 'name=channel-irrelevant sysname=system-irrelevant url=https://spacewalk.com/rpc/api user=no-such-user password=or-bad-password -i test-foo-01.com,
# Before
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: xmlrpclib.Fault: <Fault 2950: 'redstone.xmlrpc.XmlRpcFault: Either the password or username is incorrect.'>
test-foo-01.com | FAILED! => {
    "changed": false,
    "failed": true,
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_ZlQeWe/ansible_module_rhn_channel.py\", line 169, in <module>\n    main()\n  File \"/tmp/ansible_ZlQeWe/ansible_module_rhn_channel.py\", line 141, in main\n    session = client.auth.login(user, password)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1233, in __call__\n    return self.__send(self.__name, args)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1587, in __request\n    verbose=self.__verbose\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1273, in request\n    return self.single_request(host, handler, request_body, verbose)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1306, in single_request\n    return self.parse_response(response)\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 1482, in parse_response\n    return u.close()\n  File \"/usr/lib64/python2.7/xmlrpclib.py\", line 794, in close\n    raise Fault(**self._stack[0])\nxmlrpclib.Fault: <Fault 2950: 'redstone.xmlrpc.XmlRpcFault: Either the password or username is incorrect.'>\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE"
}
# After
test-foo-01.com | FAILED! => {
    "changed": false,
    "failed": true,
    "msg": "Unable to login <https://spacewalk.com/rpc/api>: redstone.xmlrpc.XmlRpcFault: Either the password or username is incorrect."
}
```