### PR TITLE
Fixed bug where it was impossible to set non-ephemeral external ips.

### DIFF
--- a/lib/ansible/modules/cloud/google/gce.py
+++ b/lib/ansible/modules/cloud/google/gce.py
@@ -155,7 +155,7 @@ options:
   external_ip:
     version_added: "1.9"
     description:
-      - type of external ip, ephemeral by default; alternatively, a list of fixed gce ips or ip names can be given (if there is not enough specified ip, 'ephemeral' will be used). Specify 'none' if no external ip is desired.
+      - type of external ip, ephemeral by default; alternatively, a fixed gce ip or ip name can be given. Specify 'none' if no external ip is desired.
     required: false
     default: "ephemeral"
   disk_auto_delete:
@@ -389,18 +389,14 @@ def create_instances(module, gce, instance_names, number):
 
     if external_ip == "none":
         instance_external_ip = None
-    elif not isinstance(external_ip, basestring):
+    elif external_ip != "ephemeral":
         try:
-            if len(external_ip) != 0:
-                instance_external_ip = external_ip.pop(0)
-                # check if instance_external_ip is an ip or a name
-                try:
-                    socket.inet_aton(instance_external_ip)
-                    instance_external_ip = GCEAddress(id='unknown', name='unknown', address=instance_external_ip, region='unknown', driver=gce)
-                except socket.error:
-                    instance_external_ip = gce.ex_get_address(instance_external_ip)
-            else:
-                instance_external_ip = 'ephemeral'
+            # check if instance_external_ip is an ip or a name
+            try:
+                socket.inet_aton(instance_external_ip)
+                instance_external_ip = GCEAddress(id='unknown', name='unknown', address=instance_external_ip, region='unknown', driver=gce)
+            except socket.error:
+                instance_external_ip = gce.ex_get_address(instance_external_ip)
         except GoogleBaseError as e:
             module.fail_json(msg='Unexpected error attempting to get a static ip %s, error: %s' % (external_ip, e.value))
     else:

--- a/lib/ansible/modules/cloud/google/gce.py
+++ b/lib/ansible/modules/cloud/google/gce.py
@@ -390,6 +390,7 @@ def create_instances(module, gce, instance_names, number):
     if external_ip == "none":
         instance_external_ip = None
     elif external_ip != "ephemeral":
+        instance_external_ip = external_ip
         try:
             # check if instance_external_ip is an ip or a name
             try:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
gce.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = 
  configured module search path = Default w/o overrides

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Current release will not allow creating an instance with a named external ip, rather
you can only specify "none" or "ephemeral".  Anything else defaults to ephemeral.

The problem was the code checked to see if the input was a string or not and the input is always a python string even when the YAML specifies a list.

The code now checks explicitly for "none" and "ephemeral" and if the input is neither, it tries to find a static IP of the specified name.

Also, there is no longer a need to try to fake a list.  The previous code just tried to take the first item in the list anyway.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```