### PR TITLE
Check the command result status in easy_install plugin (#16519)

### DIFF
--- a/lib/ansible/modules/packaging/language/easy_install.py
+++ b/lib/ansible/modules/packaging/language/easy_install.py
@@ -108,6 +108,8 @@ def _is_package_installed(module, name, easy_install, executable_arguments):
     executable_arguments = executable_arguments + ['--dry-run']
     cmd = '%s %s %s' % (easy_install, ' '.join(executable_arguments), name)
     rc, status_stdout, status_stderr = module.run_command(cmd)
+    if rc:
+        module.fail_json(msg=status_stderr)
     return not ('Reading' in status_stdout or 'Downloading' in status_stdout)
 
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`easy_install`

##### ANSIBLE VERSION
```
2.2.0.0
```

##### SUMMARY
Before install any packages, the plugin check if the package is already installed.
However, the result command was never tested (e.g. root permission).
Related to https://github.com/ansible/ansible/issues/16519 

##### TEST
```bash
- name: test easy_install
  hosts: all
  tasks:
   - name: test
     easy_install:
       name: pip

   - name: install
     pip: name=requests
```
```bahs
# with the fix
✘-2 ~/works/repos/perso/ansible/issue_16519 
00:55 $ ansible-playbook -i localhost, test.yaml -c local -v 
No config file found; using defaults

PLAY [test easy_install] *******************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [test] ********************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "error: can't create or remove files in install directory\n\nThe following error occurred while trying to add or remove files in the\ninstallation directory:\n\n    [Errno 13] Permission denied: '/usr/lib64/python2.7/site-packages/test-easy-install-13288.write-test'\n\nThe installation directory you specified (via --install-dir, --prefix, or\nthe distutils default setting) was:\n\n    /usr/lib64/python2.7/site-packages/\n\nPerhaps your account does not have write access to this directory?  If the\ninstallation directory is a system-owned directory, you may need to sign in\nas the administrator or \"root\" account.  If you do not have administrative\naccess to this machine, you may wish to choose a different installation\ndirectory, preferably one that is listed in your PYTHONPATH environment\nvariable.\n\nFor information on other options, you may wish to consult the\ndocumentation at:\n\n  https://pythonhosted.org/setuptools/easy_install.html\n\nPlease make the appropriate changes for your system and try again.\n\n"}
	to retry, use: --limit @/home/julien/works/repos/perso/ansible/issue_16519/test.retry

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1   
```
