### PR TITLE
Serial group by

### DIFF
--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -271,7 +271,7 @@ class PlaybookExecutor:
             # a list of all hosts, otherwise grab a chunk of the hosts equal
             # to the current serial item size
             if serial <= 0:
-                serialized_batches.append(all_hosts)
+                serialized_batches.append([host for _, group in grouped_hosts for host in group])
                 break
             else:
                 play_hosts = []

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -20,7 +20,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
-import itertools
+import collections
 
 from ansible import constants as C
 from ansible.executor.task_queue_manager import TaskQueueManager
@@ -253,7 +253,11 @@ class PlaybookExecutor:
                 value = group_by_templar.template(serial_group_by)
                 return value
 
-            grouped_hosts = [(len(lst), lst) for lst in (list(v) for _, v in itertools.groupby(all_hosts, group_by))]
+            grouped_dict = collections.defaultdict(list)
+            for host in all_hosts:
+                grouped_dict[group_by(host)].append(host)
+
+            grouped_hosts = [(len(lst), lst) for lst in grouped_dict.values()]
         else:
             grouped_hosts = [(len(all_hosts), all_hosts)]
 

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -257,7 +257,10 @@ class PlaybookExecutor:
             for host in all_hosts:
                 grouped_dict[group_by(host)].append(host)
 
-            grouped_hosts = [(len(lst), lst) for lst in grouped_dict.values()]
+            # sort the groups to ensure consistent and predictable ordering
+            grouped_keys = list(grouped_dict.keys())
+            grouped_keys.sort()
+            grouped_hosts = [(len(lst), lst) for lst in (grouped_dict[gr] for gr in grouped_keys)]
         else:
             grouped_hosts = [(len(all_hosts), all_hosts)]
 

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -264,6 +264,10 @@ class PlaybookExecutor:
         else:
             grouped_hosts = [(len(all_hosts), all_hosts)]
 
+        if len(grouped_hosts) == 0:
+            # shortcut: no hosts at all, no reason to continue
+            return []
+
         min_group_len = min(len(g) for _, g in grouped_hosts)
 
         cur_item = 0

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -232,7 +232,7 @@ class TaskQueueManager:
         num_hosts = len(self._inventory.get_hosts(new_play.hosts, ignore_restrictions=True))
 
         max_serial = 0
-        if new_play.serial:
+        if new_play.serial and not new_play.serial_group_by:
             # the play has not been post_validated here, so we may need
             # to convert the scalar value to a list at this point
             serial_items = new_play.serial

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -89,6 +89,7 @@ class Play(Base, Taggable, Become):
     _force_handlers      = FieldAttribute(isa='bool', always_post_validate=True)
     _max_fail_percentage = FieldAttribute(isa='percent', always_post_validate=True)
     _serial              = FieldAttribute(isa='list', default=[], always_post_validate=True)
+    _serial_group_by     = FieldAttribute(isa='string', default=None, always_post_validate=False)
     _strategy            = FieldAttribute(isa='string', default=C.DEFAULT_STRATEGY, always_post_validate=True)
 
     # =================================================================================

--- a/test/units/executor/test_playbook_executor.py
+++ b/test/units/executor/test_playbook_executor.py
@@ -172,7 +172,7 @@ class TestPlaybookExecutor(unittest.TestCase):
         play = playbook.get_plays()[0]
         play.post_validate(templar)
         mock_inventory.get_hosts.return_value = ['host0','host1','host2','host3','host4','host5','host6','host7','host8','host9']
-        self.assertEqual(map(set, pbe._get_serialized_batches(play)),
+        self.assertEqual([set(b) for b in pbe._get_serialized_batches(play)],
                               [set(['host0','host1','host2','host3','host4','host5','host6','host7','host8','host9'])])
 
         # real test of grouping feature: these test case cannot use simple strings as hosts
@@ -188,7 +188,7 @@ class TestPlaybookExecutor(unittest.TestCase):
         gh_odd = [h for h in grouping_hosts if h['testgroup'] == 'odd']
         # in the basic cases, one even and one odd host are processed together; this is just like pythonic zip
         #  (except that we require list, not tuples)
-        grouping_host_zip_pairs = map(list, zip(gh_even, gh_odd))
+        grouping_host_zip_pairs = [list(b) for b in zip(gh_even, gh_odd)]
 
         # simple case: with serial=1, it's just like python's zip
         #  and 20% is the same as 1, because both slices have size==5

--- a/test/units/executor/test_playbook_executor.py
+++ b/test/units/executor/test_playbook_executor.py
@@ -200,7 +200,7 @@ class TestPlaybookExecutor(unittest.TestCase):
             mock_inventory.get_hosts.return_value = list(grouping_hosts)
             self.assertEqual(pbe._get_serialized_batches(play), grouping_host_zip_pairs)
         # more complicated case: add some more even hosts, but no odd ones
-        gh_even_extra = [{'name': 'extra_host' + str(i), 'testgroup': 'even'} for i in range(10, 20, 2)]
+        gh_even_extra = [{'name': 'extra_host' + str(i), 'testgroup': 'even'} for i in range(10, 22, 2)]
         grouping_hosts.extend(gh_even_extra)
         # with these hosts, serial=1 first processes zip, then the even ones (one by one)
         playbook = Playbook.load(playbook_grouping_int, variable_manager=mock_var_manager, loader=fake_loader)
@@ -221,4 +221,5 @@ class TestPlaybookExecutor(unittest.TestCase):
             [gh_even[4], gh_even_extra[0], gh_odd[2]],
             [gh_even_extra[1], gh_even_extra[2], gh_odd[3]],
             [gh_even_extra[3], gh_even_extra[4], gh_odd[4]],
+            [gh_even_extra[5]]
         ])

--- a/test/units/executor/test_playbook_executor.py
+++ b/test/units/executor/test_playbook_executor.py
@@ -22,7 +22,6 @@ __metaclass__ = type
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import MagicMock
 
-from collections import Counter
 
 from ansible.executor.playbook_executor import PlaybookExecutor
 from ansible.playbook import Playbook
@@ -173,8 +172,8 @@ class TestPlaybookExecutor(unittest.TestCase):
         play = playbook.get_plays()[0]
         play.post_validate(templar)
         mock_inventory.get_hosts.return_value = ['host0','host1','host2','host3','host4','host5','host6','host7','host8','host9']
-        self.assertItemsEqual(map(Counter, pbe._get_serialized_batches(play)),
-                              [Counter(['host0','host1','host2','host3','host4','host5','host6','host7','host8','host9'])])
+        self.assertEqual(map(set, pbe._get_serialized_batches(play)),
+                              [set(['host0','host1','host2','host3','host4','host5','host6','host7','host8','host9'])])
 
         # real test of grouping feature: these test case cannot use simple strings as hosts
         # instead, playbooks are tested against several variants of inventory

--- a/test/units/executor/test_playbook_executor.py
+++ b/test/units/executor/test_playbook_executor.py
@@ -134,6 +134,13 @@ class TestPlaybookExecutor(unittest.TestCase):
         mock_inventory.get_hosts.return_value = ['host0','host1','host2','host3','host4','host5','host6','host7','host8','host9']
         self.assertEqual(pbe._get_serialized_batches(play), [['host0','host1'],['host2','host3'],['host4','host5'],['host6','host7'],['host8','host9']])
 
+        # simple serial value, but with no hosts at all - check that it does not matter
+        playbook = Playbook.load(pbe._playbooks[0], variable_manager=mock_var_manager, loader=fake_loader)
+        play = playbook.get_plays()[0]
+        play.post_validate(templar)
+        mock_inventory.get_hosts.return_value = []
+        self.assertEqual(pbe._get_serialized_batches(play), [])
+
         playbook = Playbook.load(pbe._playbooks[2], variable_manager=mock_var_manager, loader=fake_loader)
         play = playbook.get_plays()[0]
         play.post_validate(templar)
@@ -222,3 +229,11 @@ class TestPlaybookExecutor(unittest.TestCase):
             [gh_even_extra[3], gh_even_extra[4], gh_odd[4]],
             [gh_even_extra[5]]
         ])
+
+        # grouping feature, but with empty hosts - check that it does not fail
+        playbook = Playbook.load(playbook_grouping_int, variable_manager=mock_var_manager, loader=fake_loader)
+        play = playbook.get_plays()[0]
+        play.post_validate(templar)
+        mock_inventory.get_hosts.return_value = []
+        self.assertEqual(pbe._get_serialized_batches(play), [])
+


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ansible core (playbook executor)

##### ANSIBLE VERSION
```
ansible 2.3.0 (serial_group_by 8bbc821485) last updated 2016/12/28 09:40:51 (GMT +200)
```

##### SUMMARY
Use case: execute rolling upgrade of several clusters at once, in single play.

This change modifies the *serial* feature by adding optional keyword `serial_group_by` that slices hosts list by jinja2 expression (similar to the "group by" feature in sql, hence the name) and then creating batches from all these slices in parallel. This means that for _M_ slices and serial value of _N_, each batch have _M_*_N_ hosts.

Default behavior (ie without any `serial_group_by`) is fully backward compatible and this change should not cause any compatibility problems for existing playbooks.

Behaviour in detail:
- `serial_group_by` is completely ignored if there is no `serial` value
- value of `serial_group_by` can be of any type that is usable as key in python dictionary
  - it can even be static value, but that's useless - it would just create single slice (ie default behaviour)
  - jinja2 expression is evaluated for *each host*
  - special variable `host` contains the host object (`ansible.inventory.host.Host`)
    - useful attributes are: `groups` (list), `vars` (dictionary), `name` (string)
- both integer and percent values of `serial` are supported
  - percents are computed for each slice separately (ie if one slice has twice as many hosts in total, it will have twice as many hosts in each batch)

##### EXAMPLE
Host file contains four hosts forming two clusters:
```
[wfteamio]
wfteamio-1.dev7.lmc.lan
wfteamio-2.dev7.lmc.lan

[wfusrcomp]
wfusrcomp-1.dev7.lmc.lan
wfusrcomp-2.dev7.lmc.lan
```
Playbook defines that hosts should be grouped by the groups of each host:
```
- name: sample of the serial_group_by
  gather_facts: False 
  hosts: 'all'
  serial: 1
  serial_group_by: '{{host.groups}}'
  tasks:
    - debug: msg='running!'
```
When executed, this playbook first executed tasks on `wfteamio-1.dev7.lmc.lan` + `wfusrcomp-1.dev7.lmc.lan`, then `wfteamio-2.dev7.lmc.lan` + `wfusrcomp-2.dev7.lmc.lan`

