### PR TITLE
Use convert_symbols_to_format function in "deprecated" section

### DIFF
--- a/hacking/templates/rst.j2
+++ b/hacking/templates/rst.j2
@@ -30,7 +30,7 @@
 DEPRECATED
 ----------
 
-@{ deprecated }@
+@{ deprecated | convert_symbols_to_format }@
 {% endif %}
 
 Synopsis


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
hacking/templates/rst.j2

##### ANSIBLE VERSION

##### SUMMARY
Use convert_symbols_to_format function in "deprecated" section, so we can link to newer modules which supersedes the deprecated one.

Fixes #19697 

Thanks