### PR TITLE
Fix exception passed to `fail_json` on py3.4 msg

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2075,7 +2075,7 @@ class AnsibleModule(object):
                     # would end in something like:
                     #     file = _os.path.join(dir, pre + name + suf)
                     # TypeError: can't concat bytes to str
-                    self.fail_json(msg='Failed creating temp file for atomic move.  This usually happens when using Python3 less than Python3.5.  Please use Python2.x or Python3.5 or greater.', exception=sys.exc_info())
+                    self.fail_json(msg='Failed creating temp file for atomic move.  This usually happens when using Python3 less than Python3.5.  Please use Python2.x or Python3.5 or greater.', exception=traceback.format_exc(e))
 
                 b_tmp_dest_name = to_bytes(tmp_dest_name, errors='surrogate_or_strict')
 


### PR DESCRIPTION
When fixing #18160, @abadger added a warning for incompatible python versions. Unfortunately that fail_json passes the wrong object as an exception, so it (in turn) fails and the helpful message is hidden.

This fixes that.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`basic.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0 devel
```

##### SUMMARY
Fixing what was broken. Here's a sample of the failure, note the 'TypeError' at the end.


```
...
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/ansible_fhsc4t2l/ansible_modlib.zip/ansible/module_utils/basic.py", line 2068, in atomic_move
  File "/usr/lib/python3.4/tempfile.py", line 409, in mkstemp
    return _mkstemp_inner(dir, prefix, suffix, flags)
  File "/usr/lib/python3.4/tempfile.py", line 337, in _mkstemp_inner
    file = _os.path.join(dir, pre + name + suf)
TypeError: can't concat bytes to str

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/ansible_fhsc4t2l/ansible_module_copy.py", line 393, in <module>
    main()
  File "/tmp/ansible_fhsc4t2l/ansible_module_copy.py", line 372, in main
    module.atomic_move(b_mysrc, dest, unsafe_writes=module.params['unsafe_writes'])
  File "/tmp/ansible_fhsc4t2l/ansible_modlib.zip/ansible/module_utils/basic.py", line 2078, in atomic_move
  File "/tmp/ansible_fhsc4t2l/ansible_modlib.zip/ansible/module_utils/basic.py", line 1907, in fail_json
  File "/tmp/ansible_fhsc4t2l/ansible_modlib.zip/ansible/module_utils/basic.py", line 412, in remove_values
  File "/tmp/ansible_fhsc4t2l/ansible_modlib.zip/ansible/module_utils/basic.py", line 412, in <genexpr>
  File "/tmp/ansible_fhsc4t2l/ansible_modlib.zip/ansible/module_utils/basic.py", line 410, in remove_values
  File "/tmp/ansible_fhsc4t2l/ansible_modlib.zip/ansible/module_utils/basic.py", line 410, in <listcomp>
  File "/tmp/ansible_fhsc4t2l/ansible_modlib.zip/ansible/module_utils/basic.py", line 423, in remove_values
TypeError: Value of unknown type: <class 'type'>, <class 'TypeError'>
failed: [localhost] (item=report_daemon.cfg) => {
    "changed": true,
    "failed": true,
    "invocation": {
        "module_args": {
            "dest": "/mnt/git//report_daemon.cfg",
            "src": "report_daemon.cfg.j2"
        },
        "module_name": "template"
    },
    "item": "report_daemon.cfg",
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_fhsc4t2l/ansible_modlib.zip/ansible/module_utils/basic.py\", line 2052, in atomic_move\nOSError: [Errno 18] Invalid cross-device link: b'/var/go/.ansible/tmp/ansible-tmp-1482929598.3284125-278923617568427/source' -> b'/mnt/git//report_daemon.cfg'\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/tmp/ansible_fhsc4t2l/ansible_modlib.zip/ansible/module_utils/basic.py\", line 2068, in atomic_move\n  File \"/usr/lib/python3.4/tempfile.py\", line 409, in mkstemp\n    return _mkstemp_inner(dir, prefix, suffix, flags)\n  File \"/usr/lib/python3.4/tempfile.py\", line 337, in _mkstemp_inner\n    file = _os.path.join(dir, pre + name + suf)\nTypeError: can't concat bytes to str\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/tmp/ansible_fhsc4t2l/ansible_module_copy.py\", line 393, in <module>\n    main()\n  File \"/tmp/ansible_fhsc4t2l/ansible_module_copy.py\", line 372, in main\n    module.atomic_move(b_mysrc, dest, unsafe_writes=module.params['unsafe_writes'])\n  File \"/tmp/ansible_fhsc4t2l/ansible_modlib.zip/ansible/module_utils/basic.py\", line 2078, in atomic_move\n  File \"/tmp/ansible_fhsc4t2l/ansible_modlib.zip/ansible/module_utils/basic.py\", line 1907, in fail_json\n  File \"/tmp/ansible_fhsc4t2l/ansible_modlib.zip/ansible/module_utils/basic.py\", line 412, in remove_values\n  File \"/tmp/ansible_fhsc4t2l/ansible_modlib.zip/ansible/module_utils/basic.py\", line 412, in <genexpr>\n  File \"/tmp/ansible_fhsc4t2l/ansible_modlib.zip/ansible/module_utils/basic.py\", line 410, in remove_values\n  File \"/tmp/ansible_fhsc4t2l/ansible_modlib.zip/ansible/module_utils/basic.py\", line 410, in <listcomp>\n  File \"/tmp/ansible_fhsc4t2l/ansible_modlib.zip/ansible/module_utils/basic.py\", line 423, in remove_values\nTypeError: Value of unknown type: <class 'type'>, <class 'TypeError'>\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE",
    "rc": 1
}
```