### PR TITLE
git ssh wrapper: py3-compatability with strings

### DIFF
--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -314,7 +314,7 @@ def write_ssh_wrapper():
     except (IOError, OSError):
         fd, wrapper_path = tempfile.mkstemp()
     fh = os.fdopen(fd, 'w+b')
-    template = """#!/bin/sh
+    template = b("""#!/bin/sh
 if [ -z "$GIT_SSH_OPTS" ]; then
     BASEOPTS=""
 else
@@ -326,7 +326,7 @@ if [ -z "$GIT_KEY" ]; then
 else
     ssh -i "$GIT_KEY" -o IdentitiesOnly=yes $BASEOPTS "$@"
 fi
-"""
+""")
     fh.write(template)
     fh.close()
     st = os.stat(wrapper_path)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`git.py`

##### ANSIBLE VERSION
```
2.3.0 devel
```

##### SUMMARY

Wrap the fh.write(str) in b() to ensure the string is of the proper type in py2/py3. Otherwise, the following error occurs when using its ssh_wrapper:

    An exception occurred during task execution. The full traceback is:
    Traceback (most recent call last):
      File "/tmp/ansible_8r299r6t/ansible_module_git.py", line 1049, in <module>
        main()
      File "/tmp/ansible_8r299r6t/ansible_module_git.py", line 928, in main
        ssh_wrapper = write_ssh_wrapper()
      File "/tmp/ansible_8r299r6t/ansible_module_git.py", line 330, in write_ssh_wrapper
        fh.write(template)
    TypeError: 'str' does not support the buffer interface


