### PR TITLE
Add support for local repositories (file://).

### DIFF
--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -113,32 +113,32 @@ options:
 EXAMPLES = '''
 # Download the latest version of the JUnit framework artifact from Maven Central
 - maven_artifact:
-    group_id=junit
-    artifact_id=junit
-    dest=/tmp/junit-latest.jar
+    group_id: junit
+    artifact_id: junit
+    dest: /tmp/junit-latest.jar
 
 # Download JUnit 4.11 from Maven Central
 - maven_artifact:
-    group_id=junit
-    artifact_id=junit
-    version=4.11
-    dest=/tmp/junit-4.11.jar
+    group_id: junit
+    artifact_id: junit
+    version: 4.11
+    dest: /tmp/junit-4.11.jar
 
 # Download an artifact from a private repository requiring authentication
 - maven_artifact:
-    group_id=com.company
-    artifact_id=library-name
-    repository_url=https://repo.company.com/maven
-    username=user
-    password=pass
-    dest=/tmp/library-name-latest.jar
+    group_id: com.company
+    artifact_id: library-name
+    repository_url: https://repo.company.com/maven
+    username: user
+    password: pass
+    dest: /tmp/library-name-latest.jar
 
 # Download a WAR File to the Tomcat webapps directory to be deployed
 - maven_artifact:
     group_id: com.company
     artifact_id: web-app
     extension: war
-    repository_url: 'https://repo.company.com/maven'
+    repository_url: https://repo.company.com/maven
     dest: /var/lib/tomcat7/webapps/web-app.war
 
 # Passing a directory as destination, the artifact name will contain the artifact_id, version and classifier

--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -283,7 +283,13 @@ class FileSystemMavenClient:
             self.module.fail_json(msg='Copy failed. %s' % (':'.join([artifact.group_id, artifact.artifact_id, artifact.classifier, artifact.extension, artifact.url, destination, str(why)])))
 
     def checksum(self, artifact, dest):
-        return True # There is nothing to check if the artifact is local
+        if not os.path.isfile(dest):
+            return False
+        with open(create_artifact_location(artifact), 'rb') as file:
+            remote_md5 = hashlib.md5(file.read()).hexdigest()
+        with open(dest, 'rb') as file:
+            local_md5 = hashlib.md5(file.read()).hexdigest()
+        return remote_md5 == local_md5
 
 
 def main():

--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -281,7 +281,11 @@ class FileSystemMavenClient:
         return sorted(versions, key=distutils.version.LooseVersion)[-1]
 
     def download(self, artifact, destination):
-        return shutil.copy2(artifact.url, destination)
+        try:
+            src = posixpath.join(self.repo, artifact.url).replace('file:/', '').replace('//', '/')
+            return shutil.copy2(src, destination)
+        except (IOError, os.error) as why:
+            self.module.fail_json(msg='Copy failed. %s' % (':'.join([artifact.group_id, artifact.artifact_id, artifact.classifier, artifact.extension, artifact.url, destination, str(why)])))
 
     def checksum(self, artifact, dest):
         self.module.fail_json(msg=artifact.url)

--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -59,7 +59,7 @@ options:
         version_added: "2.3"
         aliases: [ repository_url, repository ]
         description:
-            - The URL of the Maven Repository to download from.
+            - The URL of the maven Repository to download from.
             - Use s3://... if the repository is hosted on Amazon S3, added in version 2.2.
         required: false
         default: http://repo1.maven.org/maven2
@@ -67,14 +67,14 @@ options:
         version_added: "2.3"
         aliases: [ username, user, uname, aws_secret_key ]
         description:
-            - The username to authenticate as to the Maven Repository, Use AWS secret key of the repository is hosted on S3.
+            - The username to authenticate as to the maven Repository, Use AWS secret key of the repository is hosted on S3.
         required: false
         default: null
     url_password:
         version_added: "2.3"
         aliases: [ password, pwd, passwd, aws_secret_access_key ]
         description:
-            - The password to authenticate with to the Maven Repository. Use AWS secret access key of the repository is hosted on S3.
+            - The password to authenticate with to the maven Repository. Use AWS secret access key of the repository is hosted on S3.
         required: false
         default: null
     dest:

--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -309,12 +309,9 @@ def main():
         )
     )
 
-    repository_url = module.params["repository_url"]
-    if not repository_url:
-        repository_url = "http://repo1.maven.org/maven2"
 
     try:
-        parsed_url = urlparse(repository_url)
+        parsed_url = urlparse(url_repository)
     except AttributeError as e:
         module.fail_json(msg='url parsing went wrong %s' % e)
 

--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -283,7 +283,6 @@ class FileSystemMavenClient:
             self.module.fail_json(msg='Copy failed. %s' % (':'.join([artifact.group_id, artifact.artifact_id, artifact.classifier, artifact.extension, artifact.url, destination, str(why)])))
 
     def checksum(self, artifact, dest):
-        self.module.fail_json(msg=artifact.url)
         return True # There is nothing to check if the artifact is local
 
 
@@ -310,7 +309,7 @@ def main():
 
 
     try:
-        parsed_url = urlparse(url_repository)
+        parsed_url = urlparse.urlparse(module.params["url_repository"])
     except AttributeError as e:
         module.fail_json(msg='url parsing went wrong %s' % e)
 

--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -116,14 +116,12 @@ EXAMPLES = '''
     group_id: junit
     artifact_id: junit
     dest: /tmp/junit-latest.jar
-
 # Download JUnit 4.11 from Maven Central
 - maven_artifact:
     group_id: junit
     artifact_id: junit
     version: 4.11
     dest: /tmp/junit-4.11.jar
-
 # Download an artifact from a private repository requiring authentication
 - maven_artifact:
     group_id: com.company
@@ -132,7 +130,6 @@ EXAMPLES = '''
     username: user
     password: pass
     dest: /tmp/library-name-latest.jar
-
 # Download a WAR File to the Tomcat webapps directory to be deployed
 - maven_artifact:
     group_id: com.company
@@ -140,14 +137,12 @@ EXAMPLES = '''
     extension: war
     repository_url: https://repo.company.com/maven
     dest: /var/lib/tomcat7/webapps/web-app.war
-
 # Passing a directory as destination, the filename will contain the artifact_id, version and classifier
 - maven_artifact:
     version: latest
     artifact_id: spring-core
     group_id: org.springframework
     dest: /tmp/
-
 # Copy a WAR file from the local maven repository to the Tomcat webapps directory to be deployed
 - maven_artifact:
     group_id: com.company
@@ -380,4 +375,4 @@ def main():
                      url_repository=repo, ignore_checksum=ignore_checksum, changed=True)
 
 if __name__ == '__main__':
-    main()
+	main()

--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -56,22 +56,22 @@ options:
         required: false
         default: jar
     url_repository:
-        version_added: 2.3
+        version_added: "2.3"
         aliases: [ repository_url, repository ]
         description:
-            - The URL of the Maven Repository to download from
+            - The URL of the Maven Repository to download from.
             - Use s3://... if the repository is hosted on Amazon S3, added in version 2.2.
         required: false
         default: http://repo1.maven.org/maven2
     url_username:
-        version_added: 2.3
+        version_added: "2.3"
         aliases: [ username, user, uname, aws_secret_key ]
         description:
             - The username to authenticate as to the Maven Repository, Use AWS secret key of the repository is hosted on S3.
         required: false
         default: null
     url_password:
-        version_added: 2.3
+        version_added: "2.3"
         aliases: [ password, pwd, passwd, aws_secret_access_key ]
         description:
             - The password to authenticate with to the Maven Repository. Use AWS secret access key of the repository is hosted on S3.
@@ -90,10 +90,10 @@ options:
         choices: [ present, absent ]
     timeout:
         description:
-            - Specifies a timeout in seconds for the connection attempt
+            - Specifies a timeout in seconds for the connection attempt.
         required: false
         default: 10
-        version_added: 2.3
+        version_added: "2.3"
     validate_certs:
         description:
             - If C(no), SSL certificates will not be validated. This should only be set to C(no) when no other option exists.
@@ -102,7 +102,7 @@ options:
         choices: ['yes', 'no']
         version_added: "1.9.3"
     ignore_checksum:
-        version_added: 2.3
+        version_added: "2.3"
         description:
             - If C(yes), the checksum verification after downloading will be ignored. May result in corrupt artifacts if the network connection fails, but enables downloading artifacts which don't have a remote checksum calculated.
         required: false
@@ -112,13 +112,26 @@ options:
 
 EXAMPLES = '''
 # Download the latest version of the JUnit framework artifact from Maven Central
-- maven_artifact: group_id=junit artifact_id=junit dest=/tmp/junit-latest.jar
+- maven_artifact:
+    group_id=junit
+    artifact_id=junit
+    dest=/tmp/junit-latest.jar
 
 # Download JUnit 4.11 from Maven Central
-- maven_artifact: group_id=junit artifact_id=junit version=4.11 dest=/tmp/junit-4.11.jar
+- maven_artifact:
+    group_id=junit
+    artifact_id=junit
+    version=4.11
+    dest=/tmp/junit-4.11.jar
 
 # Download an artifact from a private repository requiring authentication
-- maven_artifact: group_id=com.company artifact_id=library-name repository_url=https://repo.company.com/maven username=user password=pass dest=/tmp/library-name-latest.jar
+- maven_artifact:
+    group_id=com.company
+    artifact_id=library-name
+    repository_url=https://repo.company.com/maven
+    username=user
+    password=pass
+    dest=/tmp/library-name-latest.jar
 
 # Download a WAR File to the Tomcat webapps directory to be deployed
 - maven_artifact:

--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -161,9 +161,9 @@ import os
 import posixpath
 import shutil
 import distutils.version
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
-import urlparse # Override urlparse from module_utils
+import urlparse
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import fetch_url
 try:
     import boto3
     HAS_BOTO = True
@@ -213,7 +213,7 @@ class HttpMavenClient:
             key_name = parsed_url.path[1:]
             user = self.module.params.get('username', '')
             password = self.module.params.get('password', '')
-            client = boto3.client('s3', aws_access_key_id=user, aws_secret_access_key=passwd)
+            client = boto3.client('s3', aws_access_key_id=user, aws_secret_access_key=password)
             url = client.generate_presigned_url('get_object', Params={ 'Bucket': bucket, 'Key': key_name }, ExpiresIn=10)
 
         response, info = fetch_url(self.module, url, timeout=self.timeout)

--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -102,9 +102,11 @@ options:
         choices: ['yes', 'no']
         version_added: "1.9.3"
     ignore_checksum:
-        version_added: "2.3"
+        version_added: "2.4"
         description:
-            - If C(yes), the checksum verification after downloading will be ignored. May result in corrupt artifacts if the network connection fails, but enables downloading artifacts which don't have a remote checksum calculated.
+            - If C(yes), the checksum verification after downloading will be ignored.
+            - May result in corrupt artifacts if the network connection fails, but
+            - enables downloading artifacts which don't have a remote checksum calculated.
         required: false
         default: 'no'
         choices: ['yes', 'no']
@@ -266,7 +268,10 @@ class FileSystemMavenClient:
             for d in dirs:
                 versions.append(d)
         if not versions:
-            self.module.fail_json(msg='Unable to find any version for: %s' % (':'.join([artifact.group_id, artifact.artifact_id, artifact.classifier, artifact.extension])))
+            self.module.fail_json(msg='Unable to find any version for: %s' % (':'.join([artifact.group_id,
+                                                                                        artifact.artifact_id,
+                                                                                        artifact.classifier,
+                                                                                        artifact.extension])))
         return sorted(versions, key=distutils.version.LooseVersion)[-1]
 
     def get_release_version(self, artifact):
@@ -278,7 +283,10 @@ class FileSystemMavenClient:
                     continue
                 versions.append(d)
         if not versions:
-            self.module.fail_json(msg='Unable to find any version for: %s' % (':'.join([artifact.group_id, artifact.artifact_id, artifact.classifier, artifact.extension])))
+            self.module.fail_json(msg='Unable to find any version for: %s' % (':'.join([artifact.group_id,
+                                                                                        artifact.artifact_id,
+                                                                                        artifact.classifier,
+                                                                                        artifact.extension])))
         return sorted(versions, key=distutils.version.LooseVersion)[-1]
 
     def download(self, artifact, destination):
@@ -286,7 +294,13 @@ class FileSystemMavenClient:
             src = posixpath.join(self.repo, artifact.url)
             return shutil.copy2(src, destination)
         except (IOError, os.error) as why:
-            self.module.fail_json(msg='Copy failed. %s' % (':'.join([artifact.group_id, artifact.artifact_id, artifact.classifier, artifact.extension, artifact.url, destination, str(why)])))
+            self.module.fail_json(msg='Copy failed. %s' % (':'.join([artifact.group_id,
+                                                                     artifact.artifact_id,
+                                                                     artifact.classifier,
+                                                                     artifact.extension,
+                                                                     artifact.url,
+                                                                     destination,
+                                                                     str(why)])))
 
     def checksum(self, artifact, dest):
         if not os.path.isfile(dest):

--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -20,7 +20,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: maven_artifact
-short_description: Downloads an Artifact from a Maven Repository
+short_description: Downloads an artifact from a maven repository.
 version_added: "2.0"
 description:
     - Downloads an artifact from a maven repository given the maven coordinates provided to the module.
@@ -34,62 +34,66 @@ requirements:
 options:
     group_id:
         description:
-            - The Maven groupId coordinate
+            - The maven groupId coordinate.
         required: true
     artifact_id:
         description:
-            - The maven artifactId coordinate
+            - The maven artifactId coordinate.
         required: true
     version:
         description:
-            - The maven version coordinate
+            - The maven version coordinate. Special value "release" is used to specify the latest available release.
         required: false
         default: latest
     classifier:
         description:
-            - The maven classifier coordinate
+            - The maven classifier coordinate.
         required: false
         default: null
     extension:
         description:
-            - The maven type/extension coordinate
+            - The maven type/extension coordinate.
         required: false
         default: jar
-    repository_url:
+    url_repository:
+        version_added: 2.3
+        aliases: [ repository_url, repository ]
         description:
-            - The URL of the Maven Repository to download from.
+            - The URL of the Maven Repository to download from
             - Use s3://... if the repository is hosted on Amazon S3, added in version 2.2.
         required: false
         default: http://repo1.maven.org/maven2
-    username:
+    url_username:
+        version_added: 2.3
+        aliases: [ username, user, uname, aws_secret_key ]
         description:
-            - The username to authenticate as to the Maven Repository. Use AWS secret key of the repository is hosted on S3
+            - The username to authenticate as to the Maven Repository, Use AWS secret key of the repository is hosted on S3.
         required: false
         default: null
-        aliases: [ "aws_secret_key" ]
-    password:
+    url_password:
+        version_added: 2.3
+        aliases: [ password, pwd, passwd, aws_secret_access_key ]
         description:
-            - The password to authenticate with to the Maven Repository. Use AWS secret access key of the repository is hosted on S3
+            - The password to authenticate with to the Maven Repository. Use AWS secret access key of the repository is hosted on S3.
         required: false
         default: null
-        aliases: [ "aws_secret_access_key" ]
     dest:
         description:
-            - The path where the artifact should be written to
+            - The path where the artifact should be written to.
         required: true
         default: false
     state:
         description:
-            - The desired state of the artifact
+            - The desired state of the artifact.
         required: true
         default: present
-        choices: [present,absent]
+        choices: [ present, absent ]
     timeout:
         description:
             - Specifies a timeout in seconds for the connection attempt
         required: false
         default: 10
-        version_added: "2.3"
+        version_added: 2.3
     validate_certs:
         description:
             - If C(no), SSL certificates will not be validated. This should only be set to C(no) when no other option exists.
@@ -97,38 +101,24 @@ options:
         default: 'yes'
         choices: ['yes', 'no']
         version_added: "1.9.3"
-    keep_name:
+    ignore_checksum:
+        version_added: 2.3
         description:
-            - If C(yes), the downloaded artifact's name is preserved, i.e the version number remains part of it.
-            - This option only has effect when C(dest) is a directory and C(version) is set to C(latest).
+            - If C(yes), the checksum verification after downloading will be ignored. May result in corrupt artifacts if the network connection fails, but enables downloading artifacts which don't have a remote checksum calculated.
         required: false
         default: 'no'
         choices: ['yes', 'no']
-        version_added: "2.4"
 '''
 
 EXAMPLES = '''
 # Download the latest version of the JUnit framework artifact from Maven Central
-- maven_artifact:
-    group_id: junit
-    artifact_id: junit
-    dest: /tmp/junit-latest.jar
+- maven_artifact: group_id=junit artifact_id=junit dest=/tmp/junit-latest.jar
 
 # Download JUnit 4.11 from Maven Central
-- maven_artifact:
-    group_id: junit
-    artifact_id: junit
-    version: 4.11
-    dest: /tmp/junit-4.11.jar
+- maven_artifact: group_id=junit artifact_id=junit version=4.11 dest=/tmp/junit-4.11.jar
 
 # Download an artifact from a private repository requiring authentication
-- maven_artifact:
-    group_id: com.company
-    artifact_id: library-name
-    repository_url: 'https://repo.company.com/maven'
-    username: user
-    password: pass
-    dest: /tmp/library-name-latest.jar
+- maven_artifact: group_id=com.company artifact_id=library-name repository_url=https://repo.company.com/maven username=user password=pass dest=/tmp/library-name-latest.jar
 
 # Download a WAR File to the Tomcat webapps directory to be deployed
 - maven_artifact:
@@ -138,22 +128,24 @@ EXAMPLES = '''
     repository_url: 'https://repo.company.com/maven'
     dest: /var/lib/tomcat7/webapps/web-app.war
 
-# Keep a downloaded artifact's name, i.e. retain the version
+# Passing a directory as destination, the artifact name will contain the artifact_id, version and classifier
 - maven_artifact:
     version: latest
     artifact_id: spring-core
     group_id: org.springframework
     dest: /tmp/
-    keep_name: yes
 '''
 
+import lxml.etree as etree
+import os
 import hashlib
 import os
 import posixpath
-import sys
-
-from lxml import etree
-
+import shutil
+import distutils.version
+from ansible.module_utils.basic import *
+from ansible.module_utils.urls import *
+import urlparse # Override urlparse from module_utils
 try:
     import boto3
     HAS_BOTO = True
@@ -167,224 +159,132 @@ from ansible.module_utils.urls import fetch_url
 
 class Artifact(object):
     def __init__(self, group_id, artifact_id, version, classifier=None, extension='jar'):
-        if not group_id:
-            raise ValueError("group_id must be set")
-        if not artifact_id:
-            raise ValueError("artifact_id must be set")
-
         self.group_id = group_id
         self.artifact_id = artifact_id
         self.version = version
         self.classifier = classifier
+        self.extension = extension
 
-        if not extension:
-            self.extension = "jar"
-        else:
-            self.extension = extension
+    @property
+    def url(self):
+        return posixpath.join(self.group_id.replace(".", "/"), self.artifact_id, self.version, self.filename)
 
-    def is_snapshot(self):
-        return self.version and self.version.endswith("SNAPSHOT")
-
-    def path(self, with_version=True):
-        base = posixpath.join(self.group_id.replace(".", "/"), self.artifact_id)
-        if with_version and self.version:
-            return posixpath.join(base, self.version)
-        else:
-            return base
-
-    def _generate_filename(self):
-        if not self.classifier:
-            return self.artifact_id + "." + self.extension
-        else:
-            return self.artifact_id + "-" + self.classifier + "." + self.extension
-
-    def get_filename(self, filename=None):
-        if not filename:
-            filename = self._generate_filename()
-        elif os.path.isdir(filename):
-            filename = os.path.join(filename, self._generate_filename())
-        return filename
-
-    def __str__(self):
+    @property
+    def filename(self):
+        bits = [self.artifact_id, self.version]
         if self.classifier:
-            return "%s:%s:%s:%s:%s" % (self.group_id, self.artifact_id, self.extension, self.classifier, self.version)
-        elif self.extension != "jar":
-            return "%s:%s:%s:%s" % (self.group_id, self.artifact_id, self.extension, self.version)
-        else:
-            return "%s:%s:%s" % (self.group_id, self.artifact_id, self.version)
-
-    @staticmethod
-    def parse(input):
-        parts = input.split(":")
-        if len(parts) >= 3:
-            g = parts[0]
-            a = parts[1]
-            v = parts[len(parts) - 1]
-            t = None
-            c = None
-            if len(parts) == 4:
-                t = parts[2]
-            if len(parts) == 5:
-                t = parts[2]
-                c = parts[3]
-            return Artifact(g, a, v, c, t)
-        else:
-            return None
+            bits.append(self.classifier)
+        return "-".join(bits) + "." + self.extension
 
 
-class MavenDownloader:
-    def __init__(self, module, base="http://repo1.maven.org/maven2"):
+class HttpMavenClient:
+    def __init__(self, module, repository, timeout):
         self.module = module
-        if base.endswith("/"):
-            base = base.rstrip("/")
-        self.base = base
-        self.user_agent = "Maven Artifact Downloader/1.0"
-        self.latest_version_found = None
+        self.repo = repository.rstrip("/")
+        self.timeout = timeout
 
-    def find_latest_version_available(self, artifact):
-        if self.latest_version_found:
-            return self.latest_version_found
-        path = "/%s/maven-metadata.xml" % (artifact.path(False))
-        xml = self._request(self.base + path, "Failed to download maven-metadata.xml", lambda r: etree.parse(r))
-        v = xml.xpath("/metadata/versioning/versions/version[last()]/text()")
-        if v:
-            self.latest_version_found = v[0]
-            return v[0]
-
-    def find_uri_for_artifact(self, artifact):
-        if artifact.version == "latest":
-            artifact.version = self.find_latest_version_available(artifact)
-
-        if artifact.is_snapshot():
-            path = "/%s/maven-metadata.xml" % (artifact.path())
-            xml = self._request(self.base + path, "Failed to download maven-metadata.xml", lambda r: etree.parse(r))
-            timestamp = xml.xpath("/metadata/versioning/snapshot/timestamp/text()")[0]
-            buildNumber = xml.xpath("/metadata/versioning/snapshot/buildNumber/text()")[0]
-            for snapshotArtifact in xml.xpath("/metadata/versioning/snapshotVersions/snapshotVersion"):
-                if (len(snapshotArtifact.xpath("classifier/text()")) > 0 and
-                        snapshotArtifact.xpath("classifier/text()")[0] == artifact.classifier and
-                        len(snapshotArtifact.xpath("extension/text()")) > 0 and
-                        snapshotArtifact.xpath("extension/text()")[0] == artifact.extension):
-                    return self._uri_for_artifact(artifact, snapshotArtifact.xpath("value/text()")[0])
-            return self._uri_for_artifact(artifact, artifact.version.replace("SNAPSHOT", timestamp + "-" + buildNumber))
-
-        return self._uri_for_artifact(artifact, artifact.version)
-
-    def _uri_for_artifact(self, artifact, version=None):
-        if artifact.is_snapshot() and not version:
-            raise ValueError("Expected uniqueversion for snapshot artifact " + str(artifact))
-        elif not artifact.is_snapshot():
-            version = artifact.version
-        if artifact.classifier:
-            return posixpath.join(self.base, artifact.path(), artifact.artifact_id + "-" + version + "-" + artifact.classifier + "." + artifact.extension)
-
-        return posixpath.join(self.base, artifact.path(), artifact.artifact_id + "-" + version + "." + artifact.extension)
-
-    def _request(self, url, failmsg, f):
-        url_to_use = url
-        parsed_url = urlparse(url)
-        if parsed_url.scheme=='s3':
-            parsed_url = urlparse(url)
-            bucket_name = parsed_url.netloc
+    def get(self, url):
+        url = posixpath.join(self.repo, url)
+        if url.startswith("s3://"):
+            parsed_url = urlparse.urlparse(url)
+            bucket = parsed_url.netloc[:parsed_url.netloc.find('.')]
             key_name = parsed_url.path[1:]
-            client = boto3.client('s3',aws_access_key_id=self.module.params.get('username', ''), aws_secret_access_key=self.module.params.get('password', ''))
-            url_to_use = client.generate_presigned_url('get_object',Params={'Bucket':bucket_name,'Key':key_name},ExpiresIn=10)
+            user = self.module.params.get('url_username', '')
+            password = self.module.params.get('url_password', '')
+            client = boto3.client('s3', aws_access_key_id=user, aws_secret_access_key=passwd)
+            url = client.generate_presigned_url('get_object', Params={'Bucket': bucket, 'Key': key_name }, ExpiresIn=10)
 
-        req_timeout = self.module.params.get('timeout')
-
-        # Hack to add parameters in the way that fetch_url expects
-        self.module.params['url_username'] = self.module.params.get('username', '')
-        self.module.params['url_password'] = self.module.params.get('password', '')
-        self.module.params['http_agent'] = self.module.params.get('user_agent', None)
-
-        response, info = fetch_url(self.module, url_to_use, timeout=req_timeout)
+        response, info = fetch_url(self.module, url, timeout=self.timeout)
         if info['status'] != 200:
-            raise ValueError(failmsg + " because of " + info['msg'] + "for URL " + url_to_use)
-        else:
-            return f(response)
+            raise Exception("Unable to complete request (%s)" % (url))
+        return response.read()
 
+    def download_metadata(self, artifact):
+        url = "%s/maven-metadata.xml" % (posixpath.join(*artifact.url.split("/")[0:-2]))
+        response = self.get(url)
+        return etree.fromstring(response)
 
-    def download(self, artifact, filename=None):
-        filename = artifact.get_filename(filename)
-        if not artifact.version or artifact.version == "latest":
-            artifact = Artifact(artifact.group_id, artifact.artifact_id, self.find_latest_version_available(artifact),
-                                artifact.classifier, artifact.extension)
+    def get_latest_version(self, artifact):
+        # We are trusting the order returned by the XML, but should we?
+        return str(self.download_metadata(artifact).xpath("/metadata/versioning/versions/version[last()]/text()")[-1])
 
-        url = self.find_uri_for_artifact(artifact)
-        if not self.verify_md5(filename, url + ".md5"):
-            response = self._request(url, "Failed to download artifact " + str(artifact), lambda r: r)
-            if response:
-                f = open(filename, 'w')
-                # f.write(response.read())
-                self._write_chunks(response, f, report_hook=self.chunk_report)
-                f.close()
-                return True
-            else:
-                return False
-        else:
-            return True
+    def get_release_version(self, artifact):
+        return str(self.download_metadata(artifact).xpath("/metadata/versioning/release/text()")[-1])
 
-    def chunk_report(self, bytes_so_far, chunk_size, total_size):
-        percent = float(bytes_so_far) / total_size
-        percent = round(percent * 100, 2)
-        sys.stdout.write("Downloaded %d of %d bytes (%0.2f%%)\r" %
-                         (bytes_so_far, total_size, percent))
+    def get_md5(self, artifact):
+        return self.get(artifact.url + '.md5')
 
-        if bytes_so_far >= total_size:
-            sys.stdout.write('\n')
+    def download(self, artifact, destination):
+        if os.path.isdir(destination) or destination.endswith("/"):
+            destination = os.path.join(destination, artifact.filename)
+        with open(destination, 'w') as file:
+            response = self.get(artifact.url)
+            file.write(response)
+        return destination
 
-    def _write_chunks(self, response, file, chunk_size=8192, report_hook=None):
-        total_size = response.info().getheader('Content-Length').strip()
-        total_size = int(total_size)
-        bytes_so_far = 0
-
-        while 1:
-            chunk = response.read(chunk_size)
-            bytes_so_far += len(chunk)
-
-            if not chunk:
-                break
-
-            file.write(chunk)
-            if report_hook:
-                report_hook(bytes_so_far, chunk_size, total_size)
-
-        return bytes_so_far
-
-    def verify_md5(self, file, remote_md5):
-        if not os.path.exists(file):
+    def checksum(self, artifact, dest):
+        if not os.path.isfile(dest):
             return False
-        else:
-            local_md5 = self._local_md5(file)
-            remote = self._request(remote_md5, "Failed to download MD5", lambda r: r.read())
-            return local_md5 == remote
+        remote_md5 = self.get_md5(artifact)
+        local_md5 = None
+        with open(dest, 'rb') as file:
+            local_md5 = hashlib.md5(file.read()).hexdigest()
 
-    def _local_md5(self, file):
-        md5 = hashlib.md5()
-        f = open(file, 'rb')
-        for chunk in iter(lambda: f.read(8192), ''):
-            md5.update(chunk)
-        f.close()
-        return md5.hexdigest()
+        return remote_md5 == local_md5
+
+class FileSystemMavenClient:
+    def __init__(self, module, repository, timeout=None):
+        self.module = module
+        self.repo = repository.rstrip("/")
+
+    def get_latest_version(self, artifact):
+        path = posixpath.join(self.repo, artifact.group_id.replace(".", "/"), artifact.artifact_id).replace('file:/', '')
+        versions = []
+        for root, dirs, files in os.walk(path):
+            for d in dirs:
+                versions.append(d)
+        if not versions:
+            self.module.fail_json(msg='Unable to find any version for: %s' % (':'.join([artifact.group_id, artifact.artifact_id, artifact.classifier, artifact.extension])))
+        return sorted(versions, key=distutils.version.LooseVersion)[-1]
+
+    def get_release_version(self, artifact):
+        path = posixpath.join(self.repo, artifact.group_id.replace(".", "/"), artifact.artifact_id).replace('file:/', '')
+        versions = []
+        for root, dirs, files in os.walk(path):
+            for d in dirs:
+                if '-SNAPSHOT' in dirs:
+                    continue
+                versions.append(d)
+        if not versions:
+            self.module.fail_json(msg='Unable to find any version for: %s' % (':'.join([artifact.group_id, artifact.artifact_id, artifact.classifier, artifact.extension])))
+        return sorted(versions, key=distutils.version.LooseVersion)[-1]
+
+    def download(self, artifact, destination):
+        return shutil.copy2(artifact.url, destination)
+
+    def checksum(self, artifact, dest):
+        self.module.fail_json(msg=artifact.url)
+        return True # There is nothing to check if the artifact is local
 
 
 def main():
 
     module = AnsibleModule(
         argument_spec = dict(
-            group_id = dict(default=None),
-            artifact_id = dict(default=None),
-            version = dict(default="latest"),
+            group_id = dict(required=True),
+            artifact_id = dict(required=True),
+            version = dict(default='latest'),
             classifier = dict(default=None),
             extension = dict(default='jar'),
-            repository_url = dict(default=None),
-            username = dict(default=None,aliases=['aws_secret_key']),
-            password = dict(default=None, no_log=True,aliases=['aws_secret_access_key']),
-            state = dict(default="present", choices=["present","absent"]), # TODO - Implement a "latest" state
+            url_repository = dict(default='http://repo1.maven.org/maven2', aliases=['repository_url', 'repository']),
+            url_username = dict(default=None, aliases=['username', 'user', 'uname', 'aws_secret_key']),
+            url_password = dict(default=None, aliases=['password', 'pwd', 'passwd', 'aws_secret_access_key'], no_log=True),
+            http_agent = dict(default='Maven Artifact Downloader/1.0'),
+            state = dict(default='present', choices=['present','absent']),
+            dest = dict(type='path', default=None),
             timeout = dict(default=10, type='int'),
-            dest = dict(type="path", default=None),
-            validate_certs = dict(required=False, default=True, type='bool'),
-            keep_name = dict(required=False, default=False, type='bool'),
+            validate_certs = dict(default=True, type='bool'),
+            ignore_checksum = dict(default=False, type='bool'),
         )
     )
 
@@ -405,43 +305,57 @@ def main():
     version = module.params["version"]
     classifier = module.params["classifier"]
     extension = module.params["extension"]
+    repo = module.params["url_repository"]
     state = module.params["state"]
     dest = module.params["dest"]
-    keep_name = module.params["keep_name"]
+    timeout = module.params["timeout"]
+    ignore_checksum = module.params["ignore_checksum"]
 
-    #downloader = MavenDownloader(module, repository_url, repository_username, repository_password)
-    downloader = MavenDownloader(module, repository_url)
-
-    try:
-        artifact = Artifact(group_id, artifact_id, version, classifier, extension)
-    except ValueError as e:
-        module.fail_json(msg=e.args[0])
-
-    prev_state = "absent"
-    if os.path.isdir(dest):
-        version_part = version
-        if keep_name and version == 'latest':
-            version_part = downloader.find_latest_version_available(artifact)
-        dest = posixpath.join(dest, "%s-%s.%s" % (artifact_id, version_part, extension))
-    if os.path.lexists(dest) and downloader.verify_md5(dest, downloader.find_uri_for_artifact(artifact) + '.md5'):
-        prev_state = "present"
+    if repo.startswith("s3://") and not HAS_BOTO:
+        module.fail_json(msg='boto3 required when using s3:// repository URLs with this module.')
+    elif repo.startswith('file://'):
+        client = FileSystemMavenClient(module, repo, timeout)
     else:
-        path = os.path.dirname(dest)
-        if not os.path.exists(path):
-            os.makedirs(path)
-
-    if prev_state == "present":
-        module.exit_json(dest=dest, state=state, changed=False)
+        client = HttpMavenClient(module, repo, timeout)
+    artifact = Artifact(group_id, artifact_id, version, classifier, extension)
 
     try:
-        if downloader.download(artifact, dest):
-            module.exit_json(state=state, dest=dest, group_id=group_id, artifact_id=artifact_id, version=version, classifier=classifier,
-                             extension=extension, repository_url=repository_url, changed=True)
-        else:
-            module.fail_json(msg="Unable to download the artifact")
-    except ValueError as e:
+        if version == 'latest':
+            artifact.version = client.get_latest_version(artifact)
+        elif version == 'release':
+            artifact.version = client.get_release_version(artifact)
+    except Exception as e:
         module.fail_json(msg=e.args[0])
 
+    if not artifact.version:
+        module.fail_json(msg="Unable to retrieve version number. Is the version number valid? Is it a snapshot-only repository?")
+
+    if os.path.isdir(dest):
+        dest = os.path.join(dest, artifact.filename)
+
+    # Should we delete the file?
+    if state == 'absent':
+        if os.path.isfile(dest):
+            os.remove(dest)
+            module.exit_json(dest=dest, state=state, changed=True)
+        else:
+            module.exit_json(dest=dest, state=state, changed=False)
+
+    # Does the local file already exist and match the remote md5?
+    if client.checksum(artifact, dest):
+        module.exit_json(dest=dest, state=state, version=artifact.version, changed=False)
+
+    try:
+        client.download(artifact, dest)
+    except Exception as e:
+        module.fail_json(msg=e.args[0])
+
+    if ignore_checksum and not client.checksum(artifact, dest):
+        module.fail_json(msg="I was able to download the artifact (%s), but the checksum doesn't match (%s)." % (artifact.url, dest))
+
+    module.exit_json(state=state, dest=dest, group_id=group_id, artifact_id=artifact_id,
+                     version=artifact.version, classifier=classifier, extension=extension,
+                     url_repository=repo, ignore_checksum=ignore_checksum, changed=True)
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -141,12 +141,20 @@ EXAMPLES = '''
     repository_url: https://repo.company.com/maven
     dest: /var/lib/tomcat7/webapps/web-app.war
 
-# Passing a directory as destination, the artifact name will contain the artifact_id, version and classifier
+# Passing a directory as destination, the filename will contain the artifact_id, version and classifier
 - maven_artifact:
     version: latest
     artifact_id: spring-core
     group_id: org.springframework
     dest: /tmp/
+
+# Copy a WAR file from the local maven repository to the Tomcat webapps directory to be deployed
+- maven_artifact:
+    group_id: com.company
+    artifact_id: web-app
+    extension: war
+    repository_url: file://home/jenkins/.m2/repository
+    dest: /var/lib/tomcat7/webapps/web-app.war
 '''
 
 import lxml.etree as etree

--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -375,4 +375,4 @@ def main():
                      url_repository=repo, ignore_checksum=ignore_checksum, changed=True)
 
 if __name__ == '__main__':
-	main()
+    main()


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

maven_artifact
##### ANSIBLE VERSION

ansible 2.0.0.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
##### SUMMARY

Reduced code base in approximately 30%, (removed dead code, simplified some logic), using ansible's own error checking to catch the glaring ones (such as absence of required parameters).
Added ignore_checksum option, enabling artifact download without forcing remote checksum validation.
Added aliases to repository, username and password parameters for better consistency.
Fixed (unreported) issue where http credentials weren't being propagated correctly.
Module initialization parameters are mandatory according to the documentation but not in the code.
Add support for local .m2 repositories (allowing a simple 'mvn install' to work without requiring a full fledged repository).
##### TESTING

I've been using this in production on my company for a few months now (a few thousand downloads so far, very heterogeneous parameters), no issues found.