### PR TITLE
cloudfront_facts.py

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -1,0 +1,453 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'version': '1.0'}
+
+DOCUMENTATION = '''
+---
+module: cloudfront_facts
+short_description: Obtain facts about an AWS CloudFront distribution
+description:
+  - Gets information about an AWS CloudFront distribution
+requirements:
+  - boto3 >= 1.0.0
+  - python >= 2.6
+version_added: "2.2"
+author: Willem van Ketwich (@wilvk)
+options:
+    distribution_id:
+        description:
+          - The id of the CloudFront distribution. Used with distribution, distribution_config, invalidation, streaming_distribution, streaming_distribution_config, list_invalidations.
+        required: false
+    invalidation_id:
+        description:
+          - The id of the invalidation to get information about. Used with invalidation
+          required: false
+    cloud_front_origin_access_identity_id:
+        description:
+          - The id of the cloudfront origin access identity to get information about
+        required: false
+    web_acl_id:
+        description:
+          - Used with list_distributions_by_web_acl_id
+          required: false
+    domain_name_alias:
+        description:
+          - Can be used instead of distribution_id - uses the aliased CNAME for the cloudfront distribution to get the distribution id where required
+          required: false
+    all_lists:
+        description:
+            - Get all cloudfront lists that do not require parameters
+        required: false
+        default: false
+    cloud_front_origin_access_identity:
+        description:
+            - Get information about an origin access identity
+        required: false
+        default: false
+    cloud_front_origin_access_identity_config:
+        description:
+            - Get the configuration information about an origin access identity
+        required: false
+        default: false
+    distribution:
+        description:
+            - Get information about a distribution. Requires distribution_id or domain_name_alias to be specified.
+    distribution_config:
+        description:
+            - Get the configuration information about a distribution. Requires distribution_id or domain_name_alias to be specified.
+        required: false
+        default: false
+    invalidation:
+        description:
+            - Get information about an invalidation. Requires invalidation_id to be specified.
+        required: false
+        default: false
+    streaming_distribution:
+        description:
+            - Get information about a specified RTMP distribution. Requires distribution_id or domain_name_alias to be specified.
+        required: false
+        default: false
+    streaming_distribution_configuration:
+        description:
+            - Get the configuration information about a specified RTMP distribution. Requires distribution_id or domain_name_alias to be specified.
+        required: false
+        default: false
+    list_cloud_front_origin_access_identities:
+        description:
+            - Get a list of cloudfront origin access identities. Requires cloud_front_origin_access_identity_id to be set.
+        required: false
+        default: false
+    list_distributions:
+        description:
+            - Get a list of cloudfront distributions.
+        required: false
+        default: false
+    list_distributions_by_web_acl:
+        description:
+            - Get a list of distributions using web acl id as a filter. Requires web_acl_id to be set.
+        required: false
+        default: false
+    list_invalidations:
+        description:
+            - Get a list of invalidations. Requires distribution_id or domain_name_alias to be specified.
+        required: false
+        default: false
+    list_streaming_distributions:
+        description:
+            - Get a list of streaming distributions
+        required: false
+        default: false
+
+extends_documentation_fragment:
+    - aws
+    - ec2
+'''
+
+EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+
+# Get information about a distribution
+- cloudfront_facts:
+    distribution: true
+    distribution_id: my-cloudfront-distribution-id
+
+# Get information about a distribution using the CNAME of the cloudfront distribution
+- cloudfront_facts:
+    distribution: true
+    domain_name_alias: www.my-website.com
+
+# Facts are published in ansible_facts['cloudfront'][<distribution_name>]
+- debug:
+    msg: '{{ ansible_facts['cloudfront']['my-cloudfront-distribution-id'] }}'
+
+# Get all information about an invalidation for a distribution
+- cloudfront_facts:
+    invalidation: true
+    distribution_id: my-cloudfront-distribution-id
+    invalidation_id: my-cloudfront-invalidation-id
+
+# Get all information about a cloudfront origin access identity
+- cloudfront_facts:
+    cloud_front_origin_access_identity: true
+    cloud_front_origin_access_identity_id: my-cloudfront-origin-access-identity-id
+
+# Get all information about lists not requiring parameters (ie. list_cloud_front_origin_access_identities, list_distributions, list_streaming_distributions)
+- cloudfront_facts:
+    all_lists: true
+'''
+
+RETURN = '''
+cloud_front_origin_access_identity:
+    description: Describes the origin access identity information. Requires cloud_front_origin_access_identity_id to be set.
+    returned: only if cloud_front_origin_access_identity is true
+    type: dict
+cloud_front_origin_access_identity_configuration:
+    description: Describes the origin access identity information configuration information. Requires cloud_front_origin_access_identity_id to be set.
+    returned: only if cloud_front_origin_access_identity_configuration is true
+    type: dict
+distribution:
+    description: Facts about a cloudfront distribution. Requires distribution_id or domain_name_alias to be specified. Requires cloud_front_origin_access_identity_id to be set.
+    returned: only if distribution is true
+    type: dict
+distribution_config:
+    description: Facts about a cloudfront distribution's config. Requires distribution_id or domain_name_alias to be specified.
+    returned: only if distribution_config is true
+    type: dict
+invalidation:
+    description: Describes the invalidation information for the distribution. Requires invalidation_id to be specified and either distribution_id or domain_name_alias.
+    returned: only if invalidation is true
+    type: dict
+streaming_distribution:
+    description: Describes the streaming information for the distribution. Requires distribution_id or domain_name_alias to be specified.
+    returned: only if streaming_distribution is true
+    type: dict
+streaming_distribution_configuration:
+    description: Describes the streaming configuration information for the distribution. Requires distribution_id or domain_name_alias to be specified.
+    returned: only if streaming_distribution_configuration is true
+    type: dict
+'''
+
+try:
+    import boto3
+    import botocore
+    HAS_BOTO3 = True
+except ImportError:
+    HAS_BOTO3 = False
+
+from ansible.module_utils.ec2 import get_aws_connection_info
+from ansible.module_utils.basic import AnsibleModule
+from functools import partial
+import json
+import traceback
+
+class CloudFrontServiceManager:
+    """Handles CloudFront Services"""
+
+    def __init__(self, module):
+        self.module = module
+
+        try:
+            region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+            self.client = boto3_conn(module, conn_type='client',
+                                     resource='cloudfront', region=region,
+                                     endpoint=ec2_url, **aws_connect_kwargs)
+        except botocore.exceptions.NoRegionError:
+            self.module.fail_json(msg="Region must be specified as a parameter, in AWS_DEFAULT_REGION environment variable or in boto configuration file")
+        except Exception as e:
+            self.module.fail_json(msg="Can't establish connection - " + str(e), exception=traceback.format_exc(e))
+
+    def get_distribution(self, distribution_id):
+        try:
+            func = partial(self.client.get_distribution,Id=distribution_id)
+            return self.paginated_response(func, 'Distribution')
+        except Exception as e:
+            self.module.fail_json(msg="Error describing distribution - " + str(e), exception=traceback.format_exc(e))
+
+    def get_distribution_config(self, distribution_id):
+        try:
+            func = partial(self.client.get_distribution_config,Id=distribution_id)
+            return self.paginated_response(func, 'DistributionConfig')
+        except Exception as e:
+            self.module.fail_json(msg="Error describing distribution configuration - " + str(e), exception=traceback.format_exec(e))
+
+    def get_cloud_front_origin_access_identity(self, origin_access_identity_id):
+        try:
+            func = partial(self.client.get_cloud_front_origin_access_identity,Id=origin_access_identity_id)
+            return self.paginated_response(func, 'CloudFrontOriginAccessIdentity')
+        except Exception as e:
+            self.module.fail_json(msg="Error describing origin access identity - " + str(e), exception=traceback.format_exc(e))
+
+    def get_cloud_front_origin_access_identity_config(self, origin_access_identity_id):
+        try:
+            func = partial(self.client.get_cloud_front_origin_access_identity_config,Id=origin_access_identity_id)
+            return self.paginated_response(func, 'CloudFrontOriginAccessIdentityConfig')
+        except Exception as e:
+            self.module.fail_json(msg="Error describing origin access identity configuration - " + str(e), exception=traceback.format_exc(e))
+
+    def get_invalidation(self, distribution_id, invalidation_id):
+        try:
+            func = partial(self.client.get_invalidation,DistributionId=distribution_id,Id=invalidation_id)
+            return self.paginated_response(func, 'Invalidation')
+        except Exception as e:
+            self.module.fail_json(msg="Error describing invalidation - " + str(e), exception=traceback.format_exc(e))
+
+    def get_streaming_distribution(self, distribution_id):
+        try:
+            func = partial(self.client.get_streaming_distribution,Id=distribution_id)
+            return self.paginated_response(func, 'StreamingDistribution')
+        except Exception as e:
+            self.module.fail_json(msg="Error describing streaming distribution - " + str(e), exception=traceback.format_exc(e))
+
+    def get_streaming_distribution_config(self, distribution_id):
+        try:
+            func = partial(self.client.get_streaming_distribution_config,Id=distribution_id)
+            return self.paginated_response(func, 'StreamingDistributionConfig')
+        except Exception as e:
+            self.module.fail_json(msg="Error describing streaming distribution - " + str(e), exception=traceback.format_exc(e))
+
+    def list_cloud_front_origin_access_identities(self):
+        try:
+            func = partial(self.client.list_cloud_front_origin_access_identities)
+            return self.paginated_response(func, 'CloudFrontOriginAccessIdentityList')
+        except Exception as e:
+            self.module.fail_json(msg="Error listing cloud front origin access identities = " + str(e), exception=traceback.format_exc(e))
+
+    def list_distributions(self):
+        try:
+            func = partial(self.client.list_distributions)
+            return self.paginated_response(func, 'DistributionList')
+        except Exception as e:
+            self.module.fail_json(msg="Error listing distributions = " + str(e), exception=traceback.format_exc(e))
+
+    def list_distributions_by_web_acl(self, web_acl_id):
+        try:
+            func = partial(self.client.list_distributions, web_acl_id)
+            return self.paginated_response(func, 'DistributionList')
+        except Exception as e:
+            self.module.fail_json(msg="Error listing distributions by web acl id = " + str(e), exception=traceback.format_exc(e))
+
+    def list_invalidations(self):
+        try:
+            func = partial(self.client.list_invalidations)
+            return self.paginated_response(func, 'InvalidationList')
+        except Exception as e:
+            self.module.fail_json(msg="Error listing invalidations = " + str(e), exception=traceback.format_exc(e))
+
+    def list_streaming_distributions(self):
+        try:
+            func = partial(self.client.list_streaming_distributions)
+            return self.paginated_response(func, 'StreamingDistributionList')
+        except Exception as e:
+            self.module.fail_json(msg="Error listing streaming distributions = " + str(e), exception=traceback.format_exc(e))
+
+    def get_distribution_id_from_domain_name(self, domain_name):
+        try:
+            distribution_id = ""
+            distributions = self.list_distributions()
+            for dist in distributions['Items']:
+                for alias in dist['Aliases']['Items']:
+                    if str(alias).lower() == domain_name.lower():
+                        distribution_id = str(dist['Id'])
+                        break
+            return distribution_id
+        except Exception as e:
+            self.module.fail_json(msg="Error getting distribution id from domain name = " + str(e), exception=traceback.format_exc(e))
+
+    def paginated_response(self, func, result_key, next_token=None):
+        '''
+        Returns expanded response for paginated operations.
+        The 'result_key' is used to define the concatenated results that are combined from each paginated response.
+        '''
+        args=dict()
+        if next_token:
+            args['NextToken'] = next_token
+        response = func(**args)
+        result = response.get(result_key)
+        next_token = response.get('NextToken')
+        if not next_token:
+           return result
+        return result + self.paginated_response(func, result_key, next_token)
+
+def to_dict(items, key, value):
+    ''' Transforms a list of items to a Key/Value dictionary '''
+    if items:
+        return dict(zip([i[key] for i in items], [i[value] for i in items]))
+    else:
+        return dict()
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
+        distribution_id=dict(required=False, type='str'),
+        invalidation_id=dict(required=False, type='str'),
+        cloud_front_origin_access_identity_id=dict(required=False, type='str'),
+        domain_name_alias=dict(required=False, type='str'),
+        all_lists=dict(required=False, default=False, type='bool'),
+        distribution=dict(required=False, default=False, type='bool'),
+        distribution_config=dict(required=False, default=False, type='bool'),
+        cloud_front_origin_access_identity=dict(required=False, default=False, type='bool'),
+        cloud_front_origin_access_identity_config=dict(required=False, default=False, type='bool'),
+        invalidation=dict(required=False, default=False, type='bool'),
+        streaming_distribution=dict(required=False, default=False, type='bool'),
+        streaming_distribution_config=dict(required=False, default=False, type='bool'),
+        list_cloud_front_origin_access_identities=dict(required=False, default=False, type='bool'),
+        list_distributions=dict(required=False, default=False, type='bool'),
+        list_distributions_by_web_acl=dict(required=False, default=False, type='bool'),
+        list_invalidations=dict(required=False, default=False, type='bool'),
+        list_streaming_distributions=dict(required=False, default=False, type='bool')
+    ))
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
+
+    if not HAS_BOTO3:
+      module.fail_json(msg='boto3 is required.')
+
+    service_mgr = CloudFrontServiceManager(module)
+
+    distribution_id = module.params.get('distribution_id')
+    invalidation_id = module.params.get('invalidation_id')
+    cloud_front_origin_access_identity_id = module.params.get('cloud_front_origin_access_identity_id')
+    web_acl_id = module.params.get('web_acl_id')
+    domain_name_alias = module.params.get('domain_name_alias')
+
+    all_lists = module.params.get('all_lists')
+
+    distribution = module.params.get('distribution')
+    distribution_config = module.params.get('distribution_config')
+    cloud_front_origin_access_identity = module.params.get('cloudfront_origin_access_identity')
+    cloud_front_origin_access_identity_config = module.params.get('cloudfront_origin_access_identity_config')
+    invalidation = module.params.get('invalidation')
+    streaming_distribution = module.params.get('streaming_distribution')
+    streaming_distribution_config = module.params.get('streaming_distribution_config')
+
+    list_cloud_front_origin_access_identities = module.params.get('list_cloud_front_origin_access_identities')
+    list_distributions = module.params.get('list_distributions')
+    list_distributions_by_web_acl_id = module.params.get('list_distributions_by_web_acl_id');
+    list_invalidations = module.params.get('list_invalidations')
+    list_streaming_distributions = module.params.get('list_streaming_distributions')
+
+    require_distribution_id = (distribution or distribution_config or invalidation or
+            streaming_distribution or streaming_distribution_config or list_invalidations)
+
+    # validations
+    if require_distribution_id and distribution_id is None and domain_name_alias is None:
+        module.fail_json(msg='Error distribution_id or domain_name have not been specified.')
+    if (invalidation and invalidation_id is None):
+        module.fail_json(msg='Error invalidation_id has not been specified.')
+    if (cloud_front_origin_access_identity or cloud_front_origin_access_identity_config) and cloud_front_origin_access_identity_id is None:
+        module.fail_json(msg='Error cloud_front_origin_access_identity_id has not been specified.')
+    if list_distributions_by_web_acl_id and web_acl_id is None:
+        module.fail_json(msg='Error web_acl_id has not been specified.')
+
+    # get distribution id from domain name alias
+    if require_distribution_id and distribution_id is None:
+        distribution_id = service_mgr.get_distribution_id_from_domain_name(domain_name_alias)
+        if not distribution_id:
+            module.fail_json(msg='Error unable to source a distribution id from domain_name_alias')
+
+    # set appropriate ansible_facts id
+    if distribution_id:
+        result = { 'ansible_facts': { 'cloudfront': { distribution_id:{} } } }
+        facts = result['ansible_facts']['cloudfront'][distribution_id]
+    elif cloud_front_origin_access_identity_id:
+        result = { 'ansible_facts': { 'cloudfront': { cloud_front_origin_access_identity_id:{} } } }
+        facts = result['ansible_facts']['cloudfront'][cloud_front_origin_access_identity_id]
+    elif web_acl_id:
+        result = { 'ansible_facts': { 'cloudfront': { web_acl_id:{} } } }
+        facts = result['ansible_facts']['cloudfront'][web_acl_id]
+    else:
+        result = { 'ansible_facts': { 'cloudfront': {} } }
+        facts = result['ansible_facts']['cloudfront']
+
+    # call details based on options
+    if distribution:
+        facts['distribution'] = service_mgr.get_distribution(distribution_id)
+    if distribution_config:
+        facts['distribution_config'] = service_mgr.get_distribution_config(distribution_id)
+    if cloud_front_origin_access_identity:
+        facts['cloud_front_origin_access_identity'] = service_mgr.get_cloud_front_origin_access_identity(cloud_front_origin_access_identity_id)
+    if cloud_front_origin_access_identity_config:
+        facts['cloud_front_origin_access_identity_config'] = service_mgr.get_cloud_front_origin_access_identity_config(cloud_front_origin_access_identity_id)
+    if invalidation:
+        facts['invalidation'] = service_mgr.get_invalidation(distribution_id, invalidation_id)
+    if streaming_distribution:
+        facts['streaming_distribution'] = service_mgr.get_streaming_distribution(distribution_id)
+    if streaming_distribution_config:
+        facts['streaming_distribution_config'] = service_mgr.get_streaming_distribution_config(distribution_id)
+
+    # call list based on options
+    if all_lists or list_cloud_front_origin_access_identities:
+        facts['list_cloud_front_origin_access_identities'] = service_mgr.list_cloud_front_origin_access_identities()
+    if all_lists or list_distributions:
+        facts['list_distributions'] = service_mgr.list_distributions()
+    if all_lists or list_streaming_distributions:
+        facts['list_streaming_distributions'] = service_mgr.list_streaming_distributions()
+    if list_distributions_by_web_acl_id:
+        facts['list_distributions_by_web_acl'] = service_mgr.list_distributions_by_web_acl()
+    if list_invalidations:
+        facts['list_invalidations'] = service_mgr.list_invalidations(distribution_id)
+
+    result['changed'] = False
+    module.exit_json(msg="Retreived cloudfront facts.", ansible_facts=result)
+
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.ec2 import *
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -436,7 +436,7 @@ def main():
         result = { 'cloudfront': {} }
         facts = result['cloudfront']
 
-    # call details based on options
+    # get details based on options
     if distribution:
         distribution_details = service_mgr.get_distribution(distribution_id)
         facts[distribution_id]['distribution'] = distribution_details
@@ -458,7 +458,7 @@ def main():
     if streaming_distribution_config:
         facts['streaming_distribution_config'] = service_mgr.get_streaming_distribution_config(distribution_id)
 
-    # call list based on options
+    # get list based on options
     if all_lists or list_origin_access_identities:
         facts['list_origin_access_identities'] = service_mgr.list_origin_access_identities()
     if all_lists or list_distributions:

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -36,7 +36,7 @@ options:
     invalidation_id:
         description:
           - The id of the invalidation to get information about. Used with invalidation
-          required: false
+       	required: false
     cloud_front_origin_access_identity_id:
         description:
           - The id of the cloudfront origin access identity to get information about
@@ -44,11 +44,11 @@ options:
     web_acl_id:
         description:
           - Used with list_distributions_by_web_acl_id
-          required: false
+        required: false
     domain_name_alias:
         description:
           - Can be used instead of distribution_id - uses the aliased CNAME for the cloudfront distribution to get the distribution id where required
-          required: false
+        required: false
     all_lists:
         description:
             - Get all cloudfront lists that do not require parameters
@@ -67,6 +67,8 @@ options:
     distribution:
         description:
             - Get information about a distribution. Requires distribution_id or domain_name_alias to be specified.
+	required: false
+	default: false
     distribution_config:
         description:
             - Get the configuration information about a distribution. Requires distribution_id or domain_name_alias to be specified.

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -26,7 +26,7 @@ description:
 requirements:
   - boto3 >= 1.0.0
   - python >= 2.6
-version_added: "2.2"
+version_added: "2.3"
 author: Willem van Ketwich (@wilvk)
 options:
     distribution_id:

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -35,33 +35,33 @@ options:
         required: false
     invalidation_id:
         description:
-          - The id of the invalidation to get information about. Used with invalidation
+          - The id of the invalidation to get information about. Used with invalidation.
         required: false
     rigin_access_identity_id:
         description:
-          - The id of the cloudfront origin access identity to get information about
+          - The id of the cloudfront origin access identity to get information about.
         required: false
     web_acl_id:
         description:
-          - Used with list_distributions_by_web_acl_id
+          - Used with list_distributions_by_web_acl_id.
         required: false
     domain_name_alias:
         description:
-          - Can be used instead of distribution_id - uses the aliased CNAME for the cloudfront distribution to get the distribution id where required
+          - Can be used instead of distribution_id - uses the aliased CNAME for the cloudfront distribution to get the distribution id where required.
         required: false
     all_lists:
         description:
-            - Get all cloudfront lists that do not require parameters
+            - Get all cloudfront lists that do not require parameters.
         required: false
         default: false
     origin_access_identity:
         description:
-            - Get information about an origin access identity
+            - Get information about an origin access identity. Requires origin_access_identity_id to be specified.
         required: false
         default: false
     origin_access_identity_config:
         description:
-            - Get the configuration information about an origin access identity
+            - Get the configuration information about an origin access identity. Requires origin_access_identity_id to be specified.
         required: false
         default: false
     distribution:
@@ -111,7 +111,7 @@ options:
         default: false
     list_streaming_distributions:
         description:
-            - Get a list of streaming distributions
+            - Get a list of streaming distributions.
         required: false
         default: false
 
@@ -128,7 +128,7 @@ EXAMPLES = '''
     distribution: true
     distribution_id: my-cloudfront-distribution-id
 
-# Get information about a distribution using the CNAME of the cloudfront distribution
+# Get information about a distribution using the CNAME of the cloudfront distribution.
 - cloudfront_facts:
     distribution: true
     domain_name_alias: www.my-website.com
@@ -137,13 +137,13 @@ EXAMPLES = '''
 - debug:
     msg: '{{ ansible_facts['cloudfront']['my-cloudfront-distribution-id'] }}'
 
-# Get all information about an invalidation for a distribution
+# Get all information about an invalidation for a distribution.
 - cloudfront_facts:
     invalidation: true
     distribution_id: my-cloudfront-distribution-id
     invalidation_id: my-cloudfront-invalidation-id
 
-# Get all information about a cloudfront origin access identity
+# Get all information about a cloudfront origin access identity.
 - cloudfront_facts:
     origin_access_identity: true
     origin_access_identity_id: my-cloudfront-origin-access-identity-id
@@ -383,7 +383,7 @@ def main():
 
     # validations
     if require_distribution_id and distribution_id is None and domain_name_alias is None:
-        module.fail_json(msg='Error distribution_id or domain_name have not been specified.')
+        module.fail_json(msg='Error distribution_id or domain_name_alias have not been specified.')
     if (invalidation and invalidation_id is None):
         module.fail_json(msg='Error invalidation_id has not been specified.')
     if (origin_access_identity or origin_access_identity_config) and origin_access_identity_id is None:

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -36,7 +36,7 @@ options:
     invalidation_id:
         description:
           - The id of the invalidation to get information about. Used with invalidation
-       	required: false
+        required: false
     cloud_front_origin_access_identity_id:
         description:
           - The id of the cloudfront origin access identity to get information about
@@ -67,8 +67,8 @@ options:
     distribution:
         description:
             - Get information about a distribution. Requires distribution_id or domain_name_alias to be specified.
-	required: false
-	default: false
+        required: false
+        default: false
     distribution_config:
         description:
             - Get the configuration information about a distribution. Requires distribution_id or domain_name_alias to be specified.

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -312,20 +312,21 @@ class CloudFrontServiceManager:
         except Exception as e:
             self.module.fail_json(msg="Error getting distribution id from domain name = " + str(e), exception=traceback.format_exc(e))
 
-    def paginated_response(self, func, result_key, next_token=None):
+    def paginated_response(self, func, result_key):
         '''
         Returns expanded response for paginated operations.
         The 'result_key' is used to define the concatenated results that are combined from each paginated response.
         '''
         args=dict()
-        if next_token:
-            args['NextToken'] = next_token
-        response = func(**args)
-        result = response.get(result_key)
-        next_token = response.get('NextToken')
-        if not next_token:
-           return result
-        return result + self.paginated_response(func, result_key, next_token)
+        results = dict()
+        loop = True
+        while loop:
+            response = func(**args)
+            result = response.get(result_key)
+            results.update(result)
+            args['NextToken'] = response.get('NextToken')
+            loop = args['NextToken'] is not None
+        return results
 
 def main():
     argument_spec = ec2_argument_spec()

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -37,7 +37,7 @@ options:
         description:
           - The id of the invalidation to get information about. Used with invalidation
         required: false
-    cloud_front_origin_access_identity_id:
+    rigin_access_identity_id:
         description:
           - The id of the cloudfront origin access identity to get information about
         required: false
@@ -54,12 +54,12 @@ options:
             - Get all cloudfront lists that do not require parameters
         required: false
         default: false
-    cloud_front_origin_access_identity:
+    origin_access_identity:
         description:
             - Get information about an origin access identity
         required: false
         default: false
-    cloud_front_origin_access_identity_config:
+    origin_access_identity_config:
         description:
             - Get the configuration information about an origin access identity
         required: false
@@ -89,9 +89,9 @@ options:
             - Get the configuration information about a specified RTMP distribution. Requires distribution_id or domain_name_alias to be specified.
         required: false
         default: false
-    list_cloud_front_origin_access_identities:
+    list_origin_access_identities:
         description:
-            - Get a list of cloudfront origin access identities. Requires cloud_front_origin_access_identity_id to be set.
+            - Get a list of cloudfront origin access identities. Requires origin_access_identity_id to be set.
         required: false
         default: false
     list_distributions:
@@ -145,25 +145,25 @@ EXAMPLES = '''
 
 # Get all information about a cloudfront origin access identity
 - cloudfront_facts:
-    cloud_front_origin_access_identity: true
-    cloud_front_origin_access_identity_id: my-cloudfront-origin-access-identity-id
+    origin_access_identity: true
+    origin_access_identity_id: my-cloudfront-origin-access-identity-id
 
-# Get all information about lists not requiring parameters (ie. list_cloud_front_origin_access_identities, list_distributions, list_streaming_distributions)
+# Get all information about lists not requiring parameters (ie. list_origin_access_identities, list_distributions, list_streaming_distributions)
 - cloudfront_facts:
     all_lists: true
 '''
 
 RETURN = '''
-cloud_front_origin_access_identity:
-    description: Describes the origin access identity information. Requires cloud_front_origin_access_identity_id to be set.
-    returned: only if cloud_front_origin_access_identity is true
+origin_access_identity:
+    description: Describes the origin access identity information. Requires origin_access_identity_id to be set.
+    returned: only if origin_access_identity is true
     type: dict
-cloud_front_origin_access_identity_configuration:
-    description: Describes the origin access identity information configuration information. Requires cloud_front_origin_access_identity_id to be set.
-    returned: only if cloud_front_origin_access_identity_configuration is true
+origin_access_identity_configuration:
+    description: Describes the origin access identity information configuration information. Requires origin_access_identity_id to be set.
+    returned: only if origin_access_identity_configuration is true
     type: dict
 distribution:
-    description: Facts about a cloudfront distribution. Requires distribution_id or domain_name_alias to be specified. Requires cloud_front_origin_access_identity_id to be set.
+    description: Facts about a cloudfront distribution. Requires distribution_id or domain_name_alias to be specified. Requires origin_access_identity_id to be set.
     returned: only if distribution is true
     type: dict
 distribution_config:
@@ -229,14 +229,14 @@ class CloudFrontServiceManager:
         except Exception as e:
             self.module.fail_json(msg="Error describing distribution configuration - " + str(e), exception=traceback.format_exec(e))
 
-    def get_cloud_front_origin_access_identity(self, origin_access_identity_id):
+    def get_origin_access_identity(self, origin_access_identity_id):
         try:
             func = partial(self.client.get_cloud_front_origin_access_identity,Id=origin_access_identity_id)
             return self.paginated_response(func, 'CloudFrontOriginAccessIdentity')
         except Exception as e:
             self.module.fail_json(msg="Error describing origin access identity - " + str(e), exception=traceback.format_exc(e))
 
-    def get_cloud_front_origin_access_identity_config(self, origin_access_identity_id):
+    def get_origin_access_identity_config(self, origin_access_identity_id):
         try:
             func = partial(self.client.get_cloud_front_origin_access_identity_config,Id=origin_access_identity_id)
             return self.paginated_response(func, 'CloudFrontOriginAccessIdentityConfig')
@@ -264,7 +264,7 @@ class CloudFrontServiceManager:
         except Exception as e:
             self.module.fail_json(msg="Error describing streaming distribution - " + str(e), exception=traceback.format_exc(e))
 
-    def list_cloud_front_origin_access_identities(self):
+    def list_origin_access_identities(self):
         try:
             func = partial(self.client.list_cloud_front_origin_access_identities)
             return self.paginated_response(func, 'CloudFrontOriginAccessIdentityList')
@@ -332,17 +332,17 @@ def main():
     argument_spec.update(dict(
         distribution_id=dict(required=False, type='str'),
         invalidation_id=dict(required=False, type='str'),
-        cloud_front_origin_access_identity_id=dict(required=False, type='str'),
+        origin_access_identity_id=dict(required=False, type='str'),
         domain_name_alias=dict(required=False, type='str'),
         all_lists=dict(required=False, default=False, type='bool'),
         distribution=dict(required=False, default=False, type='bool'),
         distribution_config=dict(required=False, default=False, type='bool'),
-        cloud_front_origin_access_identity=dict(required=False, default=False, type='bool'),
-        cloud_front_origin_access_identity_config=dict(required=False, default=False, type='bool'),
+        origin_access_identity=dict(required=False, default=False, type='bool'),
+        origin_access_identity_config=dict(required=False, default=False, type='bool'),
         invalidation=dict(required=False, default=False, type='bool'),
         streaming_distribution=dict(required=False, default=False, type='bool'),
         streaming_distribution_config=dict(required=False, default=False, type='bool'),
-        list_cloud_front_origin_access_identities=dict(required=False, default=False, type='bool'),
+        list_origin_access_identities=dict(required=False, default=False, type='bool'),
         list_distributions=dict(required=False, default=False, type='bool'),
         list_distributions_by_web_acl=dict(required=False, default=False, type='bool'),
         list_invalidations=dict(required=False, default=False, type='bool'),
@@ -358,7 +358,7 @@ def main():
 
     distribution_id = module.params.get('distribution_id')
     invalidation_id = module.params.get('invalidation_id')
-    cloud_front_origin_access_identity_id = module.params.get('cloud_front_origin_access_identity_id')
+    origin_access_identity_id = module.params.get('origin_access_identity_id')
     web_acl_id = module.params.get('web_acl_id')
     domain_name_alias = module.params.get('domain_name_alias')
 
@@ -366,13 +366,13 @@ def main():
 
     distribution = module.params.get('distribution')
     distribution_config = module.params.get('distribution_config')
-    cloud_front_origin_access_identity = module.params.get('cloudfront_origin_access_identity')
-    cloud_front_origin_access_identity_config = module.params.get('cloudfront_origin_access_identity_config')
+    origin_access_identity = module.params.get('origin_access_identity')
+    origin_access_identity_config = module.params.get('origin_access_identity_config')
     invalidation = module.params.get('invalidation')
     streaming_distribution = module.params.get('streaming_distribution')
     streaming_distribution_config = module.params.get('streaming_distribution_config')
 
-    list_cloud_front_origin_access_identities = module.params.get('list_cloud_front_origin_access_identities')
+    list_origin_access_identities = module.params.get('list_origin_access_identities')
     list_distributions = module.params.get('list_distributions')
     list_distributions_by_web_acl_id = module.params.get('list_distributions_by_web_acl_id');
     list_invalidations = module.params.get('list_invalidations')
@@ -386,8 +386,8 @@ def main():
         module.fail_json(msg='Error distribution_id or domain_name have not been specified.')
     if (invalidation and invalidation_id is None):
         module.fail_json(msg='Error invalidation_id has not been specified.')
-    if (cloud_front_origin_access_identity or cloud_front_origin_access_identity_config) and cloud_front_origin_access_identity_id is None:
-        module.fail_json(msg='Error cloud_front_origin_access_identity_id has not been specified.')
+    if (origin_access_identity or origin_access_identity_config) and origin_access_identity_id is None:
+        module.fail_json(msg='Error origin_access_identity_id has not been specified.')
     if list_distributions_by_web_acl_id and web_acl_id is None:
         module.fail_json(msg='Error web_acl_id has not been specified.')
 
@@ -401,9 +401,9 @@ def main():
     if distribution_id:
         result = { 'ansible_facts': { 'cloudfront': { distribution_id:{} } } }
         facts = result['ansible_facts']['cloudfront'][distribution_id]
-    elif cloud_front_origin_access_identity_id:
-        result = { 'ansible_facts': { 'cloudfront': { cloud_front_origin_access_identity_id:{} } } }
-        facts = result['ansible_facts']['cloudfront'][cloud_front_origin_access_identity_id]
+    elif origin_access_identity_id:
+        result = { 'ansible_facts': { 'cloudfront': { origin_access_identity_id:{} } } }
+        facts = result['ansible_facts']['cloudfront'][origin_access_identity_id]
     elif web_acl_id:
         result = { 'ansible_facts': { 'cloudfront': { web_acl_id:{} } } }
         facts = result['ansible_facts']['cloudfront'][web_acl_id]
@@ -416,10 +416,10 @@ def main():
         facts['distribution'] = service_mgr.get_distribution(distribution_id)
     if distribution_config:
         facts['distribution_config'] = service_mgr.get_distribution_config(distribution_id)
-    if cloud_front_origin_access_identity:
-        facts['cloud_front_origin_access_identity'] = service_mgr.get_cloud_front_origin_access_identity(cloud_front_origin_access_identity_id)
-    if cloud_front_origin_access_identity_config:
-        facts['cloud_front_origin_access_identity_config'] = service_mgr.get_cloud_front_origin_access_identity_config(cloud_front_origin_access_identity_id)
+    if origin_access_identity:
+        facts['origin_access_identity'] = service_mgr.get_origin_access_identity(origin_access_identity_id)
+    if origin_access_identity_config:
+        facts['origin_access_identity_config'] = service_mgr.get_origin_access_identity_config(origin_access_identity_id)
     if invalidation:
         facts['invalidation'] = service_mgr.get_invalidation(distribution_id, invalidation_id)
     if streaming_distribution:
@@ -428,8 +428,8 @@ def main():
         facts['streaming_distribution_config'] = service_mgr.get_streaming_distribution_config(distribution_id)
 
     # call list based on options
-    if all_lists or list_cloud_front_origin_access_identities:
-        facts['list_cloud_front_origin_access_identities'] = service_mgr.list_cloud_front_origin_access_identities()
+    if all_lists or list_origin_access_identities:
+        facts['list_origin_access_identities'] = service_mgr.list_origin_access_identities()
     if all_lists or list_distributions:
         facts['list_distributions'] = service_mgr.list_distributions()
     if all_lists or list_streaming_distributions:

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -37,7 +37,7 @@ options:
         description:
           - The id of the invalidation to get information about. Used with invalidation.
         required: false
-    rigin_access_identity_id:
+    origin_access_identity_id:
         description:
           - The id of the cloudfront origin access identity to get information about.
         required: false

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -317,7 +317,7 @@ class CloudFrontServiceManager:
         Returns expanded response for paginated operations.
         The 'result_key' is used to define the concatenated results that are combined from each paginated response.
         '''
-        args=dict()
+        args = dict() 
         results = dict()
         loop = True
         while loop:
@@ -381,6 +381,12 @@ def main():
 
     require_distribution_id = (distribution or distribution_config or invalidation or
             streaming_distribution or streaming_distribution_config or list_invalidations)
+
+    # set default to list_distributions if no option specified
+    list_distributions = not (distribution or distribution_config or origin_access_identity or 
+            origin_access_identity_config or invalidation or streaming_distribution or 
+            streaming_distribution_config or list_origin_access_identities or list_distributions or 
+            list_distributions_by_web_acl_id or list_invalidations or list_streaming_distributions)
 
     # validations
     if require_distribution_id and distribution_id is None and domain_name_alias is None:

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -280,14 +280,14 @@ class CloudFrontServiceManager:
 
     def list_distributions_by_web_acl(self, web_acl_id):
         try:
-            func = partial(self.client.list_distributions, web_acl_id)
+            func = partial(self.client.list_distributions, WebAclId=web_acl_id)
             return self.paginated_response(func, 'DistributionList')
         except Exception as e:
             self.module.fail_json(msg="Error listing distributions by web acl id = " + str(e), exception=traceback.format_exc(e))
 
-    def list_invalidations(self):
+    def list_invalidations(self, distribution_id):
         try:
-            func = partial(self.client.list_invalidations)
+            func = partial(self.client.list_invalidations, DistributionId=distribution_id)
             return self.paginated_response(func, 'InvalidationList')
         except Exception as e:
             self.module.fail_json(msg="Error listing invalidations = " + str(e), exception=traceback.format_exc(e))
@@ -398,9 +398,10 @@ def main():
             streaming_distribution or streaming_distribution_config or list_invalidations)
 
     # set default to list_distributions if no option specified
-    list_distributions = not (distribution or distribution_config or origin_access_identity or 
+    if not list_distributions:
+        list_distributions = not (distribution or distribution_config or origin_access_identity or 
             origin_access_identity_config or invalidation or streaming_distribution or 
-            streaming_distribution_config or list_origin_access_identities or list_distributions or 
+            streaming_distribution_config or list_origin_access_identities or
             list_distributions_by_web_acl_id or list_invalidations or list_streaming_distributions)
 
     # validations
@@ -466,7 +467,7 @@ def main():
     if all_lists or list_streaming_distributions:
         facts['list_streaming_distributions'] = service_mgr.list_streaming_distributions()
     if list_distributions_by_web_acl_id:
-        facts['list_distributions_by_web_acl'] = service_mgr.list_distributions_by_web_acl()
+        facts['list_distributions_by_web_acl'] = service_mgr.list_distributions_by_web_acl(web_acl_id)
     if list_invalidations:
         facts['list_invalidations'] = service_mgr.list_invalidations(distribution_id)
 

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -193,7 +193,7 @@ except ImportError:
 
 from ansible.module_utils.ec2 import get_aws_connection_info
 from ansible.module_utils.ec2 import ec2_argument_spec
-from ansible.module_utils.ec2 import boto3_conn 
+from ansible.module_utils.ec2 import boto3_conn
 from ansible.module_utils.basic import AnsibleModule
 from functools import partial
 import json
@@ -330,7 +330,7 @@ class CloudFrontServiceManager:
         Returns expanded response for paginated operations.
         The 'result_key' is used to define the concatenated results that are combined from each paginated response.
         '''
-        args = dict() 
+        args = dict()
         results = dict()
         loop = True
         while loop:
@@ -402,8 +402,8 @@ def main():
             streaming_distribution or streaming_distribution_config or list_invalidations)
 
     # set default to list_distributions if no option specified
-    list_distributions = list_distributions or not (distribution or distribution_config or 
-            origin_access_identity or origin_access_identity_config or invalidation or 
+    list_distributions = list_distributions or not (distribution or distribution_config or
+            origin_access_identity or origin_access_identity_config or invalidation or
             streaming_distribution or streaming_distribution_config or list_origin_access_identities or
             list_distributions_by_web_acl_id or list_invalidations or list_streaming_distributions)
 
@@ -445,34 +445,34 @@ def main():
     # get details based on options
     if distribution:
         distribution_details = service_mgr.get_distribution(distribution_id)
-        facts[distribution_id] = distribution_details
+        facts[distribution_id].update(distribution_details)
         for alias in aliases:
-            facts[alias] = distribution_details
+            facts[alias].update(distribution_details)
     if distribution_config:
         distribution_config_details = service_mgr.get_distribution_config(distribution_id)
-        facts[distribution_id] = distribution_config_details
+        facts[distribution_id].update(distribution_config_details)
         for alias in aliases:
-            facts[alias] = distribution_config_details
+            facts[alias].update(distribution_config_details)
     if origin_access_identity:
-        facts[origin_access_identity_id] = service_mgr.get_origin_access_identity(origin_access_identity_id)
+        facts[origin_access_identity_id].update(service_mgr.get_origin_access_identity(origin_access_identity_id))
     if origin_access_identity_config:
-        facts[origin_access_identity_id] = service_mgr.get_origin_access_identity_config(origin_access_identity_id)
+        facts[origin_access_identity_id].update(service_mgr.get_origin_access_identity_config(origin_access_identity_id))
     if invalidation:
         invalidation = service_mgr.get_invalidation(distribution_id, invalidation_id)
-        facts[invalidation_id] = invalidation
-        facts[distribution_id] = invalidation
+        facts[invalidation_id].update(invalidation)
+        facts[distribution_id].update(invalidation)
         for alias in aliases:
-            facts[alias] = invalidation
+            facts[alias].update(invalidation)
     if streaming_distribution:
         streaming_distribution_details = service_mgr.get_streaming_distribution(distribution_id)
-        facts[distribution_id] = streaming_distribution_details
+        facts[distribution_id].update(streaming_distribution_details)
         for alias in aliases:
-            facts[alias] = streaming_distribution_details
+            facts[alias].update(streaming_distribution_details)
     if streaming_distribution_config:
         streaming_distribution_config_details = service_mgr.get_streaming_distribution_config(distribution_id)
         facts[distribution_id] = streaming_distribution_config_details
         for alias in aliases:
-            facts[alias] = streaming_distribution_config_details
+            facts[alias].update(streaming_distribution_config_details)
 
     # get list based on options
     if all_lists or list_origin_access_identities:

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -398,10 +398,9 @@ def main():
             streaming_distribution or streaming_distribution_config or list_invalidations)
 
     # set default to list_distributions if no option specified
-    if not list_distributions:
-        list_distributions = not (distribution or distribution_config or origin_access_identity or 
-            origin_access_identity_config or invalidation or streaming_distribution or 
-            streaming_distribution_config or list_origin_access_identities or
+    list_distributions = list_distributions or not (distribution or distribution_config or 
+            origin_access_identity or origin_access_identity_config or invalidation or 
+            streaming_distribution or streaming_distribution_config or list_origin_access_identities or
             list_distributions_by_web_acl_id or list_invalidations or list_streaming_distributions)
 
     # validations

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -404,19 +404,19 @@ def main():
         if not distribution_id:
             module.fail_json(msg='Error unable to source a distribution id from domain_name_alias')
 
-    # set appropriate ansible_facts id
+    # set appropriate cloudfront id
     if distribution_id:
-        result = { 'ansible_facts': { 'cloudfront': { distribution_id:{} } } }
-        facts = result['ansible_facts']['cloudfront'][distribution_id]
+        result = { 'cloudfront': { distribution_id:{} } }
+        facts = result['cloudfront'][distribution_id]
     elif origin_access_identity_id:
-        result = { 'ansible_facts': { 'cloudfront': { origin_access_identity_id:{} } } }
-        facts = result['ansible_facts']['cloudfront'][origin_access_identity_id]
+        result = { 'cloudfront': { origin_access_identity_id:{} } }
+        facts = result['cloudfront'][origin_access_identity_id]
     elif web_acl_id:
-        result = { 'ansible_facts': { 'cloudfront': { web_acl_id:{} } } }
-        facts = result['ansible_facts']['cloudfront'][web_acl_id]
+        result = { 'cloudfront': { web_acl_id:{} } }
+        facts = result['cloudfront'][web_acl_id]
     else:
-        result = { 'ansible_facts': { 'cloudfront': {} } }
-        facts = result['ansible_facts']['cloudfront']
+        result = { 'cloudfront': {} }
+        facts = result['cloudfront']
 
     # call details based on options
     if distribution:

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -323,13 +323,6 @@ class CloudFrontServiceManager:
            return result
         return result + self.paginated_response(func, result_key, next_token)
 
-def to_dict(items, key, value):
-    ''' Transforms a list of items to a Key/Value dictionary '''
-    if items:
-        return dict(zip([i[key] for i in items], [i[value] for i in items]))
-    else:
-        return dict()
-
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
@@ -443,7 +436,7 @@ def main():
         facts['list_invalidations'] = service_mgr.list_invalidations(distribution_id)
 
     result['changed'] = False
-    module.exit_json(msg="Retreived cloudfront facts.", ansible_facts=result)
+    module.exit_json(msg="Retrieved cloudfront facts.", ansible_facts=result)
 
 # import module snippets
 from ansible.module_utils.basic import *

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -192,6 +192,8 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.ec2 import get_aws_connection_info
+from ansible.module_utils.ec2 import ec2_argument_spec
+from ansible.module_utils.ec2 import boto3_conn 
 from ansible.module_utils.basic import AnsibleModule
 from functools import partial
 import json
@@ -439,10 +441,6 @@ def main():
 
     result['changed'] = False
     module.exit_json(msg="Retrieved cloudfront facts.", ansible_facts=result)
-
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -476,15 +476,15 @@ def main():
 
     # get list based on options
     if all_lists or list_origin_access_identities:
-        facts['list_origin_access_identities'] = service_mgr.list_origin_access_identities()
+        facts['origin_access_identities'] = service_mgr.list_origin_access_identities()
     if all_lists or list_distributions:
-        facts['list_distributions'] = service_mgr.list_distributions()
+        facts['distributions'] = service_mgr.list_distributions()
     if all_lists or list_streaming_distributions:
-        facts['list_streaming_distributions'] = service_mgr.list_streaming_distributions()
+        facts['streaming_distributions'] = service_mgr.list_streaming_distributions()
     if list_distributions_by_web_acl_id:
-        facts['list_distributions_by_web_acl'] = service_mgr.list_distributions_by_web_acl(web_acl_id)
+        facts['distributions_by_web_acl'] = service_mgr.list_distributions_by_web_acl(web_acl_id)
     if list_invalidations:
-        facts['list_invalidations'] = service_mgr.list_invalidations(distribution_id)
+        facts['invalidations'] = service_mgr.list_invalidations(distribution_id)
 
     result['changed'] = False
     module.exit_json(msg="Retrieved cloudfront facts.", ansible_facts=result)

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -494,14 +494,14 @@ def main():
             facts[alias].update(streaming_distribution_details)
     if streaming_distribution_config:
         streaming_distribution_config_details = service_mgr.get_streaming_distribution_config(distribution_id)
-        facts[distribution_id] = streaming_distribution_config_details
+        facts[distribution_id].update(streaming_distribution_config_details)
         for alias in aliases:
-            facts[alias] = streaming_distribution_config_details
+            facts[alias].update(streaming_distribution_config_details)
     if list_invalidations:
         invalidations = service_mgr.list_invalidations(distribution_id)
-        facts[distribution_id] = invalidations
+        facts[distribution_id].update(invalidations)
         for alias in aliases:
-            facts[alias] = invalidations
+            facts[alias].update(invalidations)
 
     # get list based on options
     if all_lists or list_origin_access_identities:

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -99,7 +99,7 @@ options:
             - Get a list of cloudfront distributions.
         required: false
         default: false
-    list_distributions_by_web_acl:
+    list_distributions_by_web_acl_id:
         description:
             - Get a list of distributions using web acl id as a filter. Requires web_acl_id to be set.
         required: false
@@ -281,10 +281,11 @@ class CloudFrontServiceManager:
         except Exception as e:
             self.module.fail_json(msg="Error listing distributions = " + str(e), exception=traceback.format_exc(e))
 
-    def list_distributions_by_web_acl(self, web_acl_id):
+    def list_distributions_by_web_acl_id(self, web_acl_id):
         try:
-            func = partial(self.client.list_distributions, WebAclId=web_acl_id)
-            return self.paginated_response(func, 'DistributionList')['Items']
+            func = partial(self.client.list_distributions_by_web_acl_id, WebAclId=web_acl_id)
+            distributions = self.paginated_response(func, 'DistributionList')['Items']
+            return self.keyed_list_helper(distributions)
         except Exception as e:
             self.module.fail_json(msg="Error listing distributions by web acl id = " + str(e), exception=traceback.format_exc(e))
 
@@ -376,7 +377,7 @@ def main():
         streaming_distribution_config=dict(required=False, default=False, type='bool'),
         list_origin_access_identities=dict(required=False, default=False, type='bool'),
         list_distributions=dict(required=False, default=False, type='bool'),
-        list_distributions_by_web_acl=dict(required=False, default=False, type='bool'),
+        list_distributions_by_web_acl_id=dict(required=False, default=False, type='bool'),
         list_invalidations=dict(required=False, default=False, type='bool'),
         list_streaming_distributions=dict(required=False, default=False, type='bool')
     ))
@@ -507,7 +508,7 @@ def main():
     if all_lists or list_streaming_distributions:
         facts['streaming_distributions'] = service_mgr.list_streaming_distributions()
     if list_distributions_by_web_acl_id:
-        facts['distributions_by_web_acl'] = service_mgr.list_distributions_by_web_acl(web_acl_id)
+        facts['distributions_by_web_acl_id'] = service_mgr.list_distributions_by_web_acl_id(web_acl_id)
 
     result['changed'] = False
     module.exit_json(msg="Retrieved cloudfront facts.", ansible_facts=result)

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -496,7 +496,6 @@ def main():
         streaming_distribution_config_details = service_mgr.get_streaming_distribution_config(distribution_id)
         facts[distribution_id] = streaming_distribution_config_details
         for alias in aliases:
-<<<<<<< HEAD
             facts[alias] = streaming_distribution_config_details
     if list_invalidations:
         invalidations = service_mgr.list_invalidations(distribution_id)

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -137,6 +137,9 @@ EXAMPLES = '''
 - debug:
     msg: '{{ ansible_facts['cloudfront']['my-cloudfront-distribution-id'] }}'
 
+- debug:
+    msg: '{{ ansible_facts['cloudfront']['www.my-website.com'] }}'
+
 # Get all information about an invalidation for a distribution.
 - cloudfront_facts:
     invalidation: true


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
cloud_front_facts

##### ANSIBLE VERSION
```
ansible 2.1.0.0
```

##### SUMMARY
This module allows for gathering of aws cloudfront facts using boto3. I initially developed it to get the dns name of a cloudfront distribution based on the CNAME alias. I decided to expand it to the full cloudfront facts once started. It was based on cloudformation_facts.py as a starting point. It's my first pull request so I hope it's ok. :)

It gathers facts on individual elements (get-) as well as lists, such as:

get-cloud-front-origin-access-identity
get-cloud-front-origin-access-identity-config
get-distribution
get-distribution-config
get-invalidation
get-streaming-distribution
get-streaming-distribution-config
list-cloud-front-origin-access-identities
list-distributions
list-distributions-by-web-acl-id
list-invalidations
list-streaming-distributions

It uses the following boolean inputs to specify the output:

- distribution
- distribution_config
- cloud_front_origin_access_identity
- cloud_front_origin_access_identity_config
- invalidation
- get_streaming_distribution
- get_streaming_distribution  

And the following string inputs to specify details of the facts:

- distribution_id or the domain_name_alias 
- invalidation_id 
- cloud_front_origin_access_identity_id
- web_acl_id
