### PR TITLE
doc: fix indent typo in amazon/rds.py for python sphinx doc

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds.py
+++ b/lib/ansible/modules/cloud/amazon/rds.py
@@ -266,7 +266,7 @@ EXAMPLES = '''
 - rds:
     command: facts
     instance_name: new-database
-    register: new_database_facts
+  register: new_database_facts
 
 # Rename an instance and wait for the change to take effect
 - rds:


### PR DESCRIPTION


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME

`cloud/amazon/rds.py`

##### ANSIBLE VERSION

N/A

##### SUMMARY

Current doc give this error :

```
fatal: [localhost]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_args": {
            "command": "facts",
            "register": "new_database_facts"
        },
        "module_name": "rds"
    },
    "msg": "unsupported parameter for module: register"
}
```

Register should be at the module `rds` level and not at args level in this example :

```
 - rds:
     command: facts
     instance_name: new-database
-    register: new_database_facts
+  register: new_database_facts
```

