### PR TITLE
Bugfix for docker_login access to module property

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_login.py
+++ b/lib/ansible/modules/cloud/docker/docker_login.py
@@ -318,8 +318,8 @@ def main():
         login_result={}
     )
 
-    if module.params['state'] == 'present' and module.params['registry_url'] == DEFAULT_DOCKER_REGISTRY and not module.params['email']:
-        module.fail_json(msg="'email' is required when loging into DockerHub")
+    if client.module.params['state'] == 'present' and client.module.params['registry_url'] == DEFAULT_DOCKER_REGISTRY and not client.module.params['email']:
+        client.module.fail_json(msg="'email' is required when logging into DockerHub")
 
     LoginManager(client, results)
     if 'actions' in results:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker_login

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 368a837481) last updated 2016/11/03 13:31:04 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 7cc4d3fe04) last updated 2016/11/03 13:32:10 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD e4bc618956) last updated 2016/11/03 13:32:36 (GMT +200)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY

`module` is a property of the `client` object.

Before change
```
TASK [docker_login] ************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: NameError: global name 'module' is not defined
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/var/folders/74/y_0xp6zs31b8fxxl3csvqw100000gp/T/ansible_6w8AQQ/ansible_module_docker_login.py\", line 329, in <module>\n    main()\n  File \"/var/folders/74/y_0xp6zs31b8fxxl3csvqw100000gp/T/ansible_6w8AQQ/ansible_module_docker_login.py\", line 317, in main\n    if client.module.params['state'] == 'present' and client.module.params['registry_url'] == DEFAULT_DOCKER_REGISTRY and not module.params['email']:\nNameError: global name 'module' is not defined\n", "module_stdout": "", "msg": "MODULE FAILURE"}
```

After change with `email` parameter
```
TASK [docker_login] ************************************************************
ok: [localhost]
```

After change without `email` parameter
```
TASK [docker_login] ************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "'email' is required when logging into DockerHub"}
```

Fixes #19743

Edit: Updated issue reference after migrate.