### PR TITLE
Minor rework of pamd module.  Fixed some documentation.

### DIFF
--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import string_types
 from ansible.module_utils.pycompat24 import get_exception
 
 DOCUMENTATION = """
@@ -380,7 +381,7 @@ def remove_module_arguments(service, old_rule, module_args):
     result = {'action': 'args_absent'}
     changed = False
     change_count = 0
-    if isinstance(module_args, str):
+    if isinstance(module_args, ansible.module_utils.six.string_types):
         module_args = module_args.split(' ')
 
     for rule in service.rules:
@@ -404,7 +405,7 @@ def add_module_arguments(service, old_rule, module_args):
     result = {'action': 'args_present'}
     changed = False
     change_count = 0
-    if isinstance(module_args, str):
+    if isinstance(module_args, ansible.module_utils.six.string_types):
         module_args = module_args.split(' ')
 
     for rule in service.rules:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
pamd

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
1.) Changed the module_args parameter to be a list instead of a string.  I think this improves readability of the module in a playbook.

2.) Added parameter types.

3.) Changed the default state from "None" to "updated".

4.) Some of the documentation needed to be corrected.