### PR TITLE
Fix key lookup in gather facts flag.

### DIFF
--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -201,7 +201,7 @@ class PlayIterator:
             self._host_states[host.name] = HostState(blocks=self._blocks)
             # if the host's name is in the variable manager's fact cache, then set
             # its _gathered_facts flag to true for smart gathering tests later
-            if host.name in variable_manager._fact_cache and variable_manager._fact_cache.get('module_setup', False):
+            if host.name in variable_manager._fact_cache and variable_manager._fact_cache.get(host.name).get('module_setup', False):
                 host._gathered_facts = True
             # if we're looking to start at a specific task, iterate through
             # the tasks for this host until we find the specified task


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Play Iterator

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
v2.2.0.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
With persistent facts caching and smart facts gathering (and facts effectively cached), since ansible 2.2 still for each play adding new hosts to playbook, facts are gathered from those hosts.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Before:
<!-- Paste verbatim command output below, e.g. before and after your change -->
```
$ ansible-playbook site.yml

PLAY [play1] **********************************************************************

TASK [Gathering Facts] ************************************************************
ok: [test1]

TASK [debug] **********************************************************************
ok: [test1] => {
    "msg": "A task"
}

PLAY RECAP ************************************************************************
test1                      : ok=2    changed=0    unreachable=0    failed=0
```

After:
```
$ ansible-playbook site.yml

PLAY [play1] **********************************************************************

TASK [debug] **********************************************************************
ok: [test1] => {
    "msg": "A task"
}

PLAY RECAP ************************************************************************
test1                      : ok=1    changed=0    unreachable=0    failed=0
```
