### PR TITLE
Improve ipa module

### DIFF
--- a/lib/ansible/module_utils/ipa.py
+++ b/lib/ansible/module_utils/ipa.py
@@ -105,7 +105,11 @@ class IPAClient(object):
         resp = json.loads(to_text(resp.read(), encoding=charset), encoding=charset)
         err = resp.get('error')
         if err is not None:
-            self._fail('repsonse %s' % method, err)
+            if 'name' in err and err.get('name') == u'EmptyModlist':
+                return {'ipa_changed': False}
+            else:
+                # self._fail('repsonse comp=%s, %s "%s", %s"' % (str(changed), method, str(resp), str(err)), err)
+                self._fail('repsonse %s' % method, err)
 
         if 'result' in resp:
             result = resp.get('result')

--- a/lib/ansible/module_utils/ipa.py
+++ b/lib/ansible/module_utils/ipa.py
@@ -39,6 +39,9 @@ from ansible.module_utils.six.moves.urllib.parse import quote
 from ansible.module_utils.urls import fetch_url
 
 
+
+ANSIBLE_INT_IPA_KEYS = ['state', 'ipa_prot', 'ipa_host', 'ipa_port', 'ipa_user', 'ipa_pass', 'validate_certs']
+
 class IPAClient(object):
     def __init__(self, module, host, port, protocol):
         self.host = host

--- a/lib/ansible/modules/identity/ipa/ipa_service.py
+++ b/lib/ansible/modules/identity/ipa/ipa_service.py
@@ -1,0 +1,186 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = '''
+---
+module: ipa_service
+author: Adrian Freihofer
+short_description: Manage FreeIPA services
+description:
+- Add, modify and delete a service within IPA server
+options:
+  user_certificate:
+    description: service certificate (Base-64 encoded by ansible)
+    required: false
+  ipa_krb_authz_data:
+    description:
+    - Override default list of supported PAC types.
+    - Use 'NONE' to disable PAC support for this service, e.g. this might be necessary for NFS services.
+    required: false
+  krb_principal_auth_ind:
+    description:
+    - Defines a whitelist for Authentication Indicators.
+    - Use 'otp' to allow OTP-based 2FA authentications.
+    - Use 'radius' to allow RADIUS-based 2FA authentications.
+    - Other values may be used for custom configurations.
+    required: false
+  ipa_krb_requires_pre_auth:
+    description: Pre-authentication is required for the service
+    required: false
+  ipa_krb_okas_delegate:
+    description: Client credentials may be delegated to the service
+    required: false
+  ipa_krb_okto_auth_as_delegate:
+    description: The service is allowed to authenticate on behalf of a client
+    required: false
+  force:
+    description: force principal name even if not in DNS
+    required: false
+  no_members:
+    description: Suppress processing of membership attributes.
+    required: false
+version_added: "2.3"
+'''
+
+EXAMPLES = '''
+# Ensure service is present
+- ipa_service:
+    name: "cifs/samba.example.com@EXAMPLE.COM"
+    force: True
+    ipa_host: ipa.example.com
+    ipa_user: admin
+    ipa_pass: topsecret
+'''
+
+RETURN = '''
+service:
+  description: Service as returned by IPA API
+  returned: always
+  type: dict
+'''
+
+from ansible.module_utils.ipa import IPAClient
+from ansible.module_utils.ipa import ANSIBLE_INT_IPA_KEYS
+
+class ServiceIPAClient(IPAClient):
+
+    def __init__(self, module, host, port, protocol):
+        super(ServiceIPAClient, self).__init__(module, host, port, protocol)
+
+    def service_find(self, name):
+        return self._post_json(method='service_find', name=None, item={'all': True, 'krbcanonicalname': name})
+
+    def service_add(self, name, item):
+        return self._post_json(method='service_add', name=name, item=item)
+
+    def service_mod(self, name, item):
+        return self._post_json(method='service_mod', name=name, item=item)
+
+    def service_del(self, name):
+        return self._post_json(method='service_del', name=name)
+
+
+def ensure(module, client):
+    state = module.params['state']
+    name = module.params['name']
+
+    # Fetch the service from FreeIPA if already existing
+    ipa_service = client.service_find(name=name)
+
+    changed = True
+    if state == 'present':
+        # Create a reduced copy of module.params containing only parameters forwarded to FreeIPA
+        module_service = {}
+        skipped_keys = ANSIBLE_INT_IPA_KEYS + ['name', 'krbcanonicalname', 'user_certificate', 'ipa_krb_authz_data',
+                                               'krb_principal_auth_ind', 'ipa_krb_requires_pre_auth',
+                                               'ipa_krb_okas_delegate', 'ipa_krb_okto_auth_as_delegate']
+        if ipa_service:  # Remove service_add specific fields if service_mod will be called
+            skipped_keys.extend(['force'])
+
+        for key,val in module.params.items():
+            if val is None:
+                continue
+            if key in skipped_keys:
+                continue
+            module_service[key] = val
+
+        if not module.check_mode:
+            if not ipa_service:  # service_add
+                ipa_service = client.service_add(name, item=module_service)
+            else:  # service_mod
+                ipa_service = client.service_mod(name=name, item=module_service)
+                if 'ipa_changed' in ipa_service:
+                    changed = ipa_service['ipa_changed']
+
+    else:  # service_del
+        if ipa_service:
+            if not module.check_mode:
+                client.service_del(name)
+            ipa_service = None
+        else:
+            changed = False
+
+    return changed, ipa_service
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            krbcanonicalname=dict(type='str', required=True, aliases=['name']),
+            user_certificate=dict(type='list', required=False, aliases=['usercertificate']),
+            ipa_krb_authz_data=dict(type='list', required=False, aliases=['ipakrbauthzdata']),
+            krb_principal_auth_ind=dict(type='list', required=False, aliases=['krbprincipalauthind']),
+            ipa_krb_requires_pre_auth=dict(type='bool', required=False, default=True, aliases=['ipakrbrequirespreauth']),
+            ipa_krb_okas_delegate=dict(type='bool', required=False, default=False, aliases=['ipakrbokasdelegate']),
+            ipa_krb_okto_auth_as_delegate=dict(type='bool', required=False, default=False, aliases=['ipakrboktoauthasdelegate']),
+            force=dict(type='bool', default=False),
+            no_members=dict(type='bool', default=False),
+            state=dict(type='str', required=False, default='present',
+                       choices=['present', 'absent', 'enabled', 'disabled']),
+            ipa_prot=dict(type='str', required=False, default='https', choices=['http', 'https']),
+            ipa_host=dict(type='str', required=False, default='ipa.example.com'),
+            ipa_port=dict(type='int', required=False, default=443),
+            ipa_user=dict(type='str', required=False, default='admin'),
+            ipa_pass=dict(type='str', required=True, no_log=True),
+            validate_certs=dict(type='bool', required=False, default=True),
+        ),
+        supports_check_mode=True,
+    )
+
+    client = ServiceIPAClient(module=module,
+                            host=module.params['ipa_host'],
+                            port=module.params['ipa_port'],
+                            protocol=module.params['ipa_prot'])
+    try:
+        client.login(username=module.params['ipa_user'],
+                     password=module.params['ipa_pass'])
+        changed, service = ensure(module, client)
+        module.exit_json(changed=changed, service=service)
+    except Exception:
+        e = get_exception()
+        module.fail_json(msg=str(e))
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.pycompat24 import get_exception
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/identity/ipa/ipa_user.py
+++ b/lib/ansible/modules/identity/ipa/ipa_user.py
@@ -61,14 +61,71 @@ options:
     default: "present"
     choices: ["present", "absent", "enabled", "disabled"]
   telephonenumber:
-    description:
-    - List of telephone numbers assigned to the user.
-    - If an empty list is passed all assigned telephone numbers will be deleted.
-    - If None is passed telephone numbers will not be checked or changed.
+    description: List of telephone numbers assigned to the user.
+    required: false
+  mobile:
+    description: List of mobile telephone numbers assigned to the user.
+    required: false
+  pager:
+    description: List of pager numbers assigned to the user.
+    required: false
+  facsimiletelephonenumber:
+    description: List of fax numbers assigned to the user.
     required: false
   title:
-    description: Title
+    description: Job Title
     required: false
+  initials:
+    description: initials
+    required: false
+  random:
+    description:
+    - Generate a random password if the user is created.
+    - If the user is modified this parameter is ignored.
+    - To enforce a new random password for a user set the new_random flag.
+    required: false
+    default: false
+  new_random:
+    description:
+    - This parameter is ignored if the user is created.
+    - If the user is modified and this flag is true, a new random password is generated each time Ansible runs.
+    - Normally you don't want to set this true, since this resets the password when Ansible runs.
+    required: false
+    default: false
+  street:
+    description: Street address
+    required: false
+  l:
+    description: City
+    required: false
+  st:
+    description: State/Province
+    required: false
+  postalcode:
+    description: ZIP
+    required: false
+  ou:
+    description: Org. Unit
+    required: false
+  manager:
+    description: Manager
+    required: false
+  carlicense:
+    description: Car License
+    required: false
+  homedirectory:
+    description: Home directory
+    required: false
+  uidnumber:
+    description: User ID Number (system will assign one if not provided)
+    required: false
+  gidnumber:
+    description: Group ID Number
+    required: false
+  noprivate:
+    description: Don't create user private group
+    required: false
+    default: false
   uid:
     description: uid of the user
     required: true
@@ -131,6 +188,17 @@ EXAMPLES = '''
     ipa_host: ipa.example.com
     ipa_user: admin
     ipa_pass: topsecret
+
+# Ensure Alice and Bob are present, and get a random password assigned.
+# The generated password will be added to a file located on the host running Ansible.
+- ipa_user: "{{ item|combine({'random':true, 'ipa_host':'ipa.example.com', 'ipa_pass':'admin'}) }}"
+  register: ipa_user_result
+  with_items:
+  - { 'name':'alice' }
+  - { 'name':'bob' }
+- local_action: lineinfile create=yes dest=./random_passwd.txt line="{{ item.user.uid[0] }}, {{ item.user.randompassword }}" regexp="{{ item.user.uid[0] }}"
+  when: item.user.uid is defined and item.user.randompassword is defined
+  with_items: "{{ ipa_user_result.results|default([]) }}"
 '''
 
 RETURN = '''
@@ -175,6 +243,7 @@ class UserIPAClient(IPAClient):
 def ensure(module, client):
     state = module.params['state']
     name = module.params['name']
+    new_random = module.params['new_random']
 
     # Fetch the user from FreeIPA if already existing
     ipa_user = client.user_find(name=name)
@@ -184,9 +253,12 @@ def ensure(module, client):
 
         # Create a reduced copy of module.params containing only parameters forwarded to FreeIPA
         module_user = {}
-        skipped_keys = ANSIBLE_INT_IPA_KEYS + ['name', 'uid', 'sshpubkey']
+        skipped_keys = ANSIBLE_INT_IPA_KEYS + ['name', 'uid', 'sshpubkey', 'new_random']
         if ipa_user:  # Remove user_add specific fields if user_mod will be called
-            skipped_keys.extend(['noprivate', 'random'])
+            skipped_keys = skipped_keys + ['noprivate']
+            # Do not generate a new random password until explicitly requested by new_random parameter
+            if not new_random:
+                skipped_keys = skipped_keys + ['random']
 
         if state == 'disabled':
             module_user['nsaccountlock'] = True
@@ -220,16 +292,33 @@ def main():
         argument_spec=dict(
             displayname=dict(type='str', required=False),
             givenname=dict(type='str', required=False),
+            initials=dict(type='str', required=False),
             loginshell=dict(type='str', required=False),
             mail=dict(type='list', required=False),
             sn=dict(type='str', required=False),
             uid=dict(type='str', required=True, aliases=['name']),
             password=dict(type='str', required=False, no_log=True),
+            random=dict(type='bool', required=False, default=False),
+            new_random=dict(type='bool', required=False, default=False),
+            uidnumber=dict(type='int', required=False),
+            gidnumber=dict(type='int', required=False),
             sshpubkey=dict(type='list', required=False),
             state=dict(type='str', required=False, default='present',
                        choices=['present', 'absent', 'enabled', 'disabled']),
+            street=dict(type='str', required=False),
+            l=dict(type='str', required=False),
+            st=dict(type='str', required=False),
+            postalcode=dict(type='str', required=False),
             telephonenumber=dict(type='list', required=False),
+            mobile=dict(type='list', required=False),
+            pager=dict(type='list', required=False),
+            facsimiletelephonenumber=dict(type='list', required=False),
+            ou=dict(type='str', required=False),
             title=dict(type='str', required=False),
+            manager=dict(type='str', required=False),
+            carlicense=dict(type='list', required=False),
+            homedirectory=dict(type='str', required=False),
+            noprivate=dict(type='bool', required=False, default=False),
             ipa_prot=dict(type='str', required=False, default='https', choices=['http', 'https']),
             ipa_host=dict(type='str', required=False, default='ipa.example.com'),
             ipa_port=dict(type='int', required=False, default=443),

--- a/lib/ansible/modules/identity/ipa/ipa_user.py
+++ b/lib/ansible/modules/identity/ipa/ipa_user.py
@@ -302,7 +302,7 @@ def main():
             new_random=dict(type='bool', required=False, default=False),
             uidnumber=dict(type='int', required=False),
             gidnumber=dict(type='int', required=False),
-            sshpubkey=dict(type='list', required=False),
+            ipasshpubkey=dict(type='list', required=False, aliases=['sshpubkey']),
             state=dict(type='str', required=False, default='present',
                        choices=['present', 'absent', 'enabled', 'disabled']),
             street=dict(type='str', required=False),


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
identity/ipa

##### ANSIBLE VERSION
```
ansible 2.3.0 (improve-ipa-module b255485b05) last updated 2017/01/01 22:21:22 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
ipa_user module supports only a subset of parameters available in FreeIPA. This patchset extends the list of supported parameters. Further a new module ipa_service is added.

Design change:
The ipa_user module tries to apply a given set of parameters only if this would lead to a change in FreeIPA. This requires some logic in Ansible to evaluate if the set of parameters given to Ansible differs from the set of parameters currently stored in FreeIPA. This design has some disadvantages:
- Providing a perfect and complete implementation to evaluate changes between different sets of FreeIPA parameters would be complex.
- Maintaining the code for different versions of FreeIPA might be impossible on the long run.
- Read parameters from FreeIPA and write them back only if something changed is not atomic. At least theoretically, this might lead to unexpected race conditions.

The new ipa_user module simply forwards all parameters to FreeIPA. FreeIPA returns an error if nothing changed. This error is used to set the changed flag in Ansible.