### PR TITLE
WIP: RDS split

### DIFF
--- a/lib/ansible/module_utils/rds.py
+++ b/lib/ansible/module_utils/rds.py
@@ -14,9 +14,8 @@
 # along with Ansible. If not, see <http://www.gnu.org/licenses/>.
 
 import botocore
-import time
 
-from ansible.module_utils.ec2 import boto3_tag_list_to_ansible_dict, camel_dict_to_snake_dict
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def get_db_instance(conn, instancename):
@@ -36,7 +35,7 @@ def get_db_snapshot(conn, snapshotid):
         response = conn.describe_db_snapshots(DBSnapshotIdentifier=snapshotid)
         snapshot = RDSSnapshot(response['DBSnapshots'][0])
         return snapshot
-    except botocore.exceptions.ClientError:
+    except botocore.exceptions.ClientError as e:
         if e.response['Error']['Code'] == 'DBSnapshotNotFound':
             return None
         else:
@@ -60,7 +59,7 @@ class RDSDBInstance(object):
         compare_keys = ['backup_retention', 'instance_type', 'iops',
                         'maintenance_window', 'multi_zone',
                         'replication_source',
-                        'size','storage_type', 'tags', 'zone']
+                        'size', 'storage_type', 'tags', 'zone']
         before = dict()
         after = dict()
         for k in compare_keys:

--- a/lib/ansible/module_utils/rds.py
+++ b/lib/ansible/module_utils/rds.py
@@ -16,7 +16,7 @@
 import botocore
 import time
 
-from ansible.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible.module_utils.ec2 import boto3_tag_list_to_ansible_dict, camel_dict_to_snake_dict
 
 
 def get_db_instance(conn, instancename):
@@ -54,36 +54,7 @@ class RDSDBInstance(object):
         self.data = self.get_data()
 
     def get_data(self):
-        d = {
-            'id': self.name,
-            'create_time': self.instance.get('InstanceCreateTime', ''),
-            'db_engine': self.instance['Engine'],
-            'db_name': self.instance.get('DBName'),
-            'status': self.status,
-            'availability_zone': self.instance.get('AvailabilityZone'),
-            'backup_retention': self.instance['BackupRetentionPeriod'],
-            'maintenance_window': self.instance['PreferredMaintenanceWindow'],
-            'multi_zone': self.instance['MultiAZ'],
-            'instance_type': self.instance['DBInstanceClass'],
-            'username': self.instance['MasterUsername'],
-            'replication_source': self.instance.get('ReadReplicaSourceDBInstanceIdentifier'),
-            'size': self.instance.get('AllocatedStorage'),
-            'storage_type': self.instance.get('StorageType')
-        }
-        if self.instance.get('Iops'):
-            d['iops'] = self.instance['Iops'],
-        if self.instance["VpcSecurityGroups"] is not None:
-            d['vpc_security_groups'] = ','.join(x['VpcSecurityGroupId'] for x in self.instance['VpcSecurityGroups'])
-        if self.instance.get("Endpoint"):
-            d['endpoint'] = self.instance["Endpoint"].get('Address', None)
-            d['port'] = self.instance["Endpoint"].get('Port', None)
-        else:
-            d['endpoint'] = None
-            d['port'] = None
-        if self.instance.get("Tags"):
-            d['tags'] = boto3_tag_list_to_ansible_dict(self.instance.get("Tags"))
-
-        return d
+        return camel_dict_to_snake_dict(self.instance)
 
     def diff(self, params):
         compare_keys = ['backup_retention', 'instance_type', 'iops',

--- a/lib/ansible/module_utils/rds.py
+++ b/lib/ansible/module_utils/rds.py
@@ -60,12 +60,16 @@ class RDSDBInstance(object):
                         'maintenance_window', 'multi_zone',
                         'replication_source',
                         'size', 'storage_type', 'tags', 'zone']
+        leave_if_null = ['maintenance_window', 'backup_retention']
         before = dict()
         after = dict()
         for k in compare_keys:
-            if self.params.get(k) != params.get(k):
-                before[k] = self.params.get(k)
-                after[k] = params.get(k)
+            if self.data.get(k) != params.get(k):
+                if params.get(k) == None and k in leave_if_null:
+                    pass
+                else:
+                    before[k] = self.data.get(k)
+                    after[k] = params.get(k)
         port = self.data.get('port')
         if port != params.get('port'):
             before['port'] = port

--- a/lib/ansible/module_utils/rds.py
+++ b/lib/ansible/module_utils/rds.py
@@ -1,0 +1,135 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+
+import botocore
+import time
+
+from ansible.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+
+
+def get_db_instance(conn, instancename):
+    try:
+        response = conn.describe_db_instances(DBInstanceIdentifier=instancename)
+        instance = RDSDBInstance(response['DBInstances'][0])
+        return instance
+    except botocore.exceptions.ClientError as e:
+        if e.response['Error']['Code'] == 'DBInstanceNotFound':
+            return None
+        else:
+            raise
+
+
+def get_db_snapshot(conn, snapshotid):
+    try:
+        response = conn.describe_db_snapshots(DBSnapshotIdentifier=snapshotid)
+        snapshot = RDSSnapshot(response['DBSnapshots'][0])
+        return snapshot
+    except botocore.exceptions.ClientError:
+        if e.response['Error']['Code'] == 'DBSnapshotNotFound':
+            return None
+        else:
+            raise
+
+
+class RDSDBInstance(object):
+    def __init__(self, dbinstance):
+        self.instance = dbinstance
+        if 'DBInstanceIdentifier' not in dbinstance:
+            self.name = None
+        else:
+            self.name = self.instance.get('DBInstanceIdentifier')
+        self.status = self.instance.get('DBInstanceStatus')
+        self.data = self.get_data()
+
+    def get_data(self):
+        d = {
+            'id': self.name,
+            'create_time': self.instance.get('InstanceCreateTime', ''),
+            'db_engine': self.instance['Engine'],
+            'db_name': self.instance.get('DBName'),
+            'status': self.status,
+            'availability_zone': self.instance.get('AvailabilityZone'),
+            'backup_retention': self.instance['BackupRetentionPeriod'],
+            'maintenance_window': self.instance['PreferredMaintenanceWindow'],
+            'multi_zone': self.instance['MultiAZ'],
+            'instance_type': self.instance['DBInstanceClass'],
+            'username': self.instance['MasterUsername'],
+            'replication_source': self.instance.get('ReadReplicaSourceDBInstanceIdentifier'),
+            'size': self.instance.get('AllocatedStorage'),
+            'storage_type': self.instance.get('StorageType')
+        }
+        if self.instance.get('Iops'):
+            d['iops'] = self.instance['Iops'],
+        if self.instance["VpcSecurityGroups"] is not None:
+            d['vpc_security_groups'] = ','.join(x['VpcSecurityGroupId'] for x in self.instance['VpcSecurityGroups'])
+        if self.instance.get("Endpoint"):
+            d['endpoint'] = self.instance["Endpoint"].get('Address', None)
+            d['port'] = self.instance["Endpoint"].get('Port', None)
+        else:
+            d['endpoint'] = None
+            d['port'] = None
+        if self.instance.get("Tags"):
+            d['tags'] = boto3_tag_list_to_ansible_dict(self.instance.get("Tags"))
+
+        return d
+
+    def diff(self, params):
+        compare_keys = ['backup_retention', 'instance_type', 'iops',
+                        'maintenance_window', 'multi_zone',
+                        'replication_source',
+                        'size','storage_type', 'tags', 'zone']
+        before = dict()
+        after = dict()
+        for k in compare_keys:
+            if self.params.get(k) != params.get(k):
+                before[k] = self.params.get(k)
+                after[k] = params.get(k)
+        port = self.data.get('port')
+        if port != params.get('port'):
+            before['port'] = port
+            after['port'] = params.get('port')
+        result = dict()
+        if before:
+            result = dict(before_header=self.name, before=before, after=after)
+            result['after_header'] = params.get('new_instance_name', params.get('instance_name'))
+        return result
+
+    def __eq__(self, other):
+        return not self.diff(other.instance)
+
+    def __ne__(self, other):
+        return not self == other
+
+
+class RDSSnapshot(object):
+    def __init__(self, snapshot):
+        self.snapshot = snapshot
+        self.name = self.snapshot.get('DBSnapshotIdentifier')
+        self.status = self.snapshot.get('Status')
+        self.data = self.get_data()
+
+    def get_data(self):
+        d = {
+            'id': self.name,
+            'create_time': self.snapshot.get('SnapshotCreateTime', ''),
+            'status': self.status,
+            'availability_zone': self.snapshot['AvailabilityZone'],
+            'instance_id': self.snapshot['DBInstanceIdentifier'],
+            'instance_created': self.snapshot['InstanceCreateTime'],
+            'snapshot_type': self.snapshot['SnapshotType'],
+        }
+        if self.snapshot.get('Iops'):
+            d['iops'] = self.snapshot['Iops'],
+        return d

--- a/lib/ansible/module_utils/rds.py
+++ b/lib/ansible/module_utils/rds.py
@@ -56,6 +56,15 @@ class RDSDBInstance(object):
         return camel_dict_to_snake_dict(self.instance)
 
     def diff(self, params):
+        # FIXME compare_keys should be all things that can be modified
+        # except port and instance_name which are handled separately
+        # valid_vars = ['backup_retention', 'backup_window',
+        #               'db_name',  'db_engine', 'engine_version',
+        #               'instance_type', 'iops', 'license_model',
+        #               'maint_window', 'multi_zone', 'new_instance_name',
+        #               'option_group', 'parameter_group', 'password', 'size',
+        #               'storage_type', 'subnet', 'tags', 'upgrade', 'username',
+        #               'vpc_security_groups']
         compare_keys = ['backup_retention', 'instance_type', 'iops',
                         'maintenance_window', 'multi_zone',
                         'replication_source',
@@ -70,10 +79,17 @@ class RDSDBInstance(object):
                 else:
                     before[k] = self.data.get(k)
                     after[k] = params.get(k)
-        port = self.data.get('port')
-        if port != params.get('port'):
-            before['port'] = port
-            after['port'] = params.get('port')
+        try:
+            old_port = self.data.get("endpoint")["port"]
+        except TypeError:
+            old_port = None
+        try:
+            new_port=params.get("endpoint")["port"]
+        except TypeError:
+            new_port = None
+        if old_port != new_port:
+            before['port'] = old_port
+            after['port'] = new_port
         result = dict()
         if before:
             result = dict(before_header=self.name, before=before, after=after)

--- a/lib/ansible/modules/cloud/amazon/rds_instance.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance.py
@@ -558,7 +558,10 @@ def modify_db_instance(module, conn):
 
     # modify_db_instance takes DBPortNumber in contrast to
     # create_db_instance which takes Port
-    params['DBPortNumber'] = params.pop('Port')
+    try:
+        params['DBPortNumber'] = params.pop('Port')
+    except KeyError:
+        pass
     # modify_db_instance does not accept tags
     try:
         tags = params.pop('Tags')

--- a/lib/ansible/modules/cloud/amazon/rds_instance.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance.py
@@ -708,54 +708,58 @@ def validate_parameters(required_vars, valid_vars, module):
     return params
 
 
-def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            state = dict(choices=['absent', 'present', 'rebooted'], default='present'),
-            instance_name = dict(required=True),
-            source_instance = dict(),
-            db_engine = dict(choices=DB_ENGINES),
-            size = dict(type='int'),
-            instance_type = dict(aliases=['type']),
-            username = dict(),
-            password = dict(no_log=True),
-            db_name = dict(),
-            engine_version = dict(),
-            parameter_group = dict(),
-            license_model = dict(choices=LICENSE_MODELS),
-            multi_zone = dict(type='bool', default=False),
-            iops = dict(type='int'),
-            storage_type = dict(choices=['standard', 'io1', 'gp2'], default='standard'),
-            security_groups = dict(),
-            vpc_security_groups = dict(type='list'),
-            port = dict(type='int'),
-            upgrade = dict(type='bool', default=False),
-            option_group = dict(),
-            maint_window = dict(),
-            backup_window = dict(),
-            backup_retention = dict(type='int'),
-            zone = dict(aliases=['aws_zone', 'ec2_zone']),
-            subnet = dict(),
-            wait = dict(type='bool', default=False),
-            wait_timeout = dict(type='int', default=600),
-            snapshot = dict(),
-            skip_final_snapshot = dict(type='bool'),
-            apply_immediately = dict(type='bool', default=False),
-            old_instance_name = dict(),
-            tags = dict(type='dict'),
-            publicly_accessible = dict(),
-            character_set_name = dict(),
-            force_failover = dict(type='bool', default=False),
-            force_password_update = dict(type='bool', default=False),
-        )
+argument_spec = ec2_argument_spec()
+argument_spec.update(
+    dict(
+        state = dict(choices=['absent', 'present', 'rebooted'], default='present'),
+        instance_name = dict(required=True),
+        source_instance = dict(),
+        db_engine = dict(choices=DB_ENGINES),
+        size = dict(type='int'),
+        instance_type = dict(aliases=['type']),
+        username = dict(),
+        password = dict(no_log=True),
+        db_name = dict(),
+        engine_version = dict(),
+        parameter_group = dict(),
+        license_model = dict(choices=LICENSE_MODELS),
+        multi_zone = dict(type='bool', default=False),
+        iops = dict(type='int'),
+        storage_type = dict(choices=['standard', 'io1', 'gp2'], default='standard'),
+        security_groups = dict(),
+        vpc_security_groups = dict(type='list'),
+        port = dict(type='int'),
+        upgrade = dict(type='bool', default=False),
+        option_group = dict(),
+        maint_window = dict(),
+        backup_window = dict(),
+        backup_retention = dict(type='int'),
+        zone = dict(aliases=['aws_zone', 'ec2_zone']),
+        subnet = dict(),
+        wait = dict(type='bool', default=False),
+        wait_timeout = dict(type='int', default=600),
+        snapshot = dict(),
+        skip_final_snapshot = dict(type='bool'),
+        apply_immediately = dict(type='bool', default=False),
+        old_instance_name = dict(),
+        tags = dict(type='dict'),
+        publicly_accessible = dict(),
+        character_set_name = dict(),
+        force_failover = dict(type='bool', default=False),
+        force_password_update = dict(type='bool', default=False),
     )
+)
+required_if=[
+    ('storage_type', 'io1', ['iops']),
+]
+
+
+
+def main():
 
     module = AnsibleModule(
         argument_spec=argument_spec,
-        required_if=[
-            ('storage_type', 'io1', ['iops']),
-        ],
+        required_if=required_if
     )
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
@@ -784,4 +788,5 @@ def main():
         restore_db_instance(module, conn)
     ensure_db_state(module, conn)
 
-main()
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/rds_instance.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance.py
@@ -276,6 +276,7 @@ EXAMPLES = '''
 '''
 
 import time
+import traceback
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info, boto3_conn, HAS_BOTO3
 from ansible.module_utils.ec2 import ansible_dict_to_boto3_tag_list, boto3_tag_list_to_ansible_dict

--- a/lib/ansible/modules/cloud/amazon/rds_instance.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance.py
@@ -441,7 +441,8 @@ def replicate_db_instance(module, conn):
             instance = RDSDBInstance(response['DBInstance'])
             changed = True
         except botocore.exceptions.ClientError as e:
-            module.fail_json(msg="Failed to create replica instance: %s " % str(e))
+            module.fail_json(msg="Failed to create replica instance: %s " % str(e),
+                             exception=traceback.format_exc() )
 
     if module.params.get('wait'):
         resource = await_resource(conn, instance, 'available', module)
@@ -481,7 +482,8 @@ def delete_db_instance(module, conn):
         response = conn.delete_db_instance(**params)
         instance = RDSDBInstance(response['DBInstance'])
     except botocore.exceptions.ClientError as e:
-        module.fail_json(msg="Failed to delete instance: %s" % str(e))
+        module.fail_json(msg="Failed to delete instance: %s" % str(e),
+                         exception=traceback.format_exc() )
 
     # If we're not waiting for a delete to complete then we're all done
     # so just return
@@ -494,7 +496,7 @@ def delete_db_instance(module, conn):
         if e.code == 'DBInstanceNotFound':
             module.exit_json(changed=True, operation="delete")
         else:
-            module.fail_json(msg=str(e))
+            module.fail_json(msg=str(e), exception=traceback.format_exc())
     assert(False), "error in module logic - this should not be reached"
 
 def update_rds_tags(module, conn, resource, current_tags, desired_tags):
@@ -517,7 +519,7 @@ def update_rds_tags(module, conn, resource, current_tags, desired_tags):
             conn.remove_tags_from_resource(ResourceName=resource, TagKeys=list(to_delete))
             changed = True
         except botocore.exceptions.ClientError as e:
-            module.fail_json(msg=str(e))
+            module.fail_json(msg=str(e), exception=traceback.format_exc())
     if to_add:
         try:
             conn.add_tags_to_resource(ResourceName=resource,
@@ -525,7 +527,7 @@ def update_rds_tags(module, conn, resource, current_tags, desired_tags):
                                             for k in to_add])
             changed = True
         except botocore.exceptions.ClientError as e:
-            module.fail_json(msg=str(e))
+            module.fail_json(msg=str(e), exception=traceback.format_exc())
     return changed
 
 
@@ -581,7 +583,7 @@ def modify_db_instance(module, conn):
         response = conn.modify_db_instance(**params)
         return_instance = RDSDBInstance(response['DBInstance'])
     except botocore.exceptions.ClientError as e:
-        module.fail_json(msg=str(e))
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
 
     if module.params.get('apply_immediately') and after_instance_name:
             # Wait until the new instance name is valid
@@ -646,7 +648,7 @@ def promote_db_instance(module, conn):
             instance = RDSDBInstance(response['DBInstance'])
             changed = True
         except botocore.exceptions.ClientError as e:
-            module.fail_json(msg=str(e))
+            module.fail_json(msg=str(e), exception=traceback.format_exc())
     else:
         changed = False
 
@@ -669,7 +671,7 @@ def reboot_db_instance(module, conn):
         response = conn.reboot_db_instance(**params)
         instance = RDSDBInstance(response['DBInstance'])
     except botocore.exceptions.ClientError as e:
-        module.fail_json(msg=str(e))
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
 
     if module.params.get('wait'):
         instance = await_resource(conn, instance, 'available', module)
@@ -695,7 +697,7 @@ def restore_db_instance(module, conn):
             instance = RDSDBInstance(response['DBInstance'])
             changed = True
         except botocore.exceptions.ClientError as e:
-            module.fail_json(msg=str(e))
+            module.fail_json(msg=str(e), exception=traceback.format_exc())
 
     if module.params.get('wait'):
         instance = await_resource(conn, instance, 'available', module)
@@ -735,7 +737,7 @@ def validate_parameters(required_vars, valid_vars, module):
         try:
             PARAMETER_MAP[item]
         except KeyError as e:
-            module.fail_json(msg="unexpected module parameter" + str(e))
+            module.fail_json(msg="unexpected module parameter" + str(e), exception=traceback.format_exc())
 
     if module.params.get('security_groups'):
         params['DBSecurityGroups'] = module.params.get('security_groups').split(',')

--- a/lib/ansible/modules/cloud/amazon/rds_instance.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance.py
@@ -356,6 +356,8 @@ PARAMETER_MAP = {
 
 def await_resource(conn, resource, status, module):
     wait_timeout = module.params.get('wait_timeout') + time.time()
+    # Refresh the resource immediately in case we just changed it's state; should we sleep first?
+    resource = get_db_instance(conn, resource.name)
     while wait_timeout > time.time() and resource.status != status:
         time.sleep(5)
         if wait_timeout <= time.time():

--- a/lib/ansible/modules/cloud/amazon/rds_instance.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance.py
@@ -321,7 +321,7 @@ PARAMETER_MAP = {
     'iops': 'Iops',
     'license_model': 'LicenseModel',
     'maint_window': 'PreferredMaintenanceWindow',
-    'multi_zone': 'MultiAz',
+    'multi_zone': 'MultiAZ',
     'new_instance_name': 'NewDBInstanceIdentifier',
     'new_instance_name': 'NewInstanceId',
     'option_group': 'OptionGroupName',

--- a/lib/ansible/modules/cloud/amazon/rds_instance.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance.py
@@ -516,17 +516,17 @@ def modify_db_instance(module, conn):
     force_password_update = module.params.pop('force_password_update')
     required_vars = ['instance_name']
     valid_vars = ['apply_immediately', 'backup_retention', 'backup_window',
-                  'db_name', 'engine_version',
+                  'db_name',  'db_engine', 'engine_version',
                   'instance_type', 'iops', 'license_model',
                   'maint_window', 'multi_zone', 'new_instance_name',
                   'option_group', 'parameter_group', 'password', 'port', 'size',
-                  'storage_type', 'subnet', 'tags', 'upgrade', 'vpc_security_groups']
+                  'storage_type', 'subnet', 'tags', 'upgrade', 'username', 'vpc_security_groups']
 
     existing_instance_name = module.params.get('instance_name')
     existing_instance = get_db_instance(conn, existing_instance_name)
     for immutable_key in ['username', 'db_engine', 'db_name']:
         if immutable_key in module.params:
-            if module.params[immutable_key] != existing_instance.data[immutable_key]:
+            if immutable_key in existing_instance.data and module.params[immutable_key] != existing_instance.data[immutable_key]:
                 module.fail_json(msg="Cannot modify parameter %s for instance %s" %
                                  (immutable_key, existing_instance_name))
             del(module.params[immutable_key])

--- a/lib/ansible/modules/cloud/amazon/rds_instance.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance.py
@@ -1,0 +1,765 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+
+import botocore
+import time
+
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '0.1'}
+
+DOCUMENTATION = '''
+---
+module: rds_instance
+version_added: "2.3"
+short_description: create, delete, or modify an Amazon rds instance
+description:
+     - Creates, deletes, or modifies rds instances. When creating an instance
+       it can be either a new instance or a read-only replica of an existing instance.
+options:
+  state:
+    description:
+      - Describes the desired state of the database instance.
+    required: false
+    default: present
+    choices: [ 'present', 'absent', 'rebooted' ]
+  instance_name:
+    description:
+      - Database instance identifier.
+    required: true
+  source_instance:
+    description:
+      - Name of the database when sourcing from a replica
+    required: false
+  replica:
+    description:
+    - whether or not a database is a read replica
+    default: False
+  db_engine:
+    description:
+      - The type of database. Used only when state=present.
+    required: false
+    choices: [ 'mariadb', 'MySQL', 'oracle-se1', 'oracle-se2', 'oracle-se', 'oracle-ee', 'sqlserver-ee',
+                sqlserver-se', 'sqlserver-ex', 'sqlserver-web', 'postgres', 'aurora']
+  size:
+    description:
+      - Size in gigabytes of the initial storage for the DB instance.
+    required: false
+  storage_type:
+    description:
+      - Specifies the storage type to be associated with the DB instance. C(iops) must
+        be specified if C(io1) is chosen.
+    choices: ['standard', 'gp2', 'io1' ]
+    default: standard unless iops is set
+  instance_type:
+    description:
+      - The instance type of the database. If source_instance is specified then the replica inherits the same instance type as the source instance.
+    required: false
+  username:
+    description:
+      - Master database username.
+    required: false
+  password:
+    description:
+      - Password for the master database username.
+    required: false
+  db_name:
+    description:
+      - Name of a database to create within the instance. If not specified then no database is created.
+    required: false
+  engine_version:
+    description:
+      - Version number of the database engine to use. If not specified then the current Amazon RDS default engine version is used.
+    required: false
+  parameter_group:
+    description:
+      - Name of the DB parameter group to associate with this instance. If omitted then the RDS default DBParameterGroup will be used.
+    required: false
+  license_model:
+    description:
+      - The license model for this DB instance.
+    required: false
+    choices:  [ 'license-included', 'bring-your-own-license', 'general-public-license', 'postgresql-license' ]
+  multi_zone:
+    description:
+      - Specifies if this is a Multi-availability-zone deployment. Can not be used in conjunction with zone parameter.
+    choices: [ "yes", "no" ]
+    required: false
+  iops:
+    description:
+      - Specifies the number of IOPS for the instance. Must be an integer greater than 1000.
+    required: false
+  security_groups:
+    description:
+      - Comma separated list of one or more security groups.
+    required: false
+  vpc_security_groups:
+    description:
+      - Comma separated list of one or more vpc security group ids. Also requires `subnet` to be specified.
+    required: false
+  port:
+    description:
+      - Port number that the DB instance uses for connections.
+    required: false
+    default: 3306 for mysql, 1521 for Oracle, 1433 for SQL Server, 5432 for PostgreSQL.
+  upgrade:
+    description:
+      - Indicates that minor version upgrades should be applied automatically.
+    required: false
+    default: no
+    choices: [ "yes", "no" ]
+  option_group:
+    description:
+      - The name of the option group to use. If not specified then the default option group is used.
+    required: false
+  maint_window:
+    description:
+      - "Maintenance window in format of ddd:hh24:mi-ddd:hh24:mi. (Example: Mon:22:00-Mon:23:15) If not specified then a random maintenance window is assigned.
+    required: false
+  backup_window:
+    description:
+      - Backup window in format of hh24:mi-hh24:mi. If not specified then a random backup window is assigned.
+    required: false
+  backup_retention:
+    description:
+      - Number of days backups are retained. Set to 0 to disable backups. Default is 1 day. Valid range: 0-35.
+    required: false
+  zone:
+    description:
+      - availability zone in which to launch the instance.
+    required: false
+    aliases: ['aws_zone', 'ec2_zone']
+  subnet:
+    description:
+      - VPC subnet group. If specified then a VPC instance is created.
+    required: false
+  snapshot:
+    description:
+      - Name of snapshot to take when state=absent - if no snapshot name is provided then no snapshot is taken.
+    required: false
+  wait:
+    description:
+      - Wait for the database to enter the desired state.
+    required: false
+    default: "no"
+    choices: [ "yes", "no" ]
+  wait_timeout:
+    description:
+      - how long before wait gives up, in seconds
+    default: 300
+  apply_immediately:
+    description:
+      - If enabled, the modifications will be applied as soon as possible rather than waiting for the next preferred maintenance window.
+    default: no
+    choices: [ "yes", "no" ]
+  force_failover:
+    description:
+      - Used only when state=rebooted. If enabled, the reboot is done using a MultiAZ failover.
+    required: false
+    default: "no"
+    choices: [ "yes", "no" ]
+  old_instance_name:
+    description:
+      - Name to rename an instance from.
+    required: false
+  character_set_name:
+    description:
+      - Associate the DB instance with a specified character set.
+    required: false
+  publicly_accessible:
+    description:
+      - explicitly set whether the resource should be publicly accessible or not.
+    required: false
+  cluster:
+    description:
+      -  The identifier of the DB cluster that the instance will belong to.
+    required: false
+  tags:
+    description:
+      - tags dict to apply to a resource.
+    required: false
+requirements:
+    - "python >= 2.6"
+    - "boto3"
+author:
+    - Bruce Pennypacker (@bpennypacker)
+    - Will Thames (@willthames)
+extends_documentation_fragment:
+    - aws
+    - ec2
+'''
+
+EXAMPLES = '''
+# Basic mysql provisioning example
+- rds_instance:
+    instance_name: new-database
+    db_engine: MySQL
+    size: 10
+    instance_type: db.m1.small
+    username: mysql_admin
+    password: 1nsecure
+    tags:
+      Environment: testing
+      Application: cms
+
+# Create a read-only replica and wait for it to become available
+- rds_instance:
+    instance_name: new-database-replica
+    source_instance: new_database
+    wait: yes
+    wait_timeout: 600
+
+# Promote the read replica to a standalone database by removing
+# the source_instance setting
+- rds_instance
+    instance_name: new-database-replica
+    wait: yes
+    wait_timeout: 600
+
+# Delete an instance, but create a snapshot before doing so
+- rds_instance:
+    state: absent
+    instance_name: new-database
+    snapshot: new_database_snapshot
+
+# Rename an instance and wait for the change to take effect
+- rds_instance:
+    old_instance_name: new-database
+    instance_name: renamed-database
+    wait: yes
+
+# Reboot an instance and wait for it to become available again
+- rds_instance:
+    state: rebooted
+    instance_name: database
+    wait: yes
+
+# Restore a Postgres db instance from a snapshot, wait for it to become available again, and
+#  then modify it to add your security group. Also, display the new endpoint.
+#  Note that the "publicly_accessible" option is allowed here just as it is in the AWS CLI
+- rds_instance:
+     snapshot: mypostgres-snapshot
+     instance_name: MyNewInstanceName
+     region: us-west-2
+     zone: us-west-2b
+     subnet: default-vpc-xx441xxx
+     publicly_accessible: yes
+     wait: yes
+     wait_timeout: 600
+     tags:
+         Name: pg1_test_name_tag
+  register: rds
+
+- rds_instance:
+     instance_name: MyNewInstanceName
+     region: us-west-2
+     vpc_security_groups: sg-xxx945xx
+
+- debug:
+    msg: "The new db endpoint is {{ rds.instance.endpoint }}"
+'''
+
+
+DEFAULT_PORTS= {
+    'aurora': 3306,
+    'mariadb': 3306,
+    'mysql': 3306,
+    'oracle': 1521,
+    'sqlserver': 1433,
+    'postgres': 5432,
+}
+
+DB_ENGINES = [
+    'MySQL',
+    'aurora'
+    'mariadb',
+    'oracle-ee',
+    'oracle-se',
+    'oracle-se1',
+    'oracle-se2',
+    'postgres',
+    'sqlserver-ee',
+    'sqlserver-ex',
+    'sqlserver-se',
+    'sqlserver-web',
+]
+
+
+LICENSE_MODELS = [
+    'bring-your-own-license',
+    'general-public-license',
+    'license-included',
+    'postgresql-license'
+]
+
+PARAMETER_MAP = {
+    'apply_immediately': 'ApplyImmediately',
+    'backup_retention': 'BackupRetentionPeriod',
+    'backup_window': 'PreferredBackupWindow',
+    'character_set_name': 'CharacterSetName',
+    'cluster': 'DBClusterIdentifer',
+    'db_engine': 'Engine',
+    'db_name': 'DBName',
+    'engine_version': 'EngineVersion',
+    'force_failover': 'ForceFailover',
+    'instance_name': 'DBInstanceIdentifier',
+    'instance_type': 'DBInstanceClass',
+    'iops': 'Iops',
+    'license_model': 'LicenseModel',
+    'maint_window': 'PreferredMaintenanceWindow',
+    'multi_zone': 'MultiAz',
+    'new_instance_name': 'NewDBInstanceIdentifier',
+    'new_instance_name': 'NewInstanceId',
+    'option_group': 'OptionGroupName',
+    'parameter_group': 'DBParameterGroupName',
+    'password': 'MasterUserPassword',
+    'port': 'Port',
+    'publicly_accessible': 'PubliclyAccessible',
+    'security_groups': 'DBSecurityGroup',
+    'size': 'AllocatedStorage',
+    'skip_final_snapshot': 'SkipFinalSnapshot"',
+    'source_instance': 'SourceDBInstanceIdentifier',
+    'snapshot': 'DBSnapshotIdentifier',
+    'storage_type': 'StorageType',
+    'subnet': 'DBSubnetGroupName',
+    'tags': 'Tags',
+    'upgrade': 'AutoMinorVersionUpgrade',
+    'username': 'MasterUsername',
+    'vpc_security_groups': 'VpcSecurityGroupIds',
+    'zone': 'AvailabilityZone',
+}
+
+
+def await_resource(conn, resource, status, module):
+    wait_timeout = module.params.get('wait_timeout') + time.time()
+    while wait_timeout > time.time() and resource.status != status:
+        time.sleep(5)
+        if wait_timeout <= time.time():
+            module.fail_json(msg="Timeout waiting for RDS resource %s" % resource.name)
+        # Temporary until all the rds2 commands have their responses parsed
+        if resource.name is None:
+            module.fail_json(msg="There was a problem waiting for RDS instance %s" % resource.instance)
+        resource = get_db_instance(conn, resource.name)
+        if resource is None:
+            break
+    return resource
+
+
+def create_db_instance(module, conn):
+    if module.params.get('db_engine') in ['aurora']:
+        required_vars = ['instance_name','instance_type', 'db_engine']
+        valid_vars = ['character_set_name', 'cluster', 'db_name', 'engine_version',
+                      'instance_type', 'license_model', 'maint_window',
+                      'option_group', 'parameter_group','port',
+                      'publicly_accessible', 'subnet',
+                      'upgrade', 'tags', 'zone']
+    else:
+        required_vars = ['instance_name', 'db_engine', 'size', 'instance_type', 'username', 'password']
+        valid_vars = ['backup_retention', 'backup_window',
+                      'character_set_name', 'cluster', 'db_name', 'engine_version',
+                      'instance_type', 'license_model', 'maint_window',
+                      'multi_zone', 'option_group', 'parameter_group','port',
+                      'publicly_accessible', 'storage_type', 'subnet',
+                      'upgrade', 'tags', 'vpc_security_groups', 'zone']
+
+    if module.params.get('subnet'):
+        valid_vars.append('vpc_security_groups')
+    else:
+        valid_vars.append('security_groups')
+    params = validate_parameters(required_vars, valid_vars, module)
+    instance_name = module.params.get('instance_name')
+
+    instance = get_db_instance(conn, instance_name)
+    if instance:
+        changed = False
+    else:
+        try:
+            response = conn.create_db_instance(**params)
+            instance = RDSDBInstance(response['DBInstance'])
+            changed = True
+        except botocore.exceptions.ClientError as e:
+            module.fail_json(msg="Failed to create instance: %s" % str(e))
+
+    if module.params.get('wait'):
+        resource = await_resource(conn, instance, 'available', module)
+    else:
+        resource = get_db_instance(conn, instance_name)
+
+    module.exit_json(changed=changed, instance=resource.data, operation="create")
+
+
+def replicate_db_instance(module, conn):
+    required_vars = ['instance_name', 'source_instance']
+    valid_vars = ['instance_type', 'iops', 'option_group', 'port',
+                  'publicly_accessible', 'storage_type',
+                  'tags', 'upgrade', 'zone']
+    params = validate_parameters(required_vars, valid_vars, module)
+    instance_name = module.params.get('instance_name')
+
+    instance = get_db_instance(conn, instance_name)
+    if instance:
+        changed = False
+    else:
+        try:
+            response = conn.create_db_instance_read_replica(**params)
+            instance = RDSDBInstance(response['DBInstance'])
+            changed = True
+        except botocore.exceptions.ClientError as e:
+            module.fail_json(msg="Failed to create replica instance: %s " % str(e))
+
+    if module.params.get('wait'):
+        resource = await_resource(conn, instance, 'available', module)
+    else:
+        resource = get_db_instance(conn, instance_name)
+
+    module.exit_json(changed=changed, instance=resource.data, operation="replicate")
+
+
+def delete_db_instance(module, conn):
+    required_vars = ['instance_name']
+    valid_vars = ['snapshot', 'skip_final_snapshot']
+    params = validate_parameters(required_vars, valid_vars, module)
+    instance_name = module.params.get('instance_name')
+    snapshot = module.params.get('snapshot')
+
+    result = get_db_instance(conn, instance_name)
+    if not result:
+        module.exit_json(changed=False)
+    if result.status == 'deleting':
+        module.exit_json(changed=False)
+    try:
+        if snapshot:
+            params["SkipFinalSnapshot"] = False
+            params["FinalDBSnapshotIdentifier"] = snapshot
+            del(params['DBSnapshotIdentifier'])
+        else:
+            params["SkipFinalSnapshot"] = True
+        response = conn.delete_db_instance(**params)
+        instance = RDSDBInstance(response['DBInstance'])
+    except botocore.exceptions.ClientError as e:
+        module.fail_json(msg="Failed to delete instance: %s" % str(e))
+
+    # If we're not waiting for a delete to complete then we're all done
+    # so just return
+    if not module.params.get('wait'):
+        module.exit_json(changed=True)
+    try:
+        instance = await_resource(conn, instance, 'deleted', module)
+        module.exit_json(changed=True)
+    except botocore.exceptions.ClientError as e:
+        if e.code == 'DBInstanceNotFound':
+            module.exit_json(changed=True, operation="delete")
+        else:
+            module.fail_json(msg=str(e))
+
+
+def update_rds_tags(conn, resource, current_tags, desired_tags):
+    changed = False
+    # it's much easier to do set manipulation in ansible form
+    current_tags = boto3_tag_list_to_ansible_dict(current_tags)
+    desired_tags = boto3_tag_list_to_ansible_dict(desired_tags)
+    current_keys = set(current_tags.keys())
+    desired_keys = set(desired_tags.keys())
+    to_add = desired_keys - current_keys
+    to_delete = current_keys - desired_keys
+
+    for k in desired_keys & current_keys:
+        if current_tags[k] != desired_tags[k]:
+            to_delete.append(k)
+            to_add.append(k)
+
+    if to_delete:
+        try:
+            conn.remove_tags_from_resource(ResourceName=resource,
+                                           Tags=[{'Key': k} for k in to_delete])
+            changed = True
+        except botocore.exceptions.ClientError as e:
+            module.fail_json(msg=str(e))
+    if to_add:
+        try:
+            conn.add_tags_to_resource(ResourceName=resource,
+                                      Tags=[{'Key': k, 'Value': desired_tags[k]}
+                                            for k in to_add])
+            changed = True
+        except botocore.exceptions.ClientError as e:
+            module.fail_json(msg=str(e))
+    return changed
+
+
+def modify_db_instance(module, conn):
+    required_vars = ['instance_name']
+    valid_vars = ['apply_immediately', 'backup_retention', 'backup_window',
+                  'db_name', 'engine_version', 'instance_type', 'iops', 'license_model',
+                  'maint_window', 'multi_zone', 'new_instance_name',
+                  'option_group', 'parameter_group', 'password', 'port', 'size',
+                  'storage_type', 'subnet', 'tags', 'upgrade', 'vpc_security_groups']
+
+    existing_instance_name = module.params.get('instance_name')
+    existing_instance = get_db_instance(conn, existing_instance_name)
+    for immutable_key in ['username', 'db_engine']:
+        if immutable_key in module.params:
+            if module.params[immutable_key] != existing_instance.data[immutable_key]:
+                module.fail_json(msg="Cannot modify parameter %s for instance %s" %
+                                 (immutable_key, existing_instance_name))
+            del(module.params[immutable_key])
+
+    params = validate_parameters(required_vars, valid_vars, module)
+    new_instance_name = module.params.get('new_instance_name')
+
+    will_change = existing_instance.diff(params)
+    if not will_change:
+        module.exit_json(changed=False, instance=existing_instance.data, operation="modify")
+
+    # modify_db_instance takes DBPortNumber in contrast to
+    # create_db_instance which takes Port
+    params['DBPortNumber'] = params.pop('Port')
+    # modify_db_instance does not accept tags
+    tags = params.pop('Tags')
+    # modify_db_instance does not cope with DBSubnetGroup not moving VPC!
+    if existing_instance.instance['DBSubnetGroup']['DBSubnetGroupName'] == params.get('DBSubnetGroupName'):
+        del(params['DBSubnetGroupName'])
+
+    try:
+        response = conn.modify_db_instance(**params)
+        instance = RDSDBInstance(response['DBInstance'])
+    except botocore.exceptions.ClientError as e:
+        module.fail_json(msg=str(e))
+    if params.get('apply_immediately'):
+        if new_instance_name:
+            # Wait until the new instance name is valid
+            new_instance = None
+            while not new_instance:
+                new_instance = get_db_instance(conn, new_instance_name)
+                time.sleep(5)
+
+            # Found instance but it briefly flicks to available
+            # before rebooting so let's wait until we see it rebooting
+            # before we check whether to 'wait'
+            instance = await_resource(conn, new_instance, 'rebooting', module)
+            instance_name = new_instance_name
+
+    if module.params.get('wait'):
+        instance = await_resource(conn, instance, 'available', module)
+    else:
+        instance = get_db_instance(conn, instance_name)
+
+    # guess that this changed the DB, need a way to check
+    changed = (instance != existing_instance)
+    # modify_db_instance can't modify tags directly
+    current_tags = conn.list_tags_for_resource(ResourceName=response['DBInstance']['DBInstanceArn'])['TagList']
+    if update_rds_tags(conn, response['DBInstance']['DBInstanceArn'],
+                       current_tags, tags):
+        changed = True
+    module.exit_json(changed=changed, instance=instance.data, operation="modify", diff=will_change)
+
+
+def promote_db_instance(module, conn):
+    required_vars = ['instance_name']
+    valid_vars = ['backup_retention', 'backup_window']
+    params = validate_parameters(required_vars, valid_vars, module)
+    instance_name = module.params.get('instance_name')
+
+    result = get_db_instance(conn, instance_name)
+    if not result:
+        module.fail_json(msg="DB Instance %s does not exist" % instance_name)
+
+    if result.data.get('replication_source'):
+        try:
+            response = conn.promote_read_replica(**params)
+            instance = RDSDBInstance(response['DBInstance'])
+            changed = True
+        except botocore.exceptions.ClientError as e:
+            module.fail_json(msg=str(e))
+    else:
+        changed = False
+
+    if module.params.get('wait'):
+        instance = await_resource(conn, instance, 'available', module)
+    else:
+        instance = get_db_instance(conn, instance_name)
+
+    module.exit_json(changed=changed, instance=instance.data, operation="promote")
+
+
+def reboot_db_instance(module, conn):
+    required_vars = ['instance_name']
+    valid_vars = ['force_failover']
+
+    params = validate_parameters(required_vars, valid_vars, module)
+    instance_name = module.params.get('instance_name')
+    instance = get_db_instance(conn, instance_name)
+    try:
+        response = conn.reboot_db_instance(**params)
+        instance = RDSDBInstance(response['DBInstance'])
+    except botocore.exceptions.ClientError as e:
+        module.fail_json(msg=str(e))
+
+    if module.params.get('wait'):
+        instance = await_resource(conn, instance, 'available', module)
+    else:
+        instance = get_db_instance(conn, instance_name)
+
+    module.exit_json(changed=True, instance=instance.data, operation="reboot")
+
+
+def restore_db_instance(module, conn):
+    required_vars = ['instance_name', 'snapshot']
+    valid_vars = ['db_name', 'iops', 'license_model', 'multi_zone',
+                  'option_group', 'port', 'publicly_accessible', 'storage_type',
+                  'subnet', 'tags', 'upgrade', 'zone', 'instance_type']
+    params = validate_parameters(required_vars, valid_vars, module)
+    instance_name = module.params.get('instance_name')
+
+    changed = False
+    instance = get_db_instance(conn, instance_name)
+    if not instance:
+        try:
+            response = conn.restore_db_instance_from_db_snapshot(**params)
+            instance = RDSDBInstance(response['DBInstance'])
+            changed = True
+        except botocore.exceptions.ClientError as e:
+            module.fail_json(msg=str(e))
+
+    if module.params.get('wait'):
+        instance = await_resource(conn, instance, 'available', module)
+    else:
+        instance = get_db_instance(conn, instance_name)
+
+    module.exit_json(changed=changed, instance=instance.data, operation="restore")
+
+
+def ensure_db_state(module, conn):
+    instance_name = module.params.get('instance_name')
+    instance = get_db_instance(conn, instance_name)
+    if not instance:
+        create_db_instance(module, conn)
+    if instance.data.get('replication_source') and not module.params.get('source_instance'):
+        promote_db_instance(module, conn)
+    modify_db_instance(module, conn)
+    module.exit_json(changed=False, instance=instance.data)
+
+
+def validate_parameters(required_vars, valid_vars, module):
+    for v in required_vars:
+        if not module.params.get(v):
+            module.fail_json(msg="Parameter %s required" % v)
+
+    params = {}
+    for (k, v) in PARAMETER_MAP.items():
+        if module.params.get(k):
+            if k in valid_vars or k in required_vars:
+                params[v] = module.params[k]
+            else:
+                module.fail_json(msg="Parameter %s is not valid" % k)
+
+    # needed for checking that all variables are actually in the map
+    for item in set(required_vars) | set(valid_vars):
+        try:
+            PARAMETER_MAP[item]
+        except KeyError as e:
+            module.fail_json(str(e))
+
+    if module.params.get('security_groups'):
+        params['DBSecurityGroups'] = module.params.get('security_groups').split(',')
+
+    # Convert tags dict to list of tuples that boto expects
+    if 'Tags' in params:
+        params['Tags'] = ansible_dict_to_boto3_tag_list(module.params['tags'])
+    return params
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(
+        dict(
+            state = dict(choices=['absent', 'present', 'rebooted'], default='present'),
+            instance_name = dict(required=True),
+            source_instance = dict(),
+            db_engine = dict(choices=DB_ENGINES),
+            size = dict(type='int'),
+            instance_type = dict(aliases=['type']),
+            username = dict(),
+            password = dict(no_log=True),
+            db_name = dict(),
+            engine_version = dict(),
+            parameter_group = dict(),
+            license_model = dict(choices=LICENSE_MODELS),
+            multi_zone = dict(type='bool', default=False),
+            iops = dict(type='int'),
+            storage_type = dict(choices=['standard', 'io1', 'gp2'], default='standard'),
+            security_groups = dict(),
+            vpc_security_groups = dict(type='list'),
+            port = dict(type='int'),
+            upgrade = dict(type='bool', default=False),
+            option_group = dict(),
+            maint_window = dict(),
+            backup_window = dict(),
+            backup_retention = dict(type='int'),
+            zone = dict(aliases=['aws_zone', 'ec2_zone']),
+            subnet = dict(),
+            wait = dict(type='bool', default=False),
+            wait_timeout = dict(type='int', default=600),
+            snapshot = dict(),
+            skip_final_snapshot = dict(type='bool'),
+            apply_immediately = dict(type='bool', default=False),
+            old_instance_name = dict(),
+            tags = dict(type='dict'),
+            publicly_accessible = dict(),
+            character_set_name = dict(),
+            force_failover = dict(type='bool', default=False),
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_if=[
+            ('storage_type', 'io1', ['iops']),
+        ],
+    )
+
+    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
+    if not region:
+        module.fail_json(msg="Region not specified. Unable to determine region from configuration.")
+
+    # connect to the rds endpoint
+    conn = boto3_conn(module, 'client', 'rds', region, **aws_connect_params)
+
+    if module.params['state'] == 'absent':
+        delete_db_instance(module, conn)
+    if module.params['state'] == 'rebooted':
+        reboot_db_instance(module, conn)
+
+    # set port to per db defaults if not specified
+    if module.params['port'] is None and module.params['db_engine'] is not None:
+        if '-' in module.params['db_engine']:
+            engine = module.params['db_engine'].split('-')[0]
+        else:
+            engine = module.params['db_engine']
+        module.params['port'] = DEFAULT_PORTS[engine.lower()]
+
+    if module.params.get('source_instance'):
+        replicate_db_instance(module, conn)
+    if module.params.get('snapshot'):
+        restore_db_instance(module, conn)
+    ensure_db_state(module, conn)
+
+# import module snippets
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info, boto3_conn, ansible_dict_to_boto3_tag_list
+from ansible.module_utils.rds import RDSDBInstance, get_db_instance
+
+main()

--- a/lib/ansible/modules/cloud/amazon/rds_instance_facts.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance_facts.py
@@ -16,12 +16,12 @@
 
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
-                    'version': '1.0'}
+                    'metadata_version': '1.0'}
 
 DOCUMENTATION = '''
 ---
 module: rds_instance_facts
-version_added: "2.3"
+version_added: "2.4"
 short_description: obtain facts about one or more RDS instances
 description:
   - obtain facts about one or more RDS instances

--- a/lib/ansible/modules/cloud/amazon/rds_instance_facts.py
+++ b/lib/ansible/modules/cloud/amazon/rds_instance_facts.py
@@ -1,0 +1,154 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = '''
+---
+module: rds_instance_facts
+version_added: "2.3"
+short_description: obtain facts about one or more RDS instances
+description:
+  - obtain facts about one or more RDS instances
+options:
+  name:
+    description:
+      - Name of an RDS instance.
+    required: false
+    aliases:
+      - name
+  filters:
+    description:
+      - A filter that specifies one or more DB instances to describe.
+        See U(https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBInstances.html)
+requirements:
+    - "python >= 2.6"
+    - "boto3"
+author:
+    - "Will Thames (@willthames)"
+extends_documentation_fragment:
+    - aws
+    - ec2
+'''
+
+EXAMPLES = '''
+# Get facts about an instance
+- rds_instance_facts:
+    name: new-database
+  register: new_database_facts
+
+# Get all RDS instances
+- rds_instance_facts:
+'''
+
+RETURN = '''
+instances:
+    description: zero or more instances that match the (optional) parameters
+    type: list
+    returned: always
+    sample:
+       "instances": [
+           {
+               "availability_zone": "ap-southeast-2c",
+               "backup_retention": 10,
+               "create_time": "2017-02-20T06:13:05.724000+00:00",
+               "db_engine": "postgres",
+               "endpoint": "helloworld-rds-master.cyaju3p4tyqv.ap-southeast-2.rds.amazonaws.com",
+               "id": "helloworld-rds-master",
+               "instance_type": "db.t2.micro",
+               "maintenance_window": "sun:15:40-sun:16:10",
+               "multi_zone": false,
+               "port": 5432,
+               "replication_source": null,
+               "size": 5,
+               "status": "available",
+               "username": "hello",
+               "vpc_security_groups": "sg-abcd1234"
+           },
+       ]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info, boto3_conn, HAS_BOTO3
+from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list, camel_dict_to_snake_dict
+from ansible.module_utils.rds import RDSDBInstance
+
+import traceback
+
+try:
+    import botocore
+except:
+    pass  # caught by imported HAS_BOTO3
+
+
+def instance_facts(module, conn):
+    instance_name = module.params.get('name')
+    filters = module.params.get('filters')
+
+    params = dict()
+    if instance_name:
+        params['DBInstanceIdentifier'] = instance_name
+    if filters:
+        params['Filters'] = ansible_dict_to_boto3_filter_list(filters)
+
+    marker = ''
+    results = list()
+    while True:
+        try:
+            response = conn.describe_db_instances(Marker=marker, **params)
+            results.extend(response['DBInstances'])
+            marker = response.get('Marker')
+        except botocore.exceptions.ClientError as e:
+            if e.response['Error']['Code'] == 'DBInstanceNotFound':
+                break
+            module.fail_json(msg=str(e), exception=traceback.format_exc(),
+                             **camel_dict_to_snake_dict(e.response))
+        if not marker:
+            break
+
+    module.exit_json(changed=False, instances=[RDSDBInstance(instance).data for instance in results])
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(
+        dict(
+            name = dict(aliases=['instance_name']),
+            filters = dict(type='list', default=[])
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    if not HAS_BOTO3:
+        module.fail_json(msg="botocore and boto3 are required for rds_facts module")
+
+    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
+    if not region:
+        module.fail_json(msg="Region not specified. Unable to determine region from configuration.")
+
+    # connect to the rds endpoint
+    conn = boto3_conn(module, 'client', 'rds', region, **aws_connect_params)
+
+    instance_facts(module, conn)
+
+
+main()

--- a/lib/ansible/modules/cloud/amazon/rds_snapshot.py
+++ b/lib/ansible/modules/cloud/amazon/rds_snapshot.py
@@ -1,0 +1,187 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import botocore
+import time
+
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '0.1'}
+
+DOCUMENTATION = '''
+---
+module: rds_snapshot
+version_added: "2.3"
+short_description: manage Amazon RDS snapshots
+description:
+     - Creates or deletes RDS snapshots.
+options:
+  state:
+    description:
+      - Specify the desired state of the snapshot
+    default: present
+    choices: [ 'present', 'absent']
+  snapshot:
+    description:
+      - Name of snapshot to manage
+    required: true
+  instance_name:
+    description:
+      - Database instance identifier. Required when state is present
+    required: false
+  wait:
+    description:
+      - Whether or not to wait for snapshot creation or deletion
+    required: false
+    default: "no"
+    choices: [ "yes", "no" ]
+  wait_timeout:
+    description:
+      - how long before wait gives up, in seconds
+    default: 300
+  tags:
+    description:
+      - tags dict to apply to a snapshot.
+    required: false
+    default: null
+requirements:
+    - "python >= 2.6"
+    - "boto3"
+author:
+    - "Will Thames (@willthames)"
+extends_documentation_fragment:
+    - aws
+    - ec2
+'''
+
+# FIXME: the command stuff needs a 'state' like alias to make things consistent -- MPD
+
+EXAMPLES = '''
+# Create snapshot
+- rds_snapshot:
+    instance_name: new-database
+    snapshot: new-database-snapshot
+
+# Delete snapshot
+- rds_snapshot:
+    snapshot: new-database-snapshot
+    state: absent
+
+- debug:
+    msg: "The new db endpoint is {{ rds.instance.endpoint }}"
+'''
+
+
+def await_resource(conn, resource, status, module):
+    wait_timeout = module.params.get('wait_timeout') + time.time()
+    while wait_timeout > time.time() and resource.status != status:
+        time.sleep(5)
+        if wait_timeout <= time.time():
+            module.fail_json(msg="Timeout waiting for RDS resource %s" % resource.name)
+        # Temporary until all the rds2 commands have their responses parsed
+        if resource.name is None:
+            module.fail_json(msg="There was a problem waiting for RDS snapshot %s" % resource.snapshot)
+        resource = get_db_snapshot(conn, resource.name)
+    return resource
+
+
+def delete_snapshot(module, conn):
+    snapshot = module.params.get('snapshot')
+
+    result = get_db_snapshot(conn, snapshot)
+    if not result:
+        module.exit_json(changed=False)
+    if result.status == 'deleting':
+        module.exit_json(changed=False)
+    try:
+        result = conn.delete_db_snapshot(DBSnapshotIdentifier=snapshot)
+    except Exception as e:
+        module.fail_json(msg="Failed to delete snapshot: %s" % e.message)
+
+    # If we're not waiting for a delete to complete then we're all done
+    # so just return
+    if not module.params.get('wait'):
+        module.exit_json(changed=True)
+    try:
+        await_resource(conn, result, 'deleted', module)
+        module.exit_json(changed=True)
+    except Exception as e:
+        if e.response['Error']['Code'] == 'DBSnapshotNotFound':
+            module.exit_json(changed=True)
+        else:
+            module.fail_json(msg=e.message)
+
+
+def create_snapshot(module, conn):
+    instance_name = module.params.get('instance_name')
+    if not instance_name:
+        module.fail_json(msg='instance_name is required for rds_snapshot when state=present')
+    snapshot_name = module.params.get('snapshot')
+    changed = False
+    snapshot = get_db_snapshot(conn, snapshot_name)
+    if not snapshot:
+        try:
+            resource = conn.create_db_snapshot(DBSnapshotIdentifier=snapshot_name,
+                                               DBInstanceIdentifier=instance_name)
+            snapshot = RDSSnapshot(resource['DBSnapshot'])
+            changed = True
+        except botocore.exceptions.ClientError as e:
+            module.fail_json(msg=e.message)
+
+    if module.params.get('wait'):
+        snapshot = await_resource(conn, snapshot, 'available', module)
+    else:
+        snapshot = get_db_snapshot(conn, snapshot_name)
+
+    module.exit_json(changed=changed, snapshot=snapshot.data)
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(
+        dict(
+            state = dict(choices=['present', 'absent'], default='present'),
+            snapshot = dict(required=True),
+            instance_name = dict(),
+            wait = dict(type='bool', default=False),
+            wait_timeout = dict(type='int', default=300),
+            tags = dict(type='dict', required=False),
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+    )
+
+    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
+    if not region:
+        module.fail_json(msg="Region not specified. Unable to determine region from EC2_REGION.")
+
+    # connect to the rds endpoint
+    conn = boto3_conn(module, 'client', 'rds', region, **aws_connect_params)
+
+    if module.params['state'] == 'absent':
+        delete_snapshot(module, conn)
+    else:
+        create_snapshot(module, conn)
+
+# import module snippets
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info, boto3_conn
+from ansible.module_utils.rds import RDSSnapshot, get_db_snapshot
+
+main()

--- a/lib/ansible/modules/cloud/amazon/rds_snapshot_facts.py
+++ b/lib/ansible/modules/cloud/amazon/rds_snapshot_facts.py
@@ -16,12 +16,12 @@
 
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
-                    'version': '1.0'}
+                    'metadata_version': '1.0'}
 
 DOCUMENTATION = '''
 ---
 module: rds_snapshot_facts
-version_added: "2.3"
+version_added: "2.4"
 short_description: obtain facts about one or more RDS snapshots
 description:
   - obtain facts about one or more RDS snapshots
@@ -160,4 +160,5 @@ def main():
     snapshot_facts(module, conn)
 
 
-main()
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/rds_snapshot_facts.py
+++ b/lib/ansible/modules/cloud/amazon/rds_snapshot_facts.py
@@ -85,7 +85,7 @@ snapshots:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info, boto3_conn, HAS_BOTO3
-from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list, camel_dict_to_snake_dict
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible.module_utils.rds import RDSSnapshot
 
 import traceback
@@ -135,9 +135,9 @@ def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(
         dict(
-            name = dict(aliases=['snapshot_name']),
-            instance_name = dict(),
-            snapshot_type = dict(choices=['automated', 'manual', 'shared', 'public'])
+            name=dict(aliases=['snapshot_name']),
+            instance_name=dict(),
+            snapshot_type=dict(choices=['automated', 'manual', 'shared', 'public'])
         )
     )
 

--- a/lib/ansible/modules/cloud/amazon/rds_snapshot_facts.py
+++ b/lib/ansible/modules/cloud/amazon/rds_snapshot_facts.py
@@ -1,0 +1,163 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = '''
+---
+module: rds_snapshot_facts
+version_added: "2.3"
+short_description: obtain facts about one or more RDS snapshots
+description:
+  - obtain facts about one or more RDS snapshots
+options:
+  name:
+    description:
+      - Name of an RDS snapshot. Mutually exclusive with I(instance_name)
+    required: false
+    aliases:
+      - snapshot_name
+  instance_name:
+    description:
+      - RDS instance name for which to find snapshots. Mutually exclusive with I(name)
+    required: false
+  snapshot_type:
+    description:
+      - Type of snapshot to find. By default both automated and manual
+        snapshots will be returned.
+    required: false
+    choices: ['automated', 'manual', 'shared', 'public']
+
+requirements:
+    - "python >= 2.6"
+    - "boto3"
+author:
+    - "Will Thames (@willthames)"
+extends_documentation_fragment:
+    - aws
+    - ec2
+'''
+
+EXAMPLES = '''
+# Get facts about an snapshot
+- rds_snapshot_facts:
+    name: snapshot_name
+  register: new_database_facts
+
+# Get all RDS snapshots for an RDS instance
+- rds_snapshot_facts:
+    instance_name: helloworld-rds-master
+'''
+
+RETURN = '''
+snapshots:
+    description: zero or more snapshots that match the (optional) parameters
+    type: list
+    returned: always
+    sample:
+       "snapshots": [
+           {
+               "availability_zone": "ap-southeast-2b",
+               "create_time": "2017-02-23T19:36:26.303000+00:00",
+               "id": "rds:helloworld-rds-master-2017-02-23-19-36",
+               "instance_created": "2017-02-16T23:04:16.619000+00:00",
+               "instance_id": "helloworld-rds-master",
+               "snapshot_type": "automated",
+               "status": "available"
+           }
+       ]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info, boto3_conn, HAS_BOTO3
+from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list, camel_dict_to_snake_dict
+from ansible.module_utils.rds import RDSSnapshot
+
+import traceback
+
+try:
+    import botocore
+except:
+    pass  # caught by imported HAS_BOTO3
+
+
+def snapshot_facts(module, conn):
+    snapshot_name = module.params.get('name')
+    snapshot_type = module.params.get('snapshot_type')
+    instance_name = module.params.get('instance_name')
+
+    params = dict()
+    if snapshot_name:
+        params['DBSnapshotIdentifier'] = snapshot_name
+    if instance_name:
+        params['DBInstanceIdentifier'] = instance_name
+    if snapshot_type:
+        params['SnapshotType'] = snapshot_type
+        if snapshot_type == 'public':
+            params['IsPublic'] = True
+        elif snapshot_type == 'shared':
+            params['IsShared'] = True
+
+    marker = ''
+    results = list()
+    while True:
+        try:
+            response = conn.describe_db_snapshots(Marker=marker, **params)
+            results.extend(response['DBSnapshots'])
+            marker = response.get('Marker')
+        except botocore.exceptions.ClientError as e:
+            if e.response['Error']['Code'] == 'DBSnapshotNotFound':
+                break
+            module.fail_json(msg=str(e), exception=traceback.format_exc(),
+                             **camel_dict_to_snake_dict(e.response))
+        if not marker:
+            break
+
+    module.exit_json(changed=False, snapshots=[RDSSnapshot(snapshot).data for snapshot in results])
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(
+        dict(
+            name = dict(aliases=['snapshot_name']),
+            instance_name = dict(),
+            snapshot_type = dict(choices=['automated', 'manual', 'shared', 'public'])
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        mutually_exclusive=[['name', 'instance_name']],
+    )
+
+    if not HAS_BOTO3:
+        module.fail_json(msg="botocore and boto3 are required for rds_facts module")
+
+    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
+    if not region:
+        module.fail_json(msg="Region not specified. Unable to determine region from configuration.")
+
+    # connect to the rds endpoint
+    conn = boto3_conn(module, 'client', 'rds', region, **aws_connect_params)
+
+    snapshot_facts(module, conn)
+
+
+main()

--- a/test/integration/amazon.yml
+++ b/test/integration/amazon.yml
@@ -14,6 +14,7 @@
     - { role: test_ec2_asg, tags: test_ec2_asg }
     - { role: test_ec2_vpc_nat_gateway, tags: test_ec2_vpc_nat_gateway }
     - { role: test_ecs_ecr, tags: test_ecs_ecr }
+    - { role: test_rds, tags: test_rds }
 
 # complex test for ec2_elb, split up over multiple plays
 # since there is a setup component as well as the test which

--- a/test/integration/roles/test_rds/README.md
+++ b/test/integration/roles/test_rds/README.md
@@ -1,0 +1,38 @@
+Role Name
+========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+-------------------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/test/integration/roles/test_rds/defaults/main.yml
+++ b/test/integration/roles/test_rds/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for test_rds

--- a/test/integration/roles/test_rds/handlers/main.yml
+++ b/test/integration/roles/test_rds/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for test_rds

--- a/test/integration/roles/test_rds/meta/main.yml
+++ b/test/integration/roles/test_rds/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/test/integration/roles/test_rds/tasks/main.yml
+++ b/test/integration/roles/test_rds/tasks/main.yml
@@ -40,11 +40,12 @@
   rds_snapshot:
     instance_name: "{{ instance_name }}"
     snapshot: "{{ instance_name }}-snapshot"
+    wait_timeout: 1200
     wait: yes
 
 - name: get snapshot facts
   rds_snapshot_facts:
-    snapshot: "{{ instance_name }}-snapshot"
+    instance_name: "{{ instance_name }}"
 
 - name: delete snapshot
   rds_snapshot:

--- a/test/integration/roles/test_rds/tasks/main.yml
+++ b/test/integration/roles/test_rds/tasks/main.yml
@@ -33,7 +33,7 @@
     var: rds_instance
 
 - name: get instance facts
-  rds_facts:
+  rds_instance_facts:
     instance_name: "{{ instance_name }}"
 
 - name: snapshot instance
@@ -42,8 +42,8 @@
     snapshot: "{{ instance_name }}-snapshot"
     wait: yes
 
-- name: get instance facts
-  rds_facts:
+- name: get snapshot facts
+  rds_snapshot_facts:
     snapshot: "{{ instance_name }}-snapshot"
 
 - name: delete snapshot

--- a/test/integration/roles/test_rds/tasks/main.yml
+++ b/test/integration/roles/test_rds/tasks/main.yml
@@ -96,7 +96,7 @@
 
 - name: check non modify worked
   assert:
-    that: not rds_instance_modify|changed
+    that: not rds_instance_no_modify|changed
 
 - name: create rds replica
   rds_instance:
@@ -104,10 +104,11 @@
     source_instance: "{{ instance_name }}"
     wait: yes
 
-- name: promote rds replica
-  rds_instance:
-    instance_name: "{{ instance_name }}-replica"
-    wait: yes
+# #NOT YET WORKING - bombs out with "No modifications were requested"
+# - name: promote rds replica
+#   rds_instance:
+#     instance_name: "{{ instance_name }}-replica"
+#     wait: yes
 
 - name: delete rds instance
   rds_instance:

--- a/test/integration/roles/test_rds/tasks/main.yml
+++ b/test/integration/roles/test_rds/tasks/main.yml
@@ -7,6 +7,13 @@
     #instance_name: "rds-{{ random_string }}"
     instance_name: rds-yunrxdbj
 
+# important in case we restart the tests after a fail.
+- name: ensure instance we are going to create is not present so create test is valid
+  rds_instance:
+    instance_name: "{{ instance_name }}"
+    wait: yes
+    state: absent
+
 - name: ensure non-existent instance is not present
   rds_instance:
     instance_name: "rds-XYZ-{{ random_string }}"
@@ -20,6 +27,7 @@
 - name: create rds instance
   rds_instance:
     instance_name: "{{ instance_name }}"
+    wait_timeout: 1200
     wait: yes
     size: 5
     instance_type: db.t2.micro
@@ -51,6 +59,10 @@
   rds_snapshot:
     snapshot: "{{ instance_name }}-snapshot"
     state: absent
+
+- name: get instance facts again to debug
+  rds_instance_facts:
+    instance_name: "{{ instance_name }}"
 
 - name: modify rds instance
   rds_instance:
@@ -85,7 +97,6 @@
 - name: check non modify worked
   assert:
     that: not rds_instance_modify|changed
-
 
 - name: create rds replica
   rds_instance:

--- a/test/integration/roles/test_rds/tasks/main.yml
+++ b/test/integration/roles/test_rds/tasks/main.yml
@@ -1,0 +1,123 @@
+---
+# tasks file for test_rds
+
+- name: set instance name to use
+  set_fact:
+  args:
+    #instance_name: "rds-{{ random_string }}"
+    instance_name: rds-yunrxdbj
+
+- name: ensure non-existent instance is not present
+  rds_instance:
+    instance_name: "rds-XYZ-{{ random_string }}"
+    state: absent
+
+- name: ensure non-existent snapshot is not present
+  rds_snapshot:
+    snapshot: "snapshot-XYZ-{{ random_string }}"
+    state: absent
+
+- name: create rds instance
+  rds_instance:
+    instance_name: "{{ instance_name }}"
+    wait: yes
+    size: 5
+    instance_type: db.t2.micro
+    db_engine: postgres
+    username: hello
+    password: "world123$$"
+  register: rds_instance
+
+- name: show instance details
+  debug:
+    var: rds_instance
+
+- name: get instance facts
+  rds_facts:
+    instance_name: "{{ instance_name }}"
+
+- name: snapshot instance
+  rds_snapshot:
+    instance_name: "{{ instance_name }}"
+    snapshot: "{{ instance_name }}-snapshot"
+    wait: yes
+
+- name: get instance facts
+  rds_facts:
+    snapshot: "{{ instance_name }}-snapshot"
+
+- name: delete snapshot
+  rds_snapshot:
+    snapshot: "{{ instance_name }}-snapshot"
+    state: absent
+
+- name: modify rds instance
+  rds_instance:
+    instance_name: "{{ instance_name }}"
+    wait: yes
+    size: 5
+    instance_type: db.t2.micro
+    db_engine: postgres
+    username: hello
+    port: 3307
+    apply_immediately: yes
+    wait: yes
+  register: rds_instance_modify
+
+- name: check modify instance changed
+  assert:
+    that: rds_instance_modify|changed
+
+- name: don't modify rds instance
+  rds_instance:
+    instance_name: "{{ instance_name }}"
+    wait: yes
+    size: 5
+    instance_type: db.t2.micro
+    db_engine: postgres
+    username: hello
+    port: 3307
+    apply_immediately: yes
+    wait: yes
+  register: rds_instance_no_modify
+
+- name: check non modify worked
+  assert:
+    that: not rds_instance_modify|changed
+
+
+- name: create rds replica
+  rds_instance:
+    instance_name: "{{ instance_name }}-replica"
+    source_instance: "{{ instance_name }}"
+    wait: yes
+
+- name: promote rds replica
+  rds_instance:
+    instance_name: "{{ instance_name }}-replica"
+    wait: yes
+
+- name: delete rds instance
+  rds_instance:
+    instance_name: "{{ instance_name }}"
+    state: absent
+    snapshot: "{{ instance_name }}-snapshot"
+    wait: yes
+
+- name: delete replica
+  rds_instance:
+    instance_name: "{{ instance_name }}-replica"
+    state: absent
+    wait: yes
+
+- name: restore from snapshot
+  rds_instance:
+    instance_name: "{{ instance_name }}-restore"
+    snapshot: "{{ instance_name }}-snapshot"
+    wait: yes
+
+- name: delete restored instance
+  rds_instance:
+    instance_name: "{{ instance_name }}-restore"
+    state: absent
+    wait: yes

--- a/test/integration/roles/test_rds/vars/main.yml
+++ b/test/integration/roles/test_rds/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for test_rds

--- a/test/integration/roles/test_rds_old_new/tasks/main.yml
+++ b/test/integration/roles/test_rds_old_new/tasks/main.yml
@@ -1,0 +1,196 @@
+  - name: Given that I have created an RDS with the old rds module
+    tags: test_amazon_rds
+    local_action:
+      module: rds
+      region: "{{ ec2_region }}"
+      command: create
+      instance_name: "{{ resource_prefix }}-rds"
+      db_engine: postgres
+      size: 10
+      instance_type: "db.t2.micro"
+      username: "{{ rds_master_db_user }}"
+      password: "{{ rds_db_master_password }}"
+      publicly_accessible: no
+      wait: yes
+      wait_timeout: 1200 # 600 doesn't cut it!!
+    register: rds_result
+
+  - name: When I run the new module with unchanged parameters
+    tags: test_amazon_rds
+    local_action:
+      module: rds_instance
+      region: "{{ ec2_region }}"
+      state: present
+      instance_name: "{{ resource_prefix }}-rds"
+      db_engine: postgres
+      size: 10
+      instance_type: "db.t2.micro"
+      username: "{{ rds_master_db_user }}"
+      password: "{{ rds_db_master_password }}"
+      publicly_accessible: no
+      wait: yes
+      wait_timeout: 1200 # 600 doesn't cut it!!
+    register: rds_instance_result
+
+  - name: Then the RDS should not be changed
+    tags: test_amazon_rds
+    assert:
+      that:
+        - 'rds_result.changed'
+        - 'rds_instance_result.changed == False'
+        - '"failed" not in rds_result'
+        - '"failed" not in rds_instance_result'
+#ETC..  
+
+
+  # note; we probably inherit the RDS from the previous test
+  # which will be faster.
+  - name: Given that I have created an RDS with the old rds module
+    tags: test_amazon_rds
+    local_action:
+      module: rds
+      region: "{{ ec2_region }}"
+      command: create
+      instance_name: "{{ resource_prefix }}-rds"
+      db_engine: postgres
+      size: 10
+      instance_type: "db.t2.micro"
+      username: "{{ rds_master_db_user }}"
+      password: "{{ rds_db_master_password }}"
+      publicly_accessible: no
+      wait: yes
+      wait_timeout: 1200 # 600 doesn't cut it!!
+    register: rds_result
+
+
+  - name: When I run the new module with SSD configuration
+    tags: test_amazon_rds
+    local_action:
+      module: rds_instance
+      region: "{{ ec2_region }}"
+      state: present
+      storage_type: gp2
+      instance_name: "{{ resource_prefix }}-rds"
+      db_engine: postgres
+      size: 10
+      instance_type: "db.t2.micro"
+      username: "{{ rds_master_db_user }}"
+      password: "{{ rds_db_master_password }}"
+      publicly_accessible: no
+      wait: yes
+      wait_timeout: 1200 # 600 doesn't cut it!!
+    register: result
+
+  - name: Then the RDS should have SSD disks
+    assert:
+      that:
+        - 'result.instance[0].storage_type == "gp2"'
+
+#We should probably delete the RDS at this point
+
+  - name: Given that I have created an RDS with the new rds_instance module
+    tags: test_amazon_rds
+    local_action:
+      module: rds_instance
+      region: "{{ ec2_region }}"
+      state: present
+      storage_type: gp2
+      instance_name: "{{ resource_prefix }}-rds"
+      db_engine: postgres
+      size: 10
+      instance_type: "db.t2.micro"
+      username: "{{ rds_master_db_user }}"
+      password: "{{ rds_db_master_password }}"
+      publicly_accessible: no
+      wait: yes
+      wait_timeout: 1200 # 600 doesn't cut it!!
+    register: result
+
+  - name: When I run the old module with matching parameters
+    tags: test_amazon_rds
+    local_action:
+      module: rds
+      region: "{{ ec2_region }}"
+      command: create
+      instance_name: "{{ resource_prefix }}-rds"
+      db_engine: postgres
+      size: 10
+      instance_type: "db.t2.micro"
+      username: "{{ rds_master_db_user }}"
+      password: "{{ rds_db_master_password }}"
+      publicly_accessible: no
+      wait: yes
+      wait_timeout: 1200 # 600 doesn't cut it!!
+    register: rds_result
+
+  - name: And I check the configuration with the new rds_instance module
+    tags: test_amazon_rds
+    local_action:
+      module: rds_instance
+      region: "{{ ec2_region }}"
+      state: present
+      storage_type: gp2
+      instance_name: "{{ resource_prefix }}-rds"
+      db_engine: postgres
+      size: 10
+      instance_type: "db.t2.micro"
+      username: "{{ rds_master_db_user }}"
+      password: "{{ rds_db_master_password }}"
+      publicly_accessible: no
+      wait: yes
+      wait_timeout: 1200 # 600 doesn't cut it!!
+    register: result
+
+  - name: Then the RDS should not be changed
+    tags: test_amazon_rds
+    assert:
+      that:
+        - 'result.changed == False'
+        - '"failed" not in result'
+        - 'result.instance[0].storage_type == "gp2"'
+
+  - name: Given that I have an RDS with SSD disks
+    tags: test_amazon_rds
+    local_action:
+      module: rds_instance
+      region: "{{ ec2_region }}"
+      state: present
+      storage_type: gp2
+      instance_name: "{{ resource_prefix }}-rds"
+      db_engine: postgres
+      size: 10
+      instance_type: "db.t2.micro"
+      username: "{{ rds_master_db_user }}"
+      password: "{{ rds_db_master_password }}"
+      publicly_accessible: no
+      wait: yes
+      wait_timeout: 1200 # 600 doesn't cut it!!
+    register: result
+
+#Currently covered by previous test - but check that if changing
+#  - name: When I run the old module with matching parameters except SSD
+#  - name: Then the RDS should not be changed
+#  - name: And the RDS should have SSD disks
+
+#@future?
+  # - name: Given that I create an RDS which has parameters unsupported by the old module
+  # - name: Then that module should have a default tag warning that it is new
+  # - name: And the old rds module should refuse to update RDS
+  # - name: Given that I have an RDS instance
+
+# see https://github.com/ansible/ansible/issues/20395 which should be updated
+# when this test is implemented.
+
+  # - name: When I attempt to modify that instance adding new tags
+  # tasks:
+  #   rds:
+  #     command: modify
+  #     instance_name: "{{ item.name }}"
+  #     tags:
+  #       dept: "{{ item.dept }}"
+  #       app_name: "{{ item.app_name }}"
+  #       project_name: "{{ item.project_name }}"
+  #       owner_email: "{{ item.owner_email }}"
+
+  # - name: Then those tags should be added to the RDS instance.
+  

--- a/test/integration/roles/test_rds_old_new/vars/main.yml
+++ b/test/integration/roles/test_rds_old_new/vars/main.yml
@@ -1,0 +1,2 @@
+rds_master_db_user: db_user
+rds_db_master_password: "{{ lookup('password', '/dev/null chars=ascii_letters,digits') }}"

--- a/test/units/modules/cloud/amazon/test_rds.py
+++ b/test/units/modules/cloud/amazon/test_rds.py
@@ -18,7 +18,7 @@
 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
-from ansible.compat.tests.mock import MagicMock, Mock, patch, ANY
+from ansible.compat.tests.mock import MagicMock, patch, ANY
 
 # This module should run in all cases where boto, boto3 or both are
 # present.  Individual test cases should then be ready to skip if their
@@ -27,51 +27,50 @@ import ansible.modules.cloud.amazon.rds_instance as rds_i
 import ansible.module_utils.rds as rds_u
 
 from ansible.module_utils.basic import AnsibleModule
-import ansible.module_utils.basic as ba
+import ansible.module_utils.basic as basic
 from ansible.module_utils.rds import RDSDBInstance
 import pytest
-import pdb
 import time
 boto3 = pytest.importorskip("boto3")
 boto = pytest.importorskip("boto")
 
-def diff_return_a_populated_dict(junk,junktoo):
+def diff_return_a_populated_dict(junk, junktoo):
     """ return a populated dict which will be treated as true => something changed """
-    return {"before":"fake","after":"faketoo"}
+    return {"before":"fake", "after":"faketoo"}
 
 
 def test_modify_should_return_changed_if_param_changes():
-    ba._ANSIBLE_ARGS='{"ANSIBLE_MODULE_ARGS":{"instance_name":"fred", "port": 242}}'
-    params={"port":342,"force_password_update":True,"instance_name":"fred"}
+    basic._ANSIBLE_ARGS = '{ "ANSIBLE_MODULE_ARGS": { "instance_name":"fred", "port": 242} }'
+    params = { "port": 342, "force_password_update": True, "instance_name": "fred" }
     rds_client_double = MagicMock()
-    module_double = MagicMock(AnsibleModule(argument_spec=rds_i.argument_spec,
-                                            required_if=rds_i.required_if), params=params)
+    module_double = MagicMock(AnsibleModule( argument_spec = rds_i.argument_spec,
+                                             required_if = rds_i.required_if ), params = params)
     with patch.object(RDSDBInstance, 'diff', diff_return_a_populated_dict):
         rds_i.modify_db_instance(module_double, rds_client_double)
     print("rds calls:\n" + str(rds_client_double.mock_calls))
     print("module calls:\n" + str(module_double.mock_calls))
-    module_double.exit_json.assert_called_with(changed=True, diff=ANY, instance=ANY,
-                                               operation='modify')
+    module_double.exit_json.assert_called_with(changed = True, diff = ANY, instance = ANY,
+                                               operation = 'modify')
 
 
 def test_modify_should_return_false_in_changed_if_param_same():
-    ba._ANSIBLE_ARGS='{"ANSIBLE_MODULE_ARGS":{"instance_name":"fred", "port": 342}}'
-    params={"port":342,"force_password_update":True,"instance_name":"fred"}
+    basic._ANSIBLE_ARGS = '{ "ANSIBLE_MODULE_ARGS": { "instance_name":"fred", "port": 342} }'
+    params = { "port": 342, "force_password_update": True, "instance_name": "fred" }
     rds_client_double = MagicMock()
-    module_double = MagicMock(AnsibleModule(argument_spec=rds_i.argument_spec,
-                                            required_if=rds_i.required_if), params=params)
+    module_double = MagicMock(AnsibleModule(argument_spec = rds_i.argument_spec,
+                                            required_if = rds_i.required_if), params = params)
     rds_i.modify_db_instance(module_double, rds_client_double)
     print("rds calls:\n" + str(rds_client_double.mock_calls))
     print("module calls:\n" + str(module_double.mock_calls))
-    module_double.exit_json.assert_called_with(changed=False, diff=ANY, instance=ANY,
-                                               operation='modify')
+    module_double.exit_json.assert_called_with(changed = False, diff = ANY, instance = ANY,
+                                               operation = 'modify')
 
 
 def test_diff_should_be_true_if_something_changed():
     dbinstance_double = MagicMock()
     rdi = rds_u.RDSDBInstance(dbinstance_double)
-    params={"port":342,"iops":3924,"instance_name":"fred"}
-    diff=rdi.diff(params)
+    params = { "port": 342, "iops": 3924, "instance_name": "fred" }
+    diff = rdi.diff(params)
     print("diff:\n" + str(diff))
     print("dbinstance calls:\n" + str(dbinstance_double.mock_calls))
     assert(not not diff)
@@ -80,25 +79,25 @@ def test_diff_should_be_true_if_something_changed():
 def test_diff_should_be_true_if_only_the_port_changed():
     dbinstance_double = MagicMock()
     rdi = rds_u.RDSDBInstance(dbinstance_double)
-    params={"endpoint":{"port":342}}
-    diff=rdi.diff(params)
+    params = { "endpoint": {"port": 342} }
+    diff = rdi.diff(params)
     print("diff:\n" + str(diff))
     print("dbinstance calls:\n" + str(dbinstance_double.mock_calls))
     assert(not not diff)
 
 
 def test_await_should_wait_till_not_pending():
-    sleeper_double=MagicMock()
-    get_db_instance_double = MagicMock(side_effect=[
-        MagicMock(status='rebooting', data={ "pending_modified_values":  {"a":"b", "c":"d"}}),
-        MagicMock(status='available', data={ "pending_modified_values":  {"a":"b", "c":"d"}}),
-        MagicMock(status='rebooting', data={ "pending_modified_values":  {"a":"b"}}),
-        MagicMock(status='rebooting', data={ "pending_modified_values":  {"a":"b", "c":"d"}}),
-        MagicMock(status='rebooting', data={ "pending_modified_values":  {}}),
-        MagicMock(status='available', data={ "pending_modified_values":  {"a":"b", "c":"d"}}),
-        MagicMock(status='rebooting', data={ "pending_modified_values":  {"a":"b", "c":"d"}}),
-        MagicMock(status='available', data={ "pending_modified_values":  {}}),
-        MagicMock(status='available', data={ "pending_modified_values":  {}}),
+    sleeper_double = MagicMock()
+    get_db_instance_double = MagicMock(side_effect = [
+        MagicMock( status = 'rebooting', data = { "pending_modified_values":  {"a":"b", "c":"d"}}),
+        MagicMock( status = 'available', data = { "pending_modified_values":  {"a":"b", "c":"d"}}),
+        MagicMock( status = 'rebooting', data = { "pending_modified_values":  {"a":"b"}}),
+        MagicMock( status = 'rebooting', data = { "pending_modified_values":  {"a":"b", "c":"d"}}),
+        MagicMock( status = 'rebooting', data = { "pending_modified_values":  {}}),
+        MagicMock( status = 'available', data = { "pending_modified_values":  {"a":"b", "c":"d"}}),
+        MagicMock( status = 'rebooting', data = { "pending_modified_values":  {"a":"b", "c":"d"}}),
+        MagicMock( status = 'available', data = { "pending_modified_values":  {}}),
+        MagicMock( status = 'available', data = { "pending_modified_values":  {}}),
     ])
     with patch.object(time, 'sleep',sleeper_double):
         with patch.object(rds_i, 'get_db_instance', get_db_instance_double):
@@ -113,19 +112,19 @@ def test_await_should_wait_till_not_pending():
 def test_await_should_wait_for_delete_and_handle_none():
     sleeper_double=MagicMock()
     get_db_instance_double = MagicMock(side_effect=[
-        MagicMock(status='rebooting', data={ "pending_modified_values":  {"a":"b", "c":"d"}}),
-        MagicMock(status='available', data={ "pending_modified_values":  {"a":"b", "c":"d"}}),
-        MagicMock(status='rebooting', data={ "pending_modified_values":  {"a":"b"}}),
-        MagicMock(status='rebooting', data={ "pending_modified_values":  {}}),
-        MagicMock(status='rebooting', data={ "pending_modified_values":  {"a":"b", "c":"d"}}),
-        MagicMock(status='deleting', data={ "pending_modified_values":  {}}),
+        MagicMock( status = 'rebooting', data = { "pending_modified_values":  {"a":"b", "c":"d"}}),
+        MagicMock( status = 'available', data = { "pending_modified_values":  {"a":"b", "c":"d"}}),
+        MagicMock( status = 'rebooting', data = { "pending_modified_values":  {"a":"b"}}),
+        MagicMock( status = 'rebooting', data = { "pending_modified_values":  {}}),
+        MagicMock( status = 'rebooting', data = { "pending_modified_values":  {"a":"b", "c":"d"}}),
+        MagicMock( status = 'deleting', data = { "pending_modified_values":  {}}),
         None,
         None,
     ])
     with patch.object(time, 'sleep',sleeper_double):
         with patch.object(rds_i, 'get_db_instance', get_db_instance_double):
             rds_i.await_resource(MagicMock(), MagicMock(), "deleted", MagicMock(),
-                                 await_pending=1)
+                                 await_pending = p1)
 
     print("dbinstance calls:\n" + str(get_db_instance_double.mock_calls))
     assert(len(sleeper_double.mock_calls) > 3), "await_pending didn't wait enough"

--- a/test/units/modules/cloud/amazon/test_rds.py
+++ b/test/units/modules/cloud/amazon/test_rds.py
@@ -18,12 +18,59 @@
 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
+from ansible.compat.tests.mock import MagicMock, Mock, patch, ANY
 
 # This module should run in all cases where boto, boto3 or both are
 # present.  Individual test cases should then be ready to skip if their
 # pre-requisites are not present.
+import ansible.modules.cloud.amazon.rds_instance as rds_i
+import ansible.module_utils.rds as rds_u
 
+from ansible.module_utils.basic import AnsibleModule
+import ansible.module_utils.basic as ba
+from ansible.module_utils.rds import RDSDBInstance
 import pytest
+import pdb
 boto3 = pytest.importorskip("boto3")
 boto = pytest.importorskip("boto")
 
+def diff_return_a_populated_dict(junk,junktoo):
+    """ return a populated dict which will be treated as true => something changed """
+    return {"before":"fake","after":"faketoo"}
+
+def test_modify_should_return_changed_if_param_changes():
+    ba._ANSIBLE_ARGS='{"ANSIBLE_MODULE_ARGS":{"instance_name":"fred", "port": 242}}'
+    params={"port":342,"force_password_update":True,"instance_name":"fred"}
+    rds_client_double = MagicMock()
+    module_double = MagicMock(AnsibleModule(argument_spec=rds_i.argument_spec,
+                                            required_if=rds_i.required_if), params=params)
+    with patch.object(RDSDBInstance, 'diff', diff_return_a_populated_dict):
+        rds_i.modify_db_instance(module_double, rds_client_double)
+    print("rds calls:\n" + str(rds_client_double.mock_calls))
+    print("module calls:\n" + str(module_double.mock_calls))
+    module_double.exit_json.assert_called_with(changed=True, diff=ANY, instance=ANY,
+                                               operation='modify')
+
+
+def test_modify_should_return_false_in_changed_if_param_same():
+    ba._ANSIBLE_ARGS='{"ANSIBLE_MODULE_ARGS":{"instance_name":"fred", "port": 342}}'
+    params={"port":342,"force_password_update":True,"instance_name":"fred"}
+    rds_client_double = MagicMock()
+#    pdb.set_trace()
+    module_double = MagicMock(AnsibleModule(argument_spec=rds_i.argument_spec,
+                                            required_if=rds_i.required_if), params=params)
+    rds_i.modify_db_instance(module_double, rds_client_double)
+    print("rds calls:\n" + str(rds_client_double.mock_calls))
+    print("module calls:\n" + str(module_double.mock_calls))
+    module_double.exit_json.assert_called_with(changed=False, diff=ANY, instance=ANY,
+                                               operation='modify')
+
+
+def test_diff_should_be_true_if_something_changed():
+    dbinstance_double = MagicMock()
+    rdi = rds_u.RDSDBInstance(dbinstance_double)
+    params={"port":342,"force_password_update":True,"instance_name":"fred"}
+    diff=rdi.diff(params)
+    print("diff:\n" + str(diff))
+    print("dbinstance calls:\n" + str(dbinstance_double.mock_calls))
+    assert(not not diff)

--- a/test/units/modules/cloud/amazon/test_rds.py
+++ b/test/units/modules/cloud/amazon/test_rds.py
@@ -31,12 +31,14 @@ import ansible.module_utils.basic as ba
 from ansible.module_utils.rds import RDSDBInstance
 import pytest
 import pdb
+import time
 boto3 = pytest.importorskip("boto3")
 boto = pytest.importorskip("boto")
 
 def diff_return_a_populated_dict(junk,junktoo):
     """ return a populated dict which will be treated as true => something changed """
     return {"before":"fake","after":"faketoo"}
+
 
 def test_modify_should_return_changed_if_param_changes():
     ba._ANSIBLE_ARGS='{"ANSIBLE_MODULE_ARGS":{"instance_name":"fred", "port": 242}}'
@@ -56,7 +58,6 @@ def test_modify_should_return_false_in_changed_if_param_same():
     ba._ANSIBLE_ARGS='{"ANSIBLE_MODULE_ARGS":{"instance_name":"fred", "port": 342}}'
     params={"port":342,"force_password_update":True,"instance_name":"fred"}
     rds_client_double = MagicMock()
-#    pdb.set_trace()
     module_double = MagicMock(AnsibleModule(argument_spec=rds_i.argument_spec,
                                             required_if=rds_i.required_if), params=params)
     rds_i.modify_db_instance(module_double, rds_client_double)
@@ -69,8 +70,63 @@ def test_modify_should_return_false_in_changed_if_param_same():
 def test_diff_should_be_true_if_something_changed():
     dbinstance_double = MagicMock()
     rdi = rds_u.RDSDBInstance(dbinstance_double)
-    params={"port":342,"force_password_update":True,"instance_name":"fred"}
+    params={"port":342,"iops":3924,"instance_name":"fred"}
     diff=rdi.diff(params)
     print("diff:\n" + str(diff))
     print("dbinstance calls:\n" + str(dbinstance_double.mock_calls))
     assert(not not diff)
+
+
+def test_diff_should_be_true_if_only_the_port_changed():
+    dbinstance_double = MagicMock()
+    rdi = rds_u.RDSDBInstance(dbinstance_double)
+    params={"endpoint":{"port":342}}
+    diff=rdi.diff(params)
+    print("diff:\n" + str(diff))
+    print("dbinstance calls:\n" + str(dbinstance_double.mock_calls))
+    assert(not not diff)
+
+
+def test_await_should_wait_till_not_pending():
+    sleeper_double=MagicMock()
+    get_db_instance_double = MagicMock(side_effect=[
+        MagicMock(status='rebooting', data={ "pending_modified_values":  {"a":"b", "c":"d"}}),
+        MagicMock(status='available', data={ "pending_modified_values":  {"a":"b", "c":"d"}}),
+        MagicMock(status='rebooting', data={ "pending_modified_values":  {"a":"b"}}),
+        MagicMock(status='rebooting', data={ "pending_modified_values":  {"a":"b", "c":"d"}}),
+        MagicMock(status='rebooting', data={ "pending_modified_values":  {}}),
+        MagicMock(status='available', data={ "pending_modified_values":  {"a":"b", "c":"d"}}),
+        MagicMock(status='rebooting', data={ "pending_modified_values":  {"a":"b", "c":"d"}}),
+        MagicMock(status='available', data={ "pending_modified_values":  {}}),
+        MagicMock(status='available', data={ "pending_modified_values":  {}}),
+    ])
+    with patch.object(time, 'sleep',sleeper_double):
+        with patch.object(rds_i, 'get_db_instance', get_db_instance_double):
+            rds_i.await_resource(MagicMock(), MagicMock(), "available", MagicMock(),
+                                 await_pending=1)
+
+    print("dbinstance calls:\n" + str(get_db_instance_double.mock_calls))
+    assert(len(sleeper_double.mock_calls) > 5), "await_pending didn't wait enough"
+    assert(len(get_db_instance_double.mock_calls) > 7), "await_pending didn't wait enough"
+
+
+def test_await_should_wait_for_delete_and_handle_none():
+    sleeper_double=MagicMock()
+    get_db_instance_double = MagicMock(side_effect=[
+        MagicMock(status='rebooting', data={ "pending_modified_values":  {"a":"b", "c":"d"}}),
+        MagicMock(status='available', data={ "pending_modified_values":  {"a":"b", "c":"d"}}),
+        MagicMock(status='rebooting', data={ "pending_modified_values":  {"a":"b"}}),
+        MagicMock(status='rebooting', data={ "pending_modified_values":  {}}),
+        MagicMock(status='rebooting', data={ "pending_modified_values":  {"a":"b", "c":"d"}}),
+        MagicMock(status='deleting', data={ "pending_modified_values":  {}}),
+        None,
+        None,
+    ])
+    with patch.object(time, 'sleep',sleeper_double):
+        with patch.object(rds_i, 'get_db_instance', get_db_instance_double):
+            rds_i.await_resource(MagicMock(), MagicMock(), "deleted", MagicMock(),
+                                 await_pending=1)
+
+    print("dbinstance calls:\n" + str(get_db_instance_double.mock_calls))
+    assert(len(sleeper_double.mock_calls) > 3), "await_pending didn't wait enough"
+    assert(len(get_db_instance_double.mock_calls) > 5), "await_pending didn't wait enough"

--- a/test/units/modules/cloud/amazon/test_rds.py
+++ b/test/units/modules/cloud/amazon/test_rds.py
@@ -1,0 +1,29 @@
+#
+# (c) 2017 Michael De La Rue
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+
+# This module should run in all cases where boto, boto3 or both are
+# present.  Individual test cases should then be ready to skip if their
+# pre-requisites are not present.
+
+import pytest
+boto3 = pytest.importorskip("boto3")
+boto = pytest.importorskip("boto")
+


### PR DESCRIPTION
##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
amazon RDS

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 9f2d8c2409) last updated 2017/01/02 18:37:06 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Split the existing rds module into three separate modules, and make the modules idempotent (remove the `command` argument).

The new modules are expected to be almost entirely backward compatible with the old module, other than the command change - it should be easy to update existing code to use the new modules.

The new modules are entirely boto3 -  support for boto has been dropped for the new modules.

This is currently a work in progress, there are likely to be bugs, but a lot of the key features work as it stands. 

I have also added a test suite that exercises all of the modules so that people can verify that things are working as expected.

If people find issues with this PR, the easiest way to improve the new modules while this PR is unmerged would be a PR against my branch - I can then incorporate your commits into this PR.

Implements ansible/ansible-modules-core#5343

## Known issues at time of PR

* Use of `q` module for debugging
* Some modifications don't really work as expected - #19751 might apply equally here
* Test suite takes a really long time and state transitions are very slow, so haven't yet had a successful run through.