### PR TITLE
 AWS inventory: ignore permission errors

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -590,7 +590,7 @@ class Ec2Inventory(object):
                 error = self.get_auth_error_message()
             if not e.reason == "Forbidden":
                 error = "Looks like AWS RDS is down:\n%s" % e.message
-            self.fail_with_error(error, 'getting RDS instances')
+                self.fail_with_error(error, 'getting RDS instances')
 
     def include_rds_clusters_by_region(self, region):
         if not HAS_BOTO3:
@@ -672,7 +672,9 @@ class Ec2Inventory(object):
                 error = self.get_auth_error_message()
             if not e.reason == "Forbidden":
                 error = "Looks like AWS ElastiCache is down:\n%s" % e.message
-            self.fail_with_error(error, 'getting ElastiCache clusters')
+                self.fail_with_error(error, 'getting ElastiCache clusters')
+            else:
+                return
 
         try:
             # Boto also doesn't provide wrapper classes to CacheClusters or
@@ -706,7 +708,9 @@ class Ec2Inventory(object):
                 error = self.get_auth_error_message()
             if not e.reason == "Forbidden":
                 error = "Looks like AWS ElastiCache [Replication Groups] is down:\n%s" % e.message
-            self.fail_with_error(error, 'getting ElastiCache clusters')
+                self.fail_with_error(error, 'getting ElastiCache clusters')
+            else:
+                return
 
         try:
             # Boto also doesn't provide wrapper classes to ReplicationGroups


### PR DESCRIPTION


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2 inventory script

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 9f2d8c2409) last updated 2017/01/02 18:37:06 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Ensure that AWS inventory gathering failures due to lack of
permissions result in a lack of that information, rather than
errors causing no information at all.

Refixes #5236
