### PR TITLE
shuffle filter: added optional 'seed' parameter

### DIFF
--- a/docsite/rst/playbooks_filters.rst
+++ b/docsite/rst/playbooks_filters.rst
@@ -185,6 +185,10 @@ To get a random list from an existing  list::
     {{ ['a','b','c']|shuffle }} => ['c','a','b']
     {{ ['a','b','c']|shuffle }} => ['b','c','a']
 
+As of Ansible version 2.3, it's also possible to shuffle a list idempotent. All you need is a seed.::
+
+    {{ ['a','b','c']|shuffle(seed=inventory_hostname) }} => ['b','a','c']
+
 note that when used with a non 'listable' item it is a noop, otherwise it always returns a list
 
 

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -217,10 +217,14 @@ def rand(environment, end, start=None, step=None, seed=None):
     else:
         raise errors.AnsibleFilterError('random can only be used on sequences and integers')
 
-def randomize_list(mylist):
+def randomize_list(mylist, seed=None):
     try:
         mylist = list(mylist)
-        shuffle(mylist)
+        if seed:
+            r = Random(seed)
+            r.shuffle(mylist)
+        else:
+            shuffle(mylist)
     except:
         pass
     return mylist


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
core filter - shuffle

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adds optional seed parameter to shuffle filter.

One usecase is the resolv.conf(template file) with the nameservers. It should be balanced over all DNS servers, but always the same nameserver order for the server.
The task shouldn't change the order after the first run.

Similar as in PR https://github.com/ansible/ansible/pull/18477


<!-- Paste verbatim command output below, e.g. before and after your change -->
resolv.conf.j2
```
# {{ ansible_managed }}
search abc.local
{% for server in dnsserver|shuffle(ansible_hostname) %}
nameserver {{ server }}
{% endfor %}
```
