### PR TITLE
Enable mongodb_parameter receives strings parameters

### DIFF
--- a/lib/ansible/modules/database/misc/mongodb_parameter.py
+++ b/lib/ansible/modules/database/misc/mongodb_parameter.py
@@ -219,7 +219,7 @@ def main():
     db = client.admin
 
     try:
-        after_value = db.command("setParameter", **{param: int(value)})
+        after_value = db.command("setParameter", **{param: value})
     except OperationFailure:
         e = get_exception()
         module.fail_json(msg="unable to change parameter: %s" % str(e))


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

mongodb_parameter

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

This is broken the module when using str parameters.

Value is already converted to int, if necessary at line 193
