### PR TITLE
os_router: fix checking if router needs update

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_router.py
+++ b/lib/ansible/modules/cloud/openstack/os_router.py
@@ -177,6 +177,16 @@ except ImportError:
 
 from distutils.version import StrictVersion
 
+ROUTER_INTERFACE_OWNERS = set([
+    'network:router_interface',
+    'network:router_interface_distributed',
+    'network:ha_router_replicated_interface'
+])
+
+def _router_internal_interfaces(cloud, router):
+    for port in cloud.list_router_interfaces(router, 'internal'):
+        if port['device_owner'] in ROUTER_INTERFACE_OWNERS:
+            yield port
 
 def _needs_update(cloud, module, router, network, internal_subnet_ids):
     """Decide if the given router needs an update.
@@ -218,7 +228,7 @@ def _needs_update(cloud, module, router, network, internal_subnet_ids):
     # check internal interfaces
     if module.params['interfaces']:
         existing_subnet_ids = []
-        for port in cloud.list_router_interfaces(router, 'internal'):
+        for port in _router_internal_interfaces(cloud, router):
             if 'fixed_ips' in port:
                 for fixed_ip in port['fixed_ips']:
                     existing_subnet_ids.append(fixed_ip['subnet_id'])
@@ -374,7 +384,7 @@ def main():
                     # just detach all existing internal interfaces and attach the new.
                     elif internal_ids:
                         router = updated_router
-                        ports = cloud.list_router_interfaces(router, 'internal')
+                        ports = _router_internal_interfaces(cloud, router)
                         for port in ports:
                             cloud.remove_router_interface(router, port_id=port['id'])
                         for internal_subnet_id in internal_ids:
@@ -391,7 +401,7 @@ def main():
             else:
                 # We need to detach all internal interfaces on a router before
                 # we will be allowed to delete it.
-                ports = cloud.list_router_interfaces(router, 'internal')
+                ports = _router_internal_interfaces(cloud, router)
                 router_id = router['id']
                 for port in ports:
                     cloud.remove_router_interface(router, port_id=port['id'])


### PR DESCRIPTION
##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
os_router module

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

It is currently impossible to call `os_router` if the specified router already exists on any OpenStack installation which uses HA routers (such as a default OpenStack-Ansible deploy). This bug potentially also affects OpenStack installations using DVR, although I didn't test this case.

This happens because the `os_router` module always detects the router as changed if it already exists, as it considers the HA network tenant ports as router interfaces. Even worse, the module fails because it tries to remove these HA network tenant ports from the router, an operation which is not allowed.

The proposed fix is to check if ports are owned by the router itself when enumerating router interfaces. The procedure is analogous to one adopted by Horizon [here](https://github.com/openstack/horizon/blob/01877336d19cd0f74d8a5fe8bd2e02730af7d36a/openstack_dashboard/api/neutron.py#L51-L55) and [here](https://github.com/openstack/horizon/blob/01877336d19cd0f74d8a5fe8bd2e02730af7d36a/openstack_dashboard/api/neutron.py#L474-L476).

**Before**:
```
TASK [Setup router] ***********************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Error detaching interface from router 7cd448ea-973a-42ab-9f0e-f27003e1f86f: Router 7cd448ea-973a-42ab-9f0e-f27003e1f86f does not have an interface with id 243a769f-1085-4e45-b8d4-7e177b1ffb73\nNeutron server returns request_ids: ['req-e0022e17-9754-4bd2-bbf7-9566b2688674']"}
```

**After**:
```
TASK [Setup router] ***********************************************************
ok: [localhost]
```
