### PR TITLE
Add `args` to `local_action` example in the `wait_for` module docs.

### DIFF
--- a/lib/ansible/modules/utilities/logic/wait_for.py
+++ b/lib/ansible/modules/utilities/logic/wait_for.py
@@ -169,6 +169,7 @@ EXAMPLES = '''
 # wait 300 seconds for port 22 to become open and contain "OpenSSH", don't assume the inventory_hostname is resolvable
 # and don't start checking for 10 seconds
 - local_action: wait_for
+  args:
     port: 22
     host: "{{ ansible_ssh_host | default(inventory_hostname) }}"
     search_regex: OpenSSH


### PR DESCRIPTION
In the `EXAMPLES` docstring for the `wait_for` module, the `local_action` example should use `args` to define arguments to pass to `wait_for`.  Without this, the example does not run correctly.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
`wait_for` module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /home/justin/projects/base_site/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The current `EXAMPLE` docstring for the `wait_for` module includes an example using `local_action`, but it does not currently run as-is.  To pass arguments to the module using the multi-line syntax, they have to be placed within an `args` dictionary.

This PR adds `args` so that the example runs correctly.

Before, the file and output looked like this:

```
---
- hosts: debian_8
  tasks:
    - local_action: wait_for
        port: 22
        host: "{{ ansible_ssh_host | default(inventory_hostname) }}"
        search_regex: OpenSSH
        delay: 10
```
```
ansible-playbook test.yml
```
```
ERROR! Syntax Error while loading YAML.


The error appears to have been in '/home/justin/projects/base_site/ansible/test.yml': line 5, column 13, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

    - local_action: wait_for
        port: 22
            ^ here
```

After the change, the example runs as expected:

```
---
- hosts: debian_8
  tasks:
    - local_action: wait_for
      args:
        port: 22
        host: "{{ ansible_ssh_host | default(inventory_hostname) }}"
        search_regex: OpenSSH
        delay: 10
```
```
ansible-playbook test.yml
```
```
PLAY [debian_8] ****************************************************************

TASK [setup] *******************************************************************
ok: [xxx.xxx.xxx.xxx]

TASK [wait_for] ****************************************************************
ok: [xxx.xxx.xxx.xxx -> localhost]

PLAY RECAP *********************************************************************
xxx.xxx.xxx.xxx            : ok=2    changed=0    unreachable=0    failed=0
```