### PR TITLE
ec2_group: description is only required when group state is present

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -34,7 +34,7 @@ options:
     required: true
   description:
     description:
-      - Description of the security group. Required for present state.
+      - Description of the security group. Required when C(state) is C(present).
     required: false
   vpc_id:
     description:

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -34,8 +34,8 @@ options:
     required: true
   description:
     description:
-      - Description of the security group.
-    required: true
+      - Description of the security group. Required for present state.
+    required: false
   vpc_id:
     description:
       - ID of the VPC to create the group in.
@@ -242,7 +242,7 @@ def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
         name=dict(type='str', required=True),
-        description=dict(type='str', required=True),
+        description=dict(type='str', required=False),
         vpc_id=dict(type='str'),
         rules=dict(type='list'),
         rules_egress=dict(type='list'),
@@ -268,6 +268,9 @@ def main():
     state = module.params.get('state')
     purge_rules = module.params['purge_rules']
     purge_rules_egress = module.params['purge_rules_egress']
+
+    if state == 'present' and not description:
+        module.fail_json(msg='Must provide description when state is present.')
 
     changed = False
 

--- a/test/integration/roles/test_ec2_group/tasks/main.yml
+++ b/test/integration/roles/test_ec2_group/tasks/main.yml
@@ -18,7 +18,7 @@
   assert:
     that:
        - 'result.failed'
-       - 'result.msg == "missing required arguments: description,name"'
+       - 'result.msg == "missing required arguments: name"'
 
 # ============================================================
 - name: test failure with only name
@@ -31,7 +31,7 @@
   assert:
     that:
        - 'result.failed'
-       - 'result.msg == "missing required arguments: description"'
+       - 'result.msg == "Must provide description when state is present."'
 
 # ============================================================
 - name: test failure with only description
@@ -45,6 +45,21 @@
     that:
        - 'result.failed'
        - 'result.msg == "missing required arguments: name"'
+
+# ============================================================
+- name: test failure with empty description (AWS API requires non-empty string desc)
+  ec2_group:
+    name='{{ec2_group_name}}'
+    description=''
+    region='{{ec2_region}}'
+  register: result
+  ignore_errors: true
+
+- name: assert failure with empty description
+  assert:
+    that:
+       - 'result.failed'
+       - 'result.msg == "Must provide description when state is present."'
 
 # ============================================================
 - name: test invalid region parameter
@@ -213,7 +228,6 @@
 - name: test state=absent (expected changed=true)
   ec2_group:
     name='{{ec2_group_name}}'
-    description='{{ec2_group_description}}'
     state=absent
   environment:
     EC2_REGION: '{{ec2_region}}'
@@ -231,7 +245,6 @@
 - name: test state=absent (expected changed=false)
   ec2_group:
     name='{{ec2_group_name}}'
-    description='{{ec2_group_description}}'
     state=absent
   environment:
     EC2_REGION: '{{ec2_region}}'


### PR DESCRIPTION
Fixes https://github.com/ansible/ansible/issues/19117

also note that AWS requires a non-empty description when creating a security group

Integration tests included