### PR TITLE
[timezone module] Return tzfile from _verify_timezone

### DIFF
--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -229,6 +229,7 @@ class Timezone(object):
         tzfile = '/usr/share/zoneinfo/%s' % tz
         if not os.path.isfile(tzfile):
             self.abort('given timezone "%s" is not available' % tz)
+        return tzfile
 
 
 class SystemdTimezone(Timezone):
@@ -307,7 +308,7 @@ class NosystemdTimezone(Timezone):
         super(NosystemdTimezone, self).__init__(module)
         # Validate given timezone
         if 'name' in self.value:
-            self._verify_timezone()
+            tzfile = self._verify_timezone()
             self.update_timezone  = self.module.get_bin_path('cp', required=True)
             self.update_timezone += ' %s /etc/localtime' % tzfile
         self.update_hwclock = self.module.get_bin_path('hwclock', required=True)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`timezone` module

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### SUMMARY
Fixed bug reported in #19745.

Actually, this bug has already fixed in https://github.com/ansible/ansible-modules-extras/pull/3337 by @ssummer3. However, since it has merged directly to `ansible:stable-2.2` branch rather than `devel`, the modification didn't included on repository merge.