### PR TITLE
Add warning to raw and script modules that there is no actual free_fo…

### DIFF
--- a/lib/ansible/modules/commands/raw.py
+++ b/lib/ansible/modules/commands/raw.py
@@ -27,7 +27,7 @@ version_added: historical
 options:
   free_form:
     description:
-      - the raw module takes a free form command to run
+      - the raw module takes a free form command to run. There is no parameter actually named 'free form'; see the examples!
     required: true
   executable:
     description:

--- a/lib/ansible/modules/commands/script.py
+++ b/lib/ansible/modules/commands/script.py
@@ -32,7 +32,7 @@ description:
 options:
   free_form:
     description:
-      - path to the local script file followed by optional arguments.
+      - path to the local script file followed by optional arguments. There is no parameter actually named 'free form'; see the examples!
     required: true
     default: null
     aliases: []


### PR DESCRIPTION
…rm parameter (like for command etc).

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
raw and script modules

##### ANSIBLE VERSION
n/a (taken from devel branch)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adding a note to the raw and script modules that the "free form" parameter doesn't exist as such and to check the examples, like already done on most/all similar modules, like command and the same.