### PR TITLE
Consistent path attribute for file-related modules

### DIFF
--- a/lib/ansible/modules/files/acl.py
+++ b/lib/ansible/modules/files/acl.py
@@ -27,12 +27,12 @@ short_description: Sets and retrieves file ACL information.
 description:
     - Sets and retrieves file ACL information.
 options:
-  name:
+  path:
     required: true
     default: null
     description:
       - The full path of the file or object.
-    aliases: ['path']
+    aliases: ['name']
 
   state:
     required: false
@@ -54,7 +54,7 @@ options:
     default: no
     choices: [ 'yes', 'no' ]
     description:
-      - if the target is a directory, setting this to yes will make it the default acl for entities created inside the directory. It causes an error if name is a file.
+      - if the target is a directory, setting this to yes will make it the default acl for entities created inside the directory. It causes an error if path is a file.
 
   entity:
     version_added: "1.5"
@@ -69,7 +69,6 @@ options:
     choices: [ 'user', 'group', 'mask', 'other' ]
     description:
       - the entity type of the ACL to apply, see setfacl documentation for more info.
-
 
   permissions:
     version_added: "1.5"
@@ -97,12 +96,13 @@ author:
 notes:
     - The "acl" module requires that acls are enabled on the target filesystem and that the setfacl and getfacl binaries are installed.
     - As of Ansible 2.0, this module only supports Linux distributions.
+    - As of Ansible 2.3, the I(name) option has been changed to I(path) as default, but I(name) still works as well.
 '''
 
 EXAMPLES = '''
 # Grant user Joe read access to a file
 - acl:
-    name: /etc/foo.conf
+    path: /etc/foo.conf
     entity: joe
     etype: user
     permissions: r
@@ -110,14 +110,14 @@ EXAMPLES = '''
 
 # Removes the acl for Joe on a specific file
 - acl:
-    name: /etc/foo.conf
+    path: /etc/foo.conf
     entity: joe
     etype: user
     state: absent
 
 # Sets default acl for joe on foo.d
 - acl:
-    name: /etc/foo.d
+    path: /etc/foo.d
     entity: joe
     etype: user
     permissions: rw
@@ -126,13 +126,13 @@ EXAMPLES = '''
 
 # Same as previous but using entry shorthand
 - acl:
-    name: /etc/foo.d
+    path: /etc/foo.d
     entry: "default:user:joe:rw-"
     state: present
 
 # Obtain the acl for a specific file
 - acl:
-    name: /etc/foo.conf
+    path: /etc/foo.conf
   register: acl_info
 '''
 
@@ -144,6 +144,10 @@ acl:
     sample: [ "user::rwx", "group::rwx", "other::rwx" ]
 '''
 
+import os
+
+# import module snippets
+from ansible.module_utils.basic import AnsibleModule, get_platform
 
 def split_entry(entry):
     ''' splits entry and ensures normalized return'''
@@ -258,7 +262,7 @@ def run_acl(module, cmd, check_rc=True):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            name=dict(required=True, aliases=['path'], type='path'),
+            path=dict(required=True, aliases=['name'], type='path'),
             entry=dict(required=False, type='str'),
             entity=dict(required=False, type='str', default=''),
             etype=dict(
@@ -284,7 +288,7 @@ def main():
     if get_platform().lower() not in ['linux', 'freebsd']:
         module.fail_json(msg="The acl module is not available on this system.")
 
-    path = module.params.get('name')
+    path = module.params.get('path')
     entry = module.params.get('entry')
     entity = module.params.get('entity')
     etype = module.params.get('etype')
@@ -368,9 +372,6 @@ def main():
     )
 
     module.exit_json(changed=changed, msg=msg, acl=acl)
-
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/files/blockinfile.py
+++ b/lib/ansible/modules/files/blockinfile.py
@@ -36,15 +36,13 @@ version_added: '2.0'
 description:
   - This module will insert/update/remove a block of multi-line text
     surrounded by customizable marker lines.
-notes:
-  - This module supports check mode.
-  - When using 'with_*' loops be aware that if you do not set a unique mark the block will be overwritten on each iteration.
 options:
-  dest:
-    aliases: [ name, destfile ]
+  path:
+    aliases: [ dest, destfile, name ]
     required: true
     description:
       - The file to modify.
+      - Before 2.3 this option was only usable as I(dest), I(destfile) and I(name).
   state:
     required: false
     choices: [ present, absent ]
@@ -104,12 +102,17 @@ options:
     description:
       - 'This flag indicates that filesystem links, if they exist, should be followed.'
     version_added: "2.1"
+notes:
+  - This module supports check mode.
+  - When using 'with_*' loops be aware that if you do not set a unique mark the block will be overwritten on each iteration.
+  - As of Ansible 2.3, the I(dest) option has been changed to I(path) as default, but I(dest) still works as well.
 """
 
 EXAMPLES = r"""
+# Before 2.3, option 'dest' or 'name' was used instead of 'path'
 - name: insert/update "Match User" configuration block in /etc/ssh/sshd_config
   blockinfile:
-    dest: /etc/ssh/sshd_config
+    path: /etc/ssh/sshd_config
     block: |
       Match User ansible-agent
       PasswordAuthentication no
@@ -117,7 +120,7 @@ EXAMPLES = r"""
 - name: insert/update eth0 configuration stanza in /etc/network/interfaces
         (it might be better to copy files into /etc/network/interfaces.d/)
   blockinfile:
-    dest: /etc/network/interfaces
+    path: /etc/network/interfaces
     block: |
       iface eth0 inet static
           address 192.0.2.23
@@ -125,7 +128,7 @@ EXAMPLES = r"""
 
 - name: insert/update HTML surrounded by custom markers after <body> line
   blockinfile:
-    dest: /var/www/html/index.html
+    path: /var/www/html/index.html
     marker: "<!-- {mark} ANSIBLE MANAGED BLOCK -->"
     insertafter: "<body>"
     content: |
@@ -134,13 +137,13 @@ EXAMPLES = r"""
 
 - name: remove HTML as well as surrounding markers
   blockinfile:
-    dest: /var/www/html/index.html
+    path: /var/www/html/index.html
     marker: "<!-- {mark} ANSIBLE MANAGED BLOCK -->"
     content: ""
 
 - name: Add mappings to /etc/hosts
   blockinfile:
-    dest: /etc/hosts
+    path: /etc/hosts
     block: |
       {{ item.ip }} {{ item.name }}
     marker: "# {mark} ANSIBLE MANAGED BLOCK {{ item.name }}"
@@ -157,7 +160,7 @@ from ansible.module_utils.six import b
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_bytes
 
-def write_changes(module, contents, dest):
+def write_changes(module, contents, path):
 
     tmpfd, tmpfile = tempfile.mkstemp()
     f = os.fdopen(tmpfd, 'wb')
@@ -175,7 +178,7 @@ def write_changes(module, contents, dest):
             module.fail_json(msg='failed to validate: '
                                  'rc:%s error:%s' % (rc, err))
     if valid:
-        module.atomic_move(tmpfile, dest, unsafe_writes=module.params['unsafe_writes'])
+        module.atomic_move(tmpfile, path, unsafe_writes=module.params['unsafe_writes'])
 
 
 def check_file_attrs(module, changed, message):
@@ -194,7 +197,7 @@ def check_file_attrs(module, changed, message):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            dest=dict(required=True, aliases=['name', 'destfile'], type='path'),
+            path=dict(required=True, aliases=['dest', 'destfile', 'name'], type='path'),
             state=dict(default='present', choices=['absent', 'present']),
             marker=dict(default='# {mark} ANSIBLE MANAGED BLOCK', type='str'),
             block=dict(default='', type='str', aliases=['content']),
@@ -210,23 +213,23 @@ def main():
     )
 
     params = module.params
-    dest = params['dest']
+    path = params['path']
     if module.boolean(params.get('follow', None)):
-        dest = os.path.realpath(dest)
+        path = os.path.realpath(path)
 
-    if os.path.isdir(dest):
+    if os.path.isdir(path):
         module.fail_json(rc=256,
-                         msg='Destination %s is a directory !' % dest)
+                         msg='Path %s is a directory !' % path)
 
-    path_exists = os.path.exists(dest)
+    path_exists = os.path.exists(path)
     if not path_exists:
         if not module.boolean(params['create']):
             module.fail_json(rc=257,
-                             msg='Destination %s does not exist !' % dest)
+                             msg='Path %s does not exist !' % path)
         original = None
         lines = []
     else:
-        f = open(dest, 'rb')
+        f = open(path, 'rb')
         original = f.read()
         f.close()
         lines = original.splitlines()
@@ -238,7 +241,7 @@ def main():
     present = params['state'] == 'present'
 
     if not present and not path_exists:
-        module.exit_json(changed=False, msg="File not present")
+        module.exit_json(changed=False, msg="File %s not present" % path)
 
     if insertbefore is None and insertafter is None:
         insertafter = 'EOF'
@@ -310,8 +313,8 @@ def main():
 
     if changed and not module.check_mode:
         if module.boolean(params['backup']) and path_exists:
-            module.backup_local(dest)
-        write_changes(module, result, dest)
+            module.backup_local(path)
+        write_changes(module, result, path)
 
     if module.check_mode and not path_exists:
         module.exit_json(changed=changed, msg=msg)

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -42,11 +42,12 @@ description:
     For other cases, see the M(copy) or M(template) modules.
 version_added: "0.7"
 options:
-  dest:
+  path:
     required: true
-    aliases: [ name, destfile ]
+    aliases: [ 'dest', 'destfile', 'name' ]
     description:
       - The file to modify.
+      - Before 2.3 this option was only usable as I(dest), I(destfile) and I(name).
   regexp:
     required: false
     version_added: 1.7
@@ -121,21 +122,24 @@ options:
      description:
        - All arguments accepted by the M(file) module also work here.
      required: false
+notes:
+  - As of Ansible 2.3, the I(dest) option has been changed to I(path) as default, but I(dest) still works as well.
 """
 
 EXAMPLES = r"""
+# Before 2.3, option 'dest', 'destfile' or 'name' was used instead of 'path'
 - lineinfile:
-    dest: /etc/selinux/config
+    path: /etc/selinux/config
     regexp: '^SELINUX='
     line: 'SELINUX=enforcing'
 
 - lineinfile:
-    dest: /etc/sudoers
+    path: /etc/sudoers
     state: absent
     regexp: '^%wheel'
 
 - lineinfile:
-    dest: /etc/hosts
+    path: /etc/hosts
     regexp: '^127\.0\.0\.1'
     line: '127.0.0.1 localhost'
     owner: root
@@ -143,39 +147,39 @@ EXAMPLES = r"""
     mode: 0644
 
 - lineinfile:
-    dest: /etc/httpd/conf/httpd.conf
+    path: /etc/httpd/conf/httpd.conf
     regexp: '^Listen '
     insertafter: '^#Listen '
     line: 'Listen 8080'
 
 - lineinfile:
-    dest: /etc/services
+    path: /etc/services
     regexp: '^# port for http'
     insertbefore: '^www.*80/tcp'
     line: '# port for http by default'
 
 # Add a line to a file if it does not exist, without passing regexp
 - lineinfile:
-    dest: /tmp/testfile
+    path: /tmp/testfile
     line: '192.168.1.99 foo.lab.net foo'
 
 # Fully quoted because of the ': ' on the line. See the Gotchas in the YAML docs.
-- lineinfile:
-    dest: /etc/sudoers
+- lineinfile: "
+    path: /etc/sudoers
     state: present
     regexp: '^%wheel\s'
     line: '%wheel ALL=(ALL) NOPASSWD: ALL'
 
 # Yaml requires escaping backslashes in double quotes but not in single quotes
 - lineinfile:
-    dest: /opt/jboss-as/bin/standalone.conf
-    regexp: "^(.*)Xms(\\d+)m(.*)$"
+    path: /opt/jboss-as/bin/standalone.conf
+    regexp: '^(.*)Xms(\\d+)m(.*)$'
     line: '\1Xms${xms}m\3'
     backrefs: yes
 
 # Validate the sudoers file before saving
 - lineinfile:
-    dest: /etc/sudoers
+    path: /etc/sudoers
     state: present
     regexp: '^%ADMIN ALL='
     line: '%ADMIN ALL=(ALL) NOPASSWD: ALL'
@@ -412,7 +416,7 @@ def absent(module, dest, regexp, line, backup):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            dest=dict(required=True, aliases=['name', 'destfile'], type='path'),
+            path=dict(required=True, aliases=['dest', 'destfile', 'name'], type='path'),
             state=dict(default='present', choices=['absent', 'present']),
             regexp=dict(default=None),
             line=dict(aliases=['value']),
@@ -432,11 +436,11 @@ def main():
     create = params['create']
     backup = params['backup']
     backrefs = params['backrefs']
-    dest = params['dest']
+    path = params['path']
 
-    b_dest = to_bytes(dest, errors='surrogate_or_strict')
-    if os.path.isdir(b_dest):
-        module.fail_json(rc=256, msg='Destination %s is a directory !' % dest)
+    b_path = to_bytes(path, errors='surrogate_or_strict')
+    if os.path.isdir(b_path):
+        module.fail_json(rc=256, msg='Path %s is a directory !' % path)
 
     if params['state'] == 'present':
         if backrefs and params['regexp'] is None:
@@ -453,13 +457,13 @@ def main():
 
         line = params['line']
 
-        present(module, dest, params['regexp'], line,
+        present(module, path, params['regexp'], line,
                 ins_aft, ins_bef, create, backup, backrefs)
     else:
         if params['regexp'] is None and params.get('line', None) is None:
             module.fail_json(msg='one of line= or regexp= is required with state=absent')
 
-        absent(module, dest, params['regexp'], params.get('line', None), backup)
+        absent(module, path, params['regexp'], params.get('line', None), backup)
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/files/xattr.py
+++ b/lib/ansible/modules/files/xattr.py
@@ -27,12 +27,13 @@ description:
      - Manages filesystem user defined extended attributes, requires that they are enabled
        on the target filesystem and that the setfattr/getfattr utilities are present.
 options:
-  name:
+  path:
     required: true
     default: None
-    aliases: ['path']
+    aliases: ['name']
     description:
-      - The full path of the file/object to get the facts of
+      - The full path of the file/object to get the facts of.
+      - Before 2.3 this option was only usable as I(name).
   key:
     required: false
     default: None
@@ -61,6 +62,8 @@ options:
     description:
       - if yes, dereferences symlinks and sets/gets attributes on symlink target,
         otherwise acts on symlink itself.
+notes:
+  - As of Ansible 2.3, the I(name) option has been changed to I(path) as default, but I(name) still works as well.
 
 author: "Brian Coca (@bcoca)"
 '''
@@ -68,7 +71,7 @@ author: "Brian Coca (@bcoca)"
 EXAMPLES = '''
 # Obtain the extended attributes  of /etc/foo.conf
 - xattr:
-    name: /etc/foo.conf
+    path: /etc/foo.conf
 
 # Sets the key 'foo' to value 'bar'
 - xattr:
@@ -78,7 +81,7 @@ EXAMPLES = '''
 
 # Removes the key 'foo'
 - xattr:
-    name: /etc/foo.conf
+    path: /etc/foo.conf
     key: user.foo
     state: absent
 '''
@@ -86,6 +89,10 @@ EXAMPLES = '''
 import operator
 import re
 import os
+
+# import module snippets
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.pycompat24 import get_exception
 
 def get_xattr_keys(module,path,follow):
     cmd = [ module.get_bin_path('getfattr', True) ]
@@ -156,7 +163,7 @@ def _run_xattr(module,cmd,check_rc=True):
 def main():
     module = AnsibleModule(
         argument_spec = dict(
-            name = dict(required=True, aliases=['path'], type='path'),
+            path = dict(required=True, aliases=['name'], type='path'),
             key = dict(required=False, default=None, type='str'),
             value = dict(required=False, default=None, type='str'),
             state = dict(required=False, default='read', choices=[ 'read', 'present', 'all', 'keys', 'absent' ], type='str'),
@@ -164,7 +171,7 @@ def main():
         ),
         supports_check_mode=True,
     )
-    path = module.params.get('name')
+    path = module.params.get('path')
     key = module.params.get('key')
     value = module.params.get('value')
     state = module.params.get('state')
@@ -214,8 +221,5 @@ def main():
 
     module.exit_json(changed=changed, msg=msg, xattr=res)
 
-# import module snippets
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/windows/win_lineinfile.py
+++ b/lib/ansible/modules/windows/win_lineinfile.py
@@ -30,12 +30,13 @@ description:
   - This is primarily useful when you want to change a single line in a file only.
 version_added: "2.0"
 options:
-  dest:
+  path:
     required: true
-    aliases: [ name, destfile ]
+    aliases: [ dest, destfile, name ]
     description:
       - The path of the file to modify.
       - Note that the Windows path delimiter C(\) must be escaped as C(\\) when the line is double quoted.
+      - Before 2.3 this option was only usable as I(dest), I(destfile) and I(name).
   regexp:
     required: false
     description:
@@ -101,46 +102,49 @@ options:
       - "Specifies the line separator style to use for the modified file. This defaults to the windows line separator (C(\r\n)). Note that the indicated line separator will be used for file output regardless of the original line separator that appears in the input file."
     choices: [ "windows", "unix" ]
     default: "windows"
+notes:
+  - As of Ansible 2.3, the I(dest) option has been changed to I(path) as default, but I(dest) still works as well.
 """
 
 EXAMPLES = r"""
+# Before 2.3, option 'dest', 'destfile' or 'name' was used instead of 'path'
 - win_lineinfile:
-    dest: C:\temp\example.conf
+    path: C:\temp\example.conf
     regexp: '^name='
     line: 'name=JohnDoe'
 
 - win_lineinfile:
-    dest: C:\temp\example.conf
+    path: C:\temp\example.conf
     regexp: '^name='
     state: absent
 
 - win_lineinfile:
-    dest: C:\temp\example.conf
+    path: C:\temp\example.conf
     regexp: '^127\.0\.0\.1'
     line: '127.0.0.1 localhost'
 
 - win_lineinfile:
-    dest: C:\temp\httpd.conf
+    path: C:\temp\httpd.conf
     regexp: '^Listen '
     insertafter: '^#Listen '
     line: Listen 8080
 
 - win_lineinfile:
-    dest: C:\temp\services
+    path: C:\temp\services
     regexp: '^# port for http'
     insertbefore: '^www.*80/tcp'
     line: '# port for http by default'
 
 # Create file if it doesn't exist with a specific encoding
 - win_lineinfile:
-    dest: C:\temp\utf16.txt
+    path: C:\temp\utf16.txt
     create: yes
     encoding: utf-16
     line: This is a utf-16 encoded file
 
 # Add a line to a file and ensure the resulting file uses unix line separators
 - win_lineinfile:
-    dest: C:\temp\testfile.txt
+    path: C:\temp\testfile.txt
     line: Line added to file
     newline: unix
 """


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
acl, blockinfile, ini_file, lineinfile, mount, replace, stat, win_lineinfile, xattr

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.2

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Not all file-related modules consistently use "path" as the attribute to specify a single filename, some use "dest", others use "name". Most do have aliases for either "name" or "destfile".

This change makes "path" the default attribute for (single) file-related modules, but also adds "dest" and "name" as aliases, so that people can use a consistent way of attributing paths, but also to ensure backward compatibility with existing playbooks.

This is related to an older PR ansible/ansible-modules-core#5437