### PR TITLE
Clarify state=reloaded will start service

### DIFF
--- a/lib/ansible/modules/system/service.py
+++ b/lib/ansible/modules/system/service.py
@@ -45,7 +45,9 @@ options:
           - C(started)/C(stopped) are idempotent actions that will not run
             commands unless necessary.  C(restarted) will always bounce the
             service.  C(reloaded) will always reload. B(At least one of state
-            and enabled are required.)
+            and enabled are required.) Note that reloaded will start the
+            service if it is not already started, even if your chosen init
+            system wouldn't normally.
     sleep:
         required: false
         version_added: "1.3"


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
service

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### SUMMARY
Clarifies behaviour of the service module.

Starting the service if not running might not have been expected with some init systems/scripts.

Submitting this after a suggestion in https://github.com/ansible/ansible/issues/4448#issuecomment-269927099

https://github.com/ansible/ansible-modules-core/issues/350 is also related.