### PR TITLE
filesystem module: Check for line that starts with 'data' in xfs_info output

### DIFF
--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -101,7 +101,7 @@ def _get_fs_size(fssize_cmd, dev, module):
         if rc == 0:
             for line in size.splitlines():
                 #if 'data' in line:
-                if 'data ' in line:
+                if line.startswith('data'):
                     block_size = int(line.split('=')[2].split()[0])
                     block_count = int(line.split('=')[3].split(',')[0])
                     break


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
module filesystem

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible (master)$ ansible --version
ansible 2.2.0.0
  config file = /home/jon/ansible.cfg
  configured module search path = Default w/o override
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I created an LVM volume named 'data' and it causes the filesystem module to break on the first line which does not contain the block size and block count. As a result it continues to try and resize my filesystem even though all of the device space is being utilized.

Instead of using `bsize=4096 blocks=11009024`, the module must be using `agcount=4 agsize=2752256` which is not going to match the size from `blockdev --getsize64`.

```
meta-data=/dev/mapper/ebs_vols-data isize=256    agcount=4, agsize=2752256 blks
         =                       sectsz=512   attr=2, projid32bit=1
         =                       crc=0        finobt=0
data     =                       bsize=4096   blocks=11009024, imaxpct=25
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0 ftype=0
```