### PR TITLE
vmware_guest: import iteritems

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -327,6 +327,16 @@ instance:
     sample: None
 """
 
+import os
+import time
+from netaddr import IPNetwork, IPAddress
+
+# import module snippets
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.urls import fetch_url
+from ansible.module_utils.vmware import get_all_objs, connect_to_api
+
 try:
     import json
 except ImportError:
@@ -340,13 +350,6 @@ try:
     HAS_PYVMOMI = True
 except ImportError:
     pass
-
-import os
-import time
-from netaddr import IPNetwork, IPAddress
-
-from ansible.module_utils.urls import fetch_url
-
 
 class PyVmomiDeviceHelper(object):
     """ This class is a helper to create easily VMWare Objects for PyVmomiHelper """
@@ -1714,10 +1717,6 @@ def main():
         module.fail_json(**result)
     else:
         module.exit_json(**result)
-
-
-from ansible.module_utils.vmware import *
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vmware_guest

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Without this change you get this on Python 2.7.5:

    NameError: global name 'iteritems' is not defined

I also took the time to move the imports together and made them as specific as possible. (one of the changes in my queue).