### PR TITLE
Run tests on opensuse42.2

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -23,7 +23,8 @@ matrix:
     - env: TEST=linux/centos7/1
     - env: TEST=linux/fedora24/1
     - env: TEST=linux/fedora25/1
-    - env: TEST=linux/opensuseleap/1
+    - env: TEST=linux/opensuse42.1/1
+    - env: TEST=linux/opensuse42.2/1
     - env: TEST=linux/ubuntu1204/1
     - env: TEST=linux/ubuntu1404/1
     - env: TEST=linux/ubuntu1604/1
@@ -33,7 +34,8 @@ matrix:
     - env: TEST=linux/centos7/2
     - env: TEST=linux/fedora24/2
     - env: TEST=linux/fedora25/2
-    - env: TEST=linux/opensuseleap/2
+    - env: TEST=linux/opensuse42.1/2
+    - env: TEST=linux/opensuse42.2/2
     - env: TEST=linux/ubuntu1204/2
     - env: TEST=linux/ubuntu1404/2
     - env: TEST=linux/ubuntu1604/2
@@ -43,7 +45,8 @@ matrix:
     - env: TEST=linux/centos7/3
     - env: TEST=linux/fedora24/3
     - env: TEST=linux/fedora25/3
-    - env: TEST=linux/opensuseleap/3
+    - env: TEST=linux/opensuse42.1/3
+    - env: TEST=linux/opensuse42.2/3
     - env: TEST=linux/ubuntu1204/3
     - env: TEST=linux/ubuntu1404/3
     - env: TEST=linux/ubuntu1604/3

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -134,7 +134,8 @@ Most container images are for testing with Python 2:
   - centos7
   - fedora24
   - fedora25
-  - opensuseleap
+  - opensuse42.1
+  - opensuse42.2
   - ubuntu1204 (requires `PRIVILEGED=true`)
   - ubuntu1404 (requires `PRIVILEGED=true`)
   - ubuntu1604

--- a/test/runner/completion/docker.txt
+++ b/test/runner/completion/docker.txt
@@ -2,7 +2,8 @@ centos6
 centos7
 fedora24
 fedora25
-opensuseleap
+opensuse42.1
+opensuse42.2
 ubuntu1204
 ubuntu1404
 ubuntu1604


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
integration tests

##### ANSIBLE VERSION
devel

##### SUMMARY
Enable tests on opensuse 42.2. Follow-up to #19805 that adds the docker files.

* add Dockerfile (identical to 42.1 up to the base image)
* add to shippable
* add to completion/readme
* Fixes #18645
