### PR TITLE
Use newer test images for Fedora and openSUSE.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -18,9 +18,10 @@ matrix:
 
     - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:centos6
     - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:centos7
-    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:fedora-rawhide
-    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:fedora23
-    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:opensuseleap
+    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:fedora24
+    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:fedora25
+    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:opensuse42.1
+    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:opensuse42.2
     - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1204 PRIVILEGED=true
     - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1404 PRIVILEGED=true
     - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1604
@@ -28,9 +29,10 @@ matrix:
 
     - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:centos6
     - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:centos7 PRIVILEGED=true
-    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:fedora-rawhide PRIVILEGED=true
-    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:fedora23 PRIVILEGED=true
-    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:opensuseleap PRIVILEGED=true
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:fedora24 PRIVILEGED=true
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:fedora25 PRIVILEGED=true
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:opensuse42.1 PRIVILEGED=true
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:opensuse42.2 PRIVILEGED=true
     - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1204 PRIVILEGED=true
     - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1404 PRIVILEGED=true
     - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1604 PRIVILEGED=true
@@ -38,9 +40,10 @@ matrix:
 
     - env: TEST=integration TARGET=other IMAGE=ansible/ansible:centos6
     - env: TEST=integration TARGET=other IMAGE=ansible/ansible:centos7
-    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:fedora-rawhide
-    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:fedora23
-    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:opensuseleap
+    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:fedora24
+    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:fedora25
+    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:opensuse42.1
+    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:opensuse42.2
     - env: TEST=integration TARGET=other IMAGE=ansible/ansible:ubuntu1204
     - env: TEST=integration TARGET=other IMAGE=ansible/ansible:ubuntu1404
     - env: TEST=integration TARGET=other IMAGE=ansible/ansible:ubuntu1604

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -130,9 +130,10 @@ Most container images are for testing with Python 2:
 
   - centos6
   - centos7
-  - fedora-rawhide
-  - fedora23
-  - opensuseleap
+  - fedora24
+  - fedora25
+  - opensuse42.1
+  - opensuse42.2
   - ubuntu1204 (requires `PRIVILEGED=true`)
   - ubuntu1404 (requires `PRIVILEGED=true`)
   - ubuntu1604


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

Tests

##### ANSIBLE VERSION

```
ansible 2.2.1.0 (linux-test 92340823a2) last updated 2017/01/03 13:11:32 (GMT -700)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras:  not found - use git submodule update --init lib/ansible/modules/extras
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Use newer test images for Fedora and openSUSE.