### PR TITLE
Add a encode() to AnsibleVaultEncryptedUnicode

### DIFF
--- a/lib/ansible/parsing/yaml/objects.py
+++ b/lib/ansible/parsing/yaml/objects.py
@@ -134,4 +134,4 @@ class AnsibleVaultEncryptedUnicode(yaml.YAMLObject, AnsibleUnicode):
         return unicode(self.data)
 
     def encode(self, encoding=None, errors=None):
-        return self.data.encode(encoding=encoding, errors=errors)
+        return self.data.encode(encoding, errors)

--- a/lib/ansible/parsing/yaml/objects.py
+++ b/lib/ansible/parsing/yaml/objects.py
@@ -132,3 +132,6 @@ class AnsibleVaultEncryptedUnicode(yaml.YAMLObject, AnsibleUnicode):
 
     def __unicode__(self):
         return unicode(self.data)
+
+    def encode(self, encoding=None, errors=None):
+        return self.data.encode(encoding=encoding, errors=errors)

--- a/test/units/parsing/yaml/test_objects.py
+++ b/test/units/parsing/yaml/test_objects.py
@@ -121,6 +121,15 @@ class TestAnsibleVaultEncryptedUnicode(unittest.TestCase, YamlTestUtils):
         avu = self._from_plaintext(seq)
         self.assert_values(avu,seq)
 
+    def test_unicode_from_plaintext_encode(self):
+        seq = u'some text here'
+        avu = self._from_plaintext(seq)
+        b_avu = avu.encode('utf-8', 'strict')
+        self.assertIsInstance(avu, objects.AnsibleVaultEncryptedUnicode)
+        self.assertEquals(b_avu, seq.encode('utf-8', 'strict'))
+        self.assertTrue(avu.vault is self.vault)
+        self.assertIsInstance(avu.vault, vault.VaultLib)
+
     # TODO/FIXME: make sure bad password fails differently than 'thats not encrypted'
     def test_empty_string_wrong_password(self):
         seq = ''


### PR DESCRIPTION
Without it, calling encode() on it results in a bytestring
of the encrypted !vault-encrypted string.

ssh connection plugin triggers this if ansible_password
is from a var using !vault-encrypted. That path ends up
calling .encode() instead of using the __str__.

Fixes #19795

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/yaml/objects.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (ansible_enc_unicode_encode_19795 0c0056a99a) last updated 2017/01/03 17:56:00 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

