### PR TITLE
Added prefix attribute to rabbitmq modules.

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq_vhost.py
+++ b/lib/ansible/modules/messaging/rabbitmq_vhost.py
@@ -55,6 +55,12 @@ options:
       - The state of vhost
     default: present
     choices: [present, absent]
+  prefix:
+    description:
+      - Specify a custom install prefix to a RabbitMQ installation
+    required: false
+    version_added: "2.2"
+    default: null
 '''
 
 EXAMPLES = '''
@@ -72,7 +78,23 @@ class RabbitMqVhost(object):
         self.node = node
 
         self._tracing = False
-        self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
+        self._rabbitmqctl = self._get_rmq_exec(module, 'rabbitmqctl')
+
+    def _get_rmq_exec(self, module, command):
+        prefix = module.params['prefix']
+        if prefix:
+            if os.path.isdir(os.path.join(prefix, 'bin')):
+                bin_path = os.path.join(prefix, 'bin')
+            elif os.path.isdir(os.path.join(prefix, 'sbin')):
+                bin_path = os.path.join(prefix, 'sbin')
+            else:
+                # No such path exists.
+                raise Exception("No binary folder in prefix %s" % prefix)
+
+            return bin_path + '/' + command
+
+        else:
+            return module.get_bin_path(command, True)
 
     def _exec(self, args, run_in_check_mode=False):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
@@ -119,6 +141,7 @@ def main():
         tracing=dict(default='off', aliases=['trace'], type='bool'),
         state=dict(default='present', choices=['present', 'absent']),
         node=dict(default='rabbit'),
+        prefix=dict(default=None)
     )
 
     module = AnsibleModule(


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

rabbitmq_parameter
rabbitmq_policy
rabbitmq_user
rabbitmq_vhost
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 89c826df9d) last updated 2016/09/16 15:12:47 (GMT +000)
  lib/ansible/modules/core: (detached HEAD 48d932643b) last updated 2016/09/16 15:13:15 (GMT +000)
  lib/ansible/modules/extras: (feature/gluster_volume 95f4f52167) last updated 2016/09/19 16:44:19 (GMT +000)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Added support for RabbitMQ installation on a custom location.
The change adds a prefix attribute, like the one in the module rabbitmq_plugin, to the plugins that use the command rabbitmqctl
