### PR TITLE
urls.py py3-compatability (strings)

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -602,7 +602,7 @@ class SSLValidationHandler(urllib_request.BaseHandler):
         to_add = False
 
         # Write the dummy ca cert if we are running on Mac OS X
-        if system == 'Darwin':
+        if system == b('Darwin'):
             os.write(tmp_fd, DUMMY_CA_CERT)
             # Default Homebrew path for OpenSSL certs
             paths_checked.append('/usr/local/etc/openssl')
@@ -792,7 +792,7 @@ def open_url(url, data=None, headers=None, method=None, use_proxy=True,
     # FIXME: change the following to use the generic_urlparse function
     #        to remove the indexed references for 'parsed'
     parsed = urlparse(url)
-    if parsed[0] != 'ftp':
+    if parsed[0] != b('ftp'):
         username = url_username
 
         if headers is None:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`module_utils/urls.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0
```

##### SUMMARY
These comparisons were failing ("TypeError: a bytes-like object is required, not 'str'"). This should be py2/py3 compatible.

