### PR TITLE
Fix typo in ec2_vpc_peer.py documentation

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
@@ -65,7 +65,7 @@ EXAMPLES = '''
     peer_vpc_id: vpc-87654321
     state: present
     tags:
-      Name: Peering conenction for VPC 21 to VPC 22
+      Name: Peering connection for VPC 21 to VPC 22
       CostCode: CC1234
       Project: phoenix       
   register: vpc_peer
@@ -85,7 +85,7 @@ EXAMPLES = '''
     peer_vpc_id: vpc-87654321
     state: present
     tags:
-      Name: Peering conenction for VPC 21 to VPC 22
+      Name: Peering connection for VPC 21 to VPC 22
       CostCode: CC1234
       Project: phoenix           
   register: vpc_peer
@@ -106,7 +106,7 @@ EXAMPLES = '''
     peer_owner_id: 123456789102
     state: present
     tags:
-      Name: Peering conenction for VPC 21 to VPC 22
+      Name: Peering connection for VPC 21 to VPC 22
       CostCode: CC1234
       Project: phoenix         
   register: vpc_peer
@@ -127,7 +127,7 @@ EXAMPLES = '''
     peer_vpc_id: vpc-87654321
     state: present
     tags:
-      Name: Peering conenction for VPC 21 to VPC 22
+      Name: Peering connection for VPC 21 to VPC 22
       CostCode: CC1234
       Project: phoenix          
   register: vpc_peer
@@ -147,7 +147,7 @@ EXAMPLES = '''
     peer_owner_id: 123456789102
     state: present
     tags:
-      Name: Peering conenction for VPC 21 to VPC 22
+      Name: Peering connection for VPC 21 to VPC 22
       CostCode: CC1234
       Project: phoenix        
   register: vpc_peer
@@ -159,7 +159,7 @@ EXAMPLES = '''
     profile: bot03_profile_for_cross_account
     state: accept
     tags:
-      Name: Peering conenction for VPC 21 to VPC 22
+      Name: Peering connection for VPC 21 to VPC 22
       CostCode: CC1234
       Project: phoenix
 
@@ -172,7 +172,7 @@ EXAMPLES = '''
     peer_owner_id: 123456789102
     state: present
     tags:
-      Name: Peering conenction for VPC 21 to VPC 22
+      Name: Peering connection for VPC 21 to VPC 22
       CostCode: CC1234
       Project: phoenix         
   register: vpc_peer


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

ec2_vpc_peer_module

##### CHANGES
<!-- Paste verbatim command output below, e.g. before and after your change -->
```
conenction ---> connection

```