### PR TITLE
Fix locale_gen to compare native strings rather than mixing byte and text strings

### DIFF
--- a/lib/ansible/modules/system/locale_gen.py
+++ b/lib/ansible/modules/system/locale_gen.py
@@ -55,8 +55,9 @@ import os.path
 from subprocess import Popen, PIPE, call
 import re
 
-from ansible.module_utils.basic import *
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils._text import to_native
 
 LOCALE_NORMALIZATION = {
     ".utf8": ".UTF-8",
@@ -99,6 +100,7 @@ def is_available(name, ubuntuMode):
 def is_present(name):
     """Checks if the given locale is currently installed."""
     output = Popen(["locale", "-a"], stdout=PIPE).communicate()[0]
+    output = to_native(output)
     return any(fix_case(name) == fix_case(line) for line in output.splitlines())
 
 def fix_case(name):

--- a/test/integration/destructive.yml
+++ b/test/integration/destructive.yml
@@ -22,3 +22,4 @@
     - { role: apache2_module, tags: test_apache2_module }
     # This removes ~/.ssh/known_hosts and /etc/ssh/known_hosts
     - { role: git, tags: test_git }
+    - { role: locale_gen, tags: test_locale_gen }

--- a/test/integration/targets/locale_gen/aliases
+++ b/test/integration/targets/locale_gen/aliases
@@ -1,0 +1,3 @@
+destructive
+needs/root
+posix/ci/group3

--- a/test/integration/targets/locale_gen/meta/main.yml
+++ b/test/integration/targets/locale_gen/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_tests

--- a/test/integration/targets/locale_gen/tasks/locale_gen.yml
+++ b/test/integration/targets/locale_gen/tasks/locale_gen.yml
@@ -1,0 +1,94 @@
+- name: Is the locale we're going to test against installed?
+  shell: locale -a | grep pt_BR
+  register: initial_state
+  ignore_errors: True
+
+- name: Make sure the locale is not installed
+  locale_gen:
+    name: pt_BR
+    state: absent
+
+- name: Is the locale present?
+  shell: locale -a | grep pt_BR
+  register: cleaned
+  ignore_errors: True
+
+- name: Make sure the locale is not present
+  assert:
+    that:
+      - "cleaned.rc == 1"
+
+- name: Install the locale
+  locale_gen:
+    name: pt_BR
+    state: present
+  register: output
+
+- name: Is the locale present?
+  shell: locale -a | grep pt_BR
+  register: post_check_output
+  ignore_errors: True
+
+- name: Make sure the locale is present and we say we installed it
+  assert:
+    that:
+      - "post_check_output.rc == 0"
+      - "output.changed"
+
+- name: Install the locale a second time
+  locale_gen:
+    name: pt_BR
+    state: present
+  register: output
+
+- name: Is the locale present?
+  shell: locale -a | grep pt_BR
+  register: post_check_output
+  ignore_errors: True
+
+- name: Make sure the locale is present and we reported no change
+  assert:
+    that:
+      - "post_check_output.rc == 0"
+      - "not output.changed"
+
+- name: Remove the locale
+  locale_gen:
+    name: pt_BR
+    state: absent
+  register: output
+
+- name: Is the locale present?
+  shell: locale -a | grep pt_BR
+  register: post_check_output
+  ignore_errors: True
+
+- name: Make sure the locale is absent and we reported a change
+  assert:
+    that:
+      - "post_check_output.rc == 1"
+      - "output.changed"
+
+- name: Remove the locale a second time
+  locale_gen:
+    name: pt_BR
+    state: absent
+  register: output
+
+- name: Is the locale present?
+  shell: locale -a | grep pt_BR
+  register: post_check_output
+  ignore_errors: True
+
+- name: Make sure the locale is absent and we reported no change
+  assert:
+    that:
+      - "post_check_output.rc == 1"
+      - "not output.changed"
+
+# Cleanup
+- name: Reinstall the locale we tested against if it was initially installed
+  locale_gen:
+    name: pt_BR
+    state: present
+  when: initial_state.rc == 0

--- a/test/integration/targets/locale_gen/tasks/main.yml
+++ b/test/integration/targets/locale_gen/tasks/main.yml
@@ -1,0 +1,19 @@
+# (c) 2014, James Tanner <tanner.jc@gmail.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- include: 'locale_gen.yml'
+  when: ansible_distribution in ('Ubuntu', 'Debian')


### PR DESCRIPTION

Fixes #19426

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/system/locale_gen.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.2
```
