### PR TITLE
pacemaker_cluster: Fail ansible if the cluster state is not the expected state

### DIFF
--- a/lib/ansible/modules/clustering/pacemaker_cluster.py
+++ b/lib/ansible/modules/clustering/pacemaker_cluster.py
@@ -34,6 +34,11 @@ options:
         - Indicate desired state of the cluster
       choices: ['online', 'offline', 'restart', 'cleanup']
       required: true
+    check_and_fail:
+      description:
+        - Exit if the current state is not the one indicated in the state option
+      required: false
+      default: false
     node:
       description:
         - Specify which node of the cluster you want to manage. None == the
@@ -158,6 +163,7 @@ def set_node(module, state, timeout, force, node='all'):
 def main():
     argument_spec = dict(
         state = dict(choices=['online', 'offline', 'restart', 'cleanup']),
+        check_and_fail=dict(default=False, type='bool'),
         node  = dict(default=None),
         timeout=dict(default=300, type='int'),
         force=dict(default=True, type='bool'),
@@ -168,6 +174,7 @@ def main():
     )
     changed = False
     state = module.params['state']
+    check_and_fail = module.params['check_and_fail']
     node = module.params['node']
     force = module.params['force']
     timeout = module.params['timeout']
@@ -180,6 +187,8 @@ def main():
                 module.exit_json(changed=changed,
                          out=cluster_state)
             else:
+                if check_and_fail:
+                    module.fail_json(msg="State not found to be in %s " % state)
                 set_cluster(module, state, timeout, force)
                 cluster_state = get_cluster_status(module)
                 if cluster_state == state:
@@ -195,6 +204,8 @@ def main():
                     module.exit_json(changed=changed,
                              out=cluster_state)
                 else:
+                    if check_and_fail:
+                        module.fail_json(msg="State not found to be in %s " % state)
                     # Set cluster status if needed
                     set_cluster(module, state, timeout, force)
                     cluster_state = get_node_status(module, node)


### PR DESCRIPTION
Return failure is the option is set to true.
When we start to work on a pacemaker cluster, in some usage
we need to be sure that the cluster status is what we expected.

##### ISSUE TYPE
 - Feature Pull Request
 
##### COMPONENT NAME
pacemaker_cluster

##### ANSIBLE VERSION
ansible 2.1.0.0
```

```

##### SUMMARY
Add an option to give the possibility to the user to return a failure is the
pacemaker cluster is not in the expected status.
Example:
Before making some maintenance on the pacemaker resources, we want to be sure that the cluster is up, if not that mean that something went wrong before and needs to be investigating.
```

```
