### PR TITLE
Add --installroot to YUM and DNF modules, issue #11310

### DIFF
--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -86,6 +86,15 @@ options:
     choices: ["yes", "no"]
     aliases: []
 
+  installroot:
+    description:
+      - Specifies an alternative installroot, relative to which all packages
+        will be installed.
+    required: false
+    version_added: "2.3"
+    default: "/"
+    aliases: []
+
 notes: []
 # informational: requirements for nodes
 requirements:
@@ -94,6 +103,7 @@ requirements:
 author:
   - '"Igor Gnatenko (@ignatenkobrain)" <i.gnatenko.brain@gmail.com>'
   - '"Cristian van Ee (@DJMuggs)" <cristian at cvee.org>'
+  - "Berend De Schouwer (github.com/berenddeschouwer)"
 '''
 
 EXAMPLES = '''
@@ -176,7 +186,7 @@ def _ensure_dnf(module):
                     " Please install `{0}` package.".format(package))
 
 
-def _configure_base(module, base, conf_file, disable_gpg_check):
+def _configure_base(module, base, conf_file, disable_gpg_check, installroot):
     """Configure the dnf Base object."""
     conf = base.conf
 
@@ -188,6 +198,12 @@ def _configure_base(module, base, conf_file, disable_gpg_check):
 
     # Don't prompt for user confirmations
     conf.assumeyes = True
+
+    # Set installroot
+    if installroot and installroot != '/':
+        conf.installroot = installroot
+    else:
+        conf.installroot = '/'
 
     # Change the configuration file path if provided
     if conf_file:
@@ -218,10 +234,10 @@ def _specify_repositories(base, disablerepo, enablerepo):
             repo.enable()
 
 
-def _base(module, conf_file, disable_gpg_check, disablerepo, enablerepo):
+def _base(module, conf_file, disable_gpg_check, disablerepo, enablerepo, installroot):
     """Return a fully configured dnf Base object."""
     base = dnf.Base()
-    _configure_base(module, base, conf_file, disable_gpg_check)
+    _configure_base(module, base, conf_file, disable_gpg_check, installroot)
     _specify_repositories(base, disablerepo, enablerepo)
     base.fill_sack(load_system_repo='auto')
     return base
@@ -450,6 +466,7 @@ def main():
             list=dict(),
             conf_file=dict(default=None, type='path'),
             disable_gpg_check=dict(default=False, type='bool'),
+            installroot=dict(default=None, type='path'),
         ),
         required_one_of=[['name', 'list']],
         mutually_exclusive=[['name', 'list']],
@@ -461,7 +478,7 @@ def main():
     if params['list']:
         base = _base(
             module, params['conf_file'], params['disable_gpg_check'],
-            params['disablerepo'], params['enablerepo'])
+            params['disablerepo'], params['enablerepo'], params['installroot'])
         list_items(module, base, params['list'])
     else:
         # Note: base takes a long time to run so we want to check for failure
@@ -470,7 +487,7 @@ def main():
             module.fail_json(msg="This command has to be run under the root user.")
         base = _base(
             module, params['conf_file'], params['disable_gpg_check'],
-            params['disablerepo'], params['enablerepo'])
+            params['disablerepo'], params['enablerepo'], params['installroot'])
 
         ensure(module, base, params['state'], params['name'])
 

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -93,7 +93,6 @@ options:
     required: false
     version_added: "2.3"
     default: "/"
-    aliases: []
 
 notes: []
 # informational: requirements for nodes
@@ -186,7 +185,7 @@ def _ensure_dnf(module):
                     " Please install `{0}` package.".format(package))
 
 
-def _configure_base(module, base, conf_file, disable_gpg_check, installroot):
+def _configure_base(module, base, conf_file, disable_gpg_check, installroot='/'):
     """Configure the dnf Base object."""
     conf = base.conf
 

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -199,10 +199,7 @@ def _configure_base(module, base, conf_file, disable_gpg_check, installroot='/')
     conf.assumeyes = True
 
     # Set installroot
-    if installroot and installroot != '/':
-        conf.installroot = installroot
-    else:
-        conf.installroot = '/'
+    conf.installroot = installroot
 
     # Change the configuration file path if provided
     if conf_file:
@@ -465,7 +462,7 @@ def main():
             list=dict(),
             conf_file=dict(default=None, type='path'),
             disable_gpg_check=dict(default=False, type='bool'),
-            installroot=dict(default=None, type='path'),
+            installroot=dict(default='/', type='path'),
         ),
         required_one_of=[['name', 'list']],
         mutually_exclusive=[['name', 'list']],

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -210,3 +210,33 @@
   assert:
     that:
       - non_existent_rpm|failed
+
+# Install in installroot='/'.  This should be identical to default
+- name: install sos in /
+  dnf: name=sos state=present installroot='/'
+  register: dnf_result
+
+- name: check sos with rpm in /
+  shell: rpm -q sos --root=/
+  failed_when: False
+  register: rpm_result
+
+- debug: var=dnf_result
+- debug: var=rpm_result
+
+- name: verify installation of sos in /
+  assert:
+    that:
+        - "not dnf_result.failed | default(False)"
+        - "dnf_result.changed"
+        - "rpm_result.rc == 0"
+
+- name: verify dnf module outputs in /
+  assert:
+    that:
+        - "'changed' in dnf_result"
+        - "'results' in dnf_result"
+
+- name: uninstall sos in /
+  dnf: name=sos installroot='/'
+  register: dnf_result

--- a/test/integration/targets/dnf/tasks/dnfinstallroot.yml
+++ b/test/integration/targets/dnf/tasks/dnfinstallroot.yml
@@ -1,0 +1,47 @@
+# make a installroot
+- name: Create installroot
+  local_action:
+    module: command mktemp -d "{{ lookup('env', 'TMPDIR') | default('/tmp', true) }}/ansible.test.XXXXXX"
+  register: dnfroot
+
+- name: Make a necessary directory
+  file:
+    path: "/{{ dnfroot.stdout }}/etc/dnf/vars/"
+    state: directory
+    mode: 0755
+
+- name: Populate directory
+  copy:
+    content: "{{ ansible_distribution_version }}\n"
+    dest: "/{{ dnfroot.stdout }}/etc/dnf/vars/releasever"
+
+# This will drag in > 200 MB.
+- name: attempt installroot
+  dnf: name=sos installroot="/{{ dnfroot.stdout }}/" disable_gpg_check=yes
+  register: dnf_result
+
+- name: check sos with rpm in installroot
+  shell: rpm -q sos --root="/{{ dnfroot.stdout }}/"
+  failed_when: False
+  register: rpm_result
+
+- debug: var=dnf_result
+- debug: var=rpm_result
+
+- name: verify installation of sos in installroot
+  assert:
+    that:
+        - "not dnf_result.failed | default(False)"
+        - "dnf_result.changed"
+        - "rpm_result.rc == 0"
+
+- name: verify dnf module outputs in /
+  assert:
+    that:
+        - "'changed' in dnf_result"
+        - "'results' in dnf_result"
+
+- name: cleanup installroot
+  file:
+    path: "/{{ dnfroot.stdout }}/"
+    state: absent

--- a/test/integration/targets/dnf/tasks/main.yml
+++ b/test/integration/targets/dnf/tasks/main.yml
@@ -18,5 +18,9 @@
 
 # Note: We install the yum package onto Fedora so that this will work on dnf systems
 # We want to test that for people who don't want to upgrade their systems.
+
 - include: 'dnf.yml'
   when: (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and False) or (ansible_distribution in ['Fedora'] and ansible_distribution_major_version >= 23)
+
+- include: 'dnfinstallroot.yml'
+  when: (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and False) or (ansible_distribution in ['Fedora'] and ansible_distribution_major_version >= 23)  

--- a/test/integration/targets/yum/tasks/main.yml
+++ b/test/integration/targets/yum/tasks/main.yml
@@ -19,4 +19,14 @@
 # Note: We install the yum package onto Fedora so that this will work on dnf systems
 # We want to test that for people who don't want to upgrade their systems.
 - include: 'yum.yml'
-  when: ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux', 'Fedora'] and ansible_python.version.major == 2
+  when: ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux', 'Fedora'] and
+        ansible_python.version.major == 2
+
+# We can't run yum --installroot tests on dnf systems.  Dnf systems revert to
+# yum-deprecated, and yum-deprecated refuses to run if yum.conf exists
+# so we cannot configure yum-deprecated correctly in an empty /tmp/fake.root/
+# It will always run with $releasever unset
+- include: 'yuminstallroot.yml'
+  when: (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] or
+        (ansible_distribution in ['Fedora'] and ansible_distribution_major_version < 23)) and
+        ansible_python.version.major == 2

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -197,3 +197,35 @@
   assert:
     that:
     - non_existent_rpm|failed
+
+# Install in installroot='/'
+- name: install sos
+  yum: name=sos state=present installroot='/'
+  register: yum_result
+
+- name: check sos with rpm
+  shell: rpm -q sos --root=/
+  failed_when: False
+  register: rpm_result
+
+- debug: var=yum_result
+- debug: var=rpm_result
+
+- name: verify installation of sos
+  assert:
+    that:
+        - "yum_result.rc == 0"
+        - "yum_result.changed"
+        - "rpm_result.rc == 0"
+
+- name: verify yum module outputs
+  assert:
+    that:
+        - "'changed' in yum_result"
+        - "'msg' in yum_result"
+        - "'rc' in yum_result"
+        - "'results' in yum_result"
+
+- name: uninstall sos
+  yum: name=sos installroot='/'
+  register: yum_result

--- a/test/integration/targets/yum/tasks/yuminstallroot.yml
+++ b/test/integration/targets/yum/tasks/yuminstallroot.yml
@@ -1,0 +1,60 @@
+# make a installroot
+- name: Create installroot
+  local_action:
+    module: command mktemp -d "{{ lookup('env', 'TMPDIR') | default('/tmp', true) }}/ansible.test.XXXXXX"
+  register: yumroot
+
+#- name: Populate directory
+#  file:
+#    path: "/{{ yumroot.stdout }}/etc/"
+#    state: directory
+#    mode: 0755
+#
+#- name: Populate directory2
+#  copy:
+#    content: "[main]\ndistropkgver={{ ansible_distribution_version }}\n"
+#    dest: "/{{ yumroot.stdout }}/etc/yum.conf"
+
+- name: Make a necessary directory
+  file:
+    path: "/{{ yumroot.stdout }}/etc/yum/vars/"
+    state: directory
+    mode: 0755
+
+- name: Populate directory
+  copy:
+    content: "{{ ansible_lsb.major_release }}\n"
+    dest: "/{{ yumroot.stdout }}/etc/yum/vars/releasever"
+
+# This will drag in > 200 MB.
+- name: attempt installroot
+  yum: name=sos installroot="/{{ yumroot.stdout }}/" disable_gpg_check=yes
+  register: yum_result
+  
+- name: check sos with rpm in installroot
+  shell: rpm -q sos --root="/{{ yumroot.stdout }}/"
+  failed_when: False
+  register: rpm_result
+
+- debug: var=yum_result
+- debug: var=rpm_result
+
+- name: verify installation of sos
+  assert:
+    that:
+        - "yum_result.rc == 0"
+        - "yum_result.changed"
+        - "rpm_result.rc == 0"
+
+- name: verify yum module outputs
+  assert:
+    that:
+        - "'changed' in yum_result"
+        - "'msg' in yum_result"
+        - "'rc' in yum_result"
+        - "'results' in yum_result"
+
+- name: cleanup installroot
+  file:
+    path: "/{{ yumroot.stdout }}/"
+    state: absent


### PR DESCRIPTION
This continues ansible-modules-core#1558, and
ansible-modules-core#1669

Allow specifying installroot for the yum and dnf modules
to install and remove packages in a location other than /.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
modules/packaging/os/dnf.py

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 218bab80de) last updated 2017/01/04 14:48:31 (GMT +200)
```

##### SUMMARY
Add --installroot option for YUM and DNF

Allow for using YUM and DNF to install packages in a directory other
than /.

I'm continuing other people's work, but I use it for LTSP and other root and jail-ed installs.  YUM --installroot was submitted before as #11310, and ansible-core-modules (since included in ansible) as issues # 1558 and # 1669.  I also included it in DNF, and kept the previous change author in the yum module.

Tests are included.