### PR TITLE
Update dynamic inventory zabbix.py

### DIFF
--- a/contrib/inventory/zabbix.py
+++ b/contrib/inventory/zabbix.py
@@ -24,10 +24,12 @@ Zabbix Server external inventory script.
 ========================================
 
 Returns hosts and hostgroups from Zabbix Server.
+If you want to run with --limit against a host group with space in the 
+name, use asterisk. For example --limit="Linux*servers".
 
 Configuration is read from `zabbix.ini`.
 
-Tested with Zabbix Server 2.0.6.
+Tested with Zabbix Server 2.0.6 and 3.2.3.
 """
 
 from __future__ import print_function
@@ -100,14 +102,18 @@ class ZabbixInventory(object):
 
                 data[groupname]['hosts'].append(hostname)
 
+	# Prevents Ansible from calling this script for each server with --host
+        data['_meta'] = { 'hostvars': self.meta }
+
         return data
 
     def __init__(self):
 
-        self.defaultgroup = 'group_all'
-        self.zabbix_server = None
+        self.defaultgroup    = 'group_all'
+        self.zabbix_server   = None
         self.zabbix_username = None
         self.zabbix_password = None
+        self.meta            = {}
 
         self.read_settings()
         self.read_cli()


### PR DESCRIPTION
Added _meta to improve the speed when using the zabbix.py dynamic inventory file.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
contrib/inventory/zabbix.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /home/rpettersen/ansible/projects/zabbix/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Added some instructions on how to workaround spaces in group-names in Zabbix.
Added the _meta keyword to prevent huge delay in running Ansible with this dynamic inventory file.