### PR TITLE
allow modules to set custom stats

### DIFF
--- a/lib/ansible/executor/stats.py
+++ b/lib/ansible/executor/stats.py
@@ -19,6 +19,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from ansible.utils.vars import merge_hash
+
 class AggregateStats:
     ''' holds stats about per-host activity during playbook runs '''
 
@@ -30,6 +32,9 @@ class AggregateStats:
         self.dark      = {}
         self.changed   = {}
         self.skipped   = {}
+
+        # user defined stats, which can be per host or global
+        self.custom = {}
 
     def increment(self, what, host):
         ''' helper function to bump a statistic '''
@@ -48,4 +53,32 @@ class AggregateStats:
             changed     = self.changed.get(host, 0),
             skipped     = self.skipped.get(host, 0)
         )
+
+    def set_custom_stats(self, which, what, host=None):
+        ''' allow setting of a custom fact '''
+
+        if host is None:
+            host = '_run'
+        if host not in  self.custom:
+            self.custom[host] = {which: what}
+        else:
+            self.custom[host][which] = what
+
+    def update_custom_stats(self, which, what, host=None):
+        ''' allow aggregation of a custom fact '''
+
+        if host is None:
+            host = '_run'
+        if host not in self.custom or which not in self.custom[host]:
+            return self.set_custom_stats(which, what, host)
+
+        # mismatching types
+        if type(what) != type(self.custom[host][which]):
+            return None
+
+        if isinstance(what, dict):
+            self.custom[host][which] =  merge_hash(self.custom[host][which], what)
+        else:
+            # let overloaded + take care of other types
+            self.custom[host][which] += what
 

--- a/lib/ansible/modules/utilities/logic/set_stats.py
+++ b/lib/ansible/modules/utilities/logic/set_stats.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright 2016 Ansible RedHat, Inc
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = '''
+---
+author: "Brian Coca (@bcoca)"
+module: set_stats
+short_description: Set stats for the current ansible run
+description:
+     - This module allows setting/accumulating stats on the current ansible run, either per host of for all hosts in the run.
+options:
+  data:
+    description:
+      - A dictionary of which each key represents a stat (or variable) you want to keep track of
+    required: true
+  per_host:
+    description:
+        - boolean that indicates if the stats is per host or for all hosts in the run.
+    required: no
+    default: yes
+  aggregate:
+    description:
+        - boolean that indicates if the provided value is aggregated to the existing stat C(yes) or will replace it C(no)
+    required: no
+    default: yes
+version_added: "2.3"
+'''
+
+EXAMPLES = '''
+# Aggregating packages_installed stat per host
+- set_stats:
+    data:
+      packages_installed: 31
+
+# Aggregating random stats for all hosts using complex arguments
+- set_stats:
+    data:
+      one_stat: 11
+      other_stat: "{{ local_var * 2 }}"
+      another_stat: "{{ some_registered_var.results | map(attribute='ansible_facts.some_fact') | list }}"
+    per_host: no
+
+
+# setting stats (not aggregating)
+- set_stats:
+    data:
+      the_answer: 42
+    aggregate: no
+'''

--- a/lib/ansible/plugins/action/set_stats.py
+++ b/lib/ansible/plugins/action/set_stats.py
@@ -1,0 +1,73 @@
+# Copyright 2016 Ansible (RedHat, Inc)
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.compat.six import iteritems, string_types
+from ansible.constants import mk_boolean as boolean
+from ansible.plugins.action import ActionBase
+from ansible.utils.vars import isidentifier
+
+class ActionModule(ActionBase):
+
+    TRANSFERS_FILES = False
+
+    #TODO: document this in non-empty set_stats.py module
+    def run(self, tmp=None, task_vars=None):
+        if task_vars is None:
+            task_vars = dict()
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        stats = {'data': {}, 'per_host': False, 'aggregate': True}
+
+        if self._task.args:
+            data = self._task.args.get('data', {})
+
+            if not isinstance(data, dict):
+                data = self._templar.template(data, convert_bare=False, fail_on_undefined=True)
+
+            if not isinstance(data, dict):
+                result['failed'] = True
+                result['msg'] = "The 'data' option needs to be a dictionary/hash"
+                return result
+
+            # set boolean options, defaults are set above in stats init
+            for opt in ['per_host', 'aggregate']:
+                val = self._task.args.get(opt, None)
+                if val is not None:
+                    if not isinstance(val, bool):
+                        stats[opt] = boolean(self._templar.template(val))
+                    else:
+                        stats[opt] = val
+
+            for (k, v) in iteritems(data):
+
+                k = self._templar.template(k)
+
+                if not isidentifier(k):
+                    result['failed'] = True
+                    result['msg'] = "The variable name '%s' is not valid. Variables must start with a letter or underscore character, and contain only letters, numbers and underscores." % k
+                    return result
+
+                stats['data'][k] = self._templar.template(v)
+
+        result['changed'] = False
+        result['ansible_stats'] = stats
+
+        return result


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
stats

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
can be per run or per host, also aggregate or not
set_stats action plugin as reference implementation
added doc stub