### PR TITLE
Stops New-PSDrive commandlet producing output which was causing warnings

### DIFF
--- a/lib/ansible/modules/windows/win_regedit.ps1
+++ b/lib/ansible/modules/windows/win_regedit.ps1
@@ -21,9 +21,9 @@ $ErrorActionPreference = "Stop"
 # WANT_JSON
 # POWERSHELL_COMMON
 
-New-PSDrive -PSProvider registry -Root HKEY_CLASSES_ROOT -Name HKCR -ErrorAction SilentlyContinue
-New-PSDrive -PSProvider registry -Root HKEY_USERS -Name HKU -ErrorAction SilentlyContinue
-New-PSDrive -PSProvider registry -Root HKEY_CURRENT_CONFIG -Name HCCC -ErrorAction SilentlyContinue
+New-PSDrive -PSProvider registry -Root HKEY_CLASSES_ROOT -Name HKCR -ErrorAction SilentlyContinue | Out-Null
+New-PSDrive -PSProvider registry -Root HKEY_USERS -Name HKU -ErrorAction SilentlyContinue | Out-Null
+New-PSDrive -PSProvider registry -Root HKEY_CURRENT_CONFIG -Name HCCC -ErrorAction SilentlyContinue | Out-Null
 
 $params = Parse-Args $args;
 $result = New-Object PSObject;
@@ -134,7 +134,7 @@ if($state -eq "present") {
         if (Test-RegistryValueData -Path $registryKey -Value $registryValue)
         {
             # handle binary data
-            $currentRegistryData =(Get-ItemProperty -Path $registryKey | Select-Object -ExpandProperty $registryValue) 
+            $currentRegistryData =(Get-ItemProperty -Path $registryKey | Select-Object -ExpandProperty $registryValue)
 
             if ($registryValue.ToLower() -eq "(default)") {
                 # Special case handling for the key's default property. Because .GetValueKind() doesn't work for the (default) key property


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
win_regedit

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Running `New-PSDrive` command outputs to stdout which causes invalid Json warning. Ensure no output is produced when running New-PSDrive commanlet by pipeing to `Out-Null` 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
# before
[WARNING]: Module invocation had junk after the JSON data:
ok: [myhost] => {"changed": false, "data_changed": false, "data_type_changed": false}

# after
ok: [myhost] => {"changed": false, "data_changed": false, "data_type_changed": false}
```
