### PR TITLE
os_user: fix typo (self is not defined)

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_user.py
+++ b/lib/ansible/modules/cloud/openstack/os_user.py
@@ -223,7 +223,7 @@ def main():
                 if not password:
                     msg = ("update_password is %s but a password value is "
                           "missing") % update_password
-                    self.fail_json(msg=msg)
+                    module.fail_json(msg=msg)
             default_project_id = None
             if default_project:
                 default_project_id = _get_default_project_id(cloud, default_project)


### PR DESCRIPTION
##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
os_user module

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

Minor bugfix: os_user fails with a traceback instead of returning the error message.

**Before**:
```
TASK [Create user] ************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: NameError: global name 'self' is not defined
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_9pz3fb/ansible_module_os_user.py\", line 278, in <module>\n    main()\n  File \"/tmp/ansible_9pz3fb/ansible_module_os_user.py\", line 226, in main\n    self.fail_json(msg=msg)\nNameError: global name 'self' is not defined\n", "module_stdout": "", "msg": "MODULE FAILURE"}
```

**After**:
```
TASK [Create user] ************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "update_password is always but a password value is missing"}
```
