### PR TITLE
Add support for remote docker servers to integration tests

### DIFF
--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -154,6 +154,7 @@ There are additional environment variables that can be used. A few of the more u
   - `KEEP_CONTAINERS=1` - Containers will always be preserved.
   - `SHARE_SOURCE=1` - Changes to source from the host or container will be shared between host and container.
                        _**CAUTION:** Files created by the container will be owned by root on the host._
+  - `REMOTE_DOCKER=1` - Will ultimately use `docker cp` instead of mounting your ansible directory as a docker volume, to support remote docker servers
 
 Network Tests
 =============

--- a/test/utils/shippable/integration.sh
+++ b/test/utils/shippable/integration.sh
@@ -9,6 +9,8 @@ test_target="${TARGET:-all}"
 test_ansible_dir="${TEST_ANSIBLE_DIR:-/root/ansible}"
 test_python3="${PYTHON3:-}"
 
+remote_docker="${REMOTE_DOCKER:-}"
+
 http_image="${HTTP_IMAGE:-ansible/ansible:httptester}"
 
 # Keep the docker containers after tests complete.
@@ -120,7 +122,11 @@ if [ "${skip}" ]; then
 fi
 
 if [ -z "${share_source}" ]; then
-    docker exec "${container_id}" cp -a "${test_shared_dir}" "${test_ansible_dir}"
+    if [ "${remote_docker}" ]; then
+        docker cp "${host_shared_dir}" "${container_id}:${test_ansible_dir}"
+    else
+        docker exec "${container_id}" cp -a "${test_shared_dir}" "${test_ansible_dir}"
+    fi
 fi
 
 docker exec "${container_id}" \


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME
tests

##### ANSIBLE VERSION

```
v2.3
```

##### SUMMARY
This change allows the use of `integration.sh` with remote docker servers.

As of now, using remote docker servers does not work, as we mount the ansible directory as a docker volume, which does a bind mount from the docker server into the docker container.  When using a docker server external to the system where you are running the integration tests this of course fails.

A new env var called `REMOTE_DOCKER` has been added, to use `docker cp` instead, for copying the files to the docker container for testing.

cc @mattclay 