### PR TITLE
Do not pass the password to shade.openstack_cloud

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_user.py
+++ b/lib/ansible/modules/cloud/openstack/os_user.py
@@ -178,6 +178,9 @@ def _get_default_project_id(cloud, default_project):
 
     return project['id']
 
+def _without_keys(d, keys):
+    return dict((k, v) for k, v in d.items() if k not in keys)
+
 def main():
 
     argument_spec = openstack_full_argument_spec(
@@ -210,7 +213,8 @@ def main():
     update_password = module.params['update_password']
 
     try:
-        cloud = shade.openstack_cloud(**module.params)
+        cloud = shade.openstack_cloud(**_without_keys(module.params,
+                                                      ['password']))
         user = cloud.get_user(name)
 
         domain_id = None


### PR DESCRIPTION
##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
os_user module

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

The following task fails if the `OS_PASSWORD` environment variable is used for authentication.

```
- name: Create user
  os_user:
    name: "{{ user }}"
    password: "{{ password }}"
    email: "{{ email }}"
    default_project: "{{ project }}"
    domain: "default"
```

This happens because passing a `password` param to  `shade.openstack_cloud` overrides the value of the `OS_PASSWORD` environment variable.

**Before**:
```
TASK [Create user] ************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "extra_data": null, "failed": true, "msg": "Failed to list users (Inner Exception: The request you have made requires authentication. (HTTP 401) (Request-ID: req-38660dc1-b733-459f-9efb-fb13886536ef))"}
```

**After**:
```
TASK [Create user] ************************************************************
ok: [localhost]
```
