### PR TITLE
Fix OSX defaults for lists

### DIFF
--- a/lib/ansible/modules/system/osx_defaults.py
+++ b/lib/ansible/modules/system/osx_defaults.py
@@ -116,7 +116,9 @@ EXAMPLES = '''
 '''
 
 import datetime
-from ansible.module_utils.basic import *
+import re
+
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
 
 # exceptions --------------------------------------------------------------- {{{
@@ -380,6 +382,7 @@ def main():
             value=dict(
                 default=None,
                 required=False,
+                type='raw'
             ),
             state=dict(
                 default="present",


### PR DESCRIPTION
In modern ansible, parameters default to string type.  This causes
issues for polymorphic parameters like this module's value param.  note
that this fix restores ansible-2.0 and previous behaviour but it is not
perfect.  If a parameter is specified via key=value or given on the
commandline then it will be a string before it reaches the module code.
There's nothing we can do about that.

Fixes #19585

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
modules/system/osx_defaults.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.2 and devel
```

note: this is probably better fixed only in devel as it isn't perfect.  There's a chance that users are using key-value with this module and will have to switch to yaml notation.  (This is better than the status quo as there's currently no way to use lists with the value parameter).