### PR TITLE
Changing author's e-mail for ldap_* modules

### DIFF
--- a/lib/ansible/modules/network/ldap_attr.py
+++ b/lib/ansible/modules/network/ldap_attr.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2016, Peter Sagerson <psagers@getcloak.com>
+# (c) 2016, Peter Sagerson <psagers@ignorare.net>
 # (c) 2016, Jiri Tyr <jiri.tyr@gmail.com>
 #
 # This file is part of Ansible

--- a/lib/ansible/modules/network/ldap_entry.py
+++ b/lib/ansible/modules/network/ldap_entry.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2016, Peter Sagerson <psagers@getcloak.com>
+# (c) 2016, Peter Sagerson <psagers@ignorare.net>
 # (c) 2016, Jiri Tyr <jiri.tyr@gmail.com>
 #
 # This file is part of Ansible


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

`ldap_attr` and `ldap_entry` modules

##### ANSIBLE VERSION

For Ansible v2.3.

##### SUMMARY

This PR is only changing e-mail address of the original author of these modules as per his request here:

https://bitbucket.org/psagers/ansible-ldap/pull-requests/2/adding-params-option-and-other-minor/diff#comment-29182565