### PR TITLE
new panos module to load configuration file

### DIFF
--- a/lib/ansible/modules/network/panos/panos_loadcfg.py
+++ b/lib/ansible/modules/network/panos/panos_loadcfg.py
@@ -71,11 +71,8 @@ EXAMPLES = '''
       file: "{{result.filename}}"
 '''
 
-RETURN = '''
-status:
-    description: success status
-    returned: success
-    type: string
+RETURN='''
+# Default return values
 '''
 
 ANSIBLE_METADATA = {'status': ['preview'],
@@ -114,23 +111,16 @@ def main():
         module.fail_json(msg='pan-python is required for this module')
 
     ip_address = module.params["ip_address"]
-    if not ip_address:
-        module.fail_json(msg="ip_address should be specified")
     password = module.params["password"]
-    if not password:
-        module.fail_json(msg="password is required")
     username = module.params['username']
+    file_ = module.params['file']
+    commit = module.params['commit']
 
     xapi = pan.xapi.PanXapi(
         hostname=ip_address,
         api_username=username,
         api_password=password
     )
-
-    file_ = module.params['file']
-    if file_ is None:
-        module.fail_json(msg="file is required")
-    commit = module.params['commit']
 
     changed = load_cfgfile(xapi, module, ip_address, file_)
     if changed and commit:

--- a/lib/ansible/modules/network/panos/panos_loadcfg.py
+++ b/lib/ansible/modules/network/panos/panos_loadcfg.py
@@ -1,0 +1,143 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Ansible module to manage PaloAltoNetworks Firewall
+# (c) 2016, techbizdev <techbizdev@paloaltonetworks.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: panos_loadcfg
+short_description: load configuration on PAN-OS device
+description:
+    - Load configuration on PAN-OS device
+author: "Luigi Mori (@jtschichold), Ivan Bojer (@ivanbojer)"
+version_added: "2.3"
+requirements:
+    - pan-python
+options:
+    ip_address:
+        description:
+            - IP address (or hostname) of PAN-OS device
+        required: true
+    password:
+        description:
+            - password for authentication
+        required: true
+    username:
+        description:
+            - username for authentication
+        required: false
+        default: "admin"
+    file:
+        description:
+            - configuration file to load
+        required: false
+        default: None
+    commit:
+        description:
+            - commit if changed
+        required: false
+        default: true
+'''
+
+EXAMPLES = '''
+# Import and load config file from URL
+  - name: import configuration
+    panos_import:
+      ip_address: "192.168.1.1"
+      password: "admin"
+      url: "{{ConfigURL}}"
+      category: "configuration"
+    register: result
+  - name: load configuration
+    panos_loadcfg:
+      ip_address: "192.168.1.1"
+      password: "admin"
+      file: "{{result.filename}}"
+'''
+
+RETURN = '''
+status:
+    description: success status
+    returned: success
+    type: string
+'''
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+from ansible.module_utils.basic import AnsibleModule
+
+try:
+    import pan.xapi
+    HAS_LIB = True
+except ImportError:
+    HAS_LIB = False
+
+
+def load_cfgfile(xapi, module, ip_address, file_):
+    # load configuration file
+    cmd = '<load><config><from>%s</from></config></load>' %\
+          file_
+
+    xapi.op(cmd=cmd)
+
+    return True
+
+
+def main():
+    argument_spec = dict(
+        ip_address=dict(required=True),
+        password=dict(required=True, no_log=True),
+        username=dict(default='admin'),
+        file=dict(),
+        commit=dict(type='bool', default=True)
+    )
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
+    if not HAS_LIB:
+        module.fail_json(msg='pan-python is required for this module')
+
+    ip_address = module.params["ip_address"]
+    if not ip_address:
+        module.fail_json(msg="ip_address should be specified")
+    password = module.params["password"]
+    if not password:
+        module.fail_json(msg="password is required")
+    username = module.params['username']
+
+    xapi = pan.xapi.PanXapi(
+        hostname=ip_address,
+        api_username=username,
+        api_password=password
+    )
+
+    file_ = module.params['file']
+    if file_ is None:
+        module.fail_json(msg="file is required")
+    commit = module.params['commit']
+
+    changed = load_cfgfile(xapi, module, ip_address, file_)
+    if changed and commit:
+        xapi.commit(cmd="<commit></commit>", sync=True, interval=1)
+
+    module.exit_json(changed=changed, msg="okey dokey")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
panos_loadcfg

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.1.0.0 
config file = 
configured module search path = Default w/o overrides
```

##### SUMMARY
New panos module that allows admin to apply and load new configuration into the firewall. The file has to be imported first using panos_import module.
