### PR TITLE
action plugin, e.g win_copy, win_template: fix key errors when --diff is used

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -810,11 +810,11 @@ class ActionBase(with_metaclass(ABCMeta, object)):
 
         if not peek_result.get('failed', False) or peek_result.get('rc', 0) == 0:
 
-            if peek_result['state'] == 'absent':
+            if peek_result.get('state') == 'absent':
                 diff['before'] = ''
-            elif peek_result['appears_binary']:
+            elif peek_result.get('appears_binary'):
                 diff['dst_binary'] = 1
-            elif C.MAX_FILE_SIZE_FOR_DIFF > 0 and peek_result['size'] > C.MAX_FILE_SIZE_FOR_DIFF:
+            elif peek_result.get('size') and C.MAX_FILE_SIZE_FOR_DIFF > 0 and peek_result['size'] > C.MAX_FILE_SIZE_FOR_DIFF:
                 diff['dst_larger'] = C.MAX_FILE_SIZE_FOR_DIFF
             else:
                 display.debug("Slurping the file %s" % source)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_template,win_copy, action plugin on windows

##### ANSIBLE VERSION
```
devel, 2.2, 2.1
```

##### SUMMARY
win_template and win_copy  fails with key errors if --diff is given
<!-- Paste verbatim command output below, e.g. before and after your change -->
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: KeyError: 'state'
```

This patch fixes win_template and returns a diff.