### PR TITLE
Enable FreeBSD 11.0 for CI.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -14,6 +14,7 @@ matrix:
     - env: TEST=osx/10.11
 
     - env: TEST=freebsd/10.3-STABLE
+    - env: TEST=freebsd/11.0-STABLE
 
     - env: TEST=windows/1
     - env: TEST=windows/2


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

CI

##### ANSIBLE VERSION

```
ansible 2.3.0 (ci-freebsd-11 fdc9c5c5fe) last updated 2017/01/04 15:30:57 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Enable FreeBSD 11.0 for CI.