### PR TITLE
Changes to the httptester docker image to support new client cert functionality in tests

### DIFF
--- a/test/utils/docker/httptester/Dockerfile
+++ b/test/utils/docker/httptester/Dockerfile
@@ -17,7 +17,12 @@ RUN set -x && \
     openssl req -new -nodes -out /root/ca/sni2.ansible.http.tests-req.pem -keyout /root/ca/private/sni2.ansible.http.tests-key.pem -config /etc/ssl/openssl.cnf \
         -subj "/C=US/ST=North Carolina/L=Durham/O=Ansible/CN=sni2.ansible.http.tests" && \
     yes | openssl ca -config /etc/ssl/openssl.cnf -out /root/ca/sni2.ansible.http.tests-cert.pem -infiles /root/ca/sni2.ansible.http.tests-req.pem && \
+    openssl req -new -nodes -out /root/ca/client.ansible.http.tests-req.pem -keyout /root/ca/private/client.ansible.http.tests-key.pem -config /etc/ssl/openssl.cnf \
+        -subj "/C=US/ST=North Carolina/L=Durham/O=Ansible/CN=client.ansible.http.tests"
+    yes | openssl ca -config /etc/ssl/openssl.cnf -out /root/ca/client.ansible.http.tests-cert.pem -infiles /root/ca/client.ansible.http.tests-req.pem && \
     cp /root/ca/cacert.pem /usr/share/nginx/html/cacert.pem && \
+    cp /root/ca/client.ansible.http.tests-cert.pem /usr/share/nginx/html/client.pem && \
+    cp /root/ca/private/client.ansible.http.tests-key.pem /usr/share/nginx/html/client.key && \
     pip install gunicorn httpbin
 
 ADD services.sh /services.sh

--- a/test/utils/docker/httptester/Dockerfile
+++ b/test/utils/docker/httptester/Dockerfile
@@ -18,7 +18,7 @@ RUN set -x && \
         -subj "/C=US/ST=North Carolina/L=Durham/O=Ansible/CN=sni2.ansible.http.tests" && \
     yes | openssl ca -config /etc/ssl/openssl.cnf -out /root/ca/sni2.ansible.http.tests-cert.pem -infiles /root/ca/sni2.ansible.http.tests-req.pem && \
     openssl req -new -nodes -out /root/ca/client.ansible.http.tests-req.pem -keyout /root/ca/private/client.ansible.http.tests-key.pem -config /etc/ssl/openssl.cnf \
-        -subj "/C=US/ST=North Carolina/L=Durham/O=Ansible/CN=client.ansible.http.tests"
+        -subj "/C=US/ST=North Carolina/L=Durham/O=Ansible/CN=client.ansible.http.tests" && \
     yes | openssl ca -config /etc/ssl/openssl.cnf -out /root/ca/client.ansible.http.tests-cert.pem -infiles /root/ca/client.ansible.http.tests-req.pem && \
     cp /root/ca/cacert.pem /usr/share/nginx/html/cacert.pem && \
     cp /root/ca/client.ansible.http.tests-cert.pem /usr/share/nginx/html/client.pem && \

--- a/test/utils/docker/httptester/README.rst
+++ b/test/utils/docker/httptester/README.rst
@@ -22,20 +22,20 @@ manually started using::
 
 Such as when starting a docker container::
 
-    docker run -ti --rm -p 80:80 -p 443:443 --name httptester ansible/httptester /services.sh
+    docker run -ti --rm -p 80:80 -p 443:443 --name httptester ansible/ansible:httptester /services.sh
 
 docker build
 ^^^^^^^^^^^^
 
 ::
 
-    docker build -t ansible/httptester .
+    docker build -t ansible/ansible:httptester .
 
 packer
 ^^^^^^
 
 The packer build will use ``ansible-playbook`` to perform the
-configuration, and will tag the image as ``ansible/httptester``
+configuration, and will tag the image as ``ansible/ansible:httptester``
 
 ::
 

--- a/test/utils/docker/httptester/httptester.yml
+++ b/test/utils/docker/httptester/httptester.yml
@@ -102,10 +102,29 @@
       shell: >
         yes | openssl ca -config /etc/ssl/openssl.cnf -out /root/ca/sni2.ansible.http.tests-cert.pem -infiles /root/ca/sni2.ansible.http.tests-req.pem
 
+    - name: Generate client key
+      command: >
+        openssl req -new -nodes -out /root/ca/client.ansible.http.tests-req.pem -keyout /root/ca/private/client.ansible.http.tests-key.pem -config /etc/ssl/openssl.cnf
+          -subj "/C=US/ST=North Carolina/L=Durham/O=Ansible/CN=client.ansible.http.tests"
+
+    - name: Generate client.ansible.http.tests cert
+      shell: >
+        yes | openssl ca -config /etc/ssl/openssl.cnf -out /root/ca/client.ansible.http.tests-cert.pem -infiles /root/ca/client.ansible.http.tests-req.pem
+
     - name: Copy cacert.pem into nginx doc root for easy retrieval
       copy:
-        src: /root/ca/cacert.pem
-        dest: /usr/share/nginx/html/cacert.pem
+        src: "/root/ca/cacert.pem"
+        dest: "/usr/share/nginx/html/cacert.pem"
+        remote_src: true
+
+    - copy:
+        src: /root/ca/client.ansible.http.tests-cert.pem
+        dest: /usr/share/nginx/html/client.pem
+        remote_src: true
+
+    - copy:
+        src: /root/ca/private/client.ansible.http.tests-key.pem
+        dest: /usr/share/nginx/html/client.key
         remote_src: true
 
     - name: Install gunicorn and httpbin

--- a/test/utils/docker/httptester/nginx.sites.conf
+++ b/test/utils/docker/httptester/nginx.sites.conf
@@ -7,8 +7,23 @@ server {
     ssl_certificate /root/ca/ansible.http.tests-cert.pem;
     ssl_certificate_key /root/ca/private/ansible.http.tests-key.pem;
 
+    ssl_client_certificate /root/ca/cacert.pem;
+    ssl_verify_client optional;
+
     location =/cacert.pem {
         alias /usr/share/nginx/html/cacert.pem;
+    }
+
+    location =/client.key {
+        alias /usr/share/nginx/html/client.key;
+    }
+
+    location =/client.pem {
+        alias /usr/share/nginx/html/client.pem;
+    }
+
+    location =/ssl_client_verify {
+        return 200 "ansible.http.tests:$ssl_client_verify";
     }
 
     location / {

--- a/test/utils/docker/httptester/packer.json
+++ b/test/utils/docker/httptester/packer.json
@@ -37,7 +37,8 @@
     "post-processors": [
         {
             "type": "docker-tag",
-            "repository": "ansible/httptester"
+            "repository": "ansible/ansible",
+            "tag": "httptester"
         }
     ]
 }


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME
httptester

##### ANSIBLE VERSION
```
v2.3
```

##### SUMMARY
Changes to the httptester docker image to support new client cert functionality in tests

These changes are to support https://github.com/ansible/ansible/pull/18141