### PR TITLE
Add subnet associations info to ec2_vpc_route_table_facts

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table_facts.py
@@ -74,16 +74,21 @@ def get_route_table_info(route_table):
 
     # Add any routes to array
     routes = []
+    associations = []
     for route in route_table.routes:
         routes.append(route.__dict__)
+    for association in route_table.associations:
+        associations.append(association.__dict__)
 
-    route_table_info = { 'id': route_table.id,
-                         'routes': routes,
-                         'tags': route_table.tags,
-                         'vpc_id': route_table.vpc_id
-                       }
+    route_table_info = {'id': route_table.id,
+                        'routes': routes,
+                        'associations': associations,
+                        'tags': route_table.tags,
+                        'vpc_id': route_table.vpc_id
+                        }
 
     return route_table_info
+
 
 def list_ec2_vpc_route_tables(connection, module):
 
@@ -105,7 +110,7 @@ def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(
         dict(
-            filters = dict(default=None, type='dict')
+            filters=dict(default=None, type='dict')
         )
     )
 


### PR DESCRIPTION
##### ISSUE TYPE
  - Feature Pull Request

##### COMPONENT NAME
ec2_vpc_route_table_facts

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel d182b271db) last updated 2017/01/05 14:24:17 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY 

Currently, the `ec2_vpc_route_table_facts` module does not include any information about route table associations even though this information is returned by the `get_all_route_tables` boto call. This information is extremely useful when reasoning about subnet/route table interactions. This PR rectifies that problem by just including a dict for each association in the exact same fashion as how the routes are returned to the user.

Some minor PEP8 tweaks are also included.

This is a straightforward rebase (retaining full credit) of ansible/ansible-modules-extra#3103 by @howinator