### PR TITLE
vmware_guest: add support for more virtual NICs

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -420,12 +420,20 @@ class PyVmomiDeviceHelper(object):
 
     def create_nic(self, device_type, device_label, device_infos):
         nic = vim.vm.device.VirtualDeviceSpec()
-        if device_type == 'vmxnet3':
+        if device_type == 'pcnet32':
+            nic.device = vim.vm.device.VirtualPCNet32()
+        if device_type == 'vmxnet2':
+            nic.device = vim.vm.device.VirtualVmxnet2()
+        elif device_type == 'vmxnet3':
             nic.device = vim.vm.device.VirtualVmxnet3()
         elif device_type == 'e1000':
             nic.device = vim.vm.device.VirtualE1000()
+        elif device_type == 'e1000e':
+            nic.device = vim.vm.device.VirtualE1000e()
+        elif device_type == 'sriov':
+            nic.device = vim.vm.device.VirtualSriovEthernetCard()
         else:
-            self.module.fail_json(msg="invalid device_type '%s' for network %s" %
+            self.module.fail_json(msg="Invalid device_type '%s' for network %s" %
                                       (device_type, device_infos['network']))
 
         nic.device.wakeOnLanEnabled = True
@@ -828,7 +836,12 @@ class PyVmomiHelper(object):
 
         device_list = []
         for device in vm.config.hardware.device:
-            if isinstance(device, vim.vm.device.VirtualVmxnet3) or isinstance(device, vim.vm.device.VirtualE1000):
+            if isinstance(device, vim.vm.device.VirtualPCNet32) or \
+               isinstance(device, vim.vm.device.VirtualVmxnet2) or \
+               isinstance(device, vim.vm.device.VirtualVmxnet3) or \
+               isinstance(device, vim.vm.device.VirtualE1000) or \
+               isinstance(device, vim.vm.device.VirtualE1000e) or \
+               isinstance(device, vim.vm.device.VirtualSriovEthernetCard):
                 device_list.append(device)
 
         return device_list


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vmware_guest

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
This patch adds support for all other virtual NICs, including:

 - pcnet32
 - vmxnet2
 - e1000e
 - sriov

Without this change, VMs with one of these NICs will fail with a
fault.NicSettingMismatch.summary error as it will only add interfaces,
not edit these.

This fixes #19860