### PR TITLE
(docs) Remove/update mentions of `git submodule` in docs and error me…

### DIFF
--- a/docs/docsite/rst/intro_installation.rst
+++ b/docs/docsite/rst/intro_installation.rst
@@ -333,12 +333,19 @@ Ansible also uses the following Python modules that need to be installed [1]_::
 
     $ sudo pip install paramiko PyYAML Jinja2 httplib2 six
 
-Note when updating ansible, be sure to not only update the source tree, but also the "submodules" in git
-which point at Ansible's own modules (not the same kind of modules, alas).
+To update ansible checkouts, use pull-with-rebase so any local changes are replayed.
 
 .. code-block:: bash
 
     $ git pull --rebase
+
+Note: when updating ansible checkouts that are v2.2 and older, be sure to not
+only update the source tree, but also the "submodules" in git which point at
+Ansible's own modules (not the same kind of modules, alas).
+
+.. code-block:: bash
+
+    $ git pull --rebase #same as above
     $ git submodule update --init --recursive
 
 Once running the env-setup script you'll be running from checkout and the default inventory file

--- a/docs/docsite/rst/intro_installation.rst
+++ b/docs/docsite/rst/intro_installation.rst
@@ -341,7 +341,7 @@ To update ansible checkouts, use pull-with-rebase so any local changes are repla
 
 Note: when updating ansible checkouts that are v2.2 and older, be sure to not
 only update the source tree, but also the "submodules" in git which point at
-Ansible's own modules (not the same kind of modules, alas).
+Ansible's own modules.
 
 .. code-block:: bash
 

--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -299,7 +299,7 @@ class ModuleArgsParser:
             if 'ping' not in module_loader:
                 raise AnsibleParserError("The requested action was not found in configured module paths. "
                         "Additionally, core modules are missing. If this is a checkout, "
-                        "run 'git submodule update --init --recursive' to correct this problem.",
+                        "run 'git pull --rebase' to correct this problem.",
                         obj=self._task_ds)
 
             else:

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -145,7 +145,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             else:
                 raise AnsibleError("The module %s was not found in configured module paths. "
                                    "Additionally, core modules are missing. If this is a checkout, "
-                                   "run 'git submodule update --init --recursive' to correct this problem." % (module_name))
+                                   "run 'git pull --rebase' to correct this problem." % (module_name))
 
         # insert shared code and arguments into the module
         (module_data, module_style, module_shebang) = modify_module(module_name, module_path, module_args,

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -34,7 +34,6 @@ pkgver() {
 
 build() {
   cd $pkgname
-  git submodule update --init --recursive
   make PYTHON=python2
 }
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### SUMMARY

Per core-meeting today, this change removes submodule instructions from error messages and Arch linux packaging script.