### PR TITLE
fix nxos_facts to support multiple neighbors and modules

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -332,18 +332,18 @@ class Interfaces(FactsBase):
         return interfaces
 
     def populate_neighbors(self, data):
-        data = data['TABLE_nbor']
+        data = data['TABLE_nbor']['ROW_nbor']
         if isinstance(data, dict):
             data = [data]
 
         objects = dict()
         for item in data:
-            local_intf = item['ROW_nbor']['l_port_id']
+            local_intf = item['l_port_id']
             if local_intf not in objects:
                 objects[local_intf] = list()
             nbor = dict()
-            nbor['port'] = item['ROW_nbor']['port_id']
-            nbor['host'] = item['ROW_nbor']['chassis_id']
+            nbor['port'] = item['port_id']
+            nbor['host'] = item['chassis_id']
             objects[local_intf].append(nbor)
         return objects
 
@@ -432,6 +432,8 @@ class Legacy(FactsBase):
 
     def parse_module(self, data):
         data = data['TABLE_modinfo']['ROW_modinfo']
+        if isinstance(data, dict):
+            data = [data]
         objects = list(self.transform_iterable(data, self.MODULE_MAP))
         return objects
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_facts

##### ANSIBLE VERSION
```
ansible 2.3.0
```

##### SUMMARY
Testing may have originally be done with nexus with one neighbor. When there are multiple, it returns a list (as typical with nx-api). Same thing for modules. This fixes that. 
