### PR TITLE
Removed 'no vn-segment' when state == 'absent'

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vlan.py
+++ b/lib/ansible/modules/network/nxos/nxos_vlan.py
@@ -628,7 +628,7 @@ def main():
     end_state_vlans_list = existing_vlans_list
 
     if commands:
-        if existing.get('mapped_vni'):
+        if existing.get('mapped_vni') and state != 'absent':
             if (existing.get('mapped_vni') != proposed.get('mapped_vni') and
                 existing.get('mapped_vni') != '0' and proposed.get('mapped_vni') != 'default'):
                 commands.insert(1, 'no vn-segment')


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - nxos_vlan

##### ANSIBLE VERSION
```
ansible --version
ansible 2.3.0 (nxos_vlan acec372714) last updated 2017/01/05 15:44:11 (GMT -500)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
nxos_vlan would fail if state=absent and a vn-segment is configured on the existing vlan.  The PR removes the `no vn-segment` command when the vlan exists.  Issuing the command after `no vlan xxx` causes the module to fail.

```
No changes from current module output
```
