### PR TITLE
Fix/Optimize Account/SID Translation

### DIFF
--- a/lib/ansible/modules/windows/win_share.ps1
+++ b/lib/ansible/modules/windows/win_share.ps1
@@ -23,61 +23,14 @@
 Function UserSearch
 {
     Param ([string]$accountName)
-    #Check if there's a realm specified
 
-    $searchDomain = $false
-    $searchDomainUPN = $false
-    if ($accountName.Split("\").count -gt 1)
-    {
-        if ($accountName.Split("\")[0] -ne $env:COMPUTERNAME)
-        {
-            $searchDomain = $true
-            $accountName = $accountName.split("\")[1]
-        }
-    }
-    Elseif ($accountName.contains("@"))
-    {
-        $searchDomain = $true
-        $searchDomainUPN = $true
-    }
-    Else
-    {
-        #Default to local user account
-        $accountName = $env:COMPUTERNAME + "\" + $accountName
-    }
-
-    if ($searchDomain -eq $false)
-    {
-        # do not use Win32_UserAccount, because e.g. SYSTEM (BUILTIN\SYSTEM or COMPUUTERNAME\SYSTEM) will not be listed. on Win32_Account groups will be listed too
-        $localaccount = get-wmiobject -class "Win32_Account" -namespace "root\CIMV2" -filter "(LocalAccount = True)" | where {$_.Caption -eq $accountName}
-        if ($localaccount)
-        {
-            return $localaccount.SID
-        }
-    }
-    Else
-    {
-        #Search by samaccountname
-        $Searcher = [adsisearcher]""
-
-        If ($searchDomainUPN -eq $false) {
-            $Searcher.Filter = "sAMAccountName=$($accountName)"
-        }
-        Else {
-            $Searcher.Filter = "userPrincipalName=$($accountName)"
-        }
-
-        $result = $Searcher.FindOne() 
-        if ($result)
-        {
-            $user = $result.GetDirectoryEntry()
-
-            # get binary SID from AD account
-            $binarySID = $user.ObjectSid.Value
-
-            # convert to string SID
-            return (New-Object System.Security.Principal.SecurityIdentifier($binarySID,0)).Value
-        }
+    try{
+      # Use .Net Principal so we dont need to do detection of any Domain Grouping
+      $adobj = New-Object System.Security.Principal.NTAccount($accountName);
+      return $adobj.Translate([System.Security.Principal.SecurityIdentifier]).Value
+    }catch{
+      # Could not Translate the $accountName, so Name not Exists
+      return ""
     }
 }
 Function NormalizeAccounts
@@ -224,7 +177,7 @@ Try {
                 }
             }
         }
-        
+
         # add missing permissions
         ForEach ($user in $permissionRead) {
             Grant-SmbShareAccess -Force -Name $name -AccountName $user -AccessRight "Read"
@@ -245,7 +198,7 @@ Try {
     }
 }
 Catch {
-    Fail-Json $result "an error occurred when attempting to create share $name"
+    Fail-Json  $_.Exception;
 }
 
 Exit-Json $result


### PR DESCRIPTION
rewrite to use the correct .net object, so no Domain/Local User/Group
detection is needed, as it done correclty on the .net side
Add Exception to the Fail-JSON so we get a decent Error Message, old one
not helping anything

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module/plugin/windows/win_share

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### SUMMARY
The Account-SID Translation not working correctly on some usecases

 - Rewrite to use the correct .net object, so no Domain/Local User/Group detection is needed, as it done correclty on the .net side
 - Add Exception to the Fail-JSON so we get a decent Error Message, old one not helping anything