### PR TITLE
windows module bug fix

### DIFF
--- a/lib/ansible/modules/windows/win_iis_webapplication.ps1
+++ b/lib/ansible/modules/windows/win_iis_webapplication.ps1
@@ -124,9 +124,11 @@ try {
 
 # Result
 $application = Get-WebApplication -Site $site -Name $name
-$result.application = New-Object psobject @{
-  PhysicalPath = $application.PhysicalPath
-  ApplicationPool = $application.applicationPool
+if ($application){
+    $result.application = New-Object psobject @{
+      PhysicalPath = $application.PhysicalPath
+      ApplicationPool = $application.applicationPool
+    }
 }
 
 Exit-Json $result

--- a/lib/ansible/modules/windows/win_robocopy.ps1
+++ b/lib/ansible/modules/windows/win_robocopy.ps1
@@ -114,6 +114,7 @@ Else {
 Set-Attr $result.win_robocopy "return_code" $rc
 Set-Attr $result.win_robocopy "output" $robocopy_output
 
+$changed = $false
 $cmd_msg = "Success"
 If ($rc -eq 0) {
     $cmd_msg = "No files copied."


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

win_robocopy module
win_iis_webapplication module

##### ANSIBLE VERSION

```
ansible 2.2.0.0
  config file = /home/tessa/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

#19959 fix win_robocopy throw a exception when return_code is not 1||2||4
#15390 fix win_iis_webapplication : Error when state is absent 

