### PR TITLE
Group names from tags can be only value (without tag_TAGNAME_)

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -189,6 +189,16 @@ stack_filters = False
 # see http://boto.readthedocs.org/en/latest/boto_config_tut.html
 # boto_profile = some-boto-profile-name
 
+# Group names are generated for the tags with a fix name:
+# tag_TAGNAME[_TAGVALUE] if TAGVALUE is set.
+# This option modifies this behavior. For all the tags
+# referenced in this parameter (separated by comma) and
+# if the value of the tag exists, the group name will not
+# be prefixed by tag_TAGNAME but it will only be the value
+# of the tag. It is also respecting the expand_csv_tags option.
+# Example: tag:service=redis,dns,influxdb will generate
+# three ansible groups: redis, dns and influxdb.
+# groupnames_as_tag_value_only = service
 
 [credentials]
 

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -501,6 +501,13 @@ class Ec2Inventory(object):
                     continue
                 self.ec2_instance_filters[filter_key].append(filter_value)
 
+        # Groups what will be formed of tag value only
+        self.ec2_groupnames_as_tag_value_only = []
+        if config.has_option('ec2', 'groupnames_as_tag_value_only'):
+            groupnames_as_tag_value_only = [g for g in config.get('ec2', 'groupnames_as_tag_value_only').split(',') if g]
+            for g in groupnames_as_tag_value_only:
+                self.ec2_groupnames_as_tag_value_only.append(g)
+
     def parse_cli_args(self):
         ''' Command line argument processing '''
 
@@ -972,7 +979,10 @@ class Ec2Inventory(object):
 
                 for v in values:
                     if v:
-                        key = self.to_safe("tag_" + k + "=" + v)
+                        if k in self.ec2_groupnames_as_tag_value_only:
+                            key = self.to_safe(v)
+                        else:
+                            key = self.to_safe("tag_" + k + "=" + v)
                     else:
                         key = self.to_safe("tag_" + k)
                     self.push(self.inventory, key, hostname)


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
contrib/inventory/ec2

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Group names from tags in EC2 are of hardcoded value tag_`TAGNAME` with optional _`TAGVALUE` if the tag has a value.
This is not the sexiest ever, and this PR does add a bit a flexibility in the naming of the group generated from the EC2 tags.
The idea is, when the a given tag has a value, this value can be used _as-is_ (respecting the normal sanitization process) to be the name of the group. The value will also honor the `expand_csv_tags` option.

Example:
```
tag:service = redis
```
will generate the group: `redis`

A new configuration option, `groupnames_as_tag_value_only`, allows to specify (in CVS format) the name of the tag(s) that should have this modified behaviour.

