### PR TITLE
Fix tags documentation into rabbitmq_policy module

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq_policy.py
+++ b/lib/ansible/modules/messaging/rabbitmq_policy.py
@@ -90,7 +90,7 @@ EXAMPLES = '''
     name: HA
     pattern: .*
     tags:
-      - ha-mode: all
+      ha-mode: all
 '''
 class RabbitMqPolicy(object):
     def __init__(self, module, name):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
rabbitmq_policy

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
##### reproduce
According to the documentation:
```yaml
- name: ensure the default vhost contains the HA policy
  rabbitmq_policy:
    name: HA
    pattern: .*
    tags:
      - ha-mode: all
```
##### error
```bash
fatal: [tek]: FAILED! => {"changed": false, "failed": true, "msg": "argument tags is of type <type 'list'> and we were unable to convert to dict"}
```
##### solution
It's just a typo in the documentation
```yaml
# tags must be a dict
# https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/messaging/rabbitmq_policy.py#L148
- name: ensure the default vhost contains the HA policy
  rabbitmq_policy:
    name: HA
    pattern: .*
    tags:
      ha-mode: all
```
