### PR TITLE
[GCE] gc_storage: add type parameter to expiration in argument_spec.

### DIFF
--- a/lib/ansible/modules/cloud/google/gc_storage.py
+++ b/lib/ansible/modules/cloud/google/gc_storage.py
@@ -379,7 +379,7 @@ def main():
             object         = dict(default=None),
             src            = dict(default=None),
             dest           = dict(default=None),
-            expiration     = dict(default=600, aliases=['expiry']),
+            expiration     = dict(type='int', default=600, aliases=['expiry']),
             mode           = dict(choices=['get', 'put', 'delete', 'create', 'get_url', 'get_str'], required=True),
             permission     = dict(choices=['private', 'public-read', 'authenticated-read'], default='private'),
             headers        = dict(type='dict', default={}),


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
gc_storage

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (ans-storage 8628c6d9f8) last updated 2016/12/22 02:24:09 (GMT +000)
  config file = /home/supertom/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Fixes ansible/ansible#19568

cc @ryansb 

