### PR TITLE
win_reboot: display message when scheduling reboot

### DIFF
--- a/lib/ansible/modules/windows/win_reboot.py
+++ b/lib/ansible/modules/windows/win_reboot.py
@@ -53,6 +53,10 @@ options:
     description:
     - Command to expect success for to determine the machine is ready for management
     default: whoami
+  msg:
+    description:
+    - Message to display to users
+    default: Reboot initiated by Ansible
 author:
     - Matt Davis (@nitzmahone)
 '''


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_reboot

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Show a message to users when rebooting the system.

I verified that the message is also logged in the EventLog !