### PR TITLE
device path is optional for cbs

### DIFF
--- a/lib/ansible/modules/cloud/rackspace/rax_cbs_attachments.py
+++ b/lib/ansible/modules/cloud/rackspace/rax_cbs_attachments.py
@@ -32,7 +32,7 @@ options:
     description:
       - The device path to attach the volume to, e.g. /dev/xvde
     default: null
-    required: true
+    required: false
   volume:
     description:
       - Name or id of the volume to attach/detach
@@ -188,7 +188,7 @@ def main():
     argument_spec = rax_argument_spec()
     argument_spec.update(
         dict(
-            device=dict(required=True),
+            device=dict(required=False),
             volume=dict(required=True),
             server=dict(required=True),
             state=dict(default='present', choices=['present', 'absent']),


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
rax_cbs_attachments

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### SUMMARY
```
The rax_cbs_attachments had a required declaration for the device path parameter, ie /dev/xvdn.  Rather than expend the effort to idempotently determine an available device node path at runtime, I consulted upstream documentation and found that the device parameter could be determined at the infrastructure level.  Changed true to false, tested once, seems sane.
```

per
https://developer.rackspace.com/docs/cloud-servers/v2/api-reference/svr-basic-operations/#post-attach-volume-to-server-servers-server-id-os-volume-attachments
, device is "The name of the device, such as /dev/xvdb. Specify null for
auto- assignment."