### PR TITLE
Fixes  win_iis_webapplication : Error when state is absent add null check

### DIFF
--- a/lib/ansible/modules/windows/win_iis_webapplication.ps1
+++ b/lib/ansible/modules/windows/win_iis_webapplication.ps1
@@ -124,9 +124,11 @@ try {
 
 # Result
 $application = Get-WebApplication -Site $site -Name $name
-$result.application = New-Object psobject @{
+if($application){
+  $result.application = New-Object psobject @{
   PhysicalPath = $application.PhysicalPath
   ApplicationPool = $application.applicationPool
+  }
 }
 
 Exit-Json $result


### PR DESCRIPTION
 win_iis_webapplication : Error when state is absent add null check

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
win_iis_webapplication module

##### ANSIBLE VERSION

```
ansible 2.2.0.0
  config file = /home/tessa/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
#15390 fix win_iis_webapplication : Error when state is absent