### PR TITLE
include all docs and tests in the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,4 @@
-prune v2
-prune docs/docsite
-prune docs/api
 prune ticket_stubs
-prune packaging
-prune test
 prune hacking
 include README.md COPYING
 include examples/hosts
@@ -11,8 +6,12 @@ include examples/ansible.cfg
 include lib/ansible/module_utils/powershell.ps1
 recursive-include lib/ansible/modules *
 recursive-include lib/ansible/galaxy/data *
-recursive-include docs/man *
+recursive-include docs *
+include hacking/module_formatter.py
+include hacking/dump_playbook_attributes.py
+recursive-include hacking/templates *
 recursive-include packaging *
+recursive-include test *
 include Makefile
 include VERSION
 include MANIFEST.in


### PR DESCRIPTION
also don't prune packaging (it is included later) and v2 (it does not exist)

Fixes: #19769

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
sdist

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel cba66dfedc) last updated 2017/01/07 14:29:27 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
I think it would be nice to include the docsite and tests in the release tarballs. This would help distribution packagers to provide a better experience to their users. The doscite contains a lot of valuable information and it would be nice to a) have that information available offline as a (additional) package and b) ship a copy that matches the shipped Ansible release. The tests on the other hand would allow packagers to verify their package more easily, as they can run the whole testsuite against the packaged version of ansible.

I did a quick test and each of the folders adds about 0.5MB to the release tarball. While 0.5MB is about 20% of the current tarball (and as such not too small), I think even a 3.7MB big tarball has still reasonable value and the added benefit outweighs the size.