### PR TITLE
Update ec2_ami_copy to boto3, fix encrypted support

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
@@ -17,7 +17,7 @@
 
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
-                    'version': '1.0'}
+                    'version': '1.1'}
 
 DOCUMENTATION = '''
 ---
@@ -29,25 +29,25 @@ version_added: "2.0"
 options:
   source_region:
     description:
-      - The source region the AMI should be copied from.
+      - the source region that AMI should be copied from
     required: true
   source_image_id:
     description:
-      - The ID of the AMI in source region that should be copied.
+      - the id of the image in source region that should be copied
     required: true
   name:
     description:
-      - The name of the new AMI to copy.
-    required: false
+      - The name of the new image to copy
+    required: true
     default: null
   description:
     description:
-      - A human-readable string describing the contents and purpose of the new AMI.
+      - An optional human-readable string describing the contents and purpose of the new AMI.
     required: false
     default: null
   encrypted:
     description:
-      - Whether or not the destination snapshots of the copied AMI should be encrypted.
+      - Whether or not to encrypt the target image
     required: false
     default: null
     version_added: "2.2"
@@ -59,22 +59,16 @@ options:
     version_added: "2.2"
   wait:
     description:
-      - Wait for the copied AMI to be in state 'available' before returning.
+      - wait for the copied AMI to be in state 'available' before returning.
     required: false
-    default: "no"
-    choices: [ "yes", "no" ]
-  wait_timeout:
-    description:
-      - How long before wait gives up, in seconds.
-    required: false
-    default: 1200
+    default: false
   tags:
     description:
-      - A hash/dictionary of tags to add to the new copied AMI; '{"key":"value"}' and '{"key":"value","key":"value"}'
+      - a hash/dictionary of tags to add to the new copied AMI; '{"key":"value"}' and '{"key":"value","key":"value"}'
     required: false
     default: null
 
-author: Amir Moulavi <amir.moulavi@gmail.com>
+author: Amir Moulavi <amir.moulavi@gmail.com>, Tim C <defunct@defunct.io>
 extends_documentation_fragment:
     - aws
     - ec2
@@ -128,7 +122,8 @@ EXAMPLES = '''
     kms_key_id: arn:aws:kms:us-east-1:XXXXXXXXXXXX:key/746de6ea-50a4-4bcb-8fbc-e3b29f2d367b
 '''
 
-import time
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import (boto3_conn, ec2_argument_spec, get_aws_connection_info)
 
 try:
     import boto
@@ -137,87 +132,52 @@ try:
 except ImportError:
     HAS_BOTO = False
 
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ec2 import ec2_argument_spec, ec2_connect, get_aws_connection_info
+try:
+    import boto3
+    from botocore.exceptions import ClientError, NoCredentialsError, NoRegionError
+    HAS_BOTO3 = True
+except ImportError:
+    HAS_BOTO3 = False
 
 
-def copy_image(module, ec2):
+
+def copy_image(ec2, module):
     """
     Copies an AMI
 
     module : AnsibleModule object
-    ec2: authenticated ec2 connection object
+    ec2: ec2 connection object
     """
 
-    source_region = module.params.get('source_region')
-    source_image_id = module.params.get('source_image_id')
-    name = module.params.get('name')
-    description = module.params.get('description')
-    encrypted = module.params.get('encrypted')
-    kms_key_id = module.params.get('kms_key_id')
     tags = module.params.get('tags')
-    wait_timeout = int(module.params.get('wait_timeout'))
-    wait = module.params.get('wait')
+
+    params = {'SourceRegion': module.params.get('source_region'),
+              'SourceImageId': module.params.get('source_image_id'),
+              'Name': module.params.get('name'),
+              'Description': module.params.get('description'),
+              'Encrypted': module.params.get('encrypted'),
+#              'KmsKeyId': module.params.get('kms_key_id')
+              }
+    if module.params.get('kms_key_id'):
+        params['KmsKeyId'] = module.params.get('kms_key_id')
 
     try:
-        params = {'source_region': source_region,
-                  'source_image_id': source_image_id,
-                  'name': name,
-                  'description': description,
-                  'encrypted': encrypted,
-                  'kms_key_id': kms_key_id
-        }
+        image_id = ec2.copy_image(**params)['ImageId']
+        if module.params.get('wait'):
+            ec2.get_waiter('image_available').wait(ImageIds=[image_id])
+        if module.params.get('tags'):
+            ec2.create_tags(
+                    Resources=[image_id],
+                    Tags=[{'Key' : k, 'Value': v} for k,v in module.params.get('tags').items()]
+                    )
 
-        image_id = ec2.copy_image(**params).image_id
-    except boto.exception.BotoServerError as e:
-        module.fail_json(msg="%s: %s" % (e.error_code, e.error_message))
-
-    img = wait_until_image_is_recognized(module, ec2, wait_timeout, image_id, wait)
-
-    img = wait_until_image_is_copied(module, ec2, wait_timeout, img, image_id, wait)
-
-    register_tags_if_any(module, ec2, tags, image_id)
-
-    module.exit_json(msg="AMI copy operation complete", image_id=image_id, state=img.state, changed=True)
-
-
-# register tags to the copied AMI
-def register_tags_if_any(module, ec2, tags, image_id):
-    if tags:
-        try:
-            ec2.create_tags([image_id], tags)
-        except Exception as e:
-            module.fail_json(msg=str(e))
-
-
-# wait here until the image is copied (i.e. the state becomes available
-def wait_until_image_is_copied(module, ec2, wait_timeout, img, image_id, wait):
-    wait_timeout = time.time() + wait_timeout
-    while wait and wait_timeout > time.time() and (img is None or img.state != 'available'):
-        img = ec2.get_image(image_id)
-        time.sleep(3)
-    if wait and wait_timeout <= time.time():
-        # waiting took too long
-        module.fail_json(msg="timed out waiting for image to be copied")
-    return img
-
-
-# wait until the image is recognized.
-def wait_until_image_is_recognized(module, ec2, wait_timeout, image_id, wait):
-    for i in range(wait_timeout):
-        try:
-            return ec2.get_image(image_id)
-        except boto.exception.EC2ResponseError as e:
-            # This exception we expect initially right after registering the copy with EC2 API
-            if 'InvalidAMIID.NotFound' in e.error_code and wait:
-                time.sleep(1)
-            else:
-                # On any other exception we should fail
-                module.fail_json(
-                    msg="Error while trying to find the new image. Using wait=yes and/or a longer wait_timeout may help: " + str(
-                        e))
-    else:
-        module.fail_json(msg="timed out waiting for image to be recognized")
+        module.exit_json(changed=True, image_id=image_id)
+    except ClientError as ce:
+        module.fail_json(msg=ce)
+    except NoCredentialsError:
+        module.fail_json(msg="Unable to locate AWS credentials")
+    except Exception as e:
+        module.fail_json(msg=str(e))
 
 
 def main():
@@ -225,35 +185,32 @@ def main():
     argument_spec.update(dict(
         source_region=dict(required=True),
         source_image_id=dict(required=True),
-        name=dict(),
-        description=dict(default=""),
+        name=dict(required=True),
+        description=dict(default=''),
         encrypted=dict(type='bool', required=False),
         kms_key_id=dict(type='str', required=False),
-        wait=dict(type='bool', default=False),
-        wait_timeout=dict(default=1200),
+        wait=dict(type='bool', default=False, required=False),
         tags=dict(type='dict')))
 
     module = AnsibleModule(argument_spec=argument_spec)
 
     if not HAS_BOTO:
         module.fail_json(msg='boto required for this module')
+    # TODO: Check botocore version
+    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
 
-    try:
-        ec2 = ec2_connect(module)
-    except boto.exception.NoAuthHandlerFound as e:
-        module.fail_json(msg=str(e))
+    if HAS_BOTO3:
 
-    try:
-        region, ec2_url, boto_params = get_aws_connection_info(module)
-    except boto.exception.NoAuthHandlerFound as e:
-        module.fail_json(msg=str(e))
+        try:
+            ec2 = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url,
+                             **aws_connect_params)
+        except NoRegionError:
+            module.fail_json(msg='AWS Region is required')
+    else:
+        module.fail_json(msg='boto3 required for this module')
 
-    if not region:
-        module.fail_json(msg="region must be specified")
-
-    copy_image(module, ec2)
+    copy_image(ec2, module)
 
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
@@ -24,7 +24,7 @@ DOCUMENTATION = '''
 module: ec2_ami_copy
 short_description: copies AMI between AWS regions, return new image id
 description:
-    - Copies AMI from a source region to a destination region. This module has a dependency on boto3
+    - Copies AMI from a source region to a destination region. (Since version 2.3 this module depends on boto3)
 version_added: "2.0"
 options:
   source_region:
@@ -37,7 +37,7 @@ options:
     required: true
   name:
     description:
-      - The name of the new AMI to copy.
+      - The name of the new AMI to copy. (As of 2.3 the default is 'default', in prior versions it was 'null'.)
     required: false
     default: "default"
   description:
@@ -65,7 +65,7 @@ options:
     choices: [ "yes", "no" ]
   wait_timeout:
     description:
-      - How long before wait gives up, in seconds. (Deprecated, no longer required. See boto3 Waiters)
+      - How long before wait gives up, in seconds. (As of 2.3 this option is deprecated. See boto3 Waiters)
     required: false
     default: 1200
   tags:
@@ -147,7 +147,7 @@ except ImportError:
 
 
 
-def copy_image(ec2, module):
+def copy_image(module, ec2):
     """
     Copies an AMI
 
@@ -217,7 +217,7 @@ def main():
     else:
         module.fail_json(msg='boto3 required for this module')
 
-    copy_image(ec2, module)
+    copy_image(module, ec2)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
@@ -65,7 +65,7 @@ options:
     choices: [ "yes", "no" ]
   wait_timeout:
     description:
-      - How long before wait gives up, in seconds. (Deprecated: no longer used, see boto3 Waiters)
+      - How long before wait gives up, in seconds. (Deprecated, no longer required. See boto3 Waiters)
     required: false
     default: 1200
   tags:
@@ -182,7 +182,7 @@ def copy_image(ec2, module):
     except ClientError as ce:
         module.fail_json(msg=ce.message)
     except NoCredentialsError:
-        module.fail_json(msg="Unable to authenticate, AWS credentials are invalid.")
+        module.fail_json(msg='Unable to authenticate, AWS credentials are invalid.')
     except Exception as e:
         module.fail_json(msg='Unhandled exception. (%s)' % str(e))
 
@@ -192,7 +192,7 @@ def main():
     argument_spec.update(dict(
         source_region=dict(required=True),
         source_image_id=dict(required=True),
-        name=dict(default=''),
+        name=dict(default='default'),
         description=dict(default=''),
         encrypted=dict(type='bool', required=False),
         kms_key_id=dict(type='str', required=False),


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_ami_copy

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel cba66dfedc) last updated 2017/01/07 23:03:00 (GMT +000)
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

ec2_ami_copy  currently uses boto and due to the AWS protocol version being defined as an older version the `Encrypted` parameter is not recognized by the AWS API resulting in faliure. This PR re-implements ec2_ami_copy using boto3 resolving the issue of non-functional encrypted volume support.

This problem was discovered while implementing https://github.com/trailofbits/algo/issues/133 , additional details can be found there. 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
TASK [copy_test : Copy to an encrypted image] **********************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "UnknownParameter: The parameter Encrypted is not recognized"}
        to retry, use: --limit @/home/ubuntu/src/ec2_ami_copy_test/test.retry

PLAY RECAP *********************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=1   
```
After:
```
TASK [copy_test : Copy to an encrypted image] **********************************************************************************************
changed: [localhost]

PLAY RECAP *********************************************************************************************************************************
localhost                  : ok=3    changed=1    unreachable=0    failed=0   
```