### PR TITLE
Update option desc of yum_repository module

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -128,6 +128,7 @@ options:
     default: 'yes'
     description:
       - Defines whether to install plugin dependencies.
+      - This option takes effect only if the I(version) is not defined.
 
 notes:
   - Plugin installation should be run under root or the same user which owns


### PR DESCRIPTION
##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

`jenkins_plugin`

##### ANSIBLE VERSION

```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

In reaction to the issue #20000, this PR is just making sure that the user is informed that the plugin dependencies are installed only if no `version` option is defined.