### PR TITLE
wait_for_connection: Wait for system to become reachable

### DIFF
--- a/lib/ansible/modules/utilities/logic/wait_for_connection.py
+++ b/lib/ansible/modules/utilities/logic/wait_for_connection.py
@@ -1,0 +1,55 @@
+# -*- mode: python -*-
+# (c) 2017, Dag Wieers <dag@wieers.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'status': ['stableinterface'],
+                    'supported_by': 'core',
+                    'version': '1.0'}
+
+DOCUMENTATION = '''
+---
+module: wait_for_connection
+short_description: Waitis until remote system is reachable
+description:
+  - You can wait for a set amount of time C(timeout), this is the default if nothing is specified.
+  - Waiting until the ansible connection works is useful for when systems are expected to be down and it is essential that the system is reachable before continuing.
+  - This module makes use of internal ansible transport (and configuration) and the ping/win_ping module to guarantee correct functioning of transport.
+version_added: '2.3'
+options:
+  connect_timeout:
+    description:
+      - Maximum number of seconds to wait for a connection to happen before closing and retrying.
+    required: false
+    default: 5
+  sleep:
+    description:
+      - Number of seconds to sleep between checks.
+    required: false
+    default: 1
+  timeout:
+    description:
+      - Maximum number of seconds to wait for.
+    required: false
+    default: 300
+author: 'Dag Wieers (@dagwieers)'
+'''
+
+EXAMPLES = '''
+# Wait for the remote system to be reachable
+- wait_for_connection:
+    timeout: 120
+'''

--- a/lib/ansible/modules/utilities/logic/wait_for_connection.py
+++ b/lib/ansible/modules/utilities/logic/wait_for_connection.py
@@ -1,6 +1,8 @@
-# -*- mode: python -*-
-# (c) 2017, Dag Wieers <dag@wieers.com>
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
+# (c) 2017, Dag Wieers <dag@wieers.com>
+#
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify
@@ -23,33 +25,40 @@ ANSIBLE_METADATA = {'status': ['stableinterface'],
 DOCUMENTATION = '''
 ---
 module: wait_for_connection
-short_description: Waitis until remote system is reachable
+short_description: Waitis until remote system is reachable/usable
 description:
-  - You can wait for a set amount of time C(timeout), this is the default if nothing is specified.
-  - Waiting until the ansible connection works is useful for when systems are expected to be down and it is essential that the system is reachable before continuing.
-  - This module makes use of internal ansible transport (and configuration) and the ping/win_ping module to guarantee correct functioning of transport.
-version_added: '2.3'
+- Waits for a total of C(timeout) seconds.
+- Retries the transport connection after a timeout of C(connect_timeout).
+- Tests the transport connection every C(sleep) seconds.
+- This module makes use of internal ansible transport (and configuration) and the ping/win_ping module to guarantee correct end-to-end functioning.
+version_added: "2.3"
 options:
   connect_timeout:
     description:
       - Maximum number of seconds to wait for a connection to happen before closing and retrying.
-    required: false
     default: 5
+  delay:
+    description:
+      - Number of seconds to wait before starting to poll.
+    default: 0
   sleep:
+    default: 1
     description:
       - Number of seconds to sleep between checks.
-    required: false
-    default: 1
   timeout:
     description:
       - Maximum number of seconds to wait for.
-    required: false
     default: 300
-author: 'Dag Wieers (@dagwieers)'
+author: "Dag Wieers (@dagwieers)"
 '''
 
 EXAMPLES = '''
-# Wait for the remote system to be reachable
+
+# Wait 300 seconds for system's connection to become reachable/usable by Ansible
 - wait_for_connection:
-    timeout: 120
+
+# Wait 600 seconds for system's connection, but only start checking after 60 seconds
+- wait_for_connection:
+    delay: 60
+    timeout: 600
 '''

--- a/lib/ansible/modules/utilities/logic/wait_for_connection.py
+++ b/lib/ansible/modules/utilities/logic/wait_for_connection.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['stableinterface'],
 DOCUMENTATION = '''
 ---
 module: wait_for_connection
-short_description: Waitis until remote system is reachable/usable
+short_description: Waits until remote system is reachable/usable
 description:
 - Waits for a total of C(timeout) seconds.
 - Retries the transport connection after a timeout of C(connect_timeout).
@@ -53,7 +53,6 @@ author: "Dag Wieers (@dagwieers)"
 '''
 
 EXAMPLES = '''
-
 # Wait 300 seconds for system's connection to become reachable/usable by Ansible
 - wait_for_connection:
 

--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -1,0 +1,104 @@
+# (c) 2017, Dag Wieers <dag@wieers.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# CI-required python3 boilerplate
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import socket
+import time
+
+from datetime import datetime, timedelta
+
+from ansible.plugins.action import ActionBase
+
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
+
+class TimedOutException(Exception):
+    pass
+
+
+class ActionModule(ActionBase):
+    TRANSFERS_FILES = False
+
+    DEFAULT_SLEEP = 1
+    DEFAULT_CONNECT_TIMEOUT = 5
+    DEFAULT_TIMEOUT = 600
+
+    def do_until_success_or_timeout(self, what, timeout, what_desc, sleep=1):
+        max_end_time = datetime.utcnow() + timedelta(seconds=timeout)
+
+        while datetime.utcnow() < max_end_time:
+            try:
+                what()
+                if what_desc:
+                    display.debug("wait_for_connection: %s success" % what_desc)
+                return
+            except Exception as e:
+                if what_desc:
+                    display.debug("wait_for_connection: %s fail (expected), retrying in %d seconds..." % (what_desc, sleep))
+                time.sleep(sleep)
+
+        raise TimedOutException("timed out waiting for %s: %s" % (what_desc, str(e)))
+
+    def run(self, tmp=None, task_vars=None):
+        if task_vars is None:
+            task_vars = dict()
+
+        connect_timeout = int(self._task.args.get('connect_timeout', self.DEFAULT_CONNECT_TIMEOUT))
+        timeout = int(self._task.args.get('timeout', self.DEFAULT_TIMEOUT))
+        sleep = int(self._task.args.get('sleep', self.DEFAULT_SLEEP))
+
+        if self._play_context.check_mode:
+            display.vvv("wait_for_connection: skipping for check_mode")
+            return dict(skipped=True)
+
+        winrm_host = self._connection._winrm_host
+        winrm_port = self._connection._winrm_port
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        def connect_winrm_port():
+            sock = socket.create_connection((winrm_host, winrm_port), connect_timeout)
+            sock.close()
+
+        def ping_module_test():
+            display.vvv("attempting ping module test")
+            # call connection reset between runs if it's there
+            try:
+                self._connection._reset()
+            except AttributeError:
+                pass
+
+            result = self._execute_module(module_name='win_ping')
+            if result['ping'] != 'pong':
+                 raise Exception('ping test failed')
+
+        try:
+            self.do_until_success_or_timeout(connect_winrm_port, timeout, what_desc="connection port up", sleep=sleep)
+            self.do_until_success_or_timeout(ping_module_test, timeout, what_desc="ping module test success", sleep=sleep)
+
+        except TimedOutException as e:
+            result['failed'] = True
+            result['msg'] = e.message
+
+        return result

--- a/lib/ansible/plugins/connection/accelerate.py
+++ b/lib/ansible/plugins/connection/accelerate.py
@@ -59,6 +59,8 @@ class Connection(ConnectionBase):
         super(Connection, self).__init__(*args, **kwargs)
 
         self.conn = None
+        self.host = self._play_context.remote_addr
+        self.port = int(self._play_context.accelerate_port or 5099)
         self.key = key_for_hostname(self._play_context.remote_addr)
 
     def _connect(self):
@@ -95,6 +97,12 @@ class Connection(ConnectionBase):
 
         self._connected = True
         return self
+
+    def transport_test(self, connect_timeout):
+        ''' Test the transport mechanism, if available '''
+        display.vvv("attempting transport test to %s:%s" % (self.host, self.port))
+        sock = socket.create_connection((self.host, self.port), connect_timeout)
+        sock.close()
 
     def send_data(self, data):
         packed_len = struct.pack('!Q',len(data))

--- a/lib/ansible/plugins/connection/accelerate.py
+++ b/lib/ansible/plugins/connection/accelerate.py
@@ -59,8 +59,6 @@ class Connection(ConnectionBase):
         super(Connection, self).__init__(*args, **kwargs)
 
         self.conn = None
-        self.host = self._play_context.remote_addr
-        self.port = int(self._play_context.accelerate_port or 5099)
         self.key = key_for_hostname(self._play_context.remote_addr)
 
     def _connect(self):
@@ -100,8 +98,10 @@ class Connection(ConnectionBase):
 
     def transport_test(self, connect_timeout):
         ''' Test the transport mechanism, if available '''
-        display.vvv("attempting transport test to %s:%s" % (self.host, self.port))
-        sock = socket.create_connection((self.host, self.port), connect_timeout)
+        host = self._play_context.remote_addr
+        port = int(self._play_context.accelerate_port or 5099)
+        display.vvv("attempting transport test to %s:%s" % (host, port))
+        sock = socket.create_connection((host, port), connect_timeout)
         sock.close()
 
     def send_data(self, data):

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -133,6 +133,18 @@ class Connection(ConnectionBase):
 
     transport = 'paramiko'
 
+    def __init__(self, *args, **kwargs):
+        super(Connection, self).__init__(*args, **kwargs)
+
+        self.host = self._play_context.remote_addr
+        self.port = self._play_context.port or 22
+
+    def transport_test(self, connect_timeout):
+        ''' Test the transport mechanism, if available '''
+        display.vvv("attempting transport test to %s:%s" % (self.host, self.port))
+        sock = socket.create_connection((self.host, self.port), connect_timeout)
+        sock.close()
+
     def _cache_key(self):
         return "%s__%s__" % (self._play_context.remote_addr, self._play_context.remote_user)
 

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -133,16 +133,12 @@ class Connection(ConnectionBase):
 
     transport = 'paramiko'
 
-    def __init__(self, *args, **kwargs):
-        super(Connection, self).__init__(*args, **kwargs)
-
-        self.host = self._play_context.remote_addr
-        self.port = int(self._play_context.port or 22)
-
     def transport_test(self, connect_timeout):
         ''' Test the transport mechanism, if available '''
-        display.vvv("attempting transport test to %s:%s" % (self.host, self.port))
-        sock = socket.create_connection((self.host, self.port), connect_timeout)
+        host = self._play_context.remote_addr
+        port = int(self._play_context.port or 22)
+        display.vvv("attempting transport test to %s:%s" % (host, port))
+        sock = socket.create_connection((host, port), connect_timeout)
         sock.close()
 
     def _cache_key(self):

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -137,7 +137,7 @@ class Connection(ConnectionBase):
         super(Connection, self).__init__(*args, **kwargs)
 
         self.host = self._play_context.remote_addr
-        self.port = self._play_context.port or 22
+        self.port = int(self._play_context.port or 22)
 
     def transport_test(self, connect_timeout):
         ''' Test the transport mechanism, if available '''

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -62,7 +62,7 @@ class Connection(ConnectionBase):
         super(Connection, self).__init__(*args, **kwargs)
 
         self.host = self._play_context.remote_addr
-        self.port = self._play_context.port or 22
+        self.port = int(self._play_context.port or 22)
         self.user = self._play_context.remote_user
         self.control_path = C.ANSIBLE_SSH_CONTROL_PATH
         self.control_path_dir = C.ANSIBLE_SSH_CONTROL_PATH_DIR

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -25,6 +25,7 @@ import fcntl
 import hashlib
 import os
 import pty
+import socket
 import subprocess
 import time
 
@@ -61,7 +62,7 @@ class Connection(ConnectionBase):
         super(Connection, self).__init__(*args, **kwargs)
 
         self.host = self._play_context.remote_addr
-        self.port = self._play_context.port
+        self.port = self._play_context.port or 22
         self.user = self._play_context.remote_user
         self.control_path = C.ANSIBLE_SSH_CONTROL_PATH
         self.control_path_dir = C.ANSIBLE_SSH_CONTROL_PATH_DIR
@@ -72,6 +73,12 @@ class Connection(ConnectionBase):
 
     def _connect(self):
         return self
+
+    def transport_test(self, connect_timeout):
+        ''' Test the transport mechanism, if available '''
+        display.vvv("attempting transport test to %s:%s" % (self.host, self.port))
+        sock = socket.create_connection((self.host, self.port), connect_timeout)
+        sock.close()
 
     @staticmethod
     def _create_control_path(host, port, user):

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -23,6 +23,7 @@ import inspect
 import os
 import re
 import shlex
+import socket
 import traceback
 import json
 import tempfile
@@ -88,6 +89,11 @@ class Connection(ConnectionBase):
         # FUTURE: Add runas support
 
         super(Connection, self).__init__(*args, **kwargs)
+
+    def transport_test(self, connect_timeout):
+        ''' Test the transport mechanism, if available '''
+        sock = socket.create_connection((self._winrm_host, self._winrm_port), connect_timeout)
+        sock.close()
 
     def set_host_overrides(self, host, hostvars=None):
         '''

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -90,9 +90,13 @@ class Connection(ConnectionBase):
 
         super(Connection, self).__init__(*args, **kwargs)
 
+        self.host = self._play_context.remote_addr
+        self.port = int(self._play_context.port or 5986)
+
     def transport_test(self, connect_timeout):
         ''' Test the transport mechanism, if available '''
-        sock = socket.create_connection((self._winrm_host, self._winrm_port), connect_timeout)
+        display.vvv("attempting transport test to %s:%s" % (self.host, self.port))
+        sock = socket.create_connection((self.host, self.port), connect_timeout)
         sock.close()
 
     def set_host_overrides(self, host, hostvars=None):

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -90,13 +90,12 @@ class Connection(ConnectionBase):
 
         super(Connection, self).__init__(*args, **kwargs)
 
-        self.host = self._play_context.remote_addr
-        self.port = int(self._play_context.port or 5986)
-
     def transport_test(self, connect_timeout):
         ''' Test the transport mechanism, if available '''
-        display.vvv("attempting transport test to %s:%s" % (self.host, self.port))
-        sock = socket.create_connection((self.host, self.port), connect_timeout)
+        host = self._play_context.remote_addr
+        port = int(self._play_context.port or 5986)
+        display.vvv("attempting transport test to %s:%s" % (host, port))
+        sock = socket.create_connection((host, port), connect_timeout)
         sock.close()
 
     def set_host_overrides(self, host, hostvars=None):

--- a/test/integration/targets/connection/test_connection.yml
+++ b/test/integration/targets/connection/test_connection.yml
@@ -38,3 +38,6 @@
     local_action: file path={{ local_tmp }}-汉语 state=absent
   - name: remove remote temp file
     action: "{{ action_prefix }}file path={{ remote_tmp }}-汉语 state=absent"
+
+  ### test wait_for_connection plugin
+  - wait_for_connection:

--- a/test/integration/targets/wait_for_connection/aliases
+++ b/test/integration/targets/wait_for_connection/aliases
@@ -1,0 +1,2 @@
+posix/ci/group2
+windows/ci/group2

--- a/test/integration/targets/wait_for_connection/aliases
+++ b/test/integration/targets/wait_for_connection/aliases
@@ -1,2 +1,2 @@
-posix/ci/group2
-windows/ci/group2
+posix/ci/group1
+windows/ci/group1

--- a/test/integration/targets/wait_for_connection/tasks/main.yml
+++ b/test/integration/targets/wait_for_connection/tasks/main.yml
@@ -3,10 +3,3 @@
     connect_timeout: 5
     sleep: 1
     timeout: 10
-
-- name: Test local connection on control master
-  wait_for_connection:
-    connect_timeout: 5
-    sleep: 1
-    timeout: 10
-  connection: local

--- a/test/integration/targets/wait_for_connection/tasks/main.yml
+++ b/test/integration/targets/wait_for_connection/tasks/main.yml
@@ -1,0 +1,12 @@
+- name: Test normal connection to target node
+  wait_for_connection:
+    connect_timeout: 5
+    sleep: 1
+    timeout: 10
+
+- name: Test local connection on control master
+  wait_for_connection:
+    connect_timeout: 5
+    sleep: 1
+    timeout: 10
+  connection: local


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
wait_for_connection

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
This action plugin allows to check when a system is back online and usable by Ansible.

As an example, when doing a SysPrep and running Enable-WinRM.ps1, it takes between 10 to 20 seconds between the WinRM TCP port to open, and it actually being able to serve Ansible requests. This time is variable and depends on the boot process.

Current implementation should work for all connection types using the **ping** module (or **win_ping** on winrm/powershell)

This fixes #19998