### PR TITLE
Require jinja2 < 2.9 until tests pass on 2.9.

### DIFF
--- a/test/runner/requirements/integration.txt
+++ b/test/runner/requirements/integration.txt
@@ -1,4 +1,4 @@
-jinja2
+jinja2<2.9
 jmespath
 junit-xml
 ordereddict ; python_version < '2.7'


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (jinja-2.8 093aec8a03) last updated 2017/01/08 00:40:24 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

The new [2.9 release of jinja2](http://jinja.pocoo.org/docs/2.9/changelog/#version-2-9) is causing [test failures](https://app.shippable.com/runs/58717e869a67460f009603be/4/console):

```
2017-01-08 00:00:12 TASK [check that alpaca matched all four groups] *******************************
2017-01-08 00:00:12 task path: /root/ansible/test/integration/targets/group_by/test_group_by.yml:119
2017-01-08 00:00:12 fatal: [alpaca]: FAILED! => {
2017-01-08 00:00:12     "failed": true, 
2017-01-08 00:00:12     "msg": "The conditional check 'genus_vic' failed. The error was: error while evaluating conditional (genus_vic): 'genus_vic' is undefined"
2017-01-08 00:00:12 }
```

Until the issue is resolved, I'm limiting tests to jinja2 versions prior to 2.9.