### PR TITLE
Fixes #19883: Handle INI files without ending newline

### DIFF
--- a/lib/ansible/modules/files/ini_file.py
+++ b/lib/ansible/modules/files/ini_file.py
@@ -34,6 +34,8 @@ description:
        to manage the file as a whole with, say, M(template) or M(assemble). Adds missing
        sections if they don't exist.
      - Before version 2.0, comments are discarded when the source file is read, and therefore will not show up in the destination file.
+     - Since version 2.3, this module adds missing ending newlines to files to keep in line with the POSIX standard, even when
+       no modifications need to be applied.
 version_added: "0.9"
 options:
   dest:
@@ -164,12 +166,18 @@ def do_ini(module, filename, section=None, option=None, value=None,
     if module._diff:
         diff['before'] = ''.join(ini_lines)
 
+    changed = False
+
+    # last line of file may not contain a trailing newline
+    if ini_lines[-1] == "" or ini_lines[-1][-1] != '\n':
+        ini_lines[-1] += '\n'
+        changed = True
+
     # append a fake section line to simplify the logic
     ini_lines.append('[')
 
     within_section = not section
     section_start = 0
-    changed = False
     msg = 'OK'
     if no_extra_spaces:
         assignment_format = '%s=%s\n'
@@ -203,11 +211,12 @@ def do_ini(module, filename, section=None, option=None, value=None,
                     # change the existing option line
                     if match_opt(option, line):
                         newline = assignment_format % (option, value)
-                        changed = ini_lines[index] != newline
-                        if changed:
+                        option_changed = ini_lines[index] != newline
+                        changed = changed or option_changed
+                        if option_changed:
                             msg = 'option changed'
                         ini_lines[index] = newline
-                        if changed:
+                        if option_changed:
                             # remove all possible option occurrences from the rest of the section
                             index = index + 1
                             while index < len(ini_lines):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Module `ini_file`

##### ANSIBLE VERSION
```
ansible 2.3.0 (ini-file-newline fcce5a1be5) last updated 2017/01/08 09:31:17 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY

Fixes #19883.

`readlines` returns a list of strings. The last one may or may not contain a newline, depending on whether the file has an ending newline.

The target ini file contents are created by joining all the lines. When the original file has no ending newline and we've added a line at the end, the lines that will be joined are `[..., "last file line without newline", "option = value", "[]"]`. 

The PR modifies the module to add a newline when adding an option at end of a section.


```.sh
% printf "[main]\nOPTION=value" | tee /tmp/some_file.ini                                                                                                                                                                                                                                                                                                           
[main]
OPTION=value% ansible all -i "localhost," -c local -m ini_file -a "dest=/tmp/some_file.ini section=main option=OPTION2 value=TEST"  localhost | SUCCESS => {
    "changed": true,
    "dest": "/tmp/some_file.ini",
    "gid": 0,
    "group": "wheel",
    "mode": "0644",
    "msg": "option added",
    "owner": "bob",
    "size": 35,
    "state": "file",
    "uid": 501
}

before:
% cat /tmp/some_file.ini
[main]
OPTION=valueOPTION2 = TEST
%

after:
% cat /tmp/some_file.ini
[main]
OPTION=value
OPTION2 = TEST
%
```
