### PR TITLE
Correctly link to modules

### DIFF
--- a/lib/ansible/modules/cloud/lxd/lxd_container.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_container.py
@@ -141,7 +141,7 @@ notes:
     2.1, the later requires python to be installed in the container which can
     be done with the command module.
   - You can copy a file from the host to the container
-    with the Ansible M(copy) and M(templater) module and the `lxd` connection plugin.
+    with the Ansible M(copy) and M(template) module and the `lxd` connection plugin.
     See the example below.
   - You can copy a file in the creatd container to the localhost
     with `command=lxc file pull container_name/dir/filename filename`.

--- a/lib/ansible/modules/network/dellos9/dellos9_command.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_command.py
@@ -78,7 +78,7 @@ notes:
 
   - This module requires to increase the ssh connection rate limit.
     Use the following command I(ip ssh connection-rate-limit 60) 
-    to configure the same. This can be done via M(dnos_config) module 
+    to configure the same. This can be done via M(dellos9__config) module 
     as well.
 
 """

--- a/lib/ansible/modules/network/dellos9/dellos9_config.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_config.py
@@ -149,7 +149,7 @@ notes:
 
   - This module requires to increase the ssh connection rate limit.
     Use the following command I(ip ssh connection-rate-limit 60) 
-    to configure the same. This can be done via M(dnos_config) module 
+    to configure the same. This can be done via M(dellos9_config) module 
     as well.
 """
 

--- a/lib/ansible/modules/network/dellos9/dellos9_facts.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_facts.py
@@ -52,7 +52,7 @@ notes:
 
   - This module requires to increase the ssh connection rate limit.
     Use the following command I(ip ssh connection-rate-limit 60) 
-    to configure the same. This can be done via M(dnos_config) module 
+    to configure the same. This can be done via M(dellos9_config) module 
     as well.
 """
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
dellos9_command

##### ANSIBLE VERSION


##### SUMMARY
Fixes the following errors from `make webdocs`
```
/srv/ansible/vanilla2/docs/docsite/rst/dellos9_command_module.rst:215: WARNING: undefined label: dnos_config (if the link has no caption the label must precede a section header)
/srv/ansible/vanilla2/docs/docsite/rst/dellos9_config_module.rst:240: WARNING: undefined label: dnos_config (if the link has no caption the label must precede a section header)
/srv/ansible/vanilla2/docs/docsite/rst/dellos9_facts_module.rst:242: WARNING: undefined label: dnos_config (if the link has no caption the label must precede a section header)
/srv/ansible/vanilla2/docs/docsite/rst/lxd_container_module.rst:259: WARNING: undefined label: templater (if the link has no caption the label must precede a section header)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/20019)
<!-- Reviewable:end -->
