### PR TITLE
Fix envlist in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py3{5,6)
+envlist = py26,py27,py35,py36
 
 [testenv:py35]
 deps = -r{toxinidir}/test/utils/tox/requirements-py3.txt


### PR DESCRIPTION
##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

tox.ini

##### ANSIBLE VERSION

```
ansible 2.3.0 (devel e87d6d8a70) last updated 2017/01/09 13:34:08 (GMT +300)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

There's a typo in `tox.ini` that makes `tox` without `-e` try to run `py26`, `py27`, `py3{5` and `6)` "environments":

```
$ tox -l
py26
py27
py3{5
6)
```

```
$ tox
...
py3{5 inst-nodeps: /home/mg/src/ansible/.tox/dist/ansible-2.3.0.zip
py3{5 installed: ansible==2.3.0,boto3==1.4.3,botocore==1.4.93,cffi==1.9.1,coverage==4.3.1,coveralls==1.1,cryptography==1.7.1,docopt==0.6.2,docutils==0.13.1,enum34==1.1.6,futures==3.0.5,idna==2.2,ipaddress==1.0.17,Jinja2==2.9.3,jmespath==0.9.0,linecache2==1.0.0,MarkupSafe==0.23,mock==1.0.1,nose==1.3.7,paramiko==2.1.1,passlib==1.7.0,pyasn1==0.1.9,pycparser==2.17,pycrypto==2.6.1,python-dateutil==2.6.0,python-memcached==1.58,python-systemd==0.0.9,PyYAML==3.12,redis==2.10.5,requests==2.12.4,s3transfer==0.1.10,six==1.10.0,traceback2==1.4.0,unittest2==1.1.0
py3{5 runtests: PYTHONHASHSEED='3146586047'
py3{5 runtests: commands[0] | python --version
Python 2.7.12
py3{5 runtests: commands[1] | make tests
...
6) inst-nodeps: /home/mg/src/ansible/.tox/dist/ansible-2.3.0.zip
6) installed: ansible==2.3.0,boto3==1.4.3,botocore==1.4.93,cffi==1.9.1,coverage==4.3.1,coveralls==1.1,cryptography==1.7.1,docopt==0.6.2,docutils==0.13.1,enum34==1.1.6,futures==3.0.5,idna==2.2,ipaddress==1.0.17,Jinja2==2.9.3,jmespath==0.9.0,linecache2==1.0.0,MarkupSafe==0.23,mock==1.0.1,nose==1.3.7,paramiko==2.1.1,passlib==1.7.0,pyasn1==0.1.9,pycparser==2.17,pycrypto==2.6.1,python-dateutil==2.6.0,python-memcached==1.58,python-systemd==0.0.9,PyYAML==3.12,redis==2.10.5,requests==2.12.4,s3transfer==0.1.10,six==1.10.0,traceback2==1.4.0,unittest2==1.1.0
6) runtests: PYTHONHASHSEED='3146586047'
6) runtests: commands[0] | python --version
Python 2.7.12
6) runtests: commands[1] | make tests
...
____________________________________ summary _____________________________________
ERROR:   py26: InterpreterNotFound: python2.6
  py27: commands succeeded
  py3{5: commands succeeded
ERROR:   6): commands failed
```
