### PR TITLE
Fix a test failure on Python 3.6

### DIFF
--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -464,6 +464,7 @@ class TestActionBase(unittest.TestCase):
 
         mock_connection = MagicMock()
         mock_connection.build_module_command.side_effect = build_module_command
+        mock_connection._shell.get_remote_filename.return_value = 'amodule.py'
         mock_connection._shell.join_path.side_effect = os.path.join
 
         # we're using a real play context here

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -464,7 +464,7 @@ class TestActionBase(unittest.TestCase):
 
         mock_connection = MagicMock()
         mock_connection.build_module_command.side_effect = build_module_command
-        mock_connection._shell.get_remote_filename.return_value = 'amodule.py'
+        mock_connection._shell.get_remote_filename.return_value = 'copy.py'
         mock_connection._shell.join_path.side_effect = os.path.join
 
         # we're using a real play context here


### PR DESCRIPTION
##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

unit test suite

##### ANSIBLE VERSION

```
ansible 2.3.0 (devel e87d6d8a70) last updated 2017/01/09 13:34:08 (GMT +300)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

tox -e py36 failed with

    ======================================================================
    ERROR: test_action_base__execute_module (units.plugins.action.test_action.TestActionBase)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/home/mg/src/ansible/test/units/plugins/action/test_action.py", line 507, in test_action_base__execute_module
        self.assertEqual(action_base._execute_module(), dict(_ansible_parsed=True, rc=0, stdout="ok", stdout_lines=['ok']))
      File "/home/mg/src/ansible/lib/ansible/plugins/action/__init__.py", line 596, in _execute_module
        remote_module_path = self._connection._shell.join_path(tmp, remote_module_filename)
      File "/home/mg/opt/python36/lib/python3.6/unittest/mock.py", line 939, in __call__
        return _mock_self._mock_call(*args, **kwargs)
      File "/home/mg/opt/python36/lib/python3.6/unittest/mock.py", line 1005, in _mock_call
        ret_val = effect(*args, **kwargs)
      File "/home/mg/src/ansible/.tox/py36/lib/python3.6/posixpath.py", line 92, in join
        genericpath._check_arg_types('join', a, *p)
      File "/home/mg/src/ansible/.tox/py36/lib/python3.6/genericpath.py", line 149, in _check_arg_types
        (funcname, s.__class__.__name__)) from None
    TypeError: join() argument must be str or bytes, not 'MagicMock'

because os.path.join() now checks argument types since Python 3.6 (due to pathlib support, I expect).