### PR TITLE
Fix authorized_key crash in Python3 with remote key file

### DIFF
--- a/lib/ansible/modules/system/authorized_key.py
+++ b/lib/ansible/modules/system/authorized_key.py
@@ -227,7 +227,7 @@ import re
 import shlex
 from operator import itemgetter
 
-from ansible.compat.six import PY3
+from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.urls import fetch_url
@@ -535,10 +535,11 @@ def enforce_state(module, params):
                 module.fail_json(msg=error_msg % key)
             else:
                 key = resp.read()
-                if PY3:
-                    key = key.decode()
         except Exception:
             module.fail_json(msg=error_msg % key)
+
+        # resp.read gives bytes on python3, convert to native string type
+        key = to_native(key, errors='surrogate_or_strict')
 
     # extract individual keys into an array, skipping blank lines and comments
     new_keys = [s for s in key.splitlines() if s and not s.startswith('#')]

--- a/lib/ansible/modules/system/authorized_key.py
+++ b/lib/ansible/modules/system/authorized_key.py
@@ -227,6 +227,7 @@ import re
 import shlex
 from operator import itemgetter
 
+from ansible.compat.six import PY3
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.urls import fetch_url
@@ -534,6 +535,8 @@ def enforce_state(module, params):
                 module.fail_json(msg=error_msg % key)
             else:
                 key = resp.read()
+                if PY3:
+                    key = key.decode()
         except Exception:
             module.fail_json(msg=error_msg % key)
 


### PR DESCRIPTION
* Fixes #20007
* Thanks @georgepsarakis

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
authorized_key

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /home/james/active/boss/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Python 3 reads remote file as `bytes` which need converting.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Previous crash:
<!-- Paste verbatim command output below, e.g. before and after your change -->
```
fatal: [104.131.17.109]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_name": "authorized_key"
    },
    "module_stderr": "OpenSSH_6.9p1 Ubuntu-2ubuntu0.2, OpenSSL 1.0.2d 9 Jul 2015\r\ndebug1: Reading configuration data /home/james/.ssh/config\r\ndebug1: Reading configuration data /etc/ssh/ssh_config\r\ndebug1: /etc/ssh/ssh_config line 19: Applying options for *\r\ndebug1: auto-mux: Trying existing master\r\ndebug2: fd 3 setting O_NONBLOCK\r\ndebug2: mux_client_hello_exchange: master version 4\r\ndebug3: mux_client_forwards: request forwardings: 0 local, 0 remote\r\ndebug3: mux_client_request_session: entering\r\ndebug3: mux_client_request_alive: entering\r\ndebug3: mux_client_request_alive: done pid = 22341\r\ndebug3: mux_client_request_session: session request sent\r\ndebug1: mux_client_request_session: master session id: 2\r\ndebug3: mux_client_read_packet: read header failed: Broken pipe\r\ndebug2: Received exit status from master 0\r\nShared connection to 104.131.17.109 closed.\r\n",
    "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_grkuvdsh/ansible_module_authorized_key.py\", line 527, in <module>\r\n    main()\r\n  File \"/tmp/ansible_grkuvdsh/ansible_module_authorized_key.py\", line 523, in main\r\n    results = enforce_state(module, module.params)\r\n  File \"/tmp/ansible_grkuvdsh/ansible_module_authorized_key.py\", line 433, in enforce_state\r\n    key = [s for s in key.splitlines() if s and not s.startswith('#')]\r\n  File \"/tmp/ansible_grkuvdsh/ansible_module_authorized_key.py\", line 433, in <listcomp>\r\n    key = [s for s in key.splitlines() if s and not s.startswith('#')]\r\nTypeError: startswith first arg must be bytes or a tuple of bytes, not str\r\n",
    "msg": "MODULE FAILURE"
}
```

With patch passes with
```
ok: [10.0.0.0] => {
    "changed": false,
    "exclusive": false,
    "invocation": {
        "module_args": {
            "exclusive": false,
            "key": "https://github.com/jamescooke.keys",
            "key_options": null,
            "keyfile": "/home/james/.ssh/authorized_keys",
            "manage_dir": true,
            "path": null,
            "state": "present",
            "unique": false,
            "user": "james",
            "validate_certs": true
        },
        "module_name": "authorized_key"
    },
    "key": "https://github.com/jamescooke.keys",
    "key_options": null,
    "keyfile": "/home/james/.ssh/authorized_keys",
    "manage_dir": true,
    "path": null,
    "state": "present",
    "unique": false,
    "user": "james",
    "validate_certs": true
}
```
