### PR TITLE
Fix pamd module

### DIFF
--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -381,7 +381,7 @@ def remove_module_arguments(service, old_rule, module_args):
     result = {'action': 'args_absent'}
     changed = False
     change_count = 0
-    if isinstance(module_args, ansible.module_utils.six.string_types):
+    if isinstance(module_args, string_types):
         module_args = module_args.split(' ')
 
     for rule in service.rules:
@@ -405,7 +405,7 @@ def add_module_arguments(service, old_rule, module_args):
     result = {'action': 'args_present'}
     changed = False
     change_count = 0
-    if isinstance(module_args, ansible.module_utils.six.string_types):
+    if isinstance(module_args, string_types):
         module_args = module_args.split(' ')
 
     for rule in service.rules:

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -469,7 +469,11 @@ def main():
                                 'args_absent', 'args_present']),
             path=dict(required=False, default='/etc/pam.d', type='str')
         ),
-        supports_check_mode=True
+        supports_check_mode=True,
+        required_if=[
+            ("state", "args_present", ["module_arguments"]),
+            ("state", "args_absent", ["module_arguments"])
+        ]
     )
 
     service = module.params['name']

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import string_types
 from ansible.module_utils.pycompat24 import get_exception
 
 DOCUMENTATION = """
@@ -381,8 +380,6 @@ def remove_module_arguments(service, old_rule, module_args):
     result = {'action': 'args_absent'}
     changed = False
     change_count = 0
-    if isinstance(module_args, string_types):
-        module_args = module_args.split(' ')
 
     for rule in service.rules:
         if (old_rule.rule_type == rule.rule_type and
@@ -405,8 +402,6 @@ def add_module_arguments(service, old_rule, module_args):
     result = {'action': 'args_present'}
     changed = False
     change_count = 0
-    if isinstance(module_args, string_types):
-        module_args = module_args.split(' ')
 
     for rule in service.rules:
         if (old_rule.rule_type == rule.rule_type and

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -413,7 +413,13 @@ def add_module_arguments(service, old_rule, module_args):
                 old_rule.rule_control == rule.rule_control and
                 old_rule.rule_module_path == rule.rule_module_path):
             for arg_to_add in module_args:
-                if "=" in arg_to_add:
+                if arg_to_add not in rule.rule_module_args:
+                    rule.rule_module_args.append(arg_to_add)
+                    changed = True
+                    result['added_arg_'+str(change_count)] = arg_to_add
+                    result['to_rule_'+str(change_count)] = str(rule)
+                    change_count += 1
+                elif "=" in arg_to_add:
                     pre_string = arg_to_add[:arg_to_add.index('=')+1]
                     indicies = [i for i, arg
                                 in enumerate(rule.rule_module_args)
@@ -427,12 +433,6 @@ def add_module_arguments(service, old_rule, module_args):
                             result['in_rule_' +
                                    str(change_count)] = str(rule)
                             change_count += 1
-                elif arg_to_add not in rule.rule_module_args:
-                    rule.rule_module_args.append(arg_to_add)
-                    changed = True
-                    result['added_arg_'+str(change_count)] = arg_to_add
-                    result['to_rule_'+str(change_count)] = str(rule)
-                    change_count += 1
     result['change_count'] = change_count
     return changed, result
 

--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -408,26 +408,33 @@ def add_module_arguments(service, old_rule, module_args):
                 old_rule.rule_control == rule.rule_control and
                 old_rule.rule_module_path == rule.rule_module_path):
             for arg_to_add in module_args:
-                if arg_to_add not in rule.rule_module_args:
+                if "=" in arg_to_add:
+                    pre_string = arg_to_add[:arg_to_add.index('=')+1]
+                    indicies = [i for i, arg
+                                in enumerate(rule.rule_module_args)
+                                if arg.startswith(pre_string)]
+                    if len(indicies) == 0:
+                        rule.rule_module_args.append(arg_to_add)
+                        changed = True
+                        result['added_arg_'+str(change_count)] = arg_to_add
+                        result['to_rule_'+str(change_count)] = str(rule)
+                        change_count += 1
+                    else:
+                        for i in indicies:
+                            if rule.rule_module_args[i] != arg_to_add:
+                                rule.rule_module_args[i] = arg_to_add
+                                changed = True
+                                result['updated_arg_' +
+                                       str(change_count)] = arg_to_add
+                                result['in_rule_' +
+                                       str(change_count)] = str(rule)
+                                change_count += 1
+                elif arg_to_add not in rule.rule_module_args:
                     rule.rule_module_args.append(arg_to_add)
                     changed = True
                     result['added_arg_'+str(change_count)] = arg_to_add
                     result['to_rule_'+str(change_count)] = str(rule)
                     change_count += 1
-                elif "=" in arg_to_add:
-                    pre_string = arg_to_add[:arg_to_add.index('=')+1]
-                    indicies = [i for i, arg
-                                in enumerate(rule.rule_module_args)
-                                if arg.startswith(pre_string)]
-                    for i in indicies:
-                        if rule.rule_module_args[i] != arg_to_add:
-                            rule.rule_module_args[i] = arg_to_add
-                            changed = True
-                            result['updated_arg_' +
-                                   str(change_count)] = arg_to_add
-                            result['in_rule_' +
-                                   str(change_count)] = str(rule)
-                            change_count += 1
     result['change_count'] = change_count
     return changed, result
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
pamd

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel c1f5432cc0) last updated 2017/01/09 15:06:36 (GMT +200)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY

1. Fixes wrong usage of string_types that caused NameErrors when `state: args_absent` or `state: args_present`
2. Fixes a bug that would cause `module_arguments` to be ignored when `state: args_present` is used and the argument is of the form parameter=value.
###### Task:
```yaml
- name: 5.3.3 - Ensure password reuse is limited for system-auth
  pamd:
    name: system-auth
    type: password
    control: sufficient
    module_path: pam_unix.so
    module_arguments: "remember=5"
    state: args_present
```
###### Pam.d system-auth
```
#%PAM-1.0
# This file is auto-generated.
# User changes will be destroyed the next time authconfig is run.
auth        required      pam_env.so
auth        sufficient    pam_unix.so try_first_pass nullok
auth        required      pam_deny.so

account     required      pam_unix.so

password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
password    sufficient    pam_unix.so try_first_pass use_authtok nullok sha512 shadow
password    required      pam_deny.so

session     optional      pam_keyinit.so revoke
session     required      pam_limits.so
session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
session     required      pam_unix.so
```

The provided task should add the module parameter `remember=5` to the line `password    sufficient    pam_unix.so try_first_pass use_authtok nullok sha512 shadow` but the current version ignores the new argument.
3. Fixes parameter requirements to require module_arguments when state is args_present or args_absent