### PR TITLE
Network Tests: Use inventory_hostname_short

### DIFF
--- a/test/integration/targets/asa_config/tests/cli/backup.yaml
+++ b/test/integration/targets/asa_config/tests/cli/backup.yaml
@@ -11,7 +11,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 
@@ -36,7 +36,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 

--- a/test/integration/targets/asa_config/tests/cli/toplevel.yaml
+++ b/test/integration/targets/asa_config/tests/cli/toplevel.yaml
@@ -29,7 +29,7 @@
 
 - name: teardown
   asa_config:
-    lines: ['hostname {{ inventory_hostname }}']
+    lines: ['hostname {{ inventory_hostname_short }}']
     provider: "{{ cli }}"
 
 - debug: msg="END cli/toplevel.yaml"

--- a/test/integration/targets/asa_config/tests/cli/toplevel_after.yaml
+++ b/test/integration/targets/asa_config/tests/cli/toplevel_after.yaml
@@ -36,7 +36,7 @@
   asa_config:
     lines:
       - "no snmp-server contact"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
 
 - debug: msg="END cli/toplevel_after.yaml"

--- a/test/integration/targets/asa_config/tests/cli/toplevel_before.yaml
+++ b/test/integration/targets/asa_config/tests/cli/toplevel_before.yaml
@@ -36,7 +36,7 @@
   asa_config:
     lines:
       - "no snmp-server contact"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
 
 - debug: msg="END cli/toplevel_before.yaml"

--- a/test/integration/targets/asa_config/tests/cli/toplevel_nonidempotent.yaml
+++ b/test/integration/targets/asa_config/tests/cli/toplevel_nonidempotent.yaml
@@ -32,7 +32,7 @@
 
 - name: teardown
   asa_config:
-    lines: ['hostname {{ inventory_hostname }}']
+    lines: ['hostname {{ inventory_hostname_short }}']
     provider: "{{ cli }}"
 
 - debug: msg="END cli/toplevel_nonidempotent.yaml"

--- a/test/integration/targets/dellos10_config/tests/cli/toplevel.yaml
+++ b/test/integration/targets/dellos10_config/tests/cli/toplevel.yaml
@@ -3,7 +3,7 @@
 
 - name: setup
   dellos10_config:
-    lines: ['hostname {{ inventory_hostname }}']
+    lines: ['hostname {{ inventory_hostname_short }}']
     provider: "{{ cli }}"
     match: none
 
@@ -30,7 +30,7 @@
 
 - name: teardown
   dellos10_config:
-    lines: ['hostname {{ inventory_hostname }}']
+    lines: ['hostname {{ inventory_hostname_short }}']
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/dellos10_config/tests/cli/toplevel_after.yaml
+++ b/test/integration/targets/dellos10_config/tests/cli/toplevel_after.yaml
@@ -5,7 +5,7 @@
   dellos10_config:
     lines:
       - "snmp-server contact ansible"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 
@@ -37,7 +37,7 @@
   dellos10_config:
     lines:
       - "no snmp-server contact"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/dellos10_config/tests/cli/toplevel_before.yaml
+++ b/test/integration/targets/dellos10_config/tests/cli/toplevel_before.yaml
@@ -5,7 +5,7 @@
   dellos10_config:
     lines:
       - "snmp-server contact ansible"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 
@@ -37,7 +37,7 @@
   dellos10_config:
     lines:
       - "no snmp-server contact"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/dellos10_config/tests/cli/toplevel_nonidempotent.yaml
+++ b/test/integration/targets/dellos10_config/tests/cli/toplevel_nonidempotent.yaml
@@ -3,7 +3,7 @@
 
 - name: setup
   dellos10_config:
-    lines: ['hostname {{ inventory_hostname }}']
+    lines: ['hostname {{ inventory_hostname_short }}']
     provider: "{{ cli }}"
     match: none
 
@@ -32,7 +32,7 @@
 
 - name: teardown
   dellos10_config:
-    lines: ['hostname {{ inventory_hostname }}']
+    lines: ['hostname {{ inventory_hostname_short }}']
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/dellos6_config/tests/cli/toplevel.yaml
+++ b/test/integration/targets/dellos6_config/tests/cli/toplevel.yaml
@@ -3,7 +3,7 @@
 
 - name: setup
   dellos6_config:
-    lines: ['hostname {{ inventory_hostname }}']
+    lines: ['hostname {{ inventory_hostname_short }}']
     provider: "{{ cli }}"
     match: none
 
@@ -30,7 +30,7 @@
 
 - name: teardown
   dellos6_config:
-    lines: ['hostname {{ inventory_hostname }}']
+    lines: ['hostname {{ inventory_hostname_short }}']
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/dellos6_config/tests/cli/toplevel_after.yaml
+++ b/test/integration/targets/dellos6_config/tests/cli/toplevel_after.yaml
@@ -5,7 +5,7 @@
   dellos6_config:
     lines:
       - "snmp-server contact ansible"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 
@@ -37,7 +37,7 @@
   dellos6_config:
     lines:
       - "no snmp-server contact"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/dellos6_config/tests/cli/toplevel_before.yaml
+++ b/test/integration/targets/dellos6_config/tests/cli/toplevel_before.yaml
@@ -5,7 +5,7 @@
   dellos6_config:
     lines:
       - "snmp-server contact ansible"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 
@@ -37,7 +37,7 @@
   dellos6_config:
     lines:
       - "no snmp-server contact"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/dellos6_config/tests/cli/toplevel_nonidempotent.yaml
+++ b/test/integration/targets/dellos6_config/tests/cli/toplevel_nonidempotent.yaml
@@ -3,7 +3,7 @@
 
 - name: setup
   dellos6_config:
-    lines: ['hostname {{ inventory_hostname }}']
+    lines: ['hostname {{ inventory_hostname_short }}']
     provider: "{{ cli }}"
     match: none
 
@@ -32,7 +32,7 @@
 
 - name: teardown
   dellos6_config:
-    lines: ['hostname {{ inventory_hostname }}']
+    lines: ['hostname {{ inventory_hostname_short }}']
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/dellos9_config/tests/cli/toplevel.yaml
+++ b/test/integration/targets/dellos9_config/tests/cli/toplevel.yaml
@@ -3,7 +3,7 @@
 
 - name: setup
   dellos9_config:
-    lines: ['hostname {{ inventory_hostname }}']
+    lines: ['hostname {{ inventory_hostname_short }}']
     provider: "{{ cli }}"
     match: none
 
@@ -30,7 +30,7 @@
 
 - name: teardown
   dellos9_config:
-    lines: ['hostname {{ inventory_hostname }}']
+    lines: ['hostname {{ inventory_hostname_short }}']
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/dellos9_config/tests/cli/toplevel_after.yaml
+++ b/test/integration/targets/dellos9_config/tests/cli/toplevel_after.yaml
@@ -5,7 +5,7 @@
   dellos9_config:
     lines:
       - "snmp-server contact ansible"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 
@@ -37,7 +37,7 @@
   dellos9_config:
     lines:
       - "no snmp-server contact"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/dellos9_config/tests/cli/toplevel_before.yaml
+++ b/test/integration/targets/dellos9_config/tests/cli/toplevel_before.yaml
@@ -5,7 +5,7 @@
   dellos9_config:
     lines:
       - "snmp-server contact ansible"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 
@@ -37,7 +37,7 @@
   dellos9_config:
     lines:
       - "no snmp-server contact"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/dellos9_config/tests/cli/toplevel_nonidempotent.yaml
+++ b/test/integration/targets/dellos9_config/tests/cli/toplevel_nonidempotent.yaml
@@ -3,7 +3,7 @@
 
 - name: setup
   dellos9_config:
-    lines: ['hostname {{ inventory_hostname }}']
+    lines: ['hostname {{ inventory_hostname_short }}']
     provider: "{{ cli }}"
     match: none
 
@@ -32,7 +32,7 @@
 
 - name: teardown
   dellos9_config:
-    lines: ['hostname {{ inventory_hostname }}']
+    lines: ['hostname {{ inventory_hostname_short }}']
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/eos_config/tests/cli/backup.yaml
+++ b/test/integration/targets/eos_config/tests/cli/backup.yaml
@@ -14,7 +14,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 
@@ -39,7 +39,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 

--- a/test/integration/targets/eos_config/tests/cli/config.yaml
+++ b/test/integration/targets/eos_config/tests/cli/config.yaml
@@ -3,7 +3,7 @@
 
 - name: setup
   eos_config:
-    lines: hostname {{ inventory_hostname }}
+    lines: hostname {{ inventory_hostname_short }}
     match: none
     provider: "{{ cli }}"
 
@@ -39,7 +39,7 @@
 
 - name: teardown
   eos_config:
-    lines: hostname {{ inventory_hostname }}
+    lines: hostname {{ inventory_hostname_short }}
     match: none
     provider: "{{ cli }}"
 

--- a/test/integration/targets/eos_config/tests/eapi/backup.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/backup.yaml
@@ -14,7 +14,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 
@@ -39,7 +39,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 

--- a/test/integration/targets/eos_config/tests/eapi/toplevel.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/toplevel.yaml
@@ -3,7 +3,7 @@
 
 - name: setup
   eos_config:
-    lines: hostname {{ inventory_hostname }}
+    lines: hostname {{ inventory_hostname_short }}
     match: none
     provider: "{{ eapi }}"
 
@@ -30,7 +30,7 @@
 
 - name: teardown
   eos_config:
-    lines: hostname {{ inventory_hostname }}
+    lines: hostname {{ inventory_hostname_short }}
     match: none
     provider: "{{ eapi }}"
 

--- a/test/integration/targets/eos_config/tests/eapi/toplevel_after.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/toplevel_after.yaml
@@ -5,7 +5,7 @@
   eos_config:
     lines:
       - "snmp-server contact ansible"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     match: none
     provider: "{{ eapi }}"
 
@@ -37,7 +37,7 @@
   eos_config:
     lines:
       - no snmp-server contact
-      - hostname {{ inventory_hostname }}
+      - hostname {{ inventory_hostname_short }}
     match: none
     provider: "{{ eapi }}"
 

--- a/test/integration/targets/eos_config/tests/eapi/toplevel_before.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/toplevel_before.yaml
@@ -5,7 +5,7 @@
   eos_config:
     lines:
       - "snmp-server contact ansible"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     match: none
     provider: "{{ eapi }}"
 
@@ -37,7 +37,7 @@
   eos_config:
     lines:
       - no snmp-server contact ansible
-      - hostname {{ inventory_hostname }}
+      - hostname {{ inventory_hostname_short }}
     match: none
     provider: "{{ eapi }}"
 

--- a/test/integration/targets/eos_template/tests/cli/backup.yaml
+++ b/test/integration/targets/eos_template/tests/cli/backup.yaml
@@ -14,7 +14,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 
@@ -39,7 +39,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 

--- a/test/integration/targets/eos_template/tests/eapi/backup.yaml
+++ b/test/integration/targets/eos_template/tests/eapi/backup.yaml
@@ -14,7 +14,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 
@@ -39,7 +39,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 

--- a/test/integration/targets/ios_config/tests/cli/backup.yaml
+++ b/test/integration/targets/ios_config/tests/cli/backup.yaml
@@ -14,7 +14,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 
@@ -39,7 +39,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 

--- a/test/integration/targets/ios_config/tests/cli/toplevel.yaml
+++ b/test/integration/targets/ios_config/tests/cli/toplevel.yaml
@@ -3,7 +3,7 @@
 
 - name: setup
   ios_config:
-    lines: ['hostname {{ inventory_hostname }}']
+    lines: ['hostname {{ inventory_hostname_short }}']
     provider: "{{ cli }}"
     match: none
 
@@ -30,7 +30,7 @@
 
 - name: teardown
   ios_config:
-    lines: ['hostname {{ inventory_hostname }}']
+    lines: ['hostname {{ inventory_hostname_short }}']
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/ios_config/tests/cli/toplevel_after.yaml
+++ b/test/integration/targets/ios_config/tests/cli/toplevel_after.yaml
@@ -5,7 +5,7 @@
   ios_config:
     lines:
       - "snmp-server contact ansible"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 
@@ -37,7 +37,7 @@
   ios_config:
     lines:
       - "no snmp-server contact"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/ios_config/tests/cli/toplevel_before.yaml
+++ b/test/integration/targets/ios_config/tests/cli/toplevel_before.yaml
@@ -5,7 +5,7 @@
   ios_config:
     lines:
       - "snmp-server contact ansible"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 
@@ -37,7 +37,7 @@
   ios_config:
     lines:
       - "no snmp-server contact"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/ios_config/tests/cli/toplevel_nonidempotent.yaml
+++ b/test/integration/targets/ios_config/tests/cli/toplevel_nonidempotent.yaml
@@ -3,7 +3,7 @@
 
 - name: setup
   ios_config:
-    lines: ['hostname {{ inventory_hostname }}']
+    lines: ['hostname {{ inventory_hostname_short }}']
     provider: "{{ cli }}"
     match: none
 
@@ -32,7 +32,7 @@
 
 - name: teardown
   ios_config:
-    lines: ['hostname {{ inventory_hostname }}']
+    lines: ['hostname {{ inventory_hostname_short }}']
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/ios_template/tests/cli/backup.yaml
+++ b/test/integration/targets/ios_template/tests/cli/backup.yaml
@@ -12,7 +12,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 
@@ -37,7 +37,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 

--- a/test/integration/targets/iosxr_config/tests/cli/backup.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/backup.yaml
@@ -14,7 +14,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 
@@ -39,7 +39,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 

--- a/test/integration/targets/iosxr_config/tests/cli/toplevel.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/toplevel.yaml
@@ -3,7 +3,7 @@
 
 - name: setup
   iosxr_config:
-    commands: ['hostname {{ inventory_hostname }}']
+    commands: ['hostname {{ inventory_hostname_short }}']
     provider: "{{ cli }}"
     match: none
 
@@ -30,7 +30,7 @@
 
 - name: teardown
   iosxr_config:
-    commands: ['hostname {{ inventory_hostname }}']
+    commands: ['hostname {{ inventory_hostname_short }}']
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/iosxr_config/tests/cli/toplevel_after.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/toplevel_after.yaml
@@ -5,7 +5,7 @@
   iosxr_config:
     commands:
       - "no cdp"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 
@@ -37,7 +37,7 @@
   iosxr_config:
     commands:
       - "no cdp"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/iosxr_config/tests/cli/toplevel_before.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/toplevel_before.yaml
@@ -5,7 +5,7 @@
   iosxr_config:
     commands:
       - "no cdp"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 
@@ -37,7 +37,7 @@
   iosxr_config:
     commands:
       - "no cdp"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/iosxr_config/tests/cli/toplevel_nonidempotent.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/toplevel_nonidempotent.yaml
@@ -3,7 +3,7 @@
 
 - name: setup
   iosxr_config:
-    commands: ['hostname {{ inventory_hostname }}']
+    commands: ['hostname {{ inventory_hostname_short }}']
     provider: "{{ cli }}"
     match: none
 
@@ -32,7 +32,7 @@
 
 - name: teardown
   iosxr_config:
-    commands: ['hostname {{ inventory_hostname }}']
+    commands: ['hostname {{ inventory_hostname_short }}']
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/iosxr_template/templates/basic/config.j2
+++ b/test/integration/targets/iosxr_template/templates/basic/config.j2
@@ -1,4 +1,4 @@
-hostname {{ inventory_hostname }}
+hostname {{ inventory_hostname_short }}
 !
 interface Loopback999
    description this is a test

--- a/test/integration/targets/iosxr_template/tests/cli/backup.yaml
+++ b/test/integration/targets/iosxr_template/tests/cli/backup.yaml
@@ -12,7 +12,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 
@@ -37,7 +37,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 

--- a/test/integration/targets/junos_config/tests/netconf/backup.yaml
+++ b/test/integration/targets/junos_config/tests/netconf/backup.yaml
@@ -4,14 +4,14 @@
 - name: setup
   junos_config:
     lines:
-      - set system host-name {{ inventory_hostname }}
+      - set system host-name {{ inventory_hostname_short }}
       - delete interfaces lo0
     provider: "{{ netconf }}"
 
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 
@@ -36,7 +36,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 

--- a/test/integration/targets/junos_config/tests/netconf/invalid.yaml
+++ b/test/integration/targets/junos_config/tests/netconf/invalid.yaml
@@ -16,7 +16,7 @@
 - name: configure multiple invalid command
   junos_config:
     lines:
-      - 'set system host-name {{ inventory_hostname }}'
+      - 'set system host-name {{ inventory_hostname_short }}'
       - 'set system foo'
     provider: "{{ netconf }}"
   register: result

--- a/test/integration/targets/junos_config/tests/netconf/multiple.yaml
+++ b/test/integration/targets/junos_config/tests/netconf/multiple.yaml
@@ -4,7 +4,7 @@
 - name: setup
   junos_config:
     lines:
-      - "set system host-name {{ inventory_hostname }}"
+      - "set system host-name {{ inventory_hostname_short }}"
       - "delete interfaces lo0"
     provider: "{{ netconf }}"
   register: test
@@ -12,7 +12,7 @@
 - name: configure multiple commands
   junos_config:
     lines:
-      - 'set system host-name {{ inventory_hostname }}'
+      - 'set system host-name {{ inventory_hostname_short }}'
       - 'set interfaces lo0 unit 0 family inet address 1.1.1.1/32'
     provider: "{{ netconf }}"
   register: result
@@ -28,7 +28,7 @@
 - name: check multiple commands idempotent
   junos_config:
     lines:
-      - 'set system host-name {{ inventory_hostname }}'
+      - 'set system host-name {{ inventory_hostname_short }}'
       - 'set interfaces lo0 unit 0 family inet address 1.1.1.1/32'
     provider: "{{ netconf }}"
   register: result
@@ -41,7 +41,7 @@
 - name: teardown
   junos_config:
     lines:
-      - "set system host-name {{ inventory_hostname }}"
+      - "set system host-name {{ inventory_hostname_short }}"
       - "delete interfaces lo0"
     provider: "{{ netconf }}"
   register: test

--- a/test/integration/targets/junos_config/tests/netconf/single.yaml
+++ b/test/integration/targets/junos_config/tests/netconf/single.yaml
@@ -5,7 +5,7 @@
 - name: setup
   junos_config:
     lines:
-      - set system host-name {{ inventory_hostname }}
+      - set system host-name {{ inventory_hostname_short }}
     provider: "{{ netconf }}"
 
 - name: configure single command
@@ -34,7 +34,7 @@
 - name: teardown
   junos_config:
     lines:
-      - set system host-name {{ inventory_hostname }}
+      - set system host-name {{ inventory_hostname_short }}
     provider: "{{ netconf }}"
 
 

--- a/test/integration/targets/junos_config/tests/netconf/src_basic.yaml
+++ b/test/integration/targets/junos_config/tests/netconf/src_basic.yaml
@@ -4,7 +4,7 @@
 - name: setup
   junos_config:
     lines:
-      - set system host-name {{ inventory_hostname }}
+      - set system host-name {{ inventory_hostname_short }}
       - delete interfaces lo0
     provider: "{{ netconf }}"
 

--- a/test/integration/targets/junos_netconf/tests/cli/changeport.yaml
+++ b/test/integration/targets/junos_netconf/tests/cli/changeport.yaml
@@ -35,7 +35,7 @@
 - name: Ensure we can communicate over 8080
   junos_config:
     lines:
-      - set system host-name {{ inventory_hostname }}
+      - set system host-name {{ inventory_hostname_short }}
     provider: "{{ netconf }}"
     port: 8080
 
@@ -43,7 +43,7 @@
 - name: Ensure we can NOT communicate over default port
   junos_config:
     lines:
-      - set system host-name {{ inventory_hostname }}
+      - set system host-name {{ inventory_hostname_short }}
     provider: "{{ netconf }}"
   register: result
   ignore_errors: true
@@ -62,7 +62,7 @@
 - name: Ensure we can communicate over netconf
   junos_config:
     lines:
-      - set system host-name {{ inventory_hostname }}
+      - set system host-name {{ inventory_hostname_short }}
     provider: "{{ netconf }}"
 
 - debug: msg="END netconf/changeport.yaml"

--- a/test/integration/targets/junos_netconf/tests/cli/netconf.yaml
+++ b/test/integration/targets/junos_netconf/tests/cli/netconf.yaml
@@ -23,7 +23,7 @@
 - name: Ensure we can communicate over netconf
   junos_config:
     lines:
-      - set system host-name {{ inventory_hostname }}
+      - set system host-name {{ inventory_hostname_short }}
     provider: "{{ netconf }}"
 
 # Disable netconf
@@ -52,7 +52,7 @@
 - name: Ensure we can NOT talk via netconf
   junos_config:
     lines:
-      - set system host-name {{ inventory_hostname }}
+      - set system host-name {{ inventory_hostname_short }}
     provider: "{{ netconf }}"
   register: result
   ignore_errors: true

--- a/test/integration/targets/junos_template/tests/netconf/backup.yaml
+++ b/test/integration/targets/junos_template/tests/netconf/backup.yaml
@@ -4,14 +4,14 @@
 - name: setup
   junos_config:
     lines:
-      - set system host-name {{ inventory_hostname }}
+      - set system host-name {{ inventory_hostname_short }}
       - delete interfaces lo0
     provider: "{{ netconf }}"
 
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 
@@ -36,7 +36,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 
@@ -47,7 +47,7 @@
 - name: teardown
   junos_config:
     lines:
-      - set system host-name {{ inventory_hostname }}
+      - set system host-name {{ inventory_hostname_short }}
       - delete interfaces lo0
     provider: "{{ netconf }}"
 

--- a/test/integration/targets/junos_template/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_template/tests/netconf/basic.yaml
@@ -4,7 +4,7 @@
 - name: setup
   junos_config:
     lines:
-      - set system host-name {{ inventory_hostname }}
+      - set system host-name {{ inventory_hostname_short }}
       - delete interfaces lo0
     provider: "{{ netconf }}"
 
@@ -32,7 +32,7 @@
 - name: teardown
   junos_config:
     lines:
-      - set system host-name {{ inventory_hostname }}
+      - set system host-name {{ inventory_hostname_short }}
       - delete interfaces lo0
     provider: "{{ netconf }}"
 

--- a/test/integration/targets/junos_template/tests/netconf/force.yaml
+++ b/test/integration/targets/junos_template/tests/netconf/force.yaml
@@ -4,7 +4,7 @@
 - name: setup
   junos_config:
     lines:
-      - set system host-name {{ inventory_hostname }}
+      - set system host-name {{ inventory_hostname_short }}
       - delete interfaces lo0
     provider: "{{ netconf }}"
 
@@ -35,7 +35,7 @@
 - name: teardown
   junos_config:
     lines:
-      - set system host-name {{ inventory_hostname }}
+      - set system host-name {{ inventory_hostname_short }}
       - delete interfaces lo0
     action: replace
     provider: "{{ netconf }}"

--- a/test/integration/targets/nxos_config/tests/cli/backup.yaml
+++ b/test/integration/targets/nxos_config/tests/cli/backup.yaml
@@ -14,7 +14,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 
@@ -39,7 +39,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 

--- a/test/integration/targets/nxos_config/tests/cli/toplevel.yaml
+++ b/test/integration/targets/nxos_config/tests/cli/toplevel.yaml
@@ -3,7 +3,7 @@
 
 - name: setup
   nxos_config:
-    lines: hostname {{ inventory_hostname }}
+    lines: hostname {{ inventory_hostname_short }}
     provider: "{{ cli }}"
     match: none
 
@@ -30,7 +30,7 @@
 
 - name: teardown
   nxos_config:
-    lines: hostname {{ inventory_hostname }}
+    lines: hostname {{ inventory_hostname_short }}
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/nxos_config/tests/cli/toplevel_after.yaml
+++ b/test/integration/targets/nxos_config/tests/cli/toplevel_after.yaml
@@ -5,7 +5,7 @@
   nxos_config:
     lines:
       - "snmp-server contact ansible"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 
@@ -37,7 +37,7 @@
   nxos_config:
     lines:
       - "no snmp-server contact"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/nxos_config/tests/cli/toplevel_before.yaml
+++ b/test/integration/targets/nxos_config/tests/cli/toplevel_before.yaml
@@ -5,7 +5,7 @@
   nxos_config:
     lines:
       - "snmp-server contact ansible"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 
@@ -37,7 +37,7 @@
   nxos_config:
     lines:
       - "no snmp-server contact"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/nxos_config/tests/cli/toplevel_nonidempotent.yaml
+++ b/test/integration/targets/nxos_config/tests/cli/toplevel_nonidempotent.yaml
@@ -3,7 +3,7 @@
 
 - name: setup
   nxos_config:
-    lines: hostname {{ inventory_hostname }}
+    lines: hostname {{ inventory_hostname_short }}
     provider: "{{ cli }}"
     match: none
 
@@ -32,7 +32,7 @@
 
 - name: teardown
   nxos_config:
-    lines: hostname {{ inventory_hostname }}
+    lines: hostname {{ inventory_hostname_short }}
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/nxos_config/tests/nxapi/backup.yaml
+++ b/test/integration/targets/nxos_config/tests/nxapi/backup.yaml
@@ -14,7 +14,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 
@@ -39,7 +39,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 

--- a/test/integration/targets/nxos_config/tests/nxapi/toplevel.yaml
+++ b/test/integration/targets/nxos_config/tests/nxapi/toplevel.yaml
@@ -3,7 +3,7 @@
 
 - name: setup
   nxos_config:
-    lines: hostname {{ inventory_hostname }}
+    lines: hostname {{ inventory_hostname_short }}
     provider: "{{ nxapi }}"
     match: none
 
@@ -30,7 +30,7 @@
 
 - name: teardown
   nxos_config:
-    lines: hostname {{ inventory_hostname }}
+    lines: hostname {{ inventory_hostname_short }}
     provider: "{{ nxapi }}"
     match: none
 

--- a/test/integration/targets/nxos_config/tests/nxapi/toplevel_after.yaml
+++ b/test/integration/targets/nxos_config/tests/nxapi/toplevel_after.yaml
@@ -5,7 +5,7 @@
   nxos_config:
     lines:
       - "snmp-server contact ansible"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ nxapi }}"
     match: none
 
@@ -37,7 +37,7 @@
   nxos_config:
     lines:
       - "no snmp-server contact ansible"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ nxapi }}"
     match: none
 

--- a/test/integration/targets/nxos_config/tests/nxapi/toplevel_before.yaml
+++ b/test/integration/targets/nxos_config/tests/nxapi/toplevel_before.yaml
@@ -5,7 +5,7 @@
   nxos_config:
     lines:
       - "snmp-server contact ansible"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ nxapi }}"
     match: none
 
@@ -37,7 +37,7 @@
   nxos_config:
     lines:
       - "no snmp-server contact ansible"
-      - "hostname {{ inventory_hostname }}"
+      - "hostname {{ inventory_hostname_short }}"
     provider: "{{ nxapi }}"
     match: none
 

--- a/test/integration/targets/nxos_config/tests/nxapi/toplevel_nonidempotent.yaml
+++ b/test/integration/targets/nxos_config/tests/nxapi/toplevel_nonidempotent.yaml
@@ -3,7 +3,7 @@
 
 - name: setup
   nxos_config:
-    lines: hostname {{ inventory_hostname }}
+    lines: hostname {{ inventory_hostname_short }}
     provider: "{{ nxapi }}"
     match: none
 
@@ -32,7 +32,7 @@
 
 - name: setup
   nxos_config:
-    lines: hostname {{ inventory_hostname }}
+    lines: hostname {{ inventory_hostname_short }}
     provider: "{{ nxapi }}"
     match: none
 

--- a/test/integration/targets/nxos_template/tests/cli/backup.yaml
+++ b/test/integration/targets/nxos_template/tests/cli/backup.yaml
@@ -14,7 +14,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 
@@ -39,7 +39,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 

--- a/test/integration/targets/nxos_template/tests/nxapi/backup.yaml
+++ b/test/integration/targets/nxos_template/tests/nxapi/backup.yaml
@@ -14,7 +14,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 
@@ -39,7 +39,7 @@
 - name: collect any backup files
   find:
     paths: "{{ role_path }}/backup"
-    pattern: "{{ inventory_hostname }}_config*"
+    pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
   delegate_to: localhost
 

--- a/test/integration/targets/vyos_config/tests/cli/comment.yaml
+++ b/test/integration/targets/vyos_config/tests/cli/comment.yaml
@@ -3,7 +3,7 @@
 
 - name: setup
   vyos_config:
-    lines: set system host-name {{ inventory_hostname }}
+    lines: set system host-name {{ inventory_hostname_short }}
     provider: "{{ cli }}"
     match: none
 
@@ -31,7 +31,7 @@
 
 - name: teardown
   vyos_config:
-    lines: set system host-name {{ inventory_hostname }}
+    lines: set system host-name {{ inventory_hostname_short }}
     provider: "{{ cli }}"
     match: none
 

--- a/test/integration/targets/vyos_config/tests/cli/simple.yaml
+++ b/test/integration/targets/vyos_config/tests/cli/simple.yaml
@@ -3,7 +3,7 @@
 
 - name: setup
   vyos_config:
-    lines: set system host-name {{ inventory_hostname }}
+    lines: set system host-name {{ inventory_hostname_short }}
     provider: "{{ cli }}"
     match: none
 
@@ -30,7 +30,7 @@
 
 - name: teardown
   vyos_config:
-    lines: set system host-name {{ inventory_hostname }}
+    lines: set system host-name {{ inventory_hostname_short }}
     provider: "{{ cli }}"
     match: none
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
tests

##### ANSIBLE VERSION

##### SUMMARY
When using AWS we have to use the full domain name in the inventory file, which
we rather than the short name. This change avoids that ending up being
set in the tests.

This allows VyOS tests to pass on AWS[1]

[1] With the following caveats 
* vyos_command/tests/cli/output.yaml tests for ANSIBLE_VYOS_TERMINAL_LENGTH tests still fail on devel

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/20054)
<!-- Reviewable:end -->
