### PR TITLE
unit tests for action and templar for unsafe vars

### DIFF
--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -556,3 +556,77 @@ class TestActionBase(unittest.TestCase):
             play_context.make_become_cmd.assert_called_once_with("ECHO SAME", executable=None)
         finally:
             C.BECOME_ALLOW_SAME_USER = become_allow_same_user
+
+
+class TestActionBaseCleanReturnedData(unittest.TestCase):
+    def test(self):
+
+        fake_loader = DictDataLoader({
+        })
+        mock_module_loader = MagicMock()
+        mock_shared_loader_obj = MagicMock()
+        mock_shared_loader_obj.module_loader = mock_module_loader
+        connection_loader_paths = ['/tmp/asdfadf', '/usr/lib64/whatever',
+                                   'dfadfasf',
+                                   'foo.py',
+                                   '.*',
+                                   # FIXME: a path with parans breaks the regex
+                                   # '(.*)',
+                                   '/path/to/ansible/lib/ansible/plugins/connection/custom_connection.py',
+                                   '/path/to/ansible/lib/ansible/plugins/connection/ssh.py']
+
+        def fake_all(path_only=None):
+            for path in connection_loader_paths:
+                yield path
+
+        mock_connection_loader = MagicMock()
+        mock_connection_loader.all = fake_all
+
+        mock_shared_loader_obj.connection_loader = mock_connection_loader
+        mock_connection = MagicMock()
+        #mock_connection._shell.env_prefix.side_effect = env_prefix
+
+        #action_base = DerivedActionBase(mock_task, mock_connection, play_context, None, None, None)
+        action_base = DerivedActionBase(task=None,
+                                        connection=mock_connection,
+                                        play_context=None,
+                                        loader=fake_loader,
+                                        templar=None,
+                                        shared_loader_obj=mock_shared_loader_obj)
+        data = {'ansible_playbook_python': '/usr/bin/python',
+                #'ansible_rsync_path': '/usr/bin/rsync',
+                'ansible_python_interpreter': '/usr/bin/python',
+                'ansible_ssh_some_var': 'whatever',
+                'ansible_ssh_host_key_somehost': 'some key here',
+                'some_other_var': 'foo bar'}
+        res = action_base._clean_returned_data(data)
+        print(res)
+        print('data: %s' % data)
+        self.assertNotIn('ansible_playbook_python', data)
+        self.assertNotIn('ansible_python_interpreter', data)
+        self.assertIn('ansible_ssh_host_key_somehost', data)
+        self.assertIn('some_other_var', data)
+
+
+class TestActionBaseParseReturnedData(unittest.TestCase):
+    def test(self):
+
+        fake_loader = DictDataLoader({
+        })
+        mock_module_loader = MagicMock()
+        mock_shared_loader_obj = MagicMock()
+        mock_shared_loader_obj.module_loader = mock_module_loader
+        mock_connection_loader = MagicMock()
+
+        mock_shared_loader_obj.connection_loader = mock_connection_loader
+        mock_connection = MagicMock()
+
+        action_base = DerivedActionBase(task=None,
+                                        connection=mock_connection,
+                                        play_context=None,
+                                        loader=fake_loader,
+                                        templar=None,
+                                        shared_loader_obj=mock_shared_loader_obj)
+
+        res = action_base._parse_returned_data('foo')
+        print(res)

--- a/test/units/plugins/action/test_action.py
+++ b/test/units/plugins/action/test_action.py
@@ -601,8 +601,6 @@ class TestActionBaseCleanReturnedData(unittest.TestCase):
                 'ansible_ssh_host_key_somehost': 'some key here',
                 'some_other_var': 'foo bar'}
         res = action_base._clean_returned_data(data)
-        print(res)
-        print('data: %s' % data)
         self.assertNotIn('ansible_playbook_python', data)
         self.assertNotIn('ansible_python_interpreter', data)
         self.assertIn('ansible_ssh_host_key_somehost', data)
@@ -667,10 +665,9 @@ class TestActionBaseParseReturnedData(unittest.TestCase):
                          'stdout_lines': stdout.splitlines(),
                          'stderr': err}
         res = action_base._parse_returned_data(returned_data)
-        print(res)
         self.assertTrue(res['_ansible_parsed'])
-        print(type(res['ansible_facts']))
-        self.assertIsInstance(res['ansible_facts'], AnsibleUnsafe)
+        # TODO: Should this be an AnsibleUnsafe?
+        #self.assertIsInstance(res['ansible_facts'], AnsibleUnsafe)
 
     def test_json_facts_add_host(self):
         action_base = self._action_base()
@@ -686,7 +683,6 @@ class TestActionBaseParseReturnedData(unittest.TestCase):
                          'stdout_lines': stdout.splitlines(),
                          'stderr': err}
         res = action_base._parse_returned_data(returned_data)
-        print(res)
         self.assertTrue(res['_ansible_parsed'])
-        print(type(res['ansible_facts']))
-        self.assertIsInstance(res['ansible_facts'], AnsibleUnsafe)
+        # TODO: Should this be an AnsibleUnsafe?
+        #self.assertIsInstance(res['ansible_facts'], AnsibleUnsafe)

--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -27,8 +27,8 @@ from ansible.compat.tests.mock import patch
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleUndefinedVariable
 from ansible.template import Templar, AnsibleContext, AnsibleEnvironment
-#from ansible.vars.unsafe_proxy import AnsibleUnsafe, wrap_var, is_unsafe
-from ansible.unsafe_proxy import AnsibleUnsafe, wrap_var, is_unsafe
+from ansible.vars.unsafe_proxy import AnsibleUnsafe, wrap_var
+#from ansible.unsafe_proxy import AnsibleUnsafe, wrap_var
 from units.mock.loader import DictDataLoader
 
 
@@ -280,7 +280,6 @@ class TestTemplarLookup(BaseTemplar, unittest.TestCase):
 
     def test_lookup_jinja_kwargs(self):
         res = self.templar._lookup('list', 'blip', random_keyword='12345')
-        print(dir(res))
         self.assertTrue(self.is_unsafe(res))
         #self.assertIsInstance(res, AnsibleUnsafe)
 
@@ -329,34 +328,6 @@ class TestTemplarLookup(BaseTemplar, unittest.TestCase):
     def test_lookup_jinja_none(self):
         res = self.templar._lookup('list', None)
         self.assertIsNone(res)
-
-
-class TestTemplarLookupTemplate(BaseTemplar, unittest.TestCase):
-    def test_unknown_lookup(self):
-        self.assertRaisesRegexp(AnsibleError,
-                                'lookup plugin \(sdfsdf\) not found',
-                                self.templar.template,
-                                u"{{ lookup('sdfsdf','sdfsdf') }}")
-
-#    def test_file(self):
-#        res = self.templar.template(u"{{ lookup('file', '/tmp/lookup_test') }}")
-#        print(res)
-
-    def test_env(self):
-        res = self.templar.template(u"{{ lookup('env', 'TEST_VAR') }}")
-        print(res)
-
-    def test_nested_env(self):
-        res = self.templar.template(u"{{ lookup('env', lookup('env', 'TEST_VAR_VAR')) }}")
-        print(res)
-
-#    def test_lines(self):
-#        res = self.templar.template(u"{{ lookup('lines', '/tmp/lookup_test') }}")
-#        print(res)
-
-    def test_fileglob(self):
-        res = self.templar.template(u"{{ lookup('fileglob', '/usr/share/man/man4/*') }}")
-        print(res)
 
 
 class TestAnsibleContext(BaseTemplar, unittest.TestCase):

--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -139,6 +139,22 @@ class TestTemplarTemplate(BaseTemplar, unittest.TestCase):
         unsafe_obj = AnsibleUnsafe()
         self.templar.template(unsafe_obj)
 
+    # TODO: not sure what template is supposed to do it, but it currently throws attributeError
+    @patch('ansible.template.Templar._clean_data', side_effect=AnsibleError)
+    def test_template_unsafe_wrap_var_non_string_clean_data_exception(self, mock_clean_data):
+        unsafe_obj = AnsibleUnsafe()
+
+        class SomeClass(object):
+            foo = 'bar'
+
+            def __init__(self):
+                self.blip = 'blip'
+
+        some_obj = SomeClass()
+        unsafe_obj = wrap_var(some_obj)
+        res = self.templar.template(unsafe_obj)
+        self.assertTrue(self.is_unsafe(res), 'returned value from template.template (%s) is not marked unsafe' % res)
+
 
 class TestTemplarCleanData(BaseTemplar, unittest.TestCase):
     def test_clean_data(self):

--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -19,8 +19,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from jinja2.nodes import EvalContext
-from jinja2 import Environment
 from jinja2.runtime import Context
 
 from ansible.compat.tests import unittest
@@ -28,29 +26,10 @@ from ansible.compat.tests.mock import patch
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleUndefinedVariable
-from ansible.plugins.strategy import SharedPluginLoaderObj
-from ansible.template import Templar, AnsibleEvalContext, AnsibleContext, AnsibleEnvironment
+from ansible.template import Templar, AnsibleContext, AnsibleEnvironment
 #from ansible.vars.unsafe_proxy import AnsibleUnsafe, wrap_var, is_unsafe
 from ansible.unsafe_proxy import AnsibleUnsafe, wrap_var, is_unsafe
 from units.mock.loader import DictDataLoader
-
-
-TEST_VARS = dict(
-    foo="bar",
-    bam="{{foo}}",
-    num=1,
-    var_true=True,
-    var_false=False,
-    var_dict=dict(a="b"),
-    bad_dict="{a='b'",
-    var_list=[1],
-    recursive="{{recursive}}",
-    some_var="blip",
-    some_static_var="static_blip",
-    some_keyword="{{ foo }}",
-    some_unsafe_var=wrap_var("unsafe_blip"),
-    some_unsafe_keyword=wrap_var("{{ foo }}"),
-)
 
 
 class BaseTemplar(object):
@@ -76,6 +55,18 @@ class BaseTemplar(object):
         })
         self.templar = Templar(loader=self.fake_loader, variables=self.test_vars)
 
+    def is_unsafe(self, obj):
+        if obj is None:
+            return False
+
+        if hasattr(obj, '__UNSAFE__'):
+            return True
+
+        if isinstance(obj, AnsibleUnsafe):
+            return True
+
+        return False
+
 
 class TestTemplarTemplate(BaseTemplar, unittest.TestCase):
 
@@ -92,11 +83,12 @@ class TestTemplarTemplate(BaseTemplar, unittest.TestCase):
 #        res = self.templar.template({'some_static_var': '{{ some_var }}'},
 #                                   static_vars=['different_static_vars', 'some_other_static_var'])
 
-    #def test_lookup_jinja_dict_key_in_static_vars(self):
-    #    res = self.templar.template("{'some_static_var': '{{ some_var }}'}",
-    #                               static_vars=['some_static_var'])
-    #    #self.assertEquals(res['{{ a_keyword }}'], "blip")
-    #    print(res)
+    def test_lookup_jinja_dict_key_in_static_vars(self):
+        res = self.templar.template("{'some_static_var': '{{ some_var }}'}",
+                                   static_vars=['some_static_var'])
+        #self.assertEquals(res['{{ a_keyword }}'], "blip")
+        print(res)
+
     def test_templatable(self):
         res = self.templar.templatable('foo')
         self.assertTrue(res)
@@ -122,7 +114,8 @@ class TestTemplarTemplate(BaseTemplar, unittest.TestCase):
     def test_template_convert_bare_unsafe(self):
         res = self.templar.template('some_unsafe_var', convert_bare=True, bare_deprecated=False)
         self.assertEquals(res, 'unsafe_blip')
-        self.assertIsInstance(res, AnsibleUnsafe)
+        #self.assertIsInstance(res, AnsibleUnsafe)
+        self.assertTrue(self.is_unsafe(res), 'returned value from template.template (%s) is not marked unsafe' % res)
 
     def test_template_convert_bare_filter(self):
         res = self.templar.template('bam|capitalize', convert_bare=True, bare_deprecated=False)
@@ -131,7 +124,8 @@ class TestTemplarTemplate(BaseTemplar, unittest.TestCase):
     def test_template_convert_bare_filter_unsafe(self):
         res = self.templar.template('some_unsafe_var|capitalize', convert_bare=True, bare_deprecated=False)
         self.assertEquals(res, 'Unsafe_blip')
-        self.assertIsInstance(res, AnsibleUnsafe)
+        #self.assertIsInstance(res, AnsibleUnsafe)
+        self.assertTrue(self.is_unsafe(res), 'returned value from template.template (%s) is not marked unsafe' % res)
 
     @patch('ansible.template.Templar._clean_data', side_effect=AnsibleError)
     def test_template_unsafe_clean_data_exception(self, mock_clean_data):
@@ -180,20 +174,12 @@ class TestTemplarCleanData(BaseTemplar, unittest.TestCase):
         obj = {'foo': rval}
         res = self.templar._clean_data(obj)
         self.assertEquals(res, obj)
-        print(obj)
-        import pprint
-        pprint.pprint(obj['foo'])
-        pprint.pprint(dir(obj['foo']))
-        print('res is_unsafe(%s)=%s' % (res, is_unsafe(res)))
-        print('obj is_unsafe(%s)=%s' % (obj, is_unsafe(obj)))
-        print('res["foo"] is_unsafe(%s)=%s' % (res['foo'], is_unsafe(res['foo'])))
-        print('res["foo"][3] is_unsafe(%s)=%s' % (res['foo'][3], is_unsafe(res['foo'][3])))
-        self.assertTrue(hasattr(obj['foo'], '__UNSAFE__'))
-        self.assertTrue(hasattr(res['foo'], '__UNSAFE__'))
+        self.assertTrue(self.is_unsafe(res), 'returned value of _clean_data (%s) is not marked unsafe.' % res)
 
     def test_clean_data_bad_dict(self):
         res = self.templar._clean_data(u'{{bad_dict}}')
         self.assertEquals(res, u'{#bad_dict#}')
+
 
 class TestTemplarMisc(BaseTemplar, unittest.TestCase):
     def test_templar_simple(self):
@@ -275,7 +261,8 @@ class TestTemplarLookup(BaseTemplar, unittest.TestCase):
 
     def test_lookup_jinja_defined(self):
         res = self.templar._lookup('list', '{{ some_var }}')
-        self.assertIsInstance(res, AnsibleUnsafe)
+        self.assertTrue(self.is_unsafe(res))
+        #self.assertIsInstance(res, AnsibleUnsafe)
 
     def test_lookup_jinja_dict_string_passed(self):
         self.assertRaisesRegexp(AnsibleError,
@@ -293,7 +280,9 @@ class TestTemplarLookup(BaseTemplar, unittest.TestCase):
 
     def test_lookup_jinja_kwargs(self):
         res = self.templar._lookup('list', 'blip', random_keyword='12345')
-        self.assertIsInstance(res, AnsibleUnsafe)
+        print(dir(res))
+        self.assertTrue(self.is_unsafe(res))
+        #self.assertIsInstance(res, AnsibleUnsafe)
 
     def test_lookup_jinja_list_wantlist(self):
         res = self.templar._lookup('list', '{{ some_var }}', wantlist=True)
@@ -310,7 +299,8 @@ class TestTemplarLookup(BaseTemplar, unittest.TestCase):
     def test_lookup_jinja_list_wantlist_unsafe(self):
         res = self.templar._lookup('list', '{{ some_unsafe_var }}', wantlist=True)
         for lookup_result in res:
-            self.assertIsInstance(lookup_result, AnsibleUnsafe)
+            self.assertTrue(self.is_unsafe(lookup_result))
+            #self.assertIsInstance(lookup_result, AnsibleUnsafe)
 
         # Should this be an AnsibleUnsafe
         # self.assertIsInstance(res, AnsibleUnsafe)
@@ -324,13 +314,15 @@ class TestTemplarLookup(BaseTemplar, unittest.TestCase):
 
     def test_lookup_jinja_dict_unsafe(self):
         res = self.templar._lookup('list', {'{{ some_unsafe_key }}': '{{ some_unsafe_var }}'})
-        self.assertIsInstance(res['{{ some_unsafe_key }}'], AnsibleUnsafe)
+        self.assertTrue(self.is_unsafe(res['{{ some_unsafe_key }}']))
+        #self.assertIsInstance(res['{{ some_unsafe_key }}'], AnsibleUnsafe)
         # TODO: Should this be an AnsibleUnsafe
         #self.assertIsInstance(res, AnsibleUnsafe)
 
     def test_lookup_jinja_dict_unsafe_value(self):
         res = self.templar._lookup('list', {'{{ a_keyword }}': '{{ some_unsafe_var }}'})
-        self.assertIsInstance(res['{{ a_keyword }}'], AnsibleUnsafe)
+        self.assertTrue(self.is_unsafe(res['{{ a_keyword }}']))
+        #self.assertIsInstance(res['{{ a_keyword }}'], AnsibleUnsafe)
         # TODO: Should this be an AnsibleUnsafe
         #self.assertIsInstance(res, AnsibleUnsafe)
 
@@ -367,7 +359,7 @@ class TestTemplarLookupTemplate(BaseTemplar, unittest.TestCase):
         print(res)
 
 
-class TestAnsibleContext(unittest.TestCase):
+class TestAnsibleContext(BaseTemplar, unittest.TestCase):
     def _context(self, variables=None):
         variables = variables or {}
 
@@ -388,28 +380,32 @@ class TestAnsibleContext(unittest.TestCase):
     def test_resolve_unsafe(self):
         context = self._context(variables={'some_unsafe_key': wrap_var('some_unsafe_string')})
         res = context.resolve('some_unsafe_key')
-        self.assertIsInstance(res, AnsibleUnsafe)
+        #self.assertIsInstance(res, AnsibleUnsafe)
+        self.assertTrue(self.is_unsafe(res), 'return of AnsibleContext.resolve (%s) was expected to be marked unsafe but was not' % res)
 
     def test_resolve_unsafe_list(self):
         context = self._context(variables={'some_unsafe_key': [wrap_var('some unsafe string 1')]})
         res = context.resolve('some_unsafe_key')
-        self.assertIsInstance(res[0], AnsibleUnsafe)
+        #self.assertIsInstance(res[0], AnsibleUnsafe)
+        self.assertTrue(self.is_unsafe(res), 'return of AnsibleContext.resolve (%s) was expected to be marked unsafe but was not' % res)
 
     def test_resolve_unsafe_dict(self):
         context = self._context(variables={'some_unsafe_key':
                                            {'an_unsafe_dict': wrap_var('some unsafe string 1')}
                                            })
         res = context.resolve('some_unsafe_key')
-        self.assertIsInstance(res['an_unsafe_dict'], AnsibleUnsafe)
+        self.assertTrue(self.is_unsafe(res['an_unsafe_dict']), 'return of AnsibleContext.resolve (%s) was expected to be marked unsafe but was not' % res['an_unsafe_dict'])
 
     def test_resolve(self):
         context = self._context(variables={'some_key': 'some_string'})
         res = context.resolve('some_key')
         self.assertEquals(res, 'some_string')
-        self.assertNotIsInstance(res, AnsibleUnsafe)
+        #self.assertNotIsInstance(res, AnsibleUnsafe)
+        self.assertFalse(self.is_unsafe(res), 'return of AnsibleContext.resolve (%s) was not expected to be marked unsafe but was' % res)
 
     def test_resolve_none(self):
         context = self._context(variables={'some_key': None})
         res = context.resolve('some_key')
         self.assertEquals(res, None)
-        self.assertNotIsInstance(res, AnsibleUnsafe)
+        #self.assertNotIsInstance(res, AnsibleUnsafe)
+        self.assertFalse(self.is_unsafe(res), 'return of AnsibleContext.resolve (%s) was not expected to be marked unsafe but was' % res)

--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -66,6 +66,16 @@ class BaseTemplar(object):
         if isinstance(obj, AnsibleUnsafe):
             return True
 
+        if isinstance(obj, dict):
+            for key in obj.keys():
+                if self.is_unsafe(key) or self.is_unsafe(obj[key]):
+                    return True
+
+        if isinstance(obj, list):
+            for item in obj:
+                if self.is_unsafe(item):
+                    return True
+
         return False
 
 

--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -48,6 +48,7 @@ class TestTemplar(unittest.TestCase):
             var_list=[1],
             recursive="{{recursive}}",
             some_var="blip",
+            some_static_var="static_blip",
             some_keyword="{{ foo }}",
             some_unsafe_var=wrap_var("unsafe_blip"),
             some_unsafe_keyword=wrap_var("{{ foo }}"),
@@ -94,14 +95,10 @@ class TestTemplar(unittest.TestCase):
 
     def test_lookup_jinja_kwargs(self):
         res = self.templar._lookup('list', 'blip', random_keyword='12345')
-        print(res)
-        print(type(res))
         self.assertIsInstance(res, AnsibleUnsafe)
 
     def test_lookup_jinja_list_wantlist(self):
         res = self.templar._lookup('list', '{{ some_var }}', wantlist=True)
-        print(res)
-        print(type(res))
         self.assertEquals(res, ["blip"])
 
     def test_lookup_jinja_list_wantlist_undefined(self):
@@ -114,8 +111,6 @@ class TestTemplar(unittest.TestCase):
 
     def test_lookup_jinja_list_wantlist_unsafe(self):
         res = self.templar._lookup('list', '{{ some_unsafe_var }}', wantlist=True)
-        print(res)
-        print(type(res))
         for lookup_result in res:
             self.assertIsInstance(lookup_result, AnsibleUnsafe)
 
@@ -124,22 +119,20 @@ class TestTemplar(unittest.TestCase):
 
     def test_lookup_jinja_dict(self):
         res = self.templar._lookup('list', {'{{ a_keyword }}': '{{ some_var }}'})
-        print(res)
         self.assertEquals(res['{{ a_keyword }}'], "blip")
         # TODO: Should this be an AnsibleUnsafe
         #self.assertIsInstance(res['{{ a_keyword }}'], AnsibleUnsafe)
         #self.assertIsInstance(res, AnsibleUnsafe)
 
+
     def test_lookup_jinja_dict_unsafe(self):
         res = self.templar._lookup('list', {'{{ some_unsafe_key }}': '{{ some_unsafe_var }}'})
-        print(res)
         self.assertIsInstance(res['{{ some_unsafe_key }}'], AnsibleUnsafe)
         # TODO: Should this be an AnsibleUnsafe
         #self.assertIsInstance(res, AnsibleUnsafe)
 
     def test_lookup_jinja_dict_unsafe_value(self):
         res = self.templar._lookup('list', {'{{ a_keyword }}': '{{ some_unsafe_var }}'})
-        print(res)
         self.assertIsInstance(res['{{ a_keyword }}'], AnsibleUnsafe)
         # TODO: Should this be an AnsibleUnsafe
         #self.assertIsInstance(res, AnsibleUnsafe)
@@ -147,6 +140,32 @@ class TestTemplar(unittest.TestCase):
     def test_lookup_jinja_none(self):
         res = self.templar._lookup('list', None)
         self.assertIsNone(res)
+
+#    def test_templar_template_static_dict(self):
+#        res = self.templar.template("{{var_dict}}", static_vars=['blip'])
+#        print(res)
+        #self.assertEqual(templar.template("{{var_dict}}"), dict(a="b"))
+
+#    def test_lookup_jinja_dict_key_in_static_vars(self):
+#        res = self.templar.template({'some_static_var': '{{ some_var }}'},
+#                                   static_vars=['some_static_var'])
+#        res = self.templar.template({'some_other_static_var': '{{ some_var }}'},
+#                                   static_vars=['different_static_vars', 'some_other_static_var'])
+#        res = self.templar.template({'some_static_var': '{{ some_var }}'},
+#                                   static_vars=['different_static_vars', 'some_other_static_var'])
+
+    #def test_lookup_jinja_dict_key_in_static_vars(self):
+    #    res = self.templar.template("{'some_static_var': '{{ some_var }}'}",
+    #                               static_vars=['some_static_var'])
+    #    #self.assertEquals(res['{{ a_keyword }}'], "blip")
+    #    print(res)
+    def test_templatable(self):
+        res = self.templar.templatable('foo')
+        print(res)
+
+    def test_templatablei_none(self):
+        res = self.templar.templatable(None)
+        print(res)
 
     def test_templar_simple(self):
 

--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -23,6 +23,7 @@ from jinja2.runtime import Context
 
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch
+from ansible.compat.six import string_types
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleUndefinedVariable
@@ -75,6 +76,9 @@ class BaseTemplar(object):
             for item in obj:
                 if self.is_unsafe(item):
                     return True
+
+        if isinstance(obj, string_types) and hasattr(obj, '__UNSAFE__'):
+            return True
 
         return False
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request
 - Feature Pull Request
 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
test/units/

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (test_action_templar 07c77a3d62) last updated 2017/01/09 12:12:41 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
Unit tests for actions and template.Templar related to use of ansible unsafe vars.
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
