### PR TITLE
fixing mime types in s3_sync module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_sync.py
+++ b/lib/ansible/modules/cloud/amazon/s3_sync.py
@@ -428,12 +428,11 @@ def upload_files(s3, bucket, filelist, params):
     ret = []
     for entry in filelist:
         args = {
-          'ContentLength': entry['bytes'],
           'ContentType': entry['mime_type']
         }
         if params.get('permission'):
             args['ACL'] = params['permission']
-        s3.upload_file(entry['fullpath'], bucket, entry['s3_path'], ExtraArgs=None, Callback=None, Config=None)
+        s3.upload_file(entry['fullpath'], bucket, entry['s3_path'], ExtraArgs=args, Callback=None, Config=None)
         ret.append(entry)
     return ret
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
s3_sync

##### ANSIBLE VERSION
```
ansible 2.3.0 (s3_sync_mime_fix a498861b21) last updated 2017/01/09 19:15:34 (GMT +000)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
The s3_sync module does not appropriately set the mime type of the files that it syncs to S3. This change makes a minor update to ensure that the mime type is set.  Before this, a file like index.html would have a contentType of binary/octet-stream per s3api head-object. After it has a contentType of text/html.
