### PR TITLE
Fix 'No module named network' net_template error

### DIFF
--- a/lib/ansible/plugins/action/net_template.py
+++ b/lib/ansible/plugins/action/net_template.py
@@ -25,7 +25,7 @@ import glob
 import urlparse
 
 from ansible.module_utils._text import to_text
-from ansible.plugins.network import ActionModule as _ActionModule
+from ansible.plugins.action.network import ActionModule as _ActionModule
 
 
 class ActionModule(_ActionModule):


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request
 -

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/plugins/action/net_template.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (net_template_import 3931d6996c) last updated 2017/01/09 14:30:28 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
Fix an incorrect import in net_template.py