### PR TITLE
[WIP] Add config and inventory variables for remote admin user

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -208,6 +208,7 @@ DEFAULT_MODULE_COMPRESSION= get_config(p, DEFAULTS, 'module_compression', None, 
 DEFAULT_TIMEOUT           = get_config(p, DEFAULTS, 'timeout',          'ANSIBLE_TIMEOUT',          10, value_type='integer')
 DEFAULT_POLL_INTERVAL     = get_config(p, DEFAULTS, 'poll_interval',    'ANSIBLE_POLL_INTERVAL',    15, value_type='integer')
 DEFAULT_REMOTE_USER       = get_config(p, DEFAULTS, 'remote_user',      'ANSIBLE_REMOTE_USER',      None)
+DEFAULT_REMOTE_ADMIN_USERS= get_config(p, DEFAULTS, 'remote_admin_users', 'ANSIBLE_REMOTE_ADMIN_USERS', ['root', 'toor', 'admin'], value_type='list')
 DEFAULT_ASK_PASS          = get_config(p, DEFAULTS, 'ask_pass',  'ANSIBLE_ASK_PASS',    False, value_type='boolean')
 DEFAULT_PRIVATE_KEY_FILE  = get_config(p, DEFAULTS, 'private_key_file', 'ANSIBLE_PRIVATE_KEY_FILE', None, value_type='path')
 DEFAULT_REMOTE_PORT       = get_config(p, DEFAULTS, 'remote_port',      'ANSIBLE_REMOTE_PORT',      None, value_type='integer')

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -54,6 +54,7 @@ MAGIC_VARIABLE_MAPPING = dict(
    connection       = ('ansible_connection',),
    remote_addr      = ('ansible_ssh_host', 'ansible_host'),
    remote_user      = ('ansible_ssh_user', 'ansible_user'),
+   remote_admin_users=('ansible_remote_admin_users',),
    port             = ('ansible_ssh_port', 'ansible_port'),
    ssh_executable   = ('ansible_ssh_executable',),
    accelerate_port  = ('ansible_accelerate_port',),

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -491,6 +491,7 @@ class VariableManager:
                 ansible_host=delegated_host_name,
                 ansible_port=new_port,
                 ansible_user=C.DEFAULT_REMOTE_USER,
+                ansible_admin_users=tuple(C.DEFAULT_ADMIN_USERS),
                 ansible_connection=C.DEFAULT_TRANSPORT,
             )
 


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
various

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

##### SUMMARY
Add a config and inventory variable for remote admin users.  Use it for _fixup_perms() to be able to tell when it should attempt to chown.

Fixes #18391

This is currently a Work In Progress.  The configuration variable should work.  The inventory var doesn't yet.  Since the action plugin uses the inventory var, this doesn't yet work.