### PR TITLE
Fix group_by test to work with jinja2 >= 2.9.

### DIFF
--- a/test/integration/targets/group_by/test_group_by.yml
+++ b/test/integration/targets/group_by/test_group_by.yml
@@ -25,10 +25,10 @@
       group_by: key={{ genus }}
 
     - name: group by first three letters of genus with key in quotes
-      group_by: key="{{ genus | truncate(3, true, '') }}"
+      group_by: key="{{ genus[:3] }}"
 
     - name: group by first two letters of genus with key not in quotes
-      group_by: key={{ genus | truncate(2, true, '') }}
+      group_by: key={{ genus[:2] }}
 
     - name: group by genus in uppercase using complex args
       group_by: { key: "{{ genus | upper() }}" }

--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -1,3 +1,2 @@
 coverage >= 4.2
-jinja2 < 2.9 # 2.9 introduces changes which break tests
 pywinrm >= 0.2.1 # 0.1.1 required, but 0.2.1 provides better performance


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

group_by integration test

##### ANSIBLE VERSION

```
ansible 2.3.0 (group-by-test a8feb9aa1d) last updated 2017/01/09 14:55:12 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Fix group_by test to work with jinja2 >= 2.9.

Starting with jinja 2.9, the truncate filter has different behavior, and will no longer truncate strings when the truncated version is within 5 characters of the original.