### PR TITLE
fix indent

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -129,7 +129,7 @@ if __name__ == '__main__':
             log_only = False
         else:
             display.display("to see the full traceback, use -vvv")
-            log_only = True 
+            log_only = True
         display.display(u"the full traceback was:\n\n%s" % to_text(traceback.format_exc()), log_only=log_only)
         exit_code = 250
     finally:

--- a/contrib/inventory/docker.py
+++ b/contrib/inventory/docker.py
@@ -444,7 +444,7 @@ class AnsibleDockerClient(Client):
             tls_config = TLSConfig(**kwargs)
             return tls_config
         except TLSParameterError as exc:
-           self.fail("TLS config error: %s" % exc)
+            self.fail("TLS config error: %s" % exc)
 
     def _get_connect_params(self):
         auth = self.auth_params

--- a/examples/scripts/uptime.py
+++ b/examples/scripts/uptime.py
@@ -47,7 +47,7 @@ def main():
     variable_manager.set_inventory(inventory)
 
     # create play with tasks
-    play_source =  dict(
+    play_source = dict(
             name = "Ansible Play",
             hosts = host_list,
             gather_facts = 'no',

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -83,7 +83,7 @@ class Group:
             raise Exception("can't add group to itself")
 
         # don't add if it's already there
-        if not group in self.child_groups:
+        if group not in self.child_groups:
             self.child_groups.append(group)
 
             # update the depth of the child
@@ -94,7 +94,7 @@ class Group:
 
             # now add self to child's parent_groups list, but only if there
             # isn't already a group with the same name
-            if not self.name in [g.name for g in group.parent_groups]:
+            if self.name not in [g.name for g in group.parent_groups]:
                 group.parent_groups.append(self)
 
             self.clear_hosts_cache()


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

`contrib/inventory/docker.py`


##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

fix indent and fix one python codestyle E713 in  `lib/ansible/inventory/group.py`  86L and 97L。

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
--- a/contrib/inventory/docker.py
+++ b/contrib/inventory/docker.py
@@ -444,7 +444,7 @@ class AnsibleDockerClient(Client):
             tls_config = TLSConfig(**kwargs)
             return tls_config
         except TLSParameterError as exc:
-           self.fail("TLS config error: %s" % exc)
+            self.fail("TLS config error: %s" % exc)


--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -83,7 +83,7 @@ class Group:
             raise Exception("can't add group to itself")

         # don't add if it's already there
-        if not group in self.child_groups:
+        if group not in self.child_groups:
             self.child_groups.append(group)

             # update the depth of the child
@@ -94,7 +94,7 @@ class Group:

             # now add self to child's parent_groups list, but only if there
             # isn't already a group with the same name
-            if not self.name in [g.name for g in group.parent_groups]:
+            if self.name not in [g.name for g in group.parent_groups]:
                 group.parent_groups.append(self)


```
