### PR TITLE
lxc_inventory.py: don't artificially populate the "all" group

### DIFF
--- a/contrib/inventory/lxc_inventory.py
+++ b/contrib/inventory/lxc_inventory.py
@@ -40,16 +40,15 @@ def build_dict():
     containers, including the ones not in any group, are included in the
     "all" group."""
     # Enumerate all containers, and list the groups they are in. Also,
-    # implicitly add every container to the 'all' group.
+    # add a "None" group for those containers that aren't in any group.
     containers = dict([(c,
-                        ['all'] +
-                        (lxc.Container(c).get_config_item('lxc.group') or []))
+                        (lxc.Container(c).get_config_item('lxc.group') or [None]))
                        for c in lxc.list_containers()])
 
     # Extract the groups, flatten the list, and remove duplicates
     groups = set(sum([g for g in containers.values()], []))
 
-    # Create a dictionary for each group (including the 'all' group
+    # Create a dictionary for each group
     return dict([(g, {'hosts': [k for k, v in containers.items() if g in v],
                       'vars': {'ansible_connection':'lxc'}}) for g in groups])
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

(Actually, more of an enhancement in line with POLA)

##### COMPONENT NAME
`lxc_inventory` dynamic inventory

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

It doesn't make sense to create a group named `all` in a dynamic inventory script, and to artificially populate it with all LXC containers configured on a system, because that removes the ability to target hosts that are not part of any group.

So instead of tossing all hosts into the `all` group, and then in addition have groups that actually reflect the `lxc.group` configuration parameter, create a `None` (in JSON: `null`) group that has all hosts for which `lxc.group` is unset, and then have an inventory group each for all containers that do set it.

Ansible still does the right thing with respect to the `all` group, in that all containers, whether or not they have `lxc.group` set, implicitly become part of `all`.