### PR TITLE
Fixing nxos_evpn_vni behavior when route_target_both is used

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_evpn_vni.py
+++ b/lib/ansible/modules/network/nxos/nxos_evpn_vni.py
@@ -352,11 +352,25 @@ def apply_key_map(key_map, table):
     return new_dict
 
 
+def fix_proposed(proposed_commands):
+    new_proposed = {}
+    for key, value in proposed_commands.items():
+        if key == 'route-target both':
+            new_proposed['route-target export'] = value
+            new_proposed['route-target import'] = value
+        else:
+            new_proposed[key] = value
+    return new_proposed
+
+
 def state_present(module, existing, proposed):
     commands = list()
     parents = list()
     proposed_commands = apply_key_map(PARAM_TO_COMMAND_KEYMAP, proposed)
     existing_commands = apply_key_map(PARAM_TO_COMMAND_KEYMAP, existing)
+
+    if proposed_commands.get('route-target both'):
+        proposed_commands = fix_proposed(proposed_commands)
 
     for key, value in proposed_commands.items():
         if key.startswith('route-target'):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_evpn_vni

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Fixing nxos_evpn_vni behavior when route_target_both is used.

NOTE: This affects 2.2 as well!