### PR TITLE
fix include_role files path resolving

### DIFF
--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -19,7 +19,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from os.path import basename
+from os.path import normpath
 
 from ansible.errors import AnsibleParserError
 from ansible.playbook.attribute import FieldAttribute
@@ -108,9 +108,15 @@ class IncludeRole(TaskInclude):
 
         # build options for role includes
         for key in ['tasks', 'vars', 'defaults']:
+<<<<<<< HEAD
             from_key = '%s_from' % key
             if ir.args.get(from_key):
                 ir._from_files[key] = basename(ir.args.get(from_key))
+=======
+            from_key ='%s_from' % key
+            if  ir.args.get(from_key):
+                ir._from_files[key] = normpath(ir.args.get(from_key))
+>>>>>>> fix include_role files path resolving
 
         # FIXME: find a way to make this list come from object ( attributes does not work as per below)
         # manual list as otherwise the options would set other task parameters we don't want.

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -108,15 +108,9 @@ class IncludeRole(TaskInclude):
 
         # build options for role includes
         for key in ['tasks', 'vars', 'defaults']:
-<<<<<<< HEAD
             from_key = '%s_from' % key
             if ir.args.get(from_key):
-                ir._from_files[key] = basename(ir.args.get(from_key))
-=======
-            from_key ='%s_from' % key
-            if  ir.args.get(from_key):
                 ir._from_files[key] = normpath(ir.args.get(from_key))
->>>>>>> fix include_role files path resolving
 
         # FIXME: find a way to make this list come from object ( attributes does not work as per below)
         # manual list as otherwise the options would set other task parameters we don't want.


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
include_role

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
possible solution for #20077
