### PR TITLE
win_reboot: survive an already scheduled shutdown

### DIFF
--- a/lib/ansible/modules/windows/win_reboot.py
+++ b/lib/ansible/modules/windows/win_reboot.py
@@ -57,21 +57,23 @@ options:
     description:
     - Message to display to users
     default: Reboot initiated by Ansible
+notes:
+- If a shutdown was already scheduled on the system, C(win_reboot) will abort the scheduled shutdown and enforce its own shutdown.
 author:
     - Matt Davis (@nitzmahone)
 '''
 
 EXAMPLES='''
-# unconditionally reboot the machine with all defaults
+# Unconditionally reboot the machine with all defaults
 - win_reboot:
 
-# apply updates and reboot if necessary
+# Apply updates and reboot if necessary
 - win_updates:
   register: update_result
 - win_reboot:
   when: update_result.reboot_required
 
-# reboot a slow machine that might have lots of updates to apply
+# Reboot a slow machine that might have lots of updates to apply
 - win_reboot:
     shutdown_timeout_sec: 3600
     reboot_timeout_sec: 3600

--- a/lib/ansible/plugins/action/win_reboot.py
+++ b/lib/ansible/plugins/action/win_reboot.py
@@ -83,8 +83,20 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        # initiate reboot
+        # Initiate reboot
         (rc, stdout, stderr) = self._connection.exec_command('shutdown /r /t %d /c "%s"' % (pre_reboot_delay_sec, msg))
+
+        # Test for "A system shutdown has already been scheduled. (1190)" and handle it gracefully
+        if rc == 1190:
+            result['warnings'] = ( 'A scheduled reboot was pre-empted by Ansible.' )
+
+            # Try to abort (this may fail if it was already aborted)
+            (rc, stdout1, stderr1) = self._connection.exec_command('shutdown /a')
+
+            # Initiate reboot again
+            (rc, stdout2, stderr2) = self._connection.exec_command('shutdown /r /t %d' % pre_reboot_delay_sec)
+            stdout += stdout1 + stdout2
+            stderr += stderr1 + stderr2
 
         if rc != 0:
             result['failed'] = True


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_reboot

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
These changes ensure win_reboot can survive an already scheduled
shutdown by pre-empting it.

This fixes #19982