### PR TITLE
Update references to Passlib as homepage/docsite moved

### DIFF
--- a/docs/docsite/rst/faq.rst
+++ b/docs/docsite/rst/faq.rst
@@ -288,7 +288,7 @@ The mkpasswd utility that is available on most Linux systems is a great option:
     mkpasswd --method=sha-512
 
 If this utility is not installed on your system (e.g. you are using OS X) then you can still easily
-generate these passwords using Python. First, ensure that the `Passlib <https://code.google.com/p/passlib/>`_
+generate these passwords using Python. First, ensure that the `Passlib <https://bitbucket.org/ecollins/passlib/wiki/Home>`_
 password hashing library is installed:
 
 .. code-block:: shell-session

--- a/docs/docsite/rst/playbooks_prompts.rst
+++ b/docs/docsite/rst/playbooks_prompts.rst
@@ -50,7 +50,7 @@ some other options, but otherwise works equivalently::
        prompt: "Product release version"
        private: no
 
-If `Passlib <http://pythonhosted.org/passlib/>`_ is installed, vars_prompt can also crypt the
+If `Passlib <https://passlib.readthedocs.io/en/stable/>`_ is installed, vars_prompt can also crypt the
 entered value so you can use it, for instance, with the user module to define a password::
 
    vars_prompt:


### PR DESCRIPTION
##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

docsite

##### ANSIBLE VERSION

```
git HEAD
```

##### SUMMARY

The docsite has two references to Passlib, both of them are outdated. The linked docsite has "Warning The official Passlib documentation have moved to https://passlib.readthedocs.io. Documentation at this location is still being maintained, but will be updated much less frequently." and the new homepage is referenced from there.