### PR TITLE
Junos aws

### DIFF
--- a/test/integration/targets/junos_command/tests/netconf_text/contains.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_text/contains.yaml
@@ -8,7 +8,7 @@
       - show interfaces fxp0
     display: text
     wait_for:
-      - "result[0] contains vsrx01"
+      - "result[0] contains {{ inventory_hostname_short }}"
       - "result[1] contains fxp0"
     provider: "{{ netconf }}"
   register: result

--- a/test/integration/targets/junos_command/tests/netconf_xml/contains.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/contains.yaml
@@ -8,7 +8,7 @@
       - show interfaces fxp0
     format: xml
     wait_for:
-      - "result[0].software-information.host-name contains vsrx01"
+      - "result[0].software-information.host-name contains {{ inventory_hostname_short }}"
       - "result[1].interface-information.physical-interface.name contains fxp0"
     provider: "{{ netconf }}"
   register: result

--- a/test/integration/targets/junos_command/tests/netconf_xml/equal.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/equal.yaml
@@ -7,7 +7,7 @@
       - show version
       - show interfaces fxp0
     wait_for:
-      - "result[0].software-information.host-name == vsrx01"
+      - "result[0].software-information.host-name == {{ inventory_hostname_short }}"
       - "result[1].interface-information.physical-interface.name == fxp0"
     format: xml
     provider: "{{ netconf }}"
@@ -25,7 +25,7 @@
       - show version
       - show interfaces fxp0
     wait_for:
-      - "result[0].software-information.host-name eq vsrx01"
+      - "result[0].software-information.host-name eq {{ inventory_hostname_short }}"
       - "result[1].interface-information.physical-interface.name eq fxp0"
     format: xml
     provider: "{{ netconf }}"

--- a/test/integration/targets/net_command/aliases
+++ b/test/integration/targets/net_command/aliases
@@ -1,0 +1,1 @@
+network/basics

--- a/test/integration/targets/net_command/tasks/main.yml
+++ b/test/integration/targets/net_command/tasks/main.yml
@@ -33,5 +33,3 @@
     that:
       - result.changed == true
       - "'VyOS' in result.stdout"
-
-

--- a/test/integration/targets/net_command/tasks/main.yml
+++ b/test/integration/targets/net_command/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+# Test code for the net_command module.
+# (c) 2017, Red Hat
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+# This is a placeholder test, will be fleshed out by gundalow at a later point
+
+- name: Check we can communicate using net_command
+  net_command: show version
+  connection: network_cli
+  register: result
+
+- debug:
+    msg: "{{ result.stdout }}"
+
+- name: Ensure output is valid
+  assert:
+    that:
+      - result.changed == true
+      - "'VyOS' in result.stdout"
+
+


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
net_command

##### ANSIBLE VERSION

##### SUMMARY
Also fixes the last few hardcods hostnames  in junos tests
```

ANSIBLE_ROLES_PATH=targets  ansible-playbook -vvvv -i inventory.network net_command.yml -u vyos --private-key=~/.ssh/jobarker-aworks.pem


No config file found; using defaults
Loading callback plugin default of type stdout, v2.0 from /home/johnb/git/ansible-inc/ansible/lib/ansible/plugins/callback/__init__.pyc

PLAYBOOK: net_command.yml ************************************************************************************************************************************************************************************************************************
1 plays in net_command.yml

PLAY [vyos] **************************************************************************************************************************************************************************************************************************************

TASK [net_command : Check we can communicate using net_command] **********************************************************************************************************************************************************************************
task path: /home/johnb/git/ansible-inc/ansible/test/integration/targets/net_command/tasks/main.yml:23
<ec2-54-161-180-253.compute-1.amazonaws.com> ESTABLISH CONNECTION FOR USER: vyos on PORT 22 TO ec2-54-161-180-253.compute-1.amazonaws.com
<ec2-54-161-180-253.compute-1.amazonaws.com> closing connection
changed: [ec2-54-161-180-253.compute-1.amazonaws.com] => {
    "changed": true, 
    "delta": "0:00:04.137801", 
    "end": "2017-01-10 12:09:55.136896", 
    "invocation": {
        "module_args": {
            "_raw_params": "show version"
        }
    }, 
    "rc": 0, 
    "start": "2017-01-10 12:09:50.999095", 
    "stderr": "", 
    "stdout": "Version:      VyOS 1.1.0\nDescription:  VyOS 1.1.0 (helium)\nCopyright:    2014 VyOS maintainers and contributors\nBuilt by:     maintainers@vyos.net\nBuilt on:     Thu Oct  9 22:27:26 UTC 2014\nBuild ID:     1410092227-af6433f\nSystem type:  x86 64-bit\nBoot via:     image\nHypervisor:   Xen hvm\nHW model:     HVM domU\nHW S/N:       ec23c27e-67d9-ae07-455a-311d27b03a71\nHW UUID:      EC23C27E-67D9-AE07-455A-311D27B03A71\nUptime:       12:09:55 up 3 days, 18:26,  2 users,  load average: 0.00, 0.01, 0.05", 
    "stdout_lines": [
        "Version:      VyOS 1.1.0", 
        "Description:  VyOS 1.1.0 (helium)", 
        "Copyright:    2014 VyOS maintainers and contributors", 
        "Built by:     maintainers@vyos.net", 
        "Built on:     Thu Oct  9 22:27:26 UTC 2014", 
        "Build ID:     1410092227-af6433f", 
        "System type:  x86 64-bit", 
        "Boot via:     image", 
        "Hypervisor:   Xen hvm", 
        "HW model:     HVM domU", 
        "HW S/N:       ec23c27e-67d9-ae07-455a-311d27b03a71", 
        "HW UUID:      EC23C27E-67D9-AE07-455A-311D27B03A71", 
        "Uptime:       12:09:55 up 3 days, 18:26,  2 users,  load average: 0.00, 0.01, 0.05"
    ]
}

TASK [net_command : debug] ***********************************************************************************************************************************************************************************************************************
task path: /home/johnb/git/ansible-inc/ansible/test/integration/targets/net_command/tasks/main.yml:28
ok: [ec2-54-161-180-253.compute-1.amazonaws.com] => {
    "msg": "Version:      VyOS 1.1.0\nDescription:  VyOS 1.1.0 (helium)\nCopyright:    2014 VyOS maintainers and contributors\nBuilt by:     maintainers@vyos.net\nBuilt on:     Thu Oct  9 22:27:26 UTC 2014\nBuild ID:     1410092227-af6433f\nSystem type:  x86 64-bit\nBoot via:     image\nHypervisor:   Xen hvm\nHW model:     HVM domU\nHW S/N:       ec23c27e-67d9-ae07-455a-311d27b03a71\nHW UUID:      EC23C27E-67D9-AE07-455A-311D27B03A71\nUptime:       12:09:55 up 3 days, 18:26,  2 users,  load average: 0.00, 0.01, 0.05"
}

TASK [net_command : Ensure output is valid] ******************************************************************************************************************************************************************************************************
task path: /home/johnb/git/ansible-inc/ansible/test/integration/targets/net_command/tasks/main.yml:31
ok: [ec2-54-161-180-253.compute-1.amazonaws.com] => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "that": [
                "result.changed == true", 
                "'VyOS' in result.stdout"
            ]
        }, 
        "module_name": "assert"
    }, 
    "msg": "All assertions passed"
}

PLAY RECAP ***************************************************************************************************************************************************************************************************************************************
ec2-54-161-180-253.compute-1.amazonaws.com : ok=3    changed=1    unreachable=0    failed=0   


```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/20083)
<!-- Reviewable:end -->
