### PR TITLE
sns_topic: Do not attempt to unsubscribed deleted subscriptions

### DIFF
--- a/lib/ansible/modules/cloud/amazon/sns_topic.py
+++ b/lib/ansible/modules/cloud/amazon/sns_topic.py
@@ -276,7 +276,7 @@ class SnsTopicManager(object):
                 sub_key = (sub['Protocol'], sub['Endpoint'])
                 subscriptions_existing_list.append(sub_key)
                 if self.purge_subscriptions and sub_key not in desired_subscriptions and \
-                    sub['SubscriptionArn'] != 'PendingConfirmation':
+                    sub['SubscriptionArn'] not in ('PendingConfirmation', 'Deleted'):
                     self.changed = True
                     self.subscriptions_deleted.append(sub_key)
                     if not self.check_mode:
@@ -294,7 +294,7 @@ class SnsTopicManager(object):
         # NOTE: subscriptions in 'PendingConfirmation' timeout in 3 days
         #       https://forums.aws.amazon.com/thread.jspa?threadID=85993
         for sub in self.subscriptions_existing:
-            if sub['SubscriptionArn'] != 'PendingConfirmation':
+            if sub['SubscriptionArn'] not in ('PendingConfirmation', 'Deleted'):
                 self.subscriptions_deleted.append(sub['SubscriptionArn'])
                 self.changed = True
                 if not self.check_mode:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
`sns_topic`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
This is for `devel`, but I test it using:
```
ansible 2.0.2.0
  config file = /home/mmaslowski/ansible/ansible.cfg
  configured module search path = ./modules/
```
with uncommitted changes to perform the `import *` imports required in 2.0.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Unsubscribing from SNS topics (at least via the console for email subscriptions) results in the API returning `"SubscriptionArn": "Deleted"`. With the default `purge_subscriptions`, the `sns_topic` module attempts to unsubscribe these, failing, since these aren't valid ARNs.

This pull request changes it to ignore these, exactly as if they were `PendingConfirmation`.

I wasn't able to find any reference to the `Deleted` ARN in the AWS documentation.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
