### PR TITLE
Missing documentation about the include directive for requirements files

### DIFF
--- a/docs/docsite/rst/galaxy.rst
+++ b/docs/docsite/rst/galaxy.rst
@@ -134,6 +134,37 @@ Use the following example as a guide for specifying roles in *requirements.yml*:
       scm: git
       version: "0.1"  # quoted, so YAML doesn't parse this as a floating-point value
 
+Installing Multiple Roles From Multiple Files
+=============================================
+
+At a basic level, including requirements files allows you to break up bits of roles into smaller files. Role includes pull in roles from other files.
+
+Use the following command to install roles includes in *requirements.yml*  + *webserver,yml*
+
+::
+    ansible-galaxy install -r requirements.yml
+
+Content of the *requirements.yml* file:
+
+::
+
+    # from galaxy
+    - src: yatesr.timezone
+
+    - include: <path_to_requirements>/webserver.yml
+
+
+Content of the *webserver.yml* file:
+
+::
+
+    # from github
+    - src: https://github.com/bennojoy/nginx
+
+    # from Bitbucket
+    - src: git+http://bitbucket.org/willthames/git-ansible-galaxy
+      version: v1.4
+
 Dependencies
 ============
 

--- a/docs/docsite/rst/galaxy.rst
+++ b/docs/docsite/rst/galaxy.rst
@@ -142,6 +142,7 @@ At a basic level, including requirements files allows you to break up bits of ro
 Use the following command to install roles includes in *requirements.yml*  + *webserver,yml*
 
 ::
+
     ansible-galaxy install -r requirements.yml
 
 Content of the *requirements.yml* file:

--- a/docs/docsite/rst/galaxy.rst
+++ b/docs/docsite/rst/galaxy.rst
@@ -134,7 +134,7 @@ Use the following example as a guide for specifying roles in *requirements.yml*:
       scm: git
       version: "0.1"  # quoted, so YAML doesn't parse this as a floating-point value
 
-Installing Multiple Roles From Multiple Files
+Installing multiple roles from multiple files
 =============================================
 
 At a basic level, including requirements files allows you to break up bits of roles into smaller files. Role includes pull in roles from other files.


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ansible-galaxy

##### SUMMARY
https://github.com/Lujeni/ansible/blob/devel/lib/ansible/cli/galaxy.py#L339

The `include` directive is missing documentation.
