### PR TITLE
added ability to modify nova flavor metadata in os_nova_flavor module

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_nova_flavor.py
+++ b/lib/ansible/modules/cloud/openstack/os_nova_flavor.py
@@ -91,6 +91,7 @@ options:
         - Metadata dictionary
      required: false
      default: None
+     version_added: "2.3"
 requirements: ["shade"]
 '''
 
@@ -111,8 +112,8 @@ EXAMPLES = '''
     state: absent
     name: tiny
 
-# Create flavor with metadata
-- os_nova_flavor:
+- name: Create flavor with metadata
+  os_nova_flavor:
     cloud: mycloud
     state: present
     name: tiny

--- a/lib/ansible/modules/cloud/openstack/os_nova_flavor.py
+++ b/lib/ansible/modules/cloud/openstack/os_nova_flavor.py
@@ -86,6 +86,11 @@ options:
      description:
        - Ignored. Present for backwards compatability
      required: false
+   extra_specs:
+     description:
+        - Metadata dictionary
+     required: false
+     default: None
 requirements: ["shade"]
 '''
 
@@ -105,6 +110,18 @@ EXAMPLES = '''
     cloud: mycloud
     state: absent
     name: tiny
+
+# Create flavor with metadata
+- os_nova_flavor:
+    cloud: mycloud
+    state: present
+    name: tiny
+    ram: 1024
+    vcpus: 1
+    disk: 10
+    extra_specs:
+      "quota:disk_read_iops_sec": 5000
+      "aggregate_instance_extra_specs:pinned": false
 '''
 
 RETURN = '''
@@ -153,6 +170,13 @@ flavor:
             returned: success
             type: bool
             sample: true
+        extra_specs:
+            description: Flavor metadata
+            returned: success
+            type: dict
+            sample:
+                "quota:disk_read_iops_sec": 5000
+                "aggregate_instance_extra_specs:pinned": false
 '''
 
 try:
@@ -187,6 +211,7 @@ def main():
         rxtx_factor  = dict(required=False, default=1.0, type='float'),
         is_public    = dict(required=False, default=True, type='bool'),
         flavorid     = dict(required=False, default="auto"),
+        extra_specs  = dict(required=False, default=None, type='dict'),
     )
 
     module_kwargs = openstack_module_kwargs()
@@ -203,6 +228,7 @@ def main():
 
     state = module.params['state']
     name = module.params['name']
+    extra_specs = module.params['extra_specs'] or {}
 
     try:
         cloud = shade.operator_cloud(**module.params)
@@ -227,6 +253,18 @@ def main():
                 changed=True
             else:
                 changed=False
+
+            old_extra_specs = flavor['extra_specs']
+            new_extra_specs = dict([(k, str(v)) for k, v in extra_specs.items()])
+            unset_keys = set(flavor['extra_specs'].keys()) - set(extra_specs.keys())
+
+            if unset_keys:
+                cloud.unset_flavor_specs(flavor['id'], unset_keys)
+
+            if old_extra_specs != new_extra_specs:
+                cloud.set_flavor_specs(flavor['id'], extra_specs)
+
+            changed = (changed or old_extra_specs != new_extra_specs)
 
             module.exit_json(changed=changed,
                              flavor=flavor,


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
os_nova_flavor

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### SUMMARY
This PR adds ability to specify metadata (aka extra_specs) for nova flavors using shade API.
