### PR TITLE
vmware_guest: Fix customvalues when VM doesn't exists

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -757,7 +757,6 @@ class PyVmomiHelper(object):
         return result
 
     def gather_facts(self, vm):
-
         """ Gather facts from vim.VirtualMachine object. """
         facts = {
             'module_hw': True,
@@ -977,7 +976,7 @@ class PyVmomiHelper(object):
                 self.module.exit_json(msg="customvalues items required both 'key' and 'value fields.")
 
             # If kv is not kv fetched from facts, change it
-            if kv['key'] in facts['customvalues'] and facts['customvalues'][kv['key']] != kv['value']:
+            if kv['key'] not in facts['customvalues'] or facts['customvalues'][kv['key']] != kv['value']:
                 try:
                     vm_obj.setCustomValue(key=kv['key'], value=kv['value'])
                     self.change_detected = True
@@ -1339,7 +1338,6 @@ class PyVmomiHelper(object):
         self.configure_cpu_and_memory(vm_obj=vm_obj, vm_creation=True)
         self.configure_disks(vm_obj=vm_obj)
         self.configure_network(vm_obj=vm_obj)
-        self.customize_customvalues(vm_obj=vm_obj)
 
         if len(self.params['customization']) > 0:
             self.customize_vm(vm_obj=vm_obj)
@@ -1383,6 +1381,8 @@ class PyVmomiHelper(object):
                 annotation_spec.annotation = str(self.params['annotation'])
                 task = vm.ReconfigVM_Task(annotation_spec)
                 self.wait_for_task(task)
+
+            self.customize_customvalues(vm_obj=vm)
 
             if self.params['wait_for_ip_address'] or self.params['state'] in ['poweredon', 'restarted']:
                 self.set_powerstate(vm, 'poweredon', force=False)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ANSIBLE VERSION
```
2.2.0.0
```

##### SUMMARY
Fix a problem with vmware_guest when setting custom values and VM doesn't exists

Fixes

```
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_M0rhM9/ansible_module_vmware_guest.py", line 1869, in <module>
    main()
  File "/tmp/ansible_M0rhM9/ansible_module_vmware_guest.py", line 1856, in main
    result = pyv.deploy_vm()
  File "/tmp/ansible_M0rhM9/ansible_module_vmware_guest.py", line 1342, in deploy_vm
    self.customize_customvalues(vm_obj=vm_obj)
  File "/tmp/ansible_M0rhM9/ansible_module_vmware_guest.py", line 974, in customize_customvalues
    facts = self.gather_facts(vm_obj)
  File "/tmp/ansible_M0rhM9/ansible_module_vmware_guest.py", line 764, in gather_facts
    'hw_name': vm.config.name,
AttributeError: 'NoneType' object has no attribute 'config'

fatal: [127.0.0.1]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "invocation": {
        "module_name": "vmware_guest"
    }, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_M0rhM9/ansible_module_vmware_guest.py\", line 1869, in <module>\n    main()\n  File \"/tmp/ansible_M0rhM9/ansible_module_vmware_guest.py\", line 1856, in main\n    result = pyv.deploy_vm()\n  File \"/tmp/ansible_M0rhM9/ansible_module_vmware_guest.py\", line 1342, in deploy_vm\n    self.customize_customvalues(vm_obj=vm_obj)\n  File \"/tmp/ansible_M0rhM9/ansible_module_vmware_guest.py\", line 974, in customize_customvalues\n    facts = self.gather_facts(vm_obj)\n  File \"/tmp/ansible_M0rhM9/ansible_module_vmware_guest.py\", line 764, in gather_facts\n    'hw_name': vm.config.name,\nAttributeError: 'NoneType' object has no attribute 'config'\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE"
}
```