### PR TITLE
Duplicated line in the documentation of the apt_repository module

### DIFF
--- a/lib/ansible/modules/packaging/os/apt_repository.py
+++ b/lib/ansible/modules/packaging/os/apt_repository.py
@@ -117,7 +117,6 @@ EXAMPLES = '''
 - apt_repository:
     repo: 'ppa:nginx/stable'
     codename: 'trusty'
-    repo: 'ppa:nginx/stable'
 '''
 
 import glob


### PR DESCRIPTION
Removing that extra line.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
apt_repository

##### ANSIBLE VERSION
Not applicable

##### SUMMARY
In the last example of the module, the repo attribute is duplicated.
This PR removes it.