### PR TITLE
Add test support for python 3.6.

### DIFF
--- a/test/runner/injector/cover3.6
+++ b/test/runner/injector/cover3.6
@@ -1,0 +1,1 @@
+injector.py

--- a/test/runner/injector/runner3.6
+++ b/test/runner/injector/runner3.6
@@ -1,0 +1,1 @@
+injector.py

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -74,6 +74,7 @@ SUPPORTED_PYTHON_VERSIONS = (
     '2.6',
     '2.7',
     '3.5',
+    '3.6',
 )
 
 COMPILE_PYTHON_VERSIONS = tuple(sorted(SUPPORTED_PYTHON_VERSIONS + ('2.4',)))

--- a/test/utils/shippable/other.sh
+++ b/test/utils/shippable/other.sh
@@ -4,9 +4,13 @@ set -o pipefail
 
 add-apt-repository 'deb http://archive.ubuntu.com/ubuntu trusty-backports universe'
 add-apt-repository 'ppa:fkrull/deadsnakes'
+add-apt-repository 'ppa:jonathonf/python-3.6'
 
 apt-get update -qq
-apt-get install python2.4 shellcheck -qq
+apt-get install -qq \
+    shellcheck \
+    python2.4 \
+    python3.6 \
 
 pip install tox --disable-pip-version-check
 

--- a/test/utils/shippable/units.sh
+++ b/test/utils/shippable/units.sh
@@ -2,6 +2,16 @@
 
 set -o pipefail
 
+add-apt-repository 'ppa:ubuntu-toolchain-r/test'
+add-apt-repository 'ppa:jonathonf/python-3.6'
+
+apt-get update -qq
+apt-get install -qq \
+    g++-4.9 \
+    python3.6-dev \
+
+ln -sf x86_64-linux-gnu-gcc-4.9 /usr/bin/x86_64-linux-gnu-gcc
+
 pip install tox --disable-pip-version-check
 
 ansible-test units --color -v --tox --coverage


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

Tests

##### ANSIBLE VERSION

```
ansible 2.3.0 (test-python-3.6 991c256558) last updated 2017/01/10 10:30:47 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Add test support for python 3.6.