### PR TITLE
Add docker_exec module

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_exec.py
+++ b/lib/ansible/modules/cloud/docker/docker_exec.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python
+
+from ansible.module_utils.docker_common import AnsibleDockerClient
+
+def main():
+    argument_spec = dict(
+        command=dict(type='str'),
+        name=dict(type='str', required=True),
+    )
+
+    client = AnsibleDockerClient(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    container = client.get_container(client.module.params['name'])
+    create_result = client.exec_create(container, client.module.params['command'])
+    start_result = client.exec_start(create_result)
+
+    client.module.exit_json(changed=True, result=start_result)
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/docker/docker_exec.py
+++ b/lib/ansible/modules/cloud/docker/docker_exec.py
@@ -1,4 +1,68 @@
 #!/usr/bin/python
+#
+# Copyright 2016 Red Hat | Ansible
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'committer',
+                    'version': '1.0'}
+
+DOCUMENTATION = '''
+---
+module: docker_exec
+
+short_description: run command in a docker containers
+
+description:
+  - Run commands in docker containers.
+  - Does not supports check mode
+
+version_added: "2.3.0"
+
+options:
+  command:
+    description:
+      - Command to execute in the container.
+    default: null
+    required: true
+  name:
+    description:
+      - Name of the container to run the command in.
+      - The container name may be a name or a long or short container ID.
+    required: true
+extends_documentation_fragment:
+    - docker
+
+author:
+    - "Bernie Schelberg (@bschelberg)"
+
+requirements:
+    - "python >= 2.6"
+    - "docker-py >= 1.7.0"
+    - "Docker API >= 1.20"
+'''
+
+EXAMPLES = '''
+- name: Run command in Docker container
+  docker_exec:
+    docker_host: docker.local:2375
+    name: test-container
+    command: ls
+'''
 
 from ansible.module_utils.docker_common import AnsibleDockerClient
 

--- a/lib/ansible/modules/cloud/docker/docker_exec.py
+++ b/lib/ansible/modules/cloud/docker/docker_exec.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
 #
-# Copyright 2016 Red Hat | Ansible
-#
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify
@@ -29,9 +27,9 @@ short_description: run command in a docker containers
 
 description:
   - Run commands in docker containers.
-  - Does not supports check mode
+  - Does not support check mode
 
-version_added: "2.3.0"
+version_added: "2.3"
 
 options:
   command:


### PR DESCRIPTION
##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
docker_exec

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel f04aee9754) last updated 2017/01/11 13:53:28 (GMT +1100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Allows running "docker exec" on remote Docker hosts. The new Docker modules such as docker_container support management of remote Docker hosts, and being able to do an exec remotely is useful to me. It appears to be useful to others also, see the comment on the question here: http://stackoverflow.com/questions/32878795/run-command-inside-of-docker-container-using-ansible

The module can be used in a playbook like so:
```
  - name: Register gitlab runner
    docker_exec: 
      command: <some command>
      docker_host: <docker host>
      name: <container name>
    register: exec_output

  - name: Registration output
    debug: msg="{{ exec_output.result }}"
```

Using a register and debug was the best way that I could find to see the result of the exec. Also note that it's not possible AFAIK (at least using the docker.py library) to get the return status of the command. As far as I can see, it's thrown away in docker/api/exec_api.py when it calls _get_result_tty(). As a result, we can only assume that the result is "changed=True", and leave it up to the user to determine whether or not the exec worked. Parsing the result and determining success or failure will depend on what the command was, so can't be implemented in the module.

This is my first attempt at an Ansible module, and my first use of Python at all, so any suggestions for improvements are quite welcome.