### PR TITLE
ec2_vpc_peer should remove peering connections

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
@@ -13,6 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
 ANSIBLE_METADATA = {'status': ['stableinterface'],
                     'supported_by': 'committer',
                     'version': '1.0'}
@@ -192,13 +193,14 @@ task:
   type: dictionary
 '''
 
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import boto3_conn, ec2_argument_spec
+from ansible.module_utils.ec2 import get_aws_connection_info, HAS_BOTO3
+
 try:
-    import json
     import botocore
-    import boto3
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # caught by imported HAS_BOTO3
 
 
 def tags_changed(pcx_id, client, module):
@@ -224,15 +226,19 @@ def tags_changed(pcx_id, client, module):
 
 
 def describe_peering_connections(params, client):
-    result = client.describe_vpc_peering_connections(Filters=[
-        {'Name': 'requester-vpc-info.vpc-id', 'Values': [params['VpcId']]},
-        {'Name': 'accepter-vpc-info.vpc-id', 'Values': [params['PeerVpcId']]}
-        ])
+    result = client.describe_vpc_peering_connections(
+        Filters=[
+            {'Name': 'requester-vpc-info.vpc-id', 'Values': [params['VpcId']]},
+            {'Name': 'accepter-vpc-info.vpc-id', 'Values': [params['PeerVpcId']]}
+        ]
+    )
     if result['VpcPeeringConnections'] == []:
-        result = client.describe_vpc_peering_connections(Filters=[
-            {'Name': 'requester-vpc-info.vpc-id', 'Values': [params['PeerVpcId']]},
-            {'Name': 'accepter-vpc-info.vpc-id', 'Values': [params['VpcId']]}
-            ])
+        result = client.describe_vpc_peering_connections(
+            Filters=[
+                {'Name': 'requester-vpc-info.vpc-id', 'Values': [params['PeerVpcId']]},
+                {'Name': 'accepter-vpc-info.vpc-id', 'Values': [params['VpcId']]}
+            ]
+        )
     return result
 
 
@@ -354,24 +360,26 @@ def find_pcx_by_id(pcx_id, client, module):
 
 def main():
     argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
-        vpc_id=dict(),
-        peer_vpc_id=dict(),
-        peering_id=dict(),
-        peer_owner_id=dict(),
-        tags=dict(required=False, type='dict'),
-        profile=dict(),
-        state=dict(default='present', choices=['present', 'absent', 'accept', 'reject'])
+    argument_spec.update(
+        dict(
+            vpc_id=dict(),
+            peer_vpc_id=dict(),
+            peering_id=dict(),
+            peer_owner_id=dict(),
+            tags=dict(required=False, type='dict'),
+            profile=dict(),
+            state=dict(default='present', choices=['present', 'absent', 'accept', 'reject'])
         )
     )
     module = AnsibleModule(argument_spec=argument_spec)
 
     if not HAS_BOTO3:
         module.fail_json(msg='json, botocore and boto3 are required.')
-    state = module.params.get('state').lower()
+    state = module.params.get('state')
     try:
         region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-        client = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+        client = boto3_conn(module, conn_type='client', resource='ec2',
+                            region=region, endpoint=ec2_url, **aws_connect_kwargs)
     except botocore.exceptions.NoCredentialsError as e:
         module.fail_json(msg="Can't authorize connection - "+str(e))
 
@@ -384,10 +392,6 @@ def main():
         (changed, results) = accept_reject(state, client, module)
         module.exit_json(changed=changed, peering_id=results)
 
-
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc_peer

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 6ec0369c26) last updated 2017/01/11 13:34:13 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Don't try to create tags on a vpc that you've just removed.

Avoids:

```
"msg": "An error occurred (InvalidParameterValue) when calling the CreateTags operation: You must specify one or more tags to create"
```

Although not quite sure why the `create_tags` was being called as `module.params.get('tags')` *should* have returned `None`.

I've also done some flake8 tidying, but split the commits into the functional change and the tidy change.