### PR TITLE
Send current winrm config to ansible-core-ci.

### DIFF
--- a/test/runner/lib/core_ci.py
+++ b/test/runner/lib/core_ci.py
@@ -213,12 +213,16 @@ class AnsibleCoreCI(object):
                          verbosity=1)
             return
 
+        with open('examples/scripts/ConfigureRemotingForAnsible.ps1', 'r') as winrm_config_fd:
+            winrm_config = winrm_config_fd.read()
+
         data = dict(
             config=dict(
                 platform=self.platform,
                 version=self.version,
                 public_key=self.ssh_key.pub_contents if self.ssh_key else None,
                 query=False,
+                winrm_config=winrm_config,
             )
         )
 


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (aci-winrm 8ebe676623) last updated 2017/01/10 19:44:44 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Send current winrm config to ansible-core-ci.

This causes the remote instance to use the merged copy of the script from Shippable, instead of the version from the PR, which may be lacking upstream changes.