### PR TITLE
win_service: support for Automatic (Delayed Start)

### DIFF
--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -59,6 +59,15 @@ options:
       - restarted
     default: null
     aliases: []
+  delayed:
+    description:
+      - If True, when start_mode is C(auto) the service is flagged for a delayed start.
+    default: false
+    choices:
+      - True
+      - False
+    version_added: '2.3'
+
 author: "Chris Hoffman (@chrishoffman)"
 '''
 


### PR DESCRIPTION
Add a new delayed parameter which is needed to mark the service with
Delayed Start.

Also requested by #16759.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
win_service

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Support for Automatic (Delayed Start) services on Windows.
