### PR TITLE
vmware_inventory: permit to group by custom field & customize skip_keys

### DIFF
--- a/contrib/inventory/vmware_inventory.ini
+++ b/contrib/inventory/vmware_inventory.ini
@@ -72,6 +72,16 @@ password=vmware
 # comma delimited to create as many groups as necessary
 #groupby_patterns={{ guest.guestid }},{{ 'templates' if config.template else 'guests'}}
 
+# Group by custom fields will use VMware custom fields to generate hostgroups
+# based on {{ custom_field_group_prefix }} + field_name + _ + field_value
+# Set groupby_custom_field to True will enable this feature
+# If custom field value is comma separated, multiple groups are created.
+#groupby_custom_field = False
+
+# You can customize prefix used by custom field hostgroups generation here.
+# vmware_tag_ prefix is the default and consistent with ec2_tag_
+#custom_field_group_prefix = 'vmware_tag_'
+
 # The script attempts to recurse into virtualmachine objects and serialize
 # all available data. The serialization is comprehensive but slow. If the
 # vcenter environment is large and the desired properties are known, create

--- a/contrib/inventory/vmware_inventory.ini
+++ b/contrib/inventory/vmware_inventory.ini
@@ -42,6 +42,12 @@ password=vmware
 #lower_var_keys=True
 
 
+# Don't retrieve and process some VMware attribute keys
+# Default values permit to sanitize inventory meta and to improve a little bit
+# performance by removing non-common group attributes.
+#skip_keys = declaredalarmstate,disabledmethod,dynamicproperty,dynamictype,environmentbrowser,managedby,parent,childtype,resourceconfig
+
+
 # Host alias for objects in the inventory. VMWare allows duplicate VM names
 # so they can not be considered unique. Use this setting to alter the alias
 # returned for the hosts. Any atributes for the guest can be used to build
@@ -76,6 +82,7 @@ password=vmware
 # based on {{ custom_field_group_prefix }} + field_name + _ + field_value
 # Set groupby_custom_field to True will enable this feature
 # If custom field value is comma separated, multiple groups are created.
+# Warning: This required max_object_level to be set to 2 or greater.
 #groupby_custom_field = False
 
 # You can customize prefix used by custom field hostgroups generation here.


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
contrib/vmware_inventory.py

##### ANSIBLE VERSION
```
2.2.0.0
```

##### SUMMARY
This permits to create instances, affect some custom fields like EC2 tags and then retrieve groups from custom fields like EC2 inventory

Example: i have custom field __components__ set to _icinga2,grafana_ on host _vmwaretest01_ and _vmwaretest02_
inventory output is:

```
"vmware_tag_components_icinga2": {
    "hosts": [
      "vmwaretest01",
      "vmwaretest02"
    ]
},
"vmware_tag_components_icinga2": {
    "hosts": [
      "vmwaretest01",
      "vmwaretest02"
    ]
},
```

Also permit to customize skip_keys value to enhance ourselves the inventory performance. Add resourceconfig to default skip_keys as it doesn't have interesting values for grouping in most cases