### PR TITLE
zypper: Add environment example

### DIFF
--- a/lib/ansible/modules/packaging/os/zypper.py
+++ b/lib/ansible/modules/packaging/os/zypper.py
@@ -168,7 +168,14 @@ EXAMPLES = '''
 # Install specific version (possible comparisons: <, >, <=, >=, =)
 - zypper:
     name: 'docker>=1.10'
-    state: installed
+    state: present
+
+# Wait 20 seconds to acquire the lock before failing
+- zypper:
+    name: mosh
+    state: present
+  environment:
+    ZYPP_LOCK_TIMEOUT: 20
 '''
 
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
zypper.py

##### ANSIBLE VERSION
devel

##### SUMMARY
Add example for usage of ZYPP_LOCK_TIMEOUT

Retries to require lock for zypper operation.