### PR TITLE
timezone: Tidy up docs and arg parsing

### DIFF
--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -46,7 +46,8 @@ options:
   name:
     description:
       - Name of the timezone for the system clock.
-        Default is to keep current setting.
+        Default is to keep current setting. B(At least one of name and
+        hwclock are required.)
     required: false
   hwclock:
     description:
@@ -54,6 +55,7 @@ options:
         Default is to keep current setting.
         Note that this option is recommended not to change and may fail
         to configure, especially on virtual environments such as AWS.
+        B(At least one of name and hwclock are required.)
     required: false
     aliases: ['rtc']
 author: "Shinichi TAMURA (@tmshn)"

--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -34,14 +34,14 @@ module: timezone
 short_description: Configure timezone setting
 description:
   - This module configures the timezone setting, both of the system clock
-    and of the hardware clock. I(Currently only Linux platform is supported.)
+    and of the hardware clock. I(Currently only the Linux platform is supported).
     It is recommended to restart C(crond) after changing the timezone,
     otherwise the jobs may run at the wrong time.
     It uses the C(timedatectl) command if available. Otherwise, it edits
     C(/etc/sysconfig/clock) or C(/etc/timezone) for the system clock,
     and uses the C(hwclock) command for the hardware clock.
     If you want to set up the NTP, use M(service) module.
-version_added: "2.2.0"
+version_added: "2.2"
 options:
   name:
     description:
@@ -233,7 +233,7 @@ class Timezone(object):
 
 
 class SystemdTimezone(Timezone):
-    """This is a Timezone manipulation class systemd-powered Linux.
+    """This is a Timezone manipulation class for systemd-powered Linux.
 
     It uses the `timedatectl` command to check/set all arguments.
     """
@@ -430,13 +430,12 @@ class NosystemdTimezone(Timezone):
 
 def main():
     # Construct 'module' and 'tz'
-    arg_spec = dict(
-        hwclock=dict(choices=['UTC', 'local'], aliases=['rtc']),
-        name   =dict(),
-    )
     module = AnsibleModule(
-        argument_spec=arg_spec,
-        required_one_of=[arg_spec.keys()],
+        argument_spec=dict(
+            hwclock=dict(default=None, choices=['UTC', 'local'], aliases=['rtc']),
+            name=dict(default=None),
+        ),
+        required_one_of=['hwclock', 'name'],
         supports_check_mode=True
     )
     tz = Timezone(module)


### PR DESCRIPTION
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

`timezone` module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (timezone 2177618e60) last updated 2017/01/11 15:07:10 (GMT +200)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

- small textual fixes
- ensure the [generated docs](http://docs.ansible.com/ansible/timezone_module.html) list either `hwclock` or `name` as required by using a non-generated value for `required_one_of`
