### PR TITLE
Add user_data_path parameter to ec2_lc module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_lc.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_lc.py
@@ -65,12 +65,13 @@ options:
     required: false
   user_data:
     description:
-      - opaque blob of data which is made available to the ec2 instance
+      - opaque blob of data which is made available to the ec2 instance. Mutually exclusive with I(user_data_path).
     required: false
   user_data_path:
     description:
-      - Path to the file that contains userdata for the ec2 instances
+      - Path to the file that contains userdata for the ec2 instances. Mutually exclusive with I(user_data).
     required: false
+    version_added: "2.3"
   kernel_id:
     description:
       - Kernel id for the EC2 instance
@@ -291,7 +292,7 @@ def main():
             key_name=dict(type='str'),
             security_groups=dict(type='list'),
             user_data=dict(type='str'),
-            user_data_path=dict(type='str'),
+            user_data_path=dict(type='path'),
             kernel_id=dict(type='str'),
             volumes=dict(type='list'),
             instance_type=dict(type='str'),

--- a/lib/ansible/modules/cloud/amazon/ec2_lc.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_lc.py
@@ -263,7 +263,7 @@ def create_launch_config(connection, module):
             if bdm.ebs is not None:
                 result['block_device_mappings'][-1]['ebs'] = dict(snapshot_id=bdm.ebs.snapshot_id, volume_size=bdm.ebs.volume_size)
 
-    if launch_configs[0].user_data is not None:
+    if launch_configs[0].user_data != "":
         result['user_data'] = "hidden" # Otherwise, we dump binary to the user's terminal
 
     module.exit_json(changed=changed, name=result['name'], created_time=result['created_time'],

--- a/lib/ansible/modules/cloud/amazon/ec2_lc.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_lc.py
@@ -264,7 +264,7 @@ def create_launch_config(connection, module):
             if bdm.ebs is not None:
                 result['block_device_mappings'][-1]['ebs'] = dict(snapshot_id=bdm.ebs.snapshot_id, volume_size=bdm.ebs.volume_size)
 
-    if launch_configs[0].user_data != "":
+    if user_data_path:
         result['user_data'] = "hidden" # Otherwise, we dump binary to the user's terminal
 
     module.exit_json(changed=changed, name=result['name'], created_time=result['created_time'],

--- a/lib/ansible/modules/cloud/amazon/ec2_lc.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_lc.py
@@ -139,6 +139,7 @@ EXAMPLES = '''
       ephemeral: ephemeral0
 
 '''
+import traceback
 
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *
@@ -196,10 +197,10 @@ def create_launch_config(connection, module):
 
     if user_data_path:
         try:
-            user_data_file = open(user_data_path, 'r')
-            user_data = user_data_file.read()
+            with open(user_data_path, 'r') as user_data_file:
+                user_data = user_data_file.read()
         except IOError as e:
-            module.fail_json(msg=str(e))
+            module.fail_json(msg=str(e), exception=traceback.format_exc())
 
     if volumes:
         for volume in volumes:


### PR DESCRIPTION
The existing `user_data` parameter is limited by AWS to 16KB. Much larger userdata can be submitted if gzipped, but it is not possible to use lookup plugins to read binary data.

This PR adds a `user_data_path` parameter to the `ec2_lc` module, so that binary data can be read directly by the module.