### PR TITLE
win_psexec: execute cmds on remote systems as any user

### DIFF
--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -157,10 +157,11 @@ Function Get-AnsibleParam($obj, $name, $default = $null, $resultobj, $failifempt
         }
     }
 
-    # Expand environment variables on path-type (Beware: turns $null into "")
     If ($value -ne $null -and $type -eq "path") {
+        # Expand environment variables on path-type (Beware: turns $null into "")
         $value = Expand-Environment($value)
     } ElseIf ($type -eq "bool") {
+        # Convert boolean types to real Powershell booleans
         $value = $value | ConvertTo-Bool
     }
 

--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -160,6 +160,8 @@ Function Get-AnsibleParam($obj, $name, $default = $null, $resultobj, $failifempt
     # Expand environment variables on path-type (Beware: turns $null into "")
     If ($value -ne $null -and $type -eq "path") {
         $value = Expand-Environment($value)
+    } ElseIf ($type -eq "bool") {
+        $value = $value | ConvertTo-Bool
     }
 
     $value

--- a/lib/ansible/modules/windows/win_psexec.ps1
+++ b/lib/ansible/modules/windows/win_psexec.ps1
@@ -1,0 +1,107 @@
+#!powershell
+# This file is part of Ansible
+#
+# Copyright 2017, Dag Wieers (@dagwieers) <dag@wieers.com>
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# WANT_JSON
+# POWERSHELL_COMMON
+
+# See also: https://technet.microsoft.com/en-us/sysinternals/pxexec.aspx
+
+$params = Parse-Args $args;
+
+$result = New-Object PSObject @{
+    changed = $true
+}
+
+$commandline = Get-AnsibleParam -obj $params -name "commandline" -default "whoami.exe"
+$executable = Get-AnsibleParam -obj $params -name "executable" -default "psexec.exe"
+$hostname = Get-AnsibleParam -obj $params -name "hostname"
+$username = Get-AnsibleParam -obj $params -name "username"
+$password = Get-AnsibleParam -obj $params -name "password" -failifempty $true
+$chdir = Get-AnsibleParam -obj $params -name "chdir"
+$timeout = Get-AnsibleParam -obj $params -name "timeout"
+# TODO: Implement priority options
+#$priority = Get-AnsibleParam -obj $params -name "priority"
+$extra_opts = Get-AnsibleParam -obj $params -name "extra_opts" -default @()
+
+$args = ""
+
+# Supports running on local system if not hostname is specified
+If ($hostname -Ne $Null) {
+  $args = "\\" + $hostname
+}
+
+$pinfo = New-Object System.Diagnostics.ProcessStartInfo
+
+$pinfo.FileName = $executable
+$pinfo.RedirectStandardError = $true
+$pinfo.RedirectStandardOutput = $true
+$pinfo.UseShellExecute = $false
+
+# Username is optional
+If ($username -Ne $null) {
+    $args += " -u " + $username
+}
+
+# Password is required
+If ($password -Eq $null) {
+    Fail-Json @{msg="The 'password' parameter is a required parameter."}
+} Else {
+    $args += " -p " + $password
+}
+
+If ($chdir -ne $null) {
+    $args += " -w " + $chdir
+}
+
+If ($timeout -ne $null) {
+    $args += " -n " + $timeout
+}
+
+$args += " -accepteula"
+
+# Add additional advanced options
+ForEach ($opt in $extra_opts){
+    $args += " " + $opt
+}
+
+# Defaults to whoami.exe, but also accepts a script instead of commandline
+$args += " " + $commandline
+
+# TODO: psexec has a limit to the argument length of 260 (?)
+$pinfo.Arguments = $args
+
+$p = New-Object System.Diagnostics.Process
+$p.StartInfo = $pinfo
+$p.Start() | Out-Null
+$stdout = $p.StandardOutput.ReadToEnd()
+$stderr = $p.StandardError.ReadToEnd()
+$p.WaitForExit()
+$rc = $p.ExitCode
+
+If ($rc -Eq 0) {
+    Set-Attr $result "failed" $False
+} Else {
+    Set-Attr $result "failed" $True
+}
+
+Set-Attr $result "cmd" ( $executable + " " + $args )
+Set-Attr $result "rc" $rc
+Set-Attr $result "stdout" $stdout
+Set-Attr $result "stderr" $stderr
+
+Exit-Json $result

--- a/lib/ansible/modules/windows/win_psexec.ps1
+++ b/lib/ansible/modules/windows/win_psexec.ps1
@@ -177,7 +177,12 @@ $result.stderr = $stderr
 
 $proc.WaitForExit() | Out-Null
 
-$result.rc = $proc.ExitCode
+If ($wait -eq $true) {
+    $result.rc = $proc.ExitCode
+} else {
+    $result.rc = 0
+    $result.pid = $proc.ExitCode
+}
 
 $end_datetime = [DateTime]::UtcNow
 

--- a/lib/ansible/modules/windows/win_psexec.ps1
+++ b/lib/ansible/modules/windows/win_psexec.ps1
@@ -29,20 +29,23 @@ $result = New-Object PSObject @{
 
 $command = Get-AnsibleParam -obj $params -name "command" -default "whoami.exe"
 $executable = Get-AnsibleParam -obj $params -name "executable" -default "psexec.exe"
-$hostname = Get-AnsibleParam -obj $params -name "hostname"
+$hostnames = Get-AnsibleParam -obj $params -name "hostnames"
 $username = Get-AnsibleParam -obj $params -name "username"
 $password = Get-AnsibleParam -obj $params -name "password" -failifempty $true
 $chdir = Get-AnsibleParam -obj $params -name "chdir"
+$noprofile = Get-AnsibleParam -obj $params -name "noprofile"
+$elevated = Get-AnsibleParam -obj $params -name "elevated"
+$limted = Get-AnsibleParam -obj $params -name "limited"
+$system = Get-AnsibleParam -obj $params -name "system"
+$priority = Get-AnsibleParam -obj $params -name "priority" -validateset "background","low","belownormal","abovenormal","high","realtime"
 $timeout = Get-AnsibleParam -obj $params -name "timeout"
-# TODO: Implement priority options
-#$priority = Get-AnsibleParam -obj $params -name "priority"
 $extra_opts = Get-AnsibleParam -obj $params -name "extra_opts" -default @()
 
 $args = ""
 
 # Supports running on local system if not hostname is specified
-If ($hostname -ne $null) {
-  $args = " \\$hostname"
+If ($hostnames -ne $null) {
+  $args = " \\" + $($hostnames | sort -Unique) -join ','
 }
 
 $pinfo = New-Object System.Diagnostics.ProcessStartInfo
@@ -68,8 +71,28 @@ If ($chdir -ne $null) {
     $args += ' -w "$chdir"'
 }
 
+If ($noprofile -ne $null) {
+    $args += ' -e'
+}
+
+If ($elevated -ne $null) {
+    $args += ' -h'
+}
+
+If ($system -ne $null) {
+    $args += ' -s'
+}
+
+If ($limited -ne $null) {
+    $args += ' -l'
+}
+
+If ($priority -ne $null) {
+    $args += ' -$priority'
+}
+
 If ($timeout -ne $null) {
-    $args += ' -n "$timeout"'
+    $args += ' -n $timeout'
 }
 
 $args += " -accepteula"

--- a/lib/ansible/modules/windows/win_psexec.ps1
+++ b/lib/ansible/modules/windows/win_psexec.ps1
@@ -35,7 +35,7 @@ $password = Get-AnsibleParam -obj $params -name "password" -failifempty $true
 $chdir = Get-AnsibleParam -obj $params -name "chdir"
 $noprofile = Get-AnsibleParam -obj $params -name "noprofile"
 $elevated = Get-AnsibleParam -obj $params -name "elevated"
-$limted = Get-AnsibleParam -obj $params -name "limited"
+$limited = Get-AnsibleParam -obj $params -name "limited"
 $system = Get-AnsibleParam -obj $params -name "system"
 $priority = Get-AnsibleParam -obj $params -name "priority" -validateset "background","low","belownormal","abovenormal","high","realtime"
 $timeout = Get-AnsibleParam -obj $params -name "timeout"
@@ -57,53 +57,53 @@ $pinfo.UseShellExecute = $false
 
 # Username is optional
 If ($username -ne $null) {
-    $args += ' -u "$username"'
+    $args += " -u " + $username
 }
 
 # Password is required
 If ($password -eq $null) {
     Fail-Json $result "The 'password' parameter is a required parameter."
 } Else {
-    $args += ' -p "$password"'
+    $args += " -p " + $password
 }
 
 If ($chdir -ne $null) {
-    $args += ' -w "$chdir"'
+    $args += " -w " + $chdir
 }
 
 If ($noprofile -ne $null) {
-    $args += ' -e'
+    $args += " -e"
 }
 
 If ($elevated -ne $null) {
-    $args += ' -h'
+    $args += " -h"
 }
 
 If ($system -ne $null) {
-    $args += ' -s'
+    $args += " -s"
 }
 
 If ($limited -ne $null) {
-    $args += ' -l'
+    $args += " -l"
 }
 
 If ($priority -ne $null) {
-    $args += ' -$priority'
+    $args += " -" + $priority
 }
 
 If ($timeout -ne $null) {
-    $args += ' -n $timeout'
+    $args += " -n " + $timeout
 }
 
 $args += " -accepteula"
 
 # Add additional advanced options
-ForEach ($opt in $extra_opts){
-    $args += " $opt"
+ForEach ($opt in $extra_opts) {
+    $args += " " + $opt
 }
 
 # Defaults to whoami.exe, but also accepts a script instead of command
-$args += " $command"
+$args += " " + $command
 
 # TODO: psexec has a limit to the argument length of 260 (?)
 $pinfo.Arguments = $args
@@ -122,7 +122,7 @@ If ($rc -eq 0) {
     Set-Attr $result "failed" $true
 }
 
-Set-Attr $result "cmd" "$executable$args"
+Set-Attr $result "cmd" ($executable + $args)
 Set-Attr $result "rc" $rc
 Set-Attr $result "stdout" $stdout
 Set-Attr $result "stderr" $stderr

--- a/lib/ansible/modules/windows/win_psexec.py
+++ b/lib/ansible/modules/windows/win_psexec.py
@@ -22,7 +22,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-DOCUMENTATION = """
+DOCUMENTATION = r'''
 ---
 module: win_psexec
 version_added: '2.3'
@@ -35,7 +35,6 @@ options:
     description:
     - The command line to run through PsExec (limited to 260 characters).
     required: true
-    default: whoami.exe
   executable:
     description:
     - The location of the PsExec utility (in case it is not located in your PATH).
@@ -52,22 +51,29 @@ options:
     description:
     - The password for the (remote) user to run the command as.
     - This is mandatory in order authenticate yourself.
-    required: true
   chdir:
     description:
     - Run the command from this (remote) directory.
   noprofile:
     description:
     - Run the command without loading the account's profile.
+    default: False
   elevated:
     description:
     - Run the command with elevated privileges.
+    default: False
+  interactive:
+    description:
+    - Run the program so that it interacts with the desktop on the remote system.
+    default: False
   limited:
     description:
     - Run the command as limited user (strips the Administrators group and allows only privileges assigned to the Users group).
+    default: False
   system:
     description:
     - Run the remote command in the System account.
+    default: False
   priority:
     description:
     - Used to run the command at a different priority.
@@ -81,13 +87,24 @@ options:
   timeout:
     description:
     - The connection timeout in seconds
+  wait:
+    description:
+    - Wait for the application to terminate.
+    - Only use for non-interactive applications.
+    default: True
 author: Dag Wieers (@dagwieers)
-"""
+'''
 
 EXAMPLES = r'''
-# Test the PsExec connection to the local system with your user (runs whoami)
+# Test the PsExec connection to the local system (target node) with your user
 - win_psexec:
-    password: some_password
+    command: whoami.exe
+
+# Run regedit.exe locally (on target node) as SYSTEM and interactively
+- win_psexec:
+    command: regedit.exe
+    interactive: yes
+    system: yes
 
 # Run the setup.exe installer on multiple servers using the Domain Administrator
 - win_psexec:
@@ -108,12 +125,12 @@ EXAMPLES = r'''
     priority: low
 '''
 
-RETURN = '''
+RETURN = r'''
 cmd:
     description: The complete command line used by the module, including PsExec call and additional options.
     returned: always
     type: string
-    sample: 'psexec.exe \\remote_server -u DOMAIN\Administrator -p some_password E:\setup.exe'
+    sample: psexec.exe \\remote_server -u DOMAIN\Administrator -p some_password E:\setup.exe
 rc:
     description: The return code for the command
     returned: always
@@ -123,17 +140,17 @@ stdout:
     description: The standard output from the command
     returned: always
     type: string
-    sample: 'Success.'
+    sample: Success.
 stderr:
     description: The error output from the command
     returned: always
     type: string
-    sample: 'Error 15 running E:\setup.exe'
+    sample: Error 15 running E:\setup.exe
 msg:
     description: Possible error message on failure
     returned: failed
     type: string
-    sample: "The 'password' parameter is a required parameter."
+    sample: The 'password' parameter is a required parameter.
 changed:
     description: Whether or not any changes were made.
     returned: always

--- a/lib/ansible/modules/windows/win_psexec.py
+++ b/lib/ansible/modules/windows/win_psexec.py
@@ -92,6 +92,7 @@ options:
     - Wait for the application to terminate.
     - Only use for non-interactive applications.
     default: True
+requires: [ psexec ]
 author: Dag Wieers (@dagwieers)
 '''
 

--- a/lib/ansible/modules/windows/win_psexec.py
+++ b/lib/ansible/modules/windows/win_psexec.py
@@ -1,0 +1,115 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2017, Dag Wieers <dag@wieers.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = """
+---
+module: win_psexec
+version_added: '2.3'
+short_description: Runs commands (remotely) as another (privileged) user
+description:
+- Run commands (remotely) through the PsExec service
+- Run commands as another (domain) user (with elevated privileges)
+options:
+  command:
+    description:
+    - The command line to run through PsExec (limited to 260 characters).
+    required: true
+    default whoami.exe
+  executable:
+    description:
+    - The location of the PsExec utility (in case it is not located in your PATH).
+    required: false
+    default: psexec.exe
+  hostname:
+    description:
+    - The hostname to run the command.
+    - If not provided, the command is run locally.
+    required: false
+  username:
+    description:
+    - The (remote) user to run the command as.
+    - If not provided, the current user is used.
+  password:
+    description:
+    - The password for the (remote) user to run the command as.
+    - This is mandatory in order authenticate yourself.
+    required: true
+  chdir:
+    description:
+    - The (remote) directory to work from.
+    required: false
+  timeout:
+    description:
+    - The connection timeout in seconds
+    required: false
+  priority:
+    description:
+    - The priority to run the command as.
+author: Dag Wieers (@dagwieers)
+"""
+
+EXAMPLES = r'''
+# Test the PsExec connection to the local system with your user (runs whoami)
+- win_psexec:
+    password: some_password
+
+- win_psexec:
+    commandline: E:\setup.exe
+    hostname: remote_server
+    username: DOMAIN\Administrator
+    password: some_password
+'''
+
+RETURN = '''
+cmd:
+    description: The complete command line used by the module, including PsExec call and additional options.
+    returned: always
+    type: string
+    sample: 'psexec.exe \\remote_server -u DOMAIN\Administrator -p some_password E:\setup.exe'
+rc:
+    description: The return code for the command
+    returned: always
+    type: int
+    sample: 0
+stdout:
+    description: The standard output from the command
+    returned: always
+    type: string
+    sample: 'Success.'
+stderr:
+    description: The error output from the command
+    returned: always
+    type: string
+    sample: 'Error 15 running E:\setup.exe'
+msg:
+    description: Possible error message on failure
+    returned: failed
+    type: string
+    sample: "The 'password' parameter is a required parameter."
+changed:
+    description: Whether or not any changes were made.
+    returned: always
+    type: bool
+    sample: True
+'''

--- a/lib/ansible/modules/windows/win_psexec.py
+++ b/lib/ansible/modules/windows/win_psexec.py
@@ -35,17 +35,15 @@ options:
     description:
     - The command line to run through PsExec (limited to 260 characters).
     required: true
-    default whoami.exe
+    default: whoami.exe
   executable:
     description:
     - The location of the PsExec utility (in case it is not located in your PATH).
-    required: false
     default: psexec.exe
-  hostname:
+  hostnames:
     description:
-    - The hostname to run the command.
+    - The hostnames to run the command.
     - If not provided, the command is run locally.
-    required: false
   username:
     description:
     - The (remote) user to run the command as.
@@ -57,15 +55,32 @@ options:
     required: true
   chdir:
     description:
-    - The (remote) directory to work from.
-    required: false
+    - Run the command from this (remote) directory.
+  noprofile:
+    description:
+    - Run the command without loading the account's profile.
+  elevated:
+    description:
+    - Run the command with elevated privileges.
+  limited:
+    description:
+    - Run the command as limited user (strips the Administrators group and allows only privileges assigned to the Users group).
+  system:
+    description:
+    - Run the remote command in the System account.
+  priority:
+    description:
+    - Used to run the command at a different priority.
+    choices:
+    - background
+    - low
+    - belownormal
+    - abovenormal
+    - high
+    - realtime
   timeout:
     description:
     - The connection timeout in seconds
-    required: false
-  priority:
-    description:
-    - The priority to run the command as.
 author: Dag Wieers (@dagwieers)
 """
 
@@ -74,11 +89,23 @@ EXAMPLES = r'''
 - win_psexec:
     password: some_password
 
+# Run the setup.exe installer on multiple servers using the Domain Administrator
 - win_psexec:
     command: E:\setup.exe /i /IACCEPTEULA
-    hostname: remote_server
+    hostnames:
+    - remote_server1
+    - remote_server2
     username: DOMAIN\Administrator
     password: some_password
+    priority: high
+
+# Run PsExec from custom location C:\Program Files\sysinternals\
+- win_psexec:
+    command: netsh advfirewall set allprofiles state off
+    executable: C:\Program Files\sysinternals\psexec.exe
+    hostnames: [ remote_server ]
+    password: some_password
+    priority: low
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/windows/win_psexec.py
+++ b/lib/ansible/modules/windows/win_psexec.py
@@ -75,7 +75,7 @@ EXAMPLES = r'''
     password: some_password
 
 - win_psexec:
-    commandline: E:\setup.exe
+    command: E:\setup.exe /i /IACCEPTEULA
     hostname: remote_server
     username: DOMAIN\Administrator
     password: some_password


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_psexec

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
The psexec tool is quite popular among Windows admins for automating tasks between systems. This module makes the tool available so that you can connect to remote servers with elevated privileges.

I wasn't sure if we want to have this module. If this is acceptable, I will also add the documentation + examples.

```yaml
- win_psexec:
    command: whoami.exe
    hostnames: [ remote_system ]
    username: DOMAIN\user
    password: password
    chdir: C:\Windows\Temp\
    priority: high
```