### PR TITLE
Zypper: Fix update_cache in checkmode

### DIFF
--- a/lib/ansible/modules/packaging/os/zypper.py
+++ b/lib/ansible/modules/packaging/os/zypper.py
@@ -95,7 +95,7 @@ options:
     update_cache:
         version_added: "2.2"
         description:
-          - Run the equivalent of C(zypper refresh) before the operation.
+          - Run the equivalent of C(zypper refresh) before the operation. Disabled in check mode.
         required: false
         default: "no"
         choices: [ "yes", "no" ]
@@ -442,7 +442,7 @@ def main():
     name = filter(None, name)
 
     # Refresh repositories
-    if update_cache:
+    if update_cache and not module.check_mode:
         retvals = repo_refresh(module)
 
         if retvals['rc'] != 0:

--- a/test/integration/targets/zypper/tasks/zypper.yml
+++ b/test/integration/targets/zypper/tasks/zypper.yml
@@ -334,3 +334,27 @@
         - zypperin1|changed
         - not zypperin2|changed
   when: ansible_distribution == 'openSUSE Leap' and ansible_distribution_version == '42.1'
+
+
+# check for https://github.com/ansible/ansible/issues/20139
+- name: run updatecache
+  zypper:
+    name: hello
+    state: present
+    update_cache: True
+  register: zypper_result_update_cache
+
+- name: run updatecache in check mode
+  zypper:
+    name: hello
+    state: present
+    update_cache: True
+  check_mode: True
+  register: zypper_result_update_cache_check
+
+
+- assert:
+    that:
+      - zypper_result_update_cache|success
+      - zypper_result_update_cache_check|success
+      - not zypper_result_update_cache_check|changed


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
zypper

##### ANSIBLE VERSION
devel

##### SUMMARY
Fixes #20139

Refresh does not support dry-run, so don't run it in check mode.
Also add a test for this case.
