### PR TITLE
cloud: ovirt: add ability to override luns

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
@@ -99,6 +99,7 @@ options:
             - "C(lun_id) - LUN id."
             - "C(username) - A CHAP user name for logging into a target."
             - "C(password) - A CHAP password for logging into a target."
+            - "C(override_luns) - If I(True) ISCSI storage domain luns will be overriden before adding."
             - "Note that these parameters are not idempotent."
     posixfs:
         description:
@@ -255,6 +256,7 @@ class StorageDomainModule(BaseModule):
                         password=storage.get('password'),
                     ),
                 ] if storage_type in ['iscsi', 'fcp'] else None,
+                override_luns=storage.get('override_luns'),
                 mount_options=storage.get('mount_options'),
                 vfs_type='glusterfs' if storage_type in ['glusterfs'] else storage.get('vfs_type'),
                 address=storage.get('address'),


### PR DESCRIPTION
Add the ability to wipe used luns when adding new iscsi storage

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the modules/cloud/ovirt/ovirt_storage_domains -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
