### PR TITLE
rabbitmq_user: Set no_log property on password argument

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq_user.py
@@ -238,7 +238,7 @@ class RabbitMqUser(object):
 def main():
     arg_spec = dict(
         user=dict(required=True, aliases=['username', 'name']),
-        password=dict(default=None),
+        password=dict(default=None, no_log=True),
         tags=dict(default=None),
         permissions=dict(default=list(), type='list'),
         vhost=dict(default='/'),


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
rabbitmq_user

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
The `rabbitmq_user` module includes the password parameters in log files. This PR adds the `no_log` property to the module's `password` argument.