### PR TITLE
Empty string is not valid path

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1611,7 +1611,12 @@ class AnsibleModule(object):
 
     def _check_type_path(self, value):
         value = self._check_type_str(value)
-        return os.path.expanduser(os.path.expandvars(value))
+        valid_path = os.path.expanduser(os.path.expandvars(value))
+
+        if valid_path == '':
+            raise TypeError("Path cannot be an empty string.")
+
+        return valid_path
 
     def _check_type_jsonarg(self, value):
         # Return a jsonified string.  Sometimes the controller turns a json
@@ -1665,7 +1670,10 @@ class AnsibleModule(object):
             try:
                 self.params[k] = type_checker(value)
             except (TypeError, ValueError):
-                self.fail_json(msg="argument %s is of type %s and we were unable to convert to %s" % (k, type(value), wanted))
+                e = get_exception()
+                self.fail_json(
+                    msg="argument %s is of type %s and we were unable to convert to %s" % (k, type(value), wanted),
+                    exception=str(e))
 
     def _set_defaults(self, pre=True):
         for (k,v) in self.argument_spec.items():


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

AnsibleModule class.

##### ANSIBLE VERSION

```
ansible 2.3.0 (jtyr-path_type 86a9b6c569) last updated 2017/01/11 21:09:42 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

This patch is checking for empty string passed to a module parameter of type `path`. Python is treating empty string is an invalid path:

```
In [1]: open('', 'r')
---------------------------------------------------------------------------
IOError                                   Traceback (most recent call last)
<ipython-input-1-edeadb16a11b> in <module>()
----> 1 open('', 'r')

IOError: [Errno 2] No such file or directory: ''
```

This patch will cause the `_check_type_path()` fail with a message which is then displayed in the `details` as shown below:

```
failed: [test-soe] (item={u'user_id': 1000, u'user_comment': u'My user', u'user_password': u'$6$fAknMdY5$VuAzbn3N52r7kSPN2ALSVArJJP/83NeApvsotA/fA5EIuhUB274q.6czfKWPuXbHrP0GVJuiKR8pG1F2Ybe/g3', u'group_name': u'myuser', u'group_id': 1000, u'user_name': u'myuser'}) => {
    "details": "Path can not be an empty string.", 
    "failed": true, 
    "invocation": {
        "module_args": {
            "append": "no", 
            "comment": "", 
            "createhome": "yes", 
            "force": false, 
            "group": "myuser", 
            "home": "", 
            "move_home": "no", 
            "name": "myuser", 
            "non_unique": false, 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "remove": "no", 
            "ssh_key_bits": 0, 
            "ssh_key_comment": "ansible-generated on localhost.localdomain", 
            "ssh_key_type": "rsa", 
            "state": "present", 
            "system": "no", 
            "uid": "1000", 
            "update_password": "always"
        }, 
        "module_name": "user"
    }, 
    "item": {
        "group_id": 1000, 
        "group_name": "myuser", 
        "user_comment": "My user", 
        "user_id": 1000, 
        "user_name": "myuser", 
        "user_password": "$6$fAknMdY5$VuAzbn3N52r7kSPN2ALSVArJJP/83NeApvsotA/fA5EIuhUB274q.6czfKWPuXbHrP0GVJuiKR8pG1F2Ybe/g3"
    }, 
    "msg": "argument home is of type <type 'str'> and we were unable to convert to path"
}
```
