### PR TITLE
Rename the type filter to type_debug

### DIFF
--- a/docs/docsite/rst/playbooks_filters.rst
+++ b/docs/docsite/rst/playbooks_filters.rst
@@ -622,11 +622,11 @@ Debugging Filters
 
 .. versionadded:: 2.3
 
-Use the ``type`` filter to display the underlying Python type of a variable.
+Use the ``type_debug`` filter to display the underlying Python type of a variable.
 This can be useful in debugging in situations where you may need to know the exact
 type of a variable::
 
-    {{ myvar | type }}
+    {{ myvar | type_debug }}
 
 
 A few useful filters are typically added with each new Ansible release.  The development documentation shows

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -534,5 +534,5 @@ class FilterModule(object):
             'skip'    : skipped,
 
             # debug
-            'type': lambda o: o.__class__.__name__,
+            'type_debug': lambda o: o.__class__.__name__,
         }


### PR DESCRIPTION
Because we add the names of all filters to the callable whitelist used
by safe_eval, adding a filter named type makes it so code calling "type()"
gets eval'd.  We can't think of a way to exploit this but it's
sufficiently sketchy that we're renaming it in case someone smarter than
us can think of a problem.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
lib/ansible/plugins/filter/core.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```