### PR TITLE
contrib/inventory/ec2.py correctly serialize data

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -131,6 +131,7 @@ from boto import rds
 from boto import elasticache
 from boto import route53
 import six
+from datetime import datetime
 
 from ansible.module_utils import ec2 as ec2_utils
 
@@ -1496,12 +1497,21 @@ class Ec2Inventory(object):
             regex += "\-"
         return re.sub(regex + "]", "_", word)
 
+    @classmethod
+    def json_serial(cls, obj):
+        """JSON serializer for objects not serializable by default json code"""
+
+        if isinstance(obj, datetime):
+            serial = obj.isoformat()
+            return serial
+        raise TypeError ("Type not serializable")
+
     def json_format_dict(self, data, pretty=False):
         ''' Converts a dict to a JSON object and dumps it as a formatted
         string '''
 
         if pretty:
-            return json.dumps(data, sort_keys=True, indent=2)
+            return json.dumps(data, sort_keys=True, indent=2, default=Ec2Inventory.json_serial)
         else:
             return json.dumps(data)
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
contrib/inventory/ec2.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix the following exception that was occurring when running `python ec2.py --refresh-cache` with `include_rds_clusters = True` in ec2.ini:

  TypeError: datetime.datetime(20167 1, 10, 21, 46, 24, 862000) is not JSON serializable

I believe I only saw this exception after I actually created an RDS cluster in my AWS account.

See this post for details on the fix:
http://stackoverflow.com/questions/11875770/how-to-overcome-datetime-datetime-not-json-serializable-in-python

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
BEFORE:

$ python ec2.py --refresh-cache
...
TypeError: datetime.datetime(20167 1, 10, 21, 46, 24, 862000) is not JSON serializable

AFTER:
$ python ec2.py --refresh-cache
<no exception, just expected AWS inventory output>
```
