### PR TITLE
win_shortcut: Create, manage, remove Windows shortcuts

### DIFF
--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -98,6 +98,11 @@ Function Fail-Json($obj, $message = $null)
     Exit 1
 }
 
+Function Expand-Environment($value)
+{
+    [System.Environment]::ExpandEnvironmentVariables($value)
+}
+
 # Helper function to get an "attribute" from a psobject instance in powershell.
 # This is a convenience to make getting Members from an object easier and
 # slightly more pythonic
@@ -105,7 +110,7 @@ Function Fail-Json($obj, $message = $null)
 #Get-AnsibleParam also supports Parameter validation to save you from coding that manually:
 #Example: Get-AnsibleParam -obj $params -name "State" -default "Present" -ValidateSet "Present","Absent" -resultobj $resultobj -failifempty $true
 #Note that if you use the failifempty option, you do need to specify resultobject as well.
-Function Get-AnsibleParam($obj, $name, $default = $null, $resultobj, $failifempty=$false, $emptyattributefailmessage, $ValidateSet, $ValidateSetErrorMessage)
+Function Get-AnsibleParam($obj, $name, $default = $null, $resultobj, $failifempty=$false, $emptyattributefailmessage, $ValidateSet, $ValidateSetErrorMessage, $type=$null)
 {
     # Check if the provided Member $name exists in $obj and return it or the default. 
     Try
@@ -119,7 +124,7 @@ Function Get-AnsibleParam($obj, $name, $default = $null, $resultobj, $failifempt
         {
             if ($ValidateSet -contains ($obj.$name))
             {
-                $obj.$name    
+                $value = $obj.$name
             }
             Else
             {
@@ -133,15 +138,14 @@ Function Get-AnsibleParam($obj, $name, $default = $null, $resultobj, $failifempt
         }
         Else
         {
-            $obj.$name
+            $value = $obj.$name
         }
-        
     }
     Catch
     {
         If ($failifempty -eq $false)
         {
-            $default
+            $value = $default
         }
         Else
         {
@@ -152,6 +156,13 @@ Function Get-AnsibleParam($obj, $name, $default = $null, $resultobj, $failifempt
             Fail-Json -obj $resultobj -message $emptyattributefailmessage
         }
     }
+
+    # Expand environment variables on path-type (Beware: turns $null into "")
+    If ($value -ne $null -and $type -eq 'path') {
+        $value = Expand-Environment($value)
+    }
+
+    $value
 }
 
 #Alias Get-attr-->Get-AnsibleParam for backwards compat. Only add when needed to ease debugging of scripts

--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -158,7 +158,7 @@ Function Get-AnsibleParam($obj, $name, $default = $null, $resultobj, $failifempt
     }
 
     # Expand environment variables on path-type (Beware: turns $null into "")
-    If ($value -ne $null -and $type -eq 'path') {
+    If ($value -ne $null -and $type -eq "path") {
         $value = Expand-Environment($value)
     }
 

--- a/lib/ansible/modules/windows/win_shortcut.ps1
+++ b/lib/ansible/modules/windows/win_shortcut.ps1
@@ -1,0 +1,147 @@
+#!powershell
+# (c) 2016, Dag Wieers <dag@wieers.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# WANT_JSON
+# POWERSHELL_COMMON
+#
+# Based on: http://powershellblogger.com/2016/01/create-shortcuts-lnk-or-url-files-with-powershell/
+
+$ErrorActionPreference = "Stop"
+
+$params = Parse-Args $args -supports_check_mode $true;
+
+$_ansible_check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -default $false
+
+$orig_src = Get-AnsibleParam -obj $params -name "src" -default $null
+$orig_dest = Get-AnsibleParam -obj $params -name "dest" -failifempty $true
+$state = Get-AnsibleParam -obj $params -name "state" -default "present"
+$orig_args = Get-AnsibleParam -obj $params -name "args" -default $null
+$orig_directory = Get-AnsibleParam -obj $params -name "directory" -default $null
+$hotkey = Get-AnsibleParam -obj $params -name "hotkey" -default $null
+$orig_icon = Get-AnsibleParam -obj $params -name "icon" -default $null
+$orig_description = Get-AnsibleParam -obj $params -name "description" -default $null
+$windowstyle = Get-AnsibleParam -obj $params -name "windowstyle" -default $null
+
+# Expand environment variables (Beware: turns $null into "")
+$src = [System.Environment]::ExpandEnvironmentVariables($orig_src)
+$dest = [System.Environment]::ExpandEnvironmentVariables($orig_dest)
+$args = [System.Environment]::ExpandEnvironmentVariables($orig_args)
+$directory = [System.Environment]::ExpandEnvironmentVariables($orig_directory)
+$icon = [System.Environment]::ExpandEnvironmentVariables($orig_icon)
+$description = [System.Environment]::ExpandEnvironmentVariables($orig_description)
+
+$result = New-Object PSObject @{
+    changed = $false
+    dest = $dest
+    state = $state
+}
+
+If ($state -eq "absent") {
+    If (Test-Path "$dest") {
+        # If the shortcut exists, try to remove it
+        Try {
+            Remove-Item -Path "$dest";
+        } Catch {
+            # Report removal failure
+            Fail-Json $result "Failed to remove shortcut $dest. ($($_.Exception.Message))"
+        }
+        # Report removal success
+        Set-Attr $result "changed" $true
+    } Else {
+        # Nothing to report, everything is fine already
+    }
+} ElseIf ($state -eq "present") {
+    $Shell = New-Object -ComObject ("WScript.Shell")
+    $ShortCut = $Shell.CreateShortcut($dest)
+
+    # Compare existing values with new values,
+    # report as changed if required
+
+    If ($orig_src -ne $null -and $ShortCut.TargetPath -ne $src) {
+        Set-Attr $result "changed" $true
+        Set-Attr $result "src" $src
+        $ShortCut.TargetPath = $src
+    } Else {
+        Set-Attr $result "src" $ShortCut.TargetPath
+    }
+
+    # TODO: Find a better way to do has_attr() or isinstance() ?
+    If (Get-Member -InputObject $ShortCut -Name Arguments) {
+
+        If ($orig_args -ne $null -and $ShortCut.Arguments -ne $args) {
+            Set-Attr $result "changed" $true
+            Set-Attr $result "args" $args
+            $ShortCut.Arguments = $args
+        } Else {
+            Set-Attr $result "args" $ShortCut.Arguments
+        }
+
+        If ($orig_directory -ne $null -and $ShortCut.WorkingDirectory -ne $directory) {
+            Set-Attr $result "changed" $true
+            Set-Attr $result "directory" $directory
+            $ShortCut.WorkingDirectory = $directory
+        } Else {
+            Set-Attr $result "directory" $ShortCut.WorkingDirectory
+        }
+
+        If ($hotkey -ne $null -and $ShortCut.Hotkey -ne $hotkey) {
+            Set-Attr $result "changed" $true
+            Set-Attr $result "hotkey" $hotkey
+            $ShortCut.Hotkey = $hotkey
+        } Else {
+            Set-Attr $result "hotkey" $ShortCut.Hotkey
+        }
+
+        If ($orig_icon -ne $null -and $ShortCut.IconLocation -ne $icon) {
+            Set-Attr $result "changed" $true
+            Set-Attr $result "icon" $icon
+            $ShortCut.IconLocation = $icon
+        } Else {
+            Set-Attr $result "icon" $ShortCut.IconLocation
+        }
+
+        If ($orig_description -ne $null -and $ShortCut.Description -ne $description) {
+            Set-Attr $result "changed" $true
+            Set-Attr $result "description" $description
+            $ShortCut.Description = $description
+        } Else {
+            Set-Attr $result "description" $ShortCut.Description
+        }
+
+        If ($windowstyle -ne $null -and $ShortCut.WindowStyle -ne $windowstyle) {
+            Set-Attr $result "changed" $true
+            Set-Attr $result "windowstyle" $windowstyle
+            $ShortCut.WindowStyle = $windowstyle
+        } Else {
+            Set-Attr $result "windowstyle" $ShortCut.WindowStyle
+        }
+    }
+
+    If ($result["changed"] -eq $true -and $_ansible_check_mode -ne $true) {
+        Try {
+            $ShortCut.Save()
+        } Catch {
+            Fail-Json $result "Failed to create shortcut $dest. ($($_.Exception.Message))"
+        }
+    }
+
+} else {
+    Fail-Json $result "Option 'state' must be either 'present' or 'absent'."
+}
+
+Exit-Json $result

--- a/lib/ansible/modules/windows/win_shortcut.ps1
+++ b/lib/ansible/modules/windows/win_shortcut.ps1
@@ -54,6 +54,16 @@ $result = @{
     state = $state
 }
 
+# Convert from window style name to window style id
+$windowstyles = @{
+    default = 1
+    maximized = 3
+    minimized = 7
+}
+
+# Convert from window style id to window style name
+$windowstyleids = @( "", "default", "", "maximized", "", "", "", "minimized" )
+
 If ($state -eq "absent") {
     If (Test-Path "$dest") {
         # If the shortcut exists, try to remove it
@@ -61,7 +71,7 @@ If ($state -eq "absent") {
             Remove-Item -Path "$dest";
         } Catch {
             # Report removal failure
-            Fail-Json $result "Failed to remove shortcut $dest. ($($_.Exception.Message))"
+            Fail-Json $result "Failed to remove shortcut $dest. (" + $_.Exception.Message + ")"
         }
         # Report removal success
         $result.changed = $true
@@ -119,24 +129,18 @@ If ($state -eq "absent") {
         }
         $result.description = $ShortCut.Description
 
-        If ($windowstyle -ne $null -and $ShortCut.WindowStyle -ne $windowstyle) {
+        If ($windowstyle -ne $null -and $ShortCut.WindowStyle -ne $windowstyles.$windowstyle) {
             $result.changed = $true
-            switch ($windowstyle) {
-                "default" { $windowstyle_id = 1 }
-                "maximized" { $windowstyle_id = 3 }
-                "minimized" { $windowstyle_id = 7 }
-                default { $windowstyle_id = 1 }
-            }
-            $ShortCut.WindowStyle = $windowstyle_id
+            $ShortCut.WindowStyle = $windowstyles.$windowstyle
         }
-        $result.windowstyle = $ShortCut.WindowStyle
+        $result.windowstyle = $windowstyleids[$ShortCut.WindowStyle]
     }
 
     If ($result.changed -eq $true -and $_ansible_check_mode -ne $true) {
         Try {
             $ShortCut.Save()
         } Catch {
-            Fail-Json $result "Failed to create shortcut $dest. ($($_.Exception.Message))"
+            Fail-Json $result "Failed to create shortcut $dest. (" + $_.Exception.Message + ")"
         }
     }
 }

--- a/lib/ansible/modules/windows/win_shortcut.py
+++ b/lib/ansible/modules/windows/win_shortcut.py
@@ -29,79 +29,77 @@ options:
   src:
     description:
     - Executable or URL the shortcut points to.
-    required: false
-    default: null
   description:
     description:
     - Description for the shortcut.
     - This is usually shown when hoovering the icon.
-    required: false
-    default: null
   dest:
     description:
     - Destination file for the shortcuting file.
     - File name should have a C(.lnk) or C(.url) extension.
     required: true
-    default: null
   args:
     description:
     - Additional arguments for the executable defined in C(src).
-    required: false
-    default: null
   directory:
     description:
     - Working directory for executable defined in C(src).
-    required: false
-    default: null
   icon:
     description:
     - Icon used for the shortcut
     - File name should have a C(.ico) extension.
     - The file name is followed by a comma and the number in the library file (.dll) or use 0 for an image file.
-    required: false
-    default: null
   hotkey:
     description:
     - Key combination for the shortcut.
-    required: false
-    default: null
   windowstyle:
     description:
     - Influences how the application is displayed when it is launched.
-        C(1) for default location and size
-        C(3) for maximized
-        C(7) minimized
+    choices:
+    - default
+    - maximized
+    - minimized
   state:
     description:
     - When C(present), creates or updates the shortcut.  When C(absent),
       removes the shortcut if it exists.
-    required: false
+    choices:
+    - present
+    - absent
     default: 'present'
-    choices: [ 'present', 'absent' ]
 author: Dag Wieers (@dagwieers)
 notes:
 - 'The following options can include Windows environment variables: C(dest), C(args), C(description), C(dest), C(directory), C(icon) C(src)'
+- 'Windows has two types of shortcuts: Application and URL shortcuts. URL shortcuts only consists of C(dest) and C(src)'
 '''
 
-EXAMPLES = '''
-# Create a desktop shortcut for an application
+EXAMPLES = r'''
+# Create an application shortcut on the desktop
 - win_shortcut:
     src: C:\Program Files\Mozilla Firefox\Firefox.exe
-    dest: '%PUBLIC%\Desktop\Mozilla Firefox.lnk'
+    dest: C:\Users\Public\Desktop\Mozilla Firefox.lnk
     icon: C:\Program Files\Mozilla Firefox\Firefox.exe,0
 
-# The same desktop shortcut using environment variables
+# Create the same shortcut using environment variables
 - win_shortcut:
     description: The Mozilla Firefox web browser
     src: '%PROGRAMFILES%\Mozilla Firefox\Firefox.exe'
     dest: '%PUBLIC%\Desktop\Mozilla Firefox.lnk'
     icon: '%PROGRAMFILES\Mozilla Firefox\Firefox.exe,0'
-    directory: '%PROGRAMFILES%\Mozilla Firefox\'
+    directory: '%PROGRAMFILES%\Mozilla Firefox'
 
-# Create a link to the Ansible website
+# Create a URL shortcut to the Ansible website
 - win_shortcut:
-    dest: '%PUBLIC%\Desktop\Ansible website.url'
     src: 'https://ansible.com/'
+    dest: '%PUBLIC%\Desktop\Ansible website.url'
+
+# Create an application shortcut for the Ansible website
+- win_shortcut:
+    src: '%PROGRAMFILES%\Google\Chrome\Application\chrome.exe'
+    dest: '%PUBLIC%\Desktop\Ansible website.lnk'
+    args: '--new-window https://ansible.com/'
+    directory: '%PROGRAMFILES%\Google\Chrome\Application'
+    icon: '%PROGRAMFILES%\Google\Chrome\Application\chrome.exe,0'
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/windows/win_shortcut.py
+++ b/lib/ansible/modules/windows/win_shortcut.py
@@ -1,0 +1,108 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2016, Dag Wieers <dag@wieers.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: win_shortcut
+version_added: '2.3'
+short_description: Manage shortcuts on Windows
+description:
+- Create, manage and delete Windows shortcuts
+options:
+  src:
+    description:
+    - Executable or URL the shortcut points to.
+    required: false
+    default: null
+  description:
+    description:
+    - Description for the shortcut.
+    - This is usually shown when hoovering the icon.
+    required: false
+    default: null
+  dest:
+    description:
+    - Destination file for the shortcuting file.
+    - File name should have a C(.lnk) or C(.url) extension.
+    required: true
+    default: null
+  args:
+    description:
+    - Additional arguments for the executable defined in C(src).
+    required: false
+    default: null
+  directory:
+    description:
+    - Working directory for executable defined in C(src).
+    required: false
+    default: null
+  icon:
+    description:
+    - Icon used for the shortcut
+    - File name should have a C(.ico) extension.
+    - The file name is followed by a comma and the number in the library file (.dll) or use 0 for an image file.
+    required: false
+    default: null
+  hotkey:
+    description:
+    - Key combination for the shortcut.
+    required: false
+    default: null
+  windowstyle:
+    description:
+    - Influences how the application is displayed when it is launched.
+        C(1) for default location and size
+        C(3) for maximized
+        C(7) minimized
+  state:
+    description:
+    - When C(present), creates or updates the shortcut.  When C(absent),
+      removes the shortcut if it exists.
+    required: false
+    default: 'present'
+    choices: [ 'present', 'absent' ]
+author: Dag Wieers (@dagwieers)
+notes:
+- 'The following options can include Windows environment variables: C(dest), C(args), C(description), C(dest), C(directory), C(icon) C(src)'
+'''
+
+EXAMPLES = '''
+# Create a desktop shortcut for an application
+- win_shortcut:
+    src: C:\Program Files\Mozilla Firefox\Firefox.exe
+    dest: '%PUBLIC%\Desktop\Mozilla Firefox.lnk'
+    icon: C:\Program Files\Mozilla Firefox\Firefox.exe,0
+
+# The same desktop shortcut using environment variables
+- win_shortcut:
+    description: The Mozilla Firefox web browser
+    src: '%PROGRAMFILES%\Mozilla Firefox\Firefox.exe'
+    dest: '%PUBLIC%\Desktop\Mozilla Firefox.lnk'
+    icon: '%PROGRAMFILES\Mozilla Firefox\Firefox.exe,0'
+    directory: '%PROGRAMFILES%\Mozilla Firefox\'
+
+# Create a link to the Ansible website
+- win_shortcut:
+    dest: '%PUBLIC%\Desktop\Ansible website.url'
+    src: 'https://ansible.com/'
+'''
+
+RETURN = '''
+'''


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_shortcut

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
This modules manages Windows shortcuts and all its properties.
It is idempotent and supports check-mode.

This relates to #19694