### PR TITLE
Improve non-tagged network ACL support and fix tagging

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -34,7 +34,7 @@ from ansible.module_utils.cloud import CloudRetry
 
 try:
     import boto
-    import boto.ec2 #boto does weird import stuff
+    import boto.ec2  # boto does weird import stuff
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
@@ -46,13 +46,8 @@ try:
 except:
     HAS_BOTO3 = False
 
-try:
-    from distutils.version import LooseVersion
-    HAS_LOOSE_VERSION = True
-except:
-    HAS_LOOSE_VERSION = False
-
 from ansible.module_utils.six import string_types, binary_type, text_type
+
 
 class AnsibleAWSError(Exception):
     pass
@@ -95,7 +90,9 @@ def boto3_conn(module, conn_type=None, resource=None, region=None, endpoint=None
     try:
         return _boto3_conn(conn_type=conn_type, resource=resource, region=region, endpoint=endpoint, **params)
     except ValueError:
-        module.fail_json(msg='There is an issue in the code of the module. You must specify either both, resource or client to the conn_type parameter in the boto3_conn function call')
+        module.fail_json(msg='There is an issue in the code of the module. You must specify either both, '
+                         'resource or client to the conn_type parameter in the boto3_conn function call')
+
 
 def _boto3_conn(conn_type=None, resource=None, region=None, endpoint=None, **params):
     profile = params.pop('profile_name', None)
@@ -118,6 +115,7 @@ def _boto3_conn(conn_type=None, resource=None, region=None, endpoint=None, **par
         return client, resource
 
 boto3_inventory_conn = _boto3_conn
+
 
 def aws_common_argument_spec():
     return dict(
@@ -257,7 +255,9 @@ def connect_to_aws(aws_module, region, **params):
     conn = aws_module.connect_to_region(region, **params)
     if not conn:
         if region not in [aws_module_region.name for aws_module_region in aws_module.regions()]:
-            raise AnsibleAWSError("Region %s does not seem to be available for aws module %s. If the region definitely exists, you may need to upgrade boto or extend with endpoints_path" % (region, aws_module.__name__))
+            raise AnsibleAWSError("Region %s does not seem to be available for aws module %s. "
+                                  "If the region definitely exists, you may need to upgrade boto "
+                                  "or extend with endpoints_path" % (region, aws_module.__name__))
         else:
             raise AnsibleAWSError("Unknown problem connecting to region %s for aws module %s." % (region, aws_module.__name__))
     if params.get('profile_name'):
@@ -287,6 +287,7 @@ def ec2_connect(module):
         module.fail_json(msg="Either region or ec2_url must be specified")
 
     return ec2
+
 
 def paging(pause=0, marker_property='marker'):
     """ Adds paging to boto retrieval functions that support a 'marker'
@@ -327,7 +328,6 @@ def camel_dict_to_snake_dict(camel_dict):
 
         return all_cap_re.sub(r'\1_\2', s1).lower()
 
-
     def value_is_list(camel_list):
 
         checked_list = []
@@ -340,7 +340,6 @@ def camel_dict_to_snake_dict(camel_dict):
                 checked_list.append(item)
 
         return checked_list
-
 
     snake_dict = {}
     for k, v in camel_dict.items():
@@ -485,7 +484,6 @@ def get_ec2_security_group_ids_from_names(sec_group_list, ec2_connection, vpc_id
             return sg['GroupName']
         else:
             return sg.name
-
 
     def get_sg_id(sg, boto3):
 

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway_facts.py
@@ -89,6 +89,7 @@ result:
 
 import json
 
+# import module snippets
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info, boto3_conn
 from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list, HAS_BOTO3

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -10,7 +10,6 @@ lib/ansible/galaxy/role.py
 lib/ansible/inventory/dir.py
 lib/ansible/inventory/script.py
 lib/ansible/module_utils/basic.py
-lib/ansible/module_utils/ec2.py
 lib/ansible/module_utils/facts.py
 lib/ansible/module_utils/mysql.py
 lib/ansible/modules/cloud/amazon/_ec2_vpc.py
@@ -40,7 +39,6 @@ lib/ansible/modules/cloud/amazon/ec2_snapshot_facts.py
 lib/ansible/modules/cloud/amazon/ec2_tag.py
 lib/ansible/modules/cloud/amazon/ec2_vol_facts.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_options_facts.py
-lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_net_facts.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_route_table_facts.py


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc_nacl

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 6ec0369c26) last updated 2017/01/11 13:34:13 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
* Allow network ACLs to be manipulated by ID
* Fix tag handling so that it doesn't assume that there are always tags
* Move tag manipulation to common code suitable for more resources
* Clean up some flake8 issues