### PR TITLE
Fix EIP release in ec2_vpc_nat_gateway

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway.py
@@ -662,11 +662,15 @@ def release_address(client, allocation_id, check_mode=False):
         return True, ''
 
     ip_released = False
-    params = {
-        'AllocationId': allocation_id,
-    }
     try:
-        client.release_address(**params)
+        client.describe_addresses(AllocationIds=[allocation_id])
+    except botocore.exceptions.ClientError as e:
+        # IP address likely already released
+        # Happens with gateway in 'deleted' state that
+        # still lists associations
+        return True, str(e)
+    try:
+        client.release_address(AllocationId=allocation_id)
         ip_released = True
     except botocore.exceptions.ClientError as e:
         err_msg = str(e)

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway.py
@@ -14,6 +14,18 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+# import module snippets
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info, boto3_conn
+
+import datetime
+import random
+import re
+import time
+
+from dateutil.tz import tzutc
+
+
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
@@ -216,12 +228,6 @@ try:
 except ImportError:
     HAS_BOTO3 = False
 
-import datetime
-import random
-import re
-import time
-
-from dateutil.tz import tzutc
 
 DRY_RUN_GATEWAYS = [
     {
@@ -1000,17 +1006,18 @@ def remove(client, nat_gateway_id, wait=False, wait_timeout=0,
 
 def main():
     argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
-        subnet_id=dict(type='str'),
-        eip_address=dict(type='str'),
-        allocation_id=dict(type='str'),
-        if_exist_do_not_create=dict(type='bool', default=False),
-        state=dict(default='present', choices=['present', 'absent']),
-        wait=dict(type='bool', default=False),
-        wait_timeout=dict(type='int', default=320, required=False),
-        release_eip=dict(type='bool', default=False),
-        nat_gateway_id=dict(type='str'),
-        client_token=dict(type='str'),
+    argument_spec.update(
+        dict(
+            subnet_id=dict(type='str'),
+            eip_address=dict(type='str'),
+            allocation_id=dict(type='str'),
+            if_exist_do_not_create=dict(type='bool', default=False),
+            state=dict(default='present', choices=['present', 'absent']),
+            wait=dict(type='bool', default=False),
+            wait_timeout=dict(type='int', default=320, required=False),
+            release_eip=dict(type='bool', default=False),
+            nat_gateway_id=dict(type='str'),
+            client_token=dict(type='str'),
         )
     )
     module = AnsibleModule(
@@ -1085,9 +1092,6 @@ def main():
             msg=err_msg, success=success, changed=changed, **results
         )
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc_nat_gateway

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel e35a757ee7) last updated 2017/01/12 16:42:33 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Check if EIP exists before deleting it

After deleting the NAT gateway, the EIP sometimes seems to
cease to exist afterwards. Check if it exists before deleting it.

Otherwise you get:
```
Failed to release EIP eipalloc-abdc1234: An error occurred (InvalidAllocationID.NotFound) \
when calling the ReleaseAddress operation: The allocation ID 'eipalloc-abcd1234' does not \
exist", "success": false}
```

Also fix some flake8 issues in a separate commit