### PR TITLE
Service status

### DIFF
--- a/lib/ansible/modules/system/service.py
+++ b/lib/ansible/modules/system/service.py
@@ -47,7 +47,8 @@ options:
             service.  C(reloaded) will always reload. B(At least one of state
             and enabled are required.) Note that reloaded will start the
             service if it is not already started, even if your chosen init
-            system wouldn't normally.
+            system wouldn't normally. Status will return a boolean in regard
+            of the state of the services: true for running, false for stopped.
     sleep:
         required: false
         version_added: "1.3"
@@ -125,6 +126,11 @@ EXAMPLES = '''
     name: network
     state: restarted
     args: eth0
+
+# Example action to get the status of the httpd service
+- service:
+    name: httpd
+    state: status
 
 '''
 

--- a/lib/ansible/modules/system/service.py
+++ b/lib/ansible/modules/system/service.py
@@ -40,7 +40,7 @@ options:
         - Name of the service.
     state:
         required: false
-        choices: [ started, stopped, restarted, reloaded ]
+        choices: [ started, stopped, restarted, status, reloaded ]
         description:
           - C(started)/C(stopped) are idempotent actions that will not run
             commands unless necessary.  C(restarted) will always bounce the
@@ -1484,7 +1484,7 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
             name = dict(required=True),
-            state = dict(choices=['running', 'started', 'stopped', 'restarted', 'reloaded']),
+            state = dict(choices=['running', 'started', 'stopped', 'restarted', 'status', 'reloaded']),
             sleep = dict(required=False, type='int', default=None),
             pattern = dict(required=False, default=None),
             enabled = dict(type='bool'),
@@ -1529,6 +1529,9 @@ def main():
         service.check_ps()
     else:
         service.get_service_status()
+
+    if module.params['state'] == 'status':
+        module.exit_json(changed=False, state=service.running)
 
     # Calculate if request will change service state
     service.check_service_changed()

--- a/lib/ansible/modules/system/service.py
+++ b/lib/ansible/modules/system/service.py
@@ -48,7 +48,7 @@ options:
             and enabled are required.) Note that reloaded will start the
             service if it is not already started, even if your chosen init
             system wouldn't normally. Status will return a boolean in regard
-            of the state of the services: true for running, false for stopped.
+            of the state of the services, true for running, false for stopped.
     sleep:
         required: false
         version_added: "1.3"


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
service

##### ANSIBLE VERSION

```
ansible 2.0.0.2

```

##### SUMMARY

Add the option for getting the status of a service via the service module, without changing the service state.
This option return a boolean for the current status of the service:
In the example bellow, if the httpd service is down, then the service will try to start it, and the operator won't be aware that httpd was down. It's sometimes very useful to be aware of the state of a service before doing anything.

```
Before:
ok: [localhost] => {"changed": false, "invocation": {"module_args": {"arguments": "", "enabled": null, "name": "httpd", "pattern": null, "runlevel": "default", "sleep": null, "state": "started"}, "module_name": "service"}, "name": "httpd", "state": "started"}

After:
ok: [localhost] => {"changed": false, "invocation": {"module_args": {"arguments": "", "enabled": null, "name": "httpd", "pattern": null, "runlevel": "default", "sleep": null, "state": "status"}, "module_name": "service"}, "state": true}
```
