### PR TITLE
Installroot OS version check fix

### DIFF
--- a/test/integration/targets/dnf/tasks/main.yml
+++ b/test/integration/targets/dnf/tasks/main.yml
@@ -20,7 +20,7 @@
 # We want to test that for people who don't want to upgrade their systems.
 
 - include: 'dnf.yml'
-  when: (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and False) or (ansible_distribution in ['Fedora'] and ansible_distribution_major_version >= 23)
+  when: (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and False) or (ansible_distribution in ['Fedora'] and ansible_distribution_major_version|int >= 23)
 
 - include: 'dnfinstallroot.yml'
-  when: (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and False) or (ansible_distribution in ['Fedora'] and ansible_distribution_major_version >= 23)  
+  when: (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and False) or (ansible_distribution in ['Fedora'] and ansible_distribution_major_version|int >= 23)

--- a/test/integration/targets/yum/tasks/main.yml
+++ b/test/integration/targets/yum/tasks/main.yml
@@ -28,5 +28,5 @@
 # It will always run with $releasever unset
 - include: 'yuminstallroot.yml'
   when: (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] or
-        (ansible_distribution in ['Fedora'] and ansible_distribution_major_version < 23)) and
+        (ansible_distribution in ['Fedora'] and ansible_distribution_major_version|int < 23)) and
         ansible_python.version.major == 2


### PR DESCRIPTION
Cast to int before checking the OS version.
This prevents the DNF tests from running on
Fedora < 23

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- test/integration/yum
- test/integration/dnf

##### ANSIBLE VERSION
```
git
```

##### SUMMARY
The YUM and DNF tests check for OS versions and version numbers.  The tests attempt to run the correct choice of YUM or DNF on different versions of RedHat, CentOS, ScientificLinux and Fedora.  These checks have a version number check for Fedora, with the DNF split happening at version 23.

The version check isn't cast to int, so it's always true for Fedora, regardless of the version.  This causes the DNF checks to run on Fedora <= 22.

This PR just casts to int so <= and >= works as expected.