### PR TITLE
Fix required_one_of in timezone module

### DIFF
--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -437,7 +437,7 @@ def main():
             hwclock=dict(default=None, choices=['UTC', 'local'], aliases=['rtc']),
             name=dict(default=None),
         ),
-        required_one_of=['hwclock', 'name'],
+        required_one_of=[['hwclock', 'name']],
         supports_check_mode=True
     )
     tz = Timezone(module)


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

`timezone` module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (tzfix 3da3fa2eca) last updated 2017/01/12 17:31:51 (GMT +200)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This fixes a regression I introduced in https://github.com/ansible/ansible/pull/20133:

```
fatal: [ansible-dev]: FAILED! => {"changed": false, "failed": true, "msg": "one of the following is required: h,w,c,l,o,c,k"}
```