### PR TITLE
Extend SSH Retry to put_file and fetch_file

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -393,6 +393,7 @@ class Connection(ConnectionBase):
 
         return b''.join(output), remainder
 
+    @_ssh_retry
     def _run(self, cmd, in_data, sudoable=True, checkrc=True):
         '''
         Starts the command and communicates with it until it ends.
@@ -739,7 +740,6 @@ class Connection(ConnectionBase):
     #
     # Main public methods
     #
-    @_ssh_retry
     def exec_command(self, cmd, in_data=None, sudoable=True):
         ''' run a command on the remote host '''
 
@@ -765,7 +765,6 @@ class Connection(ConnectionBase):
 
         return (returncode, stdout, stderr)
 
-    @_ssh_retry
     def put_file(self, in_path, out_path):
         ''' transfer a file from local to remote '''
 
@@ -777,7 +776,6 @@ class Connection(ConnectionBase):
 
         return self._file_transport_command(in_path, out_path, 'put')
 
-    @_ssh_retry
     def fetch_file(self, in_path, out_path):
         ''' fetch a file from remote to local '''
 

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -28,6 +28,7 @@ import pty
 import subprocess
 import time
 
+from functools import wraps
 from ansible import constants as C
 from ansible.compat import selectors
 from ansible.compat.six import PY3, text_type, binary_type
@@ -48,6 +49,54 @@ except ImportError:
     display = Display()
 
 SSHPASS_AVAILABLE = None
+
+
+def _ssh_retry(func):
+    """
+    Decorator to retry ssh/scp/sftp in the case of a connection failure
+
+    Will retry if:
+    * an exception is caught
+    * ssh returns 255
+    Will not retry if
+    * remaining_tries is <2
+    * retries limit reached
+    """
+    @wraps(func)
+    def wrapped(self, *args, **kwargs):
+        remaining_tries = int(C.ANSIBLE_SSH_RETRIES) + 1
+        cmd_summary = "%s..." % args[0]
+        for attempt in range(remaining_tries):
+            try:
+                return_tuple = func(self, *args, **kwargs)
+                display.vvv(return_tuple, host=self.host)
+                # 0 = success
+                # 1-254 = remote command return code
+                # 255 = failure from the ssh command itself
+                if return_tuple[0] != 255:
+                    break
+                else:
+                    raise AnsibleConnectionFailure("Failed to connect to the host via ssh: %s" % to_native(return_tuple[2]))
+            except (AnsibleConnectionFailure, Exception) as e:
+                if attempt == remaining_tries - 1:
+                    raise
+                else:
+                    pause = 2 ** attempt - 1
+                    if pause > 30:
+                        pause = 30
+
+                    if isinstance(e, AnsibleConnectionFailure):
+                        msg = "ssh_retry: attempt: %d, ssh return code is 255. cmd (%s), pausing for %d seconds" % (attempt, cmd_summary, pause)
+                    else:
+                        msg = "ssh_retry: attempt: %d, caught exception(%s) from cmd (%s), pausing for %d seconds" % (attempt, e, cmd_summary, pause)
+
+                    display.vv(msg, host=self.host)
+
+                    time.sleep(pause)
+                    continue
+
+        return return_tuple
+    return wrapped
 
 
 class Connection(ConnectionBase):
@@ -610,28 +659,6 @@ class Connection(ConnectionBase):
 
         return (p.returncode, b_stdout, b_stderr)
 
-    def _exec_command(self, cmd, in_data=None, sudoable=True):
-        ''' run a command on the remote host '''
-
-        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
-
-        display.vvv(u"ESTABLISH SSH CONNECTION FOR USER: {0}".format(self._play_context.remote_user), host=self._play_context.remote_addr)
-
-
-        # we can only use tty when we are not pipelining the modules. piping
-        # data into /usr/bin/python inside a tty automatically invokes the
-        # python interactive-mode but the modules are not compatible with the
-        # interactive-mode ("unexpected indent" mainly because of empty lines)
-        if not in_data and sudoable:
-            args = ('ssh', '-tt', self.host, cmd)
-        else:
-            args = ('ssh', self.host, cmd)
-
-        cmd = self._build_command(*args)
-        (returncode, stdout, stderr) = self._run(cmd, in_data, sudoable=sudoable)
-
-        return (returncode, stdout, stderr)
-
     def _file_transport_command(self, in_path, out_path, sftp_action):
         # scp and sftp require square brackets for IPv6 addresses, but
         # accept them for hostnames and IPv4 addresses too.
@@ -666,7 +693,6 @@ class Connection(ConnectionBase):
                 methods = ['sftp']
 
         success = False
-        res = None
         for method in methods:
             returncode = stdout = stderr = None
             if method == 'sftp':
@@ -696,67 +722,50 @@ class Connection(ConnectionBase):
 
             # Check the return code and rollover to next method if failed
             if returncode == 0:
-                success = True
-                break
+                return (returncode, stdout, stderr)
             else:
                 # If not in smart mode, the data will be printed by the raise below
                 if len(methods) > 1:
                     display.warning(msg='%s transfer mechanism failed on %s. Use ANSIBLE_DEBUG=1 to see detailed information' % (method, host))
                     display.debug(msg='%s' % to_native(stdout))
                     display.debug(msg='%s' % to_native(stderr))
-                res = (returncode, stdout, stderr)
 
-        if not success:
-            raise AnsibleError("failed to transfer file {0} to {1}:\n{2}\n{3}"\
-            .format(to_native(in_path), to_native(out_path), to_native(res[1]), to_native(res[2])))
+        if returncode == 255:
+            raise AnsibleConnectionFailure("Failed to connect to the host via %s: %s" % (method, to_native(stderr)))
+        else:
+            raise AnsibleError("failed to transfer file to {0} {1}:\n{2}\n{3}"\
+                    .format(to_native(in_path), to_native(out_path), to_native(stdout), to_native(stderr)))
 
     #
     # Main public methods
     #
-    def exec_command(self, *args, **kwargs):
-        """
-        Wrapper around _exec_command to retry in the case of an ssh failure
+    @_ssh_retry
+    def exec_command(self, cmd, in_data=None, sudoable=True):
+        ''' run a command on the remote host '''
 
-        Will retry if:
-        * an exception is caught
-        * ssh returns 255
-        Will not retry if
-        * remaining_tries is <2
-        * retries limit reached
-        """
+        super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
 
-        remaining_tries = int(C.ANSIBLE_SSH_RETRIES) + 1
-        cmd_summary = "%s..." % args[0]
-        for attempt in range(remaining_tries):
-            try:
-                return_tuple = self._exec_command(*args, **kwargs)
-                # 0 = success
-                # 1-254 = remote command return code
-                # 255 = failure from the ssh command itself
-                if return_tuple[0] != 255:
-                    break
-                else:
-                    raise AnsibleConnectionFailure("Failed to connect to the host via ssh: %s" % to_native(return_tuple[2]))
-            except (AnsibleConnectionFailure, Exception) as e:
-                if attempt == remaining_tries - 1:
-                    raise
-                else:
-                    pause = 2 ** attempt - 1
-                    if pause > 30:
-                        pause = 30
+        display.vvv(u"ESTABLISH SSH CONNECTION FOR USER: {0}".format(self._play_context.remote_user), host=self._play_context.remote_addr)
 
-                    if isinstance(e, AnsibleConnectionFailure):
-                        msg = "ssh_retry: attempt: %d, ssh return code is 255. cmd (%s), pausing for %d seconds" % (attempt, cmd_summary, pause)
-                    else:
-                        msg = "ssh_retry: attempt: %d, caught exception(%s) from cmd (%s), pausing for %d seconds" % (attempt, e, cmd_summary, pause)
 
-                    display.vv(msg, host=self.host)
+        # we can only use tty when we are not pipelining the modules. piping
+        # data into /usr/bin/python inside a tty automatically invokes the
+        # python interactive-mode but the modules are not compatible with the
+        # interactive-mode ("unexpected indent" mainly because of empty lines)
 
-                    time.sleep(pause)
-                    continue
+        ssh_executable = self._play_context.ssh_executable
 
-        return return_tuple
+        if not in_data and sudoable:
+            args = (ssh_executable, '-tt', self.host, cmd)
+        else:
+            args = (ssh_executable, self.host, cmd)
 
+        cmd = self._build_command(*args)
+        (returncode, stdout, stderr) = self._run(cmd, in_data, sudoable=sudoable)
+
+        return (returncode, stdout, stderr)
+
+    @_ssh_retry
     def put_file(self, in_path, out_path):
         ''' transfer a file from local to remote '''
 
@@ -766,15 +775,16 @@ class Connection(ConnectionBase):
         if not os.path.exists(to_bytes(in_path, errors='surrogate_or_strict')):
             raise AnsibleFileNotFound("file or module does not exist: {0}".format(to_native(in_path)))
 
-        self._file_transport_command(in_path, out_path, 'put')
+        return self._file_transport_command(in_path, out_path, 'put')
 
+    @_ssh_retry
     def fetch_file(self, in_path, out_path):
         ''' fetch a file from remote to local '''
 
         super(Connection, self).fetch_file(in_path, out_path)
 
         display.vvv(u"FETCH {0} TO {1}".format(in_path, out_path), host=self.host)
-        self._file_transport_command(in_path, out_path, 'get')
+        return self._file_transport_command(in_path, out_path, 'get')
 
     def reset(self):
         # If we have a persistent ssh connection (ControlPersist), we can ask it to stop listening.

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -712,14 +712,14 @@ class Connection(ConnectionBase):
                 if sftp_action == 'get':
                     # we pass sudoable=False to disable pty allocation, which
                     # would end up mixing stdout/stderr and screwing with newlines
-                    (returncode, stdout, stderr) = self._exec_command('dd if=%s bs=%s' % (in_path, BUFSIZE), sudoable=False)
+                    (returncode, stdout, stderr) = self.exec_command('dd if=%s bs=%s' % (in_path, BUFSIZE), sudoable=False)
                     out_file = open(to_bytes(out_path, errors='surrogate_or_strict'), 'wb+')
                     out_file.write(stdout)
                     out_file.close()
                 else:
                     in_data = open(to_bytes(in_path, errors='surrogate_or_strict'), 'rb').read()
                     in_data = to_bytes(in_data, nonstring='passthru')
-                    (returncode, stdout, stderr) = self._exec_command('dd of=%s bs=%s' % (out_path, BUFSIZE), in_data=in_data)
+                    (returncode, stdout, stderr) = self.exec_command('dd of=%s bs=%s' % (out_path, BUFSIZE), in_data=in_data)
 
             # Check the return code and rollover to next method if failed
             if returncode == 0:

--- a/test/units/plugins/connection/test_ssh.py
+++ b/test/units/plugins/connection/test_ssh.py
@@ -25,8 +25,10 @@ from io import StringIO
 
 import pytest
 
+from contextlib import contextmanager
+
 from ansible.compat.tests import unittest
-from ansible.compat.tests.mock import patch, MagicMock
+from ansible.compat.tests.mock import patch, MagicMock, PropertyMock
 
 from ansible import constants as C
 from ansible.compat.selectors import SelectorKey, EVENT_READ
@@ -35,6 +37,58 @@ from ansible.errors import AnsibleError, AnsibleConnectionFailure, AnsibleFileNo
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.connection import ssh
 from ansible.module_utils._text import to_bytes
+
+
+@contextmanager
+def mock_run():
+    """Callers will likely need to still set the following lines themselves:
+
+            mock_popen_res.stdout.read.side_effect = [b'stdout', b'']
+            mock_popen_res.stderr.read.side_effect = [b'']
+            type(mock_popen_res).returncode = PropertyMock(side_effect=[0] * 4)
+            mock_Popen.return_value = mock_popen_res
+            res = conn.exec_command('ssh', 'some data')
+    """
+
+    mock_select = patch('select.select').start()
+    mock_fcntl = patch('fcntl.fcntl').start()
+    mock_oswrite = patch('os.write').start()
+    mock_osclose = patch('os.close').start()
+    mock_openpty = patch('pty.openpty').start()
+    mock_Popen = patch('subprocess.Popen').start()
+
+    pc = PlayContext()
+    new_stdin = StringIO()
+
+    conn = ssh.Connection(pc, new_stdin)
+    conn._send_initial_data = MagicMock()
+    conn._terminate_process = MagicMock()
+    conn.sshpass_pipe = [MagicMock(), MagicMock()]
+
+    mock_popen_res = MagicMock()
+    mock_popen_res.poll = MagicMock()
+    mock_popen_res.wait = MagicMock()
+    mock_popen_res.stdin = MagicMock()
+    mock_popen_res.stdin.fileno.return_value = 1000
+    mock_popen_res.stdout = MagicMock()
+    mock_popen_res.stdout.fileno.return_value = 1001
+    mock_popen_res.stderr = MagicMock()
+    mock_popen_res.stderr.fileno.return_value = 1002
+    mock_Popen.return_value = mock_popen_res
+
+    def _mock_select(rlist, wlist, elist, timeout=None):
+        rvals = []
+        if mock_popen_res.stdout in rlist:
+            rvals.append(mock_popen_res.stdout)
+        if mock_popen_res.stderr in rlist:
+            rvals.append(mock_popen_res.stderr)
+        return (rvals, [], [])
+
+    mock_select.side_effect = _mock_select
+
+    yield (conn, pc, mock_Popen, mock_popen_res, mock_openpty)
+
+    patch.stopall()
 
 
 class TestConnectionBaseClass(unittest.TestCase):
@@ -85,6 +139,54 @@ class TestConnectionBaseClass(unittest.TestCase):
 
         res, stdout, stderr = conn.exec_command('ssh')
         res, stdout, stderr = conn.exec_command('ssh', 'this is some data')
+
+    def test_plugins_connection_ssh__run(self):
+        with mock_run() as (conn, pc, mock_Popen, mock_popen_res, mock_openpty):
+
+            mock_popen_res.stdout.read.side_effect = [b"some data", b""]
+            mock_popen_res.stderr.read.side_effect = [b""]
+            type(mock_popen_res).returncode = PropertyMock(side_effect=[0] * 4)
+            conn._run("ssh", "this is input data")
+
+            # test with a password set to trigger the sshpass write
+            pc.password = '12345'
+            mock_popen_res.stdout.read.side_effect = [b"some data", b"", b""]
+            mock_popen_res.stderr.read.side_effect = [b""]
+            type(mock_popen_res).returncode = PropertyMock(side_effect=[0] * 4)
+            conn._run(["ssh", "is", "a", "cmd"], "this is more data")
+
+            # test with password prompting enabled
+            pc.password = ''
+            pc.prompt = 'prompt'
+            mock_popen_res.stdout.read.side_effect = [b"prompt", b"", b""]
+            mock_popen_res.stderr.read.side_effect = [b""]
+            type(mock_popen_res).returncode = PropertyMock(side_effect=[0] * 4)
+            conn._run("ssh", "this is input data")
+
+            # test with some become settings
+            pc.prompt = ''
+            pc.become = True
+            pc.success_key = 'BECOME-SUCCESS-abcdefg'
+            pc.become_method = 'sudo'
+            mock_popen_res.stdout.read.side_effect = [b"some data", b"", b""]
+            mock_popen_res.stderr.read.side_effect = [b""]
+            type(mock_popen_res).returncode = PropertyMock(side_effect=[0] * 4)
+            conn._run("ssh", "this is input data")
+
+            # simulate no data input
+            mock_openpty.return_value = (98, 99)
+            mock_popen_res.stdout.read.side_effect = [b"some data", b"", b""]
+            mock_popen_res.stderr.read.side_effect = [b""]
+            type(mock_popen_res).returncode = PropertyMock(side_effect=[0] * 4)
+            conn._run("ssh", "")
+
+            # simulate no data input but Popen using new pty's fails
+            mock_Popen.return_value = None
+            mock_Popen.side_effect = [OSError(), mock_popen_res]
+            mock_popen_res.stdout.read.side_effect = [b"some data", b"", b""]
+            mock_popen_res.stderr.read.side_effect = [b""]
+            type(mock_popen_res).returncode = PropertyMock(side_effect=[0] * 4)
+            conn._run("ssh", "")
 
     def test_plugins_connection_ssh__examine_output(self):
         pc = PlayContext()
@@ -195,31 +297,51 @@ class TestConnectionBaseClass(unittest.TestCase):
 
     @patch('time.sleep')
     def test_plugins_connection_ssh_exec_command_retries(self, mock_sleep):
-        pc = PlayContext()
-        new_stdin = StringIO()
-        conn = ssh.Connection(pc, new_stdin)
-        conn._build_command = MagicMock()
-        conn._run = MagicMock()
-
         C.ANSIBLE_SSH_RETRIES = 9
 
         # test a regular, successful execution
-        conn._run.return_value = (0, b'stdout', b'')
-        res = conn.exec_command('ssh', 'some data')
-        self.assertEquals(res, (0, b'stdout', b''), msg='exec_command did not return the expected data')
+        with mock_run() as (conn, pc, mock_Popen, mock_popen_res, mock_openpty):
+            conn._build_command = MagicMock()
+            conn._build_command.return_value = 'ssh'
+
+            mock_popen_res.stdout.read.side_effect = [b'stdout', b'']
+            mock_popen_res.stderr.read.side_effect = [b'']
+            type(mock_popen_res).returncode = PropertyMock(side_effect=[0] * 4)
+            mock_Popen.return_value = mock_popen_res
+            res = conn.exec_command('ssh', 'some data')
+            self.assertEquals(res, (0, b'stdout', b''))
+            self.assertEquals(res, (0, b'stdout', b''), msg='exec_command did not return the expected data')
 
         # test a retry, followed by success
-        conn._run.side_effect = [(255, '', ''), (0, b'stdout', b'')]
-        res = conn.exec_command('ssh', 'some data')
-        self.assertEquals(res, (0, b'stdout', b''), msg='exec_command did not return the expected data')
+        with mock_run() as (conn, pc, mock_Popen, mock_popen_res, mock_openpty):
+            conn._build_command = MagicMock()
+            conn._build_command.return_value = 'ssh'
+
+            mock_popen_res.stdout.read.side_effect = [b"", b"stdout", b""]
+            mock_popen_res.stderr.read.side_effect = [b"", b'']
+            type(mock_popen_res).returncode = PropertyMock(side_effect=[255] * 3 + [0] * 4)
+            mock_Popen.return_value = mock_popen_res
+            res = conn.exec_command('ssh', 'some data')
+            self.assertEquals(res, (0, b'stdout', b''), msg='exec_command did not return the expected data')
 
         # test multiple failures
-        conn._run.side_effect = [(255, b'', b'')] * 10
-        self.assertRaises(AnsibleConnectionFailure, conn.exec_command, 'ssh', 'some data')
+        with mock_run() as (conn, pc, mock_Popen, mock_popen_res, mock_openpty):
+            conn._build_command = MagicMock()
+            conn._build_command.return_value = 'ssh'
+
+            mock_popen_res.stdout.read.side_effect = [b""] * 10
+            mock_popen_res.stderr.read.side_effect = [b""] * 10
+            type(mock_popen_res).returncode = PropertyMock(side_effect=[255] * 30)
+            mock_Popen.return_value = mock_popen_res
+            self.assertRaises(AnsibleConnectionFailure, conn.exec_command, 'ssh', 'some data')
 
         # test other failure from exec_command
-        conn._run.side_effect = [Exception('bad')] * 10
-        self.assertRaises(Exception, conn.exec_command, 'ssh', 'some data')
+        with mock_run() as (conn, pc, mock_Popen, mock_popen_res, mock_openpty):
+            conn._build_command = MagicMock()
+            conn._build_command.return_value = 'ssh'
+
+            mock_Popen.side_effect = [Exception('bad')] * 10
+            self.assertRaises(Exception, conn.exec_command, 'ssh', 'some data')
 
     @patch('time.sleep')
     @patch('os.path.exists')
@@ -280,11 +402,18 @@ class TestConnectionBaseClass(unittest.TestCase):
         self.assertRaises(AnsibleFileNotFound, conn.put_file, '/path/to/bad/file', '/remote/path/to/file')
 
         # test a retry, followed by success
-        with patch('ansible.plugins.connection.ssh.os') as os_mock:
-            os_mock.path.exists.return_value = True
-            conn._run.side_effect = [(255, '', ''), (0, b'stdout', b'')]
-            res = conn.put_file('/path/to/in/file', '/path/to/dest/file')
-            self.assertEquals(res, (0, b'stdout', b''), msg='put_file did not return the expected response')
+        with mock_run() as (conn, pc, mock_Popen, mock_popen_res, mock_openpty):
+            with patch('ansible.plugins.connection.ssh.os') as os_mock:
+                os_mock.path.exists.return_value = True
+                conn._build_command = MagicMock()
+                conn._build_command.return_value = 'ssh'
+
+                mock_popen_res.stdout.read.side_effect = [b"", b"stdout", b""]
+                mock_popen_res.stderr.read.side_effect = [b"", b'']
+                type(mock_popen_res).returncode = PropertyMock(side_effect=[255] * 3 + [0] * 4)
+                mock_Popen.return_value = mock_popen_res
+                res = conn.put_file('/path/to/in/file', '/path/to/dest/file')
+                self.assertEquals(res, (0, b'stdout', b''), msg='put_file did not return the expected response')
 
     @patch('time.sleep')
     def test_plugins_connection_ssh_fetch_file(self, mock_sleep):
@@ -338,9 +467,17 @@ class TestConnectionBaseClass(unittest.TestCase):
         self.assertRaises(AnsibleError, conn.fetch_file, '/path/to/bad/file', '/remote/path/to/file')
 
         # test a retry, followed by success
-        conn._run.side_effect = [(255, '', ''), (0, b'stdout', b'')]
-        res = conn.fetch_file('/path/to/in/file', '/path/to/dest/file')
-        self.assertEquals(res, (0, b'stdout', b''), msg='fetch_file did not return the expected response')
+        with mock_run() as (conn, pc, mock_Popen, mock_popen_res, mock_openpty):
+            conn._build_command = MagicMock()
+            conn._build_command.return_value = 'ssh'
+
+            mock_popen_res.stdout.read.side_effect = [b"", b"stdout", b""]
+            mock_popen_res.stderr.read.side_effect = [b"", b'']
+            type(mock_popen_res).returncode = PropertyMock(side_effect=[255] * 3 + [0] * 4)
+            mock_Popen.return_value = mock_popen_res
+
+            res = conn.fetch_file('/path/to/in/file', '/path/to/dest/file')
+            self.assertEquals(res, (0, b'stdout', b''), msg='fetch_file did not return the expected response')
 
 
 class MockSelector(object):


### PR DESCRIPTION
##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
plugins/connection/ssh.py

##### ANSIBLE VERSION

```
v2.3
```

##### SUMMARY
Currently, `ANSIBLE_SSH_RETRIES` only affects `exec_command`, and does not retry `put_file` or `fetch_file`.

This PR moves the retry logic into a `_ssh_retry` decorator, and applies it to `exec_command`, `put_file`, and `fetch_file`.

cc @jamiehannaford