### PR TITLE
Fixed failure with Redis clusters not having primary endpoint address

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -1194,12 +1194,13 @@ class Ec2Inventory(object):
         if not self.all_elasticache_replication_groups and replication_group['Status'] != 'available':
             return
 
+        # Skip clusters we cannot address (e.g. private VPC subnet or clustered redis)
+        if replication_group['NodeGroups'][0]['PrimaryEndpoint'] is None or \
+           replication_group['NodeGroups'][0]['PrimaryEndpoint']['Address'] is None:
+            return
+
         # Select the best destination address (PrimaryEndpoint)
         dest = replication_group['NodeGroups'][0]['PrimaryEndpoint']['Address']
-
-        if not dest:
-            # Skip clusters we cannot address (e.g. private VPC subnet)
-            return
 
         # Add to index
         self.index[dest] = [region, replication_group['ReplicationGroupId']]


### PR DESCRIPTION
Fixed an issue where script would fail with Redis clusters where attempting to get the address off it's primary endpoint.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2 dynamic inventory script

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
It appears the the Redis clusters don't have a Primary Endpoint address, so the script currently fails because it's trying to find a key of 'Address' off an object of None (the key of 'PrimaryEndpoint' in the parent dictionary).



Before
```
[wholroyd@wholroyd-fedora Ansible]$ ./hosts --refresh-cache --boto-profile stage
Traceback (most recent call last):
  File "./hosts", line 1510, in <module>
    Ec2Inventory()
  File "./hosts", line 186, in __init__
    self.do_api_calls_update_cache()
  File "./hosts", line 492, in do_api_calls_update_cache
    self.get_elasticache_replication_groups_by_region(region)
  File "./hosts", line 722, in get_elasticache_replication_groups_by_region
    self.add_elasticache_replication_group(replication_group, region)
  File "./hosts", line 1198, in add_elasticache_replication_group
    dest = replication_group['NodeGroups'][0]['PrimaryEndpoint']['Address']
TypeError: 'NoneType' object has no attribute '__getitem__'

```

After
```
Not posting the output of my entire us-east-1 inventory, but it does work
```