### PR TITLE
os_subnet: add support for using the default subnetpool

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_subnet.py
+++ b/lib/ansible/modules/cloud/openstack/os_subnet.py
@@ -50,7 +50,8 @@ options:
    cidr:
      description:
         - The CIDR representation of the subnet that should be assigned to
-          the subnet. Required when I(state) is 'present'
+          the subnet. Required when I(state) is 'present' and a subnetpool
+          is not specified.
      required: false
      default: None
    ip_version:
@@ -108,6 +109,11 @@ options:
      choices: ['dhcpv6-stateful', 'dhcpv6-stateless', 'slaac']
      required: false
      default: None
+   use_default_subnetpool:
+     description:
+        - Use the default subnetpool for I(ip_version) to obtain a CIDR.
+     required: false
+     default: false
    project:
      description:
         - Project name or ID containing the subnet (name admin-only)
@@ -159,6 +165,9 @@ try:
     HAS_SHADE = True
 except ImportError:
     HAS_SHADE = False
+
+
+from distutils.version import StrictVersion
 
 
 def _can_update(subnet, module, cloud):
@@ -252,6 +261,7 @@ def main():
         host_routes=dict(default=None, type='list'),
         ipv6_ra_mode=dict(default=None, choice=ipv6_mode_choices),
         ipv6_address_mode=dict(default=None, choice=ipv6_mode_choices),
+        use_default_subnetpool=dict(default=False, type='bool'),
         state=dict(default='present', choices=['absent', 'present']),
         project=dict(default=None)
     )
@@ -278,13 +288,21 @@ def main():
     host_routes = module.params['host_routes']
     ipv6_ra_mode = module.params['ipv6_ra_mode']
     ipv6_a_mode = module.params['ipv6_address_mode']
+    use_default_subnetpool = module.params['use_default_subnetpool']
     project = module.params.pop('project')
+
+    if (use_default_subnetpool and
+            StrictVersion(shade.__version__) < StrictVersion('1.16.0')):
+        module.fail_json(msg="To utilize use_default_subnetpool, the installed"
+                             " version of the shade library MUST be >=1.16.0")
 
     # Check for required parameters when state == 'present'
     if state == 'present':
-        for p in ['network_name', 'cidr']:
-            if not module.params[p]:
-                module.fail_json(msg='%s required with present state' % p)
+        if not module.params['network_name']:
+            module.fail_json(msg='network_name required with present state')
+        if not module.params['cidr'] and not use_default_subnetpool:
+            module.fail_json(msg='cidr or use_default_subnetpool required '
+                                 'with present state')
 
     if pool_start and pool_end:
         pool = [dict(start=pool_start, end=pool_end)]
@@ -316,18 +334,20 @@ def main():
 
         if state == 'present':
             if not subnet:
-                subnet = cloud.create_subnet(network_name, cidr,
-                                             ip_version=ip_version,
-                                             enable_dhcp=enable_dhcp,
-                                             subnet_name=subnet_name,
-                                             gateway_ip=gateway_ip,
-                                             disable_gateway_ip=no_gateway_ip,
-                                             dns_nameservers=dns,
-                                             allocation_pools=pool,
-                                             host_routes=host_routes,
-                                             ipv6_ra_mode=ipv6_ra_mode,
-                                             ipv6_address_mode=ipv6_a_mode,
-                                             tenant_id=project_id)
+                subnet = cloud.create_subnet(
+                    network_name, cidr,
+                    ip_version=ip_version,
+                    enable_dhcp=enable_dhcp,
+                    subnet_name=subnet_name,
+                    gateway_ip=gateway_ip,
+                    disable_gateway_ip=no_gateway_ip,
+                    dns_nameservers=dns,
+                    allocation_pools=pool,
+                    host_routes=host_routes,
+                    ipv6_ra_mode=ipv6_ra_mode,
+                    ipv6_address_mode=ipv6_a_mode,
+                    use_default_subnetpool=use_default_subnetpool,
+                    tenant_id=project_id)
                 changed = True
             else:
                 if _needs_update(subnet, module, cloud):


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME
os_subnet module

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

The `use_default_subnetpool` option was [recently added](https://review.openstack.org/#/c/416319) to the shade library. This pull request implements and documents this option in the os_subnet module.

This feature is required to add IPv6 subnets if the OpenStack installation has either BGP or prefix delegation enabled.

##### DEPENDS ON

[shade](https://pypi.python.org/pypi/shade)>1.14.1 or including [9e818c0af](https://github.com/openstack-infra/shade/commit/9e818c0afdb280a374cb2418cf4a277c3867e218)