### PR TITLE
htpasswd: fix passlib module version comparison

### DIFF
--- a/lib/ansible/modules/web_infrastructure/htpasswd.py
+++ b/lib/ansible/modules/web_infrastructure/htpasswd.py
@@ -103,7 +103,7 @@ EXAMPLES = """
 
 import os
 import tempfile
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 
 try:
     from passlib.apache import HtpasswdFile, htpasswd_context
@@ -137,7 +137,7 @@ def present(dest, username, password, crypt_scheme, create, check_mode):
         if check_mode:
             return ("Create %s" % dest, True)
         create_missing_directories(dest)
-        if StrictVersion(passlib.__version__) >= StrictVersion('1.6'):
+        if LooseVersion(passlib.__version__) >= LooseVersion('1.6'):
             ht = HtpasswdFile(dest, new=True, default_scheme=crypt_scheme, context=context)
         else:
             ht = HtpasswdFile(dest, autoload=False, default=crypt_scheme, context=context)
@@ -148,7 +148,7 @@ def present(dest, username, password, crypt_scheme, create, check_mode):
         ht.save()
         return ("Created %s and added %s" % (dest, username), True)
     else:
-        if StrictVersion(passlib.__version__) >= StrictVersion('1.6'):
+        if LooseVersion(passlib.__version__) >= LooseVersion('1.6'):
             ht = HtpasswdFile(dest, new=False, default_scheme=crypt_scheme, context=context)
         else:
             ht = HtpasswdFile(dest, default=crypt_scheme, context=context)
@@ -175,7 +175,7 @@ def absent(dest, username, check_mode):
     """ Ensures user is absent
 
     Returns (msg, changed) """
-    if StrictVersion(passlib.__version__) >= StrictVersion('1.6'):
+    if LooseVersion(passlib.__version__) >= LooseVersion('1.6'):
         ht = HtpasswdFile(dest, new=False)
     else:
         ht = HtpasswdFile(dest)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
htpasswd module

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```
(also confirmed problem exists with latest git)

##### SUMMARY

Previously, we used StrictVersion which failed to parse some passlib
version strings. For example, Debian currently ship passlib with a
__version__ of '1.7.0.post20161128115349'

StrictVersion throws an exception when parsing this version string.

Change to using LooseVersion which successfully parses version strings
such as this.

Fixes #20199

<!-- Paste verbatim command output below, e.g. before and after your change -->

Before - fails like so:

```
FAILED! => {"changed": false, "failed": true, "msg": "invalid version number '1.7.0.post20161128115349'"}
```

After - no errors
