### PR TITLE
Correct nmcli dns example and documentation. Fix example indent

### DIFF
--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -62,7 +62,7 @@ options:
         required: False
         choices: [ ethernet, team, team-slave, bond, bond-slave, bridge, vlan ]
         description:
-            - This is the type of device or network connection that you wish to create.
+            - This is the type of device or network connection that you wish to create or modify.
     mode:
         required: False
         choices: [ "balance-rr", "active-backup", "balance-xor", "broadcast", "802.3ad", "balance-tlb", "balance-alb" ]
@@ -87,7 +87,7 @@ options:
         required: False
         default: None
         description:
-            - 'A list of upto 3 dns servers, ipv4 format e.g. To add two IPv4 DNS server addresses: ["192.0.2.53", "198.51.100.53"]'
+            - 'A list of upto 3 dns servers, ipv4 format e.g. To add two IPv4 DNS server addresses: "192.0.2.53 198.51.100.53"'
     ip6:
         required: False
         default: None
@@ -101,7 +101,7 @@ options:
     dns6:
         required: False
         description:
-            - 'A list of upto 3 dns servers, ipv6 format e.g. To add two IPv6 DNS server addresses: ["2001:4860:4860::8888 2001:4860:4860::8844"]'
+            - 'A list of upto 3 dns servers, ipv6 format e.g. To add two IPv6 DNS server addresses: "2001:4860:4860::8888 2001:4860:4860::8844"'
     mtu:
         required: False
         default: 1500
@@ -424,7 +424,7 @@ EXAMPLES='''
       - conn_name: team-p2p2
 
 # To add an Ethernet connection with static IP configuration, issue a command as follows
-- nmcli:
+  - nmcli:
     conn_name: my-eth1
     ifname: eth1
     type: ethernet
@@ -433,7 +433,7 @@ EXAMPLES='''
     state: present
 
 # To add an Team connection with static IP configuration, issue a command as follows
-- nmcli:
+  - nmcli:
     conn_name: my-team1
     ifname: my-team1
     type: team
@@ -443,7 +443,7 @@ EXAMPLES='''
     autoconnect: yes
 
 # Optionally, at the same time specify IPv6 addresses for the device as follows:
-- nmcli:
+  - nmcli:
     conn_name: my-eth1
     ifname: eth1
     type: ethernet
@@ -454,22 +454,23 @@ EXAMPLES='''
     state: present
 
 # To add two IPv4 DNS server addresses:
-- nmcli:
+  - nmcli:
     conn_name: my-eth1
+    type: ethernet
     dns4:
       - 192.0.2.53
       - 198.51.100.53
     state: present
 
 # To make a profile usable for all compatible Ethernet interfaces, issue a command as follows
-- nmcli:
+  - nmcli:
     ctype: ethernet
     name: my-eth1
     ifname: '*'
     state: present
 
 # To change the property of a setting e.g. MTU, issue a command as follows:
-- nmcli:
+  - nmcli:
     conn_name: my-eth1
     mtu: 9000
     type: ethernet


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
nmcli

##### ANSIBLE VERSION
Tested with:
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

1)

Fix dns configuration documentation that caused this https://github.com/ansible/ansible-modules-extras/issues/1910

Instead of dns4: ["1.1.1.1", "2.2.2.2"] it should be "1.1.1.1, 2.2.2.2" or "1.1.1.1 2.2.2.2".
The latter is the way that is in the nmcli documentation so we'll use it here as well.

Same applies to dns6.

2)

Fix the documentation stating that the parameter type is only required for creating connections. This also caused the dns example to fail.

Related to https://github.com/ansible/ansible-modules-extras/issues/1843

3)

Fix broken indentation in multiple sections of the example playbook that caused it not to parse.



##### Errors with original

`type=ethernet` missing when trying to modify a connection (e.g. set dns)
```
TASK [nmcli] *******************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: IndexError: list index out of range
fatal: [localhost]: FAILED! => {"changed": false, "cmd": "", "failed": true, "msg": "list index out of range", "rc": 257}
        to retry, use: --limit @/root/test1.retry
```

invalid dns4 parameter format:
```
ERROR! this task 'nmcli' has extra params, which is only allowed in the following modules: command, win_command, shell, win_shell, script, include, include_vars, add_host, group_by, set_fact, raw, meta

```

and

```
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Error: failed to modify ipv4.dns: invalid IPv4 address '['8.8.8.8''.\n", "name": "eth0", "rc": 2}
```

Broken indentation:

```
ERROR! Syntax Error while loading YAML.

The error appears to have been in '/root/nmcli-add.yml': line 45, column 2, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:
 - name: try nmcli add bond - conn_name only & ip4 gw4 mode
 ^ here
```