### PR TITLE
resource overriden when conn_type='both'

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -113,8 +113,8 @@ def _boto3_conn(conn_type=None, resource=None, region=None, endpoint=None, **par
         client = boto3.session.Session(profile_name=profile).client(resource, region_name=region, endpoint_url=endpoint, **params)
         return client
     else:
-        resource = boto3.session.Session(profile_name=profile).resource(resource, region_name=region, endpoint_url=endpoint, **params)
         client = boto3.session.Session(profile_name=profile).client(resource, region_name=region, endpoint_url=endpoint, **params)
+        resource = boto3.session.Session(profile_name=profile).resource(resource, region_name=region, endpoint_url=endpoint, **params)
         return client, resource
 
 boto3_inventory_conn = _boto3_conn


### PR DESCRIPTION
Simple change to avoid resource param override when using conn_type == 'both'
in line 116 of lib/ansible/module_utils/ec2.py
def _boto3_conn(conn_type=None, resource=None, region=None, endpoint=None, **params)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/ec2.py 
##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### SUMMARY
simply swap the order of execution so that resource is last when conn_type='both'
this change avoids the function param variable from being overwritten by the boto3 resource result.

issue before change:
```
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Connection Error - Unknown service: 'ec2()'. Valid service names are: acm, apigateway, application-autoscaling, autoscaling, budgets, cloudformation, cloudfront, cloudhsm, cloudsearch, cloudsearchdomain, cloudtrail, cloudwatch, codecommit, codedeploy, codepipeline, cognito-identity, cognito-idp, cognito-sync, config, datapipeline, devicefarm, directconnect, discovery, dms, ds, dynamodb, dynamodbstreams, ec2, ecr, ecs, efs, elasticache, elasticbeanstalk, elastictranscoder, elb, elbv2, emr, es, events, firehose, gamelift, glacier, iam, importexport, inspector, iot, iot-data, kinesis, kinesisanalytics, kms, lambda, logs, machinelearning, marketplacecommerceanalytics, meteringmarketplace, opsworks, rds, redshift, route53, route53domains, s3, sdb, servicecatalog, ses, sms, snowball, sns, sqs, ssm, storagegateway, sts, support, swf, waf, workspaces"}
```