### PR TITLE
Enable first network tests on Shippable.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -20,6 +20,8 @@ matrix:
     - env: TEST=windows/2
     - env: TEST=windows/3
 
+    - env: TEST=network
+
     - env: TEST=linux/centos6/1
     - env: TEST=linux/centos7/1
     - env: TEST=linux/fedora24/1

--- a/test/integration/targets/net_command/aliases
+++ b/test/integration/targets/net_command/aliases
@@ -1,1 +1,2 @@
 network/basics
+network/ci

--- a/test/runner/requirements/network-integration.txt
+++ b/test/runner/requirements/network-integration.txt
@@ -1,0 +1,5 @@
+jinja2
+junit-xml
+paramiko
+pycrypto
+pyyaml

--- a/test/utils/shippable/network.sh
+++ b/test/utils/shippable/network.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -eux
+
+set -o pipefail
+
+ansible-test network-integration --explain 2>&1 | { grep ' network-integration: .* (targeted)$' || true; } > /tmp/network.txt
+
+target="network/ci/"
+
+if [ -s /tmp/network.txt ]; then
+    echo "Detected changes requiring integration tests specific to networking:"
+    cat /tmp/network.txt
+
+    echo "Running network integration tests for multiple platforms concurrently."
+
+    ansible-test network-integration --color -v --retry-on-error "${target}" --requirements \
+        --platform vyos/1.1.0 \
+
+else
+    echo "No changes requiring integration tests specific to networking were detected."
+    echo "Running network integration tests for a single platform only."
+
+    ansible-test network-integration --color -v --retry-on-error "${target}" --requirements \
+        --platform vyos/1.1.0
+fi

--- a/test/utils/shippable/network.sh
+++ b/test/utils/shippable/network.sh
@@ -2,8 +2,6 @@
 
 set -o pipefail
 
-pip install tox --disable-pip-version-check
-
 ansible-test network-integration --explain 2>&1 | { grep ' network-integration: .* (targeted)$' || true; } > /tmp/network.txt
 
 target="network/ci/"
@@ -14,13 +12,13 @@ if [ -s /tmp/network.txt ]; then
 
     echo "Running network integration tests for multiple platforms concurrently."
 
-    ansible-test network-integration --color -v --retry-on-error "${target}" --tox --python 2.7 \
+    ansible-test network-integration --color -v --retry-on-error "${target}" --requirements \
         --platform vyos/1.1.0 \
 
 else
     echo "No changes requiring integration tests specific to networking were detected."
     echo "Running network integration tests for a single platform only."
 
-    ansible-test network-integration --color -v --retry-on-error "${target}" --tox --python 2.7 \
+    ansible-test network-integration --color -v --retry-on-error "${target}" --requirements \
         --platform vyos/1.1.0
 fi

--- a/test/utils/shippable/network.sh
+++ b/test/utils/shippable/network.sh
@@ -2,6 +2,8 @@
 
 set -o pipefail
 
+pip install tox --disable-pip-version-check
+
 ansible-test network-integration --explain 2>&1 | { grep ' network-integration: .* (targeted)$' || true; } > /tmp/network.txt
 
 target="network/ci/"
@@ -12,13 +14,13 @@ if [ -s /tmp/network.txt ]; then
 
     echo "Running network integration tests for multiple platforms concurrently."
 
-    ansible-test network-integration --color -v --retry-on-error "${target}" --requirements \
+    ansible-test network-integration --color -v --retry-on-error "${target}" --tox --python 2.7 \
         --platform vyos/1.1.0 \
 
 else
     echo "No changes requiring integration tests specific to networking were detected."
     echo "Running network integration tests for a single platform only."
 
-    ansible-test network-integration --color -v --retry-on-error "${target}" --requirements \
+    ansible-test network-integration --color -v --retry-on-error "${target}" --tox --python 2.7 \
         --platform vyos/1.1.0
 fi


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

Tests

##### ANSIBLE VERSION

```
ansible 2.3.0 (network-ci 0028198645) last updated 2017/01/12 17:29:34 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Enable first network tests on Shippable.