### PR TITLE
Update docker example on Inventory page

### DIFF
--- a/docs/docsite/rst/intro_inventory.rst
+++ b/docs/docsite/rst/intro_inventory.rst
@@ -310,7 +310,8 @@ ansible_docker_extra_args
 Here is an example of how to instantly deploy to created containers::
 
   - name: create jenkins container
-    docker:
+    docker_container:
+      docker_host: myserver.net:4243
       name: my_jenkins
       image: jenkins
 


### PR DESCRIPTION
The docker module has been deprecated, so the example should be
updated to use the newer docker_container module.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docker

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
The docker module has been deprecated, so the example should be updated
to use the newer docker_container module.
