### PR TITLE
module_utils/basic.py: Support logical or condition in required_if

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1447,12 +1447,19 @@ class AnsibleModule(object):
             return
         for (key, val, requirements) in spec:
             missing = []
+            max_missing_count = 0
+
+            # If requirements is of type tuple at least one must be
+            # present, if it is of type list all must be present.
+            if isinstance(requirements, tuple):
+                max_missing_count = len(requirements)
+
             if key in self.params and self.params[key] == val:
                 for check in requirements:
                     count = self._count_terms((check,))
                     if count == 0:
                         missing.append(check)
-            if len(missing) > 0:
+            if len(missing) and len(missing) >= max_missing_count:
                 self.fail_json(msg="%s is %s but the following are missing: %s" % (key, val, ','.join(missing)))
 
     def _check_argument_values(self):

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1445,13 +1445,18 @@ class AnsibleModule(object):
         ''' ensure that parameters which conditionally required are present '''
         if spec is None:
             return
-        for (key, val, requirements) in spec:
+        for sp in spec:
             missing = []
             max_missing_count = 0
+            is_one_of = False
+            if len(sp) == 4:
+                key, val, requirements, is_one_of = sp
+            else:
+                key, val, requirements = sp
 
-            # If requirements is of type tuple at least one must be
-            # present, if it is of type list all must be present.
-            if isinstance(requirements, tuple):
+            # is_one_of is True at least one requirement should be
+            # present, else all requirements should be present.
+            if is_one_of:
                 max_missing_count = len(requirements)
 
             if key in self.params and self.params[key] == val:


### PR DESCRIPTION

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
basic

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible --version
ansible 2.3.0 (devel cba66dfedc)
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
Add logical 'or' condition support in 'required_if'
for requirements.
* If requirements is a list all parameters within it should
  be present.
* If requirements is a tuple atleast one parameter should
  be present
```
