### PR TITLE
Detect VyOS based on /etc/issue (support 1.0.5)

### DIFF
--- a/lib/ansible/plugins/terminal/vyos.py
+++ b/lib/ansible/plugins/terminal/vyos.py
@@ -47,6 +47,6 @@ class TerminalModule(TerminalBase):
     @staticmethod
     def guess_network_os(conn):
         stdin, stdout, stderr = conn.exec_command('cat /etc/issue')
-        if 'vyos' in stdout.read():
-            return 'VyOS'
+        if 'VyOS' in stdout.read():
+            return 'vyos'
 

--- a/lib/ansible/plugins/terminal/vyos.py
+++ b/lib/ansible/plugins/terminal/vyos.py
@@ -46,7 +46,7 @@ class TerminalModule(TerminalBase):
 
     @staticmethod
     def guess_network_os(conn):
-        stdin, stdout, stderr = conn.exec_command('cat /proc/version')
+        stdin, stdout, stderr = conn.exec_command('cat /etc/issue')
         if 'vyos' in stdout.read():
-            return 'vyos'
+            return 'VyOS'
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vyos_*

##### ANSIBLE VERSION

##### SUMMARY
The previous detection mechanism wasn't working on 1.0.5

VyOS 1.0.5
```
cat /proc/version
Linux version 3.3.8-1-amd64-vyatta (dmbaturin@squeeze64devel) (gcc version 4.4.5 (Debian 4.4.5-8) ) #1 SMP Wed Oct 30 22:54:40 CET 2013
```
Notice no `vyos` in the output


The following is consistent on 1.0.5 and 1.1.0, and feels like a cleaner check
```
cat /etc/issue
Welcome to VyOS - \n \l
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/20221)
<!-- Reviewable:end -->
