### PR TITLE
Cannot use synchronize with docker, add a note to documentation

### DIFF
--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -183,6 +183,7 @@ notes:
    - rsync daemon must be up and running with correct permission when using
      rsync protocol in source or destination path.
    - The C(synchronize) module forces `--delay-updates` to avoid leaving a destination in a broken in-between state if the underlying rsync process encounters an error. Those synchronizing large numbers of files that are willing to trade safety for performance should call rsync directly.
+   - You cannot use this module when accessing a host via docker. Because rsync needs to connect to the remote host via ssh or a direct filesystem copy
 
 author: "Timothy Appnel (@tima)"
 '''


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
synchronize
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
You can't use synchronize module over docker connection. Added a note to the documentation about it.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
synchronize uses rsync to function. rsync needs to connect to the remote host via ssh or a direct filesystem copy. This remote host is being accessed via docker instead so it cannot work.
```
