### PR TITLE
Remove outdated 'user' requirements and add a note trying to reflect reality.

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -28,7 +28,10 @@ module: user
 author: "Stephen Fromm (@sfromm)"
 version_added: "0.2"
 short_description: Manage user accounts
-requirements: [ useradd, userdel, usermod ]
+notes:
+  - There are specific requirements per platform on user management utilities. However
+    they generally come pre-installed with the system and Ansible will require they
+    are present at runtime. If they are not, a descriptive error message will be shown.
 description:
     - Manage user accounts and user attributes.
 options:


### PR DESCRIPTION
##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

`user` module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (user_13305 122799c95c) last updated 2017/01/13 15:45:26 (GMT +200)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY

This is a possible way to address #13305. We could list all the required tools per platform, however that list is likely to get outdated again, just like `requirements` did.