### PR TITLE
Correct freebsd startup test for CI.

### DIFF
--- a/test/utils/shippable/remote.sh
+++ b/test/utils/shippable/remote.sh
@@ -99,13 +99,15 @@ case "${test_platform}" in
         inventory_template="${source_root}/test/integration/inventory.winrm.template"
         inventory_file="${source_root}/test/integration/inventory.winrm"
         ping_module="win_ping"
+        ping_args=""
         ping_host="windows"
         test_function="test_windows"
         ;;
     *)
         inventory_template="${source_root}/test/integration/inventory.remote.template"
         inventory_file="${source_root}/test/integration/inventory.remote"
-        ping_module="ping"
+        ping_module="raw"
+        ping_args="id"
         ping_host="remote"
         test_function="test_remote"
         ;;
@@ -124,7 +126,7 @@ for i in $(seq 1 ${n}); do
         ANSIBLE_SSH_ARGS='' \
         ANSIBLE_HOST_KEY_CHECKING=False \
         ANSIBLE_FORCE_COLOR="${force_color}" \
-        ansible -m "${ping_module}" -i "${inventory_file}" "${ping_host}"; then
+        ansible -m "${ping_module}" -a "${ping_args}" -i "${inventory_file}" "${ping_host}"; then
         break
     fi
     sleep 5


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

CI

##### ANSIBLE VERSION

```
ansible 2.2.1.0 (ci-2.2 0c26b731f8) last updated 2017/01/13 09:25:00 (GMT -700)
```

##### SUMMARY

Correct freebsd startup test for CI.