### PR TITLE
Warn when using the deprecated HEADER_ arguments

### DIFF
--- a/lib/ansible/modules/network/basics/uri.py
+++ b/lib/ansible/modules/network/basics/uri.py
@@ -411,12 +411,12 @@ def main():
 
     # Grab all the http headers. Need this hack since passing multi-values is
     # currently a bit ugly. (e.g. headers='{"Content-Type":"application/json"}')
-    warnings = set()
+    deprecations = set()
     for key, value in six.iteritems(module.params):
         if key.startswith("HEADER_"):
-            warnings.add('Supplying headers via HEADER_* is deprecated and '
-                         'will be removed in a future version. Please use '
-                         '`headers` to supply headers for the request')
+            deprecations.add('Supplying headers via HEADER_* is deprecated and '
+                             'will be removed in a future version. Please use '
+                             '`headers` to supply headers for the request')
             skey = key.replace("HEADER_", "")
             dict_headers[skey] = value
 
@@ -465,8 +465,8 @@ def main():
         ukey = key.replace("-", "_").lower()
         uresp[ukey] = value
 
-    if warnings:
-        uresp['warnings'] = list(warnings)
+    for msg in deprecations:
+        module.deprecate(msg, 2.4)
 
     try:
         uresp['location'] = absolute_location(url, uresp['location'])

--- a/lib/ansible/modules/network/basics/uri.py
+++ b/lib/ansible/modules/network/basics/uri.py
@@ -411,8 +411,12 @@ def main():
 
     # Grab all the http headers. Need this hack since passing multi-values is
     # currently a bit ugly. (e.g. headers='{"Content-Type":"application/json"}')
+    warnings = set()
     for key, value in six.iteritems(module.params):
         if key.startswith("HEADER_"):
+            warnings.add('Supplying headers via HEADER_* is deprecated and '
+                         'will be removed in a future version. Please use '
+                         '`headers` to supply headers for the request')
             skey = key.replace("HEADER_", "")
             dict_headers[skey] = value
 
@@ -460,6 +464,9 @@ def main():
     for key, value in six.iteritems(resp):
         ukey = key.replace("-", "_").lower()
         uresp[ukey] = value
+
+    if warnings:
+        uresp['warnings'] = list(warnings)
 
     try:
         uresp['location'] = absolute_location(url, uresp['location'])

--- a/lib/ansible/modules/network/basics/uri.py
+++ b/lib/ansible/modules/network/basics/uri.py
@@ -411,10 +411,9 @@ def main():
 
     # Grab all the http headers. Need this hack since passing multi-values is
     # currently a bit ugly. (e.g. headers='{"Content-Type":"application/json"}')
-    deprecations = set()
     for key, value in six.iteritems(module.params):
         if key.startswith("HEADER_"):
-            deprecations.add('Supplying headers via HEADER_* is deprecated and '
+            module.deprecate('Supplying headers via HEADER_* is deprecated and '
                              'will be removed in a future version. Please use '
                              '`headers` to supply headers for the request')
             skey = key.replace("HEADER_", "")
@@ -464,9 +463,6 @@ def main():
     for key, value in six.iteritems(resp):
         ukey = key.replace("-", "_").lower()
         uresp[ukey] = value
-
-    for msg in deprecations:
-        module.deprecate(msg, 2.4)
 
     try:
         uresp['location'] = absolute_location(url, uresp['location'])

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -180,7 +180,8 @@
     url: 'http://{{ httpbin_host }}/digest-auth/auth/user/passwd'
     user: user
     password: passwd
-    HEADER_Cookie: "fake=fake_value"
+    headers:
+      Cookie: "fake=fake_value"
 
 - name: test PUT
   uri:
@@ -293,3 +294,11 @@
     return_content: true
   register: result
   failed_when: result.json.headers['Content-Type'] != 'text/json'
+
+- name: Test using HEADER_ generates a warning
+  uri:
+    url: "https://{{ httpbin_host }}/get"
+    HEADER_Foo: bar
+    return_content: true
+  register: result
+  failed_when: '"HEADER_*" not in result.warnings|default([""])|join("")'

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -294,11 +294,3 @@
     return_content: true
   register: result
   failed_when: result.json.headers['Content-Type'] != 'text/json'
-
-- name: Test using HEADER_ generates a warning
-  uri:
-    url: "https://{{ httpbin_host }}/get"
-    HEADER_Foo: bar
-    return_content: true
-  register: result
-  failed_when: '"HEADER_*" not in result.warnings|default([""])|join("")'


### PR DESCRIPTION
##### ISSUE TYPE
New Module Pull Request

##### COMPONENT NAME
uri

##### ANSIBLE VERSION

```
v2.3
```

##### SUMMARY
As of 2.1 we "deprecated" the `HEADER_` arguments in favor of `headers`.  This PR adds warnings to the module, so that we can proceed with deprecating `HEADER_*` in the future.