### PR TITLE
Annotate boto3 dependency in the standard location.

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
@@ -24,7 +24,7 @@ DOCUMENTATION = '''
 module: ec2_ami_copy
 short_description: copies AMI between AWS regions, return new image id
 description:
-    - Copies AMI from a source region to a destination region. (Since version 2.3 this module depends on boto3)
+    - Copies AMI from a source region to a destination region. B(Since version 2.3 this module depends on boto3.)
 version_added: "2.0"
 options:
   source_region:
@@ -73,11 +73,12 @@ options:
       - A hash/dictionary of tags to add to the new copied AMI; '{"key":"value"}' and '{"key":"value","key":"value"}'
     required: false
     default: null
-
 author: "Amir Moulavi <amir.moulavi@gmail.com>, Tim C <defunct@defunct.io>"
 extends_documentation_fragment:
     - aws
     - ec2
+requirements:
+    - boto3
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

`ec2_ami_copy` module

##### ANSIBLE VERSION

```
v2.3
```

##### SUMMARY

This module did not mark it's dependency on `boto3` in the standard location, fix that.
Noticed when looking at https://github.com/ansible/ansible/issues/20238