### PR TITLE
added ldap auth capability to hashi_vault plugin

### DIFF
--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -54,15 +54,10 @@ class HashiVault:
             raise AnsibleError("Please pip install hvac to use this module")
 
         self.url = kwargs.get('url', ANSIBLE_HASHI_VAULT_ADDR)
-<<<<<<< HEAD
-
         self.token = kwargs.get('token')
         if self.token is None:
             raise AnsibleError("No Vault Token specified")
 
-=======
-        
->>>>>>> added ldap authentication capability
         # split secret arg, which has format 'secret/hello:value' into secret='secret/hello' and secret_field='value'
         s = kwargs.get('secret')
         if s is None:


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
hashi_vault lookup plugin

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### SUMMARY
Added the ability to supply username/password credentials in a lookup, and have HashiCorp Vault authenticate against its ldap backend.


<!-- Paste verbatim command output below, e.g. before and after your change -->
```
  tasks:
    - debug:
        msg: "{{ lookup('hashi_vault', 'secret=secret/test:k token=0425f12f-ad10-811f-ec9604a6596c5e25 url=http://vault:8200')}}"

    # ldap authentication
    - debug:
        msg: "{{ lookup('hashi_vault', 'auth_method=ldap secret=secret/test:k username={{ username }} password={{ password }} url=http://vault:8200')}}"
```