### PR TITLE
fix service status setting

### DIFF
--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -359,8 +359,11 @@ def main():
         if rc == 0:
             enabled = True
         elif rc == 1:
-            # if both init script and unit file exist stdout should have enabled/disabled, otherwise use rc entries
-            if is_initd and (not out.startswith('disabled') or sysv_is_enabled(unit)):
+            # if not a user service and both init script and unit file exist stdout should have enabled/disabled, otherwise use rc entries
+            if not module.params['user'] and \
+               is_initd and \
+               (not out.strip().endswith('disabled') or sysv_is_enabled(unit)):
+
                 enabled = True
 
         # default to current state


### PR DESCRIPTION

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
systemd

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

fixes #18687 as 'disabled' can be at the end of the output
fixes #20228 by not falling back to init scripts when it is a user service
