### PR TITLE
Fix python 3.6 install on Shippable.

### DIFF
--- a/test/utils/shippable/other.sh
+++ b/test/utils/shippable/other.sh
@@ -3,14 +3,17 @@
 set -o pipefail
 
 add-apt-repository 'deb http://archive.ubuntu.com/ubuntu trusty-backports universe'
+add-apt-repository 'ppa:ubuntu-toolchain-r/test'
 add-apt-repository 'ppa:fkrull/deadsnakes'
-add-apt-repository 'ppa:jonathonf/python-3.6'
 
 apt-get update -qq
 apt-get install -qq \
     shellcheck \
     python2.4 \
-    python3.6 \
+    g++-4.9 \
+    python3.6-dev \
+
+ln -sf x86_64-linux-gnu-gcc-4.9 /usr/bin/x86_64-linux-gnu-gcc
 
 pip install tox --disable-pip-version-check
 

--- a/test/utils/shippable/units.sh
+++ b/test/utils/shippable/units.sh
@@ -3,7 +3,7 @@
 set -o pipefail
 
 add-apt-repository 'ppa:ubuntu-toolchain-r/test'
-add-apt-repository 'ppa:jonathonf/python-3.6'
+add-apt-repository 'ppa:fkrull/deadsnakes'
 
 apt-get update -qq
 apt-get install -qq \


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

CI

##### ANSIBLE VERSION

```
ansible 2.3.0 (python-3.6 8bbc04d7ea) last updated 2017/01/13 14:30:48 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Fix python 3.6 install.