### PR TITLE
Pop password from os_user params

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_user.py
+++ b/lib/ansible/modules/cloud/openstack/os_user.py
@@ -201,7 +201,7 @@ def main():
         module.fail_json(msg='shade is required for this module')
 
     name = module.params['name']
-    password = module.params['password']
+    password = module.params.pop('password')
     email = module.params['email']
     default_project = module.params['default_project']
     domain = module.params['domain']


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
os_user

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
The password param conflicts with os-client-config's password grabbing.
The rest of the params really probably should also be popped - but
keeping this just to password for now. Will follow up with a change that
does an audit of all the os_ modules

This patch was previously contributed by @emonty to the former
ansible-modules-core repo however since the merge, it was closed
and not completed.  This patch includes the necessary changes cleaned
up to work with the latest release of Ansible.  This has been
tested to work internally

```
changed: [openstack-keystone] => (item={u'domain': u'default', u'password': u'foobar', u'name': u'demo'})
```
