### PR TITLE
modified:   lib/ansible/modules/network/nxos/nxos_vxlan_vtep_vni.py

### DIFF
--- a/lib/ansible/module_utils/netcfg.py
+++ b/lib/ansible/module_utils/netcfg.py
@@ -69,6 +69,10 @@ class ConfigLine(object):
     def parents(self):
         return _obj_to_text(self._parents)
 
+    @parents.setter
+    def parents(self, p):
+        self._parents = p
+
     @property
     def path(self):
         config = _obj_to_raw(self._parents)
@@ -139,6 +143,10 @@ class NetworkConfig(object):
     @property
     def items(self):
         return self._items
+
+    @property
+    def indent(self):
+        return self._indent
 
     def __getitem__(self, key):
         for line in self:

--- a/lib/ansible/modules/network/nxos/nxos_vxlan_vtep_vni.py
+++ b/lib/ansible/modules/network/nxos/nxos_vxlan_vtep_vni.py
@@ -233,7 +233,7 @@ class CustomNetworkConfig(NetworkConfig):
 
                 except ValueError:
                     # add parent to config
-                    offset = index * self._indent
+                    offset = index * self.indent
                     obj = ConfigLine(p)
                     obj.raw = p.rjust(len(p) + offset)
                     if ancestors:
@@ -249,10 +249,10 @@ class CustomNetworkConfig(NetworkConfig):
                     if child.text == line:
                         break
                 else:
-                    offset = len(parents) * self._indent
+                    offset = len(parents) * self.indent
                     item = ConfigLine(line)
                     item.raw = line.rjust(len(line) + offset)
-                    item._parents = ancestors
+                    item.parents = ancestors
                     ancestors[-1].children.append(item)
                     self.items.append(item)
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_vxlan_vtep_vni

##### ANSIBLE VERSION
```
ansible 2.3.0 (nxos_vxlan_vtep_vni 3395a12256) last updated 2017/01/14 16:29:43 (GMT -500)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
- Corrected type mismatch in `expand_section`
- Check for empty `parents` in `get_object`
- Corrected `_indent` property in `add`
- Corrected `_parents` property in `add` since `netcfg.ConfigLine.parents` has no setter method
Fixes Issue #20260 


```
    "updates": [
        "interface nve1",
        "no member vni XXXX"
    ]
```
