### PR TITLE
Fix #20265 junos_command output for xml format

### DIFF
--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -139,7 +139,8 @@ class Netconf(object):
             if cmd.output == 'xml':
                 responses[index] = xml_to_string(responses[index])
             elif cmd.output == 'json':
-                responses[index] = xml_to_json(responses[index])
+                if not isinstance(responses[index], dict):
+                    responses[index] = xml_to_json(responses[index])
             elif cmd.args.get('command_type') == 'rpc':
                 responses[index] = str(responses[index].text).strip()
             elif 'RpcError' in responses[index]:

--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -137,6 +137,8 @@ class Netconf(object):
 
         for index, cmd in enumerate(commands):
             if cmd.output == 'xml':
+                responses[index] = xml_to_string(responses[index])
+            elif cmd.output == 'json':
                 responses[index] = xml_to_json(responses[index])
             elif cmd.args.get('command_type') == 'rpc':
                 responses[index] = str(responses[index].text).strip()


### PR DESCRIPTION

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
junos_command

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
$ ansible --version
ansible 2.3.0 (devel cba66dfedc)
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
Response received from device is of type lxml.etree._Element.
If output format in playbook is 'xml' response should be
converted to xml (string). For 'json' output format response
should be converted in json format.
```
