### PR TITLE
winrm: Improve import error message

### DIFF
--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -38,6 +38,7 @@ from ansible.compat.six.moves.urllib.parse import urlunsplit
 from ansible.errors import AnsibleError, AnsibleConnectionFailure
 from ansible.errors import AnsibleFileNotFound
 from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.pycompat24 import get_exception
 from ansible.plugins.connection import ConnectionBase
 from ansible.utils.hashing import secure_hash
 from ansible.utils.path import makedirs_safe
@@ -47,12 +48,14 @@ try:
     from winrm import Response
     from winrm.protocol import Protocol
 except ImportError:
-    raise AnsibleError("winrm is not installed")
+    e = get_exception()
+    raise AnsibleError("winrm or requests is not installed: %s" % str(e))
 
 try:
     import xmltodict
 except ImportError:
-    raise AnsibleError("xmltodict is not installed")
+    e = get_exception()
+    raise AnsibleError("xmltodict is not installed: %s" % str(e))
 
 try:
     from __main__ import display


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
winrm

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
When installing Ansible on CentOS 7 or RHEL7, you get:

    winrm is not installed

However, when you install python-winrm, you still get:

    winrm is not installed

The requests python module is needed, however it is not a dependency of
the python-winrm package. The python-winrm package does require
python-requests_ntlm, which does not seem to pull python-requests.

So for the time being (until Red Hat fixes their package) give a more
informative error message. Not sure if pip does dependencies correctly either.