### PR TITLE
win_regedit: Use "(default)" as the default value name

### DIFF
--- a/lib/ansible/modules/windows/win_regedit.ps1
+++ b/lib/ansible/modules/windows/win_regedit.ps1
@@ -32,10 +32,15 @@ Set-Attr $result "data_changed" $false;
 Set-Attr $result "data_type_changed" $false;
 
 $registryKey = Get-Attr -obj $params -name "key" -failifempty $true
-$registryValue = Get-Attr -obj $params -name "value" -default $null
+$registryValue = Get-Attr -obj $params -name "value" -default "(default)"
 $state = Get-Attr -obj $params -name "state" -validateSet "present","absent" -default "present"
 $registryData = Get-Attr -obj $params -name "data" -default $null
 $registryDataType = Get-Attr -obj $params -name "datatype" -validateSet "binary","dword","expandstring","multistring","string","qword" -default "string"
+
+# Allow empty values as the "(default)" value
+If ($registryValue -eq "") {
+    $registryValue = "(default)"
+}
 
 If ($state -eq "present" -and $registryData -eq $null -and $registryValue -ne $null)
 {

--- a/lib/ansible/modules/windows/win_regedit.py
+++ b/lib/ansible/modules/windows/win_regedit.py
@@ -37,24 +37,17 @@ options:
     description:
       - Name of Registry Key
     required: true
-    default: null
-    aliases: []
   value:
     description:
       - Name of Registry Value
-    required: true
-    default: null
-    aliases: []
+      - When left out, the default entry for that key is being used.
+    default: '(default)'
   data:
     description:
-      - Registry Value Data.  Binary data should be expressed a yaml byte array or as comma separated hex values.  An easy way to generate this is to run C(regedit.exe) and use the I(Export) option to save the registry values to a file.  In the exported file binary values will look like C(hex:be,ef,be,ef).  The C(hex:) prefix is optional. 
-    required: false
-    default: null
-    aliases: []
+      - Registry Value Data.  Binary data should be expressed a yaml byte array or as comma separated hex values.  An easy way to generate this is to run C(regedit.exe) and use the I(Export) option to save the registry values to a file.  In the exported file binary values will look like C(hex:be,ef,be,ef).  The C(hex:) prefix is optional.
   datatype:
     description:
       - Registry Value Data Type
-    required: false
     choices:
       - binary
       - dword
@@ -63,16 +56,13 @@ options:
       - string
       - qword
     default: string
-    aliases: []
   state:
     description:
       - State of Registry Value
-    required: false
     choices:
       - present
       - absent
     default: present
-    aliases: []
 author: "Adam Keech (@smadam813), Josh Ludwig (@joshludwig)"
 '''
 
@@ -80,7 +70,12 @@ EXAMPLES = r'''
 - name: Create Registry Key called MyCompany
   win_regedit:
     key: HKCU:\Software\MyCompany
-    
+
+- name: Create Registry Key called MyCompany with default value "Ansible"
+  win_regedit:
+    key: HKCU:\Software\MyCompany
+    data: Ansible
+
 - name: Create Registry Key called MyCompany, a value within MyCompany Key called "hello", and data for the value "hello" containing "world".
   win_regedit:
     key: HKCU:\Software\MyCompany
@@ -112,16 +107,12 @@ EXAMPLES = r'''
   win_regedit:
     key: HKCU:\Software\MyCompany
     state: absent
-    
+
 - name: Delete Registry Value "hello" from MyCompany Key
   win_regedit:
     key: HKCU:\Software\MyCompany
     value: hello
     state: absent
-
-- name: Creates Registry Key called 'My Company'
-  win_regedit:
-    key: HKCU:\Software\My Company
 '''
 
 RETURN = '''


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_regedit

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Currently it is unclear how to set the default value for a key. This is
e.g. used when specifying the default action for a file association.

By allowing it to be undefined, it comes more naturally. But also if it
is provided as an empty string, it makes sense to mean that it is the
"(default)" value.