### PR TITLE
win_copy: Fix for idempotency

### DIFF
--- a/lib/ansible/modules/windows/win_copy.ps1
+++ b/lib/ansible/modules/windows/win_copy.ps1
@@ -60,13 +60,13 @@ if (Test-Path $dest -PathType Container)
     $dest = Join-Path $dest $original_basename
 }
 
-$dest_checksum = Get-FileChecksum ($dest)
+$orig_checksum = Get-FileChecksum ($dest)
 $src_checksum = Get-FileChecksum ($src)
 
-If ($src_checksum.Equals($dest_checksum))
+If ($src_checksum.Equals($orig_checksum))
 {
-    # if both are "3" then both are folders, ok to copy 
-    If ($src_checksum.Equals("3")) 
+    # if both are "3" then both are folders, ok to copy
+    If ($src_checksum.Equals("3"))
     {
        # New-Item -Force creates subdirs for recursive copies
        New-Item -Force $dest -Type file
@@ -75,9 +75,9 @@ If ($src_checksum.Equals($dest_checksum))
     }
 
 }
-ElseIf (! $src_checksum.Equals($dest_checksum))
+ElseIf (-Not $src_checksum.Equals($orig_checksum))
 {
-    If ($src_checksum.Equals("3")) 
+    If ($src_checksum.Equals("3"))
     {
        Fail-Json (New-Object psobject) "If src is a folder, dest must also be a folder"
     }
@@ -88,17 +88,20 @@ ElseIf (! $src_checksum.Equals($dest_checksum))
 
 # verify before we return that the file has changed
 $dest_checksum = Get-FileChecksum ($dest)
-If ( $src_checksum.Equals($dest_checksum))
+If ($src_checksum.Equals($dest_checksum))
 {
-    $result.changed = $TRUE
+    If (-Not $orig_checksum.Equals($dest_checksum)) {
+        $result.changed = $TRUE
+    }
 }
 Else
 {
     Fail-Json (New-Object psobject) "src checksum $src_checksum did not match dest_checksum $dest_checksum  Failed to place file $original_basename in $dest"
 }
-# generate return values
 
 $info = Get-Item $dest
 $result.size = $info.Length
+$result.src = $src
+$result.dest = $dest
 
 Exit-Json $result

--- a/lib/ansible/modules/windows/win_copy.py
+++ b/lib/ansible/modules/windows/win_copy.py
@@ -38,15 +38,12 @@ options:
         with "/", only inside contents of that directory are copied to destination.
         Otherwise, if it does not end with "/", the directory itself with all contents
         is copied. This behavior is similar to Rsync.
-    required: false
-    default: null
-    aliases: []
+    required: true
   dest:
     description:
       - Remote absolute path where the file should be copied to. If src is a directory,
         this must be a directory too. Use \\ for path separators.
     required: true
-    default: null
 author: "Jon Hawkesworth (@jhawkesworth)"
 '''
 
@@ -54,19 +51,19 @@ EXAMPLES = r'''
 - name: Copy a single file
   win_copy:
     src: /srv/myfiles/foo.conf
-    dest: c:\TEMP\foo.conf
+    dest: c:\Temp\foo.conf
 
 - name: Copy files/temp_files to c:\temp
   win_copy:
     src: files/temp_files/
-    dest: c:\temp
+    dest: c:\Temp
 '''
 RETURN = r'''
 dest:
     description: destination file/path
     returned: changed
     type: string
-    sample: c:\temp
+    sample: c:\Temp
 src:
     description: source file used for the copy on the target machine
     returned: changed

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -649,8 +649,8 @@ class Connection(ConnectionBase):
                 res = (returncode, stdout, stderr)
 
         if not success:
-            raise AnsibleError("failed to transfer file to {0}:\n{1}\n{2}"\
-                    .format(to_native(out_path), to_native(res[1]), to_native(res[2])))
+            raise AnsibleError("failed to transfer file {0} to {1}:\n{2}\n{3}"\
+            .format(to_native(in_path), to_native(out_path), to_native(res[1]), to_native(res[2])))
 
     #
     # Main public methods

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -649,8 +649,8 @@ class Connection(ConnectionBase):
                 res = (returncode, stdout, stderr)
 
         if not success:
-            raise AnsibleError("failed to transfer file {0} to {1}:\n{2}\n{3}"\
-            .format(to_native(in_path), to_native(out_path), to_native(res[1]), to_native(res[2])))
+            raise AnsibleError("failed to transfer file to {0}:\n{1}\n{2}"\
+                    .format(to_native(out_path), to_native(res[1]), to_native(res[2])))
 
     #
     # Main public methods


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_copy

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
This patch fixes an idempotency issue with win_copy. Without this patch
files would always be considered changed (unless the copy operation failed).

It also fixes the resulting output cfr. what was documented.