### PR TITLE
Windows modules: Add -type "path" to path parameters

### DIFF
--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -44,7 +44,7 @@ $result = New-Object psobject @{
 };
 
 # failifempty = $false is default and thus implied
-$factpath = Get-AnsibleParam -obj $params -name fact_path
+$factpath = Get-AnsibleParam -obj $params -name fact_path -type "path"
 if ($factpath -ne $null) {
   # Get any custom facts
   Get-CustomFacts -factpath $factpath

--- a/lib/ansible/modules/windows/win_command.ps1
+++ b/lib/ansible/modules/windows/win_command.ps1
@@ -25,9 +25,9 @@ $ErrorActionPreference = "Stop"
 $parsed_args = Parse-Args $args $false
 
 $raw_command_line = $(Get-AnsibleParam $parsed_args "_raw_params" -failifempty $true).Trim()
-$chdir = Get-AnsibleParam $parsed_args "chdir"
-$creates = Get-AnsibleParam $parsed_args "creates"
-$removes = Get-AnsibleParam $parsed_args "removes"
+$chdir = Get-AnsibleParam $parsed_args "chdir" -type "path"
+$creates = Get-AnsibleParam $parsed_args "creates" -type "path"
+$removes = Get-AnsibleParam $parsed_args "removes" -type "path"
 
 $result = @{changed=$true; warnings=@(); cmd=$raw_command_line}
 

--- a/lib/ansible/modules/windows/win_copy.ps1
+++ b/lib/ansible/modules/windows/win_copy.ps1
@@ -19,13 +19,13 @@
 
 $params = Parse-Args $args
 
-$src= Get-Attr $params "src" $FALSE
+$src = Get-Attr $params "src" $FALSE -type "path"
 If ($src -eq $FALSE)
 {
     Fail-Json (New-Object psobject) "missing required argument: src"
 }
 
-$dest= Get-Attr $params "dest" $FALSE
+$dest = Get-Attr $params "dest" $FALSE -type "path"
 If ($dest -eq $FALSE)
 {
     Fail-Json (New-Object psobject) "missing required argument: dest"

--- a/lib/ansible/modules/windows/win_file_version.ps1
+++ b/lib/ansible/modules/windows/win_file_version.ps1
@@ -26,7 +26,7 @@ $result = New-Object psobject @{
     changed = $false
 }
 
-$path = Get-AnsibleParam $params "path" -failifempty $true -resultobj $result
+$path = Get-AnsibleParam $params "path" -type "path" -failifempty $true -resultobj $result
 
 If (-Not (Test-Path -Path $path -PathType Leaf)){
     Fail-Json $result "Specfied path $path does exist or is not a file."

--- a/lib/ansible/modules/windows/win_get_url.ps1
+++ b/lib/ansible/modules/windows/win_get_url.ps1
@@ -27,7 +27,7 @@ $result = New-Object psobject @{
 }
 
 $url = Get-AnsibleParam $params -name "url" -failifempty $true
-$dest = Get-AnsibleParam $params -name "dest" -failifempty $true
+$dest = Get-AnsibleParam $params -name "dest" -type "path" -failifempty $true
 
 $skip_certificate_validation = Get-AnsibleParam $params -name "skip_certificate_validation" -default $false
 $skip_certificate_validation = $skip_certificate_validation | ConvertTo-Bool

--- a/lib/ansible/modules/windows/win_robocopy.ps1
+++ b/lib/ansible/modules/windows/win_robocopy.ps1
@@ -27,8 +27,8 @@ $result = New-Object psobject @{
     changed = $false
 }
 
-$src = Get-AnsibleParam -obj $params -name "src" -failifempty $true
-$dest = Get-AnsibleParam -obj $params -name "dest" -failifempty $true
+$src = Get-AnsibleParam -obj $params -name "src" -type "path" -failifempty $true
+$dest = Get-AnsibleParam -obj $params -name "dest" -type "path" -failifempty $true
 $purge = ConvertTo-Bool (Get-AnsibleParam -obj $params -name "purge" -default $false)
 $recurse = ConvertTo-Bool (Get-AnsibleParam -obj $params -name "recurse" -default $false)
 $flags = Get-AnsibleParam -obj $params -name "flags" -default $null

--- a/lib/ansible/modules/windows/win_say.ps1
+++ b/lib/ansible/modules/windows/win_say.ps1
@@ -22,9 +22,9 @@
 $params = Parse-Args $args;
 $result = New-Object PSObject;
 $msg = Get-AnsibleParam -obj $params -name "msg"
-$msg_file = Get-AnsibleParam -obj $params -name "msg_file"
-$start_sound_path = Get-AnsibleParam -obj $params -name "start_sound_path"
-$end_sound_path = Get-AnsibleParam -obj $params -name "end_sound_path"
+$msg_file = Get-AnsibleParam -obj $params -name "msg_file" -type "path"
+$start_sound_path = Get-AnsibleParam -obj $params -name "start_sound_path" -type "path"
+$end_sound_path = Get-AnsibleParam -obj $params -name "end_sound_path" -type "path"
 $voice = Get-AnsibleParam -obj $params -name "voice"
 $speech_speed = Get-AnsibleParam -obj $params -name "speech_speed"
 $speed = 0

--- a/lib/ansible/modules/windows/win_scheduled_task.ps1
+++ b/lib/ansible/modules/windows/win_scheduled_task.ps1
@@ -28,7 +28,7 @@ $days_of_week = Get-AnsibleParam $params -name "days_of_week"
 $enabled = Get-AnsibleParam $params -name "enabled" -default $true
 $enabled = $enabled | ConvertTo-Bool
 $description = Get-AnsibleParam $params -name "description" -default " "
-$path = Get-AnsibleParam $params -name "path"
+$path = Get-AnsibleParam $params -name "path" -type "path"
 $argument = Get-AnsibleParam $params -name "argument"
 
 $result = New-Object PSObject;

--- a/lib/ansible/modules/windows/win_shell.ps1
+++ b/lib/ansible/modules/windows/win_shell.ps1
@@ -63,10 +63,10 @@ namespace Ansible.Shell
 $parsed_args = Parse-Args $args $false
 
 $raw_command_line = $(Get-AnsibleParam $parsed_args "_raw_params" -failifempty $true).Trim()
-$chdir = Get-AnsibleParam $parsed_args "chdir"
-$executable = Get-AnsibleParam $parsed_args "executable"
-$creates = Get-AnsibleParam $parsed_args "creates"
-$removes = Get-AnsibleParam $parsed_args "removes"
+$chdir = Get-AnsibleParam $parsed_args "chdir" -type "path"
+$executable = Get-AnsibleParam $parsed_args "executable" -type "path"
+$creates = Get-AnsibleParam $parsed_args "creates" -type "path"
+$removes = Get-AnsibleParam $parsed_args "removes" -type "path"
 
 $result = @{changed=$true; warnings=@(); cmd=$raw_command_line}
 

--- a/lib/ansible/modules/windows/win_unzip.ps1
+++ b/lib/ansible/modules/windows/win_unzip.ps1
@@ -27,14 +27,14 @@ $result = New-Object psobject @{
     changed = $false
 }
 
-$creates = Get-AnsibleParam -obj $params -name "creates"
+$creates = Get-AnsibleParam -obj $params -name "creates" -type "path"
 If ($creates -ne $null) {
     If (Test-Path $params.creates) {
         Exit-Json $result "The 'creates' file or directory already exists."
     }
 }
 
-$src = Get-AnsibleParam -obj $params -name "src" -failifempty $true
+$src = Get-AnsibleParam -obj $params -name "src" -type "path" -failifempty $true
 If (-Not (Test-Path -path $src)){
     Fail-Json $result "src file: $src does not exist."
 }
@@ -42,7 +42,7 @@ If (-Not (Test-Path -path $src)){
 $ext = [System.IO.Path]::GetExtension($src)
 
 
-$dest = Get-AnsibleParam -obj $params -name "dest" -failifempty $true
+$dest = Get-AnsibleParam -obj $params -name "dest" -type "path" -failifempty $true
 If (-Not (Test-Path $dest -PathType Container)){
     Try{
         New-Item -itemtype directory -path $dest

--- a/lib/ansible/modules/windows/win_uri.ps1
+++ b/lib/ansible/modules/windows/win_uri.ps1
@@ -42,7 +42,7 @@ $method = Get-AnsibleParam -obj $params "method" -default "GET"
 $content_type = Get-AnsibleParam -obj $params -name "content_type"
 $headers = Get-AnsibleParam -obj $params -name "headers"
 $body = Get-AnsibleParam -obj $params -name "body"
-$dest = Get-AnsibleParam -obj $params -name "dest" -default $null
+$dest = Get-AnsibleParam -obj $params -name "dest" -type "path" -default $null
 $use_basic_parsing = ConvertTo-Bool (Get-AnsibleParam -obj $params -name "use_basic_parsing" -default $true)
 
 $webrequest_opts.Uri = $url


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
windows modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
This PR is based on #20164 functionality to specify the parameter type
(e.g. as done for python modules).

In this case only -type "path" has a specific meaning, as it will expand
environment variables for paths. Which is typically done on Windows.

So you can do:

    - win_copy:
        src: files/some.doc
        dest: '%UserProfile%\My Documents'

    - win_shortcut:
        src: 'https://ansible.com/'
        dest: '%Public%/Desktop/Ansible website.lnk'