### PR TITLE
checks if stdout or stderr are connected to tty

### DIFF
--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -102,6 +102,9 @@ class Display:
 
         Note: msg *must* be a unicode string to prevent UnicodeError tracebacks.
         """
+        # no reason to go futher as there is nothing to print to
+        if not sys.stdout.isatty() or not sys.stderr.isatty():
+            return
 
         nocolor = msg
         if color:


### PR DESCRIPTION
this first checks if the stdout and/or stderr are connected to a real tty
(such is the case with ansible-connection) before trying to print display
statements.  If not connected to a tty, then the messages are silently
discarded.
