### PR TITLE
adds more logging to ansible-connection

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -117,19 +117,16 @@ class Server():
 
         self._start_time = datetime.datetime.now()
 
-        self.log('loading connection plugin %s' % str(play_context.connection))
-        self.conn = connection_loader.get(play_context.connection, play_context, sys.stdin)
-
         try:
-            self.log('attempting to connect to remote host')
+            self.log('loading connection plugin %s' % str(play_context.connection))
+            self.conn = connection_loader.get(play_context.connection, play_context, sys.stdin)
             self.conn._connect()
 
-            self.log('successfully connected, starting listener')
             self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             self.socket.bind(path)
             self.socket.listen(1)
         except Exception as exc:
-            self.log(str(exc))
+            self.log(traceback.format_exc())
             raise
 
         signal.signal(signal.SIGALRM, self.alarm_handler)
@@ -223,9 +220,7 @@ class Server():
                     send_data(s, to_bytes(stderr))
                 s.close()
         except Exception as e:
-            # FIXME: proper logging and error handling here
-            log('runtime exception: %s' % e)
-            print(traceback.format_exc())
+            log(traceback.format_exc())
         finally:
             # when done, close the connection properly and cleanup
             # the socket file so it can be recreated


### PR DESCRIPTION
* Server() instance will now add the entire traceback to syslog if it fail
  during init

