### PR TITLE
Windows: Fix documentation strings to be raw strings

### DIFF
--- a/lib/ansible/modules/windows/win_acl.py
+++ b/lib/ansible/modules/windows/win_acl.py
@@ -27,7 +27,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'core',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_acl
 version_added: "2.0"

--- a/lib/ansible/modules/windows/win_acl_inheritance.py
+++ b/lib/ansible/modules/windows/win_acl_inheritance.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'core',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_acl_inheritance
 version_added: "2.1"
@@ -76,6 +76,6 @@ EXAMPLES = r'''
     reorganize: True
 '''
 
-RETURN = '''
+RETURN = r'''
 
 '''

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -75,7 +75,7 @@ options:
     version_added: '2.1'
   allow_empty_checksums:
     description:
-      - Allow empty Checksums to be used 
+      - Allow empty Checksums to be used
     require: false
     default: false
     version_added: '2.2'

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'committer',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_chocolatey
 version_added: "1.9"
@@ -81,10 +81,10 @@ options:
     version_added: '2.2'
   ignore_checksums:
     description:
-      - Ignore Checksums 
+      - Ignore Checksums
     require: false
     default: false
-    version_added: '2.2'      
+    version_added: '2.2'
   ignore_dependencies:
     description:
       - Ignore dependencies, only install/upgrade the package itself
@@ -98,7 +98,7 @@ author: "Trond Hindenes (@trondhindenes), Peter Mounce (@petemounce), Pepe Barbe
 # * Time each item that is run
 # * Support 'changed' with gems - would require shelling out to `gem list` first and parsing, kinda defeating the point of using chocolatey.
 
-EXAMPLES = '''
+EXAMPLES = r'''
   # Install git
   win_chocolatey:
     name: git

--- a/lib/ansible/modules/windows/win_command.py
+++ b/lib/ansible/modules/windows/win_command.py
@@ -23,7 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'core',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_command
 short_description: Executes a command on a remote Windows node
@@ -59,24 +59,24 @@ author:
     - Matt Davis
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 # Example from Ansible Playbooks.
 - win_command: whoami
   register: whoami_out
 
 # Run the command only if the specified file does not exist.
-- win_command: wbadmin -backupTarget:c:\\backup\\ creates=c:\\backup\\
+- win_command: wbadmin -backupTarget:C:\backup\ creates=C:\backup\
 
 # You can also use the 'args' form to provide the options. This command
-# will change the working directory to c:\\somedir\\ and will only run when
-# c:\\backup\\ doesn't exist.
-- win_command: wbadmin -backupTarget:c:\\backup\\ creates=c:\\backup\\
+# will change the working directory to C:\somedir\\ and will only run when
+# C:\backup\ doesn't exist.
+- win_command: wbadmin -backupTarget:C:\backup\ creates=C:\backup\
   args:
-    chdir: c:\\somedir\\
-    creates: c:\\backup\\
+    chdir: C:\somedir\
+    creates: C:\backup\
 '''
 
-RETURN = '''
+RETURN = r'''
 msg:
     description: changed
     returned: always

--- a/lib/ansible/modules/windows/win_copy.py
+++ b/lib/ansible/modules/windows/win_copy.py
@@ -23,7 +23,7 @@ ANSIBLE_METADATA = {'status': ['stableinterface'],
                     'supported_by': 'core',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_copy
 version_added: "1.9.2"
@@ -50,7 +50,7 @@ options:
 author: "Jon Hawkesworth (@jhawkesworth)"
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Copy a single file
   win_copy:
     src: /srv/myfiles/foo.conf
@@ -61,7 +61,7 @@ EXAMPLES = '''
     src: files/temp_files/
     dest: c:\temp
 '''
-RETURN = '''
+RETURN = r'''
 dest:
     description: destination file/path
     returned: changed

--- a/lib/ansible/modules/windows/win_copy.py
+++ b/lib/ansible/modules/windows/win_copy.py
@@ -66,7 +66,7 @@ dest:
     description: destination file/path
     returned: changed
     type: string
-    sample: 'c:\temp'
+    sample: c:\temp
 src:
     description: source file used for the copy on the target machine
     returned: changed

--- a/lib/ansible/modules/windows/win_dotnet_ngen.py
+++ b/lib/ansible/modules/windows/win_dotnet_ngen.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_dotnet_ngen
 version_added: "2.0"
@@ -43,7 +43,7 @@ author: Peter Mounce
 options: {}
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
   # Run ngen tasks
   win_dotnet_ngen:
 '''

--- a/lib/ansible/modules/windows/win_environment.py
+++ b/lib/ansible/modules/windows/win_environment.py
@@ -25,13 +25,13 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_environment
 version_added: "2.0"
 short_description: Modifies environment variables on windows hosts.
 description:
-    - Uses .net Environment to set or remove environment variables and can set at User, Machine or Process level.  
+    - Uses .net Environment to set or remove environment variables and can set at User, Machine or Process level.
     - User level environment variables will be set, but not available until the user has logged off and on again.
 options:
   state:
@@ -48,12 +48,12 @@ options:
     required: true
     default: no default
   value:
-    description: 
+    description:
       - The value to store in the environment variable. Can be omitted for state=absent
     required: false
     default: no default
   level:
-    description: 
+    description:
       - The level at which to set the environment variable.
       - Use 'machine' to set for all users.
       - Use 'user' to set for the current user that ansible is connected as.
@@ -69,20 +69,20 @@ notes:
    - This module is best-suited for setting the entire value of an
      environment variable. For safe element-based management of
      path-like environment vars, use the M(win_path) module.
-   - This module does not broadcast change events.  
-     This means that the minority of windows applications which can have 
-     their environment changed without restarting will not be notified and 
-     therefore will need restarting to pick up new environment settings.  
-     User level environment variables will require the user to log out 
+   - This module does not broadcast change events.
+     This means that the minority of windows applications which can have
+     their environment changed without restarting will not be notified and
+     therefore will need restarting to pick up new environment settings.
+     User level environment variables will require the user to log out
      and in again before they become available.
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
   # Set an environment variable for all users
   win_environment:
     state: present
     name: TestVariable
-    value: "Test value"
+    value: Test value
     level: machine
   # Remove an environment variable for the current users
   win_environment:

--- a/lib/ansible/modules/windows/win_feature.py
+++ b/lib/ansible/modules/windows/win_feature.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_feature
 version_added: "1.7"

--- a/lib/ansible/modules/windows/win_file.py
+++ b/lib/ansible/modules/windows/win_file.py
@@ -23,7 +23,7 @@ ANSIBLE_METADATA = {'status': ['stableinterface'],
                     'supported_by': 'core',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_file
 version_added: "1.9.2"
@@ -58,7 +58,7 @@ options:
     choices: [ file, directory, touch, absent ]
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Create a file
   win_file:
     path: C:\temp\foo.conf

--- a/lib/ansible/modules/windows/win_file_version.py
+++ b/lib/ansible/modules/windows/win_file_version.py
@@ -21,7 +21,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_file_version
 version_added: "2.1"
@@ -48,7 +48,7 @@ EXAMPLES = r'''
     msg: '{{ exe_file_version }}'
 '''
 
-RETURN = """
+RETURN = r'''
 win_file_version.path:
   description: file path
   returned: always
@@ -84,4 +84,4 @@ win_file_version.file_private_part:
   returned: no error
   type: string
 
-"""
+'''

--- a/lib/ansible/modules/windows/win_firewall_rule.py
+++ b/lib/ansible/modules/windows/win_firewall_rule.py
@@ -21,7 +21,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_firewall_rule
 version_added: "2.0"
@@ -112,7 +112,7 @@ options:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Firewall rule to allow smtp on TCP port 25
   action: win_firewall_rule
   args:

--- a/lib/ansible/modules/windows/win_get_url.py
+++ b/lib/ansible/modules/windows/win_get_url.py
@@ -92,7 +92,7 @@ options:
 '''
 
 EXAMPLES = r'''
-- name: Download earthrise.jpg to specified path 
+- name: Download earthrise.jpg to specified path
   win_get_url:
     url: http://www.example.com/earthrise.jpg
     dest: C:\Users\RandomUser\earthrise.jpg

--- a/lib/ansible/modules/windows/win_get_url.py
+++ b/lib/ansible/modules/windows/win_get_url.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['stableinterface'],
                     'supported_by': 'core',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_get_url
 version_added: "1.7"

--- a/lib/ansible/modules/windows/win_group.py
+++ b/lib/ansible/modules/windows/win_group.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['stableinterface'],
                     'supported_by': 'core',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_group
 version_added: "1.7"
@@ -57,7 +57,7 @@ options:
 author: "Chris Hoffman (@chrishoffman)"
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Create a new group
   win_group:
     name: deploy

--- a/lib/ansible/modules/windows/win_iis_virtualdirectory.py
+++ b/lib/ansible/modules/windows/win_iis_virtualdirectory.py
@@ -22,7 +22,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_iis_virtualdirectory
 version_added: "2.0"

--- a/lib/ansible/modules/windows/win_iis_webapplication.py
+++ b/lib/ansible/modules/windows/win_iis_webapplication.py
@@ -22,7 +22,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_iis_webapplication
 version_added: "2.0"

--- a/lib/ansible/modules/windows/win_iis_webapppool.py
+++ b/lib/ansible/modules/windows/win_iis_webapppool.py
@@ -23,7 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_iis_webapppool
 version_added: "2.0"
@@ -57,7 +57,7 @@ options:
 author: Henrik Wallström
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Return information about an existing application pool
   win_iis_webapppool:
     name: DefaultAppPool

--- a/lib/ansible/modules/windows/win_iis_webbinding.py
+++ b/lib/ansible/modules/windows/win_iis_webbinding.py
@@ -23,7 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_iis_webbinding
 version_added: "2.0"
@@ -85,7 +85,7 @@ options:
 author: Henrik Wallström
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Return binding information for an existing host
   win_iis_webbinding:
     name: Default Web Site

--- a/lib/ansible/modules/windows/win_iis_website.py
+++ b/lib/ansible/modules/windows/win_iis_website.py
@@ -110,8 +110,8 @@ EXAMPLES = r'''
     ip: 127.0.0.1
     hostname: acme.local
     application_pool: "acme"
-    physical_path: 'c:\sites\acme'
-    parameters: 'logfile.directory:c:\\sites\\logs'
+    physical_path: c:\sites\acme
+    parameters: logfile.directory:c:\sites\logs
   register: website
 
 # Some commandline examples:

--- a/lib/ansible/modules/windows/win_iis_website.py
+++ b/lib/ansible/modules/windows/win_iis_website.py
@@ -22,7 +22,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_iis_website
 version_added: "2.0"
@@ -98,7 +98,7 @@ options:
 author: Henrik Wallström
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 
 # Start a website
 
@@ -110,7 +110,7 @@ EXAMPLES = '''
     ip: 127.0.0.1
     hostname: acme.local
     application_pool: "acme"
-    physical_path: 'c:\\sites\\acme'
+    physical_path: 'c:\sites\acme'
     parameters: 'logfile.directory:c:\\sites\\logs'
   register: website
 

--- a/lib/ansible/modules/windows/win_lineinfile.py
+++ b/lib/ansible/modules/windows/win_lineinfile.py
@@ -20,7 +20,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-DOCUMENTATION = """
+DOCUMENTATION = r'''
 ---
 module: win_lineinfile
 author: "Brian Lloyd <brian.d.lloyd@gmail.com>"
@@ -104,9 +104,9 @@ options:
     default: "windows"
 notes:
   - As of Ansible 2.3, the I(dest) option has been changed to I(path) as default, but I(dest) still works as well.
-"""
+'''
 
-EXAMPLES = r"""
+EXAMPLES = r'''
 # Before 2.3, option 'dest', 'destfile' or 'name' was used instead of 'path'
 - win_lineinfile:
     path: C:\temp\example.conf
@@ -147,4 +147,4 @@ EXAMPLES = r"""
     path: C:\temp\testfile.txt
     line: Line added to file
     newline: unix
-"""
+'''

--- a/lib/ansible/modules/windows/win_msi.py
+++ b/lib/ansible/modules/windows/win_msi.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['deprecated'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_msi
 version_added: "1.7"
@@ -64,7 +64,7 @@ options:
 author: "Matt Martz (@sivel)"
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Install an MSI file
   win_msi:
     path: C:\7z920-x64.msi

--- a/lib/ansible/modules/windows/win_nssm.py
+++ b/lib/ansible/modules/windows/win_nssm.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_nssm
 version_added: "2.0"
@@ -105,17 +105,17 @@ author:
   - "Hans-Joachim Kliemeck (@h0nIg)"
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 # Install and start the foo service
 - win_nssm:
     name: foo
-    application: C:\windows\\foo.exe
+    application: C:\windows\foo.exe
 
 # Install and start the foo service with a key-value pair argument
-# This will yield the following command: C:\windows\\foo.exe bar "true"
+# This will yield the following command: C:\windows\foo.exe bar "true"
 - win_nssm:
     name: foo
-    application: C:\windows\\foo.exe
+    application: C:\windows\foo.exe
     app_parameters:
         bar: true
 
@@ -123,7 +123,7 @@ EXAMPLES = '''
 # This will yield the following command: C:\windows\\foo.exe -bar "true"
 - win_nssm:
     name: foo
-    application: C:\windows\\foo.exe
+    application: C:\windows\foo.exe
     app_parameters:
         "-bar": true
 
@@ -131,7 +131,7 @@ EXAMPLES = '''
 # This will yield the following command: C:\windows\\foo.exe bar
 - win_nssm:
     name: foo
-    application: C:\windows\\foo.exe
+    application: C:\windows\foo.exe
     app_parameters:
         _: bar
 
@@ -139,7 +139,7 @@ EXAMPLES = '''
 # This will yield the following command: C:\windows\\foo.exe bar -file output.bat
 - win_nssm:
     name: foo
-    application: C:\windows\\foo.exe
+    application: C:\windows\foo.exe
     app_parameters:
         _: bar
         "-file": "output.bat"
@@ -147,27 +147,27 @@ EXAMPLES = '''
 # Install and start the foo service, redirecting stdout and stderr to the same file
 - win_nssm:
     name: foo
-    application: C:\windows\\foo.exe
-    stdout_file: C:\windows\\foo.log
-    stderr_file: C:\windows\\foo.log
+    application: C:\windows\foo.exe
+    stdout_file: C:\windows\foo.log
+    stderr_file: C:\windows\foo.log
 
 # Install and start the foo service, but wait for dependencies tcpip and adf
 - win_nssm:
     name: foo
-    application: C:\windows\\foo.exe
+    application: C:\windows\foo.exe
     dependencies: 'adf,tcpip'
 
 # Install and start the foo service with dedicated user
 - win_nssm:
     name: foo
-    application: C:\windows\\foo.exe
+    application: C:\windows\foo.exe
     user: foouser
     password: secret
 
 # Install the foo service but do not start it automatically
 - win_nssm:
     name: foo
-    application: C:\windows\\foo.exe
+    application: C:\windows\foo.exe
     state: present
     start_mode: manual
 

--- a/lib/ansible/modules/windows/win_owner.py
+++ b/lib/ansible/modules/windows/win_owner.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'core',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_owner
 version_added: "2.1"
@@ -66,6 +66,6 @@ EXAMPLES = r'''
     recurse: False
 '''
 
-RETURN = '''
+RETURN = r'''
 
 '''

--- a/lib/ansible/modules/windows/win_package.py
+++ b/lib/ansible/modules/windows/win_package.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'core',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_package
 version_added: "1.7"
@@ -33,7 +33,7 @@ author: Trond Hindenes
 short_description: Installs/Uninstalls an installable package, either from local file system or url
 description:
      - Installs or uninstalls a package.
-     - 'Optionally uses a product_id to check if the package needs installing. You can find product ids for installed programs in the windows registry either in C(HKLM:Software\\Microsoft\\Windows\CurrentVersion\\Uninstall) or for 32 bit programs C(HKLM:Software\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall)'
+     - 'Optionally uses a product_id to check if the package needs installing. You can find product ids for installed programs in the windows registry either in C(HKLM:Software\Microsoft\Windows\CurrentVersion\Uninstall) or for 32 bit programs C(HKLM:Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall)'
 options:
   path:
     description:
@@ -47,7 +47,7 @@ options:
   product_id:
     description:
       - Product id of the installed package (used for checking if already installed)
-      - You can find product ids for installed programs in the windows registry either in C(HKLM:Software\\Microsoft\\Windows\CurrentVersion\\Uninstall) or for 32 bit programs C(HKLM:Software\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall)'
+      - You can find product ids for installed programs in the windows registry either in C(HKLM:Software\Microsoft\Windows\CurrentVersion\Uninstall) or for 32 bit programs C(HKLM:Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall)'
     required: true
     aliases: [productid]
   arguments:
@@ -76,7 +76,7 @@ options:
     required: false
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Install the Visual C thingy
   win_package:
     name: Microsoft Visual C thingy

--- a/lib/ansible/modules/windows/win_ping.py
+++ b/lib/ansible/modules/windows/win_ping.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['stableinterface'],
                     'supported_by': 'core',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_ping
 version_added: "1.7"
@@ -42,7 +42,7 @@ options:
 author: "Chris Church (@cchurch)"
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 # Test connectivity to a windows host
 ansible winserver -m win_ping
 

--- a/lib/ansible/modules/windows/win_reboot.py
+++ b/lib/ansible/modules/windows/win_reboot.py
@@ -23,7 +23,7 @@ ANSIBLE_METADATA = {'status': ['stableinterface'],
                     'supported_by': 'core',
                     'version': '1.0'}
 
-DOCUMENTATION='''
+DOCUMENTATION = r'''
 ---
 module: win_reboot
 short_description: Reboot a windows machine
@@ -63,7 +63,7 @@ author:
     - Matt Davis (@nitzmahone)
 '''
 
-EXAMPLES='''
+EXAMPLES = r'''
 # Unconditionally reboot the machine with all defaults
 - win_reboot:
 
@@ -79,7 +79,7 @@ EXAMPLES='''
     reboot_timeout_sec: 3600
 '''
 
-RETURN='''
+RETURN = r'''
 rebooted:
     description: true if the machine was rebooted
     returned: always

--- a/lib/ansible/modules/windows/win_regedit.py
+++ b/lib/ansible/modules/windows/win_regedit.py
@@ -47,7 +47,7 @@ options:
     aliases: []
   data:
     description:
-      - Registry Value Data.  Binary data should be expressed a yaml byte array or as comma separated hex values.  An easy way to generate this is to run C(regedit.exe) and use the I(Export) option to save the registry values to a file.  In the exported file binary values will look like C(hex:be,ef,be,ef).  The C(hex:) prefix is optional. 
+      - Registry Value Data.  Binary data should be expressed a yaml byte array or as comma separated hex values.  An easy way to generate this is to run C(regedit.exe) and use the I(Export) option to save the registry values to a file.  In the exported file binary values will look like C(hex:be,ef,be,ef).  The C(hex:) prefix is optional.
     required: false
     default: null
     aliases: []
@@ -112,7 +112,7 @@ EXAMPLES = r'''
   win_regedit:
     key: HKCU:\Software\MyCompany
     state: absent
-    
+
 - name: Delete Registry Value "hello" from MyCompany Key
   win_regedit:
     key: HKCU:\Software\MyCompany
@@ -126,12 +126,12 @@ EXAMPLES = r'''
 
 RETURN = r'''
 data_changed:
-    description: whether this invocation changed the data in the registry value 
+    description: whether this invocation changed the data in the registry value
     returned: success
     type: boolean
     sample: False
 data_type_changed:
-    description: whether this invocation changed the datatype of the registry value 
+    description: whether this invocation changed the datatype of the registry value
     returned: success
     type: boolean
     sample: True

--- a/lib/ansible/modules/windows/win_regedit.py
+++ b/lib/ansible/modules/windows/win_regedit.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'core',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_regedit
 version_added: "2.0"
@@ -80,7 +80,7 @@ EXAMPLES = r'''
 - name: Create Registry Key called MyCompany
   win_regedit:
     key: HKCU:\Software\MyCompany
-    
+
 - name: Create Registry Key called MyCompany, a value within MyCompany Key called "hello", and data for the value "hello" containing "world".
   win_regedit:
     key: HKCU:\Software\MyCompany
@@ -124,7 +124,7 @@ EXAMPLES = r'''
     key: HKCU:\Software\My Company
 '''
 
-RETURN = '''
+RETURN = r'''
 data_changed:
     description: whether this invocation changed the data in the registry value 
     returned: success

--- a/lib/ansible/modules/windows/win_regmerge.py
+++ b/lib/ansible/modules/windows/win_regmerge.py
@@ -33,7 +33,7 @@ short_description: Merges the contents of a registry file into the windows regis
 description:
     - Wraps the reg.exe command to import the contents of a registry file.
     - Suitable for use with registry files created using M(win_template).
-    - Windows registry files have a specific format and must be constructed correctly with carriage return and line feed line endings otherwise they will not be merged.  
+    - Windows registry files have a specific format and must be constructed correctly with carriage return and line feed line endings otherwise they will not be merged.
     - Exported registry files often start with a Byte Order Mark which must be removed if the file is to templated using M(win_template).
     - Registry file format is described at U(https://support.microsoft.com/en-us/kb/310516)
     - See also M(win_template), M(win_regedit)
@@ -50,7 +50,7 @@ options:
     required: false
     default: no default
 author: "Jon Hawkesworth (@jhawkesworth)"
-notes: 
+notes:
    - Organise your registry files so that they contain a single root registry
      key if you want to use the compare_to functionality.
      This module does not force registry settings to be in the state

--- a/lib/ansible/modules/windows/win_regmerge.py
+++ b/lib/ansible/modules/windows/win_regmerge.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_regmerge
 version_added: "2.1"
@@ -44,7 +44,7 @@ options:
     required: true
     default: no default
   compare_key:
-    description: 
+    description:
       - The parent key to use when comparing the contents of the registry to the contents of the file.  Needs to be in HKLM or HKCU part of registry.  Use a PS-Drive style path for example HKLM:\SOFTWARE not HKEY_LOCAL_MACHINE\SOFTWARE
         If not supplied, or the registry key is not found, no comparison will be made, and the module will report changed.
     required: false
@@ -53,15 +53,15 @@ author: "Jon Hawkesworth (@jhawkesworth)"
 notes: 
    - Organise your registry files so that they contain a single root registry
      key if you want to use the compare_to functionality.
-     This module does not force registry settings to be in the state 
+     This module does not force registry settings to be in the state
      described in the file.  If registry settings have been modified externally
      the module will merge the contents of the file but continue to report
-     differences on subsequent runs.  
-     To force registry change, use M(win_regedit) with state=absent before 
+     differences on subsequent runs.
+     To force registry change, use M(win_regedit) with state=absent before
      using M(win_regmerge).
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
   # Merge in a registry file without comparing to current registry
   # Note that paths using / to separate are preferred as they require less special handling than \ 
   win_regmerge:
@@ -72,7 +72,7 @@ EXAMPLES = '''
     compare_to: HKLM:\SOFTWARE\myCompany
 '''
 
-RETURN = '''
+RETURN = r'''
 compare_to_key_found:
     description: whether the parent registry key has been found for comparison
     returned: when comparison key not found in registry

--- a/lib/ansible/modules/windows/win_robocopy.py
+++ b/lib/ansible/modules/windows/win_robocopy.py
@@ -108,12 +108,12 @@ src:
     description: The Source file/directory of the sync.
     returned: always
     type: string
-    sample: "c:\Some\Path"
+    sample: c:\Some\Path
 dest:
     description: The Destination file/directory of the sync.
     returned: always
     type: string
-    sample: "c:\Some\Path"
+    sample: c:\Some\Path
 recurse:
     description: Whether or not the recurse flag was toggled.
     returned: always

--- a/lib/ansible/modules/windows/win_robocopy.py
+++ b/lib/ansible/modules/windows/win_robocopy.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-DOCUMENTATION = """
+DOCUMENTATION = r'''
 ---
 module: win_robocopy
 version_added: "2.2"
@@ -67,7 +67,7 @@ notes:
     - This is not a complete port of the "synchronize" module. Unlike the "synchronize" module this only performs the sync/copy on the remote machine, not from the master to the remote machine.
     - This module does not currently support all Robocopy flags.
     - Works on Windows 7, Windows 8, Windows Server 2k8, and Windows Server 2k12
-"""
+'''
 
 EXAMPLES = r'''
 - name: Sync the contents of one directory to another
@@ -103,17 +103,17 @@ EXAMPLES = r'''
     flags: /XD SOME_DIR /XF SOME_FILE /MT:32
 '''
 
-RETURN = '''
+RETURN = r'''
 src:
     description: The Source file/directory of the sync.
     returned: always
     type: string
-    sample: "c:/Some/Path"
+    sample: "c:\Some\Path"
 dest:
     description: The Destination file/directory of the sync.
     returned: always
     type: string
-    sample: "c:/Some/Path"
+    sample: "c:\Some\Path"
 recurse:
     description: Whether or not the recurse flag was toggled.
     returned: always

--- a/lib/ansible/modules/windows/win_say.py
+++ b/lib/ansible/modules/windows/win_say.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_say
 version_added: "2.3"
@@ -74,7 +74,7 @@ notes:
    - Speech can be surprisingly slow, so its best to keep message text short.   
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
   # Warn of impending deployment
 - win_say:
     msg: Warning, deployment commencing in 5 minutes, please log out.
@@ -94,7 +94,7 @@ EXAMPLES = '''
     msg_file: AppData\Local\Temp\morning_report.txt
     end_sound_path: 'C:\Windows\Media\chimes.wav'
 '''
-RETURN = '''
+RETURN = r'''
 message_text:
     description: the text that the module attempted to speak
     returned: success

--- a/lib/ansible/modules/windows/win_say.py
+++ b/lib/ansible/modules/windows/win_say.py
@@ -64,14 +64,14 @@ options:
     required: false
     default: null
 author: "Jon Hawkesworth (@jhawkesworth)"
-notes: 
+notes:
    - Needs speakers or headphones to do anything useful.
    - To find which voices are installed, run the following powershell
      Add-Type -AssemblyName System.Speech
      $speech = New-Object -TypeName System.Speech.Synthesis.SpeechSynthesizer
      $speech.GetInstalledVoices() | ForEach-Object { $_.VoiceInfo }
      $speech.Dispose()
-   - Speech can be surprisingly slow, so its best to keep message text short.   
+   - Speech can be surprisingly slow, so its best to keep message text short.
 '''
 
 EXAMPLES = r'''
@@ -80,19 +80,19 @@ EXAMPLES = r'''
     msg: Warning, deployment commencing in 5 minutes, please log out.
   # Using a different voice and a start sound
 - win_say:
-    start_sound_path: 'C:\Windows\Media\ding.wav'
+    start_sound_path: C:\Windows\Media\ding.wav
     msg: Warning, deployment commencing in 5 minutes, please log out.
     voice: Microsoft Hazel Desktop
   # example with start and end sound
 - win_say:
-    start_sound_path: 'C:\Windows\Media\Windows Balloon.wav'
-    msg: "New software installed"
-    end_sound_path: 'C:\Windows\Media\chimes.wav'
+    start_sound_path: C:\Windows\Media\Windows Balloon.wav
+    msg: New software installed
+    end_sound_path: C:\Windows\Media\chimes.wav
   # text from file example
 - win_say:
-    start_sound_path: 'C:\Windows\Media\Windows Balloon.wav'
+    start_sound_path: C:\Windows\Media\Windows Balloon.wav
     msg_file: AppData\Local\Temp\morning_report.txt
-    end_sound_path: 'C:\Windows\Media\chimes.wav'
+    end_sound_path: C:\Windows\Media\chimes.wav
 '''
 RETURN = r'''
 message_text:

--- a/lib/ansible/modules/windows/win_scheduled_task.py
+++ b/lib/ansible/modules/windows/win_scheduled_task.py
@@ -22,7 +22,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_scheduled_task
 version_added: "2.0"
@@ -87,7 +87,7 @@ options:
     default: '\'
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 # Create a scheduled task to open a command prompt
 - win_scheduled_task:
     name: TaskName

--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['stableinterface'],
                     'supported_by': 'core',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_service
 version_added: "1.7"
@@ -62,7 +62,7 @@ options:
 author: "Chris Hoffman (@chrishoffman)"
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Restart a service
   win_service:
     name: spooler

--- a/lib/ansible/modules/windows/win_share.py
+++ b/lib/ansible/modules/windows/win_share.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'core',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_share
 version_added: "2.1"
@@ -87,7 +87,7 @@ options:
 author: Hans-Joachim Kliemeck (@h0nIg)
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 # Playbook example
 # Add share and set permissions
 ---
@@ -95,7 +95,7 @@ EXAMPLES = '''
   win_share:
     name: internal
     description: top secret share
-    path: C:/shares/internal
+    path: C:\shares\internal
     list: 'no'
     full: Administrators,CEO
     read: HR-Global
@@ -105,7 +105,7 @@ EXAMPLES = '''
   win_share:
     name: company
     description: top secret share
-    path: C:/shares/company
+    path: C:\shares\company
     list: 'yes'
     full: Administrators,CEO
     read: Global
@@ -116,6 +116,6 @@ EXAMPLES = '''
     state: absent
 '''
 
-RETURN = '''
+RETURN = r'''
 
 '''

--- a/lib/ansible/modules/windows/win_shell.py
+++ b/lib/ansible/modules/windows/win_shell.py
@@ -23,7 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'core',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_shell
 short_description: Execute shell commands on target hosts.
@@ -61,21 +61,21 @@ author:
     - Matt Davis
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 # Execute a command in the remote shell; stdout goes to the specified
 # file on the remote.
-- win_shell: C:\\somescript.ps1 >> c:\\somelog.txt
+- win_shell: C:\somescript.ps1 >> c:\somelog.txt
 
 # Change the working directory to somedir/ before executing the command.
-- win_shell: C:\\somescript.ps1 >> c:\\somelog.txt chdir=c:\\somedir
+- win_shell: C:\somescript.ps1 >> c:\somelog.txt chdir=c:\somedir
 
 # You can also use the 'args' form to provide the options. This command
 # will change the working directory to somedir/ and will only run when
 # somedir/somelog.txt doesn't exist.
-- win_shell: C:\\somescript.ps1 >> c:\\somelog.txt
+- win_shell: C:\somescript.ps1 >> c:\somelog.txt
   args:
-    chdir: c:\\somedir
-    creates: c:\\somelog.txt
+    chdir: c:\somedir
+    creates: c:\somelog.txt
 
 # Run a command under a non-Powershell interpreter (cmd in this case)
 - win_shell: echo %HOMEDIR%
@@ -84,7 +84,7 @@ EXAMPLES = '''
   register: homedir_out
 '''
 
-RETURN = '''
+RETURN = r'''
 msg:
     description: changed
     returned: always

--- a/lib/ansible/modules/windows/win_shell.py
+++ b/lib/ansible/modules/windows/win_shell.py
@@ -57,7 +57,7 @@ notes:
       explicitly required. When running ad-hoc commands, use your best judgement.
    -  WinRM will not return from a command execution until all child processes created have exited. Thus, it is not possible to use win_shell to spawn long-running child or background processes.
       Consider creating a Windows service for managing background processes.
-author: 
+author:
     - Matt Davis
 '''
 

--- a/lib/ansible/modules/windows/win_stat.py
+++ b/lib/ansible/modules/windows/win_stat.py
@@ -21,7 +21,7 @@ ANSIBLE_METADATA = {'status': ['stableinterface'],
                     'supported_by': 'core',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_stat
 version_added: "1.7"
@@ -53,7 +53,7 @@ options:
 author: "Chris Church (@cchurch)"
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Obtain information about a file
   win_stat:
     path: C:\foo.ini

--- a/lib/ansible/modules/windows/win_timezone.py
+++ b/lib/ansible/modules/windows/win_timezone.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_timezone
 version_added: "2.1"
@@ -44,10 +44,10 @@ author: Phil Schwartz
 '''
 
 
-EXAMPLES = '''
+EXAMPLES = r'''
   # Set machine's timezone to Central Standard Time
   win_timezone:
     timezone: "Central Standard Time"
 '''
 
-RETURN = '''# '''
+RETURN = r'''# '''

--- a/lib/ansible/modules/windows/win_unzip.py
+++ b/lib/ansible/modules/windows/win_unzip.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_unzip
 version_added: "2.0"

--- a/lib/ansible/modules/windows/win_updates.py
+++ b/lib/ansible/modules/windows/win_updates.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'core',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_updates
 version_added: "2.0"
@@ -60,7 +60,7 @@ options:
         choices:
         - installed
         - searched
-    log_path: 
+    log_path:
         description:
         - If set, win_updates will append update progress to the specified file. The directory must already exist.
         required: false
@@ -72,7 +72,7 @@ notes:
 - win_updates can take a significant amount of time to complete (hours, in some cases). Performance depends on many factors, including OS version, number of updates, system load, and update server load.
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 # Install all security, critical, and rollup updates
 - win_updates:
     category_names:
@@ -91,7 +91,7 @@ EXAMPLES = '''
     log_path: c:\ansible_wu.txt
 '''
 
-RETURN = '''
+RETURN = r'''
 reboot_required:
     description: True when the target server requires a reboot to complete updates (no further updates can be installed until after a reboot)
     returned: success

--- a/lib/ansible/modules/windows/win_updates.py
+++ b/lib/ansible/modules/windows/win_updates.py
@@ -99,11 +99,11 @@ reboot_required:
     sample: True
 
 updates:
-    description: List of updates that were found/installed 
+    description: List of updates that were found/installed
     returned: success
     type: dictionary
-    sample: 
-    contains: 
+    sample:
+    contains:
         title:
             description: Display name
             returned: always

--- a/lib/ansible/modules/windows/win_uri.py
+++ b/lib/ansible/modules/windows/win_uri.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-DOCUMENTATION = """
+DOCUMENTATION = r'''
 ---
 module: win_uri
 version_added: "2.1"
@@ -73,9 +73,9 @@ options:
       - False
     default: True
 author: Corwin Brown (@blakfeld)
-"""
+'''
 
-EXAMPLES = """
+EXAMPLES = r'''
 - name: Perform a GET and Store Output
   win_uri:
     url: http://example.com/endpoint
@@ -99,9 +99,9 @@ EXAMPLES = """
     url: http://www.somesite.com
     method: POST
     body: "{ 'some': 'json' }"
-"""
+'''
 
-RETURN = """
+RETURN = r'''
 url:
   description: The Target URL
   returned: always
@@ -153,4 +153,4 @@ raw_content_length:
   returned: success
   type: int
   sample: 54447
-"""
+'''

--- a/lib/ansible/modules/windows/win_user.py
+++ b/lib/ansible/modules/windows/win_user.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['stableinterface'],
                     'supported_by': 'core',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_user
 version_added: "1.7"
@@ -131,12 +131,12 @@ options:
       - query
     default: present
     aliases: []
-author: 
+author:
     - "Paul Durivage (@angstwad)"
     - "Chris Church (@cchurch)"
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Ensure user bob is present
   win_user:
     name: bob

--- a/lib/ansible/modules/windows/win_webpicmd.py
+++ b/lib/ansible/modules/windows/win_webpicmd.py
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: win_webpicmd
 version_added: "2.0"
@@ -44,7 +44,7 @@ options:
 author: Peter Mounce
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
   # Install URLRewrite2.
   win_webpicmd:
     name: URLRewrite2


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
windows modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Especially when using Windows paths they easily get confused as escaped
sequences or unicode characters. So by default use raw strings

This fixes #20295

PS If needed we can do this for all modules so that this is consistent throughout all modules (and mistakes are reduced to a minimum).