### PR TITLE
amazon: added boto3_conn to GUIDELINES.md

### DIFF
--- a/lib/ansible/modules/cloud/amazon/GUIDELINES.md
+++ b/lib/ansible/modules/cloud/amazon/GUIDELINES.md
@@ -112,11 +112,11 @@ if my_new_feauture_Parameter_is_set:
 ### Connecting to AWS
 
 To connect to AWS, you should use `get_aws_connection_info` and then
-`connect_to_aws`.
+`boto3_conn` (or `connect_to_aws` for boto).
 
-The reason for using `get_aws_connection_info` and `connect_to_aws` rather than doing it
-yourself is that they handle some of the more esoteric connection
-options such as security tokens and boto profiles.
+The reason for using these functions rather than doing it yourself is that they
+handle some of the more esoteric connection options such as security tokens and
+boto profiles.
 
 Some boto services require region to be specified. You should check for the region parameter if required.
 

--- a/lib/ansible/modules/cloud/amazon/GUIDELINES.md
+++ b/lib/ansible/modules/cloud/amazon/GUIDELINES.md
@@ -114,11 +114,10 @@ if my_new_feauture_Parameter_is_set:
 To connect to AWS, you should use `get_aws_connection_info` and then
 `boto3_conn` (or `connect_to_aws` for boto).
 
-The reason for using these functions rather than doing it yourself is that they
-handle some of the more esoteric connection options such as security tokens and
+These functions handle some of the more esoteric connection options, such as security tokens and
 boto profiles.
 
-Some boto services require region to be specified. You should check for the region parameter if required.
+Some boto services require that the region is specified. You should check for the region parameter if required.
 
 #### boto
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
`amazon/GUIDELINES.md`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
n/a
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The guidelines were out of date with respect to how to use `boto3`.