### PR TITLE
Warn when jinja2 delimiters are found in a when statement

### DIFF
--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -126,11 +126,10 @@ class Conditional:
         if conditional in all_vars and re.match("^[_A-Za-z][_a-zA-Z0-9]*$", conditional):
             conditional = all_vars[conditional]
 
-        delimiters = re.search('({{.*}}|{%.*%})', conditional)
-        if delimiters:
+        if templar._clean_data(conditional) != conditional:
             display.warning('when statements should not include jinja2 '
                             'templating delimiters such as {{ }} or {%% %%}. '
-                            'Found: %s' % ', '.join(delimiters.groups()))
+                            'Found: %s' % conditional)
 
         # make sure the templar is using the variables specified with this method
         templar.set_available_variables(variables=all_vars)

--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -30,6 +30,12 @@ from ansible.template import Templar
 from ansible.module_utils._text import to_native
 from ansible.vars.unsafe_proxy import wrap_var
 
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
 DEFINED_REGEX = re.compile(r'(hostvars\[.+\]|[\w_]+)\s+(not\s+is|is|is\s+not)\s+(defined|undefined)')
 LOOKUP_REGEX = re.compile(r'lookup\s*\(')
 
@@ -119,6 +125,12 @@ class Conditional:
 
         if conditional in all_vars and re.match("^[_A-Za-z][_a-zA-Z0-9]*$", conditional):
             conditional = all_vars[conditional]
+
+        delimiters = re.search('({{.*}}|{%.*%})', conditional)
+        if delimiters:
+            display.warning('when statements should not include jinja2 '
+                            'templating delimiters such as {{ }} or {%% %%}. '
+                            'Found: %s' % ', '.join(delimiters.groups()))
 
         # make sure the templar is using the variables specified with this method
         templar.set_available_variables(variables=all_vars)


### PR DESCRIPTION
##### ISSUE TYPE
 Feature Pull Request

##### COMPONENT NAME
conditionals

##### ANSIBLE VERSION

```
v2.3
```

##### SUMMARY

This change introduces a warning when a conditional such as `when` contains jinja2 templating, such as:

`when: "{{ foo is defined }}"`

This could be a useful warning as this is one of the more common mistakes users make, which can lead to very inconsistent behavior, due to the `"{{ foo is defined }}"` being templated before the `when` statement is actually evaluated.

This would cause a warning of:

```
[WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{ foo is defined }}
```

There may be a better way of testing this, I just couldn't immediately find it.  I was looking for a more robust way than a simple regex to test if a string was a template, but I settled on this as the least performance impacting.

I'm also trying to think of scenarios where a user might actually want to do this, and maybe it is valid, I'm just not thinking of a good use case.  Such a scenario would be when they want the template in the `when` statement, evaluated early, before the `when` statement is actually executed.

In any case, if this is not something we are interested in, I suppose we can close this.