### PR TITLE
Clean up inventory generation in ansible-test.

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -249,7 +249,7 @@ def network_inventory(remotes):
         groups[remote.platform].append(
             '%s %s' % (
                 remote.name.replace('.', '_'),
-                ' '.join('%s=%s' % (k, options[k]) for k in sorted(options)),
+                ' '.join('%s="%s"' % (k, options[k]) for k in sorted(options)),
             )
         )
 
@@ -338,7 +338,7 @@ def windows_inventory(remotes):
         hosts.append(
             '%s %s' % (
                 remote.name.replace('/', '_'),
-                ' '.join('%s=%s' % (k, options[k]) for k in sorted(options)),
+                ' '.join('%s="%s"' % (k, options[k]) for k in sorted(options)),
             )
         )
 


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (aci-inv-refactor bea11a9099) last updated 2017/01/16 11:11:45 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Clean up inventory generation in ansible-test. Also add `ansible_network_os` for network inventory.