### PR TITLE
Test the extract filter without the map filter.

### DIFF
--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -95,6 +95,13 @@
   assert:
     that: "{{_.failed}}"
 
+- name: Test extract
+  assert:
+    that:
+        - '"c" == 2 | extract(["a", "b", "c"])'
+        - '"b" == 1 | extract(["a", "b", "c"])'
+        - '"a" == 0 | extract(["a", "b", "c"])'
+
 - name: Container lookups with extract
   assert:
     that:


### PR DESCRIPTION
map + extract is the usual way to use it but map isn't available on
older versions of jinja2 that we still work with.  Test extract even on
those versions.

##### ISSUE TYPE

 - Test Pull Request

##### COMPONENT NAME

the extract filter tests.

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```
