### PR TITLE
Only test map on jinja2 >= 2.7

### DIFF
--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -104,6 +104,9 @@
         - "31 == ['x','y']|map('extract',{'x':42,'y':31})|list|last"
         - "'local' == ['localhost']|map('extract',hostvars,'ansible_connection')|list|first"
         - "'local' == ['localhost']|map('extract',hostvars,['ansible_connection'])|list|first"
+  # map was added to jinja2 in version 2.7
+  when: "{{ ( lookup('pipe', 'pip show --disable-pip-version-check jinja2 | grep ^Version: | sed \"s/^Version: //\"') |
+              version_compare('2.7', '>=') ) }}"
 
 - name: Test json_query filter
   assert:


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Integration Tests

##### ANSIBLE VERSION

```
ansible 2.3.0 (jinja2-map-test 961baad8e4) last updated 2017/01/16 13:17:01 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Only test map on jinja2 >= 2.7 since it was added in that version.