### PR TITLE
New dimensiondata vlan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ Ansible Changes By Release
   * cs_region
   * cs_role
   * cs_vpc
+- dimensiondata
+  * dimensiondata_network
+  * dimensiondata_vlan
 - f5
   * bigip_gtm_facts
   * bigip_hostname

--- a/lib/ansible/module_utils/dimensiondata.py
+++ b/lib/ansible/module_utils/dimensiondata.py
@@ -22,8 +22,11 @@
 #
 # Common methods to be used by versious module components
 import os
-from ansible.module_utils.six.moves.configparser import ConfigParser
+import re
+
+from ansible.compat.six.moves import configparser
 from ansible.module_utils.pycompat24 import get_exception
+from configparser import ConfigParser
 from os.path import expanduser
 from uuid import UUID
 
@@ -33,6 +36,9 @@ try:
     HAS_LIBCLOUD = True
 except ImportError:
     HAS_LIBCLOUD = False
+
+# MCP 2.x version patten for location (datacenter) names.
+MCP_2_LOCATION_NAME_PATTERN = re.compile(r".*MCP\s?2.*")
 
 
 # Custom Exceptions
@@ -200,8 +206,9 @@ def get_mcp_version(driver, location):
     """
     # Get location to determine if MCP 1.0 or 2.0
     location = driver.ex_get_location_by_id(location)
-    if 'MCP 2.0' in location.name:
+    if MCP_2_LOCATION_NAME_PATTERN.match(location.name):
         return '2.0'
+
     return '1.0'
 
 

--- a/lib/ansible/modules/cloud/dimensiondata/dimensiondata_network.py
+++ b/lib/ansible/modules/cloud/dimensiondata/dimensiondata_network.py
@@ -28,7 +28,7 @@ module: dimensiondata_network
 short_description: Create, update, and delete MCP 1.0 & 2.0 networks
 description:
   - Create, update, and delete MCP 1.0 & 2.0 networks
-version_added: "2.2"
+version_added: "2.3"
 author: 'Aimon Bustardo (@aimonb)'
 options:
   region:

--- a/lib/ansible/modules/cloud/dimensiondata/dimensiondata_network.py
+++ b/lib/ansible/modules/cloud/dimensiondata/dimensiondata_network.py
@@ -155,7 +155,7 @@ network:
 
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.dimensiondata import get_credentials, DimensionDataAPIException, LibcloudNotFound
+from ansible.module_utils.dimensiondata import get_credentials, get_mcp_version, DimensionDataAPIException, LibcloudNotFound
 from ansible.module_utils.pycompat24 import get_exception
 try:
     from libcloud.compute.types import Provider
@@ -184,14 +184,6 @@ def network_obj_to_dict(network, version):
         network_dict['multicast'] = None
         network_dict['status'] = network.status
     return network_dict
-
-
-def get_mcp_version(driver, location):
-    # Get location to determine if MCP 1.0 or 2.0
-    location = driver.ex_get_location_by_id(location)
-    if 'MCP 2.0' in location.name:
-        return '2.0'
-    return '1.0'
 
 
 def create_network(module, driver, mcp_version, location,

--- a/lib/ansible/modules/cloud/dimensiondata/dimensiondata_vlan.py
+++ b/lib/ansible/modules/cloud/dimensiondata/dimensiondata_vlan.py
@@ -260,7 +260,8 @@ def get_vlan(module, driver, location, network_domain, vlan_id, name):
 def delete_vlan(module, driver, location, network_domain, vlan_id, name):
     vlan = get_vlan(module, driver, location, network_domain,
                     vlan_id, name)
-    if type(vlan) is dict:
+
+    if isinstance(vlan, dict):
         return False
     try:
         return driver.ex_delete_vlan(vlan)
@@ -296,7 +297,7 @@ def expand_vlan(module, driver, location, network_domain, vlan_id, name,
                 private_ipv4_range_size):
     vlan_obj = get_vlan(module, driver, location, network_domain,
                         vlan_id, name)
-    if type(vlan_obj) is dict:
+    if isinstance(vlan_obj, dict):
         module.exit_json(changed=False, msg="VLAN not found.")
     else:
         if vlan_obj.private_ipv4_range_size == private_ipv4_range_size:
@@ -377,7 +378,7 @@ def main():
     elif action == 'read' or action == 'get':
         res = get_vlan(module, driver, location, network_domain,
                        vlan_id, name)
-        if type(res) is dict:
+        if isinstance(res, dict):
             vlan = res
         else:
             vlan = vlan_obj_to_dict(res)
@@ -408,7 +409,7 @@ def main():
         res = expand_vlan(module, driver, location, network_domain, vlan_id,
                           name, prefix_size)
 
-        if type(res) is bool:
+        if isinstance(res, bool):
             module.exit_json(changed=False, msg="VLAN already requested size.")
         else:
             module.exit_json(changes=True, msg="VLAN network size modified.",

--- a/lib/ansible/modules/cloud/dimensiondata/dimensiondata_vlan.py
+++ b/lib/ansible/modules/cloud/dimensiondata/dimensiondata_vlan.py
@@ -1,0 +1,411 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Dimension Data
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#   - Aimon Bustardo <aimon.bustardo@dimensiondata.com>
+#   - Bert Diwa      <Lamberto.Diwa@dimensiondata.com>
+#
+from ansible.module_utils.basic import *
+from ansible.module_utils.dimensiondata import *
+try:
+    from libcloud.common.dimensiondata import DimensionDataAPIException
+    from libcloud.compute.types import Provider
+    from libcloud.compute.providers import get_driver
+    import libcloud.security
+    HAS_LIBCLOUD = True
+except:
+    HAS_LIBCLOUD = False
+
+# Get regions early to use in docs etc.
+dd_regions = get_dd_regions()
+
+DOCUMENTATION = '''
+---
+module: dimensiondata_vlan
+short_description: Create, Read, Update or Delete VLANs.
+description:
+  - Create, Read, Update, Delete or Expand VLANs.
+version_added: "2.2"
+author: 'Aimon Bustardo (@aimonb)'
+options:
+  region:
+    description:
+      - The target region.
+    choices:
+      - Regions choices are defined in Apache libcloud project [libcloud/common/dimensiondata.py]
+      - Regions choices are also listed in https://libcloud.readthedocs.io/en/latest/compute/drivers/dimensiondata.html
+      - Note that the region values are available as list from dd_regions().
+      - Note that the default value "na" stands for "North America".  The code prepends 'dd-' to the region choice.
+    default: na
+  location:
+    description:
+      - The target datacenter.
+    required: true
+  name:
+    description:
+      - The name of the VLAN, required for 'create' action
+    required: false
+  description:
+    description:
+      - Additional description of the VLAN.
+    required: false
+    default: null
+  network_domain:
+    description:
+      - The network domain name of the target network.
+    required: true
+  private_ipv4_base_address:
+    description:
+        - The base IPv4 address e.g. 192.168.1.0.
+    required: false
+  private_ipv4_prefix_size:
+    description:
+        - The size of the IPv4 address space, e.g 24.
+    required: false
+  vlan_id:
+    description:
+      - The VLAN ID, required for 'update' and 'expand' action.
+    required: false
+  verify_ssl_cert:
+    description:
+      - Check that SSL certificate is valid.
+    required: false
+    default: true
+  wait:
+    description:
+      - Should we wait for the task to complete before moving onto the next.
+    required: false
+    default: false
+  wait_time:
+    description:
+      - Only applicable if wait is true.
+        This is the amount of time in seconds to wait
+    required: false
+    default: 600
+  wait_poll_interval:
+    description:
+      - The amount to time inbetween polling for task completion
+    required: false
+    default: 2
+  action:
+    description:
+      - create, read(get), update, delete or expand.
+    choices: [create, read, get, update, delete, expand]
+    default: create
+'''
+
+EXAMPLES = '''
+# Add VLAN
+- dimensiondata_vlan:
+    region: na
+    location: NA5
+    network_domain: test_network
+    name: my_vlan1
+    description: A test VLAN'd Network.
+    private_ipv4_base_address: 192.168.23.0
+    private_ipv4_prefix_size: 24
+    action: create
+    wait: yes
+# Read/Get a VLAN details
+- dimensiondata_vlan:
+    region: na
+    location: NA5
+    network_domain: test_network
+    name: my_vlan1
+    action: read
+    wait: yes
+# Update a VLAN
+# VLAN ID is required to modify a VLAN.
+- dimensiondata_vlan:
+    region: na
+    location: NA5
+    network_domain: test_network
+    vlan_id: a2c6cccc-bbbb-aaaa-0000-000028bcc47c
+    name: my_vlan_1
+    description: A test VLAN network, renamed.
+    state: present
+    wait: yes
+# Delete a VLAN by name
+- dimensiondata_vlan:
+    region: na
+    location: NA5
+    network_domain: test_network
+    name: my_vlan_1
+    action: delete
+    wait: no
+# Delete a VLAN by ID
+- dimensiondata_vlan:
+    region: na
+    location: NA5
+    network_domain: test_network
+    vlan_id: a2c6cccc-bbbb-aaaa-0000-000028bcc47c
+    action: delete
+    wait: no
+'''
+
+RETURN = '''
+vlan:
+    description: Dictionary describing the VLAN.
+    returned: On success when I(state) is 'present'
+    type: dictionary
+    contains:
+        id:
+            description: VLAN ID.
+            type: string
+            sample: "aaaaa000-a000-4050-a215-2808934ccccc"
+        name:
+            description: VLAN name.
+            type: string
+            sample: "My VLAN"
+        description:
+            description: VLAN description.
+            type: string
+            sample: "My VLAN description"
+        location:
+            description: Datacenter location.
+            type: string
+            sample: NA3
+        status:
+            description: VLAN status.
+            type: string
+            sample: NORMAL
+'''
+
+
+def vlan_obj_to_dict(vlan):
+    vlan_d = dict(id=vlan.id,
+                  name=vlan.name,
+                  description=vlan.description,
+                  location=vlan.location.id,
+                  private_ipv4_range_address=vlan.private_ipv4_range_address,
+                  private_ipv4_range_size=vlan.private_ipv4_range_size,
+                  status=vlan.status,
+                  )
+    return vlan_d
+
+
+def wait_for_vlan_state(module, driver, vlan_id, state_to_wait_for):
+    try:
+        return driver.connection.wait_for_state(
+            state_to_wait_for, driver.ex_get_vlan,
+            module.params['wait_poll_interval'],
+            module.params['wait_time'], vlan_id
+        )
+    except DimensionDataAPIException as e:
+        module.fail_json(msg='VLAN did not reach % state in time: %s'
+                         % (state, e.msg))
+
+
+def create_vlan(module, driver, location, network_domain, name, description,
+                base_address, prefix_size):
+    try:
+        vlan = driver.ex_create_vlan(network_domain, name, base_address,
+                                     description, prefix_size)
+    except DimensionDataAPIException as e:
+        if e.code == 'NAME_NOT_UNIQUE':
+            vlan = get_vlan(module, driver, location, network_domain, 'False',
+                            name)
+            return {'vlan': vlan, 'changed': False}
+        module.fail_json(msg="Failed to create VLAN: %s" % e)
+    # Wait for it to become ready
+    if module.params['wait']:
+        vlan = wait_for_vlan_state(module, driver, vlan.id, 'NORMAL')
+    return {'vlan': vlan, 'changed': True}
+
+
+def get_vlan(module, driver, location, network_domain, vlan_id, name):
+    if vlan_id is not 'False':
+        try:
+            vlan = driver.ex_get_vlan(vlan_id)
+            return vlan
+        except DimensionDataAPIException as e:
+            if e.code == "NOT_FOUND":
+                return {'id': False}
+            else:
+                module.fail_json(msg="Unexpected error: %s" % e)
+    elif name is not False:
+        try:
+            # Find vlan by name
+            vlans = driver.ex_list_vlans(location, network_domain, name)
+            # VLAN not found
+            if len(vlans) < 1:
+                return {'id': False}
+            return driver.ex_get_vlan(vlans[0].id)
+        except DimensionDataAPIException as e:
+            module.fail_json(msg="Unexpected API error: %s" % e)
+    else:
+        module.fail_json(msg="Unexpected Error: One of vlan_id or name " +
+                             "must be provided.")
+
+
+def delete_vlan(module, driver, location, network_domain, vlan_id, name):
+    vlan = get_vlan(module, driver, location, network_domain,
+                    vlan_id, name)
+    if type(vlan) is dict:
+        return False
+    try:
+        return driver.ex_delete_vlan(vlan)
+    except DimensionDataAPIException as e:
+        module.fail_json(msg="Unexpected API error: %s" % e)
+
+
+def update_vlan(module, driver, location, network_domain, vlan_id,
+                name, description):
+    vlan_obj = get_vlan(module, driver, location, network_domain,
+                        vlan_id, name)
+    if vlan_obj is False:
+        changed = False
+        vlan = False
+    elif vlan_obj.name != name or vlan_obj.description != description:
+        vlan_obj.name = name
+        vlan_obj.description = description
+        try:
+            vlan = driver.ex_update_vlan(vlan_obj)
+        except DimensionDataAPIException as e:
+            module.fail_json(msg="Failed to update VLAN: %s" % e)
+        changed = True
+    else:
+        changed = False
+        vlan = False
+    return {'changed': changed, 'vlan': vlan}
+
+
+def expand_vlan(module, driver, location, network_domain, vlan_id, name,
+                private_ipv4_range_size):
+    vlan_obj = get_vlan(module, driver, location, network_domain,
+                        vlan_id, name)
+    if type(vlan_obj) is dict:
+        module.exit_json(changed=False, msg="VLAN not found.")
+    else:
+        if vlan_obj.private_ipv4_range_size == private_ipv4_range_size:
+            return False
+        else:
+            vlan_obj.private_ipv4_range_size = private_ipv4_range_size
+            try:
+                return driver.ex_expand_vlan(vlan_obj)
+            except DimensionDataAPIException as e:
+                module.fail_json(msg="Failed to expand VLAN: %s" % e)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            region=dict(default='na', choices=dd_regions),
+            location=dict(required=True, type='str'),
+            network_domain=dict(required=True, type='str'),
+            name=dict(default=False, type='str'),
+            vlan_id=dict(default=False, type='str'),
+            description=dict(default='', type='str'),
+            private_ipv4_base_address=dict(default=False, type='str'),
+            private_ipv4_prefix_size=dict(default=False, type='str'),
+            action=dict(default='create', choices=['create', 'read', 'get',
+                                                   'update', 'delete',
+                                                   'expand']),
+            verify_ssl_cert=dict(required=False, default=True, type='bool'),
+            wait=dict(required=False, default=False, type='bool'),
+            wait_time=dict(required=False, default=600, type='int'),
+            wait_poll_interval=dict(required=False, default=2, type='int')
+        )
+    )
+
+    if not HAS_LIBCLOUD:
+        module.fail_json(msg='libcloud is required for this module.')
+
+    # set short vars for readability
+    credentials = get_credentials()
+    if credentials is False:
+        module.fail_json(msg="User credentials not found")
+    user_id = credentials['user_id']
+    key = credentials['key']
+    region = 'dd-%s' % module.params['region']
+    location = module.params['location']
+    network_domain_name = module.params['network_domain']
+    name = module.params['name']
+    vlan_id = module.params['vlan_id']
+    description = module.params['description']
+    base_address = module.params['private_ipv4_base_address']
+    prefix_size = module.params['private_ipv4_prefix_size']
+    verify_ssl_cert = module.params['verify_ssl_cert']
+    action = module.params['action']
+
+    # Instantiate driver
+    libcloud.security.VERIFY_SSL_CERT = verify_ssl_cert
+    DimensionData = get_driver(Provider.DIMENSIONDATA)
+    driver = DimensionData(user_id, key, region=region)
+
+    # Get Network Domain Object
+    network_domain = get_network_domain_by_name(driver, network_domain_name,
+                                                location)
+
+    # Process action
+    if action == 'create':
+        if name is False:
+            module.fail_json(msg="'name' is a required argument when action" +
+                                 " is 'create'")
+        res = create_vlan(module, driver, location, network_domain, name,
+                          description, base_address, prefix_size)
+        vlan = vlan_obj_to_dict(res['vlan'])
+        if res['changed'] is False:
+            module.exit_json(changed=False, msg="VLAN with name '%s'" % name +
+                             "already exists.", vlan=vlan)
+        module.exit_json(changed=True, msg="Successfully created VLAN.",
+                         vlan=vlan)
+    elif action == 'read' or action == 'get':
+        res = get_vlan(module, driver, location, network_domain,
+                       vlan_id, name)
+        if type(res) is dict:
+            vlan = res
+        else:
+            vlan = vlan_obj_to_dict(res)
+        module.exit_json(changed=False, msg="Successfully read VLAN.",
+                         vlan=vlan)
+    elif action == 'delete':
+        res = delete_vlan(module, driver, location, network_domain,
+                          vlan_id, name)
+        module.exit_json(changed=res, msg="Successfully deleted VLAN or " +
+                         "VLAN does not exist")
+    elif action == 'update':
+        if vlan_id is False:
+            module.fail_json(msg="'vlan_id' is a required argument when " +
+                             "updating a VLAN")
+        res = update_vlan(module, driver, location, network_domain, vlan_id,
+                          name, description)
+        if res['vlan'] is False and res['changed'] is False:
+            module.exit_json(changed=False, msg="VLAN did not need updating.")
+        else:
+            vlan = vlan_obj_to_dict(res['vlan'])
+            module.exit_json(changed=False, msg="Successfully updated VLAN.",
+                             vlan=vlan)
+    elif action == 'expand':
+        if vlan_id is False:
+            module.fail_json(msg="'vlan_id' is a required argument when " +
+                             "expanding a VLAN")
+        res = expand_vlan(module, driver, location, network_domain, vlan_id,
+                          name, prefix_size)
+        if type(res) is bool:
+            module.exit_json(changed=False, msg="VLAN already requested size.")
+        else:
+            module.exit_json(changes=True, msg="VLAN network size modified.",
+                             vlan=vlan_obj_to_dict(res))
+    else:
+        fail_json(msg="Requested action was " +
+                  "'%s'. Action must be one of 'create', 'read', " % state +
+                  "'update', 'expand' or 'delete'")
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/dimensiondata/dimensiondata_vlan.py
+++ b/lib/ansible/modules/cloud/dimensiondata/dimensiondata_vlan.py
@@ -41,6 +41,17 @@ options:
       - Note that the default value "na" stands for "North America".
       - The module prepends 'dd-' to the region choice.
     default: na
+  mcp_user:
+    description:
+      - The username used to authenticate to the CloudControl API.
+      - If not specified, will fall back to C(MCP_USER) from environment variable or C(~/.dimensiondata).
+    required: false
+  mcp_password:
+    description:
+      - The password used to authenticate to the CloudControl API.
+      - If not specified, will fall back to C(MCP_PASSWORD) from environment variable or C(~/.dimensiondata).
+      - Required if mcp_user is specified.
+    required: false
   location:
     description:
       - The target datacenter.

--- a/lib/ansible/modules/cloud/dimensiondata/dimensiondata_vlan.py
+++ b/lib/ansible/modules/cloud/dimensiondata/dimensiondata_vlan.py
@@ -361,8 +361,8 @@ def main():
                           description, base_address, prefix_size)
         vlan = vlan_obj_to_dict(res['vlan'])
         if res['changed'] is False:
-            module.exit_json(changed=False, msg="VLAN with name '%s'" % name +
-                             "already exists.", vlan=vlan)
+            module.exit_json(changed=False, msg="VLAN with name '%s'" +
+                             " already exists." % name, vlan=vlan)
         module.exit_json(changed=True, msg="Successfully created VLAN.",
                          vlan=vlan)
     elif action == 'read' or action == 'get':
@@ -404,8 +404,8 @@ def main():
                              vlan=vlan_obj_to_dict(res))
     else:
         fail_json(msg="Requested action was " +
-                  "'%s'. Action must be one of 'create', 'read', " % state +
-                  "'update', 'expand' or 'delete'")
+                  "'%s'. Action must be one of 'create', 'read', " +
+                  "'update', 'expand' or 'delete'" % state)
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/dimensiondata/dimensiondata_vlan.py
+++ b/lib/ansible/modules/cloud/dimensiondata/dimensiondata_vlan.py
@@ -67,7 +67,7 @@ options:
     default: null
   network_domain:
     description:
-      - The network domain name of the target network.
+      - The network domain name or Id of the target network.
     required: true
   private_ipv4_base_address:
     description:
@@ -359,7 +359,7 @@ def main():
     key = credentials['key']
     region = 'dd-%s' % module.params['region']
     location = module.params['location']
-    network_domain_name = module.params['network_domain']
+    network_domain_id_or_name = module.params['network_domain']
     name = module.params['name']
     vlan_id = module.params['vlan_id']
     description = module.params['description']
@@ -374,8 +374,9 @@ def main():
     driver = DimensionData(user_id, key, region=region)
 
     # Get Network Domain Object
-    network_domain = get_network_domain_by_name(driver, network_domain_name,
-                                                location)
+    network_domain = get_network_domain(
+        driver, network_domain_id_or_name, location
+    )
 
     # Process action
     if action == 'create':

--- a/lib/ansible/modules/cloud/dimensiondata/dimensiondata_vlan.py
+++ b/lib/ansible/modules/cloud/dimensiondata/dimensiondata_vlan.py
@@ -19,6 +19,7 @@
 # Authors:
 #   - Aimon Bustardo <aimon.bustardo@dimensiondata.com>
 #   - Bert Diwa      <Lamberto.Diwa@dimensiondata.com>
+#   - Adam Friedman  <tintoy@tintoy.io>
 #
 
 
@@ -28,7 +29,7 @@ module: dimensiondata_vlan
 short_description: Create, Read, Update or Delete VLANs.
 description:
   - Create, Read, Update, Delete or Expand VLANs.
-version_added: "2.2"
+version_added: "2.3"
 author: 'Aimon Bustardo (@aimonb)'
 options:
   region:
@@ -36,8 +37,9 @@ options:
       - The target region.
     choices:
       - Regions are defined in Apache libcloud project [libcloud/common/dimensiondata.py]
-      - They are also listed in https://libcloud.readthedocs.io/en/latest/compute/drivers/dimensiondata.html
-      - Note that the default value "na" stands for "North America". The module prepends 'dd-' to the region choice.
+      - They are also listed in U(https://libcloud.readthedocs.io/en/latest/compute/drivers/dimensiondata.html)
+      - Note that the default value "na" stands for "North America".
+      - The module prepends 'dd-' to the region choice.
     default: na
   location:
     description:
@@ -314,6 +316,8 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             region=dict(default='na'),
+            mcp_user=dict(required=False, type='str'),
+            mcp_password=dict(required=False, type='str'),
             location=dict(required=True, type='str'),
             network_domain=dict(required=True, type='str'),
             name=dict(default=False, type='str'),
@@ -321,14 +325,15 @@ def main():
             description=dict(default='', type='str'),
             private_ipv4_base_address=dict(default=False, type='str'),
             private_ipv4_prefix_size=dict(default=False, type='str'),
-            action=dict(default='create', choices=['create', 'read', 'get',
-                                                   'update', 'delete',
-                                                   'expand']),
+            action=dict(default='create', choices=['create', 'read', 'get', 'update', 'delete', 'expand']),
             verify_ssl_cert=dict(required=False, default=True, type='bool'),
             wait=dict(required=False, default=False, type='bool'),
             wait_time=dict(required=False, default=600, type='int'),
             wait_poll_interval=dict(required=False, default=2, type='int')
-        )
+        ),
+        required_together=[
+            ['mcp_user', 'mcp_password']
+        ]
     )
 
     if not HAS_LIBCLOUD:


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

ansible-module-extras/cloud/dimensiondata/dimensiondata_vlan.py
##### ANSIBLE VERSION

```
ansible 2.2.0
```
##### SUMMARY

This is Ansible module support for apache-libcloud functions.
Specifically, this code supports Ansible invocations of DimensionData's 
VLAN functionality.

This is to support a new capability within ansible, so there is no "BEFORE".
Note that this routine has an "action verb" which allows multiple different
actions to be performed on a vlan.  Below shows the ansible call to
create a vlan, along with its output.

```
    - name: create vlan named "{{vlan_name}}"
       dimensiondata_vlan:
         region: "{{dimension_data_region}}"
         location: "{{dimension_data_location}}"
         network_domain: "{{dimension_data_network_domain}}"
         name: "{{vlan_name}}"
         description: A test VLAN Network.
         private_ipv4_base_address: "{{base_ip}}"
         private_ipv4_prefix_size: "{{prefix_size|int}}"
         action: create
         wait: true
         wait_time: 300

    TASK [create vlan named "demo-vlan"] *******************************************
    changed: [127.0.0.1] => {"changed": true, "msg": "Successfully created VLAN.", "vlan": {"description": "A test VLAN Network.", "id": "9755b966-b07a-418a-a892-de5416ee992f", "location": "NA12", "name": "demo-vlan", "private_ipv4_range_address": "192.168.24.0", "private_ipv4_range_size": 24, "status": "NORMAL"}}

```
###### REQUIRES

https://github.com/ansible/ansible/pull/17604
https://github.com/apache/libcloud/pull/858
