### PR TITLE
Add support for ios to ansible-test.

### DIFF
--- a/test/runner/completion/network.txt
+++ b/test/runner/completion/network.txt
@@ -1,3 +1,4 @@
+ios/csr1000v
 junos/vmx
 junos/vsrx
 vyos/1.0.5

--- a/test/runner/lib/core_ci.py
+++ b/test/runner/lib/core_ci.py
@@ -50,6 +50,7 @@ class AnsibleCoreCI(object):
             'freebsd',
             'vyos',
             'junos',
+            'ios',
         )
 
         osx_platforms = (

--- a/test/runner/lib/manage_ci.py
+++ b/test/runner/lib/manage_ci.py
@@ -75,6 +75,7 @@ class ManageNetworkCI(object):
             'ansible_port=%s' % self.core_ci.connection.port,
             'ansible_connection=network_cli',
             'ansible_ssh_private_key_file=%s' % self.core_ci.ssh_key.key,
+            'ansible_network_os=%s' % self.core_ci.platform,
         ]
 
         name = '%s-%s' % (self.core_ci.platform, self.core_ci.version.replace('.', '_'))


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (ios 33aa7ae0db) last updated 2017/01/16 14:33:57 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Add support for ios to ansible-test.