### PR TITLE
Use distro packaged jinja2 instead of pip version.

### DIFF
--- a/test/utils/docker/centos6/Dockerfile
+++ b/test/utils/docker/centos6/Dockerfile
@@ -19,6 +19,7 @@ RUN yum clean all && \
     python-coverage \
     python-devel \
     python-httplib2 \
+    python-jinja2 \
     python-keyczar \
     python-mock \
     python-nose \
@@ -39,7 +40,7 @@ RUN yum clean all && \
     && \
     yum clean all
 
-RUN rpm -e --nodeps python-crypto && pip install --upgrade jinja2 pycrypto
+RUN rpm -e --nodeps python-crypto && pip install --upgrade pycrypto
 
 RUN /bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 RUN mkdir /etc/ansible/

--- a/test/utils/docker/ubuntu1204/Dockerfile
+++ b/test/utils/docker/ubuntu1204/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update -y && \
     python-coverage \
     python-dev \
     python-httplib2 \
+    python-jinja2 \
     python-keyczar \
     python-mock \
     python-mysqldb \
@@ -49,7 +50,7 @@ RUN apt-get update -y && \
     && \
     apt-get clean
 
-RUN pip install --upgrade jinja2 pycrypto
+RUN pip install --upgrade pycrypto
 
 # helpful things taken from the ubuntu-upstart Dockerfile:
 # https://github.com/tianon/dockerfiles/blob/4d24a12b54b75b3e0904d8a285900d88d3326361/sbin-init/ubuntu/upstart/14.04/Dockerfile


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

Integration Test Docker Images

##### ANSIBLE VERSION

```
ansible 2.3.0 (docker-update 97419378ff) last updated 2017/01/16 15:22:39 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Use distro packaged jinja2 instead of pip version.