### PR TITLE
Improve ansible-test error handling and timeouts.

### DIFF
--- a/test/runner/lib/manage_ci.py
+++ b/test/runner/lib/manage_ci.py
@@ -47,7 +47,7 @@ class ManageWindowsCI(object):
         env = ansible_environment(self.core_ci.args)
         cmd = ['ansible', '-m', 'win_ping', '-i', '%s,' % name, name, '-e', ' '.join(extra_vars)]
 
-        for _ in range(1, 90):
+        for _ in range(1, 120):
             try:
                 run_command(self.core_ci.args, cmd, env=env)
                 return


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (at-tweaks c48c453bb9) last updated 2017/01/16 16:38:28 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

- Eliminate warning/retry on old instance check.
- Increase instance start timeout for windows.
