### PR TITLE
Require coverage < 4.3.2 to avoid bugs.

### DIFF
--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -1,2 +1,2 @@
-coverage >= 4.2
+coverage >= 4.2, < 4.3.2
 pywinrm >= 0.2.1 # 0.1.1 required, but 0.2.1 provides better performance


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (coverage-fix 40b043fedc) last updated 2017/01/16 17:45:02 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Require coverage < 4.3.2 to avoid an error on python 2.6: https://app.shippable.com/runs/587d6a2c2f36a111000d7923/1/console

```
2017-01-17 00:55:56 Traceback (most recent call last):
2017-01-17 00:55:56   File "/root/src/github.com/ansible/ansible/test/runner/.tox/py26/bin/coverage-2.6", line 7, in <module>
2017-01-17 00:55:56     from coverage.cmdline import main
2017-01-17 00:55:56   File "/root/src/github.com/ansible/ansible/test/runner/.tox/py26/lib/python2.6/site-packages/coverage/__init__.py", line 13, in <module>
2017-01-17 00:55:56     from coverage.control import Coverage, process_startup
2017-01-17 00:55:56   File "/root/src/github.com/ansible/ansible/test/runner/.tox/py26/lib/python2.6/site-packages/coverage/control.py", line 14, in <module>
2017-01-17 00:55:56     from coverage import env, files
2017-01-17 00:55:56   File "/root/src/github.com/ansible/ansible/test/runner/.tox/py26/lib/python2.6/site-packages/coverage/files.py", line 16, in <module>
2017-01-17 00:55:56     from coverage.misc import contract, CoverageException, join_regex, isolate_module
2017-01-17 00:55:56   File "/root/src/github.com/ansible/ansible/test/runner/.tox/py26/lib/python2.6/site-packages/coverage/misc.py", line 287, in <module>
2017-01-17 00:55:56     class StopEverything(unittest.SkipTest):
2017-01-17 00:55:56 AttributeError: 'module' object has no attribute 'SkipTest'```