### PR TITLE
ec2_vpc: resource_tags aren't required if vpc id given

### DIFF
--- a/lib/ansible/modules/cloud/amazon/_ec2_vpc.py
+++ b/lib/ansible/modules/cloud/amazon/_ec2_vpc.py
@@ -171,6 +171,8 @@ EXAMPLES = '''
 # the delete will fail until those dependencies are removed.
 '''
 
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info, connect_to_aws
 
 import time
 
@@ -198,6 +200,7 @@ def get_vpc_info(vpc):
         'state': vpc.state,
     })
 
+
 def find_vpc(module, vpc_conn, vpc_id=None, cidr=None):
     """
     Finds a VPC that matches a specific id or cidr + tags
@@ -220,7 +223,7 @@ def find_vpc(module, vpc_conn, vpc_id=None, cidr=None):
 
     # Check for existing VPC by cidr_block or id
     if vpc_id is not None:
-        found_vpcs = vpc_conn.get_all_vpcs(None, {'vpc-id': vpc_id, 'state': 'available',})
+        found_vpcs = vpc_conn.get_all_vpcs(None, {'vpc-id': vpc_id, 'state': 'available'})
 
     else:
         previous_vpcs = vpc_conn.get_all_vpcs(None, {'cidr': cidr, 'state': 'available'})
@@ -242,6 +245,7 @@ def find_vpc(module, vpc_conn, vpc_id=None, cidr=None):
         module.fail_json(msg='Found more than one vpc based on the supplied criteria, aborting')
 
     return (found_vpc)
+
 
 def routes_match(rt_list=None, rt=None, igw=None):
 
@@ -293,6 +297,7 @@ def routes_match(rt_list=None, rt=None, igw=None):
     else:
         return True
 
+
 def rtb_changed(route_tables=None, vpc_conn=None, module=None, vpc=None, igw=None):
     """
     Checks if the remote routes match the local routes.
@@ -308,7 +313,7 @@ def rtb_changed(route_tables=None, vpc_conn=None, module=None, vpc=None, igw=Non
         False when both routes and subnet associations matched.
 
     """
-    #We add a one for the main table
+    # We add a one for the main table
     rtb_len = len(route_tables) + 1
     remote_rtb_len = len(vpc_conn.get_all_route_tables(filters={'vpc_id': vpc.id}))
     if remote_rtb_len != rtb_len:
@@ -316,13 +321,13 @@ def rtb_changed(route_tables=None, vpc_conn=None, module=None, vpc=None, igw=Non
     for rt in route_tables:
         rt_id = None
         for sn in rt['subnets']:
-            rsn = vpc_conn.get_all_subnets(filters={'cidr': sn, 'vpc_id': vpc.id })
+            rsn = vpc_conn.get_all_subnets(filters={'cidr': sn, 'vpc_id': vpc.id})
             if len(rsn) != 1:
                 module.fail_json(
-                    msg='The subnet {0} to associate with route_table {1} ' \
+                    msg='The subnet {0} to associate with route_table {1} '
                     'does not exist, aborting'.format(sn, rt)
                 )
-            nrt  = vpc_conn.get_all_route_tables(filters={'vpc_id': vpc.id, 'association.subnet-id': rsn[0].id})
+            nrt = vpc_conn.get_all_route_tables(filters={'vpc_id': vpc.id, 'association.subnet-id': rsn[0].id})
             if not nrt:
                 return True
             else:
@@ -364,7 +369,6 @@ def create_vpc(module, vpc_conn):
     vpc_spec_tags = module.params.get('resource_tags')
     wait = module.params.get('wait')
     wait_timeout = int(module.params.get('wait_timeout'))
-    resource_tags = module.params.get('resource_tags')
     changed = False
 
     # Check for existing VPC by cidr_block + tags or id
@@ -398,10 +402,10 @@ def create_vpc(module, vpc_conn):
                     time.sleep(5)
             if wait and wait_timeout <= time.time():
                 # waiting took too long
-                module.fail_json(msg = "wait for vpc availability timeout on %s" % time.asctime())
+                module.fail_json(msg="wait for vpc availability timeout on %s" % time.asctime())
 
         except boto.exception.BotoServerError as e:
-            module.fail_json(msg = "%s: %s" % (e.error_code, e.error_message))
+            module.fail_json(msg="%s: %s" % (e.error_code, e.error_message))
 
     # Done with base VPC, now change to attributes and features.
 
@@ -418,7 +422,6 @@ def create_vpc(module, vpc_conn):
         if new_tags:
             vpc_conn.create_tags(vpc.id, new_tags)
 
-
     # boto doesn't appear to have a way to determine the existing
     # value of the dns attributes, so we just set them.
     # It also must be done one at a time.
@@ -430,12 +433,11 @@ def create_vpc(module, vpc_conn):
         if not isinstance(subnets, list):
             module.fail_json(msg='subnets needs to be a list of cidr blocks')
 
-        current_subnets = vpc_conn.get_all_subnets(filters={ 'vpc_id': vpc.id })
+        current_subnets = vpc_conn.get_all_subnets(filters={'vpc_id': vpc.id})
 
         # First add all new subnets
         for subnet in subnets:
             add_subnet = True
-            subnet_tags_current = True
             new_subnet_tags = subnet.get('resource_tags', {})
             subnet_tags_delete = []
 
@@ -455,7 +457,7 @@ def create_vpc(module, vpc_conn):
                                     subnet_tags_delete.append(item)
 
                             subnet_tags_delete = [key[0] for key in subnet_tags_delete]
-                            delete_subnet_tag = vpc_conn.delete_tags(csn.id, subnet_tags_delete)
+                            vpc_conn.delete_tags(csn.id, subnet_tags_delete)
                             changed = True
                         except EC2ResponseError as e:
                             module.fail_json(msg='Unable to delete resource tag, error {0}'.format(e))
@@ -464,7 +466,7 @@ def create_vpc(module, vpc_conn):
                     if new_tags_subset_of_existing_tags is False:
                         try:
                             changed = True
-                            create_subnet_tag = vpc_conn.create_tags(csn.id, new_subnet_tags)
+                            vpc_conn.create_tags(csn.id, new_subnet_tags)
 
                         except EC2ResponseError as e:
                             module.fail_json(msg='Unable to create resource tag, error: {0}'.format(e))
@@ -478,7 +480,7 @@ def create_vpc(module, vpc_conn):
                         # to create tags results in exception.
                         # boto doesn't seem to refresh 'state' of the newly created subnet, i.e.: it's always 'pending'
                         # so i resorted to polling vpc_conn.get_all_subnets with the id of the newly added subnet
-                        while len(vpc_conn.get_all_subnets(filters={ 'subnet-id': new_subnet.id })) == 0:
+                        while len(vpc_conn.get_all_subnets(filters={'subnet-id': new_subnet.id})) == 0:
                             time.sleep(0.1)
 
                         vpc_conn.create_tags(new_subnet.id, new_subnet_tags)
@@ -558,7 +560,7 @@ def create_vpc(module, vpc_conn):
                     if route['gw'] == 'igw':
                         if not internet_gateway:
                             module.fail_json(
-                                msg='You asked for an Internet Gateway ' \
+                                msg='You asked for an Internet Gateway '
                                 '(igw) route, but you have no Internet Gateway'
                             )
                         route_kwargs['gateway_id'] = igw.id
@@ -574,10 +576,10 @@ def create_vpc(module, vpc_conn):
 
                 # Associate with subnets
                 for sn in rt['subnets']:
-                    rsn = vpc_conn.get_all_subnets(filters={'cidr': sn, 'vpc_id': vpc.id })
+                    rsn = vpc_conn.get_all_subnets(filters={'cidr': sn, 'vpc_id': vpc.id})
                     if len(rsn) != 1:
                         module.fail_json(
-                            msg='The subnet {0} to associate with route_table {1} ' \
+                            msg='The subnet {0} to associate with route_table {1} '
                             'does not exist, aborting'.format(sn, rt)
                         )
                     rsn = rsn[0]
@@ -586,7 +588,7 @@ def create_vpc(module, vpc_conn):
                     old_rt = vpc_conn.get_all_route_tables(
                         filters={'association.subnet_id': rsn.id, 'vpc_id': vpc.id}
                     )
-                    old_rt = [ x for x in old_rt if x.id is not None ]
+                    old_rt = [x for x in old_rt if x.id is not None]
                     if len(old_rt) == 1:
                         old_rt = old_rt[0]
                         association_id = None
@@ -601,7 +603,7 @@ def create_vpc(module, vpc_conn):
                 changed = True
             except EC2ResponseError as e:
                 module.fail_json(
-                    msg='Unable to create and associate route table {0}, error: ' \
+                    msg='Unable to create and associate route table {0}, error: '
                     '{1}'.format(rt, e)
                 )
 
@@ -635,7 +637,7 @@ def create_vpc(module, vpc_conn):
 
     created_vpc_id = vpc.id
     returned_subnets = []
-    current_subnets = vpc_conn.get_all_subnets(filters={ 'vpc_id': vpc.id })
+    current_subnets = vpc_conn.get_all_subnets(filters={'vpc_id': vpc.id})
 
     for sn in current_subnets:
         returned_subnets.append({
@@ -656,6 +658,7 @@ def create_vpc(module, vpc_conn):
         returned_subnets.sort(key=lambda x: order.get(x['cidr'], subnets_in_play))
 
     return (vpc_dict, created_vpc_id, returned_subnets, igw_id, changed)
+
 
 def terminate_vpc(module, vpc_conn, vpc_id=None, cidr=None):
     """
@@ -681,8 +684,8 @@ def terminate_vpc(module, vpc_conn, vpc_id=None, cidr=None):
 
     if vpc is not None:
         if vpc.state == 'available':
-            terminated_vpc_id=vpc.id
-            vpc_dict=get_vpc_info(vpc)
+            terminated_vpc_id = vpc.id
+            vpc_dict = get_vpc_info(vpc)
             try:
                 subnets = vpc_conn.get_all_subnets(filters={'vpc_id': vpc.id})
                 for sn in subnets:
@@ -720,18 +723,18 @@ def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(
         dict(
-            cidr_block = dict(),
-            instance_tenancy = dict(choices=['default', 'dedicated'], default='default'),
-            wait = dict(type='bool', default=False),
-            wait_timeout = dict(default=300),
-            dns_support = dict(type='bool', default=True),
-            dns_hostnames = dict(type='bool', default=True),
-            subnets = dict(type='list'),
-            vpc_id = dict(),
-            internet_gateway = dict(type='bool', default=False),
-            resource_tags = dict(type='dict'),
-            route_tables = dict(type='list'),
-            state = dict(choices=['present', 'absent'], default='present'),
+            cidr_block=dict(),
+            instance_tenancy=dict(choices=['default', 'dedicated'], default='default'),
+            wait=dict(type='bool', default=False),
+            wait_timeout=dict(default=300),
+            dns_support=dict(type='bool', default=True),
+            dns_hostnames=dict(type='bool', default=True),
+            subnets=dict(type='list'),
+            vpc_id=dict(),
+            internet_gateway=dict(type='bool', default=False),
+            resource_tags=dict(type='dict'),
+            route_tables=dict(type='list'),
+            state=dict(choices=['present', 'absent'], default='present'),
         )
     )
 
@@ -743,7 +746,7 @@ def main():
     if not HAS_BOTO:
         module.fail_json(msg='boto required for this module')
 
-    state = module.params.get('state')
+    module.params.get('state')
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module)
 
@@ -752,7 +755,7 @@ def main():
         try:
             vpc_conn = connect_to_aws(boto.vpc, region, **aws_connect_kwargs)
         except boto.exception.NoAuthHandlerFound as e:
-            module.fail_json(msg = str(e))
+            module.fail_json(msg=str(e))
     else:
         module.fail_json(msg="region must be specified")
 
@@ -768,9 +771,6 @@ def main():
 
     module.exit_json(changed=changed, vpc_id=new_vpc_id, vpc=vpc_dict, igw_id=igw_id, subnets=subnets_changed)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
 if __name__ == '__main__':
     main()

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -138,7 +138,6 @@ lib/ansible/module_utils/vca.py
 lib/ansible/module_utils/vmware.py
 lib/ansible/module_utils/vyos.py
 lib/ansible/modules/cloud/amazon/_ec2_ami_search.py
-lib/ansible/modules/cloud/amazon/_ec2_vpc.py
 lib/ansible/modules/cloud/amazon/aws_kms.py
 lib/ansible/modules/cloud/amazon/cloudformation.py
 lib/ansible/modules/cloud/amazon/cloudformation_facts.py


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel b8dd4dd52b) last updated 2017/01/17 16:30:08 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
It makes little sense to require resource tags if you have
the VPC ID of a VPC that you wish to delete.
