### PR TITLE
Small fix python3 compatibility in ec2.py

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -233,7 +233,10 @@ def get_aws_connection_info(module, boto3=False):
 
     for param, value in boto_params.items():
         if isinstance(value, str):
-            boto_params[param] = unicode(value, 'utf-8', 'strict')
+            try:
+                boto_params[param] = unicode(value, 'utf-8', 'strict')
+            except NameError:
+                boto_params[param] = value
 
     return region, ec2_url, boto_params
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
 
##### COMPONENT NAME
lib/ansible/module_utils/ec2.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This fix p3 compatibility to avoid using unicode() in ec2 base module with p3.
For example fixed route3 error 'NameError' with using python3 on remote
hosts by default (ubuntu 16+ or so)
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
