### PR TITLE
Add workaround for shib2 and php modules

### DIFF
--- a/lib/ansible/modules/web_infrastructure/apache2_module.py
+++ b/lib/ansible/modules/web_infrastructure/apache2_module.py
@@ -131,12 +131,6 @@ def _module_is_enabled(module):
 
     result, stdout, stderr = module.run_command("%s -M" % control_binary)
 
-    """
-    Work around for Ubuntu Xenial listing php7_module as php7.0
-    """
-    if name == "php7.0":
-        name = "php7"
-
     if result != 0:
         error_msg = "Error executing %s: %s" % (control_binary, stderr)
         if ignore_configcheck:
@@ -150,6 +144,19 @@ def _module_is_enabled(module):
             return False
         else:
             module.fail_json(msg=error_msg)
+
+    """
+    Work around for php modules; php7.x are always listed as php7_module
+    """
+    php_module = re.search(r'^(php\d)\.', name)
+    if php_module:
+        name = php_module.group(1)
+
+    """
+    Workaround for shib2; module is listed as mod_shib
+    """
+    if re.search(r'shib2', name):
+        return bool(re.search(r' mod_shib', stdout))
 
     return bool(re.search(r' ' + name + r'_module', stdout))
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request
Fix #20288 Fix ansible/ansible-modules-core#5779 Fix ansible/ansible-modules-core#5559

##### COMPONENT NAME
apache2_module

##### SUMMARY
Add a workaround for the handling of shib2 and php modules.

The shib2 module identifies itself in apache2 as mod_shib and not as expected with shib2_module. I adjusted the name for the check.

php modules are only identified in apache2 with their major version number. If e.g. php7.1 is used, the module can not be enabled/disabled, because the module identifies as php7_module. This is fixed by using only the major version to check if a php module is enabled or disabled.

I'm not really happy with this patch and open for any other suggestions.