### PR TITLE
Fix double colon which fixes block rendering

### DIFF
--- a/docs/docsite/rst/faq.rst
+++ b/docs/docsite/rst/faq.rst
@@ -150,7 +150,7 @@ How do I disable cowsay?
 ++++++++++++++++++++++++
 
 If cowsay is installed, Ansible takes it upon itself to make your day happier when running playbooks.  If you decide
-that you would like to work in a professional cow-free environment, you can either uninstall cowsay, or set an environment variable::
+that you would like to work in a professional cow-free environment, you can either uninstall cowsay, or set an environment variable:
 
 .. code-block:: shell-session
 


### PR DESCRIPTION
the 'EXPORT ANSIBLE_NOCOWS=1' rendering is broken due to a double colon in the paragraph above

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Website FAQ

##### SUMMARY
Fix minor rendering glitch in the FAQ (cowsay environment variable)