### PR TITLE
Update documentation about ldap_attr 

### DIFF
--- a/lib/ansible/modules/network/ldap_attr.py
+++ b/lib/ansible/modules/network/ldap_attr.py
@@ -166,7 +166,7 @@ EXAMPLES = """
     olcRootPW: "{SSHA}tabyipcHzhwESzRaGA7oQ/SDoBZQOGND"
 
 - name: Get rid of an unneeded attribute
-  ldap_entry:
+  ldap_attr:
     dn: uid=jdoe,ou=people,dc=example,dc=com
     name: shadowExpire
     value: ""
@@ -184,7 +184,7 @@ EXAMPLES = """
 #   bind_dn: cn=admin,dc=example,dc=com
 #   bind_pw: password
 - name: Get rid of an unneeded attribute
-  ldap_entry:
+  ldap_attr:
     dn: uid=jdoe,ou=people,dc=example,dc=com
     name: shadowExpire
     value: ""


### PR DESCRIPTION
Fixing the documentation issue #20350 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
ldap-attr ( New in version 2.3. )

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Fixes #20350 
Replace module name from ldap_entry to ldap_attr on exemples