### PR TITLE
win_unzip: Fix for working `creates:` when using environment

### DIFF
--- a/lib/ansible/modules/windows/win_unzip.ps1
+++ b/lib/ansible/modules/windows/win_unzip.ps1
@@ -29,8 +29,9 @@ $result = New-Object psobject @{
 
 $creates = Get-AnsibleParam -obj $params -name "creates" -type "path"
 If ($creates -ne $null) {
-    If (Test-Path $params.creates) {
-        Exit-Json $result "The 'creates' file or directory already exists."
+    If (Test-Path $creates) {
+        $result.msg = "The 'creates' file or directory ($creates) already exists."
+        Exit-Json $result
     }
 }
 
@@ -139,4 +140,4 @@ Set-Attr $result.win_unzip "src" $src.toString()
 Set-Attr $result.win_unzip "dest" $dest.toString()
 Set-Attr $result.win_unzip "recurse" $recurse.toString()
 
-Exit-Json $result;
+Exit-Json $result


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_unzip

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Since the module was using $params.creates, the Expand-Environment was not effective.
By using $creates correctly it works.

Also fix an incorrect Exit-Json call.