### PR TITLE
synchronize: UserKnownHostsFile=/dev/null when verify_host: false

### DIFF
--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -443,7 +443,7 @@ def main():
     ssh_opts = '-S none'
 
     if not verify_host:
-      ssh_opts = '%s -o StrictHostKeyChecking=no' % ssh_opts
+      ssh_opts = '%s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null' % ssh_opts
 
     if ssh_args:
       ssh_opts = '%s %s' % (ssh_opts, ssh_args)


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Synchronize
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Fixes part of #20311 

It adds the `-o UserKnownHostsFile=/dev/null` flag to the SSH command when the `verify_hosts=no` flag is set.