### PR TITLE
Add jinja2 groupby filter override to cast namedtuple to tuple. Fixes #20098

### DIFF
--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -27,7 +27,7 @@ UNAME := $(shell uname | tr '[:upper:]' '[:lower:]')
 
 all: other non_destructive destructive
 
-other: ansible test_test_infra parsing test_var_blending test_var_precedence unicode test_templating_settings environment test_as includes blocks pull_run pull_no_127 pull_limit_inventory check_mode test_hash test_handlers test_group_by test_vault test_tags test_lookup_paths no_log test_gathering_facts test_binary_modules_posix test_hosts_field test_lookup_properties args
+other: ansible test_test_infra parsing test_var_blending test_var_precedence unicode test_templating_settings environment test_as includes blocks pull_run pull_no_127 pull_limit_inventory check_mode test_hash test_handlers test_group_by test_vault test_tags test_lookup_paths no_log test_gathering_facts test_binary_modules_posix test_hosts_field test_lookup_properties args test_jinja2_groupby
 
 ansible:
 	(cd targets/ansible && ./runme.sh $(TEST_FLAGS))
@@ -65,6 +65,9 @@ test_gathering_facts:
 
 environment:
 	(cd targets/environment && ./runme.sh $(TEST_FLAGS))
+
+test_jinja2_groupby:
+	(cd targets/filters && ./runme.sh $(TEST_FLAGS))
 
 non_destructive: setup
 	ANSIBLE_ROLES_PATH=$(shell pwd)/targets ansible-playbook non_destructive.yml -i $(INVENTORY) -e @$(VARS_FILE) $(CREDENTIALS_ARG) -v $(TEST_FLAGS)

--- a/test/integration/targets/groupby_filter/aliases
+++ b/test/integration/targets/groupby_filter/aliases
@@ -1,0 +1,1 @@
+posix/ci/group2

--- a/test/integration/targets/groupby_filter/runme.sh
+++ b/test/integration/targets/groupby_filter/runme.sh
@@ -1,27 +1,31 @@
 #!/usr/bin/env bash
 
-set -e
+# We don't set -u here, due to pypa/virtualenv#150
+set -ex
 
 MYTMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
 
+# This is needed for the ubuntu1604py3 tests
+# Ubuntu patches virtualenv to make the default python2
+# but for the python3 tests we need virtualenv to use python3
 if [ -f /usr/bin/python3 ]
 then
-    PYTHON="--python /usr/bin/python3"
+    PYTHON="/usr/bin/python3"
 else
-    PYTHON=""
+    PYTHON="$(which python)"
 fi
 
-virtualenv --system-site-packages $PYTHON "${MYTMPDIR}/jinja2"
+virtualenv --system-site-packages --python $PYTHON "${MYTMPDIR}/jinja2"
 
 source "${MYTMPDIR}/jinja2/bin/activate"
 
 pip install -U jinja2==2.9.4
 
-ansible-playbook -i ../../inventory test_jinja2_groupby.yml -v
+ansible-playbook -i ../../inventory test_jinja2_groupby.yml -v "$@"
 
 pip install -U "jinja2<2.9.0"
 
-ansible-playbook -i ../../inventory test_jinja2_groupby.yml -v
+ansible-playbook -i ../../inventory test_jinja2_groupby.yml -v "$@"
 
 deactivate
 

--- a/test/integration/targets/groupby_filter/runme.sh
+++ b/test/integration/targets/groupby_filter/runme.sh
@@ -15,7 +15,7 @@ else
     PYTHON="$(which python)"
 fi
 
-virtualenv --system-site-packages --python $PYTHON "${MYTMPDIR}/jinja2"
+virtualenv --system-site-packages --python "$PYTHON" "${MYTMPDIR}/jinja2"
 
 source "${MYTMPDIR}/jinja2/bin/activate"
 

--- a/test/integration/targets/groupby_filter/runme.sh
+++ b/test/integration/targets/groupby_filter/runme.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # We don't set -u here, due to pypa/virtualenv#150
-set -e
+set -ex
 
 MYTMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
 
@@ -19,10 +19,8 @@ virtualenv --system-site-packages $PYTHON "${MYTMPDIR}/jinja2"
 
 source "${MYTMPDIR}/jinja2/bin/activate"
 
-echo "################"
-echo "Python path: $(which python)"
-echo "Python version: $(python -V)"
-echo "################"
+which python
+python -V
 
 pip install -U jinja2==2.9.4
 

--- a/test/integration/targets/groupby_filter/runme.sh
+++ b/test/integration/targets/groupby_filter/runme.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # We don't set -u here, due to pypa/virtualenv#150
-set -ex
+set -e
 
 MYTMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
 
@@ -10,14 +10,19 @@ MYTMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
 # but for the python3 tests we need virtualenv to use python3
 if [ -f /usr/bin/python3 ]
 then
-    PYTHON="/usr/bin/python3"
+    PYTHON="--python /usr/bin/python3"
 else
-    PYTHON="$(which python)"
+    PYTHON=""
 fi
 
-virtualenv --system-site-packages --python "$PYTHON" "${MYTMPDIR}/jinja2"
+virtualenv --system-site-packages $PYTHON "${MYTMPDIR}/jinja2"
 
 source "${MYTMPDIR}/jinja2/bin/activate"
+
+echo "################"
+echo "Python path: $(which python)"
+echo "Python version: $(python -V)"
+echo "################"
 
 pip install -U jinja2==2.9.4
 

--- a/test/integration/targets/groupby_filter/runme.sh
+++ b/test/integration/targets/groupby_filter/runme.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -e
+
+MYTMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
+
+if [ -f /usr/bin/python3 ]
+then
+    PYTHON="--python /usr/bin/python3"
+else
+    PYTHON=""
+fi
+
+virtualenv --system-site-packages $PYTHON "${MYTMPDIR}/jinja2"
+
+source "${MYTMPDIR}/jinja2/bin/activate"
+
+pip install -U jinja2==2.9.4
+
+ansible-playbook -i ../../inventory test_jinja2_groupby.yml -v
+
+pip install -U "jinja2<2.9.0"
+
+ansible-playbook -i ../../inventory test_jinja2_groupby.yml -v
+
+deactivate
+
+rm -r "${MYTMPDIR}"

--- a/test/integration/targets/groupby_filter/test_jinja2_groupby.yml
+++ b/test/integration/targets/groupby_filter/test_jinja2_groupby.yml
@@ -1,0 +1,24 @@
+---
+- name: Test jinja2 groupby
+  hosts: localhost
+  gather_facts: False
+  connection: local
+  vars:
+    fruits:
+      - name: apple
+        enjoy: yes
+      - name: orange
+        enjoy: no
+      - name: strawberry
+        enjoy: yes
+    expected: [[false, [{"enjoy": false, "name": "orange"}]], [true, [{"enjoy": true, "name": "apple"}, {"enjoy": true, "name": "strawberry"}]]]
+  tasks:
+    - debug:
+        msg: "{{ lookup('pipe', 'pip freeze | grep -i jinja2') }}"
+
+    - set_fact:
+        result: "{{ fruits | groupby('enjoy') }}"
+
+    - assert:
+        that:
+          - result == expected


### PR DESCRIPTION
##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
plugins/filters/core.py

##### ANSIBLE VERSION
```
v2.3
```

##### SUMMARY

On the heels of #20098, it was decided that we wanted a solution for people who didn't have access to jinja2<2.9 and while jinja2==2.9.5 was not yet released.

This PR overrides the `groupby` filter from jinja2, calls the jinja2 `groupby` filter, and casts the elements of the return to tuples.

Based on jinja2<2.9 I have established what the return looked like as a repr, and ensured that the fix for 2.9.4 matches.