### PR TITLE
Fix win_unzip module hang on error

### DIFF
--- a/lib/ansible/modules/windows/win_unzip.ps1
+++ b/lib/ansible/modules/windows/win_unzip.ps1
@@ -61,6 +61,7 @@ If ($ext -eq ".zip" -And $recurse -eq $false) {
         $shell = New-Object -ComObject Shell.Application
         $zipPkg = $shell.NameSpace([IO.Path]::GetFullPath($src))
         $destPath = $shell.NameSpace([IO.Path]::GetFullPath($dest))
+        # From Folder.CopyHere documentation (https://msdn.microsoft.com/en-us/library/windows/desktop/bb787866.aspx)
         # 1044 means do not display any error dialog (1024), progress dialog (4) and overwrite any file (16)
         $destPath.CopyHere($zipPkg.Items(), 1044)
         $result.changed = $true

--- a/lib/ansible/modules/windows/win_unzip.ps1
+++ b/lib/ansible/modules/windows/win_unzip.ps1
@@ -61,8 +61,8 @@ If ($ext -eq ".zip" -And $recurse -eq $false) {
         $shell = New-Object -ComObject Shell.Application
         $zipPkg = $shell.NameSpace([IO.Path]::GetFullPath($src))
         $destPath = $shell.NameSpace([IO.Path]::GetFullPath($dest))
-        # 20 means do not display any dialog (4) and overwrite any file (16)
-        $destPath.CopyHere($zipPkg.Items(), 20)
+        # 1044 means do not display any error dialog (1024), progress dialog (4) and overwrite any file (16)
+        $destPath.CopyHere($zipPkg.Items(), 1044)
         $result.changed = $true
     }
     Catch {


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_unzip

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 37f0cee2da) last updated 2017/01/17 11:47:59 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
During extracting a zip file on Windows, if there's any error (such as not enough disk space), Ansible will hang indefinitely.
The only way to unblock it is to kill the powershell process.
This fix adds an extra flag to not show UI on errors.
From [MSDN documentation](https://msdn.microsoft.com/en-us/library/windows/desktop/bb787866(v=vs.85).aspx)
