### PR TITLE
win_iis_webapppool: Set-StrictMode -Off to support attributes with no Value object.

### DIFF
--- a/lib/ansible/modules/windows/win_iis_webapppool.ps1
+++ b/lib/ansible/modules/windows/win_iis_webapppool.ps1
@@ -21,6 +21,7 @@
 # WANT_JSON
 # POWERSHELL_COMMON
 
+Set-StrictMode -Off
 $params = Parse-Args $args;
 
 # Name parameter
@@ -96,11 +97,11 @@ try {
     }
     if ($state -eq 'restarted') {
       switch ($pool.State)
-        { 
+        {
           'Stopped' { Start-WebAppPool -Name $name -ErrorAction Stop }
           default { Restart-WebAppPool -Name $name -ErrorAction Stop }
         }
-      $result.changed = $TRUE   
+      $result.changed = $TRUE
     }
   }
 } catch {
@@ -116,7 +117,7 @@ if ($pool)
     state = $pool.State
     attributes =  New-Object psobject @{}
   };
-  
+
   $pool.Attributes | ForEach { $result.info.attributes.Add($_.Name, $_.Value)};
 }
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

windows/win_iis_webapppool.ps1
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Some attempts to get the win_iis_webapppool module to be strict compliant have still not fixed an issue with setting attributes on the application pool.

After some lengthy debugging on my Windows machine, I found that on line ~82, the `Get-ItemProperty ("IIS:\AppPools\" + $name) $newParameter.Key` doesn't always return a property with a .Value object. For most properties, the value of the returned `$newParameter` is `Microsoft.IIs.PowerShell.Framework.ConfigurationAttribute`, which has a `.Value` object.

One specific case where `Get-ItemProperty` returns merely a value with no .Value object is the managedPipelineMode attribute noted on https://github.com/ansible/ansible-modules-extras/issues/1093#issuecomment-147817712. It returns a simple string like `Integrated`.

Another I found was trying to set `processModel.identityType`, which returns `SpecificUser`.

The absence of .Value is a problem on the following line because it needs to test for the existence of a null .Value object. Merely doing the check in the if statement to `$currentParameter.Value -ne $null` itself causes a warning in strict mode. Catching the warning also seems to cause an exception.

This introduces another exception to the strict rule as have been done with other iis modules.

Long list of references to link:

https://github.com/ansible/ansible/issues/12497
https://github.com/ansible/ansible/issues/12494#issuecomment-142679608
https://github.com/ansible/ansible/issues/12554
https://github.com/ansible/ansible-modules-extras/pull/1114
https://github.com/ansible/ansible-modules-extras/issues/1093#issuecomment-147817712
