### PR TITLE
Enable more network support in ansible-test.

### DIFF
--- a/test/runner/lib/classification.py
+++ b/test/runner/lib/classification.py
@@ -10,6 +10,7 @@ from lib.target import (
     walk_units_targets,
     walk_compile_targets,
     walk_sanity_targets,
+    load_integration_prefixes,
 )
 
 from lib.util import (
@@ -86,6 +87,7 @@ class PathMapper(object):
 
         self.module_names_by_path = dict((t.path, t.module) for t in self.module_targets)
         self.integration_targets_by_name = dict((t.name, t) for t in self.integration_targets)
+        self.integration_targets_by_alias = dict((a, t) for t in self.integration_targets for a in t.aliases)
 
         self.posix_integration_by_module = dict((m, t.name) for t in self.integration_targets
                                                 if 'posix/' in t.aliases for m in t.modules)
@@ -93,6 +95,8 @@ class PathMapper(object):
                                                   if 'windows/' in t.aliases for m in t.modules)
         self.network_integration_by_module = dict((m, t.name) for t in self.integration_targets
                                                   if 'network/' in t.aliases for m in t.modules)
+
+        self.prefixes = load_integration_prefixes()
 
     def classify(self, path):
         """
@@ -170,6 +174,21 @@ class PathMapper(object):
                 }
 
             if ext == '.py':
+                if name in self.prefixes and self.prefixes[name] == 'network':
+                    network_target = 'network/%s/' % name
+
+                    if network_target in self.integration_targets_by_alias:
+                        return {
+                            'network-integration': network_target,
+                            'units': 'all',
+                        }
+
+                    display.warning('Integration tests for "%s" not found.' % network_target)
+
+                    return {
+                        'units': 'all',
+                    }
+
                 return {
                     'integration': 'all',
                     'network-integration': 'all',

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -210,9 +210,12 @@ def command_network_integration(args):
         remotes = [instance.wait_for_result() for instance in instances]
         inventory = network_inventory(remotes)
 
+        filename = 'test/integration/inventory.networking'
+
+        display.info('>>> Inventory: %s\n%s' % (filename, inventory.strip()), verbosity=3)
+
         if not args.explain:
-            with open('test/integration/inventory.networking', 'w') as inventory_fd:
-                display.info('>>> Inventory: %s\n%s' % (inventory_fd.name, inventory.strip()), verbosity=3)
+            with open(filename, 'w') as inventory_fd:
                 inventory_fd.write(inventory)
     else:
         install_command_requirements(args)
@@ -299,9 +302,12 @@ def command_windows_integration(args):
         remotes = [instance.wait_for_result() for instance in instances]
         inventory = windows_inventory(remotes)
 
+        filename = 'test/integration/inventory.winrm'
+
+        display.info('>>> Inventory: %s\n%s' % (filename, inventory.strip()), verbosity=3)
+
         if not args.explain:
-            with open('test/integration/inventory.winrm', 'w') as inventory_fd:
-                display.info('>>> Inventory: %s\n%s' % (inventory_fd.name, inventory.strip()), verbosity=3)
+            with open(filename, 'w') as inventory_fd:
                 inventory_fd.write(inventory)
     else:
         install_command_requirements(args)

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -183,12 +183,20 @@ def command_network_integration(args):
     :type args: NetworkIntegrationConfig
     """
     internal_targets = command_integration_filter(args, walk_network_integration_targets())
+    platform_targets = set(a for t in internal_targets for a in t.aliases if a.startswith('network/'))
 
     if args.platform:
         instances = []  # type: list [lib.thread.WrappedThread]
 
         for platform_version in args.platform:
             platform, version = platform_version.split('/', 1)
+            platform_target = 'network/%s/' % platform
+
+            if platform_target not in platform_targets and 'network/basics/' not in platform_targets:
+                display.warning('Skipping "%s" because selected tests do not target the "%s" platform.' % (
+                    platform_version, platform))
+                continue
+
             instance = lib.thread.WrappedThread(functools.partial(network_run, args, platform, version))
             instance.daemon = True
             instance.start()

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -269,12 +269,12 @@ def network_inventory(remotes):
     for group in groups:
         hosts = '\n'.join(groups[group])
 
-        template += """
+        template += textwrap.dedent("""
         [%s]
         %s
-        """ % (group, hosts)
+        """) % (group, hosts)
 
-    inventory = textwrap.dedent(template)
+    inventory = template
 
     return inventory
 

--- a/test/utils/shippable/network.sh
+++ b/test/utils/shippable/network.sh
@@ -14,6 +14,7 @@ if [ -s /tmp/network.txt ]; then
 
     ansible-test network-integration --color -v --retry-on-error "${target}" --requirements \
         --platform vyos/1.1.0 \
+        --platform ios/csr1000v \
 
 else
     echo "No changes requiring integration tests specific to networking were detected."


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (network-ci a75b15ab4b) last updated 2017/01/17 15:31:48 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Enable more network support in ansible-test.