### PR TITLE
Replace lxc-clone with lxc-copy (Fixes #19890)

### DIFF
--- a/lib/ansible/modules/cloud/lxc/lxc_container.py
+++ b/lib/ansible/modules/cloud/lxc/lxc_container.py
@@ -477,7 +477,15 @@ LXC_COMMAND_MAP = {
         }
     },
     'clone': {
-        'variables': {
+        'variables-lxc-copy': {
+            'backing_store': '--backingstorage',
+            'lxc_path': '--lxcpath',
+            'fs_size': '--fssize',
+            'name': '--name',
+            'clone_name': '--newname'
+        },
+        # lxc-clone is deprecated in favor of lxc-copy
+        'variables-lxc-clone': {
             'backing_store': '--backingstore',
             'lxc_path': '--lxcpath',
             'fs_size': '--fssize',
@@ -792,13 +800,20 @@ class LxcContainerManagement(object):
             self.state_change = True
             self.container.stop()
 
+        # lxc-clone is deprecated in favor of lxc-copy
+        clone_vars = 'variables-lxc-copy'
+        clone_cmd = self.module.get_bin_path('lxc-copy')
+        if not clone_cmd:
+            clone_vars = 'variables-lxc-clone'
+            clone_cmd = self.module.get_bin_path('lxc-clone', True)
+
         build_command = [
-            self.module.get_bin_path('lxc-clone', True),
+            clone_cmd,
         ]
 
         build_command = self._add_variables(
             variables_dict=self._get_vars(
-                variables=LXC_COMMAND_MAP['clone']['variables']
+                variables=LXC_COMMAND_MAP['clone'][clone_vars]
             ),
             build_command=build_command
         )
@@ -814,7 +829,7 @@ class LxcContainerManagement(object):
 
         rc, return_data, err = self._run_command(build_command)
         if rc != 0:
-            message = "Failed executing lxc-clone."
+            message = "Failed executing %s." % os.path.basename(clone_cmd)
             self.failure(
                 err=err, rc=rc, msg=message, command=' '.join(
                     build_command


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lxc

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel d9f2e7949f) last updated 2017/01/17 23:24:47 (GMT +100)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
The command lxc-clone is deprecated in favor of lxc-copy.  This patch keeps a backward compatible layer with older versions of lxc, if the lxc-copy command is not found it will fall back to the old lxc-clone command. Fixes #19890