### PR TITLE
Update coverage constraints for ansible-test.

### DIFF
--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -1,2 +1,2 @@
-coverage >= 4.2, < 4.3.2
+coverage >= 4.2, != 4.3.2 # features in 4.2+ required, avoid known bug in 4.3.2 on python 2.6
 pywinrm >= 0.2.1 # 0.1.1 required, but 0.2.1 provides better performance


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (coverage-req 52d31cef9e) last updated 2017/01/17 16:37:37 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Update coverage constraints for ansible-test.

Now that the [coverage 4.3.2 bug on python 2.6](https://bitbucket.org/ned/coveragepy/issues/554/traceback-on-python-26-starting-with-432) has been fixed, we only need to exclude that version.