### PR TITLE
Add docker image output to Shippable pre_ci.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -55,6 +55,8 @@ matrix:
     - env: TEST=linux/ubuntu1604/3
     - env: TEST=linux/ubuntu1604py3/3
 build:
+  pre_ci:
+    - docker images | grep u14pyt
   pre_ci_boot:
     options: "--privileged=false --net=bridge"
   ci:


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

shippable.yml

##### ANSIBLE VERSION

```
ansible 2.3.0 (ci-debug b36fbaec67) last updated 2017/01/17 16:44:25 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Add docker image output to Shippable pre_ci.