### PR TITLE
cloud: ovirt: Ignore 404 error when getting entity

### DIFF
--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -247,6 +247,20 @@ def search_by_name(service, name, **kwargs):
     return res[0]
 
 
+def get_entity(service):
+    """
+    Ignore SDK Error in case of getting an entity from service.
+    """
+    entity = None
+    try:
+        entity = service.get()
+    except sdk.Error:
+        # We can get here 404, we should ignore it, in case
+        # of removing entity for example.
+        pass
+    return entity
+
+
 def wait(
     service,
     condition,
@@ -270,7 +284,7 @@ def wait(
         start = time.time()
         while time.time() < start + timeout:
             # Exit if the condition of entity is valid:
-            entity = service.get()
+            entity = get_entity(service)
             if condition(entity):
                 return
             elif fail_condition(entity):

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_networks.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_networks.py
@@ -33,6 +33,7 @@ from ansible.module_utils.ovirt import (
     create_connection,
     equal,
     get_dict_of_struct,
+    get_entity,
     get_link_name,
     ovirt_full_argument_spec,
     search_by_name,
@@ -192,7 +193,7 @@ class HostNetworksModule(BaseModule):
         update = False
         bond = self._module.params['bond']
         networks = self._module.params['networks']
-        nic = nic_service.get()
+        nic = get_entity(nic_service)
 
         if nic is None:
             return update

--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
@@ -34,6 +34,7 @@ from ansible.module_utils.ovirt import (
     check_sdk,
     create_connection,
     equal,
+    get_entity,
     ovirt_full_argument_spec,
     search_by_name,
     wait,
@@ -285,7 +286,7 @@ class StorageDomainModule(BaseModule):
             return
 
         attached_sd_service = attached_sds_service.storage_domain_service(storage_domain.id)
-        attached_sd = attached_sd_service.get()
+        attached_sd = get_entity(attached_sd_service)
 
         if attached_sd and attached_sd.status != sdstate.MAINTENANCE:
             if not self._module.check_mode:
@@ -305,7 +306,7 @@ class StorageDomainModule(BaseModule):
             return
 
         attached_sd_service = attached_sds_service.storage_domain_service(storage_domain.id)
-        attached_sd = attached_sd_service.get()
+        attached_sd = get_entity(attached_sd_service)
 
         if attached_sd and attached_sd.status == sdstate.MAINTENANCE:
             if not self._module.check_mode:
@@ -333,7 +334,7 @@ class StorageDomainModule(BaseModule):
 
         # If storage domain isn't attached, attach it:
         attached_sd_service = self._service.service(storage_domain.id)
-        if attached_sd_service.get() is None:
+        if get_entity(attached_sd_service) is None:
             self._service.add(
                 otypes.StorageDomain(
                     id=storage_domain.id,


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
cloud/ovirt/*

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Since Python SDK v4.1 when we are getting an entity which doesn't exists, for example:

 GET /vms/123

the Python SDK will raise an sdk.Error, with 404 HTTP error. Previously SDK returned 'None'.
This patch accustom the Ansible oVirt code, to respect this behaviour.