### PR TITLE
vmware_inventory.py: skip_keys can use a full key path

### DIFF
--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -669,7 +669,7 @@ class VMWareInventory(object):
             methods = dir(vobj)
             methods = [str(x) for x in methods if not x.startswith('_')]
             methods = [x for x in methods if x not in self.bad_types]
-            methods = [x for x in methods if not x.lower() in self.skip_keys]
+            methods = [x for x in methods if not inkey + '.' + x.lower() in self.skip_keys]
             methods = sorted(methods)
 
             for method in methods:


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
contrib/inventory/vmware_inventory.py

##### ANSIBLE VERSION
```
2.2.1.0
```

##### SUMMARY
use inkey attribute in _process_object_types recursive loop to generate key name in skip_keys directive.

This permit to ignore nested variables, for example summary.vm to optimize inventory collect
