### PR TITLE
win_msi: Add -type "path" to path parameters

### DIFF
--- a/lib/ansible/modules/windows/win_msi.ps1
+++ b/lib/ansible/modules/windows/win_msi.ps1
@@ -19,52 +19,45 @@
 # WANT_JSON
 # POWERSHELL_COMMON
 
-$params = Parse-Args $args;
+# TODO: Add check-mode support
 
-$path = Get-Attr $params "path" -failifempty $true
-$state = Get-Attr $params "state" "present"
-$creates = Get-Attr $params "creates" $false
-$extra_args = Get-Attr $params "extra_args" ""
-$wait = Get-Attr $params "wait" $false | ConvertTo-Bool
+$params = Parse-Args $args
 
-$result = New-Object psobject @{
+$path = Get-AnsibleParam -obj $params -name "path" -type "path" -failifempty $true
+$state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present","absent"
+$creates = Get-AnsibleParam -obj $params -name "creates" -type "path"
+$extra_args = Get-AnsibleParam -obj $params -name "extra_args" -type "str" -default ""
+$wait = Get-AnsibleParam -obj $params -name "wait" -type "bool" -default $false
+
+$result = @{
     changed = $false
-};
-
-If (($creates -ne $false) -and ($state -ne "absent") -and (Test-Path $creates))
-{
-    Exit-Json $result;
 }
 
-$logfile = [IO.Path]::GetTempFileName();
-if ($state -eq "absent")
-{
-  If ($wait)
-  {
-    Start-Process -FilePath msiexec.exe -ArgumentList "/x `"$path`" /qn /l $logfile $extra_args" -Verb Runas -Wait;
-  }
-  Else
-  {
-    Start-Process -FilePath msiexec.exe -ArgumentList "/x `"$path`" /qn /l $logfile $extra_args" -Verb Runas;
-  }
-}
-Else
-{
-  If ($wait)
-  {
-    Start-Process -FilePath msiexec.exe -ArgumentList "/i `"$path`" /qn /l $logfile $extra_args" -Verb Runas -Wait;
-  }
-  Else
-  {
-    Start-Process -FilePath msiexec.exe -ArgumentList "/i `"$path`" /qn /l $logfile $extra_args" -Verb Runas;
-  }
+if (($creates -ne $null) -and ($state -ne "absent") -and (Test-Path $creates)) {
+    Exit-Json $result
 }
 
-Set-Attr $result "changed" $true;
+$logfile = [IO.Path]::GetTempFileName()
+if ($state -eq "absent") {
 
-$logcontents = Get-Content $logfile | Out-String;
-Remove-Item $logfile;
+    if ($wait) {
+        Start-Process -FilePath msiexec.exe -ArgumentList "/x `"$path`" /qn /l $logfile $extra_args" -Verb Runas -Wait
+    } else {
+        Start-Process -FilePath msiexec.exe -ArgumentList "/x `"$path`" /qn /l $logfile $extra_args" -Verb Runas
+    }
 
-Set-Attr $result "log" $logcontents;
+} else {
 
-Exit-Json $result;
+    if ($wait) {
+        Start-Process -FilePath msiexec.exe -ArgumentList "/i `"$path`" /qn /l $logfile $extra_args" -Verb Runas -Wait
+    } else {
+        Start-Process -FilePath msiexec.exe -ArgumentList "/i `"$path`" /qn /l $logfile $extra_args" -Verb Runas
+    }
+
+}
+
+$result.changed = $true
+$result.log = Get-Content $logfile | Out-String
+Remove-Item $logfile
+
+Exit-Json $result

--- a/lib/ansible/modules/windows/win_msi.py
+++ b/lib/ansible/modules/windows/win_msi.py
@@ -41,7 +41,6 @@ options:
     extra_args:
         description:
             - Additional arguments to pass to the msiexec.exe command
-        required: false
     state:
         description:
             - Whether the MSI file should be installed or uninstalled
@@ -61,6 +60,9 @@ options:
             - true
             - false
         default: false
+notes:
+- Check-mode support is currently not supported.
+- Please look into M(win_package) instead, this package will be deprecated in Ansible v2.3.
 author: "Matt Martz (@sivel)"
 '''
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_msi

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
I intended to update the documentation, but it appears the website docs are behind the actual documentation (as the website doesn't show the default values for booleans).

So I ended up adding the missing -type "path" and use the default $null value for undefined parameters. And then made the code more conforming the newer Windows infrastructure.