### PR TITLE
amazon: extract boto_exception to ec2 module

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -127,6 +127,23 @@ def _boto3_conn(conn_type=None, resource=None, region=None, endpoint=None, **par
 boto3_inventory_conn = _boto3_conn
 
 
+def boto_exception(err):
+    """
+    Extracts the error message from a boto exception.
+
+    :param err: Exception from boto
+    :return: Error message
+    """
+    if hasattr(err, 'error_message'):
+        error = err.error_message
+    elif hasattr(err, 'message'):
+        error = str(err.message) + ' ' + str(err) + ' - ' + str(type(err))
+    else:
+        error = '%s: %s' % (Exception, err)
+
+    return error
+
+
 def aws_common_argument_spec():
     return dict(
         ec2_url=dict(),

--- a/lib/ansible/modules/cloud/amazon/GUIDELINES.md
+++ b/lib/ansible/modules/cloud/amazon/GUIDELINES.md
@@ -282,6 +282,10 @@ with Ansible format, this function will convert the keys to snake_case.
 Converts a an Ansible list of filters to a boto3 friendly list of dicts.  This is useful for
 any boto3 _facts modules.
 
+### boto_exception
+
+Pass an exception returned from boto or boto3, and this funciton will consistently get the message from the exception.
+
 #### boto3_tag_list_to_ansible_dict
 
 Converts a boto3 tag list to an Ansible dict. Boto3 returns tags as a list of dicts containing keys called

--- a/lib/ansible/modules/cloud/amazon/GUIDELINES.md
+++ b/lib/ansible/modules/cloud/amazon/GUIDELINES.md
@@ -284,7 +284,18 @@ any boto3 _facts modules.
 
 ### boto_exception
 
-Pass an exception returned from boto or boto3, and this funciton will consistently get the message from the exception.
+Pass an exception returned from boto or boto3, and this function will consistently get the message from the exception.
+
+```
+import traceback
+from ansible.module_utils.ec2 import boto_exception
+try:
+    ...
+except boto.exception.BotoServerError as err:
+    error_msg = boto_exception(err)
+    module.fail_json(msg=error_msg, traceback=traceback.format_exc())
+```
+
 
 #### boto3_tag_list_to_ansible_dict
 

--- a/lib/ansible/modules/cloud/amazon/GUIDELINES.md
+++ b/lib/ansible/modules/cloud/amazon/GUIDELINES.md
@@ -293,7 +293,7 @@ try:
     ...
 except boto.exception.BotoServerError as err:
     error_msg = boto_exception(err)
-    module.fail_json(msg=error_msg, traceback=traceback.format_exc())
+    module.fail_json(msg=error_msg, exception=traceback.format_exc())
 ```
 
 

--- a/lib/ansible/modules/cloud/amazon/aws_kms.py
+++ b/lib/ansible/modules/cloud/amazon/aws_kms.py
@@ -104,6 +104,7 @@ statement_label = {
 
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import boto_exception
 
 # import a class, we'll use a fully qualified path
 import ansible.module_utils.ec2
@@ -117,16 +118,6 @@ try:
 except ImportError:
     HAS_BOTO3 = False
 
-def boto_exception(err):
-    '''generic error message handler'''
-    if hasattr(err, 'error_message'):
-        error = err.error_message
-    elif hasattr(err, 'message'):
-        error = str(err.message) + ' ' + str(err) + ' - ' + str(type(err))
-    else:
-        error = '%s: %s' % (Exception, err)
-
-    return error
 
 def get_arn_from_kms_alias(kms, aliasname):
     ret = kms.list_aliases()

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -250,17 +250,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_bytes
 
 
-def boto_exception(err):
-    '''generic error message handler'''
-    if hasattr(err, 'error_message'):
-        error = err.error_message
-    elif hasattr(err, 'message'):
-        error = err.message + ' ' + str(err) + ' - ' + str(type(err))
-    else:
-        error = '%s: %s' % (Exception, err)
-
-    return error
-
 
 def get_stack_events(cfn, stack_name):
     '''This event data was never correct, it worked as a side effect. So the v2.3 format is different.'''

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -245,7 +245,7 @@ except ImportError:
 
 import ansible.module_utils.ec2
 # import a class, otherwise we'll use a fully qualified path
-from ansible.module_utils.ec2 import AWSRetry
+from ansible.module_utils.ec2 import AWSRetry, boto_exception
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_bytes
 

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
@@ -109,16 +109,6 @@ try:
 except ImportError:
     HAS_BOTO=False
 
-def boto_exception(err):
-    '''generic error message handler'''
-    if hasattr(err, 'error_message'):
-        error = err.error_message
-    elif hasattr(err, 'message'):
-        error = err.message
-    else:
-        error = '%s: %s' % (Exception, err)
-
-    return error
 
 def vpc_exists(module, vpc, name, cidr_block, multi):
     """Returns None or a vpc object depending on the existence of a VPC. When supplied

--- a/lib/ansible/modules/cloud/amazon/ecs_ecr.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_ecr.py
@@ -141,18 +141,6 @@ except ImportError:
     HAS_BOTO3 = False
 
 
-def boto_exception(err):
-    '''boto error message handler'''
-    if hasattr(err, 'error_message'):
-        error = err.error_message
-    elif hasattr(err, 'message'):
-        error = err.message
-    else:
-        error = '%s: %s' % (Exception, err)
-
-    return error
-
-
 def build_kwargs(registry_id):
     """
     Builds a kwargs dict which may contain the optional registryId.

--- a/lib/ansible/modules/cloud/amazon/iam.py
+++ b/lib/ansible/modules/cloud/amazon/iam.py
@@ -172,17 +172,6 @@ try:
 except ImportError:
     HAS_BOTO = False
 
-def boto_exception(err):
-    '''generic error message handler'''
-    if hasattr(err, 'error_message'):
-        error = err.error_message
-    elif hasattr(err, 'message'):
-        error = err.message
-    else:
-        error = '%s: %s' % (Exception, err)
-
-    return error
-
 
 def _paginate(func, attr):
     '''

--- a/lib/ansible/modules/cloud/amazon/iam_cert.py
+++ b/lib/ansible/modules/cloud/amazon/iam_cert.py
@@ -120,18 +120,6 @@ except ImportError:
     HAS_BOTO = False
 
 
-def boto_exception(err):
-    '''generic error message handler'''
-    if hasattr(err, 'error_message'):
-        error = err.error_message
-    elif hasattr(err, 'message'):
-        error = err.message
-    else:
-        error = '%s: %s' % (Exception, err)
-
-    return error
-
-
 def cert_meta(iam, name):
     certificate = iam.get_server_certificate(name).get_server_certificate_result.server_certificate
     ocert = certificate.certificate_body

--- a/lib/ansible/modules/cloud/amazon/iam_policy.py
+++ b/lib/ansible/modules/cloud/amazon/iam_policy.py
@@ -129,20 +129,8 @@ except ImportError:
     HAS_BOTO = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ec2 import connect_to_aws, ec2_argument_spec, get_aws_connection_info
+from ansible.module_utils.ec2 import connect_to_aws, ec2_argument_spec, get_aws_connection_info, boto_exception
 from ansible.module_utils.six import string_types
-
-
-def boto_exception(err):
-    '''generic error message handler'''
-    if hasattr(err, 'error_message'):
-        error = err.error_message
-    elif hasattr(err, 'message'):
-        error = err.message
-    else:
-        error = '%s: %s' % (Exception, err)
-
-    return error
 
 
 def user_action(module, iam, name, policy_name, skip, pdoc, state):

--- a/lib/ansible/modules/cloud/amazon/s3_sync.py
+++ b/lib/ansible/modules/cloud/amazon/s3_sync.py
@@ -217,17 +217,6 @@ except ImportError:
     pass
 
 
-def boto_exception(err):
-    '''generic error message handler'''
-    if hasattr(err, 'error_message'):
-        error = err.error_message
-    elif hasattr(err, 'message'):
-        error = str(err.message) + ' ' + str(err) + ' - ' + str(type(err))
-    else:
-        error = '%s: %s' % (Exception, err)
-
-    return error
-
 # the following function, calculate_multipart_etag, is from tlastowka
 # on github and is used under its (compatible) GPL license. So this
 # license applies to the following function.

--- a/lib/ansible/modules/cloud/amazon/s3_sync.py
+++ b/lib/ansible/modules/cloud/amazon/s3_sync.py
@@ -207,7 +207,7 @@ from dateutil import tz
 
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ec2 import camel_dict_to_snake_dict, ec2_argument_spec, boto3_conn, get_aws_connection_info, HAS_BOTO3
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict, ec2_argument_spec, boto3_conn, get_aws_connection_info, HAS_BOTO3, boto_exception
 
 
 try:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request (code improvement)

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
amazon modules

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The `boto_exception` function was copy/pasted throughout several Amazon
modules. This causes a consistency problem, since some improvements to
message formatting were applied to some module but not others. Now all
modules use the same, improved function.