### PR TITLE
win_copy: Add force parameter and check-mode support

### DIFF
--- a/lib/ansible/modules/windows/win_copy.ps1
+++ b/lib/ansible/modules/windows/win_copy.ps1
@@ -27,7 +27,7 @@ $force = Get-AnsibleParam -obj $params -name "force" -type "bool" -default $true
 $original_basename = Get-AnsibleParam -obj $params -name "original_basename" -type "str" -failifempty $true
 
 $result = @{
-    changed = $false
+    changed = $FALSE
     original_basename = $original_basename
     src = $src
     dest = $dest
@@ -42,46 +42,44 @@ if (($force -eq $false) -and (Test-Path -Path $dest)) {
     Exit-Json $result
 }
 
-# Detect if doing recursive folder copy and create any non-existent destination sub folder
+# detect if doing recursive folder copy and create any non-existent destination sub folder
 $parent = Split-Path -Path $original_basename -Parent
-if ($parent.length -gt 0) {
+if ($parent.length -gt 0)
+{
     $dest_folder = Join-Path $dest $parent
-    if (-not $check_mode) {
-        New-Item -Force $dest_folder -Type directory
-    }
+    New-Item -Path $dest_folder -Type Directory -Force -WhatIf:$check_mode
 }
 
-# If $dest is a dir, append $original_basename so the file gets copied with its intended name.
-if (Test-Path -Path $dest -PathType Container) {
+# if $dest is a dir, append $original_basename so the file gets copied with its intended name.
+if (Test-Path -Path $dest -PathType Container)
+{
     $dest = Join-Path -Path $dest -ChildPath $original_basename
 }
 
-$orig_checksum = Get-FileChecksum($dest)
-$src_checksum = Get-FileChecksum($src)
+$orig_checksum = Get-FileChecksum ($dest)
+$src_checksum = Get-FileChecksum ($src)
 
-if ($src_checksum.Equals($orig_checksum)) {
-
-    # If both are "3" then both are folders, ok to copy
-    if ($src_checksum.Equals("3")) {
+If ($src_checksum.Equals($orig_checksum))
+{
+    # if both are "3" then both are folders, ok to copy
+    If ($src_checksum.Equals("3"))
+    {
        # New-Item -Force creates subdirs for recursive copies
-       if (-not $check_mode) {
-           New-Item -Force $dest -Type file
-           Copy-Item -Path $src -Destination $dest -Force
-       }
+       New-Item -Path $dest -Type File -Force -WhatIf:$check_mode
+       Copy-Item -Path $src -Destination $dest -Force -WhatIf:$check_mode
        $result.changed = $true
        $result.operation = "folder_copy"
     }
 
-} elseif (-not $src_checksum.Equals($orig_checksum)) {
-
-    if ($src_checksum.Equals("3")) {
+}
+ElseIf (-Not $src_checksum.Equals($orig_checksum))
+{
+    If ($src_checksum.Equals("3"))
+    {
         Fail-Json $result "If src is a folder, dest must also be a folder"
     }
-
     # The checksums don't match, there's something to do
-    if (-not $check_mode) {
-        Copy-Item -Path $src -Destination $dest -Force
-    }
+    Copy-Item -Path $src -Destination $dest -Force -WhatIf:$check_mode
 
     $result.changed = $true
     $result.operation = "file_copy"
@@ -89,11 +87,11 @@ if ($src_checksum.Equals($orig_checksum)) {
 
 # Verify before we return that the file has changed
 $dest_checksum = Get-FileChecksum($dest)
-if (-not $src_checksum.Equals($dest_checksum) -and -not $check_mode) {
+If (-Not $src_checksum.Equals($dest_checksum) -And -Not $check_mode)
+{
     Fail-Json $result "src checksum $src_checksum did not match dest_checksum $dest_checksum, failed to place file $original_basename in $dest"
 }
 
-# Generate return values
 $info = Get-Item $dest
 $result.size = $info.Length
 $result.src = $src

--- a/lib/ansible/modules/windows/win_copy.py
+++ b/lib/ansible/modules/windows/win_copy.py
@@ -44,6 +44,15 @@ options:
       - Remote absolute path where the file should be copied to. If src is a directory,
         this must be a directory too. Use \\ for path separators.
     required: true
+  force:
+    version_added: "2.3"
+    description:
+      - If set to C(yes), the remote file will be replaced when content is different than the source.
+      - If set to C(no), the remote file will only be transferred if the destination does not exist.
+    default: True
+    choices:
+    - yes
+    - no
 author: "Jon Hawkesworth (@jhawkesworth)"
 '''
 
@@ -51,29 +60,29 @@ EXAMPLES = r'''
 - name: Copy a single file
   win_copy:
     src: /srv/myfiles/foo.conf
-    dest: c:\Temp\foo.conf
+    dest: C:\Temp\foo.conf
 
 - name: Copy files/temp_files to c:\temp
   win_copy:
     src: files/temp_files/
-    dest: c:\Temp
+    dest: C:\Temp\
 '''
 RETURN = r'''
 dest:
     description: destination file/path
     returned: changed
     type: string
-    sample: c:\Temp
+    sample: C:\Temp\
 src:
     description: source file used for the copy on the target machine
     returned: changed
     type: string
-    sample: "/home/httpd/.ansible/tmp/ansible-tmp-1423796390.97-147729857856000/source"
+    sample: /home/httpd/.ansible/tmp/ansible-tmp-1423796390.97-147729857856000/source
 checksum:
     description: sha1 checksum of the file after running copy
     returned: success
     type: string
-    sample: "6e642bb8dd5c2e027bf21dd923337cbb4214f827"
+    sample: 6e642bb8dd5c2e027bf21dd923337cbb4214f827
 size:
     description: size of the target, after execution
     returned: changed (single files only)
@@ -83,11 +92,11 @@ operation:
     description: whether a single file copy took place or a folder copy
     returned: changed (single files only)
     type: string
-    sample: "file_copy"
+    sample: file_copy
 original_basename:
     description: basename of the copied file
     returned: changed (single files only)
     type: string
-    sample: "foo.txt"
+    sample: foo.txt
 '''
 

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -471,7 +471,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         res = self._low_level_execute_command(cmd, sudoable=sudoable)
         return res
 
-    def _execute_remote_stat(self, path, all_vars, follow, tmp=None):
+    def _execute_remote_stat(self, path, all_vars, follow, tmp=None, checksum=True):
         '''
         Get information from remote file.
         '''
@@ -479,7 +479,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             path=path,
             follow=follow,
             get_md5=False,
-            get_checksum=True,
+            get_checksum=checksum,
             checksum_algo='sha1',
         )
         mystat = self._execute_module(module_name='stat', module_args=module_args, task_vars=all_vars, tmp=tmp, delete_remote_tmp=(tmp is None), wrap_async=False)

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -158,8 +158,7 @@ class ActionModule(ActionBase):
             # If the local file does not exist, get_real_file() raises AnsibleFileNotFound
             try:
                 source_full = self._loader.get_real_file(source_full)
-            except AnsibleFileNotFound:
-                e = get_exception()
+            except AnsibleFileNotFound as e:
                 result['failed'] = True
                 result['msg'] = "could not find src=%s, %s" % (source_full, e)
                 self._remove_tmp_path(tmp)


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_copy

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
The rationale behind this is that if you're working with +3GB files,
creating the checksum takes a lot of time, which we can avoid by simply
testing if the file exists.

I also took the liberty to put the various parameters together. It
probably takes a (neglible) performance hit but makes the code a bit
easier to inspect/work with, as its closer to all other windows modules.

On a normal run, the action plugin does a local checksum of the source
and a remote checksum of the destination. And afterwards, the module
will do another remote checksum of the copied source, a remote checksum
of the original destination, and another remote checksum of the copied
destination.

On a very huge file (think 4GB) that means **no less than 5x reading the
complete file** *If you have a large cache you may get away with it, otherwise
you're doomed !*

This patch will ensure with `force: no` that no checksums are being
performed by the action plugin and the module. We do this by delaying
the checksum calls until we have determined whether the destination in
fact exists. More optimisations are still possible, especially in the case the
destination does not exist (we don't need a checksum in that case anyhow).