### PR TITLE
Add feature - win_package - allow non-zero return codes - Issue #20408

### DIFF
--- a/lib/ansible/modules/windows/win_package.ps1
+++ b/lib/ansible/modules/windows/win_package.ps1
@@ -850,6 +850,7 @@ function Set-TargetResource
                     if($process)
                     {
                         $exitCode = $process.ExitCode
+                        Set-Attr -obj $result -name "exit_code" -value $exitCode
                     }
                 }
             }

--- a/lib/ansible/modules/windows/win_package.py
+++ b/lib/ansible/modules/windows/win_package.py
@@ -74,6 +74,12 @@ options:
       - Password of an account with access to the package if it's located on a file share. Only needed if the winrm user doesn't have access to the package. Also specify user_name for this to function properly.
     default: null
     required: false
+  expected_return_code:
+    description:
+      - One or more return codes from the package installation that indicates success.
+      - If not provided, defaults to 0
+    required: no
+    default: 0
 '''
 
 EXAMPLES = '''
@@ -94,4 +100,24 @@ EXAMPLES = '''
     path: https://download.microsoft.com/download/A/F/0/AF0071F3-B198-4A35-AA90-C68D103BDCCF/rdcman.msi
     product_id: '{0240359E-6A4C-4884-9E94-B397A02D893C}'
     state: absent
+    
+# Specify the expected non-zero return code when successful
+# In this case 3010 indicates 'reboot required'
+- name: 'Microsoft .NET Framework 4.5.1'
+    win_package:
+      path: https://download.microsoft.com/download/1/6/7/167F0D79-9317-48AE-AEDB-17120579F8E2/NDP451-KB2858728-x86-x64-AllOS-ENU.exe
+      productid: '{7DEBE4EB-6B40-3766-BB35-5CBBC385DA37}'
+      arguments: '/q /norestart'
+      ensure: present
+      expected_return_code: 3010    
+
+# Specify multiple non-zero return codes when successful
+# In this case we can say that both 0 (SUCCESSFUL) and 3010 (REBOOT REQUIRED) codes are acceptable
+  - name: 'Microsoft .NET Framework 4.5.1'
+    win_package:
+      path: https://download.microsoft.com/download/1/6/7/167F0D79-9317-48AE-AEDB-17120579F8E2/NDP451-KB2858728-x86-x64-AllOS-ENU.exe
+      productid: '{7DEBE4EB-6B40-3766-BB35-5CBBC385DA37}'
+      arguments: '/q /norestart'
+      ensure: present
+      expected_return_code: [0,3010]
 '''


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_package

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel 06e30485ea) last updated 2017/01/16 20:03:34 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/custom_modules']

This has existed in this module in previous 2.x releases as well.  I confirmed that this is an issue in the latest devel branch as of this writing.

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Resolves Feature Request #20408 
- Adds 'exit_code' to the json returned to Ansible. This will show users what the actual return code was
- Updates the documentation in the .py file to show the embedded/already existing expected_return_code attribute as a usable parameter.
- Updates the documentation in the .py file to show two examples of using the exposed attribute to provide support for non-zero but successful error codes

<!-- Paste verbatim command output below, e.g. before and after your change -->

**Before**
 SomeInstallerNeedsREboot.exe exits with 3010, indicating reboot needed.   In this case, the package is installed but since the non-zero but successful exit code isn't handled it shows as failed.
```
- name: Install Package
  win_package:
    path:  d:\build\SomeInstallerNeedsReboot.exe
    product_id: 'SomeInstallerNeedsReboot'
    
    
fatal: [server1.mycompany.com]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_name": "win_package"
    },
    "msg": "The return code 3010 was not expected. Configuration is likely not correct",
    "name": "d:\\build\\SomeInstallerNeedsReboot.exe"
}
```
**After**
Allowing for expected_return_code (single int or list of ints) allows this use case to be properly handled

```
- name: Install Package
  win_package:
    path:  d:\build\SomeInstallerNeedsReboot.exe
    product_id: 'SomeInstallerNeedsReboot'
    expected_return_code: 3010
    
    OR
    
    
- name: Install Package
  win_package:
    path:  d:\build\SomeInstallerNeedsReboot.exe
    product_id: 'SomeInstallerNeedsReboot'
    expected_return_code: [0,3010]

changed: [server1.mycompany.com] => {
    "changed": true,
    "exit_code": 3010,
    "invocation": {
        "module_name": "win_package"
    },
    "name": "d:\\build\\SomeInstallerNeedsReboot.exe",
    "restart_required": true
}
```
