### PR TITLE
Fix typos in os_quota.py

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_quota.py
+++ b/lib/ansible/modules/cloud/openstack/os_quota.py
@@ -32,7 +32,7 @@ version_added: "2.3"
 author: "Michael Gale (gale.michael@gmail.com)"
 description:
     - Manage OpenStack Quotas. Quotas can be created,
-      updated or deleted using this module. A auota will be updated
+      updated or deleted using this module. A quota will be updated
       if matches an existing project and is present.
 options:
     name:
@@ -115,7 +115,7 @@ options:
     rbac_policy:
         required: False
         default: None
-        description: Number of polcies to allow.
+        description: Number of policies to allow.
     router:
         required: False
         default: None


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
os_quota.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (typo 5438e0463c) last updated 2017/01/18 11:21:22 (GMT -500)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Fix typos in os_quota.py

* Replace 'auota' with 'quota'
* Replace 'polcies' with 'policies'