### PR TITLE
Fix argument name to fail_json(), detail -> details

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -21,8 +21,8 @@
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
-from ansible.module_utils.urls import fetch_url
-from ansible.module_utils.urls import url_argument_spec
+from ansible.module_utils.urls import fetch_url, url_argument_spec
+from ansible.module_utils._text import to_native
 import base64
 import hashlib
 import json
@@ -586,7 +586,7 @@ class JenkinsPlugin(object):
                 e = get_exception()
                 self.module.fail_json(
                     msg="Cannot close the tmp updates file %s." % updates_file,
-                    detail=str(e))
+                    details=to_native(e))
 
         # Open the updates file
         try:
@@ -595,7 +595,7 @@ class JenkinsPlugin(object):
             e = get_exception()
             self.module.fail_json(
                 msg="Cannot open temporal updates file.",
-                details=str(e))
+                details=to_native(e))
 
         i = 0
         for line in f:
@@ -658,7 +658,7 @@ class JenkinsPlugin(object):
             e = get_exception()
             self.module.fail_json(
                 msg='Cannot close the temporal plugin file %s.' % tmp_f,
-                details=str(e))
+                details=to_native(e))
 
         # Move the file onto the right place
         self.module.atomic_move(tmp_f, f)
@@ -785,7 +785,7 @@ def main():
         e = get_exception()
         module.fail_json(
             msg='Cannot convert %s to float.' % module.params['timeout'],
-            details=str(e))
+            details=to_native(e))
 
     # Set version to latest if state is latest
     if module.params['state'] == 'latest':


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

`jenkins_plugin.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
v2.3
```

##### SUMMARY
Also use `to_native(e)` instead of `str(e)` while here as `str()` itself might throw an exception when handling non-ASCII chars as pointed out by @abadger