### PR TITLE
Generate ssh key once for network tests.

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -21,6 +21,7 @@ import lib.thread
 
 from lib.core_ci import (
     AnsibleCoreCI,
+    SshKey,
 )
 
 from lib.manage_ci import (
@@ -187,6 +188,9 @@ def command_network_integration(args):
 
     if args.platform:
         instances = []  # type: list [lib.thread.WrappedThread]
+
+        # generate an ssh key (if needed) up front once, instead of for each instance
+        SshKey(args)
 
         for platform_version in args.platform:
             platform, version = platform_version.split('/', 1)


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (at-ssh 30ec764593) last updated 2017/01/18 12:51:34 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Generate ssh key once for network tests.

This should avoid a race condition on Shippable when starting multiple network instances.