### PR TITLE
Pass the HOME environment variable to testenv in tox.ini (Fixes #20424)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,10 @@ commands =
     py27: python -m compileall -fq -x 'test/samples' lib test contrib
     py3{5,6}: python -m compileall -fq -x 'test/samples|lib/ansible/modules' lib test contrib
     make tests
+passenv =
+    # Pass HOME to the test environment to avoid the missing HOME env
+    # variable error. See issue: #20424
+    HOME
 
 
 [flake8]


### PR DESCRIPTION
In order to avoid the "missing HOME variable" issue when running the
unit tests, this patch is passing the HOME environment variable to
[testenv].

Fixes #20424

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
N/A

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 4673a9c9c2) last updated 2017/01/18 17:51:21 (GMT +100)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Running unit tests with ```tox -epy27``` fails in some environments with: ERROR: Missing environment variable: HOME. 

This pull request is passing the HOME variable to the [testenv] in tox.ini to avoid this problem.