### PR TITLE
Use multiple AWS regions in ansible-test.

### DIFF
--- a/test/runner/lib/core_ci.py
+++ b/test/runner/lib/core_ci.py
@@ -19,7 +19,7 @@ from lib.util import (
     ApplicationError,
     run_command,
     make_dirs,
-    CommonConfig,
+    EnvironmentConfig,
     display,
     is_shippable,
 )
@@ -29,7 +29,7 @@ class AnsibleCoreCI(object):
     """Client for Ansible Core CI services."""
     def __init__(self, args, platform, version, stage='prod', persist=True, name=None):
         """
-        :type args: CommonConfig
+        :type args: EnvironmentConfig
         :type platform: str
         :type version: str
         :type stage: str
@@ -347,7 +347,7 @@ class SshKey(object):
     """Container for SSH key used to connect to remote instances."""
     def __init__(self, args):
         """
-        :type args: CommonConfig
+        :type args: EnvironmentConfig
         """
         tmp = os.path.expanduser('~/.ansible/test/')
 

--- a/test/runner/lib/cover.py
+++ b/test/runner/lib/cover.py
@@ -5,9 +5,21 @@ from __future__ import absolute_import, print_function
 import os
 import re
 
-from lib.target import walk_module_targets
-from lib.util import display, ApplicationError, run_command
-from lib.executor import EnvironmentConfig, Delegate, install_command_requirements
+from lib.target import (
+    walk_module_targets,
+)
+
+from lib.util import (
+    display,
+    ApplicationError,
+    EnvironmentConfig,
+    run_command,
+)
+
+from lib.executor import (
+    Delegate,
+    install_command_requirements,
+)
 
 COVERAGE_DIR = 'test/results/coverage'
 COVERAGE_FILE = os.path.join(COVERAGE_DIR, 'coverage')

--- a/test/runner/lib/delegation.py
+++ b/test/runner/lib/delegation.py
@@ -11,7 +11,6 @@ import lib.thread
 
 from lib.executor import (
     SUPPORTED_PYTHON_VERSIONS,
-    EnvironmentConfig,
     IntegrationConfig,
     SubprocessError,
     ShellConfig,
@@ -29,6 +28,7 @@ from lib.manage_ci import (
 
 from lib.util import (
     ApplicationError,
+    EnvironmentConfig,
     run_command,
     common_environment,
     display,

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, print_function
 import glob
 import os
 import tempfile
-import sys
 import time
 import textwrap
 import functools
@@ -31,6 +30,7 @@ from lib.manage_ci import (
 
 from lib.util import (
     CommonConfig,
+    EnvironmentConfig,
     ApplicationWarning,
     ApplicationError,
     SubprocessError,
@@ -1037,17 +1037,6 @@ def detect_changes_local(args):
     return sorted(names)
 
 
-def docker_qualify_image(name):
-    """
-    :type name: str
-    :rtype: str
-    """
-    if not name or any((c in name) for c in ('/', ':')):
-        return name
-
-    return 'ansible/ansible:%s' % name
-
-
 def get_integration_filter(args, targets):
     """
     :type args: IntegrationConfig
@@ -1190,48 +1179,6 @@ class SanityFunc(SanityTest):
 
         self.func = func
         self.intercept = intercept
-
-
-class EnvironmentConfig(CommonConfig):
-    """Configuration common to all commands which execute in an environment."""
-    def __init__(self, args, command):
-        """
-        :type args: any
-        """
-        super(EnvironmentConfig, self).__init__(args)
-
-        self.command = command
-
-        self.local = args.local is True
-
-        if args.tox is True or args.tox is False or args.tox is None:
-            self.tox = args.tox is True
-            self.tox_args = 0
-            self.python = args.python if 'python' in args else None  # type: str
-        else:
-            self.tox = True
-            self.tox_args = 1
-            self.python = args.tox  # type: str
-
-        self.docker = docker_qualify_image(args.docker)  # type: str
-        self.remote = args.remote  # type: str
-
-        self.docker_privileged = args.docker_privileged if 'docker_privileged' in args else False  # type: bool
-        self.docker_util = docker_qualify_image(args.docker_util if 'docker_util' in args else '')  # type: str
-        self.docker_pull = args.docker_pull if 'docker_pull' in args else False  # type: bool
-
-        self.tox_sitepackages = args.tox_sitepackages  # type: bool
-
-        self.remote_stage = args.remote_stage  # type: str
-
-        self.requirements = args.requirements  # type: bool
-
-        self.python_version = self.python or '.'.join(str(i) for i in sys.version_info[:2])
-
-        self.delegate = self.tox or self.docker or self.remote
-
-        if self.delegate:
-            self.requirements = True
 
 
 class TestConfig(EnvironmentConfig):

--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -444,6 +444,7 @@ class EnvironmentConfig(CommonConfig):
         self.tox_sitepackages = args.tox_sitepackages  # type: bool
 
         self.remote_stage = args.remote_stage  # type: str
+        self.remote_aws_region = args.remote_aws_region  # type: str
 
         self.requirements = args.requirements  # type: bool
 

--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -413,4 +413,57 @@ class CommonConfig(object):
         self.verbosity = args.verbosity  # type: int
 
 
+class EnvironmentConfig(CommonConfig):
+    """Configuration common to all commands which execute in an environment."""
+    def __init__(self, args, command):
+        """
+        :type args: any
+        """
+        super(EnvironmentConfig, self).__init__(args)
+
+        self.command = command
+
+        self.local = args.local is True
+
+        if args.tox is True or args.tox is False or args.tox is None:
+            self.tox = args.tox is True
+            self.tox_args = 0
+            self.python = args.python if 'python' in args else None  # type: str
+        else:
+            self.tox = True
+            self.tox_args = 1
+            self.python = args.tox  # type: str
+
+        self.docker = docker_qualify_image(args.docker)  # type: str
+        self.remote = args.remote  # type: str
+
+        self.docker_privileged = args.docker_privileged if 'docker_privileged' in args else False  # type: bool
+        self.docker_util = docker_qualify_image(args.docker_util if 'docker_util' in args else '')  # type: str
+        self.docker_pull = args.docker_pull if 'docker_pull' in args else False  # type: bool
+
+        self.tox_sitepackages = args.tox_sitepackages  # type: bool
+
+        self.remote_stage = args.remote_stage  # type: str
+
+        self.requirements = args.requirements  # type: bool
+
+        self.python_version = self.python or '.'.join(str(i) for i in sys.version_info[:2])
+
+        self.delegate = self.tox or self.docker or self.remote
+
+        if self.delegate:
+            self.requirements = True
+
+
+def docker_qualify_image(name):
+    """
+    :type name: str
+    :rtype: str
+    """
+    if not name or any((c in name) for c in ('/', ':')):
+        return name
+
+    return 'ansible/ansible:%s' % name
+
+
 display = Display()  # pylint: disable=locally-disabled, invalid-name

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -51,6 +51,10 @@ from lib.target import (
     walk_sanity_targets,
 )
 
+from lib.core_ci import (
+    AWS_ENDPOINTS,
+)
+
 import lib.cover
 
 
@@ -409,6 +413,7 @@ def add_environments(parser, tox_version=False, tox_only=False):
             docker=None,
             remote=None,
             remote_stage=None,
+            remote_aws_region=None,
         )
 
         return
@@ -432,6 +437,12 @@ def add_environments(parser, tox_version=False, tox_only=False):
                         help='remote stage to use: %(choices)s',
                         choices=['prod', 'dev'],
                         default='prod')
+
+    remote.add_argument('--remote-aws-region',
+                        metavar='REGION',
+                        help='remote aws region to use: %(choices)s (default: auto)',
+                        choices=sorted(AWS_ENDPOINTS),
+                        default=None)
 
 
 def add_extra_docker_options(parser, integration=True):


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (at-regions 4ae84aa163) last updated 2017/01/18 15:50:17 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Use multiple AWS regions in ansible-test when launching EC2 instances on ansible-core-ci. This should allow us to get better performance by utilizing launch credits from other regions.