### PR TITLE
Enable Windows 2016 on Shippable.

### DIFF
--- a/test/runner/lib/core_ci.py
+++ b/test/runner/lib/core_ci.py
@@ -71,7 +71,7 @@ class AnsibleCoreCI(object):
                 self.ci_key += '.%s' % args.remote_aws_region
             elif is_shippable():
                 # split Shippable jobs across multiple regions to maximize use of launch credits
-                if self.platform == 'freebsd':
+                if self.platform == 'windows':
                     region = 'us-east-2'
                 else:
                     region = 'us-east-1'

--- a/test/utils/shippable/windows.sh
+++ b/test/utils/shippable/windows.sh
@@ -26,7 +26,9 @@ if [ -s /tmp/windows.txt ]; then
         --windows 2008-SP2 \
         --windows 2008-R2_SP1 \
         --windows 2012-RTM \
-        --windows 2012-R2_RTM
+        --windows 2012-R2_RTM \
+        --windows 2016-English-Full-Base \
+
 else
     echo "No changes requiring integration tests specific to Windows were detected."
     echo "Running Windows integration tests for a single version only."


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (windows-ci 7aa8e33b56) last updated 2017/01/18 18:20:49 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Enable Windows 2016 on Shippable.

Also launch Windows instances on us-east-2 and all others on us-east-1.