### PR TITLE
allow vars to be set for all in yaml inv

### DIFF
--- a/examples/hosts.yaml
+++ b/examples/hosts.yaml
@@ -4,7 +4,7 @@
 #
 #   - Comments begin with the '#' character
 #   - Blank lines are ignored
-#   - Top level entries are assumed to be groups
+#   - Top level entries are assumed to be groups, except for 'vars'
 #   - Hosts must be specified in a group's hosts:
 #     and they must be a key (: terminated)
 #   - groups can have children, hosts and vars keys
@@ -41,3 +41,7 @@
 ##      webservers:
 ##          hosts:
 ##              beta.example.org:
+
+# Starting in 2.3, to set vars in the 'all' group just create a 'vars' section on the root.
+##vars:
+## testvar: testvalue

--- a/lib/ansible/inventory/yaml.py
+++ b/lib/ansible/inventory/yaml.py
@@ -63,7 +63,11 @@ class InventoryParser(object):
         # We expect top level keys to correspond to groups, iterate over them
         # to get host, vars and subgroups (which we iterate over recursivelly)
         for group_name in data.keys():
-            self._parse_groups(group_name, data[group_name])
+            if group_name == 'vars':
+                # top 'group' named vars is really a vars section for 'all' group
+                self._parse_groups('all', {'vars': data['vars']})
+            else:
+                self._parse_groups(group_name, data[group_name])
 
         # Finally, add all top-level groups as children of 'all'.
         # We exclude ungrouped here because it was already added as a child of
@@ -85,10 +89,10 @@ class InventoryParser(object):
 
             if 'vars' in group_data:
                 for var in group_data['vars']:
-                    if var != 'ansible_group_priority':
-                        self.groups[group].set_variable(var, group_data['vars'][var])
-                    else:
+                    if var == 'ansible_group_priority':
                         self.groups[group].set_priority(group_data['vars'][var])
+                    else:
+                        self.groups[group].set_variable(var, group_data['vars'][var])
 
             if 'children' in group_data:
                 for subgroup in group_data['children']:


### PR DESCRIPTION

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
inventory 

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Allows vars to be set for 'all' in yaml inventory, the consequence is not allowing to have a top level group named 'vars'.

fixes #20304 