### PR TITLE
Expand the ~ in the temporary directory path

### DIFF
--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -114,7 +114,7 @@ class ShellBase(object):
                 basetmpdir = '/tmp'
         else:
             basetmpdir = C.DEFAULT_REMOTE_TMP
-        basetmp = self.join_path(basetmpdir, basefile)
+        basetmp = os.path.expanduser(self.join_path(basetmpdir, basefile))
 
         cmd = 'mkdir -p %s echo %s %s' % (self._SHELL_SUB_LEFT, basetmp, self._SHELL_SUB_RIGHT)
         cmd += ' %s echo %s=%s echo %s %s' % (self._SHELL_AND, basefile, self._SHELL_SUB_LEFT, basetmp, self._SHELL_SUB_RIGHT)


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

`plugins/shell/__init__.py`

##### ANSIBLE VERSION

devel and 2.2.1

##### SUMMARY

The PR https://github.com/ansible/ansible/pull/18551 breaks ansible in some specific configurations, because `~` is not always expanded into `$HOME`.

The issue has already been discussed in https://github.com/ansible/ansible/issues/20332

This fix will also need to be backported to the 2.2.1 branch.

The 2.2 branch can be tested with: `pip install git+git://github.com/MiLk/ansible.git@fixes/20332-2.2`.
The 2.3 branch can be tested with: `pip install git+git://github.com/MiLk/ansible.git@fixes/20332`.

