### PR TITLE
Doc module meta grammar fixes

### DIFF
--- a/hacking/templates/rst.j2
+++ b/hacking/templates/rst.j2
@@ -169,8 +169,8 @@ Notes
 {% endif %}
 
 {% if not deprecated %}
-{% set support = { 'core': 'This module is maintained by those with core commit privileges', 'committer': 'This module is supported mainly by the community and is curated by core committers', 'community': 'This module is community maintained without core committer oversight'} %}
-{% set module_states = { 'preview': 'it is not guaranteed to have a backwards compatible interface', 'stableinterface': 'the maintainers for this module guarantee that the no backward incompatible interface changes will be made'} %}
+{% set support = { 'core': 'This module is maintained by those with core commit privileges', 'committer': 'This module is supported mainly by the community and is curated by core committers.', 'community': 'This module is community maintained without core committer oversight.'} %}
+{% set module_states = { 'preview': 'it is not guaranteed to have a backwards compatible interface', 'stableinterface': 'the maintainers for this module guarantee that no backward incompatible interface changes will be made'} %}
 
 {% if metadata %}
 {% if metadata.status %}


### PR DESCRIPTION
* Remove unnecessary 'the'
* End sentences with a period