### PR TITLE
Fixes #20412 junos_config delete command fix

### DIFF
--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -237,7 +237,7 @@ def diff_commands(commands, config):
     updates = list()
     visited = set()
 
-    for item in commands:
+    for index, item in enumerate(commands):
         if len(item) > 0:
             if not item.startswith('set') and not item.startswith('delete'):
                 raise ValueError('line must start with either `set` or `delete`')
@@ -246,7 +246,9 @@ def diff_commands(commands, config):
                 updates.append(item)
 
             elif item.startswith('delete'):
-                for entry in config:
+                for entry in config + commands[0:index]:
+                    if entry.startswith('set'):
+                        entry = entry[4:]
                     if entry.startswith(item[7:]) and item not in visited:
                         updates.append(item)
                         visited.add(item)


### PR DESCRIPTION

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
junos_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible --version
ansible 2.2.1.0 
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
If same config hierarchy is set and deleted in one playbook
for delete statement add support to check if the config is present
on device or in the playbook. If it is present add delete statement in
updated config list.
```
