### PR TITLE
Fix bug 20253: yaml representer for AnsibleUnsafeText

### DIFF
--- a/lib/ansible/parsing/yaml/dumper.py
+++ b/lib/ansible/parsing/yaml/dumper.py
@@ -25,6 +25,7 @@ from ansible.compat.six import PY3
 from ansible.parsing.yaml.objects import AnsibleUnicode, AnsibleSequence, AnsibleMapping
 from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
 from ansible.vars.hostvars import HostVars
+from ansible.vars.unsafe_proxy import AnsibleUnsafeText
 
 
 class AnsibleDumper(yaml.SafeDumper):
@@ -69,4 +70,9 @@ AnsibleDumper.add_representer(
 AnsibleDumper.add_representer(
     AnsibleVaultEncryptedUnicode,
     represent_vault_encrypted_unicode,
+)
+
+AnsibleDumper.add_representer(
+    AnsibleUnsafeText,
+    represent_unicode,
 )


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
yaml

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file = /vagrant/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Fixes #20253 `The error was: RepresenterError: cannot represent an object`.
Works for me.
