### PR TITLE
Correctly call get_config

### DIFF
--- a/lib/ansible/modules/network/ios/_ios_template.py
+++ b/lib/ansible/modules/network/ios/_ios_template.py
@@ -150,7 +150,7 @@ def get_current_config(module):
         flags = ['all']
     else:
         flags = []
-    return get_config(flags=flags)
+    return get_config(module=module, flags=flags)
 
 def main():
     """ main entry point for module execution
@@ -182,7 +182,7 @@ def main():
     result = {'changed': False}
 
     if module.params['backup']:
-        result['__backup__'] = get_config()
+        result['__backup__'] = get_config(module=module)
 
     if not module.params['force']:
         contents = get_current_config(module)
@@ -195,7 +195,7 @@ def main():
 
     if commands:
         if not module.check_mode:
-            load_config(commands)
+            load_config(module, commands)
         result['changed'] = True
 
     result['updates'] = commands

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -246,6 +246,7 @@ def check_args(module, warnings):
                 'network provider arguments are no longer supported.  Please '
                 'use connection: network_cli for the task'
             )
+            warnings.append(key)
             break
 
 def extract_banners(config):
@@ -366,8 +367,8 @@ def main():
         if match != 'none':
             config, have_banners = get_running_config(module)
             path = module.params['parents']
-            configobjs = candidate.difference(config, path=path,match=match,
-                                            replace=replace)
+            configobjs = candidate.difference(config, path=path, match=match,
+                                              replace=replace)
         else:
             configobjs = candidate.items
             have_banners = {}
@@ -398,7 +399,7 @@ def main():
             result['changed'] = True
 
     if module.params['backup']:
-        result['__backup__'] = get_config()
+        result['__backup__'] = get_config(module=module)
 
     if module.params['save']:
         if not module.check_mode:

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -246,7 +246,6 @@ def check_args(module, warnings):
                 'network provider arguments are no longer supported.  Please '
                 'use connection: network_cli for the task'
             )
-            warnings.append(key)
             break
 
 def extract_banners(config):

--- a/test/units/modules/network/ios/test_ios_template.py
+++ b/test/units/modules/network/ios/test_ios_template.py
@@ -29,7 +29,7 @@ from ansible.errors import AnsibleModuleExit
 from ansible.modules.network.ios import _ios_template
 from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
-
+from ansible.module_utils.local import LocalAnsibleModule
 
 def set_module_args(args):
     args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
@@ -118,7 +118,11 @@ class TestIosTemplateModule(unittest.TestCase):
         src = load_fixture('ios_template_config.cfg')
         set_module_args(dict(src=src, include_defaults=False))
         self.execute_module()
-        self.get_config.assert_called_with(flags=[])
+        _, kwargs = self.get_config.call_args
+        # Ensure flags doesn't contain "default", or any other value
+        assert kwargs['flags'] == []
+        assert isinstance(kwargs['module'], LocalAnsibleModule)
+
 
     def test_ios_template_backup(self):
         set_module_args(dict(backup=True))

--- a/test/units/modules/network/ios/test_ios_template.py
+++ b/test/units/modules/network/ios/test_ios_template.py
@@ -120,8 +120,8 @@ class TestIosTemplateModule(unittest.TestCase):
         self.execute_module()
         _, kwargs = self.get_config.call_args
         # Ensure flags doesn't contain "default", or any other value
-        assert kwargs['flags'] == []
-        assert isinstance(kwargs['module'], LocalAnsibleModule)
+        self.assertEqual(kwargs['flags'], [])
+        self.assertIsInstance(kwargs['module'], LocalAnsibleModule)
 
 
     def test_ios_template_backup(self):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ios_template
ios_config

##### ANSIBLE VERSION
```
ansible 2.3.0 (aws-ios 1c914d1cea) last updated 2017/01/19 12:02:32 (GMT +100)
```

##### SUMMARY
https://github.com/ansible/ansible/commit/258c6ada520e72b3040ad9729c8b95f11d5edc22#diff-00bd5d0956da509605bc7ced00d0a999R384

Found when fixing integration tests, also pylint confirms

```
pylint --errors-only *
No config file found, using default configuration
************* Module ansible.modules.network.ios.ios_config
E:401,31: No value for argument 'module' in function call (no-value-for-parameter)
E:401,31: No value for argument 'module' in function call (no-value-for-parameter)
************* Module ansible.modules.network.ios.ios_facts
E:148, 0: Unable to import 'ansible.module_utils.six.moves' (import-error)
E:449,14: Undefined variable 'get_exception' (undefined-variable)
E:148, 0: Unable to import 'ansible.module_utils.six.moves' (import-error)
E:449,14: Undefined variable 'get_exception' (undefined-variable)
************* Module ansible.modules.network.ios._ios_template
E:153,11: No value for argument 'module' in function call (no-value-for-parameter)
E:185,31: No value for argument 'module' in function call (no-value-for-parameter)
E:198,12: No value for argument 'commands' in function call (no-value-for-parameter)
E:153,11: No value for argument 'module' in function call (no-value-for-parameter)
E:185,31: No value for argument 'module' in function call (no-value-for-parameter)
E:198,12: No value for argument 'commands' in function call (no-value-for-parameter)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/20452)
<!-- Reviewable:end -->
