### PR TITLE
lineinfile: add regex as an alias for regexp

### DIFF
--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -40,6 +40,7 @@ options:
     aliases: [ dest, destfile, name ]
     required: true
   regexp:
+    aliases: [ 'regex' ]
     description:
       - The regular expression to look for in every line of the file. For
         C(state=present), the pattern to replace if found. Only the last line
@@ -459,7 +460,7 @@ def main():
         argument_spec=dict(
             path=dict(type='path', required=True, aliases=['dest', 'destfile', 'name']),
             state=dict(type='str', default='present', choices=['absent', 'present']),
-            regexp=dict(type='str'),
+            regexp=dict(type='str', aliases=['regex']),
             line=dict(type='str', aliases=['value']),
             insertafter=dict(type='str'),
             insertbefore=dict(type='str'),


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/files/lineinfile.py

##### ANSIBLE VERSION
```
ansible 2.3.0 (lininfile-regex-alias 442071ae46) last updated 2017/01/19 14:39:11 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
the param is called regexp, but a lot of people spell it regex add an alias to help them