### PR TITLE
Specify in gitlab_user requirements one needs to have admin rights

### DIFF
--- a/lib/ansible/modules/source_control/gitlab_user.py
+++ b/lib/ansible/modules/source_control/gitlab_user.py
@@ -32,6 +32,7 @@ version_added: "2.1"
 author: "Werner Dijkerman (@dj-wasabi)"
 requirements:
     - pyapi-gitlab python module
+    - administrator rights on the Gitlab server
 options:
     server_url:
         description:


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
gitlab_user

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
After much plumbing through the source code, python-gitlab and the Gitlab API I found out why I cannot update my ssh keys through this module - because it expects the user to have admin rights on the server. This could be made clearer in the requirements because the Gitlab API allows one to change his/her own profile without admin rights, it's just that the module or the underlying library doesn't cover this use case.
