### PR TITLE
Disable pull of updated Shippable docker image.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -58,6 +58,9 @@ build:
   pre_ci:
     - docker images | grep u14pyt
   pre_ci_boot:
+    image_name: drydock/u14pyt
+    image_tag: prod
+    pull: false
     options: "--privileged=false --net=bridge"
   ci:
     - test/utils/shippable/timing.sh test/utils/shippable/shippable.sh


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

shippable.yml

##### ANSIBLE VERSION

```
ansible 2.3.0 (shippable-pull-fix 61caaf77fd) last updated 2017/01/19 10:25:57 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Disable pull of updated Shippable docker image.

This should improve reliability of our jobs on Shippable.

The Shippable AMIs should already have the latest docker image,
per Shippable support, so pull doesn't provide any benefit for us.
