### PR TITLE
Fixes #20469 - Corrected an arg name and changed upload_file parameter to utilize th…

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_sync.py
+++ b/lib/ansible/modules/cloud/amazon/s3_sync.py
@@ -428,12 +428,12 @@ def upload_files(s3, bucket, filelist, params):
     ret = []
     for entry in filelist:
         args = {
-          'ContentLength': entry['bytes'],
+          'Metadata':{'Content-Length': str(entry['bytes'])},
           'ContentType': entry['mime_type']
         }
         if params.get('permission'):
             args['ACL'] = params['permission']
-        s3.upload_file(entry['fullpath'], bucket, entry['s3_path'], ExtraArgs=None, Callback=None, Config=None)
+        s3.upload_file(entry['fullpath'], bucket, entry['s3_path'], ExtraArgs=args, Callback=None, Config=None)
         ret.append(entry)
     return ret
 


### PR DESCRIPTION
…e args that were set so mime_map works correctly.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/cloud/amazon/s3_sync.py

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
The args were set but not used, so I changed that. Now mime_map in the playbook is reflected in what was uploaded to a bucket. One arg name was incorrect so I fixed it. This fixes #20469. 

```
Mime sniffing seems to be working properly (excerpt from verbose output):

        {
            "_strategy": "date_size",
            "bytes": 9,
            "chopped_path": "myfile.txt",
            "fullpath": "/XXXX/myfolder/myfile.txt",
            "local_etag": "\"f463e2453bfbb7b384911347be4f6298\"",
            "mime_type": "text/plain",
            "modified_epoch": 1484846695,
            "s3_path": "myfolder/myfile.txt",
            "why": "no s3_head"
        }
```
