### PR TITLE
Use jinja2 import instead of pip to get version.

### DIFF
--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -112,7 +112,7 @@
         - "'local' == ['localhost']|map('extract',hostvars,'ansible_connection')|list|first"
         - "'local' == ['localhost']|map('extract',hostvars,['ansible_connection'])|list|first"
   # map was added to jinja2 in version 2.7
-  when: "{{ ( lookup('pipe', 'pip show --disable-pip-version-check jinja2 | grep ^Version: | sed \"s/^Version: //\"') |
+  when: "{{ ( lookup('pipe', '{{ ansible_python[\"executable\"] }} -c \"import jinja2; print(jinja2.__version__)\"') |
               version_compare('2.7', '>=') ) }}"
 
 - name: Test json_query filter


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

filters integration test

##### ANSIBLE VERSION

```
ansible 2.3.0 (filter-test db27314817) last updated 2017/01/19 10:54:56 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Use jinja2 import instead of pip to get version.

This resolves issues with older versions of pip.
