### PR TITLE
fix variable name typo on lib/ansible/plugins/lookup/mongodb.py

### DIFF
--- a/lib/ansible/plugins/lookup/mongodb.py
+++ b/lib/ansible/plugins/lookup/mongodb.py
@@ -78,7 +78,7 @@ class LookupModule(LookupBase):
         elif isinstance(result, dict):
             new_dict = {}
             for key in result.keys():
-                value = reslut[key] # python2 and 3 compatible....
+                value = result[key] # python2 and 3 compatible....
                 new_dict[key] = self.convert_mongo_result_to_valid_json(value)
             return new_dict
         elif isinstance(result, datetime.datetime):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/plugins/lookup/mongodb.py


##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (fix_code_typo aa91b96568) last updated 2017/01/19 17:44:07 (GMT -200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

There was a typo error on the code.
That means every time the ansible lookup module received a dict, things would fail.
