### PR TITLE
Fix ec2_vpc deprecation docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Ansible Changes By Release
   the old overwriting behaviour via the config option.  In 2.5, multiple --tags
   options will be merged with no way to go back to the old behaviour.
 * Modules
-  * ec2_vpc will be deprecated in 2.5
+  * ec2_vpc will be deprecated in 2.3 and removed in 2.5
 
 ###New Modules:
 - archive

--- a/lib/ansible/modules/cloud/amazon/_ec2_vpc.py
+++ b/lib/ansible/modules/cloud/amazon/_ec2_vpc.py
@@ -26,7 +26,7 @@ description:
     - Create or terminates AWS virtual private clouds.  This module has a dependency on python-boto.
 version_added: "1.4"
 deprecated: >-
-  Deprecated in 2.3. Use M(epc_vpc_net) along with supporting modules including
+  Deprecated in 2.3. Use M(ec2_vpc_net) along with supporting modules including
   M(ec2_vpc_igw), M(ec2_vpc_route_table), M(ec2_vpc_subnet), M(ec2_vpc_dhcp_options),
   M(ec2_vpc_nat_gateway), M(ec2_vpc_nacl).
 options:


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ec2_vpc

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 1839c8699d) last updated 2017/01/20 10:54:48 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides

```

##### SUMMARY
Clarify the CHANGELOG with deprecation timeline
Correct name of `ec2_vpc_net` module to be used instead

Fixes issues identified by @mattclay in #20344 