### PR TITLE
Add an URI splitting filters

### DIFF
--- a/docs/docsite/rst/playbooks_filters.rst
+++ b/docs/docsite/rst/playbooks_filters.rst
@@ -501,6 +501,20 @@ which will produce this output:
 
 .. _other_useful_filters:
 
+.. uri_filter:
+
+URI Filter
+`````````````````
+
+.. versionadded:: 2.4
+
+The `uri` filter allows to extract the hostname, path, port or scheme from an URI::
+
+    {{ "http://localhost:9000/foo" | uri('hostname') }}
+    # => 'localhost'
+    {{ "http://localhost:9000/foo" | uri('path') }}
+    # => '/foo'
+
 Other Useful Filters
 ````````````````````
 
@@ -635,7 +649,7 @@ Combinations always require a set size::
 
 To get a list combining the elements of other lists use ``zip``::
 
-    - name: give me list combo of 2 lists 
+    - name: give me list combo of 2 lists
       debug: msg="{{ [1,2,3,4,5]|zip(['a','b','c','d','e','f'])|list }}"
 
     - name: give me shortest combo of 2 lists

--- a/docs/docsite/rst/playbooks_filters.rst
+++ b/docs/docsite/rst/playbooks_filters.rst
@@ -508,12 +508,24 @@ URI Filter
 
 .. versionadded:: 2.4
 
-The `uri` filter extracts the hostname, path, port or scheme from an URI::
+The ``uri`` filter extracts the hostname, path, port or scheme from an URI. With no arguments, it extracts the base URL::
 
-    {{ "http://localhost:9000/foo" | uri('hostname') }}
-    # => 'localhost'
-    {{ "http://localhost:9000/foo" | uri('path') }}
-    # => '/foo'
+    {{ "http://www.acme.com:9000/dir/index.html" | uri }}
+    # => 'http://www.acme.com:9000'
+
+    {{ "http://www.acme.com:9000/dir/index.html" | uri('hostname') }}
+    # => 'www.acme.com'
+
+    {{ "http://www.acme.com:9000/dir/index.html" | uri('path') }}
+    # => '/dir/index.html'
+
+    {{ "http://www.acme.com:9000/dir/index.html" | uri('port') }}
+    # => '9000'
+
+    {{ "http://www.acme.com:9000/dir/index.html" | uri('scheme') }}
+    # => 'http'
+
+
 
 Other Useful Filters
 ````````````````````
@@ -602,7 +614,7 @@ To replace text in a string with regex, use the "regex_replace" filter::
 
     # convert "localhost:80" to "localhost, 80" using named groups
     {{ 'localhost:80' | regex_replace('^(?P<host>.+):(?P<port>\\d+)$', '\\g<host>, \\g<port>') }}
-    
+
     # convert "localhost:80" to "localhost"
     {{ 'localhost:80' | regex_replace(':80') }}
 

--- a/docs/docsite/rst/playbooks_filters.rst
+++ b/docs/docsite/rst/playbooks_filters.rst
@@ -508,7 +508,7 @@ URI Filter
 
 .. versionadded:: 2.4
 
-The `uri` filter allows to extract the hostname, path, port or scheme from an URI::
+The `uri` filter extracts the hostname, path, port or scheme from an URI::
 
     {{ "http://localhost:9000/foo" | uri('hostname') }}
     # => 'localhost'

--- a/lib/ansible/plugins/filter/uri.py
+++ b/lib/ansible/plugins/filter/uri.py
@@ -1,7 +1,7 @@
 # (c) 2017, Andrea Scarpino <me@andreascarpino.it>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
+from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 

--- a/lib/ansible/plugins/filter/uri.py
+++ b/lib/ansible/plugins/filter/uri.py
@@ -1,0 +1,80 @@
+# (c) 2017, Andrea Scarpino <me@andreascarpino.it>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from functools import partial
+import types
+
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
+
+from ansible import errors
+
+
+def _hostname_query(value):
+    ''' Fetch the hostname from an URI '''
+
+    return urlparse(value).hostname
+
+
+def _path_query(value):
+    ''' Fetch the path from an URI '''
+
+    return urlparse(value).path
+
+
+def _port_query(value):
+    ''' Fetch the port from an URI '''
+
+    return urlparse(value).port
+
+
+def _scheme_query(value):
+    ''' Fetch the scheme from an URI '''
+
+    return urlparse(value).scheme
+
+
+def uri(value, query = ''):
+    ''' Check if string is an URI and filter it '''
+
+    query_func_map = {
+        'hostname': _hostname_query,
+        'path': _path_query,
+        'port': _port_query,
+        'scheme': _scheme_query,
+    }
+
+    try:
+        return query_func_map[query](value)
+    except KeyError:
+        return False
+
+
+# ---- Ansible filters ----
+class FilterModule(object):
+    ''' URI filter '''
+
+
+    def filters(self):
+        return {
+            'uri': uri
+        }

--- a/lib/ansible/plugins/filter/uri.py
+++ b/lib/ansible/plugins/filter/uri.py
@@ -1,25 +1,16 @@
 # (c) 2017, Andrea Scarpino <me@andreascarpino.it>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-# Make coding more python3-ish
-from __future__ import (absolute_import, division, print_function)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from functools import partial
-import types
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
 
 try:
     from urllib.parse import urlparse
@@ -53,7 +44,15 @@ def _scheme_query(value):
     return urlparse(value).scheme
 
 
-def uri(value, query = ''):
+def _default_query(value):
+    ''' Return the URL minus the file by default '''
+
+    default_url = urlparse(value).scheme + '://' + urlparse(value).netloc
+
+    return default_url
+
+
+def uri(value, query='', alias='uri'):
     ''' Check if string is an URI and filter it '''
 
     query_func_map = {
@@ -61,18 +60,19 @@ def uri(value, query = ''):
         'path': _path_query,
         'port': _port_query,
         'scheme': _scheme_query,
+        '': _default_query
     }
 
     try:
         return query_func_map[query](value)
     except KeyError:
-        return False
+        raise errors.AnsibleFilterError(alias + ': unknown filter type: %s' % query)
+    return False
 
 
 # ---- Ansible filters ----
 class FilterModule(object):
     ''' URI filter '''
-
 
     def filters(self):
         return {

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -20,23 +20,29 @@
   shell: echo hi
   register: some_registered_var
 
-- debug: var=some_registered_var
+- debug:
+    var: some_registered_var
 
 - name: Verify that we workaround a py26 json bug
-  template: src=py26json.j2 dest={{output_dir}}/py26json.templated mode=0644
+  template:
+    src: py26json.j2
+    dest: "{{ output_dir }}/py26json.templated"
+    mode: 0644
 
 - name: 9851 - Verify that we don't trigger https://github.com/ansible/ansible/issues/9851
   copy:
-    content: " [{{item|to_nice_json}}]"
-    dest: "{{output_dir}}/9851.out"
+    content: " [{{ item | to_nice_json }}]"
+    dest: "{{ output_dir }}/9851.out"
   with_items:
   - {"k": "Quotes \"'\n"}
 
 - name: 9851 - copy known good output into place
-  copy: src=9851.txt dest={{output_dir}}/9851.txt
+  copy:
+    src: 9851.txt
+    dest: "{{ output_dir }}/9851.txt"
 
 - name: 9851 - Compare generated json to known good
-  shell: diff -w {{output_dir}}/9851.out {{output_dir}}/9851.txt
+  shell: diff -w {{ output_dir }}/9851.out {{ output_dir }}/9851.txt
   register: diff_result_9851
 
 - name: 9851 - verify generated file matches known good
@@ -45,72 +51,78 @@
         - 'diff_result_9851.stdout == ""'
 
 - name: fill in a basic template
-  template: src=foo.j2 dest={{output_dir}}/foo.templated mode=0644
+  template:
+    src: foo.j2
+    dest: "{{ output_dir }}/foo.templated"
+    mode: 0644
   register: template_result
 
 - name: copy known good into place
-  copy: src=foo.txt dest={{output_dir}}/foo.txt
+  copy:
+    src: foo.txt
+    dest: "{{ output_dir }}/foo.txt"
 
 - name: compare templated file to known good
-  shell: diff -w {{output_dir}}/foo.templated {{output_dir}}/foo.txt
+  shell: diff -w {{ output_dir }}/foo.templated {{ output_dir }}/foo.txt
   register: diff_result
 
 - name: verify templated file matches known good
   assert:
     that:
-        - 'diff_result.stdout == ""'
+      - 'diff_result.stdout == ""'
 
 - name: Verify human_readable
   tags: "human_readable"
   assert:
     that:
-        - '"1.00 Bytes" == 1|human_readable'
-        - '"1.00 bits" == 1|human_readable(isbits=True)'
-        - '"10.00 KB" == 10240|human_readable'
-        - '"97.66 MB" == 102400000|human_readable'
-        - '"0.10 GB" == 102400000|human_readable(unit="G")'
-        - '"0.10 Gb" == 102400000|human_readable(isbits=True, unit="G")'
+      - '"1.00 Bytes" == 1|human_readable'
+      - '"1.00 bits" == 1|human_readable(isbits=True)'
+      - '"10.00 KB" == 10240|human_readable'
+      - '"97.66 MB" == 102400000|human_readable'
+      - '"0.10 GB" == 102400000|human_readable(unit="G")'
+      - '"0.10 Gb" == 102400000|human_readable(isbits=True, unit="G")'
 
 - name: Verify human_to_bytes
   tags: "human_to_bytes"
   assert:
     that:
-        - "{{'0'|human_to_bytes}}        == 0"
-        - "{{'0.1'|human_to_bytes}}      == 0"
-        - "{{'0.9'|human_to_bytes}}      == 1"
-        - "{{'1'|human_to_bytes}}        == 1"
-        - "{{'10.00 KB'|human_to_bytes}} == 10240"
-        - "{{   '11 MB'|human_to_bytes}} == 11534336"
-        - "{{  '1.1 GB'|human_to_bytes}} == 1181116006"
-        - "{{'10.00 Kb'|human_to_bytes(isbits=True)}} == 10240"
+      - "{{'0'|human_to_bytes}}        == 0"
+      - "{{'0.1'|human_to_bytes}}      == 0"
+      - "{{'0.9'|human_to_bytes}}      == 1"
+      - "{{'1'|human_to_bytes}}        == 1"
+      - "{{'10.00 KB'|human_to_bytes}} == 10240"
+      - "{{   '11 MB'|human_to_bytes}} == 11534336"
+      - "{{  '1.1 GB'|human_to_bytes}} == 1181116006"
+      - "{{'10.00 Kb'|human_to_bytes(isbits=True)}} == 10240"
 
 - name: Verify human_to_bytes (bad string)
-  tags: "human_to_bytes"
-  set_fact: bad_string="{{'10.00 foo'|human_to_bytes}}"
+  set_fact:
+    bad_string: "{{ '10.00 foo' | human_to_bytes }}"
   ignore_errors: yes
-  register: _
+  tags: human_to_bytes
+  register: _human_bytes_test
 
 - name: Verify human_to_bytes (bad string)
-  tags: "human_to_bytes"
+  tags: human_to_bytes
   assert:
-    that: "{{_.failed}}"
+    that: "{{_human_bytes_test.failed}}"
 
 - name: Test extract
   assert:
     that:
-        - '"c" == 2 | extract(["a", "b", "c"])'
-        - '"b" == 1 | extract(["a", "b", "c"])'
-        - '"a" == 0 | extract(["a", "b", "c"])'
+      - '"c" == 2 | extract(["a", "b", "c"])'
+      - '"b" == 1 | extract(["a", "b", "c"])'
+      - '"a" == 0 | extract(["a", "b", "c"])'
 
 - name: Container lookups with extract
   assert:
     that:
-        - "'x' == [0]|map('extract',['x','y'])|list|first"
-        - "'y' == [1]|map('extract',['x','y'])|list|first"
-        - "42 == ['x']|map('extract',{'x':42,'y':31})|list|first"
-        - "31 == ['x','y']|map('extract',{'x':42,'y':31})|list|last"
-        - "'local' == ['localhost']|map('extract',hostvars,'ansible_connection')|list|first"
-        - "'local' == ['localhost']|map('extract',hostvars,['ansible_connection'])|list|first"
+      - "'x' == [0]|map('extract',['x','y'])|list|first"
+      - "'y' == [1]|map('extract',['x','y'])|list|first"
+      - "42 == ['x']|map('extract',{'x':42,'y':31})|list|first"
+      - "31 == ['x','y']|map('extract',{'x':42,'y':31})|list|last"
+      - "'local' == ['localhost']|map('extract',hostvars,'ansible_connection')|list|first"
+      - "'local' == ['localhost']|map('extract',hostvars,['ansible_connection'])|list|first"
   # map was added to jinja2 in version 2.7
   when: "{{ ( lookup('pipe', '{{ ansible_python[\"executable\"] }} -c \"import jinja2; print(jinja2.__version__)\"') |
               version_compare('2.7', '>=') ) }}"

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -125,3 +125,11 @@
     that:
       - '"{{ "hash" | hash("sha1") }}" == "2346ad27d7568ba9896f1b7da6b5991251debdf2"'
       - '"{{ "café" | hash("sha1") }}" == "f424452a9673918c6f09b0cdd35b20be8e6ae7d7"'
+
+- name: Test uri filter
+  assert:
+    that:
+      - "'http://localhost:9000/foo' | uri('hostname') == 'localhost'"
+      - "'http://localhost:9000/foo' | uri('path') == '/foo'"
+      - "'http://localhost:9000/foo' | uri('port') == 9000"
+      - "'http://localhost:9000/foo' | uri('scheme') == 'http'"

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -141,7 +141,20 @@
 - name: Test uri filter
   assert:
     that:
-      - "'http://localhost:9000/foo' | uri('hostname') == 'localhost'"
-      - "'http://localhost:9000/foo' | uri('path') == '/foo'"
-      - "'http://localhost:9000/foo' | uri('port') == 9000"
-      - "'http://localhost:9000/foo' | uri('scheme') == 'http'"
+      - "'http://www.acme.com:9000/dir/index.html' | uri('hostname') == 'www.acme.com'"
+      - "'http://www.acme.com:9000/dir/index.html' | uri('path') == '/dir/index.html'"
+      - "'http://www.acme.com:9000/dir/index.html' | uri('port') == 9000"
+      - "'http://www.acme.com:9000/dir/index.html' | uri('scheme') == 'http'"
+      - "'http://www.acme.com:9000/dir/index.html' | uri == 'http://www.acme.com:9000'"
+
+- name: Test uri filter bad argument
+  debug:
+    var: "'http://www.acme.com:9000/dir/index.html' | uri('bad_filter')"
+  register: _bad_uri_filter
+  ignore_errors: yes
+
+- name: Verify uri filter showed an error message
+  assert:
+    that:
+      - _bad_uri_filter | failed
+      - "'unknown filter type' in _bad_uri_filter.msg"


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
uri_filter

##### ANSIBLE VERSION
```
ansible 2.2.1.0
```

##### SUMMARY
Adds an URI filter useful to fetch hostname, path, port or scheme from an URI.