### PR TITLE
Minor docs update - Fix doc string handler notify call

### DIFF
--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -34,7 +34,7 @@ DOCUMENTATION = '''
 module: yum_repository
 author: Jiri Tyr (@jtyr)
 version_added: '2.1'
-short_description: Add and remove YUM repositories
+short_description: Add or remove YUM repositories
 description:
   - Add or remove YUM repositories in RPM-based Linux distributions.
 
@@ -437,7 +437,7 @@ EXAMPLES = '''
   yum_repository:
     name: epel
     state: absent
-  notify: yum-clean-all
+  notify: yum-clean-metadata
 
 - name: Remove repository from a specific repo file
   yum_repository:


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/packaging/os/yum_repository.py 
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel 216e2c8813) last updated 2017/01/20 07:07:31 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Updated handler notify call to match the actually handler name in the example. Current documentation shows the task calling yum-clean-all but the handler in the documentation is yum-clean-metadata. Issue #20179.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
-short_description: Add and remove YUM repositories		+short_description: Add or remove YUM repositories
-  notify: yum-clean-all		+  notify: yum-clean-metadata
```