### PR TITLE
Fixes #19601 - Cleans up formatting and introduces a new s3.py option 'ignore_nonexistent_bucket'

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3.py
+++ b/lib/ansible/modules/cloud/amazon/s3.py
@@ -302,7 +302,7 @@ def bucket_check(module, s3, bucket, validate=True):
     try:
         result = s3.lookup(bucket, validate=validate)
     except s3.provider.storage_response_error as e:
-        module.fail_json(msg="Failed while looking up bucket (during bucket_check) %s: %s" % (bucket, e)),
+        module.fail_json(msg="Failed while looking up bucket (during bucket_check) %s: %s" % (bucket, e),
                 exception=traceback.format_exc())
     return bool(result)
 
@@ -314,7 +314,7 @@ def create_bucket(module, s3, bucket, location=None):
         for acl in module.params.get('permission'):
             bucket.set_acl(acl)
     except s3.provider.storage_response_error as e:
-        module.fail_json(msg="Failed while creating bucket %s: %s" % (bucket, e),
+        module.fail_json(msg="Failed while creating bucket or setting acl (check that you have CreateBucket and PutBucketAcl permission) %s: %s" % (bucket, e),
                 exception=traceback.format_exc())
     if bucket:
         return True
@@ -469,7 +469,7 @@ def main():
     bucket = module.params.get('bucket')
     encrypt = module.params.get('encrypt')
     expiry = int(module.params['expiry'])
-    dest = os.path.expanduser(module.params.get('dest', ''))
+    dest = module.params.get('dest', '')
     headers = module.params.get('headers')
     marker = module.params.get('marker')
     max_keys = module.params.get('max_keys')
@@ -484,6 +484,9 @@ def main():
     rgw = module.params.get('rgw')
     src = module.params.get('src')
     ignore_nonexistent_bucket = module.params.get('ignore_nonexistent_bucket')
+
+    if dest:
+        dest = os.path.expanduser(dest)
 
     for acl in module.params.get('permission'):
         if acl not in CannedACLStrings:

--- a/lib/ansible/modules/cloud/amazon/s3.py
+++ b/lib/ansible/modules/cloud/amazon/s3.py
@@ -554,9 +554,9 @@ def main():
         keyrtn = key_check(module, s3, bucket, obj, version=version, validate=validate)
         if keyrtn is False:
             if version is not None:
-                module.fail_json(msg="Key %s with version id %s does not exist."% (obj, version), failed=True)
+                module.fail_json(msg="Key %s with version id %s does not exist."% (obj, version))
             else:
-                module.fail_json(msg="Key %s or source bucket %s does not exist."% (obj, bucket), failed=True)
+                module.fail_json(msg="Key %s or source bucket %s does not exist."% (obj, bucket))
 
         # If the destination path doesn't exist or overwrite is True, no need to do the md5um etag check, so just download.
         pathrtn = path_check(dest)
@@ -595,7 +595,7 @@ def main():
         # Lets check the src path.
         pathrtn = path_check(src)
         if not pathrtn:
-            module.fail_json(msg="Local object for PUT does not exist", failed=True)
+            module.fail_json(msg="Local object for PUT does not exist")
 
         # Lets check to see if bucket exists to get ground truth.
         if bucketrtn:
@@ -631,13 +631,13 @@ def main():
     # Delete an object from a bucket, not the entire bucket
     if mode == 'delobj':
         if obj is None:
-            module.fail_json(msg="object parameter is required", failed=True)
+            module.fail_json(msg="object parameter is required")
         if bucket:
             deletertn = delete_key(module, s3, bucket, obj, validate=validate)
             if deletertn is True:
                 module.exit_json(msg="Object %s deleted from bucket %s." % (obj, bucket), changed=True)
         else:
-            module.fail_json(msg="Bucket parameter is required.", failed=True)
+            module.fail_json(msg="Bucket parameter is required.")
 
 
     # Delete an entire bucket, including all objects in the bucket
@@ -647,7 +647,7 @@ def main():
             if deletertn is True:
                 module.exit_json(msg="Bucket %s and all keys have been deleted."%bucket, changed=True)
         else:
-            module.fail_json(msg="Bucket parameter is required.", failed=True)
+            module.fail_json(msg="Bucket parameter is required.")
 
     # Support for listing a set of keys
     if mode == 'list':
@@ -655,7 +655,7 @@ def main():
 
         # If the bucket does not exist then bail out
         if bucket_object is None:
-            module.fail_json(msg="Target bucket (%s) cannot be found"% bucket, failed=True)
+            module.fail_json(msg="Target bucket (%s) cannot be found"% bucket)
 
         list_keys(module, bucket_object, prefix, marker, max_keys)
 
@@ -685,13 +685,13 @@ def main():
     # Support for grabbing the time-expired URL for an object in S3/Walrus.
     if mode == 'geturl':
         if not bucket and not obj:
-            module.fail_json(msg="Bucket and Object parameters must be set", failed=True)
+            module.fail_json(msg="Bucket and Object parameters must be set")
 
         keyrtn = key_check(module, s3, bucket, obj, validate=validate)
         if keyrtn:
             get_download_url(module, s3, bucket, obj, expiry, validate=validate)
         else:
-            module.fail_json(msg="Key %s does not exist." % obj, failed=True)
+            module.fail_json(msg="Key %s does not exist." % obj)
 
     if mode == 'getstr':
         if bucket and obj:
@@ -699,9 +699,9 @@ def main():
             if keyrtn:
                 download_s3str(module, s3, bucket, obj, version=version, validate=validate)
             elif version is not None:
-                module.fail_json(msg="Key %s with version id %s does not exist." % (obj, version), failed=True)
+                module.fail_json(msg="Key %s with version id %s does not exist." % (obj, version))
             else:
-                module.fail_json(msg="Key %s does not exist." % obj, failed=True)
+                module.fail_json(msg="Key %s does not exist." % obj)
 
     module.exit_json(failed=False)
 

--- a/lib/ansible/modules/cloud/amazon/s3.py
+++ b/lib/ansible/modules/cloud/amazon/s3.py
@@ -152,7 +152,7 @@ options:
     version_added: "1.3"
   ignore_nonexistent_bucket:
     description:
-      - Overrides initial bucket lookups in case bucket or iam policies are restrictive. Example: a user may have the GetObject permission but no other permissions. In this case using the option mode: get will fail without specifying ignore_nonexistent_bucket: True.
+      - "Overrides initial bucket lookups in case bucket or iam policies are restrictive. Example: a user may have the GetObject permission but no other permissions. In this case using the option mode: get will fail without specifying ignore_nonexistent_bucket: True."
     default: false
     aliases: []
     version_added: "2.2"

--- a/lib/ansible/modules/cloud/amazon/s3.py
+++ b/lib/ansible/modules/cloud/amazon/s3.py
@@ -461,8 +461,7 @@ def main():
     bucket = module.params.get('bucket')
     encrypt = module.params.get('encrypt')
     expiry = int(module.params['expiry'])
-    if module.params.get('dest'):
-        dest = module.params.get('dest')
+    dest = os.path.expanduser(module.params.get('dest', ''))
     headers = module.params.get('headers')
     marker = module.params.get('marker')
     max_keys = module.params.get('max_keys')

--- a/lib/ansible/modules/cloud/amazon/s3.py
+++ b/lib/ansible/modules/cloud/amazon/s3.py
@@ -531,7 +531,7 @@ def main():
     # First, we check to see if the bucket exists, we get "bucket" returned.
     bucketrtn = bucket_check(module, s3, bucket)
     if mode not in ('create', 'put', 'delete') and not bucketrtn:
-        module.fail_json(msg="Source bucket cannot be found from new condition", failed=True)
+        module.fail_json(msg="Source bucket cannot be found.", failed=True)
 
     # If our mode is a GET operation (download), go through the procedure as appropriate ...
     if mode == 'get':

--- a/lib/ansible/modules/cloud/amazon/s3.py
+++ b/lib/ansible/modules/cloud/amazon/s3.py
@@ -540,7 +540,7 @@ def main():
 
     # First, we check to see if the bucket exists, we get "bucket" returned.
     bucketrtn = bucket_check(module, s3, bucket)
-    
+
     if not ignore_nonexistent_bucket:
         validate = True
         if mode not in ('create', 'put', 'delete') and not bucketrtn:

--- a/lib/ansible/modules/cloud/amazon/s3.py
+++ b/lib/ansible/modules/cloud/amazon/s3.py
@@ -150,6 +150,12 @@ options:
     default: null
     aliases: []
     version_added: "1.3"
+  ignore_nonexistent_bucket:
+    description:
+      - Overrides initial bucket lookups in case bucket or iam policies are restrictive
+    default: false
+    aliases: []
+    version_added: "2.2"
 
 requirements: [ "boto" ]
 author:
@@ -267,9 +273,9 @@ try:
 except ImportError:
     HAS_BOTO = False
 
-def key_check(module, s3, bucket, obj, version=None):
+def key_check(module, s3, bucket, obj, version=None, validate=True):
     try:
-        bucket = s3.lookup(bucket)
+        bucket = s3.lookup(bucket, validate)
         key_check = bucket.get_key(obj, version_id=version)
     except s3.provider.storage_response_error as e:
         if version is not None and e.status == 400: # If a specified version doesn't exist a 400 is returned.
@@ -281,8 +287,8 @@ def key_check(module, s3, bucket, obj, version=None):
     else:
         return False
 
-def keysum(module, s3, bucket, obj, version=None):
-    bucket = s3.lookup(bucket)
+def keysum(module, s3, bucket, obj, version=None, validate=True):
+    bucket = s3.lookup(bucket, validate)
     key_check = bucket.get_key(obj, version_id=version)
     if not key_check:
         return None
@@ -292,9 +298,9 @@ def keysum(module, s3, bucket, obj, version=None):
         module.fail_json(msg="Files uploaded with multipart of s3 are not supported with checksum, unable to compute checksum.")
     return md5_remote
 
-def bucket_check(module, s3, bucket):
+def bucket_check(module, s3, bucket, validate=True):
     try:
-        result = s3.lookup(bucket)
+        result = s3.lookup(bucket, validate)
     except s3.provider.storage_response_error as e:
         module.fail_json(msg="Failed while looking up bucket (during bucket_check) %s: %s" % (bucket, str(e)),
                 exception=traceback.format_exc())
@@ -338,17 +344,17 @@ def delete_bucket(module, s3, bucket):
     except s3.provider.storage_response_error as e:
         module.fail_json(msg= str(e))
 
-def delete_key(module, s3, bucket, obj):
+def delete_key(module, s3, bucket, obj, validate=True):
     try:
-        bucket = s3.lookup(bucket)
+        bucket = s3.lookup(bucket, validate)
         bucket.delete_key(obj)
         module.exit_json(msg="Object deleted from bucket %s"%bucket, changed=True)
     except s3.provider.storage_response_error as e:
         module.fail_json(msg= str(e))
 
-def create_dirkey(module, s3, bucket, obj):
+def create_dirkey(module, s3, bucket, obj, validate=True):
     try:
-        bucket = s3.lookup(bucket)
+        bucket = s3.lookup(bucket, validate)
         key = bucket.new_key(obj)
         key.set_contents_from_string('')
         module.exit_json(msg="Virtual directory %s created in bucket %s" % (obj, bucket.name), changed=True)
@@ -362,9 +368,9 @@ def path_check(path):
         return False
 
 
-def upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt, headers):
+def upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt, headers, validate=True):
     try:
-        bucket = s3.lookup(bucket)
+        bucket = s3.lookup(bucket, validate)
         key = bucket.new_key(obj)
         if metadata:
             for meta_key in metadata.keys():
@@ -378,10 +384,10 @@ def upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt, heade
     except s3.provider.storage_copy_error as e:
         module.fail_json(msg= str(e))
 
-def download_s3file(module, s3, bucket, obj, dest, retries, version=None):
+def download_s3file(module, s3, bucket, obj, dest, retries, version=None, validate=True):
     # retries is the number of loops; range/xrange needs to be one
     # more to get that count of loops.
-    bucket = s3.lookup(bucket)
+    bucket = s3.lookup(bucket, validate)
     key = bucket.get_key(obj, version_id=version)
     for x in range(0, retries + 1):
         try:
@@ -396,18 +402,18 @@ def download_s3file(module, s3, bucket, obj, dest, retries, version=None):
             # otherwise, try again, this may be a transient timeout.
             pass
 
-def download_s3str(module, s3, bucket, obj, version=None):
+def download_s3str(module, s3, bucket, obj, version=None, validate=True):
     try:
-        bucket = s3.lookup(bucket)
+        bucket = s3.lookup(bucket, validate)
         key = bucket.get_key(obj, version_id=version)
         contents = key.get_contents_as_string()
         module.exit_json(msg="GET operation complete", contents=contents, changed=True)
     except s3.provider.storage_copy_error as e:
         module.fail_json(msg= str(e))
 
-def get_download_url(module, s3, bucket, obj, expiry, changed=True):
+def get_download_url(module, s3, bucket, obj, expiry, changed=True, validate=True):
     try:
-        bucket = s3.lookup(bucket)
+        bucket = s3.lookup(bucket, validate)
         key = bucket.lookup(obj)
         url = key.generate_url(expiry)
         module.exit_json(msg="Download url:", url=url, expiry=expiry, changed=changed)
@@ -435,25 +441,26 @@ def is_walrus(s3_url):
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
-        bucket         = dict(required=True),
-        dest           = dict(default=None, type='path'),
-        encrypt        = dict(default=True, type='bool'),
-        expiry         = dict(default=600, aliases=['expiration']),
-        headers        = dict(type='dict'),
-        marker         = dict(default=None),
-        max_keys       = dict(default=1000),
-        metadata       = dict(type='dict'),
-        mode           = dict(choices=['get', 'put', 'delete', 'create', 'geturl', 'getstr', 'delobj', 'list'], required=True),
-        object         = dict(type='path'),
-        permission     = dict(type='list', default=['private']),
-        version        = dict(default=None),
-        overwrite      = dict(aliases=['force'], default='always'),
-        prefix         = dict(default=None),
-        retries        = dict(aliases=['retry'], type='int', default=0),
-        s3_url         = dict(aliases=['S3_URL']),
-        rgw            = dict(default='no', type='bool'),
-        src            = dict(),
-    ),
+        bucket                          = dict(required=True),
+        dest                            = dict(default=None),
+        encrypt                         = dict(default=True, type='bool'),
+        expiry                          = dict(default=600, aliases=['expiration']),
+        headers                         = dict(type='dict'),
+        marker                          = dict(default=None),
+        max_keys                        = dict(default=1000),
+        metadata                        = dict(type='dict'),
+        mode                            = dict(choices=['get', 'put', 'delete', 'create', 'geturl', 'getstr', 'delobj', 'list'], required=True),
+        object                          = dict(),
+        permission                      = dict(type='list', default=['private']),
+        version                         = dict(default=None),
+        overwrite                       = dict(aliases=['force'], default='always'),
+        prefix                          = dict(default=None),
+        retries                         = dict(aliases=['retry'], type='int', default=0),
+        s3_url                          = dict(aliases=['S3_URL']),
+        rgw                             = dict(default='no', type='bool'),
+        src                             = dict(),
+        ignore_nonexistent_bucket       = dict(default=False, type='bool')
+        ),
     )
     module = AnsibleModule(argument_spec=argument_spec)
 
@@ -477,6 +484,7 @@ def main():
     s3_url = module.params.get('s3_url')
     rgw = module.params.get('rgw')
     src = module.params.get('src')
+    ignore_nonexistent_bucket = module.params.get('ignore_nonexistent_bucket')
 
     for acl in module.params.get('permission'):
         if acl not in CannedACLStrings:
@@ -530,39 +538,45 @@ def main():
 
     # First, we check to see if the bucket exists, we get "bucket" returned.
     bucketrtn = bucket_check(module, s3, bucket)
-    if mode not in ('create', 'put', 'delete') and not bucketrtn:
-        module.fail_json(msg="Source bucket cannot be found.", failed=True)
+    
+    if not ignore_nonexistent_bucket:
+        validate = True
+        if mode not in ('create', 'put', 'delete') and not bucketrtn:
+            module.fail_json(msg="Source bucket cannot be found.", failed=True)
+    else:
+        validate = False
 
     # If our mode is a GET operation (download), go through the procedure as appropriate ...
     if mode == 'get':
         # Next, we check to see if the key in the bucket exists. If it exists, it also returns key_matches md5sum check.
-        keyrtn = key_check(module, s3, bucket, obj, version=version)
+        keyrtn = key_check(module, s3, bucket, obj, version=version, validate=validate)
         if keyrtn is False:
             if version is not None:
                 module.fail_json(msg="Key %s with version id %s does not exist."% (obj, version), failed=True)
             else:
-                module.fail_json(msg="Key %s does not exist."%obj, failed=True)
+                module.fail_json(msg="Key %s does not exist."%obj, failed=True)  # we could change this to specify that the problem may also be a nonexistent bucket
 
         # If the destination path doesn't exist or overwrite is True, no need to do the md5um etag check, so just download.
         pathrtn = path_check(dest)
         if pathrtn is False or overwrite == 'always':
-            download_s3file(module, s3, bucket, obj, dest, retries, version=version)
+            download_s3file(module, s3, bucket, obj, dest, retries, version=version, validate=validate)
 
         # Compare the remote MD5 sum of the object with the local dest md5sum, if it already exists.
         if pathrtn is True:
-            md5_remote = keysum(module, s3, bucket, obj, version=version)
+            md5_remote = keysum(module, s3, bucket, obj, version=version, validate=validate)
             md5_local = module.md5(dest)
             if md5_local == md5_remote:
                 sum_matches = True
+                module.exit_json(msg="Local and remote object are identical, ignoring. Use overwrite=always parameter to force.", changed=False)
                 if overwrite == 'always':
-                    download_s3file(module, s3, bucket, obj, dest, retries, version=version)
+                    download_s3file(module, s3, bucket, obj, dest, retries, version=version, validate=validate)
                 else:
                     module.exit_json(msg="Local and remote object are identical, ignoring. Use overwrite=always parameter to force.", changed=False)
             else:
                 sum_matches = False
 
                 if overwrite in ('always', 'different'):
-                    download_s3file(module, s3, bucket, obj, dest, retries, version=version)
+                    download_s3file(module, s3, bucket, obj, dest, retries, version=version, validate=validate)
                 else:
                     module.exit_json(msg="WARNING: Checksums do not match. Use overwrite parameter to force download.")
 
@@ -617,7 +631,7 @@ def main():
         if obj is None:
             module.fail_json(msg="object parameter is required", failed=True)
         if bucket:
-            deletertn = delete_key(module, s3, bucket, obj)
+            deletertn = delete_key(module, s3, bucket, obj, validate=validate)
             if deletertn is True:
                 module.exit_json(msg="Object %s deleted from bucket %s." % (obj, bucket), changed=True)
         else:
@@ -671,17 +685,17 @@ def main():
         if not bucket and not obj:
             module.fail_json(msg="Bucket and Object parameters must be set", failed=True)
 
-        keyrtn = key_check(module, s3, bucket, obj)
+        keyrtn = key_check(module, s3, bucket, obj, validate=validate)
         if keyrtn:
-            get_download_url(module, s3, bucket, obj, expiry)
+            get_download_url(module, s3, bucket, obj, expiry, validate=validate)
         else:
             module.fail_json(msg="Key %s does not exist." % obj, failed=True)
 
     if mode == 'getstr':
         if bucket and obj:
-            keyrtn = key_check(module, s3, bucket, obj, version=version)
+            keyrtn = key_check(module, s3, bucket, obj, version=version, validate=validate)
             if keyrtn:
-                download_s3str(module, s3, bucket, obj, version=version)
+                download_s3str(module, s3, bucket, obj, version=version, validate=validate)
             elif version is not None:
                 module.fail_json(msg="Key %s with version id %s does not exist." % (obj, version), failed=True)
             else:

--- a/lib/ansible/modules/cloud/amazon/s3.py
+++ b/lib/ansible/modules/cloud/amazon/s3.py
@@ -678,7 +678,7 @@ def main():
                     module.exit_json(msg="Bucket %s and key %s already exists."% (bucket, obj), changed=False)
                 else:
                     create_dirkey(module, s3, bucket, dirobj)
-            if bucketrtn:
+            else:
                 created = create_bucket(module, s3, bucket, location)
                 create_dirkey(module, s3, bucket, dirobj)
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/s3.py

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Fixes #19601. Improves error messages and cleans up some formatting and excessive code. Also introduces a new option 'ignore_nonexistent_bucket' (the default is False) to appropriately set the 'validate' kwarg for s3.lookup.
Example for the use of ignore_nonexistent_bucket: if a user has the GetObject permission but no other permissions, mode: get will fail since the module by default attempts to lookup the bucket. If ignore_nonexistent_buckets is set to True a user with GetObject permission but no other permissions will be able to get the object.

Before:
```
ansible-playbook s3-test.yml
 [WARNING]: Host file not found: /etc/ansible/hosts

 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [localhost] ****************************************************************************************

TASK [Gathering Facts] **********************************************************************************
 [WARNING]: Removed unexpected internal key in module return: _ansible_verbose_override = True

ok: [localhost]

TASK [download file from s3] ****************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Source bucket cannot be found"}
	to retry, use: --limit @/Users/shertel/Workspace/01-18-17/ansible/s3-test.retry

PLAY RECAP **********************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1
```

After:
```
ansible-playbook s3-test.yml
 [WARNING]: Host file not found: /etc/ansible/hosts

 [WARNING]: provided hosts list is empty, only localhost is available

PLAY [localhost] ****************************************************************************************

TASK [Gathering Facts] **********************************************************************************
 [WARNING]: Removed unexpected internal key in module return: _ansible_verbose_override = True

ok: [localhost]

TASK [download file from s3] ****************************************************************************
changed: [localhost]

PLAY RECAP **********************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0
```
