### PR TITLE
Select a windows reference module

### DIFF
--- a/lib/ansible/modules/windows/win_service.ps1
+++ b/lib/ansible/modules/windows/win_service.ps1
@@ -19,87 +19,90 @@
 # WANT_JSON
 # POWERSHELL_COMMON
 
-$params = Parse-Args $args;
+$ErrorActionPreference = "Stop"
 
-$result = New-Object PSObject;
-Set-Attr $result "changed" $false;
+$params = Parse-Args $args -supports_check_mode $true
 
-$name = Get-Attr $params "name" -failifempty $true
-$state = Get-Attr $params "state" $false
-$startMode = Get-Attr $params "start_mode" $false
+$check_mode = Get-AnsibleParam -obj $params "_ansible_check_mode" -type "bool" -default $false
 
-If ($state) {
-    $state = $state.ToString().ToLower()
-    If (($state -ne 'started') -and ($state -ne 'stopped') -and ($state -ne 'restarted')) {
-        Fail-Json $result "state is '$state'; must be 'started', 'stopped', or 'restarted'"
-    }
+$name = Get-AnsibleParam -obj $params -name "name" -failifempty $true
+$state = Get-AnsibleParam -obj $params -name "state" -default "started" -validateset "started","stopped","restarted"
+$start_mode = Get-AnsibleParam -obj $params -name "start_mode" -validateset "auto","manual","disabled"
+
+$result = @{
+    changed = $false
+    warnings = @()
 }
 
-If ($startMode) {
-    $startMode = $startMode.ToString().ToLower()
-    If (($startMode -ne 'auto') -and ($startMode -ne 'manual') -and ($startMode -ne 'disabled')) {
-        Fail-Json $result "start mode is '$startMode'; must be 'auto', 'manual', or 'disabled'"
-    }
+$service = Get-Service -Name $name -ErrorAction SilentlyContinue
+if (-not $service) {
+    Fail-Json $result "Service '$name' not installed"
 }
 
-$svcName = $name
-$svc = Get-Service -Name $svcName -ErrorAction SilentlyContinue
-If (-not $svc) {
-    Fail-Json $result "Service '$svcName' not installed"
-}
+$result.name = $service.ServiceName
+$result.display_name = $service.DisplayName
+
 # Use service name instead of display name for remaining actions.
-If ($svcName -ne $svc.ServiceName) {
-    $svcName = $svc.ServiceName
+if ($name -ne $service.ServiceName) {
+    $result.warnings += "Please use `"$service.ServiceName`" as service name instead of `"$name`""
+    $name = $service.ServiceName
 }
 
-Set-Attr $result "name" $svc.ServiceName
-Set-Attr $result "display_name" $svc.DisplayName
-
-$svcMode = Get-WmiObject -Class Win32_Service -Property StartMode -Filter "Name='$svcName'"
-If ($startMode) {
-    If ($svcMode.StartMode.ToLower() -ne $startMode) {
-        Set-Service -Name $svcName -StartupType $startMode
-        Set-Attr $result "changed" $true
-        Set-Attr $result "start_mode" $startMode
-    }
-    Else {
-        Set-Attr $result "start_mode" $svcMode.StartMode.ToLower()
-    }
-}
-Else {
-    Set-Attr $result "start_mode" $svcMode.StartMode.ToLower()
-}
-
-If ($state) {
-    If ($state -eq "started" -and $svc.Status -ne "Running") {
-        try {
-            Start-Service -Name $svcName -ErrorAction Stop
+$current_mode = Get-WmiObject -Class Win32_Service -Property StartMode -Filter "Name='$name'"
+$result.start_mode = $current_mode.StartMode.ToLower()
+if ($start_mode -ne $null) {
+    if ($start_mode -ne $result.start_mode) {
+        if ($check_mode) {
+            Set-Service -Name $name -StartupType $start_mode -WhatIf
+        } else {
+            Set-Service -Name $name -StartupType $start_mode
         }
-        catch {
-            Fail-Json $result $_.Exception.Message
-        }
-        Set-Attr $result "changed" $true;
-    }
-    ElseIf ($state -eq "stopped" -and $svc.Status -ne "Stopped") {
-        try {
-            Stop-Service -Name $svcName -ErrorAction Stop
-        }
-        catch {
-            Fail-Json $result $_.Exception.Message
-        }
-        Set-Attr $result "changed" $true;
-    }
-    ElseIf ($state -eq "restarted") {
-        try {
-            Restart-Service -Name $svcName -ErrorAction Stop
-        }
-        catch {
-            Fail-Json $result $_.Exception.Message
-        }
-        Set-Attr $result "changed" $true;
+        $result.changed = $true
+        $result.start_mode = $start_mode
     }
 }
-$svc.Refresh()
-Set-Attr $result "state" $svc.Status.ToString().ToLower()
 
-Exit-Json $result;
+if ($state -eq "started" -and $service.Status -ne "Running") {
+
+    try {
+        if ($check_mode) {
+            Start-Service -Name $name -WhatIf
+        } else {
+            Start-Service -Name $name
+        }
+    } catch {
+        Fail-Json $result $_.Exception.Message
+    }
+    $result.changed = $true
+
+} elseif ($state -eq "stopped" -and $service.Status -ne "Stopped") {
+
+    try {
+        if ($check_mode) {
+            Stop-Service -Name $name -WhatIf
+        } else {
+            Stop-Service -Name $name
+        }
+    } catch {
+        Fail-Json $result $_.Exception.Message
+    }
+    $result.changed = $true
+
+} elseif ($state -eq "restarted") {
+
+    try {
+        if ($checkmode) {
+            Restart-Service -Name $name -WhatIf
+        } else {
+            Restart-Service -Name $name
+        }
+    } catch {
+        Fail-Json $result $_.Exception.Message
+    }
+    $result.changed = $true
+
+}
+$service.Refresh()
+$result.state = $service.Status.ToString().ToLower()
+
+Exit-Json $result

--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -28,7 +28,7 @@ ANSIBLE_METADATA = {'status': ['stableinterface'],
 DOCUMENTATION = r'''
 ---
 module: win_service
-version_added: "1.7"
+version_added: '1.7'
 short_description: Manages Windows services
 description:
     - Manages Windows services
@@ -37,12 +37,9 @@ options:
     description:
       - Name of the service
     required: true
-    default: null
-    aliases: []
   start_mode:
     description:
       - Set the startup type for the service
-    required: false
     choices:
       - auto
       - manual
@@ -50,16 +47,13 @@ options:
   state:
     description:
       - C(started)/C(stopped) are idempotent actions that will not run
-        commands unless necessary.  C(restarted) will always bounce the
-        service.
-    required: false
+        commands unless necessary.
+      - C(restarted) will always bounce the service.
     choices:
       - started
       - stopped
       - restarted
-    default: null
-    aliases: []
-author: "Chris Hoffman (@chrishoffman)"
+author: Chris Hoffman (@chrishoffman)
 '''
 
 EXAMPLES = r'''


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_service

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
As discussed in #20505 we would like to point from the documentation to
a module we choose as the reference module for Windows.

I picked win_service and cleaned it up to the best of my abilities.
I also added check-mode support as an example.

Let the bikeshedding begin !