### PR TITLE
Bug/docker service stderr3

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_service.py
@@ -511,20 +511,72 @@ def stdout_redirector(path_name):
     finally:
         sys.stdout = old_stdout
 
-def get_stdout(path_name):
-    full_stdout = ''
-    last_line = ''
+@contextmanager
+def stderr_redirector(path_name):
+    old_fh = sys.stderr
+    fd = open(path_name, 'w')
+    sys.stderr = fd
+    try:
+        yield
+    finally:
+        sys.stderr = old_fh
+
+def make_redirection_tempfiles():
+    _, out_redir_name = tempfile.mkstemp(prefix="ansible")    
+    _, err_redir_name = tempfile.mkstemp(prefix="ansible")
+    return (out_redir_name, err_redir_name)
+
+def cleanup_redirection_tempfiles(out_name, err_name):
+    get_redirected_output(out_name)
+    get_redirected_output(err_name)
+
+def get_redirected_output(path_name):
+    output = []
     with open(path_name, 'r') as fd:
         for line in fd:
             # strip terminal format/color chars
             new_line = re.sub(r'\x1b\[.+m', '', line.encode('ascii'))
-            full_stdout += new_line
-            if new_line.strip():
-                # Assuming last line contains the error message
-                last_line = new_line.strip().encode('utf-8')
+            output.append(new_line)
     fd.close()
     os.remove(path_name)
-    return full_stdout, last_line
+    return output
+
+def attempt_extract_errors(exc_str, stdout, stderr):
+    errors = [l.strip() for l in stderr if l.strip().startswith('ERROR:')]
+    errors.extend([l.strip() for l in stdout if l.strip().startswith('ERROR:')])
+
+    warnings = [l.strip() for l in stderr if l.strip().startswith('WARNING:')]
+    warnings.extend([l.strip() for l in stdout if l.strip().startswith('WARNING:')])
+
+    # assume either the exception body (if present) or the last warning was the 'most'
+    # fatal.
+
+    if exc_str.strip():
+        msg = exc_str.strip()
+    elif errors:
+        msg = errors[-1].encode('utf-8')
+    else:
+        msg = 'unknown cause'
+
+    return {
+        'warnings': [w.encode('utf-8') for w in warnings],
+        'errors': [e.encode('utf-8') for e in errors],
+        'msg': msg,
+        'module_stderr': ''.join(stderr),
+        'module_stdout': ''.join(stdout)
+    }
+
+def get_failure_info(exc, out_name, err_name=None, msg_format='%s'):
+    if err_name is None:
+        stderr = []
+    else:
+        stderr = get_redirected_output(err_name)
+    stdout = get_redirected_output(out_name)
+
+    reason = attempt_extract_errors(str(exc), stdout, stderr)
+    reason['msg'] = msg_format % reason['msg']
+    return reason
+
 
 class ContainerManager(DockerBaseClass):
 
@@ -690,25 +742,26 @@ class ContainerManager(DockerBaseClass):
                     result['actions'].append(result_action)
 
         if not self.check_mode and result['changed']:
-            _, fd_name = tempfile.mkstemp(prefix="ansible")
+            out_redir_name, err_redir_name = make_redirection_tempfiles()
             try:
-                with stdout_redirector(fd_name):
-                    do_build = build_action_from_opts(up_options)
-                    self.log('Setting do_build to %s' % do_build)
-                    self.project.up(
-                        service_names=service_names,
-                        start_deps=start_deps,
-                        strategy=converge,
-                        do_build=do_build,
-                        detached=detached,
-                        remove_orphans=self.remove_orphans,
-                        timeout=self.timeout)
+                with stdout_redirector(out_redir_name):
+                    with stderr_redirector(err_redir_name):
+                        do_build = build_action_from_opts(up_options)
+                        self.log('Setting do_build to %s' % do_build)
+                        self.project.up(
+                            service_names=service_names,
+                            start_deps=start_deps,
+                            strategy=converge,
+                            do_build=do_build,
+                            detached=detached,
+                            remove_orphans=self.remove_orphans,
+                            timeout=self.timeout)
             except Exception as exc:
-                full_stdout, last_line= get_stdout(fd_name)
-                self.client.module.fail_json(msg="Error starting project %s" % str(exc), module_stderr=last_line,
-                                             module_stdout=full_stdout)
+                fail_reason = get_failure_info(exc, out_redir_name, err_redir_name,
+                                               msg_format="Error starting project %s")
+                self.client.module.fail_json(**fail_reason)
             else:
-                get_stdout(fd_name)
+                cleanup_redirection_tempfiles(out_redir_name, err_redir_name)
 
         if self.stopped:
             stop_output = self.cmd_stop(service_names)
@@ -911,16 +964,17 @@ class ContainerManager(DockerBaseClass):
                     ))
                 result['actions'].append(service_res)
         if not self.check_mode and result['changed']:
-            _, fd_name = tempfile.mkstemp(prefix="ansible")
+            out_redir_name, err_redir_name = make_redirection_tempfiles()
             try:
-                with stdout_redirector(fd_name):
-                    self.project.stop(service_names=service_names, timeout=self.timeout)
+                with stdout_redirector(out_redir_name):
+                    with stderr_redirector(err_redir_name):
+                        self.project.stop(service_names=service_names, timeout=self.timeout)
             except Exception as exc:
-                full_stdout, last_line = get_stdout(fd_name)
-                self.client.module.fail_json(msg="Error stopping project %s" % str(exc), module_stderr=last_line,
-                                             module_stdout=full_stdout)
+                fail_reason = get_failure_info(exc, out_redir_name, err_redir_name,
+                                               msg_format="Error stopping project %s")
+                self.client.module.fail_json(**fail_reason)
             else:
-                get_stdout(fd_name)
+                cleanup_redirection_tempfiles(out_redir_name, err_redir_name)
         return result
 
     def cmd_restart(self, service_names):
@@ -945,16 +999,17 @@ class ContainerManager(DockerBaseClass):
                 result['actions'].append(service_res)
 
         if not self.check_mode and result['changed']:
-            _, fd_name = tempfile.mkstemp(prefix="ansible")
+            out_redir_name, err_redir_name = make_redirection_tempfiles()
             try:
-                with stdout_redirector(fd_name):
-                    self.project.restart(service_names=service_names, timeout=self.timeout)
+                with stdout_redirector(out_redir_name):
+                    with stderr_redirector(err_redir_name):
+                        self.project.restart(service_names=service_names, timeout=self.timeout)
             except Exception as exc:
-                full_stdout, last_line = get_stdout(fd_name)
-                self.client.module.fail_json(msg="Error restarting project %s" % str(exc), module_stderr=last_line,
-                                             module_stdout=full_stdout)
+                fail_reason = get_failure_info(exc, out_redir_name, err_redir_name,
+                                               msg_format="Error restarting project %s")
+                self.client.module.fail_json(**fail_reason)
             else:
-                get_stdout(fd_name)
+                cleanup_redirection_tempfiles(out_redir_name, err_redir_name)
         return result
 
     def cmd_scale(self):


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
`docker_service`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (bug/docker_service_stderr3 8e15fe9f76) last updated 2017/01/19 21:05:29 (GMT +100)
  config file = /Users/shabble/work/mhn-automation/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Extends the output-capturing behaviour to include stderr when calling `docker-compose` as a library, since it typically raises empty exceptions and logs useful diagnostic info to stderr by default.  Without access to this output, it is extremely difficult to determine why a docker-compose task might be failing, especially with inline definitions or templated compose-files.

This PR mostly just replicates ansible/ansible-modules-core#5165 and extends the handling to consider stderr as well.

There's a little bit of logic in trying to guess the appropriate message to include in the `.fail_json` msg parameter, but module stderr and stdout are included unmodified in case it guesses wrongly.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #20480 
<!-- Paste verbatim command output below, e.g. before and after your change -->

Output before (-vvv)
```
[...]
fatal: [ansibledocker.mhn]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_args": {
            "api_version": null,
            "build": false,
            "cacert_path": null,
            "cert_path": null,
            "debug": true,
            "definition": {
                "services": {
                    "testcontainer": {
                        "command": "sleep 100",
                        "image": "busybox",
                        "ports": [
                            "8001:8000"
                        ]
                    },
                    "testcontainer2": {
                        "command": "sleep 100",
                        "image": "busybox",
                        "ports": [
                            "8001:8000"
                        ]
                    }
                },
                "version": "2"
            },
            "dependencies": true,
            "docker_host": null,
            "files": null,
            "filter_logger": false,
            "hostname_check": false,
            "key_path": null,
            "nocache": false,
            "project_name": "foo",
            "project_src": null,
            "pull": false,
            "recreate": "smart",
            "remove_images": null,
            "remove_orphans": false,
            "remove_volumes": false,
            "restarted": false,
            "scale": null,
            "services": null,
            "ssl_version": null,
            "state": "present",
            "stopped": false,
            "timeout": 10,
            "tls": null,
            "tls_hostname": null,
            "tls_verify": null
        },
        "module_name": "docker_service"
    },
    "module_stderr": "",
    "module_stdout": "",
    "msg": "Error starting project "
}

```
Using testcase from bug in #20480 

Output after:
```
fatal: [ansibledocker.mhn]: FAILED! => {
    "changed": false,
    "errors": [
        "ERROR: for testcontainer2  Cannot start service testcontainer2: driver failed programming external connectivity on endpoint foo_testcontainer2_1 (d1b78ff057e5e00b8c2711781292ba76eff9928024e944dc275ecc76b98f9b20): Bind for 0.0.0.0:8001 failed: port is already allocated"
    ],
    "failed": true,
    "invocation": {
        "module_args": {
            "api_version": null,
            "build": false,
            "cacert_path": null,
            "cert_path": null,
            "debug": true,
            "definition": {
                "services": {
                    "testcontainer": {
                        "command": "sleep 100",
                        "image": "busybox",
                        "ports": [
                            "8001:8000"
                        ]
                    },
                    "testcontainer2": {
                        "command": "sleep 100",
                        "image": "busybox",
                        "ports": [
                            "8001:8000"
                        ]
                    }
                },
                "version": "2"
            },
            "dependencies": true,
            "docker_host": null,
            "files": null,
            "filter_logger": false,
            "hostname_check": false,
            "key_path": null,
            "nocache": false,
            "project_name": "foo",
            "project_src": null,
            "pull": false,
            "recreate": "smart",
            "remove_images": null,
            "remove_orphans": false,
            "remove_volumes": false,
            "restarted": false,
            "scale": null,
            "services": null,
            "ssl_version": null,
            "state": "present",
            "stopped": false,
            "timeout": 10,
            "tls": null,
            "tls_hostname": null,
            "tls_verify": null
        },
        "module_name": "docker_service"
    },
    "module_stderr": "\nERROR: for testcontainer2  Cannot start service testcontainer2: driver failed programming external connectivity on endpoint foo_testcontainer2_1 (d1b78ff057e5e00b8c2711781292ba76eff9928024e944dc275ecc76b98f9b20): Bind for 0.0.0.0:8001 failed: port is already allocated\n",
    "module_stdout": "",
    "msg": "Error starting project ERROR: for testcontainer2  Cannot start service testcontainer2: driver failed programming external connectivity on endpoint foo_testcontainer2_1 (d1b78ff057e5e00b8c2711781292ba76eff9928024e944dc275ecc76b98f9b20): Bind for 0.0.0.0:8001 failed: port is already allocated",
    "warnings": []
}
```

###### Review considerations

* Correct use of `.encode()` when processing output? I'm not totally confident this is currently ideal.
* Inclusion of empty dicts in returned json? In the example, `warnings` is empty but still included. I'm not sure if it would make more sense to omit it entirely if so.