### PR TITLE
win_uri: module cleanup and added check-mode support

### DIFF
--- a/lib/ansible/modules/windows/win_uri.py
+++ b/lib/ansible/modules/windows/win_uri.py
@@ -36,6 +36,7 @@ options:
   url:
     description:
       - HTTP or HTTPS URL in the form of (http|https)://host.domain:port/path
+    required: True
   method:
     description:
       - The HTTP Method of the request or response.
@@ -61,7 +62,6 @@ options:
     version_added: "2.3"
     description:
       - Output the response body to a file.
-    default: None
   headers:
     description:
       - 'Key Value pairs for headers. Example "Host: www.somesite.com"'
@@ -84,19 +84,19 @@ EXAMPLES = r'''
 # Set a HOST header to hit an internal webserver:
 - name: Hit a Specific Host on the Server
   win_uri:
-    url: http://example.com
+    url: http://example.com/
     method: GET
     headers:
       host: www.somesite.com
 
 - name: Perform a HEAD on an Endpoint
   win_uri:
-    url: http://www.example.com
+    url: http://www.example.com/
     method: HEAD
 
 - name: POST a Body to an Endpoint
   win_uri:
-    url: http://www.somesite.com
+    url: http://www.somesite.com/
     method: POST
     body: "{ 'some': 'json' }"
 '''
@@ -106,17 +106,17 @@ url:
   description: The Target URL
   returned: always
   type: string
-  sample: "https://www.ansible.com"
+  sample: https://www.ansible.com
 method:
   description: The HTTP method used.
   returned: always
   type: string
-  sample: "GET"
+  sample: GET
 content_type:
   description: The "content-type" header used.
   returned: always
   type: string
-  sample: "application/json"
+  sample: application/json
 use_basic_parsing:
   description: The state of the "use_basic_parsing" flag.
   returned: always
@@ -137,7 +137,7 @@ status_description:
   description: A summery of the status.
   returned: success
   type: string
-  stample: "OK"
+  sample: OK
 raw_content:
   description: The raw content of the HTTP response.
   returned: success


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_uri

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
The following changes have been made:
- Added check-mode support
- Added parameter type support
- Replace PSObject by a normal dictionary
- Improve idempotency (only when $dest is provided it is not idempotent *yet*)