### PR TITLE
win_shortcut: Small cleanup

### DIFF
--- a/lib/ansible/modules/windows/win_shortcut.ps1
+++ b/lib/ansible/modules/windows/win_shortcut.ps1
@@ -21,14 +21,9 @@
 
 # Based on: http://powershellblogger.com/2016/01/create-shortcuts-lnk-or-url-files-with-powershell/
 
-# TODO: Add debug information with what has changed using windows functions
-# TODO: Ensure that by default variables default to $null automatically (so that they can be tested)
-
 $ErrorActionPreference = "Stop"
 
-$params = Parse-Args $args -supports_check_mode $true;
-
-$_ansible_check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -default $false
+$params = Parse-Args $args -supports_check_mode $true
 
 $src = Get-AnsibleParam -obj $params -name "src" -type "path" -default $null
 $dest = Get-AnsibleParam -obj $params -name "dest" -type "path" -failifempty $true
@@ -38,14 +33,10 @@ $directory = Get-AnsibleParam -obj $params -name "directory" -type "path" -defau
 $hotkey = Get-AnsibleParam -obj $params -name "hotkey" -type "string" -default $null
 $icon = Get-AnsibleParam -obj $params -name "icon" -type "path" -default $null
 $orig_description = Get-AnsibleParam -obj $params -name "description" -type "string" -default $null
-$windowstyle = Get-AnsibleParam -obj $params -name "windowstyle" -type "string" -validateset "default","maximized","minimized" -default $null
+$windowstyle = Get-AnsibleParam -obj $params -name "windowstyle" -type "string" -validateset "normal","maximized","minimized" -default $null
 
 # Expand environment variables on non-path types (Beware: turns $null into "")
-#$src = [System.Environment]::ExpandEnvironmentVariables($orig_src)
-#$dest = [System.Environment]::ExpandEnvironmentVariables($orig_dest)
 $args = Expand-Environment($orig_args)
-#$directory = [System.Environment]::ExpandEnvironmentVariables($orig_directory)
-#$icon = [System.Environment]::ExpandEnvironmentVariables($orig_icon)
 $description = Expand-Environment($orig_description)
 
 $result = @{
@@ -56,22 +47,24 @@ $result = @{
 
 # Convert from window style name to window style id
 $windowstyles = @{
-    default = 1
+    normal = 1
     maximized = 3
     minimized = 7
 }
 
 # Convert from window style id to window style name
-$windowstyleids = @( "", "default", "", "maximized", "", "", "", "minimized" )
+$windowstyleids = @( "", "normal", "", "maximized", "", "", "", "minimized" )
 
 If ($state -eq "absent") {
-    If (Test-Path "$dest") {
-        # If the shortcut exists, try to remove it
-        Try {
-            Remove-Item -Path "$dest";
-        } Catch {
-            # Report removal failure
-            Fail-Json $result "Failed to remove shortcut $dest. (" + $_.Exception.Message + ")"
+    If (Test-Path -Path $dest) {
+        If ($check_mode -ne $true) {
+            # If the shortcut exists, try to remove it
+            Try {
+                Remove-Item -Path $dest
+            } Catch {
+                # Report removal failure
+                Fail-Json $result "Failed to remove shortcut $dest. (" + $_.Exception.Message + ")"
+            }
         }
         # Report removal success
         $result.changed = $true
@@ -94,7 +87,6 @@ If ($state -eq "absent") {
     # Determine if we have a WshShortcut or WshUrlShortcut by checking the Arguments property
     # A WshUrlShortcut objects only consists of a TargetPath property
 
-    # TODO: Find a better way to do has_attr() or isinstance() ?
     If (Get-Member -InputObject $ShortCut -Name Arguments) {
 
         # This is a full-featured application shortcut !
@@ -110,7 +102,7 @@ If ($state -eq "absent") {
         }
         $result.directory = $ShortCut.WorkingDirectory
 
-        # FIXME: Not all values are accepted here !
+        # FIXME: Not all values are accepted here ! Improve docs too.
         If ($hotkey -ne $null -and $ShortCut.Hotkey -ne $hotkey) {
             $result.changed = $true
             $ShortCut.Hotkey = $hotkey
@@ -136,7 +128,7 @@ If ($state -eq "absent") {
         $result.windowstyle = $windowstyleids[$ShortCut.WindowStyle]
     }
 
-    If ($result.changed -eq $true -and $_ansible_check_mode -ne $true) {
+    If ($result.changed -eq $true -and $check_mode -ne $true) {
         Try {
             $ShortCut.Save()
         } Catch {


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_shortcut

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
Small improvements:
- Remove obsolete comments
- Use $check_mode instead of my own $_ansible_check_mode
- Renamed "default" window style to "normal" (as is used by Windows documentation)
- A fix for check-mode support (when state=absent)