### PR TITLE
Fix exc on ansible-console --ask-vault-pass with empty password

### DIFF
--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -423,7 +423,7 @@ class ConsoleCLI(CLI, cmd.Cmd):
             vault_pass = CLI.read_vault_password_file(self.options.vault_password_file, loader=self.loader)
             self.loader.set_vault_password(vault_pass)
         elif self.options.ask_vault_pass:
-            vault_pass = self.ask_vault_passwords()[0]
+            vault_pass = self.ask_vault_passwords()
             self.loader.set_vault_password(vault_pass)
 
         self.variable_manager = VariableManager()


### PR DESCRIPTION
Fixes #20502

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/cli/console.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (vault_ansible_console_20502 72b196ee5b) last updated 2017/01/20 12:02:07 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules', u'/home/adrian/ansible/lib/modules/']


```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
