### PR TITLE
Disable IOS tests for the moment

### DIFF
--- a/test/integration/targets/ios_facts/tasks/main.yaml
+++ b/test/integration/targets/ios_facts/tasks/main.yaml
@@ -1,2 +1,2 @@
 ---
-- { include: cli.yaml, tags: ['cli'] }
+#- { include: cli.yaml, tags: ['cli'] }


### PR DESCRIPTION
The ios_facts module hasn't been updated by @privateip yet, so disable the tests.

Peter, Can you please add reverting this change to your PR when you refactor `ios_facts`, thanks