### PR TITLE
Handles exceptions raised when getting network interfaces

### DIFF
--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -573,10 +573,14 @@ class AzureInventory(object):
                                                                              certificate_url=listener.certificate_url))
 
             for interface in machine.network_profile.network_interfaces:
-                interface_reference = self._parse_ref_id(interface.id)
-                network_interface = self._network_client.network_interfaces.get(
-                    interface_reference['resourceGroups'],
-                    interface_reference['networkInterfaces'])
+                try:
+                    interface_reference = self._parse_ref_id(interface.id)
+                    network_interface = self._network_client.network_interfaces.get(
+                        interface_reference['resourceGroups'],
+                        interface_reference['networkInterfaces']
+                    )
+                except CloudError:
+                    continue
                 if network_interface.primary:
                     if self.group_by_security_group and \
                        self._security_groups[resource_group].get(network_interface.id, None):


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
contrib/inventory/azure_rm.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
The possibility exists that a ResourceNotFound error may be
raised if the network interface under a resource group is
not found.

This patch handles the exception and continues on with processing
of the interfaces.