### PR TITLE
Fixed issue in gce_net with firewall rules that have protocols that d…

### DIFF
--- a/lib/ansible/modules/cloud/google/gce_net.py
+++ b/lib/ansible/modules/cloud/google/gce_net.py
@@ -208,7 +208,7 @@ def format_allowed_section(allowed):
         return []
     if ports.count(","):
         ports = ports.split(",")
-    elif:
+    elif ports:
         ports = [ports]
     return_val = {"IPProtocol": protocol}
     if ports:

--- a/lib/ansible/modules/cloud/google/gce_net.py
+++ b/lib/ansible/modules/cloud/google/gce_net.py
@@ -208,7 +208,7 @@ def format_allowed_section(allowed):
         return []
     if ports.count(","):
         ports = ports.split(",")
-    else:
+    elif:
         ports = [ports]
     return_val = {"IPProtocol": protocol}
     if ports:
@@ -231,7 +231,7 @@ def sorted_allowed_list(allowed_list):
     # sort by protocol
     allowed_by_protocol = sorted(allowed_list,key=lambda x: x['IPProtocol'])
     # sort the ports list
-    return sorted(allowed_by_protocol, key=lambda y: y['ports'].sort())
+    return sorted(allowed_by_protocol, key=lambda y: y.get('ports', []).sort())
 
 
 def main():


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
gce_net

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Firewall rules in GCE that have a value for the "allowed" field do not have a dictionary key for 'ports' when the none is specified. An example of this would be the protocol "icmp". This causes the comparison of the firewall rule in YAML and the firewall in GCE to raise an error as described in the issue.

This change removes the addition of a "port" placeholder when the YAML rule is formatted and fixes the sorting problem when a ports dictionary key is not present.

Fixes #20506 
