### PR TITLE
Add check_mode to get_url 

### DIFF
--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -40,7 +40,7 @@ description:
        or by using the use_proxy option.
      - HTTP redirects can redirect from HTTP to HTTPS so you should be sure that
        your proxy environment for both protocols is correct.
-     - When run with --check, it will do a HEAD request to validate the URL but
+     - From Ansible 2.4 when run with C(--check), it will do a HEAD request to validate the URL but
        will not download the entire file or verify it against hashes.
 version_added: "0.6"
 options:

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -40,6 +40,8 @@ description:
        or by using the use_proxy option.
      - HTTP redirects can redirect from HTTP to HTTPS so you should be sure that
        your proxy environment for both protocols is correct.
+     - When run with --check, it will do a HEAD request to validate the URL but
+       will not download the entire file or verify it against hashes.
 version_added: "0.6"
 options:
   url:
@@ -420,6 +422,7 @@ def main():
     # If the remote URL exists, we're done with check mode
     if module.check_mode:
         os.remove(tmpsrc)
+        res_args = dict( url = url, dest = dest, src = tmpsrc, changed = True, msg = info.get('msg', ''))
         module.exit_json(**res_args)
 
     # raise an error if there is no tmpsrc file

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -325,7 +325,7 @@ def main():
         # not checking because of daisy chain to file module
         argument_spec = argument_spec,
         add_file_common_args=True,
-        supports_check_mode=True
+        supports_check_mode=True,
     )
 
     url  = module.params['url']

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -65,6 +65,28 @@
     that:
         - result.failed
 
+- name: test HTTP HEAD request for file in check mode
+  get_url: url="http://{{ httpbin_host }}/get" dest={{output_dir}}/get_url_check.txt force=yes
+  check_mode: True
+  register: result
+
+- name: assert that the HEAD request was successful in check mode
+  assert:
+    that:
+    - result.changed
+    - '"OK" in result.msg'
+
+- name: test HTTP HEAD for nonexistent URL in check mode
+  get_url: url="http://brokenurl.test/missingfile.test" dest={{output_dir}}/shouldnotexist.html force=yes
+  check_mode: True
+  register: result
+  ignore_errors: True
+
+- name: assert that HEAD request for nonexistent URL failed
+  assert:
+    that:
+    - result.failed
+
 - name: test https fetch
   get_url: url="https://{{ httpbin_host }}/get" dest={{output_dir}}/get_url.txt force=yes
   register: result

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -77,7 +77,7 @@
     - '"OK" in result.msg'
 
 - name: test HTTP HEAD for nonexistent URL in check mode
-  get_url: url=" http://{ {httpbin_host }}/DOESNOTEXIST" dest={{ output_dir }}/shouldnotexist.html force=yes
+  get_url: url="http://{{ httpbin_host }}/DOESNOTEXIST" dest={{ output_dir }}/shouldnotexist.html force=yes
   check_mode: True
   register: result
   ignore_errors: True

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -66,7 +66,7 @@
         - result.failed
 
 - name: test HTTP HEAD request for file in check mode
-  get_url: url="http://{{ httpbin_host }}/get" dest={{output_dir}}/get_url_check.txt force=yes
+  get_url: url="http://{{ httpbin_host }}/get" dest={{ output_dir }}/get_url_check.txt force=yes
   check_mode: True
   register: result
 
@@ -77,7 +77,7 @@
     - '"OK" in result.msg'
 
 - name: test HTTP HEAD for nonexistent URL in check mode
-  get_url: url="http://brokenurl.test/missingfile.test" dest={{output_dir}}/shouldnotexist.html force=yes
+  get_url: url=" http://{ {httpbin_host }}/DOESNOTEXIST" dest={{ output_dir }}/shouldnotexist.html force=yes
   check_mode: True
   register: result
   ignore_errors: True


### PR DESCRIPTION
Add check_mode to get_url that does a HEAD request to make sure the URL exists, but doesn't write the real file

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
get_url
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible-2.2.0.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #20531 
To make sure the URL exists in check mode, do a HEAD request and write to the temp location, then clean it up and exit without copying to the real destination.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
