### PR TITLE
Add document about connecting to localhost

### DIFF
--- a/docs/docsite/rst/intro_getting_started.rst
+++ b/docs/docsite/rst/intro_getting_started.rst
@@ -54,12 +54,6 @@ public SSH key should be located in ``authorized_keys`` on those systems::
     bserver.example.org
    
    
-And if you want to connect to localhost, you write ``/etc/ansible/hosts`` as below::
-
-    localhost ansible_connection=local
-
-
-
 This is an inventory file, which is also explained in greater depth here:  :doc:`intro_inventory`.
 
 We'll assume you are using SSH keys for authentication.  To set up SSH agent to avoid retyping passwords, you can
@@ -113,6 +107,21 @@ explore what you can do with different modules, and to learn about the Ansible
 :doc:`playbooks` language.  Ansible is not just about running commands, it
 also has powerful configuration management and deployment features.  There's more to
 explore, but you already have a fully working infrastructure!
+
+Tips
+
+Only the local server, you do not need to write on inventory file to specify the local server.
+All you have to do is typing "localhost" or "127.0.0.1" on where specifies a server name.
+
+Example:
+
+.. code-block:: bash
+
+    $ ansible localhost -m ping
+
+Also, you can specify localhost explicitly by writing like this on your inventory file::
+
+    localhost ansible_connection=local
 
 .. _a_note_about_host_key_checking:
 

--- a/docs/docsite/rst/intro_getting_started.rst
+++ b/docs/docsite/rst/intro_getting_started.rst
@@ -110,8 +110,7 @@ explore, but you already have a fully working infrastructure!
 
 Tips
 
-Only the local server, you do not need to write on inventory file to specify the local server.
-All you have to do is typing "localhost" or "127.0.0.1" on where specifies a server name.
+When running commands, you can specify the local server by using "localhost" or "127.0.0.1" for the server name.
 
 Example:
 
@@ -119,7 +118,7 @@ Example:
 
     $ ansible localhost -m ping
 
-Also, you can specify localhost explicitly by writing like this on your inventory file::
+You can specify localhost explicitly by adding this to your inventory file::
 
     localhost ansible_connection=local
 

--- a/docs/docsite/rst/intro_getting_started.rst
+++ b/docs/docsite/rst/intro_getting_started.rst
@@ -52,6 +52,13 @@ public SSH key should be located in ``authorized_keys`` on those systems::
     192.0.2.50
     aserver.example.org
     bserver.example.org
+   
+   
+And if you want to connect to localhost, you write ``/etc/ansible/hosts`` as below::
+
+    localhost ansible_connection=local
+
+
 
 This is an inventory file, which is also explained in greater depth here:  :doc:`intro_inventory`.
 

--- a/docs/docsite/rst/intro_getting_started.rst
+++ b/docs/docsite/rst/intro_getting_started.rst
@@ -116,11 +116,11 @@ Example:
 
 .. code-block:: bash
 
-    $ ansible localhost -m ping
+    $ ansible localhost -m ping -e 'ansible_python_interpreter="/usr/bin/env python"'
 
 You can specify localhost explicitly by adding this to your inventory file::
 
-    localhost ansible_connection=local
+    localhost ansible_connection=local ansible_python_interpreter="/usr/bin/env python"
 
 .. _a_note_about_host_key_checking:
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In "Your first commands" section of "Getting Started", the example instructs users to prepare some remote servers. But, as the first example to try ansible, it might be a good idea to add document how to ping to localhost.

If you write `localhost` or `127.0.0.1` in `/etc/ansible/hosts`, below error occurs.

```
localhost | UNREACHABLE! => {
    "changed": false,
    "msg": "Failed to connect to the host via ssh.",
    "unreachable": true
}
```

Indeed, you cannot confirm communication to localhost if you do not specify localhost with this way of writing in `/etc/ansible/hosts`:

```
[Local]
localhost ansible_connection=local
```

I think it is good to add description of the way of specify localhost, and ping.

