### PR TITLE
win_service: Add option to force stop or restart

### DIFF
--- a/lib/ansible/modules/windows/win_service.ps1
+++ b/lib/ansible/modules/windows/win_service.ps1
@@ -27,6 +27,7 @@ Set-Attr $result "changed" $false;
 $name = Get-Attr $params "name" -failifempty $true
 $state = Get-Attr $params "state" $false
 $startMode = Get-Attr $params "start_mode" $false
+$force = Get-AnsibleParam -obj $params -name "force" -type "bool" -default $false
 
 If ($state) {
     $state = $state.ToString().ToLower()
@@ -54,6 +55,7 @@ If ($svcName -ne $svc.ServiceName) {
 
 Set-Attr $result "name" $svc.ServiceName
 Set-Attr $result "display_name" $svc.DisplayName
+Set-Attr $result "state" $svc.Status.ToString().ToLower()
 
 $svcMode = Get-WmiObject -Class Win32_Service -Property StartMode -Filter "Name='$svcName'"
 If ($startMode) {
@@ -82,7 +84,7 @@ If ($state) {
     }
     ElseIf ($state -eq "stopped" -and $svc.Status -ne "Stopped") {
         try {
-            Stop-Service -Name $svcName -ErrorAction Stop
+            Stop-Service -Name $svcName -Force:$force -ErrorAction Stop
         }
         catch {
             Fail-Json $result $_.Exception.Message
@@ -91,7 +93,7 @@ If ($state) {
     }
     ElseIf ($state -eq "restarted") {
         try {
-            Restart-Service -Name $svcName -ErrorAction Stop
+            Restart-Service -Name $svcName -Force:$force -ErrorAction Stop
         }
         catch {
             Fail-Json $result $_.Exception.Message

--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -59,6 +59,14 @@ options:
       - restarted
     default: null
     aliases: []
+  force:
+    description:
+    - Override restrictions that prevent C(stopped) or C(restarted) from succeeding,
+      e.g. using C(force) will stop and restart a service that has dependent services.
+    default: false
+    choices:
+    - 'no'
+    - 'yes'
 author: "Chris Hoffman (@chrishoffman)"
 '''
 

--- a/test/integration/targets/win_service/tasks/main.yml
+++ b/test/integration/targets/win_service/tasks/main.yml
@@ -194,3 +194,27 @@
       - "not win_service_stop_disabled_again|changed"
       - "win_service_stop_disabled_again.start_mode == 'disabled'"
       - "win_service_stop_disabled_again.state == 'stopped'"
+
+- name: restart EventSystem service
+  win_service: name=EventSystem state=restarted
+  ignore_errors: yes
+  register: win_service_eventsystem_restart
+
+- name: check that restarting the service failed
+  assert:
+    that:
+      - "win_service_eventsystem_restart|failed"
+      - "win_service_eventsystem_restart.start_mode == 'auto'"
+      - "win_service_eventsystem_restart.state == 'running'"
+
+- name: force restart EventSystem service
+  win_service: name=EventSystem state=restarted force=yes
+  register: win_service_eventsystem_restart_force
+
+- name: check that stopping the service again succeeds without changes
+  assert:
+    that:
+      - "win_service_eventsystem_restart_force|changed"
+      - "win_service_eventsystem_restart_force.start_mode == 'auto'"
+      - "win_service_eventsystem_restart_force.state == 'running'"
+


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_service

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
This change adds a boolean option to force stop or restart a service.