### PR TITLE
redhat_subscription: Document & enforce org_id

### DIFF
--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -251,7 +251,7 @@ class Rhsm(RegistrationBase):
             Raises:
               * Exception - if error occurs while running command
         '''
-        args = ['subscription-manager', 'config']
+        args = [SUBMAN_CMD, 'config']
 
         # Pass supplied **kwargs as parameters to subscription-manager.  Ignore
         # non-configuration parameters and replace '_' with '.'.  For example,
@@ -275,7 +275,7 @@ class Rhsm(RegistrationBase):
             return os.path.isfile('/etc/pki/consumer/cert.pem') and \
                    os.path.isfile('/etc/pki/consumer/key.pem')
 
-        args = ['subscription-manager', 'identity']
+        args = [SUBMAN_CMD, 'identity']
         rc, stdout, stderr = self.module.run_command(args, check_rc=False)
         if rc == 0:
             return True
@@ -289,7 +289,7 @@ class Rhsm(RegistrationBase):
             Raises:
               * Exception - if error occurs while running command
         '''
-        args = ['subscription-manager', 'register']
+        args = [SUBMAN_CMD, 'register']
 
         # Generate command arguments
         if activationkey:
@@ -332,7 +332,7 @@ class Rhsm(RegistrationBase):
             items = ["--all"]
 
         if items:
-            args = ['subscription-manager', 'unsubscribe'] + items
+            args = [SUBMAN_CMD, 'unsubscribe'] + items
             rc, stderr, stdout = self.module.run_command(args, check_rc=True)
         return serials
 
@@ -342,7 +342,7 @@ class Rhsm(RegistrationBase):
             Raises:
               * Exception - if error occurs while running command
         '''
-        args = ['subscription-manager', 'unregister']
+        args = [SUBMAN_CMD, 'unregister']
         rc, stderr, stdout = self.module.run_command(args, check_rc=True)
 
     def subscribe(self, regexp):
@@ -505,6 +505,9 @@ def main():
     consumer_name = module.params["consumer_name"]
     consumer_id = module.params["consumer_id"]
     force_register = module.params["force_register"]
+
+    global SUBMAN_CMD
+    SUBMAN_CMD = module.get_bin_path('subscription-manager', True)
 
     # Ensure system is registered
     if state == 'present':


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
redhat_subscription

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 61e6e7868c) last updated 2017/01/21 22:31:04 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
* Fail cleanly when a system does not have subscription-manager installed (like a CentOS machine)
* Document and enforce the need to pass `org_id` when one wants to use an activation key (Fixes: #20542)

before 1:
```
fatal: [vm]: FAILED! => {"changed": false, "cmd": "subscription-manager identity", "failed": true, "msg": "[Errno 2] No such file or directory", "rc": 2}
```

after 1:
```
fatal: [vm]: FAILED! => {"changed": false, "failed": true, "msg": "Could not find subscription-manager. Please ensure it is installed."}
```

before 2:
```
fatal: [vm]: FAILED! => {"changed": false, "cmd": "subscription-manager register --activationkey ak-egolov-test1", "failed": true, "msg": "Error: Must provide --org with activation keys.", "rc": 64, "stderr": "Error: Must provide --org with activation keys.\n", "stdout": "", "stdout_lines": []}
```

after 2:
```
fatal: [vm]: FAILED! => {"changed": false, "failed": true, "msg": "Missing arguments, If registering with an activationkey, must supply Organization ID"}
```
