### PR TITLE
Roledeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ Ansible Changes By Release
 * Modules
   * ec2_vpc will be deprecated in 2.3 and removed in 2.5
 
+###Modules Notes:
+- oVirt/RHV
+  * Add dynamic inventory.
+  * Add support for 4.1 features.
+  * Add support for data centers, clusters, hosts, storage domains and networks management.
+  * Add support for hosts and virtual machines affinity groups and labels.
+  * Add support for users, groups and permissions management.
+  * Improved virtual machines and disks management.
+
 ###New Modules:
 - archive
 - beadm
@@ -76,6 +85,41 @@ Ansible Changes By Release
   * infini_vol
 - omapi_host
 - openwrt_init
+- ovirt:
+  * ovirt_affinity_labels_facts
+  * ovirt_affinity_labels
+  * ovirt_clusters_facts
+  * ovirt_clusters
+  * ovirt_datacenters_facts
+  * ovirt_datacenters
+  * ovirt_external_providers_facts
+  * ovirt_external_providers
+  * ovirt_groups_facts
+  * ovirt_groups
+  * ovirt_host_networks
+  * ovirt_host_pm
+  * ovirt_hosts_facts
+  * ovirt_hosts
+  * ovirt_mac_pools
+  * ovirt_networks_facts
+  * ovirt_networks
+  * ovirt_nics_facts
+  * ovirt_nics
+  * ovirt_permissions_facts
+  * ovirt_permissions
+  * ovirt_quotas_facts
+  * ovirt_quotas
+  * ovirt_storage_domains_facts
+  * ovirt_storage_domains
+  * ovirt_tags_facts
+  * ovirt_tags
+  * ovirt_templates_facts
+  * ovirt_templates
+  * ovirt_users_facts
+  * ovirt_users
+  * ovirt_vmpools_facts
+  * ovirt_vmpools
+  * ovirt_vms_facts
 - packet:
   * packet_device
   * packet_sshkey

--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -124,6 +124,7 @@ expand_csv_tags = False
 group_by_instance_id = True
 group_by_region = True
 group_by_availability_zone = True
+group_by_aws_account = False
 group_by_ami_id = True
 group_by_instance_type = True
 group_by_key_pair = True

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -236,7 +236,7 @@ DEFAULT_VAR_COMPRESSION_LEVEL = get_config(p, DEFAULTS, 'var_compression_level',
 DEFAULT_INTERNAL_POLL_INTERVAL = get_config(p, DEFAULTS, 'internal_poll_interval', None, 0.001, value_type='float')
 ERROR_ON_MISSING_HANDLER  = get_config(p, DEFAULTS, 'error_on_missing_handler', 'ANSIBLE_ERROR_ON_MISSING_HANDLER', True, value_type='boolean')
 SHOW_CUSTOM_STATS = get_config(p, DEFAULTS, 'show_custom_stats', 'ANSIBLE_SHOW_CUSTOM_STATS', False, value_type='boolean')
-DEFAULT_ROLE_SKIP_DEPENDENCIES    = get_config(p, DEFAULTS, 'role_skip_dependencies', 'ROLE_SKIP_DEPENDENCIES', 0, integer=True)
+DEFAULT_ROLE_SKIP_DEPENDENCIES    = get_config(p, DEFAULTS, 'role_skip_dependencies', 'ROLE_SKIP_DEPENDENCIES', False, value_type='boolean')
 
 # static includes
 DEFAULT_TASK_INCLUDES_STATIC    = get_config(p, DEFAULTS, 'task_includes_static', 'ANSIBLE_TASK_INCLUDES_STATIC', False, value_type='boolean')

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -236,6 +236,7 @@ DEFAULT_VAR_COMPRESSION_LEVEL = get_config(p, DEFAULTS, 'var_compression_level',
 DEFAULT_INTERNAL_POLL_INTERVAL = get_config(p, DEFAULTS, 'internal_poll_interval', None, 0.001, value_type='float')
 ERROR_ON_MISSING_HANDLER  = get_config(p, DEFAULTS, 'error_on_missing_handler', 'ANSIBLE_ERROR_ON_MISSING_HANDLER', True, value_type='boolean')
 SHOW_CUSTOM_STATS = get_config(p, DEFAULTS, 'show_custom_stats', 'ANSIBLE_SHOW_CUSTOM_STATS', False, value_type='boolean')
+DEFAULT_ROLE_SKIP_DEPENDENCIES    = get_config(p, DEFAULTS, 'role_skip_dependencies', 'ROLE_SKIP_DEPENDENCIES', 0, integer=True)
 
 # static includes
 DEFAULT_TASK_INCLUDES_STATIC    = get_config(p, DEFAULTS, 'task_includes_static', 'ANSIBLE_TASK_INCLUDES_STATIC', False, value_type='boolean')

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -236,7 +236,7 @@ DEFAULT_VAR_COMPRESSION_LEVEL = get_config(p, DEFAULTS, 'var_compression_level',
 DEFAULT_INTERNAL_POLL_INTERVAL = get_config(p, DEFAULTS, 'internal_poll_interval', None, 0.001, value_type='float')
 ERROR_ON_MISSING_HANDLER  = get_config(p, DEFAULTS, 'error_on_missing_handler', 'ANSIBLE_ERROR_ON_MISSING_HANDLER', True, value_type='boolean')
 SHOW_CUSTOM_STATS = get_config(p, DEFAULTS, 'show_custom_stats', 'ANSIBLE_SHOW_CUSTOM_STATS', False, value_type='boolean')
-DEFAULT_ROLE_SKIP_DEPENDENCIES    = get_config(p, DEFAULTS, 'role_skip_dependencies', 'ROLE_SKIP_DEPENDENCIES', False, value_type='boolean')
+DEFAULT_SKIP_ROLE_DEPENDENCIES    = get_config(p, DEFAULTS, 'skip_role_dependencies', 'ANSIBLE_SKIP_ROLE_DEPENDENCIES', False, value_type='boolean')
 
 # static includes
 DEFAULT_TASK_INCLUDES_STATIC    = get_config(p, DEFAULTS, 'task_includes_static', 'ANSIBLE_TASK_INCLUDES_STATIC', False, value_type='boolean')

--- a/lib/ansible/module_utils/vyos2.py
+++ b/lib/ansible/module_utils/vyos2.py
@@ -1,0 +1,88 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# (c) 2016 Red Hat Inc.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+_DEVICE_CONFIGS = {}
+
+def get_config(module, target='commands'):
+    cmd = ' '.join(['show configuration', target])
+
+    try:
+        return _DEVICE_CONFIGS[cmd]
+    except KeyError:
+        rc, out, err = module.exec_command(cmd)
+        if rc != 0:
+            module.fail_json(msg='unable to retrieve current config', stderr=err)
+        cfg = str(out).strip()
+        _DEVICE_CONFIGS[cmd] = cfg
+        return cfg
+
+def run_commands(module, commands, check_rc=True):
+    assert isinstance(commands, list), 'commands must be a list'
+    responses = list()
+
+    for cmd in commands:
+        rc, out, err = module.exec_command(cmd)
+        if check_rc and rc != 0:
+            module.fail_json(msg=err, rc=rc)
+        responses.append(out)
+    return responses
+
+def load_config(module, commands, commit=False, comment=None, save=False):
+    assert isinstance(commands, list), 'commands must be a list'
+    commands.insert(0, 'configure')
+
+    for cmd in commands:
+        rc, out, err = module.exec_command(cmd, check_rc=False)
+        if rc != 0:
+            # discard any changes in case of failure
+            module.exec_command('exit discard')
+            module.fail_json(msg='configuration failed')
+
+    diff = None
+    if module._diff:
+        rc, out, err = module.exec_command('compare')
+        if not out.startswith('No changes'):
+            rc, out, err = module.exec_command('show')
+            diff = str(out).strip()
+
+    if commit:
+        cmd = 'commit'
+        if comment:
+            cmd += ' comment "%s"' % comment
+        module.exec_command(cmd)
+
+    if save:
+        module.exec_command(cmd)
+
+    if not commit:
+        module.exec_command('exit discard')
+    else:
+        module.exec_command('exit')
+
+    if diff:
+        return diff

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -207,6 +207,7 @@ options:
     description:
       - Specify the logging driver. Docker uses json-file by default.
     choices:
+      - none
       - json-file
       - syslog
       - journald
@@ -1961,7 +1962,9 @@ def main():
         kill_signal=dict(type='str'),
         labels=dict(type='dict'),
         links=dict(type='list'),
-        log_driver=dict(type='str', choices=['json-file', 'syslog', 'journald', 'gelf', 'fluentd', 'awslogs', 'splunk'], default=None),
+        log_driver=dict(type='str',
+                        choices=['none', 'json-file', 'syslog', 'journald', 'gelf', 'fluentd', 'awslogs', 'splunk'],
+                        default=None),
         log_options=dict(type='dict', aliases=['log_opt']),
         mac_address=dict(type='str'),
         memory=dict(type='str', default='0'),

--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -33,7 +33,7 @@ short_description: Manage hostname
 requirements: [ hostname ]
 description:
     - Set system's hostname, supports most OSs/Distributions, including those using systemd.
-    - Note, this module does *NOT* modify /etc/hosts. You need to modify it yourself using other modules like template or replace.
+    - Note, this module does *NOT* modify C(/etc/hosts). You need to modify it yourself using other modules like template or replace.
     - Windows, HP-UX and AIX are not currently supported
 options:
     name:

--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -32,10 +32,9 @@ version_added: "1.4"
 short_description: Manage hostname
 requirements: [ hostname ]
 description:
-    - Set system's hostname.
-    - Currently implemented on Debian, Ubuntu, Fedora, RedHat, openSUSE, Linaro, ScientificLinux, Arch, CentOS, AMI, Alpine Linux.
-    - Any distribution that uses systemd as their init system.
+    - Set system's hostname, supports most OSs/Distributions, including those using systemd.
     - Note, this module does *NOT* modify /etc/hosts. You need to modify it yourself using other modules like template or replace.
+    - Windows, HP-UX and AIX are not currently supported
 options:
     name:
         required: true

--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -37,11 +37,13 @@ DOCUMENTATION = '''
 module: timezone
 short_description: Configure timezone setting
 description:
-  - This module configures the timezone setting, both of the system clock and of the hardware clock. If you want to set up the NTP, use M(service) module.  As of version 2.3 support was added for SmartOS and BSDs.
+  - This module configures the timezone setting, both of the system clock and of the hardware clock. If you want to set up the NTP, use M(service) module.
   - It is recommended to restart C(crond) after changing the timezone, otherwise the jobs may run at the wrong time.
-  - On Linux it uses the C(timedatectl) command if available. Otherwise, it edits C(/etc/sysconfig/clock) or C(/etc/timezone) for the system clock, and uses the C(hwclock) command for the hardware clock.
-  - On SmartOS the C(sm-set-timezone) utility is used to set the zone timezone.
-  - "On *BSD, C(/etc/localtime) is modified."
+  - Several different tools are used depending on the OS/Distribution involved.
+    For Linux it can use C(timedatectl)  or edit C(/etc/sysconfig/clock) or C(/etc/timezone) andC(hwclock).
+    On SmartOS , C(sm-set-timezone), for *BSD, C(/etc/localtime) is modified.
+  - As of version 2.3 support was added for SmartOS and BSDs.
+  - Windows, AIX and HPUX are not supported, please let us know if you find any other OS/distro in which this fails.
 version_added: "2.2"
 options:
   name:

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -200,7 +200,7 @@ class Role(Base, Become, Conditional, Taggable):
         metadata = self._load_role_yaml('meta')
         if metadata:
             self._metadata = RoleMetadata.load(metadata, owner=self, variable_manager=self._variable_manager, loader=self._loader)
-            if C.DEFAULT_ROLE_SKIP_DEPENDENCIES != 0:
+            if not C.DEFAULT_ROLE_SKIP_DEPENDENCIES:
                 self._dependencies = self._load_dependencies()
         else:
             self._metadata = RoleMetadata()

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -200,7 +200,7 @@ class Role(Base, Become, Conditional, Taggable):
         metadata = self._load_role_yaml('meta')
         if metadata:
             self._metadata = RoleMetadata.load(metadata, owner=self, variable_manager=self._variable_manager, loader=self._loader)
-            if not C.DEFAULT_ROLE_SKIP_DEPENDENCIES:
+            if not C.DEFAULT_SKIP_ROLE_DEPENDENCIES:
                 self._dependencies = self._load_dependencies()
         else:
             self._metadata = RoleMetadata()

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -23,6 +23,7 @@ import collections
 import os
 
 from ansible.compat.six import iteritems, binary_type, text_type
+from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.playbook.attribute import FieldAttribute
 from ansible.playbook.base import Base
@@ -199,7 +200,8 @@ class Role(Base, Become, Conditional, Taggable):
         metadata = self._load_role_yaml('meta')
         if metadata:
             self._metadata = RoleMetadata.load(metadata, owner=self, variable_manager=self._variable_manager, loader=self._loader)
-            self._dependencies = self._load_dependencies()
+            if C.DEFAULT_ROLE_SKIP_DEPENDENCIES != 0:
+                self._dependencies = self._load_dependencies()
         else:
             self._metadata = RoleMetadata()
 

--- a/lib/ansible/plugins/callback/selective.py
+++ b/lib/ansible/plugins/callback/selective.py
@@ -1,0 +1,258 @@
+# (c) Fastly, inc 2016
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+selective.py callback plugin.
+
+This callback only prints tasks that have been tagged with `print_action` or that have failed.
+Tasks that are not printed are placed with a '.'.
+
+For example:
+
+- debug: msg="This will not be printed"
+- debug: msg="But this will"
+  tags: [print_action]"
+
+This allows operators to focus on the tasks that provide value only.
+
+If you increase verbosity all tasks are printed.
+"""
+
+from __future__ import (absolute_import, division, print_function)
+
+import difflib
+import os
+
+from ansible.plugins.callback import CallbackBase
+from ansible.module_utils._text import to_text
+
+__metaclass__ = type
+
+
+COLORS = {
+    'normal': '\033[0m',
+    'ok': '\033[92m',
+    'bold': '\033[1m',
+    'not_so_bold': '\033[1m\033[34m',
+    'changed': '\033[93m',
+    'failed': '\033[91m',
+    'endc': '\033[0m',
+    'skipped': '\033[96m',
+}
+
+DONT_COLORIZE = os.getenv('ANSIBLE_SELECTIVE_DONT_COLORIZE', default=False)
+
+
+def dict_diff(prv, nxt):
+    """Return a dict of keys that differ with another config object."""
+    keys = set(prv.keys() + nxt.keys())
+    result = {}
+    for k in keys:
+        if prv.get(k) != nxt.get(k):
+            result[k] = (prv.get(k), nxt.get(k))
+    return result
+
+
+def colorize(msg, color):
+    """Given a string add necessary codes to format the string."""
+    if DONT_COLORIZE:
+        return msg
+    else:
+        return '{}{}{}'.format(COLORS[color], msg, COLORS['endc'])
+
+
+class CallbackModule(CallbackBase):
+    """selective.py callback plugin."""
+
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'stdout'
+    CALLBACK_NAME = 'selective'
+
+    def __init__(self, display=None):
+        """selective.py callback plugin."""
+        super(CallbackModule, self).__init__(display)
+        self.last_skipped = False
+        self.last_task_name = None
+        self.printed_last_task = False
+
+    def _print_task(self, task_name=None):
+        if task_name is None:
+            task_name = self.last_task_name
+
+        if not self.printed_last_task:
+            self.printed_last_task = True
+            line_length = 120
+            if self.last_skipped:
+                print()
+            msg = colorize("# {} {}".format(task_name,
+                                            '*' * (line_length - len(task_name))), 'bold')
+            print(msg)
+
+    def _indent_text(self, text, indent_level):
+        lines = text.splitlines()
+        result_lines = []
+        for l in lines:
+            result_lines.append("{}{}".format(' '*indent_level, l))
+        return '\n'.join(result_lines)
+
+    def _print_diff(self, diff, indent_level):
+        if isinstance(diff, dict):
+            try:
+                diff = '\n'.join(difflib.unified_diff(diff['before'].splitlines(),
+                                                      diff['after'].splitlines(),
+                                                      fromfile=diff.get('before_header',
+                                                                        'new_file'),
+                                                      tofile=diff['after_header']))
+            except AttributeError:
+                diff = dict_diff(diff['before'], diff['after'])
+        if diff:
+            diff = colorize(str(diff), 'changed')
+            print(self._indent_text(diff, indent_level+4))
+
+    def _print_host_or_item(self, host_or_item, changed, msg, diff, is_host, error, stdout, stderr):
+        if is_host:
+            indent_level = 0
+            name = colorize(host_or_item.name, 'not_so_bold')
+        else:
+            indent_level = 4
+            if isinstance(host_or_item, dict):
+                if 'key' in host_or_item.keys():
+                    host_or_item = host_or_item['key']
+            name = colorize(to_text(host_or_item), 'bold')
+
+        if error:
+            color = 'failed'
+            change_string = colorize('FAILED!!!', color)
+        else:
+            color = 'changed' if changed else 'ok'
+            change_string = colorize("changed={}".format(changed), color)
+
+        msg = colorize(msg, color)
+
+        line_length = 120
+        spaces = ' ' * (40-len(name)-indent_level)
+        line = "{}  * {}{}- {}".format(' ' * indent_level, name, spaces, change_string)
+
+        if len(msg) < 50:
+            line += ' -- {}'.format(msg)
+            print("{} {}---------".format(line, '-' * (line_length - len(line))))
+        else:
+            print("{} {}".format(line, '-' * (line_length - len(line))))
+            print(self._indent_text(msg, indent_level+4))
+
+        if diff is not None:
+            self._print_diff(diff, indent_level)
+        if stdout is not None:
+            stdout = colorize(stdout, 'failed')
+            print(self._indent_text(stdout, indent_level+4))
+        if stderr is not None:
+            stderr = colorize(stderr, 'failed')
+            print(self._indent_text(stderr, indent_level+4))
+
+    def v2_playbook_on_play_start(self, play):
+        """Run on start of the play."""
+        pass
+
+    def v2_playbook_on_task_start(self, task, **kwargs):
+        """Run when a task starts."""
+        self.last_task_name = task.get_name()
+        self.printed_last_task = False
+
+    def v2_runner_on_ok(self, result, **kwargs):
+        """Run when a task finishes correctly."""
+        failed = 'failed' in result._result
+        unreachable = 'unreachable' in result._result
+
+        if 'print_action' in result._task.tags or failed or unreachable or \
+           self._display.verbosity > 1:
+            self._print_task()
+            self.last_skipped = False
+            msg = to_text(result._result.get('msg', '')) or\
+                to_text(result._result.get('reason', ''))
+            self._print_host_or_item(result._host,
+                                     result._result.get('changed', False),
+                                     msg,
+                                     result._result.get('diff', None),
+                                     is_host=True,
+                                     error=failed or unreachable,
+                                     stdout=result._result.get('module_stdout', None),
+                                     stderr=result._result.get('exception', None),
+                                     )
+            if 'results' in result._result:
+                for r in result._result['results']:
+                    failed = 'failed' in r
+                    self._print_host_or_item(r['item'],
+                                             r.get('changed', False),
+                                             to_text(r.get('msg', '')),
+                                             r.get('diff', None),
+                                             is_host=False,
+                                             error=failed,
+                                             stdout=r.get('module_stdout', None),
+                                             stderr=r.get('exception', None),
+                                             )
+        else:
+            self.last_skipped = True
+            print('.', end="")
+
+    def v2_playbook_on_stats(self, stats):
+        """Display info about playbook statistics."""
+        print()
+        self.printed_last_task = False
+        self._print_task('STATS')
+
+        hosts = sorted(stats.processed.keys())
+        for host in hosts:
+            s = stats.summarize(host)
+
+            if s['failures'] or s['unreachable']:
+                color = 'failed'
+            elif s['changed']:
+                color = 'changed'
+            else:
+                color = 'ok'
+
+            msg = '{}    : ok={}\tchanged={}\tfailed={}\tunreachable={}'.format(
+                                    host, s['ok'], s['changed'], s['failures'], s['unreachable'])
+            print(colorize(msg, color))
+
+    def v2_runner_on_skipped(self, result, **kwargs):
+        """Run when a task is skipped."""
+        if self._display.verbosity > 1:
+            self._print_task()
+            self.last_skipped = False
+
+            line_length = 120
+            spaces = ' ' * (31-len(result._host.name)-4)
+
+            line = "  * {}{}- {}".format(colorize(result._host.name, 'not_so_bold'),
+                                         spaces,
+                                         colorize("skipped", 'skipped'),)
+
+            reason = result._result.get('skipped_reason', '') or \
+                result._result.get('skip_reason', '')
+            if len(reason) < 50:
+                line += ' -- {}'.format(reason)
+                print("{} {}---------".format(line, '-' * (line_length - len(line))))
+            else:
+                print("{} {}".format(line, '-' * (line_length - len(line))))
+                print(self._indent_text(reason, 8))
+                print(reason)
+
+    v2_playbook_on_handler_task_start = v2_playbook_on_task_start
+    v2_runner_on_failed = v2_runner_on_ok
+    v2_runner_on_unreachable = v2_runner_on_ok
+

--- a/lib/ansible/plugins/terminal/vyos.py
+++ b/lib/ansible/plugins/terminal/vyos.py
@@ -19,6 +19,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import os
 import re
 
 from ansible.plugins.terminal import TerminalBase
@@ -38,9 +39,12 @@ class TerminalModule(TerminalBase):
         re.compile(r"\n\s+Set failed"),
     ]
 
+    terminal_length = os.getenv('ANSIBLE_VYOS_TERMINAL_LENGTH', 10000)
+
     def on_open_shell(self):
         try:
             self._exec_cli_command('set terminal length 0')
+            self._exec_cli_command('set terminal length %s' % self.terminal_length)
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')
 

--- a/test/units/modules/network/vyos/fixtures/show_version
+++ b/test/units/modules/network/vyos/fixtures/show_version
@@ -1,0 +1,14 @@
+Version:      VyOS 1.1.7
+Description:  VyOS 1.1.7 (helium)
+Copyright:    2016 VyOS maintainers and contributors
+Built by:     maintainers@vyos.net
+Built on:     Wed Feb 17 09:57:31 UTC 2016
+Build ID:     1602170957-4459750
+System type:  x86 64-bit
+Boot via:     image
+Hypervisor:   VMware
+HW model:     VMware Virtual Platform
+HW S/N:       VMware-42 3c 26 25 44 c5 0a 91-cf 2c 97 2b fe 9b 25 be
+HW UUID:      423C2625-44C5-0A91-CF2C-972BFE9B25BE
+Uptime:       01:08:20 up 52 days,  2:13,  1 user,  load average: 0.00, 0.01, 0.05
+

--- a/test/units/modules/network/vyos/test_vyos_command.py
+++ b/test/units/modules/network/vyos/test_vyos_command.py
@@ -1,0 +1,145 @@
+# (c) 2016 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import patch, MagicMock
+from ansible.errors import AnsibleModuleExit
+from ansible.modules.network.vyos import vyos_command
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+
+
+fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
+fixture_data = {}
+
+
+def set_module_args(args):
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)
+
+
+def load_fixture(name):
+    path = os.path.join(fixture_path, name)
+
+    if path in fixture_data:
+        return fixture_data[path]
+
+    with open(path) as f:
+        data = f.read()
+
+    try:
+        data = json.loads(data)
+    except:
+        pass
+
+    fixture_data[path] = data
+    return data
+
+
+class TestVyosCommandModule(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_run_commands = patch('ansible.modules.network.vyos.vyos_command.run_commands')
+        self.run_commands = self.mock_run_commands.start()
+
+    def tearDown(self):
+        self.mock_run_commands.stop()
+
+    def execute_module(self, failed=False, changed=False):
+
+        def load_from_file(*args, **kwargs):
+            module, commands = args
+            output = list()
+
+            for item in commands:
+                try:
+                    obj = json.loads(item)
+                    command = obj['command']
+                except ValueError:
+                    command = item
+                filename = str(command).replace(' ', '_')
+                output.append(load_fixture(filename))
+            return output
+
+        self.run_commands.side_effect = load_from_file
+
+        with self.assertRaises(AnsibleModuleExit) as exc:
+            vyos_command.main()
+
+        result = exc.exception.result
+
+        if failed:
+            self.assertTrue(result.get('failed'))
+        else:
+            self.assertEqual(result.get('changed'), changed, result)
+
+        return result
+
+    def test_vyos_command_simple(self):
+        set_module_args(dict(commands=['show version']))
+        result = self.execute_module()
+        self.assertEqual(len(result['stdout']), 1)
+        self.assertTrue(result['stdout'][0].startswith('Version:      VyOS'))
+
+    def test_vyos_command_multiple(self):
+        set_module_args(dict(commands=['show version', 'show version']))
+        result = self.execute_module()
+        self.assertEqual(len(result['stdout']), 2)
+        self.assertTrue(result['stdout'][0].startswith('Version:      VyOS'))
+
+    def test_vyos_command_wait_for(self):
+        wait_for = 'result[0] contains "VyOS maintainers"'
+        set_module_args(dict(commands=['show version'], wait_for=wait_for))
+        self.execute_module()
+
+    def test_vyos_command_wait_for_fails(self):
+        wait_for = 'result[0] contains "test string"'
+        set_module_args(dict(commands=['show version'], wait_for=wait_for))
+        self.execute_module(failed=True)
+        self.assertEqual(self.run_commands.call_count, 10)
+
+    def test_vyos_command_retries(self):
+        wait_for = 'result[0] contains "test string"'
+        set_module_args(dict(commands=['show version'], wait_for=wait_for, retries=2))
+        self.execute_module(failed=True)
+        self.assertEqual(self.run_commands.call_count, 2)
+
+    def test_vyos_command_match_any(self):
+        wait_for = ['result[0] contains "VyOS maintainers"',
+                    'result[0] contains "test string"']
+        set_module_args(dict(commands=['show version'], wait_for=wait_for, match='any'))
+        self.execute_module()
+
+    def test_vyos_command_match_all(self):
+        wait_for = ['result[0] contains "VyOS maintainers"',
+                    'result[0] contains "maintainers@vyos.net"']
+        set_module_args(dict(commands=['show version'], wait_for=wait_for, match='all'))
+        self.execute_module()
+
+    def test_vyos_command_match_all_failure(self):
+        wait_for = ['result[0] contains "VyOS maintainers"',
+                    'result[0] contains "test string"']
+        commands = ['show version', 'show version']
+        set_module_args(dict(commands=commands, wait_for=wait_for, match='all'))
+        self.execute_module(failed=True)


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
role/metadata

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible-playbook 2.3.0 (roledep cae224d3d2) last updated 2017/01/22 17:31:48 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
add new ROLE_SKIP_DEPENDENCIES  configuration variable (boolean, default false):
if false: act normally
if true: don't load dependencies from metadata.
this can be useful when we have two roles A and B in a playbook.
Let's say:
- hosts: localhost
  roles:
    - { role: yum, tags: ["yum","dnf"] }
    - { role: sshd, tags: ["sshd"] }
sshd depends on yum (in metadata/main.yml), but you occasionnally want to run sshd without running tasks from yum role (because it would update all packages), and you don't even want to run tasks in yum.
This of course implies tag "sshd" (in the given example) is only in sshd role.
In case of complex playbooks, this might accelerate the run drastically if one want to run a single role/tag.
```
