### PR TITLE
update GCE instance image with Debian 8 Jessie

### DIFF
--- a/lib/ansible/modules/cloud/google/gce.py
+++ b/lib/ansible/modules/cloud/google/gce.py
@@ -33,7 +33,8 @@ description:
 options:
   image:
     description:
-       - image string to use for the instance
+      - image string to use for the instance (default will follow latest
+        stable debian image)
     required: false
     default: "debian-8"
   instance_names:

--- a/lib/ansible/modules/cloud/google/gce.py
+++ b/lib/ansible/modules/cloud/google/gce.py
@@ -35,7 +35,7 @@ options:
     description:
        - image string to use for the instance
     required: false
-    default: "debian-7"
+    default: "debian-8"
   instance_names:
     description:
       - a comma-separated list of instance names to create or destroy
@@ -617,7 +617,7 @@ def change_instance_state(module, gce, instance_names, number, zone_name, state)
 def main():
     module = AnsibleModule(
         argument_spec = dict(
-            image = dict(default='debian-7'),
+            image = dict(default='debian-8'),
             instance_names = dict(),
             machine_type = dict(default='n1-standard-1'),
             metadata = dict(),


### PR DESCRIPTION
* debian-7 is marked as "DEPRECATED" in Google Compute Engine Images
  * as a result, by default use `debian-8` Jessie

Resolves:
Related:
Signed-off-by: Daniel Andrei Minca <mandrei17@gmail.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - ~Feature Pull Request~
 - ~New Module Pull Request~
 - :white_check_mark: Bugfix Pull Request
 - :white_check_mark: Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
**cloud / google / gce** module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file = /home/dminca/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* `debian-7` was marked as **Deprecated** in Google Compute Engine
  * as a result, use `debian-8` Jessie, as it's latest stable image

![selection_006](https://cloud.githubusercontent.com/assets/5355219/22201509/9a7fabf4-e16c-11e6-9072-ac52049185d9.png)

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
