### PR TITLE
Fixed bug in ecs_taskdefinition for new task with forced revision 1.

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -255,9 +255,9 @@ def main():
                 # We cannot reactivate an inactive revision
                 module.fail_json(msg="A task in family '%s' already exists for revsion %d, but it is inactive" % (family, revision))
             elif not existing:
-                if len(existing_definitions_in_family) == 0 and revision != 1:
+                if not existing_definitions_in_family and revision != 1:
                     module.fail_json(msg="You have specified a revision of %d but a created revision would be 1" % revision)
-                elif existing_definitions_in_family[-1]['revision'] + 1 != revision:
+                elif existing_definitions_in_family and existing_definitions_in_family[-1]['revision'] + 1 != revision:
                     module.fail_json(msg="You have specified a revision of %d but a created revision would be %d" % (revision, existing_definitions_in_family[-1]['revision'] + 1))
         else:
             existing = None


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ecs_taskdefinition

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (fix_bug_ecs_taskdefinition 4e2bce23d5) last updated 2017/01/23 13:47:41 (GMT +200)
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
While creating a new task definition and setting revision number to 1, it would hit unhandled condition and fall out with ```IndexError: list index out of range```

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
Before the change
```
Traceback (most recent call last):
  File "/var/folders/kx/jbjv4rfj4k36_9_nx0jt5rbc0000gn/T/ansible_mHTeUx/ansible_module_ecs_taskdefinition.py", line 382, in <module>
    main()
  File "/var/folders/kx/jbjv4rfj4k36_9_nx0jt5rbc0000gn/T/ansible_mHTeUx/ansible_module_ecs_taskdefinition.py", line 260, in main
    elif existing_definitions_in_family[-1]['revision'] + 1 != revision:
IndexError: list index out of range
```
OK after the change.
