### PR TITLE
lambda: Remove the note about supporting S3 uploads only

### DIFF
--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -96,8 +96,6 @@ options:
       - List of VPC security group IDs to associate with the Lambda function. Required when vpc_subnet_ids is used.
     required: false
     default: None
-notes:
-  - 'Currently this module only supports uploaded code via S3'
 author:
     - 'Steyn Huizinga (@steynovich)'
 extends_documentation_fragment:
@@ -141,7 +139,7 @@ tasks:
 
 RETURN = '''
 output:
-  description: the data returned by create_function in boto3
+  description: the data returned by get_function in boto3
   returned: success
   type: dict
   sample:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lambda

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (detached HEAD 188c3c608a) last updated 2017/01/23 14:45:28 (GMT +200)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The module supports also ZIP uploads which are documented, so do not note that only S3 uploads work.

Also refer to the correct boto3 function in the return value description.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
