### PR TITLE
Fix typo on test_ios_config_before_after_no_change test

### DIFF
--- a/test/units/modules/network/ios/test_ios_config.py
+++ b/test/units/modules/network/ios/test_ios_config.py
@@ -149,7 +149,7 @@ class TestIosConfigModule(unittest.TestCase):
         commands = ['hostname foo', 'test1', 'test2']
         self.execute_module(changed=True, commands=commands, sort=False)
 
-    def test_ios_config_before_after_no_chnage(self):
+    def test_ios_config_before_after_no_change(self):
         set_module_args(dict(lines=['hostname router'],
                              before=['test1', 'test2'],
                              after=['test3','test4']))


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

ios_config
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (fix_ios_test_typo 637741cc2e) last updated 2017/01/23 15:25:59 (GMT +200)
```

##### SUMMARY

Fix typo on test_ios_config_before_after_no_change test