### PR TITLE
Replace PyCrypto with pyca/cryptography

### DIFF
--- a/hacking/README.md
+++ b/hacking/README.md
@@ -17,7 +17,7 @@ and do not wish to install them from your operating system package manager, you
 can install them from pip
 
     $ easy_install pip               # if pip is not already available
-    $ pip install pyyaml jinja2 nose pytest passlib pycrypto
+    $ pip install pyyaml jinja2 nose pytest passlib cryptography
 
 From there, follow ansible instructions on docs.ansible.com as normal.
 

--- a/lib/ansible/executor/process/worker.py
+++ b/lib/ansible/executor/process/worker.py
@@ -26,14 +26,6 @@ import traceback
 
 from jinja2.exceptions import TemplateNotFound
 
-# TODO: not needed if we use the cryptography library with its default RNG
-# engine
-HAS_ATFORK=True
-try:
-    from Crypto.Random import atfork
-except ImportError:
-    HAS_ATFORK=False
-
 from ansible.errors import AnsibleConnectionFailure
 from ansible.executor.task_executor import TaskExecutor
 from ansible.executor.task_result import TaskResult
@@ -94,9 +86,6 @@ class WorkerProcess(multiprocessing.Process):
         #import cProfile, pstats, StringIO
         #pr = cProfile.Profile()
         #pr.enable()
-
-        if HAS_ATFORK:
-            atfork()
 
         try:
             # execute the task and build a TaskResult from the result

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(name='ansible',
       license='GPLv3',
       # Ansible will also make use of a system copy of python-six if installed but use a
       # Bundled copy if it's not.
-      install_requires=['paramiko', 'jinja2', "PyYAML", 'setuptools', 'pycrypto >= 2.6'],
+      install_requires=['paramiko', 'jinja2', "PyYAML", 'setuptools', 'cryptography'],
       package_dir={ '': 'lib' },
       packages=find_packages('lib'),
       package_data={

--- a/test/runner/requirements/integration.txt
+++ b/test/runner/requirements/integration.txt
@@ -1,8 +1,8 @@
+cryptography
 jinja2
 jmespath
 junit-xml
 ordereddict ; python_version < '2.7'
 paramiko
 passlib
-pycrypto
 pyyaml

--- a/test/runner/requirements/network-integration.txt
+++ b/test/runner/requirements/network-integration.txt
@@ -1,5 +1,5 @@
+cryptography
 jinja2
 junit-xml
 paramiko
-pycrypto
 pyyaml

--- a/test/runner/requirements/sanity.txt
+++ b/test/runner/requirements/sanity.txt
@@ -1,3 +1,4 @@
+cryptography
 jinja2
 mock
 pylint

--- a/test/runner/requirements/sanity.txt
+++ b/test/runner/requirements/sanity.txt
@@ -1,6 +1,7 @@
 cryptography
 jinja2
 mock
+paramiko
 pylint
 voluptuous
 yamllint

--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -1,9 +1,9 @@
 boto3
+cryptography
 jinja2
 mock
 nose
 passlib
-pycrypto
 pytest
 python-memcached
 pyyaml

--- a/test/runner/requirements/windows-integration.txt
+++ b/test/runner/requirements/windows-integration.txt
@@ -1,5 +1,6 @@
 cryptography
 jinja2
 junit-xml
+paramiko
 pywinrm
 pyyaml

--- a/test/runner/requirements/windows-integration.txt
+++ b/test/runner/requirements/windows-integration.txt
@@ -1,3 +1,4 @@
+cryptography
 jinja2
 junit-xml
 pywinrm

--- a/test/units/parsing/vault/test_vault_editor.py
+++ b/test/units/parsing/vault/test_vault_editor.py
@@ -23,7 +23,6 @@ __metaclass__ = type
 import sys
 import os
 import tempfile
-from nose.plugins.skip import SkipTest
 
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch
@@ -33,27 +32,6 @@ from ansible.parsing.vault import VaultLib
 from ansible.parsing.vault import VaultEditor
 from ansible.module_utils._text import to_bytes, to_text
 
-
-# Counter import fails for 2.0.1, requires >= 2.6.1 from pip
-try:
-    from Crypto.Util import Counter
-    HAS_COUNTER = True
-except ImportError:
-    HAS_COUNTER = False
-
-# KDF import fails for 2.0.1, requires >= 2.6.1 from pip
-try:
-    from Crypto.Protocol.KDF import PBKDF2
-    HAS_PBKDF2 = True
-except ImportError:
-    HAS_PBKDF2 = False
-
-# AES IMPORTS
-try:
-    from Crypto.Cipher import AES as AES
-    HAS_AES = True
-except ImportError:
-    HAS_AES = False
 
 v10_data = """$ANSIBLE_VAULT;1.0;AES
 53616c7465645f5fd0026926a2d415a28a2622116273fbc90e377225c12a347e1daf4456d36a77f9
@@ -106,9 +84,6 @@ class TestVaultEditor(unittest.TestCase):
 
     def test_decrypt_1_0(self):
         # Skip testing decrypting 1.0 files if we don't have access to AES, KDF or Counter.
-        if not HAS_AES or not HAS_COUNTER or not HAS_PBKDF2:
-            raise SkipTest
-
         v10_file = tempfile.NamedTemporaryFile(delete=False)
         with v10_file as f:
             f.write(to_bytes(v10_data))
@@ -133,9 +108,6 @@ class TestVaultEditor(unittest.TestCase):
         assert fdata.strip() == "foo", "incorrect decryption of 1.0 file: %s" % fdata.strip()
 
     def test_decrypt_1_1(self):
-        if not HAS_AES or not HAS_COUNTER or not HAS_PBKDF2:
-            raise SkipTest
-
         v11_file = tempfile.NamedTemporaryFile(delete=False)
         with v11_file as f:
             f.write(to_bytes(v11_data))
@@ -160,10 +132,6 @@ class TestVaultEditor(unittest.TestCase):
         assert fdata.strip() == "foo", "incorrect decryption of 1.0 file: %s" % fdata.strip()
 
     def test_rekey_migration(self):
-        # Skip testing rekeying files if we don't have access to AES, KDF or Counter.
-        if not HAS_AES or not HAS_COUNTER or not HAS_PBKDF2:
-            raise SkipTest
-
         v10_file = tempfile.NamedTemporaryFile(delete=False)
         with v10_file as f:
             f.write(to_bytes(v10_data))

--- a/test/utils/docker/centos6/Dockerfile
+++ b/test/utils/docker/centos6/Dockerfile
@@ -9,6 +9,8 @@ RUN yum clean all && \
     file \
     gcc \
     git \
+    libffi \
+    libffi-devel \
     make \
     mercurial \
     mysql \
@@ -16,6 +18,7 @@ RUN yum clean all && \
     mysql-server \
     openssh-clients \
     openssh-server \
+    openssl-devel \
     python-coverage \
     python-devel \
     python-httplib2 \
@@ -39,8 +42,6 @@ RUN yum clean all && \
     zip \
     && \
     yum clean all
-
-RUN rpm -e --nodeps python-crypto && pip install --upgrade pycrypto
 
 RUN /bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 RUN mkdir /etc/ansible/

--- a/test/utils/docker/centos7/Dockerfile
+++ b/test/utils/docker/centos7/Dockerfile
@@ -17,14 +17,18 @@ RUN yum clean all && \
     bzip2 \
     dbus-python \
     file \
+    gcc \
     git \
     iproute \
+    libffi \
+    libffi-devel \
     make \
     mariadb-server \
     mercurial \
     MySQL-python \
     openssh-clients \
     openssh-server \
+    openssl-devel \
     python-coverage \
     python-httplib2 \
     python-jinja2 \

--- a/test/utils/docker/centos7/Dockerfile
+++ b/test/utils/docker/centos7/Dockerfile
@@ -30,6 +30,7 @@ RUN yum clean all && \
     openssh-server \
     openssl-devel \
     python-coverage \
+    python-devel \
     python-httplib2 \
     python-jinja2 \
     python-keyczar \

--- a/test/utils/docker/fedora24/Dockerfile
+++ b/test/utils/docker/fedora24/Dockerfile
@@ -17,6 +17,7 @@ RUN dnf clean all && \
     dbus-python \
     file \
     findutils \
+    gcc \
     git \
     glibc-locale-source \
     iproute \
@@ -32,6 +33,7 @@ RUN dnf clean all && \
     procps \
     python2-dnf \
     python-coverage \
+    python-devel \
     python-httplib2 \
     python-jinja2 \
     python-keyczar \

--- a/test/utils/docker/fedora24/Dockerfile
+++ b/test/utils/docker/fedora24/Dockerfile
@@ -20,12 +20,15 @@ RUN dnf clean all && \
     git \
     glibc-locale-source \
     iproute \
+    libffi \
+    libffi-devel \
     make \
     mariadb-server \
     mercurial \
     MySQL-python \
     openssh-clients \
     openssh-server \
+    openssl-devel \
     procps \
     python2-dnf \
     python-coverage \

--- a/test/utils/docker/fedora25/Dockerfile
+++ b/test/utils/docker/fedora25/Dockerfile
@@ -20,12 +20,15 @@ RUN dnf clean all && \
     git \
     glibc-locale-source \
     iproute \
+    libffi \
+    libffi-devel \
     make \
     mariadb-server \
     mercurial \
     MySQL-python \
     openssh-clients \
     openssh-server \
+    openssl-devel \
     procps \
     python2-dnf \
     python-coverage \

--- a/test/utils/docker/opensuse42.1/Dockerfile
+++ b/test/utils/docker/opensuse42.1/Dockerfile
@@ -21,6 +21,8 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     openssh \
     postgresql-server \
     python-coverage \
+    python-cryptography \
+    python-devel \
     python-httplib2 \
     python-jinja2 \
     python-keyczar \

--- a/test/utils/docker/opensuse42.2/Dockerfile
+++ b/test/utils/docker/opensuse42.2/Dockerfile
@@ -21,6 +21,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     openssh \
     postgresql-server \
     python-coverage \
+    python-cryptography \
     python-httplib2 \
     python-jinja2 \
     python-keyczar \

--- a/test/utils/docker/ubuntu1204/Dockerfile
+++ b/test/utils/docker/ubuntu1204/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update -y && \
     gawk \
     gcc \
     git \
+    libffi-dev \
+    libssl-dev \
     libxml2-utils \
     locales \
     make \
@@ -49,8 +51,6 @@ RUN apt-get update -y && \
     zip \
     && \
     apt-get clean
-
-RUN pip install --upgrade pycrypto
 
 # helpful things taken from the ubuntu-upstart Dockerfile:
 # https://github.com/tianon/dockerfiles/blob/4d24a12b54b75b3e0904d8a285900d88d3326361/sbin-init/ubuntu/upstart/14.04/Dockerfile

--- a/test/utils/docker/ubuntu1404/Dockerfile
+++ b/test/utils/docker/ubuntu1404/Dockerfile
@@ -16,6 +16,8 @@ RUN apt-get update -y && \
     fakeroot \
     gawk \
     git \
+    libffi-dev \
+    libssl-dev \
     libxml2-utils \
     locales \
     make \

--- a/test/utils/docker/ubuntu1604/Dockerfile
+++ b/test/utils/docker/ubuntu1604/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update -y && \
     gawk \
     git \
     iproute2 \
+    libffi-dev \
+    libssl-dev \
     libxml2-utils \
     locales \
     lsb-release \

--- a/test/utils/docker/ubuntu1604py3/Dockerfile
+++ b/test/utils/docker/ubuntu1604py3/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get update -y && \
     gawk \
     git \
     iproute2 \
+    libffi-dev \
+    libssl-dev \
     libxml2-utils \
     locales \
     lsb-release \

--- a/test/utils/shippable/other.sh
+++ b/test/utils/shippable/other.sh
@@ -12,6 +12,10 @@ apt-get install -qq \
     python2.4 \
     g++-4.9 \
     python3.6-dev \
+    libssl-dev \
+    libffi-dev \
+
+pip install cryptography
 
 ln -sf x86_64-linux-gnu-gcc-4.9 /usr/bin/x86_64-linux-gnu-gcc
 

--- a/test/utils/shippable/other.sh
+++ b/test/utils/shippable/other.sh
@@ -15,8 +15,6 @@ apt-get install -qq \
     libssl-dev \
     libffi-dev \
 
-pip install cryptography
-
 ln -sf x86_64-linux-gnu-gcc-4.9 /usr/bin/x86_64-linux-gnu-gcc
 
 pip install tox --disable-pip-version-check

--- a/test/utils/tox/requirements.txt
+++ b/test/utils/tox/requirements.txt
@@ -11,7 +11,7 @@ unittest2
 redis
 python-memcached
 python-systemd
-pycrypto
+cryptography
 botocore
 boto3
 pytest


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
vault, crypto components

##### ANSIBLE VERSION
current devel branch

##### SUMMARY
This PR replaces PyCrypto, a largely moribund project written in poorly vetted bespoke C (with multiple outstanding CVEs), with pyca/cryptography.

pyca/cryptography is implicitly a dependency in many cases through paramiko (2.0+) as well as the new openssl_publickey module, which requires pyOpenSSL 16.0+. Additionally, pyca/cryptography is already presented as an optional dependency for better performance with Vault.

This commit leverages cryptography's padding module, constant time comparisons, fork safety, and block cipher constructs to reduce the amount of code ansible needs to maintain. Otherwise, I have attempted to minimize refactoring to ease review. Future PRs could further simplify several things.

While the code changes are only moderate, this is a significant dependency change. cryptography leverages OpenSSL/LibreSSL, so users on Linux will need to have the development headers for OpenSSL to be able to successfully install. This is an increased burden over the existing PyCrypto dependency (which only requires a C compiler). There are tentative plans to offer a binary wheel using `manylinux1` in the future, but that is not yet available. On Mac and Windows, binary wheels ship today so users simply need to have an up-to-date pip. Of course, since many users are already doing this to obtain paramiko 2.0+ the burden isn't too high. cryptography is also packaged by every major linux distribution, further reducing the challenge.

If this PR is accepted a future PR could easily remove the optional pyOpenSSL dependency and directly utilize cryptography for the public key module.

Full disclosure: I am one of the authors of pyca/cryptography. I strongly believe PyCrypto should no longer be used, but I do have a horse in this race :smile: