### PR TITLE
Handle ';' as comment char in sysctl files

### DIFF
--- a/lib/ansible/modules/system/sysctl.py
+++ b/lib/ansible/modules/system/sysctl.py
@@ -307,7 +307,7 @@ class SysctlModule(object):
             self.file_lines.append(line)
 
             # don't split empty lines or comments
-            if not line or line.startswith("#"):
+            if not line or line.startswith(("#", ";")):
                 continue
 
             k, v = line.split('=',1)
@@ -320,7 +320,7 @@ class SysctlModule(object):
         checked = []
         self.fixed_lines = []
         for line in self.file_lines:
-            if not line.strip() or line.strip().startswith("#"):
+            if not line.strip() or line.strip().startswith(("#", ";")):
                 self.fixed_lines.append(line)
                 continue
             tmpline = line.strip()


### PR DESCRIPTION
Fixes #20569

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/system/sysctl.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (sysctl_comments_20569 e35734c7d3) last updated 2017/01/23 15:31:32 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules', u'/home/adrian/ansible/lib/modules/']

```

##### SUMMARY
Fixes #20569 (probably)

(module errors if sysctl file uses ';' as comment char instead of  '#').

';' is valid comment char based on http://man7.org/linux/man-pages/man5/sysctl.conf.5.html