### PR TITLE
The '-s' option for restart/refresh is only supported on Oracle Solaris >= 11

### DIFF
--- a/lib/ansible/modules/system/service.py
+++ b/lib/ansible/modules/system/service.py
@@ -1303,6 +1303,19 @@ class SunOSService(Service):
         if not self.svcadm_cmd:
             self.module.fail_json(msg='unable to find svcadm binary')
 
+        if self.svcadm_supports_sync():
+            self.svcadm_sync = '-s'
+        else:
+            self.svcadm_sync = ''
+
+    def svcadm_supports_sync(self):
+        # Support for synchronous restart/refresh is only supported on
+        # Oracle Solaris >= 11.
+        for line in open('/etc/release', 'r').readlines():
+            m = re.match('\s+Oracle Solaris (\d+\.\d+).*', line.rstrip())
+            if m and m.groups()[0] > 10:
+                return True
+
     def get_service_status(self):
         status = self.get_sunos_svcs_status()
         # Only 'online' is considered properly running. Everything else is off
@@ -1394,9 +1407,9 @@ class SunOSService(Service):
         elif self.action == 'stop':
             subcmd = "disable -st"
         elif self.action == 'reload':
-            subcmd = "refresh -s"
+            subcmd = "refresh %s" % (self.svcadm_sync)
         elif self.action == 'restart' and status == 'online':
-            subcmd = "restart -s"
+            subcmd = "restart %s" % (self.svcadm_sync)
         elif self.action == 'restart' and status != 'online':
             subcmd = "enable -rst"
 


### PR DESCRIPTION


##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

`service` module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
v2.3
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

In https://github.com/ansible/ansible-modules-core/commit/ebcc46fa27de3a62904cd85392b50598271905d2 the `-s` flag was added for `restarted` and `reloaded`. However this is only supported on Solaris >= 11, and not on older versions or the illumos distributions.

Before:
```
TASK [ensure ssh is restarted] *************************************************
fatal: [calafate-gz]: FAILED! => {"changed": false, "failed": true, "msg": "svcadm: Pattern '-s' doesn't match any ins
tances\n"}
```

After:
```
TASK [ensure ssh is restarted] *************************************************
changed: [calafate-gz] => {"changed": true, "name": "ssh", "state": "started"}
```

Closes #20102