### PR TITLE
Fix git remote url change detection.

### DIFF
--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -637,7 +637,7 @@ def set_remote_url(git_path, module, repo, dest, remote):
     ''' updates repo from remote sources '''
     # Return if remote URL isn't changing.
     remote_url = get_remote_url(git_path, module, dest, remote)
-    if remote_url == repo or remote_url == unfrackgitpath(repo):
+    if remote_url == repo or unfrackgitpath(remote_url) == unfrackgitpath(repo):
         return False
 
     command = [git_path, 'remote', 'set-url', remote, repo]
@@ -1009,7 +1009,7 @@ def main():
         # exit if already at desired sha version
         if module.check_mode:
             remote_url = get_remote_url(git_path, module, dest, remote)
-            remote_url_changed = remote_url and remote_url != repo and remote_url != unfrackgitpath(repo)
+            remote_url_changed = remote_url and remote_url != repo and unfrackgitpath(remote_url) != unfrackgitpath(repo)
         else:
             remote_url_changed = set_remote_url(git_path, module, repo, dest, remote)
         result.update(remote_url_changed=remote_url_changed)

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -294,6 +294,9 @@ def head_splitter(headfile, remote, module=None, fail_on_error=False):
 
 
 def unfrackgitpath(path):
+    if path is None:
+        return None
+
     # copied from ansible.utils.path
     return os.path.normpath(os.path.realpath(os.path.expanduser(os.path.expandvars(path))))
 

--- a/test/integration/targets/git/tasks/checkout-new-tag.yml
+++ b/test/integration/targets/git/tasks/checkout-new-tag.yml
@@ -48,9 +48,6 @@
     that:
       - not update_new_tag|changed
       - "'newtag' in listoftags.stdout_lines"
-  # This test fails on osx.
-  # Skipping it here so the remaining tests can be enabled.
-  when: '{{ ansible_distribution != "MacOSX" }}'
 
 
 - name: clear checkout_dir


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

git module

##### ANSIBLE VERSION

```
ansible 2.3.0 (git-fix 23acd88d6b) last updated 2017/01/23 15:47:18 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

When comparing paths, unfrackgitpath must be called on both sides
of the comparison. Otherwise comparisons involving symlinks will
return incorrect results.
