### PR TITLE
roledeps

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -239,6 +239,7 @@ DEFAULT_INTERNAL_POLL_INTERVAL = get_config(p, DEFAULTS, 'internal_poll_interval
 ERROR_ON_MISSING_HANDLER  = get_config(p, DEFAULTS, 'error_on_missing_handler', 'ANSIBLE_ERROR_ON_MISSING_HANDLER', True, value_type='boolean')
 SHOW_CUSTOM_STATS = get_config(p, DEFAULTS, 'show_custom_stats', 'ANSIBLE_SHOW_CUSTOM_STATS', False, value_type='boolean')
 NAMESPACE_FACTS = get_config(p, DEFAULTS, 'restrict_facts_namespace', 'ANSIBLE_RESTRICT_FACTS', False, value_type='boolean')
+DEFAULT_SKIP_ROLE_DEPENDENCIES    = get_config(p, DEFAULTS, 'skip_role_dependencies', 'ANSIBLE_SKIP_ROLE_DEPENDENCIES', False, value_type='boolean')
 
 # static includes
 DEFAULT_TASK_INCLUDES_STATIC    = get_config(p, DEFAULTS, 'task_includes_static', 'ANSIBLE_TASK_INCLUDES_STATIC', False, value_type='boolean')

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -22,7 +22,6 @@ __metaclass__ = type
 import collections
 import os
 
-from ansible.compat.six import iteritems, binary_type, text_type
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.module_utils.six import iteritems, binary_type, text_type

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -22,6 +22,8 @@ __metaclass__ = type
 import collections
 import os
 
+from ansible.compat.six import iteritems, binary_type, text_type
+from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.module_utils.six import iteritems, binary_type, text_type
 from ansible.playbook.attribute import FieldAttribute
@@ -200,7 +202,8 @@ class Role(Base, Become, Conditional, Taggable):
         metadata = self._load_role_yaml('meta')
         if metadata:
             self._metadata = RoleMetadata.load(metadata, owner=self, variable_manager=self._variable_manager, loader=self._loader)
-            self._dependencies = self._load_dependencies()
+            if not C.DEFAULT_SKIP_ROLE_DEPENDENCIES:
+                self._dependencies = self._load_dependencies()
         else:
             self._metadata = RoleMetadata()
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
role/metadata

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible-playbook 2.3.0 (roledeps ff45139e08) last updated 2017/01/24 09:38:32 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
add new SKIP_ROLE_DEPENDENCIES  configuration variable (boolean, default false):
if false: act normally
if true: don't load dependencies from metadata.
this can be useful when we have two roles A and B in a playbook.
Let's say:
- hosts: localhost
  roles:
    - { role: yum, tags: ["yum","dnf"] }
    - { role: sshd, tags: ["sshd"] }
sshd depends on yum (in metadata/main.yml), but you occasionnally want to run sshd without running tasks from yum role (because it would update all packages), and you don't even want to run tasks in yum.
This of course implies tag "sshd" (in the given example) is only in sshd role.
In case of complex playbooks, this might accelerate the run drastically if one want to run a single role/tag.
```
rewrite from https://github.com/ansible/ansible/pull/20550 (due to some rebase errors on my local repo, sorry for the time lost)
