### PR TITLE
Clean downloaded rpm files after install

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -290,24 +290,23 @@ def ensure_yum_utils(module):
 
 def fetch_rpm_from_url(spec, module=None):
     # download package so that we can query it
-    tempdir = tempfile.mkdtemp()
-    package = os.path.join(tempdir, str(spec.rsplit('/', 1)[1]))
+    package_name, _ = os.path.splitext(str(spec.rsplit('/', 1)[1]))
+    package_file = tempfile.NamedTemporaryFile(prefix=package_name, suffix='.rpm', delete=False)
+    module.add_cleanup_file(package_file.name)
     try:
         rsp, info = fetch_url(module, spec)
         if not rsp:
             module.fail_json(msg="Failure downloading %s, %s" % (spec, info['msg']))
-        f = open(package, 'w')
         data = rsp.read(BUFSIZE)
         while data:
-            f.write(data)
+            package_file.write(data)
             data = rsp.read(BUFSIZE)
-        f.close()
+        package_file.close()
     except Exception:
         e = get_exception()
-        shutil.rmtree(tempdir)
         if module:
             module.fail_json(msg="Failure downloading %s, %s" % (spec, e))
-    return package
+    return package_file.name
 
 def po_to_nevra(po):
 
@@ -477,13 +476,6 @@ def what_provides(module, repoq, req_spec, conf_file, qf=def_qf, en_repos=None, 
         en_repos = []
     if dis_repos is None:
         dis_repos = []
-
-    if req_spec.endswith('.rpm') and '://' not in req_spec:
-        return req_spec
-
-    elif '://' in req_spec:
-        local_path = fetch_rpm_from_url(req_spec, module=module)
-        return local_path
 
     if not repoq:
 
@@ -655,7 +647,6 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, i
     res['msg'] = ''
     res['rc'] = 0
     res['changed'] = False
-    tempdir = tempfile.mkdtemp()
 
     for spec in items:
         pkg = None
@@ -754,13 +745,6 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, i
         cmd = yum_basecmd + ['install'] + pkgs
 
         if module.check_mode:
-            # Remove rpms downloaded for EL5 via url
-            try:
-                shutil.rmtree(tempdir)
-            except Exception:
-                e = get_exception()
-                module.fail_json(msg="Failure deleting temp directory %s, %s" % (tempdir, e))
-
             module.exit_json(changed=True, results=res['results'], changes=dict(installed=pkgs))
 
         changed = True
@@ -793,13 +777,6 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, i
 
         # Record change
         res['changed'] = changed
-
-    # Remove rpms downloaded for EL5 via url
-    try:
-        shutil.rmtree(tempdir)
-    except Exception:
-        e = get_exception()
-        module.fail_json(msg="Failure deleting temp directory %s, %s" % (tempdir, e))
 
     return res
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
`yum` module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel 0333fb77d2) last updated 2017/01/24 10:39:12 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible']
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This pull request will ensure that the downloaded files are always deleted when using `yum` module with urls. Currently, the dowloaded files are still present in `/tmp` (or the temporary directory used on the target machine) when ansible has finished. This can exhaust the disk space or the memory (for tmpfs) of the machine when the ansible playbook is run several times.

It will also prevent errors when using `state=latest` with local rpm or rpm fetched from url, simply ignoring them if they are already installed. Here is the output we get before the fix:


```
failed: [test5] (item=[u'http://example.com/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm']) => {"changed": true, "failed": true,
"item": ["http://example.com/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm"], "msg": "Error: Nothing to do", "rc": 1,
"results": ["Loaded plugins: fastestmirror
Examining /var/tmp/yum-root-EevoYD/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm: oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64
/var/tmp/yum-root-EevoYD/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm: does not update installed package."]}
```

After the fix, the update is simply ignored:

```
ok: [test5] => (item=[u'http://example.com/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm']) => {"changed": false,
"item": ["http://example.com/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm"], "msg": "", "rc": 0, "results": [""]}
```

And it still works if the package is not installed:

```
changed: [test5] => (item=[u'http://example.com/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm']) =>
{"changed": true, "item": ["http://example.com/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64.rpm"], "msg": "", "rc": 0,
"results": ["Loaded plugins: fastestmirror
Examining /tmp/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64roiPxH.rpm: oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64
Marking /tmp/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64roiPxH.rpm to be installed
Resolving Dependencies
--> Running transaction check
---> Package oracle-instantclient11.2-basic.x86_64 0:11.2.0.4.0-1 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
Package
Arch   Version
Repository                                                 Size
================================================================================
Installing:
oracle-instantclient11.2-basic
x86_64 11.2.0.4.0-1
/oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64roiPxH 179 M

Transaction Summary
================================================================================
Install  1 Package

Total size: 179 M
Installed size: 179 M
Downloading packages:
Running transaction check
Running transaction test
Transaction test succeeded
Running transaction
Installing : oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64           1/1 
Verifying  : oracle-instantclient11.2-basic-11.2.0.4.0-1.x86_64           1/1 

Installed:
oracle-instantclient11.2-basic.x86_64 0:11.2.0.4.0-1                          

Complete!"]}
```

Finally, all the downloaded files are removed up from the `/tmp` directory.

##### TODO

This fix might also be needed for `apt` module.
