### PR TITLE
Updating credstash link to the new link

### DIFF
--- a/docs/docsite/rst/playbooks_lookups.rst
+++ b/docs/docsite/rst/playbooks_lookups.rst
@@ -217,7 +217,7 @@ The Credstash Lookup
 ````````````````````
 .. versionadded:: 2.0
 
-Credstash is a small utility for managing secrets using AWS's KMS and DynamoDB: https://github.com/LuminalOSS/credstash
+Credstash is a small utility for managing secrets using AWS's KMS and DynamoDB: https://github.com/fugue/credstash
 
 First, you need to store your secrets with credstash:
 


### PR DESCRIPTION
We changed the name of the github repo awhile back and I noticed it was out of date in the docs.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
credstash lookup plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
$ ansible --version
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This change updates the credstash lookup docs to use the new github url for the projects in the Fugue organization. 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
