### PR TITLE
Allow change kernel boot parameters of oVirt hosts

### DIFF
--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -283,15 +283,15 @@ def wait(
     if wait:
         start = time.time()
         while time.time() < start + timeout:
+            # Sleep for `poll_interval` seconds if none of the conditions apply:
+            time.sleep(float(poll_interval))
+
             # Exit if the condition of entity is valid:
             entity = get_entity(service)
             if condition(entity):
                 return
             elif fail_condition(entity):
                 raise Exception("Error while waiting on result state of the entity.")
-
-            # Sleep for `poll_interval` seconds if nor of the conditions apply:
-            time.sleep(float(poll_interval))
 
 
 def __get_auth_dict():


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt_hosts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR  primarly fixes issue https://github.com/ansible/ansible/issues/20549.
In addition, it add ```reinstall``` state to ```ovirt_hosts``` module, so users can easily reinstall after boot parameters change. Also adds ```override_display``` and making sure we are waiting before running a first poll request to entity state.