### PR TITLE
Add domain_id parameter to openstack os_group

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_group.py
+++ b/lib/ansible/modules/cloud/openstack/os_group.py
@@ -45,6 +45,12 @@ options:
         - Group description
      required: false
      default: None
+   domain_id:
+     description:
+        - Domain id to create the group in if the cloud supports domains.
+     required: false
+     default: None
+     version_added: "2.3"
    state:
      description:
        - Should the resource be present or absent.
@@ -62,6 +68,7 @@ EXAMPLES = '''
     state: present
     name: demo
     description: "Demo Group"
+    domain_id: demoid
 
 # Update the description on existing "demo" group
 - os_group:
@@ -69,6 +76,7 @@ EXAMPLES = '''
     state: present
     name: demo
     description: "Something else"
+    domain_id: demoid
 
 # Delete group named "demo"
 - os_group:
@@ -116,6 +124,7 @@ def main():
     argument_spec = openstack_full_argument_spec(
         name=dict(required=True),
         description=dict(required=False, default=None),
+        domain_id=dict(required=False, default=None),
         state=dict(default='present', choices=['absent', 'present']),
     )
 
@@ -129,11 +138,12 @@ def main():
 
     name = module.params.pop('name')
     description = module.params.pop('description')
+    domain_id = module.params.pop('domain_id')
     state = module.params.pop('state')
 
     try:
         cloud = shade.operator_cloud(**module.params)
-        group = cloud.get_group(name)
+        group = cloud.get_group(name, filters={'domain_id': domain_id})
 
         if module.check_mode:
             module.exit_json(changed=_system_state_change(state, description, group))
@@ -141,7 +151,7 @@ def main():
         if state == 'present':
             if group is None:
                 group = cloud.create_group(
-                    name=name, description=description)
+                    name=name, description=description, domain=domain_id)
                 changed = True
             else:
                 if description is not None and group.description != description:


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
cloud/openstack/os_group

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible']
```

##### SUMMARY
Previously, the os_group module did not have any way to specify under
which domain a group should be created. This meant that a group could
only be created for the default domain. The keystone API supports the
domain_id parameter for group creation[1] as does the shade library[2]
so this patch adds the support in the ansible module.

[1] http://developer.openstack.org/api-ref/identity/v3/index.html?expanded=create-group-detail#create-group
[2] http://docs.openstack.org/infra/shade/usage.html#shade.OperatorCloud.create_group
