### PR TITLE
Fix issue with cc and bcc getting added to mail if unset

### DIFF
--- a/lib/ansible/plugins/callback/mail.py
+++ b/lib/ansible/plugins/callback/mail.py
@@ -58,9 +58,9 @@ def mail(subject='Ansible error mail', sender=None, to=None, cc=None, bcc=None, 
     b_content += b_body
 
     b_addresses = b_to.split(b',')
-    if b_cc:
+    if cc:
         b_addresses += b_cc.split(b',')
-    if b_bcc:
+    if bcc:
         b_addresses += b_bcc.split(b',')
 
     for b_address in b_addresses:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible/lib/ansible/plugins/callback/mail.py

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  ```

##### SUMMARY
"None" was being added as a recipient on the email if cc or bcc were unset and defaulting to None. This was throwing the following smtplib exception:
```python
smtplib.SMTPRecipientsRefused: {'None': (550, '5.1.1 <None>... User unknown')}
```

ansible-playbook runs were erroring as follows:
```python
[WARNING]: Failure using method (v2_runner_on_failed) in callback plugin (</usr/lib/python2.7/dist-packages/ansible/plugins/callback/mail.CallbackModule object at 0x7f0d2a139f10>): {'None': (550, '5.1.1 <None>... User unknown')}
```

This was fixed by changing the conditional that adds in cc and bcc to the address list to check the cc and bcc variables instead of the b_cc and b_bcc variables that had been transformed to byte strings.
