### PR TITLE
Break so that insertbefore and insertafter affect the *first* occurre…

### DIFF
--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -286,6 +286,7 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
             if insertbefore:
                 # + 1 for the previous line
                 index[1] = lineno
+            break
 
     msg = ''
     changed = False


### PR DESCRIPTION
…nce of the `before` regex

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/files/lineinfile
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (lineinfile-fix-20582 8e14fdcdb2) last updated 2017/01/24 16:32:52 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Fixes #20582

This change makes the module break out of the loop to find occurrences of the insertbefore/insertafter regex on the first occurrence. If, for example, a file looks like:

```
Ryan
Brown
Brown
```
Using `^Brown$` as the `insertbefore` regular expression will result (currently) inserting a line between the two Brown's rather than before the first Brown.
