### PR TITLE
Increase timeout for http server in uri test.

### DIFF
--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -43,7 +43,7 @@
 
 - name: start SimpleHTTPServer
   shell: cd {{ files_dir }} && {{ ansible_python.executable }} {{ output_dir}}/testserver.py {{ http_port }}
-  async: 60 # this test set takes ~15 seconds to run
+  async: 120 # this test set can take ~1m to run on FreeBSD (via Shippable)
   poll: 0
 
 - wait_for: port={{ http_port }}


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

uri integration tests

##### ANSIBLE VERSION

```
ansible 2.3.0 (uri-timeout 95d15da453) last updated 2017/01/24 14:11:26 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Increase timeout for http server in uri test.