### PR TITLE
Use separators to remove trailing space added to lines end with comma

### DIFF
--- a/lib/ansible/parsing/utils/jsonify.py
+++ b/lib/ansible/parsing/utils/jsonify.py
@@ -30,12 +30,13 @@ def jsonify(result, format=False):
     if result is None:
         return "{}"
 
+    separators = None
     indent = None
     if format:
         indent = 4
+        separators = (',', ': ')
 
     try:
-        return json.dumps(result, sort_keys=True, indent=indent, ensure_ascii=False)
+        return json.dumps(result, sort_keys=True, indent=indent, ensure_ascii=False, separators=separators)
     except UnicodeDecodeError:
-        return json.dumps(result, sort_keys=True, indent=indent)
-
+        return json.dumps(result, sort_keys=True, indent=indent, separators=separators)


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/parsing/utils/jsonify.py

##### ANSIBLE VERSION

```
ansible 2.3.0 (devel 61e6e7868c) last updated 2017/01/21 09:04:05 (GMT +700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Rework of https://github.com/ansible/ansible/pull/20536
