### PR TITLE
Idempotence problems with win_nssm's app_parameters

### DIFF
--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -252,7 +252,7 @@ Function Nssm-Update-AppParameters
                         $singleLineParams = "$val " + $singleLineParams
                     }
                 } else {
-                    $singleLineParams = $singleLineParams + "$key ""$val"""
+                    $singleLineParams = $singleLineParams + "$key $val"
                 }
             }
 

--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -265,6 +265,7 @@ Function Nssm-Update-AppParameters
 
     if ($results -ne $singleLineParams)
     {
+        Set-Attr $result "old_nssm_single_line_app_parameters" $results
         if ($appParameters -or $appParametersFree)
         {
             $cmd = "set ""$name"" AppParameters $singleLineParams"

--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -245,7 +245,12 @@ Function Nssm-Update-AppParameters
                 $appParamVals += $val
 
                 if ($key -eq "_") {
-                    $singleLineParams = "$val " + $singleLineParams
+                    if ($appParametersHash.Count -eq 1)
+                    {
+                        $singleLineParams = "$val"
+                    } else {
+                        $singleLineParams = "$val " + $singleLineParams
+                    }
                 } else {
                     $singleLineParams = $singleLineParams + "$key ""$val"""
                 }


### PR DESCRIPTION
Fix for https://github.com/ansible/ansible/issues/20625

I added useful info about changes in AppParameters, removed extra space for one 'noname' parameter and removed quotes for named parameters.