### PR TITLE
postgres_db: add dump and restore support

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -325,12 +325,13 @@ def db_restore(module, target,
 def do_with_password(module, cmd, login_password):
     try:
         if login_password:
-            os.environ["PGPASSWORD"] = login_password
+            raise NotSupportedError(
+                'login_password not supported'
+            )
         rc, stderr, stdout = module.run_command(cmd, use_unsafe_shell=True)
         return rc, stderr, stdout
     finally:
-        if login_password:
-            del os.environ["PGPASSWORD"]
+        pass
 
 # ===========================================
 # Module execution.

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -280,22 +280,22 @@ def db_restore(module, target,
 
     flags = []
     if db:
-        flags.append(' --dbname={0} '.format(pipes.quote(db)))
-    if host:
-        flags.append('--host={0} '.format(host))
+        flags.append(' --dbname={0}'.format(pipes.quote(db)))
+    if login_host:
+        flags.append(' --host={0}'.format(login_host))
     if port:
-        flags.append('--port={0} '.format(port))
-    if user:
-        flags.append('--username={0} '.format(user))
+        flags.append(' --port={0}'.format(port))
+    if login_user:
+        flags.append(' --username={0}'.format(login_user))
 
     comp_prog_path = None
     cmd = module.get_bin_path('psql', True)
 
     if os.path.splitext(target)[-1] == '.sql':
-        flags.append('--file={0} '.format(target))
+        flags.append(' --file={0}'.format(target))
 
     elif os.path.splitext(target)[-1] == '.tar':
-        flags.append('--format=Tar {0}'.format(target))
+        flags.append(' --format=Tar {0}'.format(target))
         comp_prog_path = [module.get_bin_path('pg_restore', True)]
 
     elif os.path.splitext(target)[-1] == '.gz':
@@ -449,14 +449,12 @@ def main():
             try:
                 rc, stdout, stderr = method(module, target, db, **kw)
                 if rc != 0:
-                    module.fail_json(msg="{0}".format(stderr))
+                    module.fail_json(msg="stdout: {0}\nstderr: {1}".format(stdout, stderr))
                 else:
                     module.exit_json(changed=True, msg=stdout)
             except SQLParseError:
                 e = get_exception()
                 module.fail_json(msg=str(e))
-            except Exception:
-                e = get_exception()
 
     except NotSupportedError:
         e = get_exception()

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -328,7 +328,9 @@ def db_restore(module, target,
     return do_with_password(module, cmd, password)
 
 def do_with_password(module, cmd, password):
-    env = {"PGPASSWORD": password}
+    env = {}
+    if password:
+        env = {"PGPASSWORD": password}
     rc, stderr, stdout = module.run_command(cmd, use_unsafe_shell=True, environ_update=env)
     return rc, stderr, stdout, cmd
 

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -239,12 +239,12 @@ def db_dump(module, target,
     flags = ''
     if db:
         flags += ' {0}'.format(pipes.quote(db))
-    elif host:
-        flags += ' --host={0}'.format(pipes.quote(host))
-        if port:
-            flags += ' --port={0}'.format(pipes.quote(port))
+    if host:
+        flags += ' --host={0}'.format(host)
+    if port:
+        flags += ' --port={0}'.format(port)
     if user:
-        flags += ' --username={0}'.format(pipes.quote(user))
+        flags += ' --username={0}'.format(user)
 
     cmd = module.get_bin_path('pg_dump', True)
     comp_prog_path = None
@@ -309,7 +309,8 @@ def db_restore(module, target,
     elif os.path.splitext(target)[-1] == '.xz':
         comp_prog_path = module.get_bin_path('xzcat', True)
 
-    cmd += flags[0]
+    for flag in flags:
+        cmd += flag
 
     if comp_prog_path:
         p1 = subprocess.Popen([comp_prog_path, target], stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -59,14 +59,7 @@ options:
     required: false
     default: null
   state:
-    description:
-      - The database state.
-      - "present" implies that the database should be created if necessary.
-      - "absent" implies that the database should be removed if present.
-      - "dump" requires a target definition to which the database will be backed up. (Added in 2.3)
-      - "restore" also requires a target definition from which the database will be restored. (Added in 2.3)
-      - The format of the backup will be detected based on the target name.
-      - Supported formats for "dump" and "restore" are: .gz, .tar, .bz, .xz, and .sql
+    description: "The database state. present implies that the database should be created if necessary. absent implies that the database should be removed if present. dump requires a target definition to which the database will be backed up. (Added in 2.3) restore also requires a target definition from which the database will be restored. (Added in 2.3) The format of the backup will be detected based on the target name. Supported formats for dump and restore are: .gz, .tar, .bz, .xz, and .sql"
     required: false
     default: present
     choices: [ "present", "absent", "dump", "restore" ]

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -59,6 +59,7 @@ options:
     required: false
     default: null
   state:
+    version_added: "2.3"
     description:
       - The database state
     required: false
@@ -67,14 +68,14 @@ options:
     backup:
       - Back up to a destination, requires target as well. Supported formats are
         .gz, .tar, .bz, .xz, and .sql
-    restore:
-      version_added: "2.3"
-      description:
-        - Restore from a destination. See backup for supported options
-    target:
-      version_added: "2.3"
-      description:
-        - File to back up or restore from.
+  restore:
+    version_added: "2.3"
+    description:
+      - Restore from a destination. See backup for supported options
+  target:
+    version_added: "2.3"
+    description:
+      - File to back up or restore from.
 author: "Ansible Core Team"
 extends_documentation_fragment:
 - postgres

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -214,7 +214,7 @@ def db_matches(cursor, db, owner, template, encoding, lc_collate, lc_ctype):
         else:
             return True
 
-def db_dump(module, target, db, host, user, port):
+def db_dump(module, target, db=None, host=None, user=None, port=None):
     if db:
       flags = ' --dbname={0}'.format(pipes.quote(db))
     if host:
@@ -250,7 +250,7 @@ def db_dump(module, target, db, host, user, port):
     rc, stderr, stdout = module.run_command(cmd, use_unsafe_shell=True)
     return rc, stderr, stdout
 
-def db_import(module, target, db, host, user, port):
+def db_import(module, target, db=None, host=None, user=None, port=None):
     # set initial flags. These are the same in pg_restore as psql
     flags = []
     if db:

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -59,7 +59,13 @@ options:
     required: false
     default: null
   state:
-    description: "The database state. present implies that the database should be created if necessary. absent implies that the database should be removed if present. dump requires a target definition to which the database will be backed up. (Added in 2.4) restore also requires a target definition from which the database will be restored. (Added in 2.4) The format of the backup will be detected based on the target name. Supported formats for dump and restore are: .gz, .tar, .bz, .xz, and .sql"
+    description: |
+        The database state. present implies that the database should be created if necessary.
+        absent implies that the database should be removed if present.
+        dump requires a target definition to which the database will be backed up.
+        (Added in 2.4) restore also requires a target definition from which the database will be restored.
+        (Added in 2.4) The format of the backup will be detected based on the target name.
+        Supported formats for dump and restore are: .gz, .tar, .bz, .xz, and .sql
     required: false
     default: present
     choices: [ "present", "absent", "dump", "restore" ]

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -59,19 +59,17 @@ options:
     required: false
     default: null
   state:
-    version_added: "2.3"
     description:
-      - The database state
+      - The database state.
+      - "present" implies that the database should be created if necessary.
+      - "absent" implies that the database should be removed if present.
+      - "dump" requires a target definition to which the database will be backed up. (Added in 2.3)
+      - "restore" also requires a target definition from which the database will be restored. (Added in 2.3)
+      - The format of the backup will be detected based on the target name.
+      - Supported formats for "dump" and "restore" are: .gz, .tar, .bz, .xz, and .sql
     required: false
     default: present
     choices: [ "present", "absent", "dump", "restore" ]
-    backup:
-      - Back up to a destination, requires target as well. Supported formats are
-        .gz, .tar, .bz, .xz, and .sql
-  restore:
-    version_added: "2.3"
-    description:
-      - Restore from a destination. See backup for supported options
   target:
     version_added: "2.3"
     description:

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -59,12 +59,12 @@ options:
     required: false
     default: null
   state:
-    description: "The database state. present implies that the database should be created if necessary. absent implies that the database should be removed if present. dump requires a target definition to which the database will be backed up. (Added in 2.3) restore also requires a target definition from which the database will be restored. (Added in 2.3) The format of the backup will be detected based on the target name. Supported formats for dump and restore are: .gz, .tar, .bz, .xz, and .sql"
+    description: "The database state. present implies that the database should be created if necessary. absent implies that the database should be removed if present. dump requires a target definition to which the database will be backed up. (Added in 2.4) restore also requires a target definition from which the database will be restored. (Added in 2.4) The format of the backup will be detected based on the target name. Supported formats for dump and restore are: .gz, .tar, .bz, .xz, and .sql"
     required: false
     default: present
     choices: [ "present", "absent", "dump", "restore" ]
   target:
-    version_added: "2.3"
+    version_added: "2.4"
     description:
       - File to back up or restore from.
 author: "Ansible Core Team"

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -67,10 +67,14 @@ options:
     backup:
       - Back up to a destination, requires target as well. Supported formats are
         .gz, .tar, .bz, .xz, and .sql
-   restore:
-     - Restore from a destination. See backup for supported options
-   target:
-     - File to back up or restore from.
+    restore:
+      version_added: "2.2"
+      description:
+        - Restore from a destination. See backup for supported options
+    target:
+      version_added: "2.2"
+      description:
+        - File to back up or restore from.
 author: "Ansible Core Team"
 extends_documentation_fragment:
 - postgres

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -68,11 +68,11 @@ options:
       - Back up to a destination, requires target as well. Supported formats are
         .gz, .tar, .bz, .xz, and .sql
     restore:
-      version_added: "2.2"
+      version_added: "2.3"
       description:
         - Restore from a destination. See backup for supported options
     target:
-      version_added: "2.2"
+      version_added: "2.3"
       description:
         - File to back up or restore from.
 author: "Ansible Core Team"

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -221,13 +221,13 @@ def db_dump(module, target,
         )
 
     if db:
-      flags = ' --dbname={0}'.format(pipes.quote(db))
+        flags = ' --dbname={0}'.format(pipes.quote(db))
     if host:
-      flags += ' --host={0}'.format(pipes.quote(host))
+        flags += ' --host={0}'.format(pipes.quote(host))
     if port:
-      flags += ' --port={0}'.format(pipes.quote(port))
+        flags += ' --port={0}'.format(pipes.quote(port))
     if user:
-      flags += ' --username={0}'.format(pipes.quote(user))
+        flags += ' --username={0}'.format(pipes.quote(user))
 
     cmd = module.get_bin_path('pg_dump', True)
     comp_prog_path = None
@@ -236,20 +236,20 @@ def db_dump(module, target,
         flags += ' --format=t'
     if os.path.splitext(target)[-1] == '.gz':
         if module.get_bin_path('pigz'):
-          comp_prog_path = module.get_bin_path('pigz', True)
+            comp_prog_path = module.get_bin_path('pigz', True)
         else:
-          comp_prog_path = module.get_bin_path('gzip', True)
+            comp_prog_path = module.get_bin_path('gzip', True)
     elif os.path.splitext(target)[-1] == '.bz2':
-      comp_prog_path = module.get_bin_path('bzip2', True)
+        comp_prog_path = module.get_bin_path('bzip2', True)
     elif os.path.splitext(target)[-1] == '.xz':
-      comp_prog_path = module.get_bin_path('xz', True)
+        comp_prog_path = module.get_bin_path('xz', True)
 
     cmd += flags
 
     if comp_prog_path:
-      cmd = '{0}|{1} > {2}'.format(cmd, comp_prog_path, pipes.quote(target))
+        cmd = '{0}|{1} > {2}'.format(cmd, comp_prog_path, pipes.quote(target))
     else:
-      cmd = '{0} > {1}'.format(cmd, pipes.quote(target))
+        cmd = '{0} > {1}'.format(cmd, pipes.quote(target))
 
 
     rc, stderr, stdout = module.run_command(cmd, use_unsafe_shell=True)
@@ -268,19 +268,19 @@ def db_restore(module, target,
 
     flags = []
     if db:
-      flags.append(' --dbname={0} '.format(pipes.quote(db)))
+        flags.append(' --dbname={0} '.format(pipes.quote(db)))
     if host:
-      flags.append('--host={0} '.format(host))
+        flags.append('--host={0} '.format(host))
     if port:
-      flags.append('--port={0} '.format(port))
+        flags.append('--port={0} '.format(port))
     if user:
-      flags.append('--username={0} '.format(user))
+        flags.append('--username={0} '.format(user))
 
     comp_prog_path = None
     cmd = module.get_bin_path('psql', True)
 
     if os.path.splitext(target)[-1] == '.sql':
-      flags.append('--file={0} '.format(target))
+        flags.append('--file={0} '.format(target))
 
     elif os.path.splitext(target)[-1] == '.tar':
         flags.append('--format=Tar {0}'.format(target))
@@ -295,18 +295,18 @@ def db_restore(module, target,
     cmd += flags[0]
 
     if comp_prog_path:
-      p1 = subprocess.Popen([comp_prog_path, target], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-      p2 = subprocess.Popen(cmd, stdin=p1.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
-      (stdout2, stderr2) = p2.communicate()
-      p1.stdout.close()
-      p1.wait()
-      if p1.returncode != 0:
-        stderr1 = p1.stderr.read()
-        return p1.returncode, '', stderr1
-      else:
-        return p2.returncode, '', stderr2
+        p1 = subprocess.Popen([comp_prog_path, target], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p2 = subprocess.Popen(cmd, stdin=p1.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        (stdout2, stderr2) = p2.communicate()
+        p1.stdout.close()
+        p1.wait()
+        if p1.returncode != 0:
+            stderr1 = p1.stderr.read()
+            return p1.returncode, '', stderr1
+        else:
+            return p2.returncode, '', stderr2
     else:
-      cmd = '{0} < {1}'.format(cmd, pipes.quote(target))
+        cmd = '{0} < {1}'.format(cmd, pipes.quote(target))
 
     rc, stderr, stdout = module.run_command(cmd, use_unsafe_shell=True)
     return rc, stderr, stdout
@@ -434,14 +434,14 @@ def main():
             try:
                 rc, stdout, stderr = db_restore(module, target, db, **kw)
                 if rc != 0:
-                  module.fail_json(msg="{0}".format(stderr))
+                    module.fail_json(msg="{0}".format(stderr))
                 else:
-                  module.exit_json(changed=True, msg=stdout)
-            except Exception:
-                e = get_exception()
+                    module.exit_json(changed=True, msg=stdout)
             except SQLParseError:
                 e = get_exception()
                 module.fail_json(msg=str(e))
+            except Exception:
+                e = get_exception()
 
     except NotSupportedError:
         e = get_exception()

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -263,10 +263,10 @@ def db_dump(module, target,
     rc, stderr, stdout = module.run_command(cmd, use_unsafe_shell=True)
     return rc, stderr, stdout
 
-def db_import(module, target,
-              db=None, host=None,
-              user=None, port=None,
-              password=None):
+def db_restore(module, target,
+               db=None, host=None,
+               user=None, port=None,
+               password=None):
     # set initial flags. These are the same in pg_restore as psql
 
     if password:
@@ -332,7 +332,7 @@ def main():
         encoding=dict(default=""),
         lc_collate=dict(default=""),
         lc_ctype=dict(default=""),
-        state=dict(default="present", choices=["absent", "present", "dump", "import"]),
+        state=dict(default="present", choices=["absent", "present", "dump", "restore"]),
         target=dict(default=""),
     ))
 
@@ -438,9 +438,9 @@ def main():
                 e = get_exception()
                 module.fail_json(msg=str(e))
 
-        elif state == "import":
+        elif state == "restore":
             try:
-                rc, stdout, stderr = db_import(module, target, db, **kw)
+                rc, stdout, stderr = db_restore(module, target, db, **kw)
                 if rc != 0:
                   module.fail_json(msg="{0}".format(stderr))
                 else:

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -223,9 +223,9 @@ def db_dump(module, target,
             password=None):
 
     if password:
-          raise NotSupportedError(
+        raise NotSupportedError(
             'password not supported for pg_dump'
-          )
+        )
 
     if db:
       flags = ' --dbname={0}'.format(pipes.quote(db))
@@ -269,9 +269,9 @@ def db_restore(module, target,
     # set initial flags. These are the same in pg_restore as psql
 
     if password:
-          raise NotSupportedError(
+        raise NotSupportedError(
             'password not supported for pg_restore'
-          )
+        )
 
     flags = []
     if db:

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -218,7 +218,16 @@ def db_matches(cursor, db, owner, template, encoding, lc_collate, lc_ctype):
         else:
             return True
 
-def db_dump(module, target, db=None, host=None, user=None, port=None):
+def db_dump(module, target,
+            db=None, host=None,
+            user=None, port=None,
+            password=None):
+
+    if password:
+          raise NotSupportedError(
+            'password not supported for pg_dump'
+          )
+
     if db:
       flags = ' --dbname={0}'.format(pipes.quote(db))
     if host:
@@ -254,8 +263,17 @@ def db_dump(module, target, db=None, host=None, user=None, port=None):
     rc, stderr, stdout = module.run_command(cmd, use_unsafe_shell=True)
     return rc, stderr, stdout
 
-def db_import(module, target, db=None, host=None, user=None, port=None):
+def db_import(module, target,
+              db=None, host=None,
+              user=None, port=None,
+              password=None):
     # set initial flags. These are the same in pg_restore as psql
+
+    if password:
+          raise NotSupportedError(
+            'password not supported for pg_restore'
+          )
+
     flags = []
     if db:
       flags.append(' --dbname={0} '.format(pipes.quote(db)))

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -1011,6 +1011,13 @@
     that:
       - "result.stdout_lines[-1] == '(0 rows)'"
 
+# dump/restore tests
+# ============================================================
+- include: state_dump_restore.yml file=dbdata.sql
+- include: state_dump_restore.yml file=dbdata.gz
+- include: state_dump_restore.yml file=dbdata.bz2
+- include: state_dump_restore.yml file=dbdata.xz
+
 #
 # Cleanup
 #

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -1014,9 +1014,13 @@
 # dump/restore tests
 # ============================================================
 - include: state_dump_restore.yml file=dbdata.sql
-- include: state_dump_restore.yml file=dbdata.gz
-- include: state_dump_restore.yml file=dbdata.bz2
-- include: state_dump_restore.yml file=dbdata.xz
+- include: state_dump_restore.yml file=dbdata.sql.gz
+- include: state_dump_restore.yml file=dbdata.sql.bz2
+- include: state_dump_restore.yml file=dbdata.sql.xz
+- include: state_dump_restore.yml file=dbdata.tar
+- include: state_dump_restore.yml file=dbdata.tar.gz
+- include: state_dump_restore.yml file=dbdata.tar.bz2
+- include: state_dump_restore.yml file=dbdata.tar.xz
 
 #
 # Cleanup

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -1011,16 +1011,20 @@
     that:
       - "result.stdout_lines[-1] == '(0 rows)'"
 
-# dump/restore tests
+# dump/restore tests per format
 # ============================================================
-- include: state_dump_restore.yml file=dbdata.sql
-- include: state_dump_restore.yml file=dbdata.sql.gz
-- include: state_dump_restore.yml file=dbdata.sql.bz2
-- include: state_dump_restore.yml file=dbdata.sql.xz
-- include: state_dump_restore.yml file=dbdata.tar
-- include: state_dump_restore.yml file=dbdata.tar.gz
-- include: state_dump_restore.yml file=dbdata.tar.bz2
-- include: state_dump_restore.yml file=dbdata.tar.xz
+- include: state_dump_restore.yml test_fixture=user file=dbdata.sql
+- include: state_dump_restore.yml test_fixture=user file=dbdata.sql.gz
+- include: state_dump_restore.yml test_fixture=user file=dbdata.sql.bz2
+- include: state_dump_restore.yml test_fixture=user file=dbdata.sql.xz
+- include: state_dump_restore.yml test_fixture=user file=dbdata.tar
+- include: state_dump_restore.yml test_fixture=user file=dbdata.tar.gz
+- include: state_dump_restore.yml test_fixture=user file=dbdata.tar.bz2
+- include: state_dump_restore.yml test_fixture=user file=dbdata.tar.xz
+
+# dump/restore tests per other logins
+# ============================================================
+- include: state_dump_restore.yml file=dbdata.tar test_fixture=admin
 
 #
 # Cleanup

--- a/test/integration/targets/postgresql/tasks/state_dump_restore.yml
+++ b/test/integration/targets/postgresql/tasks/state_dump_restore.yml
@@ -26,6 +26,8 @@
          name: "{{ db_name }}"
          owner: "{{ db_user1 }}"
          login_user: "{{ pg_user }}"
+
+- set_fact:
      user_str: "env PGPASSWORD=password psql -h localhost -U {{ db_user1 }} {{ db_name }}"
      user_map:
          name: "{{ db_name }}"
@@ -34,11 +36,23 @@
          login_host: "localhost"
          login_user: "{{ db_user1 }}"
          login_password: "password"
+  when: test_fixture == "user"
+
+- set_fact:
+     user_str: "psql {{ db_name }}"
+     user_map:
+         name: "{{ db_name }}"
+         target: "{{ db_file_name }}"
+         owner: "{{ db_user1 }}"
+         login_host: "localhost"
+         login_user: "{{ pg_user }}"
+  when: test_fixture == "admin"
 
 - set_fact:
      sql_create: "create table employee(id int, name varchar(100));"
      sql_insert: "insert into employee values (47,'Joe Smith');"
      sql_select: "select * from  employee;"
+     sql_schema: "grant usage on schema public to {{ db_user1 }}; grant create on schema public to {{ db_user1 }};"
 
 - name: state dump/restore - create database
   postgresql_db: "{{ admin_map | combine({'state': 'present'}) }}"
@@ -72,6 +86,9 @@
 
 - name: state dump/restore - re-create database
   postgresql_db: "{{ admin_map | combine({'state': 'present'}) }}"
+
+- name: state dump/restore - grant permissions to user
+  command: '{{ admin_str }} -c "{{ sql_schema }}"'
 
 - name: test state=restore to restore the database (expect changed=true)
   postgresql_db: "{{ user_map | combine({'state': 'restore'}) }}"

--- a/test/integration/targets/postgresql/tasks/state_dump_restore.yml
+++ b/test/integration/targets/postgresql/tasks/state_dump_restore.yml
@@ -32,19 +32,20 @@
      user_map:
          name: "{{ db_name }}"
          target: "{{ db_file_name }}"
+         target_opts: "-n public"
          owner: "{{ db_user1 }}"
          login_host: "localhost"
          login_user: "{{ db_user1 }}"
          login_password: "password"
   when: test_fixture == "user"
+  # "-n public" is required to work around pg_restore issues with plpgsql
 
 - set_fact:
-     user_str: "psql {{ db_name }}"
+     user_str: "psql -U {{ pg_user }} {{ db_name }}"
      user_map:
          name: "{{ db_name }}"
          target: "{{ db_file_name }}"
          owner: "{{ db_user1 }}"
-         login_host: "localhost"
          login_user: "{{ pg_user }}"
   when: test_fixture == "admin"
 
@@ -52,7 +53,6 @@
      sql_create: "create table employee(id int, name varchar(100));"
      sql_insert: "insert into employee values (47,'Joe Smith');"
      sql_select: "select * from  employee;"
-     sql_schema: "grant usage on schema public to {{ db_user1 }}; grant create on schema public to {{ db_user1 }};"
 
 - name: state dump/restore - create database
   postgresql_db: "{{ admin_map | combine({'state': 'present'}) }}"
@@ -86,9 +86,6 @@
 
 - name: state dump/restore - re-create database
   postgresql_db: "{{ admin_map | combine({'state': 'present'}) }}"
-
-- name: state dump/restore - grant permissions to user
-  command: '{{ admin_str }} -c "{{ sql_schema }}"'
 
 - name: test state=restore to restore the database (expect changed=true)
   postgresql_db: "{{ user_map | combine({'state': 'restore'}) }}"

--- a/test/integration/targets/postgresql/tasks/state_dump_restore.yml
+++ b/test/integration/targets/postgresql/tasks/state_dump_restore.yml
@@ -21,11 +21,19 @@
 - set_fact: db_file_name="{{tmp_dir}}/{{file}}"
 
 - set_fact:
-     pg_str: "psql -U {{ pg_user }} {{ db_name }}"
-     pg_map:
+     admin_str: "psql -U {{ pg_user }}"
+     admin_map:
+         name: "{{ db_name }}"
+         owner: "{{ db_user1 }}"
+         login_user: "{{ pg_user }}"
+     user_str: "env PGPASSWORD=password psql -h localhost -U {{ db_user1 }} {{ db_name }}"
+     user_map:
          name: "{{ db_name }}"
          target: "{{ db_file_name }}"
-         login_user: "{{ pg_user }}"
+         owner: "{{ db_user1 }}"
+         login_host: "localhost"
+         login_user: "{{ db_user1 }}"
+         login_password: "password"
 
 - set_fact:
      sql_create: "create table employee(id int, name varchar(100));"
@@ -33,19 +41,19 @@
      sql_select: "select * from  employee;"
 
 - name: state dump/restore - create database
-  postgresql_db: "{{ pg_map | combine({'state': 'present'}) }}"
+  postgresql_db: "{{ admin_map | combine({'state': 'present'}) }}"
 
 - name: state dump/restore - create table employee
-  command: '{{ pg_str }} -c "{{ sql_create }}"'
+  command: '{{ user_str }} -c "{{ sql_create }}"'
 
 - name: state dump/restore - insert data into table employee
-  command: '{{ pg_str }} -c "{{ sql_insert }}"'
+  command: '{{ user_str }} -c "{{ sql_insert }}"'
 
 - name: state dump/restore - file name should not exist
   file: name={{ db_file_name }} state=absent
 
 - name: test state=dump to backup the database (expect changed=true)
-  postgresql_db: "{{ pg_map | combine({'state': 'dump'}) }}"
+  postgresql_db: "{{ user_map | combine({'state': 'dump'}) }}"
   register: result
   become_user: "{{ pg_user }}"
   become: True
@@ -60,13 +68,13 @@
   register: result
 
 - name: state dump/restore - remove database for restore
-  postgresql_db: "{{ pg_map | combine({'state': 'absent'}) }}"
+  postgresql_db: "{{ user_map | combine({'state': 'absent'}) }}"
 
 - name: state dump/restore - re-create database
-  postgresql_db: "{{ pg_map | combine({'state': 'present'}) }}"
+  postgresql_db: "{{ admin_map | combine({'state': 'present'}) }}"
 
 - name: test state=restore to restore the database (expect changed=true)
-  postgresql_db: "{{ pg_map | combine({'state': 'restore'}) }}"
+  postgresql_db: "{{ user_map | combine({'state': 'restore'}) }}"
   register: result
   become_user: "{{ pg_user }}"
   become: True
@@ -75,7 +83,7 @@
   assert: { that: "result.changed == true" }
 
 - name: select data from table employee
-  command: '{{ pg_str }} -c "{{ sql_select }}"'
+  command: '{{ user_str }} -c "{{ sql_select }}"'
   register: result
 
 - name: assert data in database is from the restore database
@@ -85,7 +93,7 @@
        - "'Joe Smith' in result.stdout"
 
 - name: state dump/restore - remove database name
-  postgresql_db: "{{ pg_map | combine({'state': 'absent'}) }}"
+  postgresql_db: "{{ user_map | combine({'state': 'absent'}) }}"
 
 - name: remove file name
   file: name={{ db_file_name }}  state=absent

--- a/test/integration/targets/postgresql/tasks/state_dump_restore.yml
+++ b/test/integration/targets/postgresql/tasks/state_dump_restore.yml
@@ -21,11 +21,11 @@
 - set_fact: db_file_name="{{tmp_dir}}/{{file}}"
 
 - set_fact:
-     pg_str: "psql -U postgres {{ db_name }}"
+     pg_str: "psql -U {{ pg_user }} {{ db_name }}"
      pg_map:
          name: "{{ db_name }}"
          target: "{{ db_file_name }}"
-         login_user: "postgres"
+         login_user: "{{ pg_user }}"
 
 - set_fact:
      sql_create: "create table employee(id int, name varchar(100));"
@@ -33,7 +33,7 @@
      sql_select: "select * from  employee;"
 
 - name: state dump/restore - create database
-  postgresql_db: name={{ db_name }} state=present
+  postgresql_db: "{{ pg_map | combine({'state': 'present'}) }}"
 
 - name: state dump/restore - create table employee
   command: '{{ pg_str }} -c "{{ sql_create }}"'
@@ -47,7 +47,7 @@
 - name: test state=dump to backup the database (expect changed=true)
   postgresql_db: "{{ pg_map | combine({'state': 'dump'}) }}"
   register: result
-  become_user: postgres
+  become_user: "{{ pg_user }}"
   become: True
 
 - name: assert output message backup the database
@@ -60,15 +60,15 @@
   register: result
 
 - name: state dump/restore - remove database for restore
-  postgresql_db: name={{ db_name }} state=absent
+  postgresql_db: "{{ pg_map | combine({'state': 'absent'}) }}"
 
 - name: state dump/restore - re-create database
-  postgresql_db: name={{ db_name }} state=present
+  postgresql_db: "{{ pg_map | combine({'state': 'present'}) }}"
 
 - name: test state=restore to restore the database (expect changed=true)
   postgresql_db: "{{ pg_map | combine({'state': 'restore'}) }}"
   register: result
-  become_user: postgres
+  become_user: "{{ pg_user }}"
   become: True
 
 - name: assert output message restore the database
@@ -85,7 +85,7 @@
        - "'Joe Smith' in result.stdout"
 
 - name: state dump/restore - remove database name
-  postgresql_db: name={{ db_name }} state=absent
+  postgresql_db: "{{ pg_map | combine({'state': 'absent'}) }}"
 
 - name: remove file name
   file: name={{ db_file_name }}  state=absent

--- a/test/integration/targets/postgresql/tasks/state_dump_restore.yml
+++ b/test/integration/targets/postgresql/tasks/state_dump_restore.yml
@@ -1,0 +1,97 @@
+# test code for state dump and restore for postgresql_db module
+# copied from mysql_db/tasks/state_dump_import.yml
+# (c) 2014,  Wayne Rosario <wrosario@ansible.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# ============================================================
+- set_fact: db_file_name="{{tmp_dir}}/{{file}}"
+
+- set_fact:
+     pg_str: "env PGPASSWORD=password psql -h localhost -U {{ db_user1 }} {{ db_name }}"
+     pg_map:
+         name: "{{ db_name }}"
+         target: "{{ db_file_name }}"
+         login_host: "localhost"
+         login_user: "{{ db_user1 }}"
+         login_password: "password"
+
+- set_fact:
+     sql_create: "create table employee(id int, name varchar(100));"
+     sql_insert: "insert into employee values (47,'Joe Smith');"
+     sql_update: "update employee set name='John Doe' where id=47;"
+     sql_select: "select * from  employee;"
+
+- name: state dump/restore - create database
+  postgresql_db: name={{ db_name }} state=present owner={{ db_user1 }}
+  become_user: "{{ pg_user }}"
+  become: True
+
+- name: state dump/restore - create table employee
+  command: '{{ pg_str }} -c "{{ sql_create }}"'
+
+- name: state dump/restore - insert data into table employee
+  command: '{{ pg_str }} -c "{{ sql_insert }}"'
+
+- name: state dump/restore - file name should not exist
+  file: name={{ db_file_name }} state=absent
+
+- name: test state=dump to backup the database (expect changed=true)
+  postgresql_db: "{{ pg_map | combine({'state': 'dump'}) }}"
+  register: result
+
+- name: assert output message backup the database
+  assert:
+    that:
+       - "result.changed == true"
+       - "result.db =='{{ db_name }}'"
+
+- name: assert database was backup successfully
+  command: file {{ db_file_name }}
+  register: result
+
+- name: update database table employee
+  command: '{{ pg_str }} -c "{{ sql_update }}"'
+
+- name: test state=restore to restore the database (expect changed=true)
+  postgresql_db: "{{ pg_map | combine({'state': 'restore'}) }}"
+  register: result
+
+- name: assert output message restore the database
+  assert: { that: "result.changed == true" }
+
+- name: select data from table employee
+  command: '{{ pg_str }} -c "{{ sql_create }}"'
+  register: result
+
+- name: assert data in database is from the restore database
+  assert:
+    that:
+       - "'47' in result.stdout"
+       - "'Joe Smith' in result.stdout"
+
+- name: state dump/restore - remove database name
+  postgresql_db: name={{ db_name }} state=absent
+  become_user: "{{ pg_user }}"
+  become: True
+
+- name: state dump/restore - remove user
+  postgresql_user: name={{ db_user1 }} state=absent
+  become_user: "{{ pg_user }}"
+  become: True
+
+- name: remove file name
+  file: name={{ db_file_name }}  state=absent

--- a/test/integration/targets/postgresql/tasks/state_dump_restore.yml
+++ b/test/integration/targets/postgresql/tasks/state_dump_restore.yml
@@ -21,24 +21,19 @@
 - set_fact: db_file_name="{{tmp_dir}}/{{file}}"
 
 - set_fact:
-     pg_str: "env PGPASSWORD=password psql -h localhost -U {{ db_user1 }} {{ db_name }}"
+     pg_str: "psql -U postgres {{ db_name }}"
      pg_map:
          name: "{{ db_name }}"
          target: "{{ db_file_name }}"
-         login_host: "localhost"
-         login_user: "{{ db_user1 }}"
-         login_password: "password"
+         login_user: "postgres"
 
 - set_fact:
      sql_create: "create table employee(id int, name varchar(100));"
      sql_insert: "insert into employee values (47,'Joe Smith');"
-     sql_update: "update employee set name='John Doe' where id=47;"
      sql_select: "select * from  employee;"
 
 - name: state dump/restore - create database
-  postgresql_db: name={{ db_name }} state=present owner={{ db_user1 }}
-  become_user: "{{ pg_user }}"
-  become: True
+  postgresql_db: name={{ db_name }} state=present
 
 - name: state dump/restore - create table employee
   command: '{{ pg_str }} -c "{{ sql_create }}"'
@@ -52,29 +47,35 @@
 - name: test state=dump to backup the database (expect changed=true)
   postgresql_db: "{{ pg_map | combine({'state': 'dump'}) }}"
   register: result
+  become_user: postgres
+  become: True
 
 - name: assert output message backup the database
   assert:
     that:
        - "result.changed == true"
-       - "result.db =='{{ db_name }}'"
 
-- name: assert database was backup successfully
+- name: assert database was backed up successfully
   command: file {{ db_file_name }}
   register: result
 
-- name: update database table employee
-  command: '{{ pg_str }} -c "{{ sql_update }}"'
+- name: state dump/restore - remove database for restore
+  postgresql_db: name={{ db_name }} state=absent
+
+- name: state dump/restore - re-create database
+  postgresql_db: name={{ db_name }} state=present
 
 - name: test state=restore to restore the database (expect changed=true)
   postgresql_db: "{{ pg_map | combine({'state': 'restore'}) }}"
   register: result
+  become_user: postgres
+  become: True
 
 - name: assert output message restore the database
   assert: { that: "result.changed == true" }
 
 - name: select data from table employee
-  command: '{{ pg_str }} -c "{{ sql_create }}"'
+  command: '{{ pg_str }} -c "{{ sql_select }}"'
   register: result
 
 - name: assert data in database is from the restore database
@@ -85,13 +86,6 @@
 
 - name: state dump/restore - remove database name
   postgresql_db: name={{ db_name }} state=absent
-  become_user: "{{ pg_user }}"
-  become: True
-
-- name: state dump/restore - remove user
-  postgresql_user: name={{ db_user1 }} state=absent
-  become_user: "{{ pg_user }}"
-  become: True
 
 - name: remove file name
   file: name={{ db_file_name }}  state=absent


### PR DESCRIPTION
Originally filed as https://github.com/ansible/ansible-modules-core/pull/2752 by @autotune. 

---

Ended up just recreating the branch with the specific modified file on there per #2751. The issue template has been re-posted below as well:

Issue Type:

Can you help us out in labelling this by telling us what kind of ticket this this? You can say:
Feature Pull Request

Component Name:
postgresql_db module

Ansible Version: 2.1.0

Ansible Configuration:

Standard config.

Environment:

[autotune@ansibledev ansible-modules-core]$ cat /etc/redhat-release
CentOS Linux release 7.1.1503 (Core)

Summary:

This module adds an import and dump state to the core postgresql_db Module that supports .tar, .gz, .xz, .bz, and a standard .sql file:

```

---
- hosts: local
  tasks:
- name:
  2731_postgresql_db: name=ansitest login_user=postgres state=dump login_host=127.0.0.1 target=~/dev/features/2731/ansitest.sql.xz
```

Steps To Reproduce:

Run the above playbook with a database that exists in postgres called "ansitest" and do a dump. Run the same playbook with "state=import" and change name to an new, empty database, and import.

Expected Results:

Either a new dump created in the form of a compressed file or an imported database.

Actual Results:

See above.
