### PR TITLE
Typo value => values

### DIFF
--- a/lib/ansible/modules/network/ldap_attr.py
+++ b/lib/ansible/modules/network/ldap_attr.py
@@ -169,7 +169,7 @@ EXAMPLES = """
   ldap_attr:
     dn: uid=jdoe,ou=people,dc=example,dc=com
     name: shadowExpire
-    value: ""
+    values: ""
     state: exact
     server_uri: ldap://localhost/
     bind_dn: cn=admin,dc=example,dc=com
@@ -187,7 +187,7 @@ EXAMPLES = """
   ldap_attr:
     dn: uid=jdoe,ou=people,dc=example,dc=com
     name: shadowExpire
-    value: ""
+    values: ""
     state: exact
     params: "{{ ldap_auth }}"
 """


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ldap_attr

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
A couple of the examples in the ldap_attr module throw errors. It turns out it's just a typo because they use `value` where they should use `values`