### PR TITLE
Add MariadDB GTID support to mysql_replication module

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -106,13 +106,10 @@ options:
     master_use_gtid:
         description:
             - MariaDB Global Transaction ID parameter
-        required: False
-        choices:
-            - current_pos
-            - slave_pos
-            - no
-        default: null
-        version_added: "2.4"
+        type: str
+        choices: [ current_pos, 'no', slave_pos ]
+        default: 'no'
+        version_added: "2.8"
 
 extends_documentation_fragment: mysql
 '''
@@ -220,7 +217,7 @@ def main():
             mode=dict(default="getslave", choices=["getmaster", "getslave", "changemaster", "stopslave", "startslave", "resetslave", "resetslaveall"]),
             master_auto_position=dict(default=False, type='bool'),
             master_host=dict(default=None),
-            master_use_gtid=dict(default=None, choices=["current_pos", "slave_pos", "no"]),
+            master_use_gtid=dict(type='str', choices=["current_pos", "no", "slave_pos"]),
             master_user=dict(default=None),
             master_password=dict(default=None, no_log=True),
             master_port=dict(default=None, type='int'),
@@ -351,7 +348,7 @@ def main():
             chm_params['master_ssl_cipher'] = master_ssl_cipher
         if master_auto_position:
             chm.append("MASTER_AUTO_POSITION = 1")
-        if master_use_gtid:
+        if master_use_gtid != 'no':
             chm.append("MASTER_USE_GTID=%s" % master_use_gtid)
         try:
             changemaster(cursor, chm, chm_params)

--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -105,10 +105,10 @@ options:
         version_added: "2.0"
     master_use_gtid:
         description:
-            - MariaDB Global Transaction ID parameter
+            - MariaDB Global Transaction ID parameter.
+            - By default no GTID is used.
         type: str
-        choices: [ current_pos, 'no', slave_pos ]
-        default: 'no'
+        choices: [ current_pos, slave_pos ]
         version_added: "2.8"
 
 extends_documentation_fragment: mysql
@@ -217,7 +217,7 @@ def main():
             mode=dict(default="getslave", choices=["getmaster", "getslave", "changemaster", "stopslave", "startslave", "resetslave", "resetslaveall"]),
             master_auto_position=dict(default=False, type='bool'),
             master_host=dict(default=None),
-            master_use_gtid=dict(type='str', choices=["current_pos", "no", "slave_pos"]),
+            master_use_gtid=dict(type='str', choices=['current_pos', 'slave_pos']),
             master_user=dict(default=None),
             master_password=dict(default=None, no_log=True),
             master_port=dict(default=None, type='int'),
@@ -348,7 +348,7 @@ def main():
             chm_params['master_ssl_cipher'] = master_ssl_cipher
         if master_auto_position:
             chm.append("MASTER_AUTO_POSITION = 1")
-        if master_use_gtid != 'no':
+        if master_use_gtid is not None:
             chm.append("MASTER_USE_GTID=%s" % master_use_gtid)
         try:
             changemaster(cursor, chm, chm_params)

--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -103,6 +103,16 @@ options:
         required: false
         default: null
         version_added: "2.0"
+    master_use_gtid:
+        description:
+            - MariaDB Global Transaction ID parameter
+        required: False
+        choices:
+            - current_pos
+            - slave_pos
+            - no
+        default: null
+        version_added: "2.4"
 
 extends_documentation_fragment: mysql
 '''
@@ -210,6 +220,7 @@ def main():
             mode=dict(default="getslave", choices=["getmaster", "getslave", "changemaster", "stopslave", "startslave", "resetslave", "resetslaveall"]),
             master_auto_position=dict(default=False, type='bool'),
             master_host=dict(default=None),
+            master_use_gtid=dict(default=None, choices=["current_pos", "slave_pos", "no"]),
             master_user=dict(default=None),
             master_password=dict(default=None, no_log=True),
             master_port=dict(default=None, type='int'),
@@ -248,6 +259,7 @@ def main():
     master_ssl_key = module.params["master_ssl_key"]
     master_ssl_cipher = module.params["master_ssl_cipher"]
     master_auto_position = module.params["master_auto_position"]
+    master_use_gtid = module.params["master_use_gtid"]
     ssl_cert = module.params["ssl_cert"]
     ssl_key = module.params["ssl_key"]
     ssl_ca = module.params["ssl_ca"]
@@ -339,6 +351,8 @@ def main():
             chm_params['master_ssl_cipher'] = master_ssl_cipher
         if master_auto_position:
             chm.append("MASTER_AUTO_POSITION = 1")
+        if master_use_gtid:
+            chm.append("MASTER_USE_GTID=%s" % master_use_gtid)
         try:
             changemaster(cursor, chm, chm_params)
         except MySQLdb.Warning:


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
mysql_replication module

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
The mysql_replication module does not support the MariaDB GTID. See https://mariadb.com/kb/en/mariadb/gtid/ for more information about mariaDB GTID.
See also https://github.com/ansible/ansible-modules-extras/issues/817 from the ansible-module-extra repo.


I added a new parameter to the mysql_replication module :
```yaml
    master_use_gtid:
        description:
            - MariaDB Global Transaction ID parameter
        required: False
        choices:
            - current_pos
            - slave_pos
            - no
        default: null
```

Without this patch, we needed to use the `command` module:
```yaml
  - name: assigning master to slaves
    command: mysql -u root -p{{mysql_root_password}} -e "change master '{{ master_host }}' to master_host='{{ master_host }}', master_user='{{ mysql_replica_user }}', master_password='{{ mysql_replica_pass }}', master_use_gtid=current_pos;"
```

Now you can use the mysl_replication module:
```yaml
  - name: assigning master to slaves
    mysql_replication:
      mode: changemaster
      master_host: {{ master_host }}
      master_user: "{{ mysql_replica_user }}"
      master_password: "{{ mysql_replica_pass }}"
      master_use_gtid: current_pos
```