### PR TITLE
Fix OpenStack keystone domain idempotency

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_keystone_domain.py
+++ b/lib/ansible/modules/cloud/openstack/os_keystone_domain.py
@@ -106,7 +106,8 @@ id:
 '''
 
 def _needs_update(module, domain):
-    if domain.description != module.params['description']:
+    if module.params['description'] is not None and \
+       domain.description != module.params['description']:
         return True
     if domain.enabled != module.params['enabled']:
         return True


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloud/openstack/os_keystone_domain

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible']
```

##### SUMMARY
Without this patch, the os_keystone_domain module is not idempotent if
the description is empty because the description parameter is None in
ansible, but the keystone client returns an empty unicode string.
Following the example of other OpenStack modules, this patch fixes the
issue by checking whether the module parameter is None before going on
to check its value.