### PR TITLE
Fix crash when converting to json the result of an (i)map

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -167,6 +167,8 @@ from ansible.module_utils.six import (PY2, PY3, b, binary_type, integer_types,
 from ansible.module_utils.six.moves import map, reduce
 from ansible.module_utils._text import to_native, to_bytes, to_text
 
+ITERABLETYPE = (map,)
+
 PASSWORD_MATCH = re.compile(r'^(?:.+[-_\s])?pass(?:[-_\s]?(?:word|phrase|wrd|wd)?)(?:[-_\s].+)?$', re.I)
 
 _NUMBERTYPES = tuple(list(integer_types) + [float])
@@ -366,7 +368,7 @@ def return_values(obj):
         if obj:
             yield to_native(obj, errors='surrogate_or_strict')
         return
-    elif isinstance(obj, SEQUENCETYPE):
+    elif isinstance(obj, SEQUENCETYPE) or isinstance(obj, ITERABLETYPE):
         for element in obj:
             for subelement in return_values(element):
                 yield subelement


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/module_utils/basic.py`

##### ANSIBLE VERSION
```
2.2.0.0
```

##### SUMMARY
Results of `map`s command (patched by `six` to become `imaps`) can't be converted to json. The current behavior breaks some modules as `haproxy`.
This patch makes the results of `imaps` intelligible as a sequence type.