### PR TITLE
Fixing nxos modules when interface is loopback

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
@@ -607,6 +607,9 @@ def main():
                                                     'message_digest_password']],
                                 supports_check_mode=True)
 
+    if not module.params['interface'].startswith('loopback'):
+        module.params['interface'] = module.params['interface'].capitalize()
+
     for param in ['message_digest_encryption_type',
                   'message_digest_algorithm_type',
                   'message_digest_password']:

--- a/lib/ansible/modules/network/nxos/nxos_vrf_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrf_interface.py
@@ -387,7 +387,7 @@ def get_vrf_list(module):
 def get_interface_info(interface, module):
     if not interface.startswith('loopback'):
         interface = interface.capitalize()
-    command = 'show run | section interface.{0}'.format(interface.capitalize())
+    command = 'show run | section interface.{0}'.format(interface)
     vrf_regex = ".*vrf\s+member\s+(?P<vrf>\S+).*"
 
     try:

--- a/lib/ansible/modules/network/nxos/nxos_vrf_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrf_interface.py
@@ -385,6 +385,8 @@ def get_vrf_list(module):
 
 
 def get_interface_info(interface, module):
+    if not interface.startswith('loopback'):
+        interface = interface.capitalize()
     command = 'show run | section interface.{0}'.format(interface.capitalize())
     vrf_regex = ".*vrf\s+member\s+(?P<vrf>\S+).*"
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_interface_ospf, nxos_vrf_interface

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Solves #19088

This  need backporting to stable-2.2 as well.
