### PR TITLE
Modifying how optional parameters are handled in rds.py. Fixes #20370

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds.py
+++ b/lib/ansible/modules/cloud/amazon/rds.py
@@ -1001,11 +1001,14 @@ def validate_parameters(required_vars, valid_vars, module):
 
     params = {}
     for (k, v) in optional_params.items():
-        if module.params.get(k) and k not in required_vars:
+        if module.params.get(k) in [True, False] and k not in required_vars:
             if k in valid_vars:
                 params[v] = module.params[k]
             else:
-                module.fail_json(msg="Parameter %s is not valid for %s command" % (k, command))
+                if module.params.get(k) == False:
+                    pass
+                else:
+                    module.fail_json(msg="Parameter %s is not valid for %s command" % (k, command))
 
     if module.params.get('security_groups'):
         params[sec_group] = module.params.get('security_groups').split(',')

--- a/lib/ansible/modules/cloud/amazon/rds.py
+++ b/lib/ansible/modules/cloud/amazon/rds.py
@@ -1001,7 +1001,7 @@ def validate_parameters(required_vars, valid_vars, module):
 
     params = {}
     for (k, v) in optional_params.items():
-        if module.params.get(k) in [True, False] and k not in required_vars:
+        if module.params.get(k) is not None and k not in required_vars:
             if k in valid_vars:
                 params[v] = module.params[k]
             else:


### PR DESCRIPTION
Allowing options to be set to false/no. Previously ignored unless set to true/yes.

Added a conditional for invalid parameters since the default is false instead of null for some options (e.g. force_failover, apply_immediately, upgrade).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/rds.py

##### ANSIBLE VERSION
```
ansible 2.3.0 (rds_param_fix f695114736) last updated 2017/01/25 10:43:30 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Fixes #20370. 
The problem: if a parameter was set to False it would be ignored (preventing the user from turning an option off). For example, if the user modified their instance using `multi_zone: no` in their playbook it wouldn't be added to the parameters used (just like the optional parameters that were by default set to null or false). So I changed that to allow parameters that were not None.
This introduced a second problem since not all defaults are null. I added a couple lines to allow if the parameter was both invalid and False to be ignored since it may be the default. If there's an easy way to ensure it's the default it might be a good thing to add.
Another way we could fix that second issue is to make all the defaults null.

The command output stayed the same after the change. The result after the change now reflects that output.
Excerpt:
```
...
TASK [modify db instance] *********************************************************************
....
changed: [localhost] => {
    "changed": true,
    "instance": {
        ...
        "multi_zone": true,
        "port": 3306,
        "replication_source": null,
        "status": "available",
        ...
    },
    "invocation": {
        "module_args": {
            "apply_immediately": true,
            ...
            "multi_zone": false,
            ...
        },
        "module_name": "rds"
    }
}

PLAY RECAP ************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0
```
