### PR TITLE
Reminder that lookup(‘file’) can be used

### DIFF
--- a/lib/ansible/modules/files/blockinfile.py
+++ b/lib/ansible/modules/files/blockinfile.py
@@ -128,7 +128,7 @@ EXAMPLES = r"""
 
 – name: insert/update configuration using a local file
   blockinfile:
-    block: "{{ lookup(‘file’, ‘./local/ssh_config’) }}"
+    block: "{{ lookup('file', './local/ssh_config') }}"
     dest: "/etc/ssh/ssh_config"
     backup: yes
 

--- a/lib/ansible/modules/files/blockinfile.py
+++ b/lib/ansible/modules/files/blockinfile.py
@@ -126,7 +126,7 @@ EXAMPLES = r"""
           address 192.0.2.23
           netmask 255.255.255.0
 
-– name: insert/update configuration using a local file
+- name: insert/update configuration using a local file
   blockinfile:
     block: "{{ lookup('file', './local/ssh_config') }}"
     dest: "/etc/ssh/ssh_config"

--- a/lib/ansible/modules/files/blockinfile.py
+++ b/lib/ansible/modules/files/blockinfile.py
@@ -126,6 +126,12 @@ EXAMPLES = r"""
           address 192.0.2.23
           netmask 255.255.255.0
 
+– name: insert/update configuration using a local file
+  blockinfile:
+    block: "{{ lookup(‘file’, ‘./local/ssh_config’) }}"
+    dest: "/etc/ssh/ssh_config"
+    backup: yes
+
 - name: insert/update HTML surrounded by custom markers after <body> line
   blockinfile:
     path: /var/www/html/index.html


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
blockinfile

##### ANSIBLE VERSION
Dev

##### SUMMARY
Sometimes a block of text does not easily fit into a playbook, so this acts as a reminder (or a prompt for anyone who hasn't used this before) that the content could be stored in an separate file.

I've also included `backup: yes` as I think this is a good example of where a backup might be needed.