### PR TITLE
Correct links to modules source code

### DIFF
--- a/docs/docsite/_themes/srtd/footer.html
+++ b/docs/docsite/_themes/srtd/footer.html
@@ -30,6 +30,6 @@
   {%- endif %}
   </p>
 <p>
-Ansible docs are generated from <a href="https://github.com/ansible/ansible">GitHub sources</A> using <A HREF="http://sphinx-doc.org/">Sphinx</A> using a theme provided by <a href="http://readthedocs.org">Read the Docs</a>. {% if pagename.endswith("_module") %}. Module documentation is not edited directly, but is generated from the source code for the modules. To submit an update to module docs, edit the 'DOCUMENTATION' metadata in the module itself.{% endif %}
+Ansible docs are generated from <a href="https://github.com/ansible/ansible">GitHub sources</a> using <a href="http://sphinx-doc.org/">Sphinx</a> using a theme provided by <a href="http://readthedocs.org">Read the Docs</a>. {% if pagename.endswith("_module") %}. Module documentation is not edited directly, but is generated from the source code for the modules.  To submit an update to module docs, edit the 'DOCUMENTATION' metadata in the <a href="https://github.com/ansible/ansible/tree/devel/lib/ansible/modules">modules directory</a> of the <a href="https://github.com/ansible/ansible/">core source code repository</a>. {% endif %}
 </p>
 </footer>


### PR DESCRIPTION
##### ISSUE TYPE
Docs Pull Request

##### COMPONENT NAME
Website (https://docs.ansible.com/)

##### SUMMARY
As per issue #20647, the modules are now in the main Ansible repository.