### PR TITLE
Synchronous actions were introduced in Solaris 11.2 to be precise.

### DIFF
--- a/lib/ansible/modules/system/service.py
+++ b/lib/ansible/modules/system/service.py
@@ -1310,10 +1310,10 @@ class SunOSService(Service):
 
     def svcadm_supports_sync(self):
         # Support for synchronous restart/refresh is only supported on
-        # Oracle Solaris >= 11.
+        # Oracle Solaris >= 11.2
         for line in open('/etc/release', 'r').readlines():
             m = re.match('\s+Oracle Solaris (\d+\.\d+).*', line.rstrip())
-            if m and m.groups()[0] > 10:
+            if m and m.groups()[0] >= 11.2:
                 return True
 
     def get_service_status(self):


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

`service`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
v2.3
```

##### SUMMARY

As discussed on IRC, `-s` was added in Solaris 11.2.
