### PR TITLE
Ansible module introspect

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -207,6 +207,7 @@ DEFAULT_MODULE_ARGS       = get_config(p, DEFAULTS, 'module_args',      'ANSIBLE
 DEFAULT_MODULE_LANG       = get_config(p, DEFAULTS, 'module_lang',      'ANSIBLE_MODULE_LANG',      os.getenv('LANG', 'en_US.UTF-8'))
 DEFAULT_MODULE_SET_LOCALE = get_config(p, DEFAULTS, 'module_set_locale','ANSIBLE_MODULE_SET_LOCALE',False, value_type='boolean')
 DEFAULT_MODULE_COMPRESSION= get_config(p, DEFAULTS, 'module_compression', None, 'ZIP_DEFLATED')
+DEFAULT_MODULE_INTROSPECT = get_config(p, DEFAULTS, 'module_introspect', 'ANSIBLE_MODULE_INTROSPECT', False)
 DEFAULT_TIMEOUT           = get_config(p, DEFAULTS, 'timeout',          'ANSIBLE_TIMEOUT',          10, value_type='integer')
 DEFAULT_POLL_INTERVAL     = get_config(p, DEFAULTS, 'poll_interval',    'ANSIBLE_POLL_INTERVAL',    15, value_type='integer')
 DEFAULT_REMOTE_USER       = get_config(p, DEFAULTS, 'remote_user',      'ANSIBLE_REMOTE_USER',      None)

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -208,6 +208,7 @@ DEFAULT_MODULE_LANG       = get_config(p, DEFAULTS, 'module_lang',      'ANSIBLE
 DEFAULT_MODULE_SET_LOCALE = get_config(p, DEFAULTS, 'module_set_locale','ANSIBLE_MODULE_SET_LOCALE',False, value_type='boolean')
 DEFAULT_MODULE_COMPRESSION= get_config(p, DEFAULTS, 'module_compression', None, 'ZIP_DEFLATED')
 DEFAULT_MODULE_INTROSPECT = get_config(p, DEFAULTS, 'module_introspect', 'ANSIBLE_MODULE_INTROSPECT', False)
+DEFAULT_MODULE_INTROSPECT_ONLY = get_config(p, DEFAULTS, 'module_introspect_only', 'ANSIBLE_MODULE_INTROSPECT_ONLY', False)
 DEFAULT_TIMEOUT           = get_config(p, DEFAULTS, 'timeout',          'ANSIBLE_TIMEOUT',          10, value_type='integer')
 DEFAULT_POLL_INTERVAL     = get_config(p, DEFAULTS, 'poll_interval',    'ANSIBLE_POLL_INTERVAL',    15, value_type='integer')
 DEFAULT_REMOTE_USER       = get_config(p, DEFAULTS, 'remote_user',      'ANSIBLE_REMOTE_USER',      None)

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -628,6 +628,8 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
         params = dict(ANSIBLE_MODULE_ARGS=module_args,)
         python_repred_params = repr(json.dumps(params))
 
+        include_introspection = module_args.get('_ansible_module_introspect', False)
+
         try:
             compression_method = getattr(zipfile, module_compression)
         except AttributeError:
@@ -676,6 +678,15 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
 
                     py_module_cache = { ('__init__',): b'' }
                     recursive_finder(module_name, b_module_data, py_module_names, py_module_cache, zf)
+                    if include_introspection:
+                        py_module_names.add(('introspection',))
+                    else:
+                        # FIXME: if there is a way to get recursive_finder to ignore a ansible.module_utils import
+                        try:
+                            py_module_names.remove(('introspection',))
+                        except KeyError:
+                            pass
+
                     zf.close()
                     zipdata = base64.b64encode(zipoutput.getvalue())
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -677,7 +677,10 @@ class AnsibleModule(object):
         self.argument_spec = argument_spec
         self.supports_check_mode = supports_check_mode
         self.check_mode = False
+        # Should we include module introspection info
         self.introspect = False
+        # If true, only return the introspection info and dont change any state
+        self.introspect_only = False
         self.no_log = no_log
         self.cleanup_files = []
         self._debug = False
@@ -691,7 +694,7 @@ class AnsibleModule(object):
         self._deprecations = []
 
         self.aliases = {}
-        self._legal_inputs = ['_ansible_check_mode', '_ansible_no_log', '_ansible_debug', '_ansible_diff', '_ansible_verbosity', '_ansible_selinux_special_fs', '_ansible_module_name', '_ansible_version', '_ansible_syslog_facility', '_ansible_socket', '_ansible_module_introspect']
+        self._legal_inputs = ['_ansible_check_mode', '_ansible_no_log', '_ansible_debug', '_ansible_diff', '_ansible_verbosity', '_ansible_selinux_special_fs', '_ansible_module_name', '_ansible_version', '_ansible_syslog_facility', '_ansible_socket', '_ansible_module_introspect', '_ansible_module_introspect_only']
 
         if add_file_common_args:
             for k, v in FILE_COMMON_ARGUMENTS.items():
@@ -1462,6 +1465,8 @@ class AnsibleModule(object):
                 unsupported_parameters.add(k)
             elif k == '_ansible_module_introspect':
                 self.introspect = v
+            elif k == '_ansible_module_introspect_only':
+                self.introspect_only = v
 
 
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -824,12 +824,12 @@ class AnsibleModule(object):
         data['module_path'] = get_module_path()
         data['locale'] = locale.getlocale()
 
-        module_data = self._introspect_module()
-        data.update(module_data)
+        module_info = self._introspect_module_info()
+        data.update(module_info)
 
         return data
 
-    def _introspect_module(self):
+    def _introspect_module_info(self):
         data = {}
 
         import __main__

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -807,23 +807,38 @@ class AnsibleModule(object):
         data = {}
         data['name'] = self._name
         data['ansible_version'] = self.ansible_version
+
         data['argument_spec'] = self.argument_spec
         data['supports_check_mode'] = self.supports_check_mode
         data['check_mode'] = self.check_mode
+
+        data['supported_params'] = self._public_legal_inputs
+
+        # The effective params used by the module. Include params supplied by user as
+        # well as any required defaults.
+
+        # The valid module parameters as well as the _ansible_* parameters used interally by ansible
+        data['params'] = self.params
+
+        data['aliases'] = self.aliases
+        data['legal_inputs'] = self._legal_inputs
+
+        data['used_fallbacks'] = self._used_fallbacks
+
+        # A list of params that were not provided by the user and the default was used.
+        data['used_defaults'] = self._used_defaults
+
+        data['module_path'] = get_module_path()
+
         data['no_log'] = self.no_log
         data['no_log_values'] = list(self.no_log_values)
+
+        # module invocation options
         data['cleanup_files'] = self.cleanup_files
         data['debug'] = self._debug
         data['diff'] = self._diff
         data['verbosity'] = self._verbosity
         data['run_command_environ_update'] = self.run_command_environ_update
-        data['aliases'] = self.aliases
-        data['legal_inputs'] = self._legal_inputs
-        data['supported_params'] = self._public_legal_inputs
-        data['params'] = self.params
-        data['used_fallbacks'] = self._used_fallbacks
-        data['used_defaults'] = self._used_defaults
-        data['module_path'] = get_module_path()
         data['locale'] = locale.getlocale()
 
         module_info = self._introspect_module_info()

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -799,8 +799,6 @@ class AnsibleModule(object):
         else:
             raise TypeError("deprecate requires a string not a %s" % type(msg))
 
-        if self.introspect and self.introspect_only:
-            self.exit_json(msg="Introspect only mode.")
 
     def _introspect(self):
         data = {}
@@ -860,7 +858,6 @@ class AnsibleModule(object):
         data['metadata'] = module_meta_info
 
         return data
-
 
     def load_file_common_arguments(self, params):
         '''
@@ -1512,8 +1509,6 @@ class AnsibleModule(object):
             elif k == '_ansible_module_introspect_only':
                 self.introspect_only = v
 
-
-
             #clean up internal params:
             if k.startswith('_ansible_'):
                 del self.params[k]
@@ -2060,12 +2055,13 @@ class AnsibleModule(object):
         kwargs = remove_values(kwargs, self.no_log_values)
         print('\n%s' % self.jsonify(kwargs))
 
-
     def exit_json(self, **kwargs):
         ''' return from the module, without error '''
 
         if not 'changed' in kwargs:
             kwargs['changed'] = False
+        if self.introspect:
+            kwargs['introspect'] = self._introspect()
 
         self.do_cleanup_files()
         self._return_formatted(kwargs)

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -665,7 +665,8 @@ class AnsibleFallbackNotFound(Exception):
 class AnsibleModule(object):
     def __init__(self, argument_spec, bypass_checks=False, no_log=False,
         check_invalid_arguments=True, mutually_exclusive=None, required_together=None,
-        required_one_of=None, add_file_common_args=False, supports_check_mode=False, required_if=None):
+        required_one_of=None, add_file_common_args=False, supports_check_mode=False,
+        required_if=None):
 
         '''
         common code for quickly building an ansible module in Python

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -665,9 +665,7 @@ class AnsibleFallbackNotFound(Exception):
 class AnsibleModule(object):
     def __init__(self, argument_spec, bypass_checks=False, no_log=False,
         check_invalid_arguments=True, mutually_exclusive=None, required_together=None,
-        required_one_of=None, add_file_common_args=False, supports_check_mode=False,
-        required_if=None, module_documentation=None, module_metadata=None, module_return=None,
-                 module_examples=None):
+        required_one_of=None, add_file_common_args=False, supports_check_mode=False, required_if=None):
 
         '''
         common code for quickly building an ansible module in Python
@@ -679,6 +677,7 @@ class AnsibleModule(object):
         self.argument_spec = argument_spec
         self.supports_check_mode = supports_check_mode
         self.check_mode = False
+        self.introspect = False
         self.no_log = no_log
         self.cleanup_files = []
         self._debug = False
@@ -768,10 +767,6 @@ class AnsibleModule(object):
         if not self.no_log:
             self._log_invocation()
 
-        self.module_documentation = module_documentation
-        self.module_metadata = module_metadata
-        self.module_return = module_return
-        self.module_examples = module_examples
         # finally, make sure we're in a sane working dir
         self._set_cwd()
 
@@ -814,10 +809,11 @@ class AnsibleModule(object):
         data['locale'] = locale.getlocale()
         data['used_defaults'] = self._used_defaults
         data['module_path'] = get_module_path()
-        data['module_documentation'] = self.module_documentation
-        data['module_metadata'] = self.module_metadata
-        data['module_return'] = self.module_return
-        data['module_examples'] = self.module_examples
+        import __main__
+        data['module_documentation'] = getattr(__main__, 'DOCUMENTATION', None)
+        data['module_metadata'] = getattr(__main__, 'ANSIBLE_METADATA', None)
+        data['module_return'] = getattr(__main__, 'RETURN', None)
+        data['module_examples'] = getattr(__main__, 'EXAMPLES', None)
         return data
 
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -169,6 +169,8 @@ from ansible.module_utils._text import to_native, to_bytes, to_text
 
 PASSWORD_MATCH = re.compile(r'^(?:.+[-_\s])?pass(?:[-_\s]?(?:word|phrase|wrd|wd)?)(?:[-_\s].+)?$', re.I)
 
+import __main__ as module_main
+
 _NUMBERTYPES = tuple(list(integer_types) + [float])
 
 # Deprecated compat.  Only kept in case another module used these names  Using
@@ -832,11 +834,10 @@ class AnsibleModule(object):
     def _introspect_module_info(self):
         data = {}
 
-        import __main__
-        data['module_documentation'] = getattr(__main__, 'DOCUMENTATION', None)
-        data['module_metadata'] = getattr(__main__, 'ANSIBLE_METADATA', None)
-        data['module_return'] = getattr(__main__, 'RETURN', None)
-        data['module_examples'] = getattr(__main__, 'EXAMPLES', None)
+        data['module_documentation'] = getattr(module_main, 'DOCUMENTATION', None)
+        data['module_metadata'] = getattr(module_main, 'ANSIBLE_METADATA', None)
+        data['module_return'] = getattr(module_main, 'RETURN', None)
+        data['module_examples'] = getattr(module_main, 'EXAMPLES', None)
         return data
 
 

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -36,6 +36,7 @@ from ansible.module_utils.basic import get_all_subclasses
 from ansible.module_utils.six import PY3, iteritems
 from ansible.module_utils.six.moves import configparser, StringIO, reduce
 from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils import introspection
 
 try:
     import selinux
@@ -608,25 +609,11 @@ class Facts(object):
         return size_total, size_available
 
     def get_python_facts(self):
-        self.facts['python'] = {
-            'version': {
-                'major': sys.version_info[0],
-                'minor': sys.version_info[1],
-                'micro': sys.version_info[2],
-                'releaselevel': sys.version_info[3],
-                'serial': sys.version_info[4]
-            },
-            'version_info': list(sys.version_info),
-            'executable': sys.executable,
-            'has_sslcontext': HAS_SSLCONTEXT
-        }
-        try:
-            self.facts['python']['type'] = sys.subversion[0]
-        except AttributeError:
-            try:
-                self.facts['python']['type'] = sys.implementation.name
-            except AttributeError:
-                self.facts['python']['type'] = None
+
+        python_info = introspection.python_info()
+        python_info['has_sslcontext'] = HAS_SSLCONTEXT
+
+        self.facts['python'] = python_info
 
 
 class Distribution(object):

--- a/lib/ansible/module_utils/introspection.py
+++ b/lib/ansible/module_utils/introspection.py
@@ -113,7 +113,7 @@ def python_paths_info():
     path_info['path'] = sys.path
     path_info['prefix'] = sys.prefix
     path_info['exec_prefix'] = sys.exec_prefix
-    path_info['meta_path'] = sys.meta_path
+    path_info['meta_path'] = [repr(x) for x in sys.meta_path]
 
     # items in path hooks can be custom types, namely zipimporter
     path_info['path_hooks'] = [repr(x) for x in sys.path_hooks]

--- a/lib/ansible/module_utils/introspection.py
+++ b/lib/ansible/module_utils/introspection.py
@@ -91,6 +91,14 @@ def python_info():
     # items in path hooks can be custom types, namely zipimporter
     python_info['sys_path_hooks'] = [repr(x) for x in sys.path_hooks]
 
+    sys_modules_info = {}
+    for name, py_module in sys.modules.items():
+        module_repr = None
+        if py_module:
+            module_repr = repr(py_module)
+        sys_modules_info[name] = module_repr
+
+    python_info['sys_modules'] = sys_modules_info
     # Note: sys.version and other info is already collected in get_python_facts
     #       during fact collection. This info could be collected there as well.
 

--- a/lib/ansible/module_utils/introspection.py
+++ b/lib/ansible/module_utils/introspection.py
@@ -80,6 +80,23 @@ def python_site_info():
     return python_info
 
 
+def python_version_info():
+    version_info = {}
+
+    # Note: sys.version and other info is already collected in get_python_facts
+    #       during fact collection. This info could be collected there as well.
+    versions = {'major': sys.version_info[0],
+                'minor': sys.version_info[1],
+                'micro': sys.version_info[2],
+                'releaselevel': sys.version_info[3],
+                'serial': sys.version_info[4]}
+
+    version_info['version'] = versions
+    version_info['version_list'] = list(sys.version_info)
+
+    return version_info
+
+
 def python_info():
     python_info = {}
 
@@ -88,6 +105,7 @@ def python_info():
     python_info['sys_prefix'] = sys.prefix
     python_info['sys_exec_prefix'] = sys.exec_prefix
     python_info['sys_meta_path'] = sys.meta_path
+
     # items in path hooks can be custom types, namely zipimporter
     python_info['sys_path_hooks'] = [repr(x) for x in sys.path_hooks]
 
@@ -99,8 +117,21 @@ def python_info():
         sys_modules_info[name] = module_repr
 
     python_info['sys_modules'] = sys_modules_info
-    # Note: sys.version and other info is already collected in get_python_facts
-    #       during fact collection. This info could be collected there as well.
+
+    python_info['executable'] = sys.executable
+
+    python_type = None
+    try:
+        python_type = sys.subversion[0]
+    except AttributeError:
+        try:
+            python_type = sys.implementation.name
+        except AttributeError:
+            pass
+    python_info['type'] = python_type
+
+    versions = python_version_info()
+    python_info.update(versions)
 
     return python_info
 

--- a/lib/ansible/module_utils/introspection.py
+++ b/lib/ansible/module_utils/introspection.py
@@ -1,0 +1,119 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Copyright (c), Adrian Likins <alikins@redhat.com>, 2016-2017
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+import locale
+import os
+import sys
+
+import __main__ as module_main
+
+
+def _module_meta_info():
+    meta_info = {}
+
+    meta_info['documentation'] = getattr(module_main, 'DOCUMENTATION', None)
+    meta_info['metadata'] = getattr(module_main, 'ANSIBLE_METADATA', None)
+    meta_info['return'] = getattr(module_main, 'RETURN', None)
+    meta_info['examples'] = getattr(module_main, 'EXAMPLES', None)
+
+    return meta_info
+
+
+def process_info():
+    process_info = {}
+
+    process_info['pid'] = os.getpid()
+    process_info['uid'] = os.getuid()
+    process_info['euid'] = os.geteuid()
+    process_info['gid'] = os.getgid()
+    process_info['cwd'] = os.getcwdu()
+    process_info['ppid'] = os.getppid()
+
+    return process_info
+
+
+def python_site_info():
+    import site
+
+    python_info = {}
+
+    # These only exist for python 2.6+
+    try:
+        python_info['site_PREFIXES'] = site.PREFIXES
+        python_info['site_USER_SITE'] = site.USER_SITE
+        python_info['site_USER_BASE'] = site.USER_BASE
+    except AttributeError:
+        pass
+
+    # only exists in python 2.7+
+    try:
+        python_info['site_getsitepackages'] = site.getsitepackages()
+    except AttributeError:
+        pass
+
+    return python_info
+
+
+def python_info():
+    python_info = {}
+
+    python_info['sys_argv'] = sys.argv
+    python_info['sys_path'] = sys.path
+    python_info['sys_prefix'] = sys.prefix
+    python_info['sys_exec_prefix'] = sys.exec_prefix
+    python_info['sys_meta_path'] = sys.meta_path
+    # items in path hooks can be custom types, namely zipimporter
+    python_info['sys_path_hooks'] = [repr(x) for x in sys.path_hooks]
+
+    # Note: sys.version and other info is already collected in get_python_facts
+    #       during fact collection. This info could be collected there as well.
+
+    return python_info
+
+
+def env_info():
+    return os.environ.copy()
+
+
+def module_invocation():
+    # info about the env and runtime of the module as it was invoked
+    data = {}
+    data['locale'] = locale.getlocale()
+
+    data['python'] = python_info()
+
+    data['python_site_info'] = python_site_info()
+
+    data['process'] = process_info()
+
+    # facts collects env info as well, but the goal here is to collect the
+    # env this particular module invocation is using.
+    data['environment'] = env_info()
+
+    return data

--- a/lib/ansible/module_utils/introspection.py
+++ b/lib/ansible/module_utils/introspection.py
@@ -45,6 +45,54 @@ def _module_meta_info():
     return meta_info
 
 
+def module_info(module):
+    '''Gather info about the module and return a serializable dict containing it.
+
+    Used if a module is invoked with the _ansible_module_introspect parameter. The
+    data returned will be added to the json results under the top level 'introspect' key.'''
+
+    # TODO: support a introspect_subset ala gather_subset (and try to share the code)
+    data = {}
+    data['name'] = module._name
+    data['ansible_version'] = module.ansible_version
+
+    data['argument_spec'] = module.argument_spec
+    data['supports_check_mode'] = module.supports_check_mode
+    data['check_mode'] = module.check_mode
+
+    data['supported_params'] = module._public_legal_inputs
+
+    # The effective params used by the module. Include params supplied by user as
+    # well as any required defaults.
+
+    # The valid module parameters as well as the _ansible_* parameters used interally by ansible
+    data['params'] = module.params
+
+    data['aliases'] = module.aliases
+    data['legal_inputs'] = module._legal_inputs
+
+    data['used_fallbacks'] = module._used_fallbacks
+
+    # A list of params that were not provided by the user and the default was used.
+    data['used_defaults'] = module._used_defaults
+
+    data['no_log'] = module.no_log
+    data['no_log_values'] = list(module.no_log_values)
+
+    # module invocation options
+    data['cleanup_files'] = module.cleanup_files
+    data['debug'] = module._debug
+    data['diff'] = module._diff
+    data['verbosity'] = module._verbosity
+    data['run_command_environ_update'] = module.run_command_environ_update
+
+    # The DOCUMENTATION, EXAMPLES, METADATA, etc
+    module_meta_info = _module_meta_info()
+    data['metadata'] = module_meta_info
+
+    return data
+
+
 def process_info():
     process_info = {}
 

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -585,6 +585,10 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         # set module introspect
         module_args['_ansible_module_introspect'] = C.DEFAULT_MODULE_INTROSPECT
 
+        # If we want the module to only do introspection and no other actions
+        # TODO: introspect only in play/task context ?
+        module_args['_ansible_module_introspect_only'] = C.DEFAULT_MODULE_INTROSPECT_ONLY
+
         # let module know we are in diff mode
         module_args['_ansible_diff'] = self._play_context.diff
 

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -582,6 +582,9 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         # set debug in the module arguments, if required
         module_args['_ansible_debug'] = C.DEFAULT_DEBUG
 
+        # set module introspect
+        module_args['_ansible_module_introspect'] = C.DEFAULT_MODULE_INTROSPECT
+
         # let module know we are in diff mode
         module_args['_ansible_diff'] = self._play_context.diff
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/module_utils

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (cowsay_py 9fe6a5a3f5) last updated 2017/01/25 16:01:30 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules', u'/home/adrian/ansible/lib/modules/']


```

##### SUMMARY
Adds support for module introspection. If invoked with the right options, the json returned from a python ansible module  will include an assortment of additional info about the module, it's args and values, and the environment and runtime it ran in. 

The new info goes into an 'introspection' key in the retrurned json (aside facts and invocation).

A couple of use cases.

1) running a module and introspecting it's arg spec (returned as a data structure here). In combo with 'introspect_only' this can help tools that want to dynamically inspect a modules args

 The info can also be returned in additional to normal module return data. So a tool like Tower that invoked modules and records the results, the arg spec could be used to generate a 'run again with different args' page. Or possibly the CLI could augment 'retry' files.

2) Module debugging and troubleshooting

  The introspection data includes a lot of info that usually requires ANSIBLE_KEEP_REMOTE_FILES, module 'explode', editing the module source, and running again. 

 For troubleshooting something like 'is this using the right python module for libfoobarblip?', flipping on introspection and seeing python sys.path and 'site' options is much quicker. 

 Other info like uid, euid, pid, module file name, the default args used, etc will be useful for debugging/troubleshooting.

3) event logging and auditting

  This adds a lot of context info about a module/task and does it with structured data. Using that info to populate something like an ELK stack would provide a lot of historical info for later review.

4) playbook troubleshooting

  It can be hard to figure out what default args end up being used when a module is invoked. The introspection info provides a lot of extra context to help.

An example invocation:


```
[fedora-25:ansible (ansible_module_introspect %)]$ ANSIBLE_MODULE_INTROSPECT=1 bin/ansible -i hosts grimlock -m copy -a 'src=/tmp/test_file dest=/tmp/setup.py' -C -D
```

``` json
grimlock | SUCCESS => {
    "changed": false, 
    "checksum": "4fbebcd2162b75b9e8f490397c148d4ae635a32a", 
    "dest": "/tmp/setup.py", 
    "gid": 1002, 
    "group": "adrian", 
    "introspect": {
        "module": {
            "aliases": {
                "attr": "attributes", 
                "dest": "path", 
                "name": "path"
            }, 
            "ansible_version": "2.3.0", 
            "argument_spec": {
                "attributes": {
                    "aliases": [
                        "attr"
                    ]
                }, 
                "backup": {}, 
                "content": {
                    "no_log": true
                }, 
                "delimiter": {}, 
                "diff_peek": {
                    "default": null
                }, 
                "directory_mode": {}, 
                "follow": {
                    "default": false, 
                    "type": "bool"
                }, 
                "force": {
                    "default": false, 
                    "required": false, 
                    "type": "bool"
                }, 
                "group": {}, 
                "mode": {
                    "type": "raw"
                }, 
                "original_basename": {
                    "required": false
                }, 
                "owner": {}, 
                "path": {
                    "aliases": [
                        "dest", 
                        "name"
                    ], 
                    "required": true, 
                    "type": "path"
                }, 
                "recurse": {
                    "default": false, 
                    "type": "bool"
                }, 
                "regexp": {}, 
                "remote_src": {}, 
                "selevel": {}, 
                "serole": {}, 
                "setype": {}, 
                "seuser": {}, 
                "src": {
                    "default": null, 
                    "required": false, 
                    "type": "path"
                }, 
                "state": {
                    "choices": [
                        "file", 
                        "directory", 
                        "link", 
                        "hard", 
                        "touch", 
                        "absent"
                    ], 
                    "default": null
                }, 
                "unsafe_writes": {
                    "type": "bool"
                }, 
                "validate": {
                    "default": null, 
                    "required": false
                }
            }, 
            "check_mode": true, 
            "cleanup_files": [], 
            "debug": false, 
            "diff": true, 
            "legal_inputs": [
                "_ansible_check_mode", 
                "_ansible_no_log", 
                "_ansible_debug", 
                "_ansible_diff", 
                "_ansible_verbosity", 
                "_ansible_selinux_special_fs", 
                "_ansible_module_name", 
                "_ansible_version", 
                "_ansible_syslog_facility", 
                "_ansible_module_introspect", 
                "_ansible_module_introspect_only", 
                "directory_mode", 
                "force", 
                "remote_src", 
                "path", 
                "dest", 
                "name", 
                "owner", 
                "follow", 
                "group", 
                "unsafe_writes", 
                "state", 
                "content", 
                "serole", 
                "diff_peek", 
                "setype", 
                "selevel", 
                "original_basename", 
                "regexp", 
                "validate", 
                "src", 
                "seuser", 
                "recurse", 
                "delimiter", 
                "mode", 
                "attributes", 
                "attr", 
                "backup"
            ], 
            "metadata": {
                "documentation": "\n---\nmodule: file\nversion_added: \"historical\"\nshort_description: Sets attributes of files\nextends_documentation_fragment: files\ndescription:\n     - Sets attributes of files, symlinks, and directories, or removes\n       files/symlinks/directories. Many other modules support the same options as\n       the M(file) module - including M(copy), M(template), and M(assemble).\nnotes:\n    - See also M(copy), M(template), M(assemble)\nrequirements: [ ]\nauthor:\n    - \"Ansible Core Team\"\n    - \"Michael DeHaan\"\noptions:\n  path:\n    description:\n      - 'path to the file being managed.  Aliases: I(dest), I(name)'\n    required: true\n    default: []\n    aliases: ['dest', 'name']\n  state:\n    description:\n      - If C(directory), all immediate subdirectories will be created if they\n        do not exist, since 1.7 they will be created with the supplied permissions.\n        If C(file), the file will NOT be created if it does not exist, see the M(copy)\n        or M(template) module if you want that behavior.  If C(link), the symbolic\n        link will be created or changed. Use C(hard) for hardlinks. If C(absent),\n        directories will be recursively deleted, and files or symlinks will be unlinked.\n        Note that M(file) will not fail if the C(path) does not exist as the state did not change.\n        If C(touch) (new in 1.4), an empty file will be created if the C(path) does not\n        exist, while an existing file or directory will receive updated file access and\n        modification times (similar to the way `touch` works from the command line).\n    required: false\n    default: file\n    choices: [ file, link, directory, hard, touch, absent ]\n  src:\n    required: false\n    default: null\n    description:\n      - path of the file to link to (applies only to C(state=link)). Will accept absolute,\n        relative and nonexisting paths. Relative paths are not expanded.\n  recurse:\n    required: false\n    default: \"no\"\n    choices: [ \"yes\", \"no\" ]\n    version_added: \"1.1\"\n    description:\n      - recursively set the specified file attributes (applies only to state=directory)\n  force:\n    required: false\n    default: \"no\"\n    choices: [ \"yes\", \"no\" ]\n    description:\n      - 'force the creation of the symlinks in two cases: the source file does\n        not exist (but will appear later); the destination exists and is a file (so, we need to unlink the\n        \"path\" file and create symlink to the \"src\" file in place of it).'\n  follow:\n    required: false\n    default: \"no\"\n    choices: [ \"yes\", \"no\" ]\n    version_added: \"1.8\"\n    description:\n      - 'This flag indicates that filesystem links, if they exist, should be followed.'\n", 
                "examples": "\n# change file ownership, group and mode. When specifying mode using octal numbers, first digit should always be 0.\n- file:\n    path: /etc/foo.conf\n    owner: foo\n    group: foo\n    mode: 0644\n- file:\n    src: /file/to/link/to\n    dest: /path/to/symlink\n    owner: foo\n    group: foo\n    state: link\n- file:\n    src: '/tmp/{{ item.src }}'\n    dest: '{{ item.dest }}'\n    state: link\n  with_items:\n    - { src: 'x', dest: 'y' }\n    - { src: 'z', dest: 'k' }\n\n# touch a file, using symbolic modes to set the permissions (equivalent to 0644)\n- file:\n    path: /etc/foo.conf\n    state: touch\n    mode: \"u=rw,g=r,o=r\"\n\n# touch the same file, but add/remove some permissions\n- file:\n    path: /etc/foo.conf\n    state: touch\n    mode: \"u+rw,g-wx,o-rwx\"\n\n# create a directory if it doesn't exist\n- file:\n    path: /etc/some_directory\n    state: directory\n    mode: 0755\n", 
                "metadata": {
                    "status": [
                        "stableinterface"
                    ], 
                    "supported_by": "core", 
                    "version": "1.0"
                }, 
                "return": null
            }, 
            "module_path": "/tmp/ansible_5vOSC5/ansible_modlib.zip/ansible/module_utils", 
            "name": "file", 
            "no_log": false, 
            "no_log_values": [], 
            "params": {
                "attributes": null, 
                "backup": null, 
                "content": null, 
                "delimiter": null, 
                "dest": "/tmp/setup.py", 
                "diff_peek": null, 
                "directory_mode": null, 
                "follow": false, 
                "force": false, 
                "group": null, 
                "mode": null, 
                "original_basename": "test_file", 
                "owner": null, 
                "path": "/tmp/setup.py", 
                "recurse": false, 
                "regexp": null, 
                "remote_src": null, 
                "selevel": null, 
                "serole": null, 
                "setype": null, 
                "seuser": null, 
                "src": "test_file", 
                "state": null, 
                "unsafe_writes": null, 
                "validate": null
            }, 
            "run_command_environ_update": {}, 
            "supported_params": [
                "directory_mode", 
                "force", 
                "remote_src", 
                "path", 
                "dest", 
                "name", 
                "owner", 
                "follow", 
                "group", 
                "unsafe_writes", 
                "state", 
                "content", 
                "serole", 
                "diff_peek", 
                "setype", 
                "selevel", 
                "original_basename", 
                "regexp", 
                "validate", 
                "src", 
                "seuser", 
                "recurse", 
                "delimiter", 
                "mode", 
                "attributes", 
                "attr", 
                "backup"
            ], 
            "supports_check_mode": true, 
            "used_defaults": {
                "attributes": null, 
                "backup": null, 
                "content": null, 
                "delimiter": null, 
                "diff_peek": null, 
                "directory_mode": null, 
                "follow": false, 
                "force": false, 
                "group": null, 
                "mode": null, 
                "owner": null, 
                "recurse": false, 
                "regexp": null, 
                "remote_src": null, 
                "selevel": null, 
                "serole": null, 
                "setype": null, 
                "seuser": null, 
                "state": null, 
                "unsafe_writes": null, 
                "validate": null
            }, 
            "used_fallbacks": {}, 
            "verbosity": 0
        }, 
        "module_invocation": {
            "environment": {
                "CVS_RSH": "ssh", 
                "EDITOR": "vim -f",
                "GIT_PROMPT": "/usr/share/git-core/contrib/completion/git-prompt.sh", 
                "GIT_PS1_SHOWCOLORHINTS": "1", 
                "GIT_PS1_SHOWUNTRACKEDFILES": "1", 
                "GIT_PS1_SHOWUPSTREAM": "verbose", 
                "GOPATH": "/home/adrian/gopath", 
                "GUESTFISH_INIT": "\\e[1;34m", 
                "GUESTFISH_OUTPUT": "\\e[0m", 
                "GUESTFISH_PS1": "\\[\\e[1;32m\\]><fs>\\[\\e[0;31m\\] ", 
                "GUESTFISH_RESTORE": "\\e[0m", 
                "HISTFILESIZE": "500000", 
                "HISTSIZE": "300000", 
                "HISTTIMEFORMAT": "%F %T ", 
                "HOME": "/home/adrian", 
                "HOSTNAME": "grimlock", 
                "ID": "rhel", 
                "JAVA_HOME": "/usr/lib/jvm/java", 
                "KDEDIRS": "/usr", 
                "LANG": "en_US.utf8", 
                "LC_MEASUREMENT": "en_US.utf8", 
                "LC_MONETARY": "en_US.utf8", 
                "LC_NUMERIC": "en_US.utf8", 
                "LC_PAPER": "en_US.utf8", 
                "LC_TIME": "en_US.utf8", 
                "LESSOPEN": "||/usr/bin/lesspipe.sh %s", 
                "LOGNAME": "adrian", 
                "M2_REPO": "/home/adrian/.m2/repository", 
                "MAIL": "/var/mail/adrian", 
                "PATH": "/home/adrian/bin:/usr/lib64/qt-3.3/bin:/usr/local/bin:/usr/bin:/home/adrian/.cabal/bin:/home/adrian/gopath/bin:/home/adrian/.local/bin", 
                "PKG_CONFIG_PATH": "/usr/local/lib/pkgconfig/", 
                "PWD": "/home/adrian", 
                "PYTHONPATH": "/tmp/ansible_5vOSC5/ansible_modlib.zip", 
                "PYTHONSTARTUP": "/home/adrian/.pystartup", 
                "QTDIR": "/usr/lib64/qt-3.3", 
                "QTINC": "/usr/lib64/qt-3.3/include", 
                "QTLIB": "/usr/lib64/qt-3.3/lib", 
                "QT_GRAPHICSSYSTEM_CHECKED": "1", 
                "QT_PLUGIN_PATH": "/usr/lib64/kde4/plugins:/usr/lib/kde4/plugins", 
                "SELINUX_LEVEL_REQUESTED": "", 
                "SELINUX_ROLE_REQUESTED": "", 
                "SELINUX_USE_CURRENT_RANGE": "", 
                "SHELL": "/bin/bash", 
                "SHLVL": "2", 
                "SSH_ASKPASS": "/usr/libexec/openssh/gnome-ssh-askpass", 
                "SSH_AUTH_SOCK": "/tmp/ssh-EWP2ppAm1O/agent.3298", 
                "SSH_CLIENT": "192.168.1.35 40784 22", 
                "SSH_CONNECTION": "192.168.1.35 40784 192.168.1.36 22", 
                "USER": "adrian", 
                "USER_LS_COLORS": "", 
                "VAGRANT_DEFAULT_PROVIDER": "libvirt", 
                "VERSION_ID": "7.2", 
                "VIRTUALENVWRAPPER_HOOK_DIR": "/home/adrian/.virtualenvs", 
                "VIRTUALENVWRAPPER_PROJECT_FILENAME": ".project", 
                "VIRTUALENVWRAPPER_SCRIPT": "/home/adrian/bin/virtualenvwrapper.sh", 
                "WORKON_HOME": "/home/adrian/.virtualenvs", 
                "XDG_RUNTIME_DIR": "/run/user/1000", 
                "XDG_SESSION_ID": "131323", 
                "XMODIFIERS": "@im=ibus", 
                "_": "/usr/bin/python"
            }, 
            "locale": [
                "en_US", 
                "UTF-8"
            ], 
            "process": {
                "cwd": "/home/adrian", 
                "euid": 1000, 
                "gid": 1002, 
                "pid": 3688, 
                "ppid": 3687, 
                "uid": 1000
            }, 
            "python": {
                "sys_argv": [
                    "/tmp/ansible_5vOSC5/ansible_module_file.py"
                ], 
                "sys_exec_prefix": "/usr", 
                "sys_meta_path": [], 
                "sys_path": [
                    "/tmp/ansible_5vOSC5", 
                    "/tmp/ansible_5vOSC5/ansible_modlib.zip", 
                    "/home/adrian/.local/lib/python2.7/site-packages/_pdbpp_path_hack", 
                    "/home/adrian/.local/lib/python2.7/site-packages/Gelatin-DEVELOPMENT-py2.7.egg", 
                    "/home/adrian/.local/lib/python2.7/site-packages/keyring-2.0dev-py2.7.egg", 
                    "/home/adrian/.local/lib/python2.7/site-packages/ansible_lint-2.1.2-py2.7.egg", 
                    "/home/adrian/.local/lib/python2.7/site-packages/github_comments-1.3-py2.7.egg", 
                    "/usr/lib/python2.7/site-packages/yolk-0.4.3-py2.7.egg", 
                    "/usr/lib/python2.7/site-packages/rho-0.0.21-py2.7.egg", 
                    "/usr/lib/python2.7/site-packages/tbgrep-0.2.3-py2.7.egg", 
                    "/usr/lib/python2.7/site-packages/translate_toolkit-1.13.0_alpha1-py2.7.egg", 
                    "/usr/lib/python2.7/site-packages/centpkg-0.4.4-py2.7.egg", 
                    "/usr/lib/python2.7/site-packages/rainbow_logging_handler-2.2.2-py2.7.egg", 
                    "/usr/lib/python2.7/site-packages/bkr.systemscan-1.6-py2.7.egg", 
                    "/usr/lib/python2.7/site-packages/github_comments-1.3-py2.7.egg", 
                    "/usr/lib/python2.7/site-packages/noselog-0.0.5-py2.7.egg", 
                    "/usr/lib/python2.7/site-packages/tito-0.6.2-py2.7.egg", 
                    "/usr/lib/python2.7/site-packages/maproxy-0.0.12-py2.7.egg", 
                    "/home/adrian/.local/lib/python2.7/site-packages/subscription_manager-1.17.3-py2.7.egg", 
                    "/tmp/ansible_5vOSC5/ansible_modlib.zip", 
                    "/usr/lib64/python27.zip", 
                    "/usr/lib64/python2.7", 
                    "/usr/lib64/python2.7/plat-linux2", 
                    "/usr/lib64/python2.7/lib-tk", 
                    "/usr/lib64/python2.7/lib-old", 
                    "/usr/lib64/python2.7/lib-dynload", 
                    "/home/adrian/.local/lib/python2.7/site-packages", 
                    "/usr/lib/python2.7/site-packages", 
                    "/usr/lib64/python2.7/site-packages", 
                    "/usr/lib64/python2.7/site-packages/gtk-2.0"
                ], 
                "sys_path_hooks": [
                    "<type 'zipimport.zipimporter'>"
                ], 
                "sys_prefix": "/usr"
            }, 
            "python_site_info": {
                "site_PREFIXES": [
                    "/usr", 
                    "/usr"
                ], 
                "site_USER_BASE": "/home/adrian/.local", 
                "site_USER_SITE": "/home/adrian/.local/lib/python2.7/site-packages", 
                "site_getsitepackages": [
                    "/usr/lib64/python2.7/site-packages", 
                    "/usr/lib/python2.7/site-packages", 
                    "/usr/lib/site-python"
                ]
            }
        }
    }, 
    "mode": "0664", 
    "owner": "adrian", 
    "path": "/tmp/setup.py", 
    "secontext": "unconfined_u:object_r:user_tmp_t:s0", 
    "size": 2077, 
    "state": "file", 
    "uid": 1000
}
```
