### PR TITLE
Only set git config during test if unset.

### DIFF
--- a/test/integration/targets/git/tasks/setup.yml
+++ b/test/integration/targets/git/tasks/setup.yml
@@ -21,8 +21,11 @@
   shell: gpg --version 2>1 | head -1 | sed -e 's/gpg (GnuPG) //'
   register: gpg_version
 
-- name: set dummy git config
-  shell: git config --global user.email "noreply@example.com"; git config --global user.name "Ansible Test Runner"
+- name: set git global user.email if not already set
+  shell: git config --global user.email || git config --global user.email "noreply@example.com"
+
+- name: set git global user.name if not already set
+  shell: git config --global user.name  || git config --global user.name  "Ansible Test Runner"
 
 - name: create repo_dir
   file: path={{repo_dir}} state=directory


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

git integration test

##### ANSIBLE VERSION

```
ansible 2.3.0 (git-test-config f68a49962f) last updated 2017/01/25 17:54:10 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

This makes the git test less destructive.