### PR TITLE
nmcli should not return error if trying to delete an absent connection

### DIFF
--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -1167,8 +1167,8 @@ def main():
                 module.exit_json(changed=True)
             (rc, out, err)=nmcli.down_connection()
             (rc, out, err)=nmcli.remove_connection()
-        if rc!=0:
-            module.fail_json(name =('No Connection named %s exists' % nmcli.conn_name), msg=err, rc=rc)
+            if rc!=0:
+                module.fail_json(name =('No Connection named %s exists' % nmcli.conn_name), msg=err, rc=rc)
 
     elif nmcli.state=='present':
         if nmcli.connection_exists():


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nmcli module

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
This PR fixes an issue [#1062 (ansible-modules-extras).](https://github.com/ansible/ansible-modules-extras/issues/1062)

Currently, nmcli fails if trying to make non-existent connection state absent.
I think nmcli's `state=absent` is a specified connection should not be exist.