### PR TITLE
New aws_region_facts module to be able to get facts from AWS regions

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_region_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_region_facts.py
@@ -1,0 +1,120 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.0',
+    'supported_by': 'community',
+    'status': ['preview']
+}
+
+DOCUMENTATION = '''
+module: aws_region_facts
+short_description: Gather facts about AWS regions.
+description:
+    - Gather facts about AWS regions.
+version_added: '2.4'
+author: 'Henrique Rodrigues (github.com/Sodki)'
+options:
+  filters:
+    description:
+      - A dict of filters to apply. Each dict item consists of a filter key and a filter value. See \
+      U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) for \
+      possible filters. Filter names and values are case sensitive. You can also use underscores (_) \
+      instead of dashes (-) in the filter keys, which will take precedence in case of conflict.
+    required: false
+    default: {}
+extends_documentation_fragment:
+    - aws
+requirements: [botocore, boto3]
+'''
+
+EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+
+# Gather facts about all regions
+- aws_region_facts:
+
+# Gather facts about a single region
+- aws_region_facts:
+    filters:
+      region-name: eu-west-1
+'''
+
+RETURN = '''
+regions:
+    description: >
+        Regions that match the provided filters. Each element consists of a dict with all the information related
+        to that region.
+    type: list
+    sample: "[{
+        'endpoint': 'ec2.us-west-1.amazonaws.com',
+        'region_name': 'us-west-1'
+    }]"
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import get_aws_connection_info, ec2_argument_spec, boto3_conn
+from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list, camel_dict_to_snake_dict, HAS_BOTO3
+
+try:
+    from botocore.exceptions import ClientError
+except ImportError:
+    pass  # will be detected by imported HAS_BOTO3
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(
+        dict(
+            filters=dict(default={}, type='dict')
+        )
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec)
+
+    if not HAS_BOTO3:
+        module.fail_json(msg='boto3 required for this module')
+
+    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
+
+    if region:
+        connection = boto3_conn(
+            module,
+            conn_type='client',
+            resource='ec2',
+            region=region,
+            endpoint=ec2_url,
+            **aws_connect_params
+        )
+    else:
+        module.fail_json(msg='region must be specified')
+
+    # Replace filter key underscores with dashes, for compatibility
+    sanitized_filters = dict((k.replace('_', '-'), v) for k,v in module.params.get('filters').items())
+
+    try:
+        regions = connection.describe_regions(
+            Filters=ansible_dict_to_boto3_filter_list(sanitized_filters)
+        )
+    except ClientError as e:
+        module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+
+    module.exit_json(regions=[camel_dict_to_snake_dict(r) for r in regions['Regions']])
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/aws_region_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_region_facts.py
@@ -1,18 +1,6 @@
 #!/usr/bin/python
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.0',
@@ -25,19 +13,19 @@ module: aws_region_facts
 short_description: Gather facts about AWS regions.
 description:
     - Gather facts about AWS regions.
-version_added: '2.4'
+version_added: '2.5'
 author: 'Henrique Rodrigues (github.com/Sodki)'
 options:
   filters:
     description:
-      - A dict of filters to apply. Each dict item consists of a filter key and a filter value. See \
-      U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) for \
-      possible filters. Filter names and values are case sensitive. You can also use underscores (_) \
-      instead of dashes (-) in the filter keys, which will take precedence in case of conflict.
-    required: false
+      - A dict of filters to apply. Each dict item consists of a filter key and a filter value. See
+        U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) for
+        possible filters. Filter names and values are case sensitive. You can also use underscores (_)
+        instead of dashes (-) in the filter keys, which will take precedence in case of conflict.
     default: {}
 extends_documentation_fragment:
     - aws
+    - ec2
 requirements: [botocore, boto3]
 '''
 
@@ -66,12 +54,14 @@ regions:
 '''
 
 
+import traceback
+from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import get_aws_connection_info, ec2_argument_spec, boto3_conn
 from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list, camel_dict_to_snake_dict, HAS_BOTO3
 
 try:
-    from botocore.exceptions import ClientError
+    from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
     pass  # will be detected by imported HAS_BOTO3
 
@@ -90,18 +80,14 @@ def main():
         module.fail_json(msg='boto3 required for this module')
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
-
-    if region:
-        connection = boto3_conn(
-            module,
-            conn_type='client',
-            resource='ec2',
-            region=region,
-            endpoint=ec2_url,
-            **aws_connect_params
-        )
-    else:
-        module.fail_json(msg='region must be specified')
+    connection = boto3_conn(
+        module,
+        conn_type='client',
+        resource='ec2',
+        region=region,
+        endpoint=ec2_url,
+        **aws_connect_params
+    )
 
     # Replace filter key underscores with dashes, for compatibility
     sanitized_filters = dict((k.replace('_', '-'), v) for k,v in module.params.get('filters').items())
@@ -111,7 +97,12 @@ def main():
             Filters=ansible_dict_to_boto3_filter_list(sanitized_filters)
         )
     except ClientError as e:
-        module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+        module.fail_json(msg="Unable to describe regions: {0}".format(to_native(e)),
+                         exception=traceback.format_exc(),
+                         **camel_dict_to_snake_dict(e.response))
+    except BotoCoreError as e:
+        module.fail_json(msg="Unable to describe regions: {0}".format(to_native(e)),
+                         exception=traceback.format_exc())
 
     module.exit_json(regions=[camel_dict_to_snake_dict(r) for r in regions['Regions']])
 

--- a/lib/ansible/modules/cloud/amazon/aws_region_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_region_facts.py
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 ANSIBLE_METADATA = {
-    'metadata_version': '1.0',
+    'metadata_version': '1.1',
     'supported_by': 'community',
     'status': ['preview']
 }
@@ -20,7 +20,7 @@ options:
     description:
       - A dict of filters to apply. Each dict item consists of a filter key and a filter value. See
         U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html) for
-        possible filters. Filter names and values are case sensitive. You can also use underscores (_)
+        possible filters. Filter names and values are case sensitive. You can also use underscores
         instead of dashes (-) in the filter keys, which will take precedence in case of conflict.
     default: {}
 extends_documentation_fragment:
@@ -43,6 +43,7 @@ EXAMPLES = '''
 
 RETURN = '''
 regions:
+    returned: on success
     description: >
         Regions that match the provided filters. Each element consists of a dict with all the information related
         to that region.
@@ -90,7 +91,7 @@ def main():
     )
 
     # Replace filter key underscores with dashes, for compatibility
-    sanitized_filters = dict((k.replace('_', '-'), v) for k,v in module.params.get('filters').items())
+    sanitized_filters = dict((k.replace('_', '-'), v) for k, v in module.params.get('filters').items())
 
     try:
         regions = connection.describe_regions(


### PR DESCRIPTION
##### ISSUE TYPE

 - New Module Pull Request

##### COMPONENT NAME

aws_region_facts

##### ANSIBLE VERSION

```
ansible 2.3.0 (devel 28e39ca42f) last updated 2017/01/25 16:44:10 (GMT +100)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

This is a new module that allows to query EC2 and obtain a a list of regions. It's useful if you want to iterate through the regions in search of something specific. I wrote this module because it was something I needed to do.

This implementation uses the same skeleton as `ec2_group_facts`.