### PR TITLE
ovirt: Add support to diff

### DIFF
--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -57,6 +57,7 @@ def get_dict_of_struct(struct, connection=None, fetch_nested=False, attributes=N
     Convert SDK Struct type into dictionary.
     """
     res = {}
+
     def remove_underscore(val):
         if val.startswith('_'):
             val = val[1:]
@@ -100,10 +101,10 @@ def get_dict_of_struct(struct, connection=None, fetch_nested=False, attributes=N
 
     if struct is not None:
         for key, value in struct.__dict__.items():
-            key = remove_underscore(key)
             if value is None:
                 continue
 
+            key = remove_underscore(key)
             res[key] = convert_value(value)
 
     return res
@@ -342,7 +343,7 @@ def ovirt_facts_full_argument_spec(**kwargs):
     spec = dict(
         auth=__get_auth_dict(),
         fetch_nested=dict(default=False, type='bool'),
-        nested_attributes=dict(type='list'),
+        nested_attributes=dict(type='list', default=list()),
     )
     spec.update(kwargs)
     return spec
@@ -361,7 +362,7 @@ def ovirt_full_argument_spec(**kwargs):
         wait=dict(default=True, type='bool'),
         poll_interval=dict(default=3, type='int'),
         fetch_nested=dict(default=False, type='bool'),
-        nested_attributes=dict(type='list'),
+        nested_attributes=dict(type='list', default=list()),
     )
     spec.update(kwargs)
     return spec

--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -293,15 +293,15 @@ def wait(
     if wait:
         start = time.time()
         while time.time() < start + timeout:
-            # Sleep for `poll_interval` seconds if none of the conditions apply:
-            time.sleep(float(poll_interval))
-
             # Exit if the condition of entity is valid:
             entity = get_entity(service)
             if condition(entity):
                 return
             elif fail_condition(entity):
                 raise Exception("Error while waiting on result state of the entity.")
+
+            # Sleep for `poll_interval` seconds if none of the conditions apply:
+            time.sleep(float(poll_interval))
 
         raise Exception("Timeout exceed while waiting on result state of the entity.")
 

--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -18,6 +18,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import collections
 import inspect
 import os
 import time
@@ -55,47 +56,55 @@ def get_dict_of_struct(struct, connection=None, fetch_nested=False, attributes=N
     """
     Convert SDK Struct type into dictionary.
     """
+    res = {}
     def remove_underscore(val):
         if val.startswith('_'):
             val = val[1:]
             remove_underscore(val)
         return val
 
-    res = {}
+    def convert_value(value):
+        nested = False
+
+        if isinstance(value, sdk.Struct):
+            return get_dict_of_struct(value)
+        elif isinstance(value, Enum) or isinstance(value, datetime):
+            return str(value)
+        elif isinstance(value, list) or isinstance(value, sdk.List):
+            if isinstance(value, sdk.List) and fetch_nested and value.href:
+                try:
+                    value = connection.follow_link(value)
+                    nested = True
+                except sdk.Error:
+                    value = []
+
+            ret = []
+            for i in value:
+                if isinstance(i, sdk.Struct):
+                    if not nested:
+                        ret.append(get_dict_of_struct(i))
+                    else:
+                        nested_obj = dict(
+                            (attr, convert_value(getattr(i, attr)))
+                            for attr in attributes if getattr(i, attr, None)
+                        )
+                        nested_obj['id'] = getattr(i, 'id', None),
+                        ret.append(nested_obj)
+                elif isinstance(i, Enum):
+                    ret.append(str(i))
+                else:
+                    ret.append(i)
+            return ret
+        else:
+            return value
+
     if struct is not None:
         for key, value in struct.__dict__.items():
-            nested = False
             key = remove_underscore(key)
             if value is None:
                 continue
 
-            elif isinstance(value, sdk.Struct):
-                res[key] = get_dict_of_struct(value)
-            elif isinstance(value, Enum) or isinstance(value, datetime):
-                res[key] = str(value)
-            elif isinstance(value, list) or isinstance(value, sdk.List):
-                if isinstance(value, sdk.List) and fetch_nested and value.href:
-                    value = connection.follow_link(value)
-                    nested = True
-
-                res[key] = []
-                for i in value:
-                    if isinstance(i, sdk.Struct):
-                        if not nested:
-                            res[key].append(get_dict_of_struct(i))
-                        else:
-                            nested_obj = dict(
-                                (attr, getattr(i, attr))
-                                for attr in attributes if getattr(i, attr, None)
-                            )
-                            nested_obj['id'] = getattr(i, 'id', None),
-                            res[key].append(nested_obj)
-                    elif isinstance(i, Enum):
-                        res[key].append(str(i))
-                    else:
-                        res[key].append(i)
-            else:
-                res[key] = value
+            res[key] = convert_value(value)
 
     return res
 
@@ -293,6 +302,8 @@ def wait(
             elif fail_condition(entity):
                 raise Exception("Error while waiting on result state of the entity.")
 
+        raise Exception("Timeout exceed while waiting on result state of the entity.")
+
 
 def __get_auth_dict():
     OVIRT_URL = os.environ.get('OVIRT_URL')
@@ -401,6 +412,7 @@ class BaseModule(object):
         self._module = module
         self._service = service
         self._changed = changed
+        self._diff = {'after': dict(), 'before': dict()}
 
     @property
     def changed(self):
@@ -464,6 +476,15 @@ class BaseModule(object):
         """
         pass
 
+    def diff_update(self, after, update):
+        for k, v in update.items():
+            if isinstance(v, collections.Mapping):
+                after[k] = self.diff_update(after.get(k, dict()), v)
+            else:
+                after[k] = update[k]
+        return after
+
+
     def create(self, entity=None, result_state=None, fail_condition=lambda e: False, search_params=None, **kwargs):
         """
         Method which is called when state of the entity is 'present'. If user
@@ -492,9 +513,25 @@ class BaseModule(object):
             # Entity exists, so update it:
             entity_service = self._service.service(entity.id)
             if not self.update_check(entity):
+                new_entity = self.build_entity()
                 if not self._module.check_mode:
-                    entity_service.update(self.build_entity())
+                    updated_entity = entity_service.update(new_entity)
                     self.post_update(entity)
+
+                # Update diffs only if user specified --diff paramter,
+                # so we don't useless overload API:
+                if self._module._diff:
+                    before = get_dict_of_struct(
+                        entity,
+                        self._connection,
+                        fetch_nested=True,
+                        attributes=['name'],
+                    )
+                    after = before.copy()
+                    self.diff_update(after, get_dict_of_struct(new_entity))
+                    self._diff['before'] = before
+                    self._diff['after'] = after
+
                 self.changed = True
         else:
             # Entity don't exists, so create it:
@@ -530,6 +567,7 @@ class BaseModule(object):
                 fetch_nested=self._module.params.get('fetch_nested'),
                 attributes=self._module.params.get('nested_attributes'),
             ),
+            'diff': self._diff,
         }
 
     def pre_remove(self, entity):
@@ -539,6 +577,12 @@ class BaseModule(object):
         :param entity: Entity which we want to remove.
         """
         pass
+
+    def entity_name(self, entity):
+        return "{e_type} '{e_name}'".format(
+            e_type=type(entity).__name__.lower(),
+            e_name=getattr(entity, 'name', None),
+        )
 
     def remove(self, entity=None, search_params=None, **kwargs):
         """
@@ -568,7 +612,6 @@ class BaseModule(object):
         entity_service = self._service.service(entity.id)
         if not self._module.check_mode:
             entity_service.remove(**kwargs)
-
             wait(
                 service=entity_service,
                 condition=lambda entity: not entity,
@@ -662,6 +705,7 @@ class BaseModule(object):
                 fetch_nested=self._module.params.get('fetch_nested'),
                 attributes=self._module.params.get('nested_attributes'),
             ),
+            'diff': self._diff,
         }
 
     def search_entity(self, search_params=None):

--- a/lib/ansible/modules/cloud/ovirt/ovirt_auth.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_auth.py
@@ -190,6 +190,7 @@ def main():
             ('state', 'absent', ['ovirt_auth']),
             ('state', 'present', ['username', 'password', 'url']),
         ],
+        supports_check_mode=True,
     )
     check_sdk(module)
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
@@ -34,6 +34,7 @@ from ansible.module_utils.ovirt import (
     convert_to_bytes,
     create_connection,
     equal,
+    get_entity,
     get_link_name,
     ovirt_full_argument_spec,
     search_by_name,
@@ -627,7 +628,7 @@ class VmsModule(BaseModule):
 
             # Attach disk to VM:
             disk_attachments_service = self._service.service(entity.id).disk_attachments_service()
-            if disk_attachments_service.attachment_service(disk_id).get() is None:
+            if get_entity(disk_attachments_service.attachment_service(disk_id)) is None:
                 if not self._module.check_mode:
                     disk_attachments_service.add(
                         otypes.DiskAttachment(

--- a/lib/ansible/utils/module_docs_fragments/ovirt.py
+++ b/lib/ansible/utils/module_docs_fragments/ovirt.py
@@ -69,5 +69,5 @@ requirements:
 notes:
   - "In order to use this module you have to install oVirt Python SDK.
      To ensure it's installed with correct version you can create the following task:
-     pip: name=ovirt-engine-sdk-python version=4.0.0"
+     I(pip: name=ovirt-engine-sdk-python version=4.0.0)"
 '''


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR contains more improvments:

 - Patch that add support to 'log' messages done by the module, and also the possibility to see what attributes of specific object was updated, by using library deepdif.

 - Patch that improves the conversion from oVirt Python object to JSON, so it now also fetches nested Python objects, not only strings.

 - It fixes the waiting of host 'reinstalled' state, because it's better to specify why specific action should wait, instead of wait always for all.

 - fix 404 for `ovirt_vms` introduces by new feature in oVirt Python SDK 4.1.