### PR TITLE
one more bug fix for ansible-connection

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -122,7 +122,7 @@ class Server():
         self.conn = connection_loader.get(play_context.connection, play_context, sys.stdin)
         self.conn._connect()
         if not self.conn.connected:
-            raise AnsibleConnectionFailure(err)
+            raise AnsibleConnectionFailure('unable to connect to remote host')
 
         self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self.socket.bind(path)
@@ -283,8 +283,6 @@ def main():
         if pid == 0:
             try:
                 server = Server(sf_path, pc)
-            except AnsibleConnectionFailure as exc:
-                log(str(exc), pc.remote_addr)
             except Exception as exc:
                 log(traceback.format_exc(), pc.remote_addr)
             fcntl.lockf(lock_fd, fcntl.LOCK_UN)


### PR DESCRIPTION
The connection instance will now return a meaningful error if the
connection property returns False
