### PR TITLE
Fix Config error in rhn_register

### DIFF
--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -166,9 +166,9 @@ class Rhn(RegistrationBase):
         # well
         def get_option_default(self, key, default=''):
             # the class in rhn-client-tools that this comes from didn't
-            # implement __contains__() until 2.5.x.  That's why we check if
-            # the key is present in the dictionary that is the actual storage
-            if key in self.dict:
+            # implement __contains__() until 2.5.x. The Config object implements
+            # has_key on all versions, so we use that.
+            if self.has_key(key):
                 return self[key]
             else:
                 return default


### PR DESCRIPTION
On RHEL6, if a server url was not provides as a task arg,
this module would throw the error:

  AttributeError: Config instance has no attribute 'dict'

There is no 'dict' attribute on the up2date_client.config.Config
class. Revert this back to using has_key() for checking for
config entries. Note that Config() is not a dict, so warnings
about deprecated has_key() are misleading here.

Fixes #20652

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/packaging/os/rhn_register.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (rhn_reg_has_key_20652 d59a11e1c8) last updated 2017/01/26 14:05:33 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules', u'/home/adrian/ansible/lib/modules/']

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
