### PR TITLE
include upgraded packages in pacman upgrade action

### DIFF
--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -91,6 +91,14 @@ options:
         version_added: "2.0"
 '''
 
+RETURN = '''
+packages:
+    description: a list of packages that have been changed
+    returned: when upgrade is set to yes
+    type: list of strings
+    sample: ['package', 'other-package']
+'''
+
 EXAMPLES = '''
 # Install package foo
 - pacman:

--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -193,13 +193,20 @@ def upgrade(module, pacman_path):
     rc, stdout, stderr = module.run_command(cmdneedrefresh, check_rc=False)
     data = stdout.split('\n')
     data.remove('')
+    diff = {
+        'before': '',
+        'after': '',
+        'after_header': 'upgraded'
+    }
 
     if rc == 0:
+        if module._diff:
+            diff['after'] = '\n'.join(data) + '\n'
         if module.check_mode:
-            module.exit_json(changed=True, msg="%s package(s) would be upgraded" % (len(data)), packages=data)
+            module.exit_json(changed=True, msg="%s package(s) would be upgraded" % (len(data)), packages=data, diff=diff)
         rc, stdout, stderr = module.run_command(cmdupgrade, check_rc=False)
         if rc == 0:
-            module.exit_json(changed=True, msg='System upgraded', packages=data)
+            module.exit_json(changed=True, msg='System upgraded', packages=data, diff=diff)
         else:
             module.fail_json(msg="Could not upgrade")
     else:

--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -191,18 +191,19 @@ def upgrade(module, pacman_path):
     cmdupgrade = "%s -Suq --noconfirm" % (pacman_path)
     cmdneedrefresh = "%s -Qqu" % (pacman_path)
     rc, stdout, stderr = module.run_command(cmdneedrefresh, check_rc=False)
+    data = stdout.split('\n')
+    data.remove('')
 
     if rc == 0:
         if module.check_mode:
-            data = stdout.split('\n')
-            module.exit_json(changed=True, msg="%s package(s) would be upgraded" % (len(data) - 1))
+            module.exit_json(changed=True, msg="%s package(s) would be upgraded" % (len(data)), packages=data)
         rc, stdout, stderr = module.run_command(cmdupgrade, check_rc=False)
         if rc == 0:
-            module.exit_json(changed=True, msg='System upgraded')
+            module.exit_json(changed=True, msg='System upgraded', packages=data)
         else:
             module.fail_json(msg="Could not upgrade")
     else:
-        module.exit_json(changed=False, msg='Nothing to upgrade')
+        module.exit_json(changed=False, msg='Nothing to upgrade', packages=data)
 
 def remove_packages(module, pacman_path, packages):
     if module.params["recurse"] or module.params["force"]:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
pacman module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel d4449d082e) last updated 2017/01/26 11:34:53 (GMT -400)
  config file = /home/<username>/code/<playbooks repo>/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Include a list of packages that were upgraded when performing a pacman upgrade task (or would be, if running in check mode). The upgraded packages are returned as a new key in the interest of not breaking backwards compatibility. Also this way there's less risk of flooding the user's screen with a huge list of packages.

I envision this being useful for registering the return of an upgrade so that handlers could selectively restart services after being upgraded.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
ok: [<hostname>] => {
    "updates": {
        "changed": true, 
        "msg": "System upgraded"
    }
}
```
After:
```
ok: [<hostname>] => {
    "updates": {
        "changed": true, 
        "msg": "System upgraded", 
        "packages": [
            "gnupg", 
            "python2-parsedatetime", 
            "python2-requests"
        ]
    }
}
```