### PR TITLE
default voice of Alex seems safer

### DIFF
--- a/lib/ansible/modules/notification/osx_say.py
+++ b/lib/ansible/modules/notification/osx_say.py
@@ -53,7 +53,7 @@ EXAMPLES = '''
   delegate_to: localhost
 '''
 
-DEFAULT_VOICE='Trinoids'
+DEFAULT_VOICE='Alex'
 
 def say(module, msg, voice):
     module.run_command(["/usr/bin/say", msg, "--voice=%s" % (voice)], check_rc=True)


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ansible/modules/notification/osx_say.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The voice paramater is not required and the current default fails on macOS Sierra. Alex is a safer default as it's persisted across versions up to this point.

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
**Playbook:**
# talk.yml
--- 
- hosts: localhost
  connection: local

  tasks:
    - name: osx say something
      osx_say:
        msg: '{{ inventory_hostname }} is talking'

**BEFORE the fix:**
$ ansible-playbook talk.yml

PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [osx say something] *******************************************************
fatal: [localhost]: FAILED! => {"changed": false, "cmd": "/usr/bin/say 'localhost is talking again' --voice=Trinoids", "failed": true, "msg": "Voice `Trinoids' not found.", "rc": 1, "stderr": "Voice `Trinoids' not found.\n", "stdout": "", "stdout_lines": []}

PLAY RECAP *********************************************************************
localhost

**AFTER the fix:**
$ ansible-playbook talk.yml

PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [osx say something] *******************************************************
ok: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0

```
