### PR TITLE
Make unused redhat_subscriptions do something

### DIFF
--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -283,7 +283,8 @@ class Rhsm(RegistrationBase):
             return False
 
     def register(self, username, password, autosubscribe, activationkey, org_id,
-                 consumer_type, consumer_name, consumer_id, force_register, environment):
+                 consumer_type, consumer_name, consumer_id, force_register, environment,
+                 rhsm_baseurl, server_insecure):
         '''
             Register the current system to the provided RHSM or Sat6 server
             Raises:
@@ -294,6 +295,12 @@ class Rhsm(RegistrationBase):
         # Generate command arguments
         if force_register:
             args.extend(['--force'])
+
+        if rhsm_baseurl:
+            args.extend(['--baseurl', rhsm_baseurl])
+
+        if server_insecure:
+            args.extend(['--insecure'])
 
         if activationkey:
             args.extend(['--activationkey', activationkey])
@@ -535,7 +542,7 @@ def main():
                 rhsm.configure(**module.params)
                 rhsm.register(username, password, autosubscribe, activationkey, org_id,
                              consumer_type, consumer_name, consumer_id, force_register,
-                             environment)
+                             environment, rhsm_baseurl, server_insecure)
                 subscribed_pool_ids = rhsm.subscribe(pool)
             except Exception:
                 e = get_exception()


### PR DESCRIPTION
rhsm_baseurl/server_insecure were module params that were
never used previously. Hook them up for register options.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/packaging/os/redhat_subscriptions.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (redhat_subs_rhsm_baseurl 5f7a9854c3) last updated 2017/01/26 17:41:08 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules', u'/home/adrian/ansible/lib/modules/']

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
