### PR TITLE
Azure Inventory: Use tenant in UserPassCredentials if set.

### DIFF
--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -276,7 +276,7 @@ class AzureRM(object):
         elif self.credentials.get('ad_user') is not None and self.credentials.get('password') is not None:
             tenant = self.credentials.get('tenant')
             if tenant is not None:
-                self.azure_credentials = UserPassCredentials(self.credentials['ad_user'], self.credentials['password'], tenant=tenant)          
+                self.azure_credentials = UserPassCredentials(self.credentials['ad_user'], self.credentials['password'], tenant=tenant)
             else:
                 self.azure_credentials = UserPassCredentials(self.credentials['ad_user'], self.credentials['password'])
         else:
@@ -490,8 +490,7 @@ class AzureInventory(object):
                 try:
                     virtual_machines = self._compute_client.virtual_machines.list(resource_group)
                 except Exception as exc:
-                    sys.exit("Error: fetching virtual machines for resource group {0} - {1}".format(resource_group,
-                                                                                                    str(exc)))
+                    sys.exit("Error: fetching virtual machines for resource group {0} - {1}".format(resource_group, str(exc)))
                 if self._args.host or self.tags:
                     selected_machines = self._selected_machines(virtual_machines)
                     self._load_machines(selected_machines)
@@ -801,6 +800,7 @@ def main():
                  "Do you have Azure >= 2.0.0rc5 installed? (try `pip install 'azure>=2.0.0rc5' --upgrade`)".format(AZURE_MIN_VERSION, azure_compute_version))
 
     AzureInventory()
+
 
 if __name__ == '__main__':
     main()

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -274,7 +274,11 @@ class AzureRM(object):
                                                                  secret=self.credentials['secret'],
                                                                  tenant=self.credentials['tenant'])
         elif self.credentials.get('ad_user') is not None and self.credentials.get('password') is not None:
-            self.azure_credentials = UserPassCredentials(self.credentials['ad_user'], self.credentials['password'])
+            tenant = self.credentials.get('tenant')
+            if tenant is not None:
+                self.azure_credentials = UserPassCredentials(self.credentials['ad_user'], self.credentials['password'], tenant=tenant)          
+            else:
+                self.azure_credentials = UserPassCredentials(self.credentials['ad_user'], self.credentials['password'])
         else:
             self.fail("Failed to authenticate with provided credentials. Some attributes were missing. "
                       "Credentials must include client_id, secret and tenant or ad_user and password.")


### PR DESCRIPTION
If you have multiple Tenants you need to set the tenant in https://github.com/Azure/msrestazure-for-python/blob/master/msrestazure/azure_active_directory.py otherwise the azure_rm.py call will fail.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible/contrib/inventory/azure_rm.py

##### ANSIBLE VERSION

```
2.2.1.0
```

##### SUMMARY
If you have multiple Tenants you need to set the tenant in https://github.com/Azure/msrestazure-for-python/blob/master/msrestazure/azure_active_directory.py otherwise the azure_rm.py call will fail.


```
$ python azure_rm.py
Traceback (most recent call last):
  File "azure_rm.py", line 802, in <module>
    main()
  File "azure_rm.py", line 799, in main
    AzureInventory()
  File "azure_rm.py", line 442, in __init__
    self.get_inventory()
  File "azure_rm.py", line 507, in get_inventory
    self._load_machines(virtual_machines)
  File "azure_rm.py", line 510, in _load_machines
    for machine in machines:
  File "/Users/ph/.virtualenvs/pydata/lib/python2.7/site-packages/msrest/paging.py", line 60, in __iter__
    for i in self.next():
  File "/Users/ph/.virtualenvs/pydata/lib/python2.7/site-packages/msrest/paging.py", line 92, in next
    self._response = self._get_next(self.next_link)
  File "/Users/ph/.virtualenvs/pydata/lib/python2.7/site-packages/azure/mgmt/compute/operations/virtual_machines_operations.py", line 626, in internal_paging
    raise exp
msrestazure.azure_exceptions.CloudError: Azure Error: InvalidAuthenticationTokenTenant
Message: The access token is from the wrong issuer XXXX'. It must match the tenant 'XXX' associated with this subscription. Please use the authority (URL) 'XXX' to get the token. Note, if the subscription is transferred to another tenant there is no impact to the services, but information about new tenant could take time to propagate (up to an hour). If you just transferred your subscription and see this error message, please try back later.
```