### PR TITLE
use tenant in UserPassCredentials if set

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -172,7 +172,11 @@ class AzureRMModuleBase(object):
                                                                  secret=self.credentials['secret'],
                                                                  tenant=self.credentials['tenant'])
         elif self.credentials.get('ad_user') is not None and self.credentials.get('password') is not None:
-            self.azure_credentials = UserPassCredentials(self.credentials['ad_user'], self.credentials['password'])
+            tenant = self.credentials.get('tenant')
+            if tenant is not None:
+                self.azure_credentials = UserPassCredentials(self.credentials['ad_user'], self.credentials['password'], tenant=tenant)          
+            else:
+                self.azure_credentials = UserPassCredentials(self.credentials['ad_user'], self.credentials['password'])
         else:
             self.fail("Failed to authenticate with provided credentials. Some attributes were missing. "
                       "Credentials must include client_id, secret and tenant or ad_user and password.")

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -174,7 +174,7 @@ class AzureRMModuleBase(object):
         elif self.credentials.get('ad_user') is not None and self.credentials.get('password') is not None:
             tenant = self.credentials.get('tenant')
             if tenant is not None:
-                self.azure_credentials = UserPassCredentials(self.credentials['ad_user'], self.credentials['password'], tenant=tenant)          
+                self.azure_credentials = UserPassCredentials(self.credentials['ad_user'], self.credentials['password'], tenant=tenant)
             else:
                 self.azure_credentials = UserPassCredentials(self.credentials['ad_user'], self.credentials['password'])
         else:


### PR DESCRIPTION
If you have multiple Tenants you need to set the tenant in https://github.com/Azure/msrestazure-for-python/blob/master/msrestazure/azure_active_directory.py otherwise call call will fail.

see: https://github.com/ansible/ansible/pull/20750

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/azure_rm_common.py 

##### ANSIBLE VERSION

```
2.2.1.0
```

##### SUMMARY
If you have multiple Tenants you need to set the tenant in https://github.com/Azure/msrestazure-for-python/blob/master/msrestazure/azure_active_directory.py otherwise the call will fail.

