### PR TITLE
apt_repository: check for enabled repositories correctly

### DIFF
--- a/lib/ansible/modules/packaging/os/apt_repository.py
+++ b/lib/ansible/modules/packaging/os/apt_repository.py
@@ -458,10 +458,11 @@ class UbuntuSourcesList(SourcesList):
         _repositories = []
         for parsed_repos in self.files.values():
             for parsed_repo in parsed_repos:
-                enabled = parsed_repo[1]
+                valid = parsed_repo[1]
+                enabled = parsed_repo[2]
                 source_line = parsed_repo[3]
 
-                if not enabled:
+                if not valid or not enabled:
                     continue
 
                 if source_line.startswith('ppa:'):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### SUMMARY

Fixes #20754.

Details: UbuntuSourcesList.add_source() had a quick check for PPAs being
already present in the source lists.  The check was looking for the PPAs
URL to be present in self.repo_urls, which should contain all valid and
enabled repositories.

The enabled check in repo_urls was incorrect.  It was checking the tuple's
2nd item (which means "valid") and ignoring the 3rd item (which means
"enabled").

self.files contains tuples (line_number, valid, enabled, source_line,
comment_text).  Ideally it would be using named tuples instead of
indexing, to avoid bugs like that, but Python 2.4 didn't have named
tuples, so we can't do that (yet).

##### COMPONENT NAME
apt_repository

##### ANSIBLE VERSION
```
ansible 2.3.0 (apt-repository-disabled-ppa 4480c76ea2) last updated 2017/01/27 17:36:36 (GMT +300)
  config file = /home/mg/src/mg-infra/ansible.cfg
  configured module search path = Default w/o overrides
```