### PR TITLE
add variable precedence warning to set_fact documentation.

### DIFF
--- a/lib/ansible/modules/utilities/logic/set_fact.py
+++ b/lib/ansible/modules/utilities/logic/set_fact.py
@@ -30,7 +30,7 @@ short_description: Set host facts from a task
 description:
      - This module allows setting new variables.  Variables are set on a host-by-host basis just like facts discovered by the setup module.
      - These variables will be available to subsequent plays during an ansible-playbook run, but will not be saved across executions even if you use a fact cache.
-     - Per the standard Ansible variable precedence rules, many other types of variables have a higher priority, so this value will be ignored. See U(http://docs.ansible.com/ansible/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable) for more information.
+     - Per the standard Ansible variable precedence rules, many other types of variables have a higher priority, so this value may be overridden. See U(http://docs.ansible.com/ansible/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable) for more information.
 options:
   key_value:
     description:

--- a/lib/ansible/modules/utilities/logic/set_fact.py
+++ b/lib/ansible/modules/utilities/logic/set_fact.py
@@ -30,6 +30,7 @@ short_description: Set host facts from a task
 description:
      - This module allows setting new variables.  Variables are set on a host-by-host basis just like facts discovered by the setup module.
      - These variables will be available to subsequent plays during an ansible-playbook run, but will not be saved across executions even if you use a fact cache.
+     - Per the standard Ansible variable precedence rules, many other types of variables have a higher priority, so this value will be ignored. See U(http://docs.ansible.com/ansible/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable) for more information.
 options:
   key_value:
     description:


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
`set_fact`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0
```

##### SUMMARY
set_fact is ignored by things, especially the `-e` override. I believe it's worth mentioning. Not sure how to link to other documentation.
