### PR TITLE
add iptables tcp-flags option

### DIFF
--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -126,7 +126,7 @@ options:
   tcp_flags:
     description:
       - TCP flags specification. tcp_flags expects a dict with the two keys
-        "flags" and "flags_set". The "flags" list is the mask: a list of
+        "flags" and "flags_set". The "flags" list is the mask, a list of
         flags you want to examine. The "flags_set" list tells which one(s)
         should be set. If one of the two values is missing, the --tcp-flags option
         will be ignored.

--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -131,7 +131,7 @@ options:
         should be set. If one of the two values is missing, the --tcp-flags option
         will be ignored.
     required: false
-    default: null
+    default: {}
   match:
     description:
       - Specifies a match to use, that is, an extension module that tests for

--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -123,6 +123,15 @@ options:
         inverts the sense of the address.
     required: false
     default: null
+  tcp_flags:
+    description:
+      - TCP flags specification. tcp_flags expects a dict with the two keys
+        "flags" and "flags_set". The "flags" list is the mask: a list of
+        flags you want to examine. The "flags_set" list tells which one(s)
+        should be set. If one of the two values is missing, the --tcp-flags option
+        will be ignored.
+    required: false
+    default: null
   match:
     description:
       - Specifies a match to use, that is, an extension module that tests for
@@ -358,6 +367,10 @@ def append_param(rule, param, flag, is_list):
         if param is not None:
             rule.extend([flag, param])
 
+def append_tcp_flags(rule, param, flag):
+    if param:
+        if 'flags' in param and 'flags_set' in param:
+            rule.extend([flag, ','.join(param['flags']), ','.join(param['flags_set'])])
 
 def append_csv(rule, param, flag):
     if param:
@@ -380,6 +393,7 @@ def construct_rule(params):
     append_param(rule, params['source'], '-s', False)
     append_param(rule, params['destination'], '-d', False)
     append_param(rule, params['match'], '-m', True)
+    append_tcp_flags(rule, params['tcp_flags'], '--tcp-flags')
     append_param(rule, params['jump'], '-j', False)
     append_param(rule, params['to_destination'], '--to-destination', False)
     append_param(rule, params['to_source'], '--to-source', False)
@@ -485,6 +499,7 @@ def main():
             destination=dict(required=False, default=None, type='str'),
             to_destination=dict(required=False, default=None, type='str'),
             match=dict(required=False, default=[], type='list'),
+            tcp_flags=dict(required=False, default={}, type='dict'),
             jump=dict(required=False, default=None, type='str'),
             goto=dict(required=False, default=None, type='str'),
             in_interface=dict(required=False, default=None, type='str'),


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
iptables module

##### ANSIBLE VERSION
```
ansible 2.3.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add the opportunity to use tcp-flags in the iptables module.
The function is required if you want to detect stealth scans and DROP
or REJECT them.
For an easy usage, two lists are used. One for the flags to examine and a
second one for the flag, that should be set.