### PR TITLE
fix exception when an image has no name

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -349,7 +349,7 @@ class AnsibleDockerClient(Client):
         try:
             for container in self.containers(all=True):
                 self.log("testing container: %s" % (container['Names']))
-                if search_name in container['Names']:
+                if isinstance(container['Names'], list) and search_name in container['Names']:
                     result = container
                     break
                 if container['Id'].startswith(name):


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

`ansible.module_utils.docker_common`

##### SUMMARY

Fixes #18497

This prevents an exception from occurring when an image has no name.  While images normally have names it is possible, at least on older versions of Docker, for an image to "lose" its name during a failed `docker rm`.