### PR TITLE
iam_cert return arn and allow use with ansible vault

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam_cert.py
+++ b/lib/ansible/modules/cloud/amazon/iam_cert.py
@@ -138,7 +138,11 @@ def cert_meta(iam, name):
                                                  server_certificate.\
                                                  server_certificate_metadata.\
                                                  expiration
-    return opath, ocert, ocert_id, upload_date, exp
+    arn         = iam.get_server_certificate(name).get_server_certificate_result.\
+                                                 server_certificate.\
+                                                 server_certificate_metadata.\
+                                                 arn
+    return opath, ocert, ocert_id, upload_date, exp, arn
 
 def dup_check(module, iam, name, new_name, cert, orig_cert_names, orig_cert_bodies, dup_ok):
     update=False
@@ -184,34 +188,34 @@ def cert_action(module, iam, name, cpath, new_name, new_path, state,
         update = dup_check(module, iam, name, new_name, cert, orig_cert_names,
                            orig_cert_bodies, dup_ok)
         if update:
-            opath, ocert, ocert_id, upload_date, exp = cert_meta(iam, name)
+            opath, ocert, ocert_id, upload_date, exp, arn = cert_meta(iam, name)
             changed=True
             if new_name and new_path:
                 iam.update_server_cert(name, new_cert_name=new_name, new_path=new_path)
                 module.exit_json(changed=changed, original_name=name, new_name=new_name,
                                  original_path=opath, new_path=new_path, cert_body=ocert,
-                                 upload_date=upload_date, expiration_date=exp)
+                                 upload_date=upload_date, expiration_date=exp, arn=arn)
             elif new_name and not new_path:
                 iam.update_server_cert(name, new_cert_name=new_name)
                 module.exit_json(changed=changed, original_name=name, new_name=new_name,
                                  cert_path=opath, cert_body=ocert,
-                                 upload_date=upload_date, expiration_date=exp)
+                                 upload_date=upload_date, expiration_date=exp, arn=arn)
             elif not new_name and new_path:
                 iam.update_server_cert(name, new_path=new_path)
                 module.exit_json(changed=changed, name=new_name,
                                  original_path=opath, new_path=new_path, cert_body=ocert,
-                                 upload_date=upload_date, expiration_date=exp)
+                                 upload_date=upload_date, expiration_date=exp, arn=arn)
             else:
                 changed=False
                 module.exit_json(changed=changed, name=name, cert_path=opath, cert_body=ocert,
-                                 upload_date=upload_date, expiration_date=exp,
+                                 upload_date=upload_date, expiration_date=exp, arn=arn,
                                  msg='No new path or name specified. No changes made')
         else:
             changed=True
             iam.upload_server_cert(name, cert, key, cert_chain=chain, path=cpath)
-            opath, ocert, ocert_id, upload_date, exp = cert_meta(iam, name)
+            opath, ocert, ocert_id, upload_date, exp, arn = cert_meta(iam, name)
             module.exit_json(changed=changed, name=name, cert_path=opath, cert_body=ocert,
-                                 upload_date=upload_date, expiration_date=exp)
+                                 upload_date=upload_date, expiration_date=exp, arn=arn)
     elif state == 'absent':
         if name in orig_cert_names:
             changed=True

--- a/lib/ansible/modules/cloud/amazon/iam_cert.py
+++ b/lib/ansible/modules/cloud/amazon/iam_cert.py
@@ -159,6 +159,9 @@ def dup_check(module, iam, name, new_name, cert, orig_cert_names, orig_cert_bodi
                     if slug_orig_cert_bodies == slug_cert:
                         update=True
                         break
+                    elif slug_cert.startswith(slug_orig_cert_bodies):
+                        update=True
+                        break
                     elif slug_orig_cert_bodies != slug_cert:
                         module.fail_json(changed=False, msg='A cert with the name %s already exists and'
                                                            ' has a different certificate body associated'


### PR DESCRIPTION
##### SUMMARY
Return certificate ARN in all success cases with `iam_cert`, allowing idempotent provisioning of other AWS services like elastic load balancers directly in the same playbook (which require an ARN for SSL for example).

There is also an included fix to allow duplicates to be correctly detected when the certificate body includes the authority chain directly (the data returned by AWS previously did not match).

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
iam_cert

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 4339be2fa8) last updated 2017/06/18 00:39:45 (GMT +1100)
  config file = None
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible-work/ansible/lib/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```
##### ADDITIONAL INFORMATION

