### PR TITLE
cloudfront_facts.py added summary, fixes and refactoring

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -202,7 +202,7 @@ except ImportError:
 
 from ansible.module_utils.ec2 import get_aws_connection_info
 from ansible.module_utils.ec2 import ec2_argument_spec
-from ansible.module_utils.ec2 import boto3_conn 
+from ansible.module_utils.ec2 import boto3_conn
 from ansible.module_utils.basic import AnsibleModule
 from functools import partial
 import json

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -368,17 +368,17 @@ class CloudFrontServiceManager:
             distributions = self.list_streaming_distributions(False) if streaming else self.list_distributions(False)
             for dist in distributions:
                 temp_distribution = {}
-                temp_distribution.update( 
-                    { 
-                        'Id': dist['Id'], 
-                        'ARN': dist['ARN'], 
-                        'Status': dist['Status'], 
-                        'LastModifiedTime': dist['LastModifiedTime'], 
-                        'DomainName': dist['DomainName'], 
-                        'Comment':  dist['Comment'], 
-                        'PriceClass': dist['PriceClass'], 
-                        'Enabled': dist['Enabled'], 
-                        'Aliases': [] 
+                temp_distribution.update(
+                    {
+                        'Id': dist['Id'],
+                        'ARN': dist['ARN'],
+                        'Status': dist['Status'],
+                        'LastModifiedTime': dist['LastModifiedTime'],
+                        'DomainName': dist['DomainName'],
+                        'Comment':  dist['Comment'],
+                        'PriceClass': dist['PriceClass'],
+                        'Enabled': dist['Enabled'],
+                        'Aliases': []
                     } )
                 if 'Items' in dist['Aliases']:
                     for alias in dist['Aliases']['Items']:
@@ -513,7 +513,7 @@ def main():
     streaming_distribution_config     = module.params.get('streaming_distribution_config')
     list_origin_access_identities     = module.params.get('list_origin_access_identities')
     list_distributions                = module.params.get('list_distributions')
-    list_distributions_by_web_acl_id  = module.params.get('list_distributions_by_web_acl_id');
+    list_distributions_by_web_acl_id  = module.params.get('list_distributions_by_web_acl_id')
     list_invalidations                = module.params.get('list_invalidations')
     list_streaming_distributions      = module.params.get('list_streaming_distributions')
     summary                           = module.params.get('summary')
@@ -521,14 +521,14 @@ def main():
     result = { 'cloudfront': {} } 
     facts = {}
     aliases = []
-    
-    require_distribution_id = (distribution or distribution_config or invalidation or streaming_distribution or 
+
+    require_distribution_id = (distribution or distribution_config or invalidation or streaming_distribution or
         streaming_distribution_config or list_invalidations)
 
     # set default to summary if no option specified
-    summary = summary or not (distribution or distribution_config or origin_access_identity or 
-        origin_access_identity_config or invalidation or streaming_distribution or streaming_distribution_config or 
-        list_origin_access_identities or list_distributions_by_web_acl_id or list_invalidations or 
+    summary = summary or not (distribution or distribution_config or origin_access_identity or
+        origin_access_identity_config or invalidation or streaming_distribution or streaming_distribution_config or
+        list_origin_access_identities or list_distributions_by_web_acl_id or list_invalidations or
         list_streaming_distributions or list_distributions)
 
     # validations
@@ -589,7 +589,7 @@ def main():
     if list_invalidations:
         invalidations = service_mgr.list_invalidations(distribution_id)
         facts = set_facts_for_distribution_id_and_alias(invalidations, facts, distribution_id, aliases)
-    
+ 
     # get list based on options
     if all_lists or list_origin_access_identities:
         facts['origin_access_identities'] = service_mgr.list_origin_access_identities()

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -27,11 +27,7 @@ description:
 requirements:
   - boto3 >= 1.0.0
   - python >= 2.6
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
 version_added: "2.3"
-=======
-version_added: "2.2"
->>>>>>> initial commit of cloudfront_facts.py
 author: Willem van Ketwich (@wilvk)
 options:
     distribution_id:
@@ -40,7 +36,6 @@ options:
         required: false
     invalidation_id:
         description:
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
           - The id of the invalidation to get information about. Used with invalidation.
         required: false
     origin_access_identity_id:
@@ -68,45 +63,13 @@ options:
     origin_access_identity_config:
         description:
             - Get the configuration information about an origin access identity. Requires origin_access_identity_id to be specified.
-=======
-          - The id of the invalidation to get information about. Used with invalidation
-          required: false
-    cloud_front_origin_access_identity_id:
-        description:
-          - The id of the cloudfront origin access identity to get information about
-        required: false
-    web_acl_id:
-        description:
-          - Used with list_distributions_by_web_acl_id
-          required: false
-    domain_name_alias:
-        description:
-          - Can be used instead of distribution_id - uses the aliased CNAME for the cloudfront distribution to get the distribution id where required
-          required: false
-    all_lists:
-        description:
-            - Get all cloudfront lists that do not require parameters
-        required: false
-        default: false
-    cloud_front_origin_access_identity:
-        description:
-            - Get information about an origin access identity
-        required: false
-        default: false
-    cloud_front_origin_access_identity_config:
-        description:
-            - Get the configuration information about an origin access identity
->>>>>>> initial commit of cloudfront_facts.py
         required: false
         default: false
     distribution:
         description:
             - Get information about a distribution. Requires distribution_id or domain_name_alias to be specified.
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
         required: false
         default: false
-=======
->>>>>>> initial commit of cloudfront_facts.py
     distribution_config:
         description:
             - Get the configuration information about a distribution. Requires distribution_id or domain_name_alias to be specified.
@@ -127,15 +90,9 @@ options:
             - Get the configuration information about a specified RTMP distribution. Requires distribution_id or domain_name_alias to be specified.
         required: false
         default: false
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
     list_origin_access_identities:
         description:
             - Get a list of cloudfront origin access identities. Requires origin_access_identity_id to be set.
-=======
-    list_cloud_front_origin_access_identities:
-        description:
-            - Get a list of cloudfront origin access identities. Requires cloud_front_origin_access_identity_id to be set.
->>>>>>> initial commit of cloudfront_facts.py
         required: false
         default: false
     list_distributions:
@@ -143,11 +100,7 @@ options:
             - Get a list of cloudfront distributions.
         required: false
         default: false
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
     list_distributions_by_web_acl_id:
-=======
-    list_distributions_by_web_acl:
->>>>>>> initial commit of cloudfront_facts.py
         description:
             - Get a list of distributions using web acl id as a filter. Requires web_acl_id to be set.
         required: false
@@ -159,11 +112,7 @@ options:
         default: false
     list_streaming_distributions:
         description:
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
             - Get a list of streaming distributions.
-=======
-            - Get a list of streaming distributions
->>>>>>> initial commit of cloudfront_facts.py
         required: false
         default: false
 
@@ -180,11 +129,7 @@ EXAMPLES = '''
     distribution: true
     distribution_id: my-cloudfront-distribution-id
 
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
 # Get information about a distribution using the CNAME of the cloudfront distribution.
-=======
-# Get information about a distribution using the CNAME of the cloudfront distribution
->>>>>>> initial commit of cloudfront_facts.py
 - cloudfront_facts:
     distribution: true
     domain_name_alias: www.my-website.com
@@ -193,20 +138,15 @@ EXAMPLES = '''
 - debug:
     msg: '{{ ansible_facts['cloudfront']['my-cloudfront-distribution-id'] }}'
 
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
 - debug:
     msg: '{{ ansible_facts['cloudfront']['www.my-website.com'] }}'
 
 # Get all information about an invalidation for a distribution.
-=======
-# Get all information about an invalidation for a distribution
->>>>>>> initial commit of cloudfront_facts.py
 - cloudfront_facts:
     invalidation: true
     distribution_id: my-cloudfront-distribution-id
     invalidation_id: my-cloudfront-invalidation-id
 
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
 # Get all information about a cloudfront origin access identity.
 - cloudfront_facts:
     origin_access_identity: true
@@ -220,13 +160,11 @@ EXAMPLES = '''
     cloud_front_origin_access_identity_id: my-cloudfront-origin-access-identity-id
 
 # Get all information about lists not requiring parameters (ie. list_cloud_front_origin_access_identities, list_distributions, list_streaming_distributions)
->>>>>>> initial commit of cloudfront_facts.py
 - cloudfront_facts:
     all_lists: true
 '''
 
 RETURN = '''
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
 origin_access_identity:
     description: Describes the origin access identity information. Requires origin_access_identity_id to be set.
     returned: only if origin_access_identity is true
@@ -237,18 +175,6 @@ origin_access_identity_configuration:
     type: dict
 distribution:
     description: Facts about a cloudfront distribution. Requires distribution_id or domain_name_alias to be specified. Requires origin_access_identity_id to be set.
-=======
-cloud_front_origin_access_identity:
-    description: Describes the origin access identity information. Requires cloud_front_origin_access_identity_id to be set.
-    returned: only if cloud_front_origin_access_identity is true
-    type: dict
-cloud_front_origin_access_identity_configuration:
-    description: Describes the origin access identity information configuration information. Requires cloud_front_origin_access_identity_id to be set.
-    returned: only if cloud_front_origin_access_identity_configuration is true
-    type: dict
-distribution:
-    description: Facts about a cloudfront distribution. Requires distribution_id or domain_name_alias to be specified. Requires cloud_front_origin_access_identity_id to be set.
->>>>>>> initial commit of cloudfront_facts.py
     returned: only if distribution is true
     type: dict
 distribution_config:
@@ -277,11 +203,8 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.ec2 import get_aws_connection_info
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
 from ansible.module_utils.ec2 import ec2_argument_spec
 from ansible.module_utils.ec2 import boto3_conn
-=======
->>>>>>> initial commit of cloudfront_facts.py
 from ansible.module_utils.basic import AnsibleModule
 from functools import partial
 import json
@@ -306,18 +229,13 @@ class CloudFrontServiceManager:
     def get_distribution(self, distribution_id):
         try:
             func = partial(self.client.get_distribution,Id=distribution_id)
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
             return self.paginated_response(func)
-=======
-            return self.paginated_response(func, 'Distribution')
->>>>>>> initial commit of cloudfront_facts.py
         except Exception as e:
             self.module.fail_json(msg="Error describing distribution - " + str(e), exception=traceback.format_exc(e))
 
     def get_distribution_config(self, distribution_id):
         try:
             func = partial(self.client.get_distribution_config,Id=distribution_id)
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
             return self.paginated_response(func)
         except Exception as e:
             self.module.fail_json(msg="Error describing distribution configuration - " + str(e), exception=traceback.format_exec(e))
@@ -333,52 +251,26 @@ class CloudFrontServiceManager:
         try:
             func = partial(self.client.get_cloud_front_origin_access_identity_config,Id=origin_access_identity_id)
             return self.paginated_response(func)
-=======
-            return self.paginated_response(func, 'DistributionConfig')
-        except Exception as e:
-            self.module.fail_json(msg="Error describing distribution configuration - " + str(e), exception=traceback.format_exec(e))
-
-    def get_cloud_front_origin_access_identity(self, origin_access_identity_id):
-        try:
-            func = partial(self.client.get_cloud_front_origin_access_identity,Id=origin_access_identity_id)
-            return self.paginated_response(func, 'CloudFrontOriginAccessIdentity')
-        except Exception as e:
-            self.module.fail_json(msg="Error describing origin access identity - " + str(e), exception=traceback.format_exc(e))
-
-    def get_cloud_front_origin_access_identity_config(self, origin_access_identity_id):
-        try:
-            func = partial(self.client.get_cloud_front_origin_access_identity_config,Id=origin_access_identity_id)
-            return self.paginated_response(func, 'CloudFrontOriginAccessIdentityConfig')
->>>>>>> initial commit of cloudfront_facts.py
         except Exception as e:
             self.module.fail_json(msg="Error describing origin access identity configuration - " + str(e), exception=traceback.format_exc(e))
 
     def get_invalidation(self, distribution_id, invalidation_id):
         try:
             func = partial(self.client.get_invalidation,DistributionId=distribution_id,Id=invalidation_id)
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
             return self.paginated_response(func)
-=======
-            return self.paginated_response(func, 'Invalidation')
->>>>>>> initial commit of cloudfront_facts.py
         except Exception as e:
             self.module.fail_json(msg="Error describing invalidation - " + str(e), exception=traceback.format_exc(e))
 
     def get_streaming_distribution(self, distribution_id):
         try:
             func = partial(self.client.get_streaming_distribution,Id=distribution_id)
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
             return self.paginated_response(func)
-=======
-            return self.paginated_response(func, 'StreamingDistribution')
->>>>>>> initial commit of cloudfront_facts.py
         except Exception as e:
             self.module.fail_json(msg="Error describing streaming distribution - " + str(e), exception=traceback.format_exc(e))
 
     def get_streaming_distribution_config(self, distribution_id):
         try:
             func = partial(self.client.get_streaming_distribution_config,Id=distribution_id)
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
             return self.paginated_response(func)
         except Exception as e:
             self.module.fail_json(msg="Error describing streaming distribution - " + str(e), exception=traceback.format_exc(e))
@@ -412,62 +304,22 @@ class CloudFrontServiceManager:
         try:
             func = partial(self.client.list_invalidations, DistributionId=distribution_id)
             return self.paginated_response(func, 'InvalidationList')['Items']
-=======
-            return self.paginated_response(func, 'StreamingDistributionConfig')
-        except Exception as e:
-            self.module.fail_json(msg="Error describing streaming distribution - " + str(e), exception=traceback.format_exc(e))
-
-    def list_cloud_front_origin_access_identities(self):
-        try:
-            func = partial(self.client.list_cloud_front_origin_access_identities)
-            return self.paginated_response(func, 'CloudFrontOriginAccessIdentityList')
-        except Exception as e:
-            self.module.fail_json(msg="Error listing cloud front origin access identities = " + str(e), exception=traceback.format_exc(e))
-
-    def list_distributions(self):
-        try:
-            func = partial(self.client.list_distributions)
-            return self.paginated_response(func, 'DistributionList')
-        except Exception as e:
-            self.module.fail_json(msg="Error listing distributions = " + str(e), exception=traceback.format_exc(e))
-
-    def list_distributions_by_web_acl(self, web_acl_id):
-        try:
-            func = partial(self.client.list_distributions, web_acl_id)
-            return self.paginated_response(func, 'DistributionList')
-        except Exception as e:
-            self.module.fail_json(msg="Error listing distributions by web acl id = " + str(e), exception=traceback.format_exc(e))
-
-    def list_invalidations(self):
-        try:
-            func = partial(self.client.list_invalidations)
-            return self.paginated_response(func, 'InvalidationList')
->>>>>>> initial commit of cloudfront_facts.py
         except Exception as e:
             self.module.fail_json(msg="Error listing invalidations = " + str(e), exception=traceback.format_exc(e))
 
     def list_streaming_distributions(self):
         try:
             func = partial(self.client.list_streaming_distributions)
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
             streaming_distributions = self.paginated_response(func, 'StreamingDistributionList')['Items']
             return self.keyed_list_helper(streaming_distributions)
-=======
-            return self.paginated_response(func, 'StreamingDistributionList')
->>>>>>> initial commit of cloudfront_facts.py
         except Exception as e:
             self.module.fail_json(msg="Error listing streaming distributions = " + str(e), exception=traceback.format_exc(e))
 
     def get_distribution_id_from_domain_name(self, domain_name):
         try:
             distribution_id = ""
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
             distributions = self.list_distributions(False)
             for dist in distributions:
-=======
-            distributions = self.list_distributions()
-            for dist in distributions['Items']:
->>>>>>> initial commit of cloudfront_facts.py
                 for alias in dist['Aliases']['Items']:
                     if str(alias).lower() == domain_name.lower():
                         distribution_id = str(dist['Id'])
@@ -476,7 +328,6 @@ class CloudFrontServiceManager:
         except Exception as e:
             self.module.fail_json(msg="Error getting distribution id from domain name = " + str(e), exception=traceback.format_exc(e))
 
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
     def get_aliases_from_distribution_id(self, distribution_id):
         aliases = []
         try:
@@ -491,14 +342,10 @@ class CloudFrontServiceManager:
             self.module.fail_json(msg="Error getting list of aliases from distribution_id = " + str(e), exception=traceback.format_exc(e))
 
     def paginated_response(self, func, result_key=""):
-=======
-    def paginated_response(self, func, result_key, next_token=None):
->>>>>>> initial commit of cloudfront_facts.py
         '''
         Returns expanded response for paginated operations.
         The 'result_key' is used to define the concatenated results that are combined from each paginated response.
         '''
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
         args = dict()
         results = dict()
         loop = True
@@ -523,43 +370,23 @@ class CloudFrontServiceManager:
             for alias in aliases:
                 keyed_list.update({alias: item})
         return keyed_list
-=======
-        args=dict()
-        if next_token:
-            args['NextToken'] = next_token
-        response = func(**args)
-        result = response.get(result_key)
-        next_token = response.get('NextToken')
-        if not next_token:
-           return result
-        return result + self.paginated_response(func, result_key, next_token)
-
-<<<<<<< 0b1d3017bba14aae2ae52ad03d42e16ad5686660
 def to_dict(items, key, value):
     ''' Transforms a list of items to a Key/Value dictionary '''
     if items:
         return dict(zip([i[key] for i in items], [i[value] for i in items]))
     else:
         return dict()
->>>>>>> initial commit of cloudfront_facts.py
 
-=======
->>>>>>> modification as per review from @georgepsarakis
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
         distribution_id=dict(required=False, type='str'),
         invalidation_id=dict(required=False, type='str'),
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
         origin_access_identity_id=dict(required=False, type='str'),
-=======
-        cloud_front_origin_access_identity_id=dict(required=False, type='str'),
->>>>>>> initial commit of cloudfront_facts.py
         domain_name_alias=dict(required=False, type='str'),
         all_lists=dict(required=False, default=False, type='bool'),
         distribution=dict(required=False, default=False, type='bool'),
         distribution_config=dict(required=False, default=False, type='bool'),
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
         origin_access_identity=dict(required=False, default=False, type='bool'),
         origin_access_identity_config=dict(required=False, default=False, type='bool'),
         invalidation=dict(required=False, default=False, type='bool'),
@@ -568,16 +395,6 @@ def main():
         list_origin_access_identities=dict(required=False, default=False, type='bool'),
         list_distributions=dict(required=False, default=False, type='bool'),
         list_distributions_by_web_acl_id=dict(required=False, default=False, type='bool'),
-=======
-        cloud_front_origin_access_identity=dict(required=False, default=False, type='bool'),
-        cloud_front_origin_access_identity_config=dict(required=False, default=False, type='bool'),
-        invalidation=dict(required=False, default=False, type='bool'),
-        streaming_distribution=dict(required=False, default=False, type='bool'),
-        streaming_distribution_config=dict(required=False, default=False, type='bool'),
-        list_cloud_front_origin_access_identities=dict(required=False, default=False, type='bool'),
-        list_distributions=dict(required=False, default=False, type='bool'),
-        list_distributions_by_web_acl=dict(required=False, default=False, type='bool'),
->>>>>>> initial commit of cloudfront_facts.py
         list_invalidations=dict(required=False, default=False, type='bool'),
         list_streaming_distributions=dict(required=False, default=False, type='bool')
     ))
@@ -585,21 +402,13 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
 
     if not HAS_BOTO3:
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
         module.fail_json(msg='boto3 is required.')
-=======
-      module.fail_json(msg='boto3 is required.')
->>>>>>> initial commit of cloudfront_facts.py
 
     service_mgr = CloudFrontServiceManager(module)
 
     distribution_id = module.params.get('distribution_id')
     invalidation_id = module.params.get('invalidation_id')
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
     origin_access_identity_id = module.params.get('origin_access_identity_id')
-=======
-    cloud_front_origin_access_identity_id = module.params.get('cloud_front_origin_access_identity_id')
->>>>>>> initial commit of cloudfront_facts.py
     web_acl_id = module.params.get('web_acl_id')
     domain_name_alias = module.params.get('domain_name_alias')
 
@@ -607,18 +416,12 @@ def main():
 
     distribution = module.params.get('distribution')
     distribution_config = module.params.get('distribution_config')
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
     origin_access_identity = module.params.get('origin_access_identity')
     origin_access_identity_config = module.params.get('origin_access_identity_config')
-=======
-    cloud_front_origin_access_identity = module.params.get('cloudfront_origin_access_identity')
-    cloud_front_origin_access_identity_config = module.params.get('cloudfront_origin_access_identity_config')
->>>>>>> initial commit of cloudfront_facts.py
     invalidation = module.params.get('invalidation')
     streaming_distribution = module.params.get('streaming_distribution')
     streaming_distribution_config = module.params.get('streaming_distribution_config')
 
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
     list_origin_access_identities = module.params.get('list_origin_access_identities')
     list_distributions = module.params.get('list_distributions')
     list_distributions_by_web_acl_id = module.params.get('list_distributions_by_web_acl_id')
@@ -643,24 +446,6 @@ def main():
         module.fail_json(msg='Error invalidation_id has not been specified.')
     if (origin_access_identity or origin_access_identity_config) and origin_access_identity_id is None:
         module.fail_json(msg='Error origin_access_identity_id has not been specified.')
-=======
-    list_cloud_front_origin_access_identities = module.params.get('list_cloud_front_origin_access_identities')
-    list_distributions = module.params.get('list_distributions')
-    list_distributions_by_web_acl_id = module.params.get('list_distributions_by_web_acl_id');
-    list_invalidations = module.params.get('list_invalidations')
-    list_streaming_distributions = module.params.get('list_streaming_distributions')
-
-    require_distribution_id = (distribution or distribution_config or invalidation or
-            streaming_distribution or streaming_distribution_config or list_invalidations)
-
-    # validations
-    if require_distribution_id and distribution_id is None and domain_name_alias is None:
-        module.fail_json(msg='Error distribution_id or domain_name have not been specified.')
-    if (invalidation and invalidation_id is None):
-        module.fail_json(msg='Error invalidation_id has not been specified.')
-    if (cloud_front_origin_access_identity or cloud_front_origin_access_identity_config) and cloud_front_origin_access_identity_id is None:
-        module.fail_json(msg='Error cloud_front_origin_access_identity_id has not been specified.')
->>>>>>> initial commit of cloudfront_facts.py
     if list_distributions_by_web_acl_id and web_acl_id is None:
         module.fail_json(msg='Error web_acl_id has not been specified.')
 
@@ -670,7 +455,6 @@ def main():
         if not distribution_id:
             module.fail_json(msg='Error unable to source a distribution id from domain_name_alias')
 
-<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
     # set appropriate cloudfront id
     if distribution_id and not list_invalidations:
         result = { 'cloudfront': { distribution_id: {} } }
@@ -745,56 +529,6 @@ def main():
 
     result['changed'] = False
     module.exit_json(msg="Retrieved cloudfront facts.", ansible_facts=result)
-=======
-    # set appropriate ansible_facts id
-    if distribution_id:
-        result = { 'ansible_facts': { 'cloudfront': { distribution_id:{} } } }
-        facts = result['ansible_facts']['cloudfront'][distribution_id]
-    elif cloud_front_origin_access_identity_id:
-        result = { 'ansible_facts': { 'cloudfront': { cloud_front_origin_access_identity_id:{} } } }
-        facts = result['ansible_facts']['cloudfront'][cloud_front_origin_access_identity_id]
-    elif web_acl_id:
-        result = { 'ansible_facts': { 'cloudfront': { web_acl_id:{} } } }
-        facts = result['ansible_facts']['cloudfront'][web_acl_id]
-    else:
-        result = { 'ansible_facts': { 'cloudfront': {} } }
-        facts = result['ansible_facts']['cloudfront']
-
-    # call details based on options
-    if distribution:
-        facts['distribution'] = service_mgr.get_distribution(distribution_id)
-    if distribution_config:
-        facts['distribution_config'] = service_mgr.get_distribution_config(distribution_id)
-    if cloud_front_origin_access_identity:
-        facts['cloud_front_origin_access_identity'] = service_mgr.get_cloud_front_origin_access_identity(cloud_front_origin_access_identity_id)
-    if cloud_front_origin_access_identity_config:
-        facts['cloud_front_origin_access_identity_config'] = service_mgr.get_cloud_front_origin_access_identity_config(cloud_front_origin_access_identity_id)
-    if invalidation:
-        facts['invalidation'] = service_mgr.get_invalidation(distribution_id, invalidation_id)
-    if streaming_distribution:
-        facts['streaming_distribution'] = service_mgr.get_streaming_distribution(distribution_id)
-    if streaming_distribution_config:
-        facts['streaming_distribution_config'] = service_mgr.get_streaming_distribution_config(distribution_id)
-
-    # call list based on options
-    if all_lists or list_cloud_front_origin_access_identities:
-        facts['list_cloud_front_origin_access_identities'] = service_mgr.list_cloud_front_origin_access_identities()
-    if all_lists or list_distributions:
-        facts['list_distributions'] = service_mgr.list_distributions()
-    if all_lists or list_streaming_distributions:
-        facts['list_streaming_distributions'] = service_mgr.list_streaming_distributions()
-    if list_distributions_by_web_acl_id:
-        facts['list_distributions_by_web_acl'] = service_mgr.list_distributions_by_web_acl()
-    if list_invalidations:
-        facts['list_invalidations'] = service_mgr.list_invalidations(distribution_id)
-
-    result['changed'] = False
-    module.exit_json(msg="Retrieved cloudfront facts.", ansible_facts=result)
-
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
->>>>>>> initial commit of cloudfront_facts.py
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -374,7 +374,7 @@ class CloudFrontServiceManager:
                 temp_distribution = {}
                 for key_name in key_list:
                     temp_distribution.update( { key_name: dist[key_name] } )
-                temp_distribution.update( { 'Aliases': [] } ) 
+                temp_distribution.update( { 'Aliases': [] } )
                 temp_distribution.update( { 'ETag': self.get_etag_from_distribution_id(dist['Id'], streaming) } )
                 if 'Items' in dist['Aliases']:
                     for alias in dist['Aliases']['Items']:

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -537,7 +537,7 @@ def main():
     invalidation = module.params.get('invalidation')
     streaming_distribution = module.params.get('streaming_distribution')
     streaming_distribution_config = module.params.get('streaming_distribution_config')
-    
+ 
     list_origin_access_identities = module.params.get('list_origin_access_identities')
     list_distributions = module.params.get('list_distributions')
     list_distributions_by_web_acl_id = module.params.get('list_distributions_by_web_acl_id')

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -495,24 +495,24 @@ def set_facts_for_distribution_id_and_alias(details, facts, distribution_id, ali
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
-        distribution_id = dict(required=False, type='str'),
-        invalidation_id = dict(required=False, type='str'),
-        origin_access_identity_id = dict(required=False, type='str'),
-        domain_name_alias = dict(required=False, type='str'),
-        all_lists = dict(required=False, default=False, type='bool'),
-        distribution = dict(required=False, default=False, type='bool'),
-        distribution_config = dict(required=False, default=False, type='bool'),
-        origin_access_identity = dict(required=False, default=False, type='bool'),
-        origin_access_identity_config = dict(required=False, default=False, type='bool'),
-        invalidation = dict(required=False, default=False, type='bool'),
-        streaming_distribution = dict(required=False, default=False, type='bool'),
-        streaming_distribution_config = dict(required=False, default=False, type='bool'),
-        list_origin_access_identities = dict(required=False, default=False, type='bool'),
-        list_distributions = dict(required=False, default=False, type='bool'),
-        list_distributions_by_web_acl_id = dict(required=False, default=False, type='bool'),
-        list_invalidations = dict(required=False, default=False, type='bool'),
-        list_streaming_distributions = dict(required=False, default=False, type='bool'),
-        summary = dict(required=False, default=False, type='bool')
+        distribution_id=dict(required=False, type='str'),
+        invalidation_id=dict(required=False, type='str'),
+        origin_access_identity_id=dict(required=False, type='str'),
+        domain_name_alias=dict(required=False, type='str'),
+        all_lists=dict(required=False, default=False, type='bool'),
+        distribution=dict(required=False, default=False, type='bool'),
+        distribution_config=dict(required=False, default=False, type='bool'),
+        origin_access_identity=dict(required=False, default=False, type='bool'),
+        origin_access_identity_config=dict(required=False, default=False, type='bool'),
+        invalidation=dict(required=False, default=False, type='bool'),
+        streaming_distribution=dict(required=False, default=False, type='bool'),
+        streaming_distribution_config=dict(required=False, default=False, type='bool'),
+        list_origin_access_identities=dict(required=False, default=False, type='bool'),
+        list_distributions=dict(required=False, default=False, type='bool'),
+        list_distributions_by_web_acl_id=dict(required=False, default=False, type='bool'),
+        list_invalidations=dict(required=False, default=False, type='bool'),
+        list_streaming_distributions=dict(required=False, default=False, type='bool'),
+        summary=dict(required=False, default=False, type='bool')
     ))
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -495,24 +495,24 @@ def set_facts_for_distribution_id_and_alias(details, facts, distribution_id, ali
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
-        distribution_id                   = dict(required=False, type='str'),
-        invalidation_id                   = dict(required=False, type='str'),
-        origin_access_identity_id         = dict(required=False, type='str'),
-        domain_name_alias                 = dict(required=False, type='str'),
-        all_lists                         = dict(required=False, default=False, type='bool'),
-        distribution                      = dict(required=False, default=False, type='bool'),
-        distribution_config               = dict(required=False, default=False, type='bool'),
-        origin_access_identity            = dict(required=False, default=False, type='bool'),
-        origin_access_identity_config     = dict(required=False, default=False, type='bool'),
-        invalidation                      = dict(required=False, default=False, type='bool'),
-        streaming_distribution            = dict(required=False, default=False, type='bool'),
-        streaming_distribution_config     = dict(required=False, default=False, type='bool'),
-        list_origin_access_identities     = dict(required=False, default=False, type='bool'),
-        list_distributions                = dict(required=False, default=False, type='bool'),
-        list_distributions_by_web_acl_id  = dict(required=False, default=False, type='bool'),
-        list_invalidations                = dict(required=False, default=False, type='bool'),
-        list_streaming_distributions      = dict(required=False, default=False, type='bool'),
-        summary                           = dict(required=False, default=False, type='bool')
+        distribution_id = dict(required=False, type='str'),
+        invalidation_id = dict(required=False, type='str'),
+        origin_access_identity_id = dict(required=False, type='str'),
+        domain_name_alias = dict(required=False, type='str'),
+        all_lists = dict(required=False, default=False, type='bool'),
+        distribution = dict(required=False, default=False, type='bool'),
+        distribution_config = dict(required=False, default=False, type='bool'),
+        origin_access_identity = dict(required=False, default=False, type='bool'),
+        origin_access_identity_config = dict(required=False, default=False, type='bool'),
+        invalidation = dict(required=False, default=False, type='bool'),
+        streaming_distribution = dict(required=False, default=False, type='bool'),
+        streaming_distribution_config = dict(required=False, default=False, type='bool'),
+        list_origin_access_identities = dict(required=False, default=False, type='bool'),
+        list_distributions = dict(required=False, default=False, type='bool'),
+        list_distributions_by_web_acl_id = dict(required=False, default=False, type='bool'),
+        list_invalidations = dict(required=False, default=False, type='bool'),
+        list_streaming_distributions = dict(required=False, default=False, type='bool'),
+        summary = dict(required=False, default=False, type='bool')
     ))
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
@@ -522,25 +522,25 @@ def main():
 
     service_mgr = CloudFrontServiceManager(module)
 
-    distribution_id                   = module.params.get('distribution_id')
-    invalidation_id                   = module.params.get('invalidation_id')
-    origin_access_identity_id         = module.params.get('origin_access_identity_id')
-    web_acl_id                        = module.params.get('web_acl_id')
-    domain_name_alias                 = module.params.get('domain_name_alias')
-    all_lists                         = module.params.get('all_lists')
-    distribution                      = module.params.get('distribution')
-    distribution_config               = module.params.get('distribution_config')
-    origin_access_identity            = module.params.get('origin_access_identity')
-    origin_access_identity_config     = module.params.get('origin_access_identity_config')
-    invalidation                      = module.params.get('invalidation')
-    streaming_distribution            = module.params.get('streaming_distribution')
-    streaming_distribution_config     = module.params.get('streaming_distribution_config')
-    list_origin_access_identities     = module.params.get('list_origin_access_identities')
-    list_distributions                = module.params.get('list_distributions')
-    list_distributions_by_web_acl_id  = module.params.get('list_distributions_by_web_acl_id')
-    list_invalidations                = module.params.get('list_invalidations')
-    list_streaming_distributions      = module.params.get('list_streaming_distributions')
-    summary                           = module.params.get('summary')
+    distribution_id = module.params.get('distribution_id')
+    invalidation_id = module.params.get('invalidation_id')
+    origin_access_identity_id = module.params.get('origin_access_identity_id')
+    web_acl_id = module.params.get('web_acl_id')
+    domain_name_alias = module.params.get('domain_name_alias')
+    all_lists = module.params.get('all_lists')
+    distribution = module.params.get('distribution')
+    distribution_config = module.params.get('distribution_config')
+    origin_access_identity = module.params.get('origin_access_identity')
+    origin_access_identity_config = module.params.get('origin_access_identity_config')
+    invalidation = module.params.get('invalidation')
+    streaming_distribution = module.params.get('streaming_distribution')
+    streaming_distribution_config = module.params.get('streaming_distribution_config')
+    list_origin_access_identities = module.params.get('list_origin_access_identities')
+    list_distributions = module.params.get('list_distributions')
+    list_distributions_by_web_acl_id = module.params.get('list_distributions_by_web_acl_id')
+    list_invalidations = module.params.get('list_invalidations')
+    list_streaming_distributions = module.params.get('list_streaming_distributions')
+    summary = module.params.get('summary')
 
     result = { 'cloudfront': {} }
     facts = {}

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -202,7 +202,7 @@ except ImportError:
 
 from ansible.module_utils.ec2 import get_aws_connection_info
 from ansible.module_utils.ec2 import ec2_argument_spec
-from ansible.module_utils.ec2 import boto3_conn
+from ansible.module_utils.ec2 import boto3_conn 
 from ansible.module_utils.basic import AnsibleModule
 from functools import partial
 import json

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -32,23 +32,23 @@ author: Willem van Ketwich (@wilvk)
 options:
     distribution_id:
         description:
-            - The id of the CloudFront distribution. Used with distribution, distribution_config, invalidation, streaming_distribution, streaming_distribution_config, list_invalidations.
+          - The id of the CloudFront distribution. Used with distribution, distribution_config, invalidation, streaming_distribution, streaming_distribution_config, list_invalidations.
         required: false
     invalidation_id:
         description:
-            - The id of the invalidation to get information about. Used with invalidation.
+          - The id of the invalidation to get information about. Used with invalidation.
         required: false
     origin_access_identity_id:
         description:
-            - The id of the cloudfront origin access identity to get information about.
+          - The id of the cloudfront origin access identity to get information about.
         required: false
     web_acl_id:
         description:
-            - Used with list_distributions_by_web_acl_id.
+          - Used with list_distributions_by_web_acl_id.
         required: false
     domain_name_alias:
         description:
-            - Can be used instead of distribution_id - uses the aliased CNAME for the cloudfront distribution to get the distribution id where required.
+          - Can be used instead of distribution_id - uses the aliased CNAME for the cloudfront distribution to get the distribution id where required.
         required: false
     all_lists:
         description:

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -527,7 +527,9 @@ def main():
     origin_access_identity_id = module.params.get('origin_access_identity_id')
     web_acl_id = module.params.get('web_acl_id')
     domain_name_alias = module.params.get('domain_name_alias')
+
     all_lists = module.params.get('all_lists')
+
     distribution = module.params.get('distribution')
     distribution_config = module.params.get('distribution_config')
     origin_access_identity = module.params.get('origin_access_identity')
@@ -535,6 +537,7 @@ def main():
     invalidation = module.params.get('invalidation')
     streaming_distribution = module.params.get('streaming_distribution')
     streaming_distribution_config = module.params.get('streaming_distribution_config')
+    
     list_origin_access_identities = module.params.get('list_origin_access_identities')
     list_distributions = module.params.get('list_distributions')
     list_distributions_by_web_acl_id = module.params.get('list_distributions_by_web_acl_id')
@@ -542,9 +545,9 @@ def main():
     list_streaming_distributions = module.params.get('list_streaming_distributions')
     summary = module.params.get('summary')
 
+    aliases = []
     result = { 'cloudfront': {} }
     facts = {}
-    aliases = []
 
     require_distribution_id = (distribution or distribution_config or invalidation or streaming_distribution or
         streaming_distribution_config or list_invalidations)

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -371,18 +371,10 @@ class CloudFrontServiceManager:
             distributions = self.list_streaming_distributions(False) if streaming else self.list_distributions(False)
             for dist in distributions:
                 temp_distribution = {}
-                temp_distribution.update(
-                    {
-                        'Id': dist['Id'],
-                        'ARN': dist['ARN'],
-                        'Status': dist['Status'],
-                        'LastModifiedTime': dist['LastModifiedTime'],
-                        'DomainName': dist['DomainName'],
-                        'Comment':  dist['Comment'],
-                        'PriceClass': dist['PriceClass'],
-                        'Enabled': dist['Enabled'],
-                        'Aliases': []
-                    } )
+                key_list = ['Id', 'ARN', 'Status', 'LastModifiedTime', 'DomainName', 'Comment', 'PriceClass', 'Enabled' ]
+                for key_name in key_list:
+                    temp_distribution.update( { key_name: dist[key_name] } )
+                temp_distribution.update( { 'Aliases': [] } ) 
                 temp_distribution.update( { 'ETag': self.get_etag_from_distribution_id(dist['Id'], streaming) } )
                 if 'Items' in dist['Aliases']:
                     for alias in dist['Aliases']['Items']:

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -525,6 +525,8 @@ def main():
         facts['streaming_distributions'] = service_mgr.list_streaming_distributions()
     if list_distributions_by_web_acl_id:
         facts['distributions_by_web_acl_id'] = service_mgr.list_distributions_by_web_acl_id(web_acl_id)
+    if list_invalidations:
+        facts['list_invalidations'] = service_mgr.list_invalidations(distribution_id)
 
     result['changed'] = False
     module.exit_json(msg="Retrieved cloudfront facts.", ansible_facts=result)

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -441,24 +441,24 @@ class CloudFrontServiceManager:
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
-        distribution_id=dict(required=False, type='str'),
-        invalidation_id=dict(required=False, type='str'),
-        origin_access_identity_id=dict(required=False, type='str'),
-        domain_name_alias=dict(required=False, type='str'),
-        all_lists=dict(required=False, default=False, type='bool'),
-        distribution=dict(required=False, default=False, type='bool'),
-        distribution_config=dict(required=False, default=False, type='bool'),
-        origin_access_identity=dict(required=False, default=False, type='bool'),
-        origin_access_identity_config=dict(required=False, default=False, type='bool'),
-        invalidation=dict(required=False, default=False, type='bool'),
-        streaming_distribution=dict(required=False, default=False, type='bool'),
-        streaming_distribution_config=dict(required=False, default=False, type='bool'),
-        list_origin_access_identities=dict(required=False, default=False, type='bool'),
-        list_distributions=dict(required=False, default=False, type='bool'),
-        list_distributions_by_web_acl_id=dict(required=False, default=False, type='bool'),
-        list_invalidations=dict(required=False, default=False, type='bool'),
-        list_streaming_distributions=dict(required=False, default=False, type='bool'),
-        summary=dict(required=False, default=False, type='bool')
+        distribution_id                   = dict(required=False, type='str'),
+        invalidation_id                   = dict(required=False, type='str'),
+        origin_access_identity_id         = dict(required=False, type='str'),
+        domain_name_alias                 = dict(required=False, type='str'),
+        all_lists                         = dict(required=False, default=False, type='bool'),
+        distribution                      = dict(required=False, default=False, type='bool'),
+        distribution_config               = dict(required=False, default=False, type='bool'),
+        origin_access_identity            = dict(required=False, default=False, type='bool'),
+        origin_access_identity_config     = dict(required=False, default=False, type='bool'),
+        invalidation                      = dict(required=False, default=False, type='bool'),
+        streaming_distribution            = dict(required=False, default=False, type='bool'),
+        streaming_distribution_config     = dict(required=False, default=False, type='bool'),
+        list_origin_access_identities     = dict(required=False, default=False, type='bool'),
+        list_distributions                = dict(required=False, default=False, type='bool'),
+        list_distributions_by_web_acl_id  = dict(required=False, default=False, type='bool'),
+        list_invalidations                = dict(required=False, default=False, type='bool'),
+        list_streaming_distributions      = dict(required=False, default=False, type='bool'),
+        summary                           = dict(required=False, default=False, type='bool')
     ))
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
@@ -468,29 +468,25 @@ def main():
 
     service_mgr = CloudFrontServiceManager(module)
 
-    distribution_id = module.params.get('distribution_id')
-    invalidation_id = module.params.get('invalidation_id')
-    origin_access_identity_id = module.params.get('origin_access_identity_id')
-    web_acl_id = module.params.get('web_acl_id')
-    domain_name_alias = module.params.get('domain_name_alias')
-
-    all_lists = module.params.get('all_lists')
-
-    distribution = module.params.get('distribution')
-    distribution_config = module.params.get('distribution_config')
-    origin_access_identity = module.params.get('origin_access_identity')
-    origin_access_identity_config = module.params.get('origin_access_identity_config')
-    invalidation = module.params.get('invalidation')
-    streaming_distribution = module.params.get('streaming_distribution')
-    streaming_distribution_config = module.params.get('streaming_distribution_config')
-
-    list_origin_access_identities = module.params.get('list_origin_access_identities')
-    list_distributions = module.params.get('list_distributions')
-    list_distributions_by_web_acl_id = module.params.get('list_distributions_by_web_acl_id')
-    list_invalidations = module.params.get('list_invalidations')
-    list_streaming_distributions = module.params.get('list_streaming_distributions')
-
-    summary = module.params.get('summary')
+    distribution_id                   = module.params.get('distribution_id')
+    invalidation_id                   = module.params.get('invalidation_id')
+    origin_access_identity_id         = module.params.get('origin_access_identity_id')
+    web_acl_id                        = module.params.get('web_acl_id')
+    domain_name_alias                 = module.params.get('domain_name_alias')
+    all_lists                         = module.params.get('all_lists')
+    distribution                      = module.params.get('distribution')
+    distribution_config               = module.params.get('distribution_config')
+    origin_access_identity            = module.params.get('origin_access_identity')
+    origin_access_identity_config     = module.params.get('origin_access_identity_config')
+    invalidation                      = module.params.get('invalidation')
+    streaming_distribution            = module.params.get('streaming_distribution')
+    streaming_distribution_config     = module.params.get('streaming_distribution_config')
+    list_origin_access_identities     = module.params.get('list_origin_access_identities')
+    list_distributions                = module.params.get('list_distributions')
+    list_distributions_by_web_acl_id  = module.params.get('list_distributions_by_web_acl_id');
+    list_invalidations                = module.params.get('list_invalidations')
+    list_streaming_distributions      = module.params.get('list_streaming_distributions')
+    summary                           = module.params.get('summary')
 
     aliases = []
 

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -154,10 +154,10 @@ EXAMPLES = '''
 
 # Get all information about lists not requiring parameters (ie. list_origin_access_identities, list_distributions, list_streaming_distributions)
 - cloudfront_facts:
-    cloud_front_origin_access_identity: true
-    cloud_front_origin_access_identity_id: my-cloudfront-origin-access-identity-id
+    origin_access_identity: true
+    origin_access_identity_id: my-cloudfront-origin-access-identity-id
 
-# Get all information about lists not requiring parameters (ie. list_cloud_front_origin_access_identities, list_distributions, list_streaming_distributions)
+# Get all information about lists not requiring parameters (ie. list_origin_access_identities, list_distributions, list_streaming_distributions)
 - cloudfront_facts:
     all_lists: true
 '''

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -32,23 +32,23 @@ author: Willem van Ketwich (@wilvk)
 options:
     distribution_id:
         description:
-          - The id of the CloudFront distribution. Used with distribution, distribution_config, invalidation, streaming_distribution, streaming_distribution_config, list_invalidations.
+            - The id of the CloudFront distribution. Used with distribution, distribution_config, invalidation, streaming_distribution, streaming_distribution_config, list_invalidations.
         required: false
     invalidation_id:
         description:
-          - The id of the invalidation to get information about. Used with invalidation.
+            - The id of the invalidation to get information about. Used with invalidation.
         required: false
     origin_access_identity_id:
         description:
-          - The id of the cloudfront origin access identity to get information about.
+            - The id of the cloudfront origin access identity to get information about.
         required: false
     web_acl_id:
         description:
-          - Used with list_distributions_by_web_acl_id.
+            - Used with list_distributions_by_web_acl_id.
         required: false
     domain_name_alias:
         description:
-          - Can be used instead of distribution_id - uses the aliased CNAME for the cloudfront distribution to get the distribution id where required.
+            - Can be used instead of distribution_id - uses the aliased CNAME for the cloudfront distribution to get the distribution id where required.
         required: false
     all_lists:
         description:
@@ -115,6 +115,11 @@ options:
             - Get a list of streaming distributions.
         required: false
         default: false
+    summary:
+        description:
+            - Returns a summary of all distributions, streaming distributions and origin_access_identities. This is the default behaviour if no option is selected.
+        required: false
+        default: false
 
 extends_documentation_fragment:
     - aws
@@ -123,6 +128,10 @@ extends_documentation_fragment:
 
 EXAMPLES = '''
 # Note: These examples do not set authentication details, see the AWS Guide for details.
+
+# Get a summary of distributions
+- cloudfront_facts:
+    summary: true
 
 # Get information about a distribution
 - cloudfront_facts:
@@ -190,6 +199,10 @@ streaming_distribution:
 streaming_distribution_configuration:
     description: Describes the streaming configuration information for the distribution. Requires distribution_id or domain_name_alias to be specified.
     returned: only if streaming_distribution_configuration is true
+    type: dict
+summary:
+    description: Gives a summary of distributions (distribution ids, aliases and invalidation ids), streaming distributions (distribution ids and aliases) and origin access identities (origin access identity ids).
+    returned: as default or if summary is true
     type: dict
 '''
 

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -276,14 +276,21 @@ class CloudFrontServiceManager:
     def list_origin_access_identities(self):
         try:
             func = partial(self.client.list_cloud_front_origin_access_identities)
-            return self.paginated_response(func, 'CloudFrontOriginAccessIdentityList')['Items']
+            origin_access_identity_list = self.paginated_response(func, 'CloudFrontOriginAccessIdentityList')
+            if origin_access_identity_list['Quantity'] > 0:
+              return origin_access_identity_list['Items']
+            return {}
         except Exception as e:
             self.module.fail_json(msg="Error listing cloud front origin access identities = " + str(e), exception=traceback.format_exc(e))
 
     def list_distributions(self, keyed=True):
         try:
             func = partial(self.client.list_distributions)
-            distribution_list = self.paginated_response(func, 'DistributionList')['Items']
+            distribution_list = self.paginated_response(func, 'DistributionList')
+            if distribution_list['Quantity'] == 0:
+                return {}
+            else:
+                distribution_list = distribution_list['Items']
             if not keyed:
                 return distribution_list
             return self.keyed_list_helper(distribution_list)
@@ -293,17 +300,21 @@ class CloudFrontServiceManager:
     def list_distributions_by_web_acl_id(self, web_acl_id):
         try:
             func = partial(self.client.list_distributions_by_web_acl_id, WebAclId=web_acl_id)
-            distributions = self.paginated_response(func, 'DistributionList')['Items']
-            return self.keyed_list_helper(distributions)
+            distribution_list = self.paginated_response(func, 'DistributionList')
+            if distribution_list['Quantity'] == 0:
+                return {}
+            else:
+                distribution_list = distribution_list['Items']
+            return self.keyed_list_helper(distribution_list)
         except Exception as e:
             self.module.fail_json(msg="Error listing distributions by web acl id = " + str(e), exception=traceback.format_exc(e))
 
     def list_invalidations(self, distribution_id):
         try:
             func = partial(self.client.list_invalidations, DistributionId=distribution_id)
-            invalidations = self.paginated_response(func, 'InvalidationList')
-            if invalidations['Quantity'] > 0:
-                return invalidations['Items']
+            invalidation_list = self.paginated_response(func, 'InvalidationList')
+            if invalidation_list['Quantity'] > 0:
+                return invalidation_list['Items']
             return {}
         except Exception as e:
             self.module.fail_json(msg="Error listing invalidations = " + str(e), exception=traceback.format_exc(e))
@@ -311,7 +322,11 @@ class CloudFrontServiceManager:
     def list_streaming_distributions(self, keyed=True):
         try:
             func = partial(self.client.list_streaming_distributions)
-            streaming_distribution_list = self.paginated_response(func, 'StreamingDistributionList')['Items']
+            streaming_distribution_list = self.paginated_response(func, 'StreamingDistributionList')
+            if streaming_distribution_list['Quantity'] == 0:
+                return {}
+            else:
+                streaming_distribution_list = streaming_distribution_list['Items']
             if not keyed:
                 return streaming_distribution_list
             return self.keyed_list_helper(streaming_distribution_list)

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -513,7 +513,6 @@ def main():
     streaming_distribution_config     = module.params.get('streaming_distribution_config')
     list_origin_access_identities     = module.params.get('list_origin_access_identities')
     list_distributions                = module.params.get('list_distributions')
-
     list_distributions_by_web_acl_id  = module.params.get('list_distributions_by_web_acl_id');
     list_invalidations                = module.params.get('list_invalidations')
     list_streaming_distributions      = module.params.get('list_streaming_distributions')

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -27,7 +27,11 @@ description:
 requirements:
   - boto3 >= 1.0.0
   - python >= 2.6
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
 version_added: "2.3"
+=======
+version_added: "2.2"
+>>>>>>> initial commit of cloudfront_facts.py
 author: Willem van Ketwich (@wilvk)
 options:
     distribution_id:
@@ -36,6 +40,7 @@ options:
         required: false
     invalidation_id:
         description:
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
           - The id of the invalidation to get information about. Used with invalidation.
         required: false
     origin_access_identity_id:
@@ -63,13 +68,45 @@ options:
     origin_access_identity_config:
         description:
             - Get the configuration information about an origin access identity. Requires origin_access_identity_id to be specified.
+=======
+          - The id of the invalidation to get information about. Used with invalidation
+          required: false
+    cloud_front_origin_access_identity_id:
+        description:
+          - The id of the cloudfront origin access identity to get information about
+        required: false
+    web_acl_id:
+        description:
+          - Used with list_distributions_by_web_acl_id
+          required: false
+    domain_name_alias:
+        description:
+          - Can be used instead of distribution_id - uses the aliased CNAME for the cloudfront distribution to get the distribution id where required
+          required: false
+    all_lists:
+        description:
+            - Get all cloudfront lists that do not require parameters
+        required: false
+        default: false
+    cloud_front_origin_access_identity:
+        description:
+            - Get information about an origin access identity
+        required: false
+        default: false
+    cloud_front_origin_access_identity_config:
+        description:
+            - Get the configuration information about an origin access identity
+>>>>>>> initial commit of cloudfront_facts.py
         required: false
         default: false
     distribution:
         description:
             - Get information about a distribution. Requires distribution_id or domain_name_alias to be specified.
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
         required: false
         default: false
+=======
+>>>>>>> initial commit of cloudfront_facts.py
     distribution_config:
         description:
             - Get the configuration information about a distribution. Requires distribution_id or domain_name_alias to be specified.
@@ -90,9 +127,15 @@ options:
             - Get the configuration information about a specified RTMP distribution. Requires distribution_id or domain_name_alias to be specified.
         required: false
         default: false
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
     list_origin_access_identities:
         description:
             - Get a list of cloudfront origin access identities. Requires origin_access_identity_id to be set.
+=======
+    list_cloud_front_origin_access_identities:
+        description:
+            - Get a list of cloudfront origin access identities. Requires cloud_front_origin_access_identity_id to be set.
+>>>>>>> initial commit of cloudfront_facts.py
         required: false
         default: false
     list_distributions:
@@ -100,7 +143,11 @@ options:
             - Get a list of cloudfront distributions.
         required: false
         default: false
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
     list_distributions_by_web_acl_id:
+=======
+    list_distributions_by_web_acl:
+>>>>>>> initial commit of cloudfront_facts.py
         description:
             - Get a list of distributions using web acl id as a filter. Requires web_acl_id to be set.
         required: false
@@ -112,7 +159,11 @@ options:
         default: false
     list_streaming_distributions:
         description:
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
             - Get a list of streaming distributions.
+=======
+            - Get a list of streaming distributions
+>>>>>>> initial commit of cloudfront_facts.py
         required: false
         default: false
 
@@ -129,7 +180,11 @@ EXAMPLES = '''
     distribution: true
     distribution_id: my-cloudfront-distribution-id
 
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
 # Get information about a distribution using the CNAME of the cloudfront distribution.
+=======
+# Get information about a distribution using the CNAME of the cloudfront distribution
+>>>>>>> initial commit of cloudfront_facts.py
 - cloudfront_facts:
     distribution: true
     domain_name_alias: www.my-website.com
@@ -138,26 +193,40 @@ EXAMPLES = '''
 - debug:
     msg: '{{ ansible_facts['cloudfront']['my-cloudfront-distribution-id'] }}'
 
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
 - debug:
     msg: '{{ ansible_facts['cloudfront']['www.my-website.com'] }}'
 
 # Get all information about an invalidation for a distribution.
+=======
+# Get all information about an invalidation for a distribution
+>>>>>>> initial commit of cloudfront_facts.py
 - cloudfront_facts:
     invalidation: true
     distribution_id: my-cloudfront-distribution-id
     invalidation_id: my-cloudfront-invalidation-id
 
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
 # Get all information about a cloudfront origin access identity.
 - cloudfront_facts:
     origin_access_identity: true
     origin_access_identity_id: my-cloudfront-origin-access-identity-id
 
 # Get all information about lists not requiring parameters (ie. list_origin_access_identities, list_distributions, list_streaming_distributions)
+=======
+# Get all information about a cloudfront origin access identity
+- cloudfront_facts:
+    cloud_front_origin_access_identity: true
+    cloud_front_origin_access_identity_id: my-cloudfront-origin-access-identity-id
+
+# Get all information about lists not requiring parameters (ie. list_cloud_front_origin_access_identities, list_distributions, list_streaming_distributions)
+>>>>>>> initial commit of cloudfront_facts.py
 - cloudfront_facts:
     all_lists: true
 '''
 
 RETURN = '''
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
 origin_access_identity:
     description: Describes the origin access identity information. Requires origin_access_identity_id to be set.
     returned: only if origin_access_identity is true
@@ -168,6 +237,18 @@ origin_access_identity_configuration:
     type: dict
 distribution:
     description: Facts about a cloudfront distribution. Requires distribution_id or domain_name_alias to be specified. Requires origin_access_identity_id to be set.
+=======
+cloud_front_origin_access_identity:
+    description: Describes the origin access identity information. Requires cloud_front_origin_access_identity_id to be set.
+    returned: only if cloud_front_origin_access_identity is true
+    type: dict
+cloud_front_origin_access_identity_configuration:
+    description: Describes the origin access identity information configuration information. Requires cloud_front_origin_access_identity_id to be set.
+    returned: only if cloud_front_origin_access_identity_configuration is true
+    type: dict
+distribution:
+    description: Facts about a cloudfront distribution. Requires distribution_id or domain_name_alias to be specified. Requires cloud_front_origin_access_identity_id to be set.
+>>>>>>> initial commit of cloudfront_facts.py
     returned: only if distribution is true
     type: dict
 distribution_config:
@@ -196,8 +277,11 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.ec2 import get_aws_connection_info
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
 from ansible.module_utils.ec2 import ec2_argument_spec
 from ansible.module_utils.ec2 import boto3_conn
+=======
+>>>>>>> initial commit of cloudfront_facts.py
 from ansible.module_utils.basic import AnsibleModule
 from functools import partial
 import json
@@ -222,13 +306,18 @@ class CloudFrontServiceManager:
     def get_distribution(self, distribution_id):
         try:
             func = partial(self.client.get_distribution,Id=distribution_id)
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
             return self.paginated_response(func)
+=======
+            return self.paginated_response(func, 'Distribution')
+>>>>>>> initial commit of cloudfront_facts.py
         except Exception as e:
             self.module.fail_json(msg="Error describing distribution - " + str(e), exception=traceback.format_exc(e))
 
     def get_distribution_config(self, distribution_id):
         try:
             func = partial(self.client.get_distribution_config,Id=distribution_id)
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
             return self.paginated_response(func)
         except Exception as e:
             self.module.fail_json(msg="Error describing distribution configuration - " + str(e), exception=traceback.format_exec(e))
@@ -244,26 +333,52 @@ class CloudFrontServiceManager:
         try:
             func = partial(self.client.get_cloud_front_origin_access_identity_config,Id=origin_access_identity_id)
             return self.paginated_response(func)
+=======
+            return self.paginated_response(func, 'DistributionConfig')
+        except Exception as e:
+            self.module.fail_json(msg="Error describing distribution configuration - " + str(e), exception=traceback.format_exec(e))
+
+    def get_cloud_front_origin_access_identity(self, origin_access_identity_id):
+        try:
+            func = partial(self.client.get_cloud_front_origin_access_identity,Id=origin_access_identity_id)
+            return self.paginated_response(func, 'CloudFrontOriginAccessIdentity')
+        except Exception as e:
+            self.module.fail_json(msg="Error describing origin access identity - " + str(e), exception=traceback.format_exc(e))
+
+    def get_cloud_front_origin_access_identity_config(self, origin_access_identity_id):
+        try:
+            func = partial(self.client.get_cloud_front_origin_access_identity_config,Id=origin_access_identity_id)
+            return self.paginated_response(func, 'CloudFrontOriginAccessIdentityConfig')
+>>>>>>> initial commit of cloudfront_facts.py
         except Exception as e:
             self.module.fail_json(msg="Error describing origin access identity configuration - " + str(e), exception=traceback.format_exc(e))
 
     def get_invalidation(self, distribution_id, invalidation_id):
         try:
             func = partial(self.client.get_invalidation,DistributionId=distribution_id,Id=invalidation_id)
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
             return self.paginated_response(func)
+=======
+            return self.paginated_response(func, 'Invalidation')
+>>>>>>> initial commit of cloudfront_facts.py
         except Exception as e:
             self.module.fail_json(msg="Error describing invalidation - " + str(e), exception=traceback.format_exc(e))
 
     def get_streaming_distribution(self, distribution_id):
         try:
             func = partial(self.client.get_streaming_distribution,Id=distribution_id)
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
             return self.paginated_response(func)
+=======
+            return self.paginated_response(func, 'StreamingDistribution')
+>>>>>>> initial commit of cloudfront_facts.py
         except Exception as e:
             self.module.fail_json(msg="Error describing streaming distribution - " + str(e), exception=traceback.format_exc(e))
 
     def get_streaming_distribution_config(self, distribution_id):
         try:
             func = partial(self.client.get_streaming_distribution_config,Id=distribution_id)
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
             return self.paginated_response(func)
         except Exception as e:
             self.module.fail_json(msg="Error describing streaming distribution - " + str(e), exception=traceback.format_exc(e))
@@ -297,22 +412,62 @@ class CloudFrontServiceManager:
         try:
             func = partial(self.client.list_invalidations, DistributionId=distribution_id)
             return self.paginated_response(func, 'InvalidationList')['Items']
+=======
+            return self.paginated_response(func, 'StreamingDistributionConfig')
+        except Exception as e:
+            self.module.fail_json(msg="Error describing streaming distribution - " + str(e), exception=traceback.format_exc(e))
+
+    def list_cloud_front_origin_access_identities(self):
+        try:
+            func = partial(self.client.list_cloud_front_origin_access_identities)
+            return self.paginated_response(func, 'CloudFrontOriginAccessIdentityList')
+        except Exception as e:
+            self.module.fail_json(msg="Error listing cloud front origin access identities = " + str(e), exception=traceback.format_exc(e))
+
+    def list_distributions(self):
+        try:
+            func = partial(self.client.list_distributions)
+            return self.paginated_response(func, 'DistributionList')
+        except Exception as e:
+            self.module.fail_json(msg="Error listing distributions = " + str(e), exception=traceback.format_exc(e))
+
+    def list_distributions_by_web_acl(self, web_acl_id):
+        try:
+            func = partial(self.client.list_distributions, web_acl_id)
+            return self.paginated_response(func, 'DistributionList')
+        except Exception as e:
+            self.module.fail_json(msg="Error listing distributions by web acl id = " + str(e), exception=traceback.format_exc(e))
+
+    def list_invalidations(self):
+        try:
+            func = partial(self.client.list_invalidations)
+            return self.paginated_response(func, 'InvalidationList')
+>>>>>>> initial commit of cloudfront_facts.py
         except Exception as e:
             self.module.fail_json(msg="Error listing invalidations = " + str(e), exception=traceback.format_exc(e))
 
     def list_streaming_distributions(self):
         try:
             func = partial(self.client.list_streaming_distributions)
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
             streaming_distributions = self.paginated_response(func, 'StreamingDistributionList')['Items']
             return self.keyed_list_helper(streaming_distributions)
+=======
+            return self.paginated_response(func, 'StreamingDistributionList')
+>>>>>>> initial commit of cloudfront_facts.py
         except Exception as e:
             self.module.fail_json(msg="Error listing streaming distributions = " + str(e), exception=traceback.format_exc(e))
 
     def get_distribution_id_from_domain_name(self, domain_name):
         try:
             distribution_id = ""
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
             distributions = self.list_distributions(False)
             for dist in distributions:
+=======
+            distributions = self.list_distributions()
+            for dist in distributions['Items']:
+>>>>>>> initial commit of cloudfront_facts.py
                 for alias in dist['Aliases']['Items']:
                     if str(alias).lower() == domain_name.lower():
                         distribution_id = str(dist['Id'])
@@ -321,6 +476,7 @@ class CloudFrontServiceManager:
         except Exception as e:
             self.module.fail_json(msg="Error getting distribution id from domain name = " + str(e), exception=traceback.format_exc(e))
 
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
     def get_aliases_from_distribution_id(self, distribution_id):
         aliases = []
         try:
@@ -335,10 +491,14 @@ class CloudFrontServiceManager:
             self.module.fail_json(msg="Error getting list of aliases from distribution_id = " + str(e), exception=traceback.format_exc(e))
 
     def paginated_response(self, func, result_key=""):
+=======
+    def paginated_response(self, func, result_key, next_token=None):
+>>>>>>> initial commit of cloudfront_facts.py
         '''
         Returns expanded response for paginated operations.
         The 'result_key' is used to define the concatenated results that are combined from each paginated response.
         '''
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
         args = dict()
         results = dict()
         loop = True
@@ -363,17 +523,40 @@ class CloudFrontServiceManager:
             for alias in aliases:
                 keyed_list.update({alias: item})
         return keyed_list
+=======
+        args=dict()
+        if next_token:
+            args['NextToken'] = next_token
+        response = func(**args)
+        result = response.get(result_key)
+        next_token = response.get('NextToken')
+        if not next_token:
+           return result
+        return result + self.paginated_response(func, result_key, next_token)
+
+def to_dict(items, key, value):
+    ''' Transforms a list of items to a Key/Value dictionary '''
+    if items:
+        return dict(zip([i[key] for i in items], [i[value] for i in items]))
+    else:
+        return dict()
+>>>>>>> initial commit of cloudfront_facts.py
 
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
         distribution_id=dict(required=False, type='str'),
         invalidation_id=dict(required=False, type='str'),
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
         origin_access_identity_id=dict(required=False, type='str'),
+=======
+        cloud_front_origin_access_identity_id=dict(required=False, type='str'),
+>>>>>>> initial commit of cloudfront_facts.py
         domain_name_alias=dict(required=False, type='str'),
         all_lists=dict(required=False, default=False, type='bool'),
         distribution=dict(required=False, default=False, type='bool'),
         distribution_config=dict(required=False, default=False, type='bool'),
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
         origin_access_identity=dict(required=False, default=False, type='bool'),
         origin_access_identity_config=dict(required=False, default=False, type='bool'),
         invalidation=dict(required=False, default=False, type='bool'),
@@ -382,6 +565,16 @@ def main():
         list_origin_access_identities=dict(required=False, default=False, type='bool'),
         list_distributions=dict(required=False, default=False, type='bool'),
         list_distributions_by_web_acl_id=dict(required=False, default=False, type='bool'),
+=======
+        cloud_front_origin_access_identity=dict(required=False, default=False, type='bool'),
+        cloud_front_origin_access_identity_config=dict(required=False, default=False, type='bool'),
+        invalidation=dict(required=False, default=False, type='bool'),
+        streaming_distribution=dict(required=False, default=False, type='bool'),
+        streaming_distribution_config=dict(required=False, default=False, type='bool'),
+        list_cloud_front_origin_access_identities=dict(required=False, default=False, type='bool'),
+        list_distributions=dict(required=False, default=False, type='bool'),
+        list_distributions_by_web_acl=dict(required=False, default=False, type='bool'),
+>>>>>>> initial commit of cloudfront_facts.py
         list_invalidations=dict(required=False, default=False, type='bool'),
         list_streaming_distributions=dict(required=False, default=False, type='bool')
     ))
@@ -389,13 +582,21 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
 
     if not HAS_BOTO3:
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
         module.fail_json(msg='boto3 is required.')
+=======
+      module.fail_json(msg='boto3 is required.')
+>>>>>>> initial commit of cloudfront_facts.py
 
     service_mgr = CloudFrontServiceManager(module)
 
     distribution_id = module.params.get('distribution_id')
     invalidation_id = module.params.get('invalidation_id')
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
     origin_access_identity_id = module.params.get('origin_access_identity_id')
+=======
+    cloud_front_origin_access_identity_id = module.params.get('cloud_front_origin_access_identity_id')
+>>>>>>> initial commit of cloudfront_facts.py
     web_acl_id = module.params.get('web_acl_id')
     domain_name_alias = module.params.get('domain_name_alias')
 
@@ -403,12 +604,18 @@ def main():
 
     distribution = module.params.get('distribution')
     distribution_config = module.params.get('distribution_config')
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
     origin_access_identity = module.params.get('origin_access_identity')
     origin_access_identity_config = module.params.get('origin_access_identity_config')
+=======
+    cloud_front_origin_access_identity = module.params.get('cloudfront_origin_access_identity')
+    cloud_front_origin_access_identity_config = module.params.get('cloudfront_origin_access_identity_config')
+>>>>>>> initial commit of cloudfront_facts.py
     invalidation = module.params.get('invalidation')
     streaming_distribution = module.params.get('streaming_distribution')
     streaming_distribution_config = module.params.get('streaming_distribution_config')
 
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
     list_origin_access_identities = module.params.get('list_origin_access_identities')
     list_distributions = module.params.get('list_distributions')
     list_distributions_by_web_acl_id = module.params.get('list_distributions_by_web_acl_id')
@@ -433,6 +640,24 @@ def main():
         module.fail_json(msg='Error invalidation_id has not been specified.')
     if (origin_access_identity or origin_access_identity_config) and origin_access_identity_id is None:
         module.fail_json(msg='Error origin_access_identity_id has not been specified.')
+=======
+    list_cloud_front_origin_access_identities = module.params.get('list_cloud_front_origin_access_identities')
+    list_distributions = module.params.get('list_distributions')
+    list_distributions_by_web_acl_id = module.params.get('list_distributions_by_web_acl_id');
+    list_invalidations = module.params.get('list_invalidations')
+    list_streaming_distributions = module.params.get('list_streaming_distributions')
+
+    require_distribution_id = (distribution or distribution_config or invalidation or
+            streaming_distribution or streaming_distribution_config or list_invalidations)
+
+    # validations
+    if require_distribution_id and distribution_id is None and domain_name_alias is None:
+        module.fail_json(msg='Error distribution_id or domain_name have not been specified.')
+    if (invalidation and invalidation_id is None):
+        module.fail_json(msg='Error invalidation_id has not been specified.')
+    if (cloud_front_origin_access_identity or cloud_front_origin_access_identity_config) and cloud_front_origin_access_identity_id is None:
+        module.fail_json(msg='Error cloud_front_origin_access_identity_id has not been specified.')
+>>>>>>> initial commit of cloudfront_facts.py
     if list_distributions_by_web_acl_id and web_acl_id is None:
         module.fail_json(msg='Error web_acl_id has not been specified.')
 
@@ -442,6 +667,7 @@ def main():
         if not distribution_id:
             module.fail_json(msg='Error unable to source a distribution id from domain_name_alias')
 
+<<<<<<< 309a37de862dd73acdd0d85102299031ee40537d
     # set appropriate cloudfront id
     if distribution_id and not list_invalidations:
         result = { 'cloudfront': { distribution_id: {} } }
@@ -516,6 +742,56 @@ def main():
 
     result['changed'] = False
     module.exit_json(msg="Retrieved cloudfront facts.", ansible_facts=result)
+=======
+    # set appropriate ansible_facts id
+    if distribution_id:
+        result = { 'ansible_facts': { 'cloudfront': { distribution_id:{} } } }
+        facts = result['ansible_facts']['cloudfront'][distribution_id]
+    elif cloud_front_origin_access_identity_id:
+        result = { 'ansible_facts': { 'cloudfront': { cloud_front_origin_access_identity_id:{} } } }
+        facts = result['ansible_facts']['cloudfront'][cloud_front_origin_access_identity_id]
+    elif web_acl_id:
+        result = { 'ansible_facts': { 'cloudfront': { web_acl_id:{} } } }
+        facts = result['ansible_facts']['cloudfront'][web_acl_id]
+    else:
+        result = { 'ansible_facts': { 'cloudfront': {} } }
+        facts = result['ansible_facts']['cloudfront']
+
+    # call details based on options
+    if distribution:
+        facts['distribution'] = service_mgr.get_distribution(distribution_id)
+    if distribution_config:
+        facts['distribution_config'] = service_mgr.get_distribution_config(distribution_id)
+    if cloud_front_origin_access_identity:
+        facts['cloud_front_origin_access_identity'] = service_mgr.get_cloud_front_origin_access_identity(cloud_front_origin_access_identity_id)
+    if cloud_front_origin_access_identity_config:
+        facts['cloud_front_origin_access_identity_config'] = service_mgr.get_cloud_front_origin_access_identity_config(cloud_front_origin_access_identity_id)
+    if invalidation:
+        facts['invalidation'] = service_mgr.get_invalidation(distribution_id, invalidation_id)
+    if streaming_distribution:
+        facts['streaming_distribution'] = service_mgr.get_streaming_distribution(distribution_id)
+    if streaming_distribution_config:
+        facts['streaming_distribution_config'] = service_mgr.get_streaming_distribution_config(distribution_id)
+
+    # call list based on options
+    if all_lists or list_cloud_front_origin_access_identities:
+        facts['list_cloud_front_origin_access_identities'] = service_mgr.list_cloud_front_origin_access_identities()
+    if all_lists or list_distributions:
+        facts['list_distributions'] = service_mgr.list_distributions()
+    if all_lists or list_streaming_distributions:
+        facts['list_streaming_distributions'] = service_mgr.list_streaming_distributions()
+    if list_distributions_by_web_acl_id:
+        facts['list_distributions_by_web_acl'] = service_mgr.list_distributions_by_web_acl()
+    if list_invalidations:
+        facts['list_invalidations'] = service_mgr.list_invalidations(distribution_id)
+
+    result['changed'] = False
+    module.exit_json(msg="Retreived cloudfront facts.", ansible_facts=result)
+
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.ec2 import *
+>>>>>>> initial commit of cloudfront_facts.py
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -518,7 +518,7 @@ def main():
     list_streaming_distributions      = module.params.get('list_streaming_distributions')
     summary                           = module.params.get('summary')
 
-    result = { 'cloudfront': {} } 
+    result = { 'cloudfront': {} }
     facts = {}
     aliases = []
 
@@ -589,7 +589,7 @@ def main():
     if list_invalidations:
         invalidations = service_mgr.list_invalidations(distribution_id)
         facts = set_facts_for_distribution_id_and_alias(invalidations, facts, distribution_id, aliases)
- 
+
     # get list based on options
     if all_lists or list_origin_access_identities:
         facts['origin_access_identities'] = service_mgr.list_origin_access_identities()

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -229,9 +229,7 @@ class CloudFrontServiceManager:
 
         try:
             region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-            self.client = boto3_conn(module, conn_type='client',
-                                     resource='cloudfront', region=region,
-                                     endpoint=ec2_url, **aws_connect_kwargs)
+            self.client = boto3_conn(module, conn_type='client', resource='cloudfront', region=region, endpoint=ec2_url, **aws_connect_kwargs)
         except botocore.exceptions.NoRegionError:
             self.module.fail_json(msg="Region must be specified as a parameter, in AWS_DEFAULT_REGION environment variable or in boto configuration file")
         except Exception as e:
@@ -358,10 +356,10 @@ class CloudFrontServiceManager:
             origin_access_identity_list = { 'origin_access_identities': [] }
             origin_access_identities = self.list_origin_access_identities()
             for origin_access_identity in origin_access_identities:
-                origin_access_identity_list['origin_access_identities'].append( origin_access_identity['Id'] )
+                origin_access_identity_list['origin_access_identities'].append(origin_access_identity['Id'])
             return origin_access_identity_list
         except Exception as e:
-            self.module.fail_json(msg="Error generating summary of origin_access_identity= " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error generating summary of origin access identities = " + str(e), exception=traceback.format_exc(e))
 
     def summary_get_distribution_list(self, streaming=False):
         try:
@@ -384,13 +382,13 @@ class CloudFrontServiceManager:
                     } )
                 if 'Items' in dist['Aliases']:
                     for alias in dist['Aliases']['Items']:
-                        temp_distribution['Aliases'].append( alias )
+                        temp_distribution['Aliases'].append(alias)
                 if not streaming:
                     temp_distribution.update( { 'WebACLId': dist['WebACLId'] } )
-                    invalidation_ids = self.get_list_of_invalidation_ids_from_distribution_id( dist['Id'] )
+                    invalidation_ids = self.get_list_of_invalidation_ids_from_distribution_id(dist['Id'])
                     if invalidation_ids:
                         temp_distribution.update( { 'Invalidations': invalidation_ids } )
-                distribution_list[list_name].append( temp_distribution )
+                distribution_list[list_name].append(temp_distribution)
             return distribution_list
         except Exception as e:
             self.module.fail_json(msg="Error generating summary of distributions = " + str(e), exception=traceback.format_exc(e))
@@ -459,8 +457,8 @@ class CloudFrontServiceManager:
             if 'Items' in item['Aliases']:
 	        aliases = item['Aliases']['Items']
                 for alias in aliases:
-                    keyed_list.update({alias: item})
-            keyed_list.update({distribution_id: item})
+                    keyed_list.update( { alias: item } )
+            keyed_list.update( { distribution_id: item } )
         return keyed_list
 
 def set_facts_for_distribution_id_and_alias(details, facts, distribution_id, aliases):
@@ -523,15 +521,14 @@ def main():
     facts = {}
     aliases = []
     
-    require_distribution_id = (distribution or distribution_config or invalidation or
-            streaming_distribution or streaming_distribution_config or list_invalidations)
+    require_distribution_id = (distribution or distribution_config or invalidation or streaming_distribution or 
+        streaming_distribution_config or list_invalidations)
 
     # set default to summary if no option specified
-    summary = summary or not (distribution or distribution_config or
-            origin_access_identity or origin_access_identity_config or invalidation or
-            streaming_distribution or streaming_distribution_config or list_origin_access_identities or
-            list_distributions_by_web_acl_id or list_invalidations or list_streaming_distributions or
-            list_distributions)
+    summary = summary or not (distribution or distribution_config or origin_access_identity or 
+        origin_access_identity_config or invalidation or streaming_distribution or streaming_distribution_config or 
+        list_origin_access_identities or list_distributions_by_web_acl_id or list_invalidations or 
+        list_streaming_distributions or list_distributions)
 
     # validations
     if require_distribution_id and distribution_id is None and domain_name_alias is None:
@@ -566,7 +563,6 @@ def main():
         facts = { origin_access_identity_id: {} }
     elif web_acl_id:
         facts = { web_acl_id: {} }
-
 
 # get details based on options
     if distribution:

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -229,7 +229,9 @@ class CloudFrontServiceManager:
 
         try:
             region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-            self.client = boto3_conn(module, conn_type='client', resource='cloudfront', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+            self.client = boto3_conn(module, conn_type='client',
+                                     resource='cloudfront', region=region,
+                                     endpoint=ec2_url, **aws_connect_kwargs)
         except botocore.exceptions.NoRegionError:
             self.module.fail_json(msg="Region must be specified as a parameter, in AWS_DEFAULT_REGION environment variable or in boto configuration file")
         except Exception as e:

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -534,6 +534,7 @@ class CloudFrontServiceManager:
            return result
         return result + self.paginated_response(func, result_key, next_token)
 
+<<<<<<< 0b1d3017bba14aae2ae52ad03d42e16ad5686660
 def to_dict(items, key, value):
     ''' Transforms a list of items to a Key/Value dictionary '''
     if items:
@@ -542,6 +543,8 @@ def to_dict(items, key, value):
         return dict()
 >>>>>>> initial commit of cloudfront_facts.py
 
+=======
+>>>>>>> modification as per review from @georgepsarakis
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
@@ -786,7 +789,7 @@ def main():
         facts['list_invalidations'] = service_mgr.list_invalidations(distribution_id)
 
     result['changed'] = False
-    module.exit_json(msg="Retreived cloudfront facts.", ansible_facts=result)
+    module.exit_json(msg="Retrieved cloudfront facts.", ansible_facts=result)
 
 # import module snippets
 from ansible.module_utils.basic import *

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -153,8 +153,6 @@ EXAMPLES = '''
     origin_access_identity_id: my-cloudfront-origin-access-identity-id
 
 # Get all information about lists not requiring parameters (ie. list_origin_access_identities, list_distributions, list_streaming_distributions)
-=======
-# Get all information about a cloudfront origin access identity
 - cloudfront_facts:
     cloud_front_origin_access_identity: true
     cloud_front_origin_access_identity_id: my-cloudfront-origin-access-identity-id

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -526,7 +526,7 @@ def main():
     if list_distributions_by_web_acl_id:
         facts['distributions_by_web_acl_id'] = service_mgr.list_distributions_by_web_acl_id(web_acl_id)
     if list_invalidations:
-        facts['list_invalidations'] = service_mgr.list_invalidations(distribution_id)
+        facts['invalidations'] = service_mgr.list_invalidations(distribution_id)
 
     result['changed'] = False
     module.exit_json(msg="Retrieved cloudfront facts.", ansible_facts=result)

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -301,17 +301,71 @@ class CloudFrontServiceManager:
     def list_invalidations(self, distribution_id):
         try:
             func = partial(self.client.list_invalidations, DistributionId=distribution_id)
-            return self.paginated_response(func, 'InvalidationList')['Items']
+            invalidations = self.paginated_response(func, 'InvalidationList')
+            if invalidations['Quantity'] > 0:
+                return invalidations['Items']
+            return {}
         except Exception as e:
             self.module.fail_json(msg="Error listing invalidations = " + str(e), exception=traceback.format_exc(e))
 
-    def list_streaming_distributions(self):
+    def list_streaming_distributions(self, keyed=True):
         try:
             func = partial(self.client.list_streaming_distributions)
-            streaming_distributions = self.paginated_response(func, 'StreamingDistributionList')['Items']
-            return self.keyed_list_helper(streaming_distributions)
+            streaming_distribution_list = self.paginated_response(func, 'StreamingDistributionList')['Items']
+            if not keyed:
+                return streaming_distribution_list
+            return self.keyed_list_helper(streaming_distribution_list)
         except Exception as e:
             self.module.fail_json(msg="Error listing streaming distributions = " + str(e), exception=traceback.format_exc(e))
+
+    def summary(self):
+        try:
+            summary_dict = {}
+            distribution_list = { 'distributions': [] }
+            origin_access_identity_id_list = { 'origin_access_identities': [] }
+            streaming_distributions_list = { 'streaming_distributions': [] }
+
+            distributions = self.list_distributions(False)
+            for dist in distributions:
+                for alias in dist['Aliases']['Items']:
+                    distribution_id = str(dist['Id'])
+                    temp_dist = { 'alias': alias }
+                    temp_dist.update( { 'distribution_id': distribution_id } )
+                    invalidation_ids = self.get_list_of_invalidation_ids_from_distribution_id(distribution_id)
+                    if invalidation_ids:
+                        temp_dist.update( {'invalidations': invalidation_ids } )
+                    distribution_list['distributions'].append(temp_dist)
+
+            origin_access_identities = self.list_origin_access_identities()
+            for origin_access_identity in origin_access_identities:
+                origin_access_identity_id_list['origin_access_identities'].append(str(origin_access_identity['Id']))
+
+            streaming_distributions = self.list_streaming_distributions(False)
+            for streaming_distribution in streaming_distributions:
+                for streaming_alias in streaming_distribution['Aliases']['Items']:
+                    streaming_distribution_id = str(streaming_distribution['Id'])
+                    temp_streaming_distribution = { 'alias': streaming_alias }
+                    temp_streaming_distribution.update( { 'distribution_id': streaming_distribution_id } )
+                    streaming_distributions_list['streaming_distributions'].append(temp_streaming_distribution)
+
+            summary_dict.update(distribution_list)
+            summary_dict.update(origin_access_identity_id_list)
+            summary_dict.update(streaming_distributions_list)
+
+            return summary_dict
+
+        except Exception as e:
+            self.module.fail_json(msg="Error generating summary = " + str(e), exception=traceback.format_exc(e))
+
+    def get_list_of_invalidation_ids_from_distribution_id(self, distribution_id):
+        try:
+            invalidation_ids = []
+            invalidations = self.list_invalidations(distribution_id)
+            for invalidation in invalidations:
+                invalidation_ids.append(str(invalidation['Id']))
+            return invalidation_ids
+        except Exception as e:
+            self.module.fail_json(msg="Error getting list of invalidation ids = " + str(e), exception=traceback.format_exc(e))
 
     def get_distribution_id_from_domain_name(self, domain_name):
         try:
@@ -388,7 +442,8 @@ def main():
         list_distributions=dict(required=False, default=False, type='bool'),
         list_distributions_by_web_acl_id=dict(required=False, default=False, type='bool'),
         list_invalidations=dict(required=False, default=False, type='bool'),
-        list_streaming_distributions=dict(required=False, default=False, type='bool')
+        list_streaming_distributions=dict(required=False, default=False, type='bool'),
+        summary=dict(required=False, default=False, type='bool')
     ))
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
@@ -420,16 +475,19 @@ def main():
     list_invalidations = module.params.get('list_invalidations')
     list_streaming_distributions = module.params.get('list_streaming_distributions')
 
+    summary = module.params.get('summary')
+
     aliases = []
 
     require_distribution_id = (distribution or distribution_config or invalidation or
             streaming_distribution or streaming_distribution_config or list_invalidations)
 
-    # set default to list_distributions if no option specified
-    list_distributions = list_distributions or not (distribution or distribution_config or
+    # set default to summary if no option specified
+    summary = summary or not (distribution or distribution_config or
             origin_access_identity or origin_access_identity_config or invalidation or
             streaming_distribution or streaming_distribution_config or list_origin_access_identities or
-            list_distributions_by_web_acl_id or list_invalidations or list_streaming_distributions)
+            list_distributions_by_web_acl_id or list_invalidations or list_streaming_distributions or
+            list_distributions)
 
     # validations
     if require_distribution_id and distribution_id is None and domain_name_alias is None:
@@ -456,7 +514,7 @@ def main():
         if invalidation_id:
             result['cloudfront'].update( { invalidation_id: {} } )
         facts = result['cloudfront']
-    elif list_invalidations:
+    elif distribution_id and list_invalidations:
         result = { 'cloudfront': { 'invalidations': {} } }
         facts = result['cloudfront']['invalidations']
         aliases = service_mgr.get_aliases_from_distribution_id(distribution_id)
@@ -505,9 +563,9 @@ def main():
             facts[alias].update(streaming_distribution_config_details)
     if list_invalidations:
         invalidations = service_mgr.list_invalidations(distribution_id)
-        facts[distribution_id].update(invalidations)
+        facts.update({distribution_id:invalidations})
         for alias in aliases:
-            facts[alias].update(invalidations)
+            facts.update({alias: invalidations})
 
     # get list based on options
     if all_lists or list_origin_access_identities:
@@ -520,6 +578,10 @@ def main():
         facts['distributions_by_web_acl_id'] = service_mgr.list_distributions_by_web_acl_id(web_acl_id)
     if list_invalidations:
         facts['invalidations'] = service_mgr.list_invalidations(distribution_id)
+
+    # default summary option
+    if summary:
+        facts['summary'] = service_mgr.summary()
 
     result['changed'] = False
     module.exit_json(msg="Retrieved cloudfront facts.", ansible_facts=result)

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -456,7 +456,7 @@ class CloudFrontServiceManager:
         for item in list_to_key:
             distribution_id = item['Id']
             if 'Items' in item['Aliases']:
-            aliases = item['Aliases']['Items']
+                aliases = item['Aliases']['Items']
                 for alias in aliases:
                     keyed_list.update( { alias: item } )
             keyed_list.update( { distribution_id: item } )

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -367,11 +367,11 @@ class CloudFrontServiceManager:
     def summary_get_distribution_list(self, streaming=False):
         try:
             list_name = 'streaming_distributions' if streaming else 'distributions'
+            key_list = ['Id', 'ARN', 'Status', 'LastModifiedTime', 'DomainName', 'Comment', 'PriceClass', 'Enabled' ]
             distribution_list = { list_name: [] }
             distributions = self.list_streaming_distributions(False) if streaming else self.list_distributions(False)
             for dist in distributions:
                 temp_distribution = {}
-                key_list = ['Id', 'ARN', 'Status', 'LastModifiedTime', 'DomainName', 'Comment', 'PriceClass', 'Enabled' ]
                 for key_name in key_list:
                     temp_distribution.update( { key_name: dist[key_name] } )
                 temp_distribution.update( { 'Aliases': [] } ) 

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -556,10 +556,10 @@ def main():
         if invalidation_id:
             facts.update( { invalidation_id: {} } )
     elif distribution_id and list_invalidations:
-        facts = { 'invalidations': {} }
+        facts = { distribution_id: {} }
         aliases = service_mgr.get_aliases_from_distribution_id(distribution_id)
         for alias in aliases:
-            facts['invalidations'].update( { alias: {} } )
+            facts.update( { alias: {} } )
     elif origin_access_identity_id:
         facts = { origin_access_identity_id: {} }
     elif web_acl_id:
@@ -567,28 +567,24 @@ def main():
 
     # get details based on options
     if distribution:
-        distribution_details = service_mgr.get_distribution(distribution_id)
-        facts = set_facts_for_distribution_id_and_alias(distribution_details, facts, distribution_id, aliases)
+        facts_to_set = service_mgr.get_distribution(distribution_id)
     if distribution_config:
-        distribution_config_details = service_mgr.get_distribution_config(distribution_id)
-        facts = set_facts_for_distribution_id_and_alias(distribution_config_details, facts, distribution_id, aliases)
+        facts_to_set = service_mgr.get_distribution_config(distribution_id)
     if origin_access_identity:
         facts[origin_access_identity_id].update(service_mgr.get_origin_access_identity(origin_access_identity_id))
     if origin_access_identity_config:
         facts[origin_access_identity_id].update(service_mgr.get_origin_access_identity_config(origin_access_identity_id))
     if invalidation:
-        invalidation = service_mgr.get_invalidation(distribution_id, invalidation_id)
-        facts[invalidation_id].update(invalidation)
-        facts = set_facts_for_distribution_id_and_alias(invalidation, facts, distribution_id, aliases)
+        facts_to_set = service_mgr.get_invalidation(distribution_id, invalidation_id)
+        facts[invalidation_id].update(facts_to_set)
     if streaming_distribution:
-        streaming_distribution_details = service_mgr.get_streaming_distribution(distribution_id)
-        facts = set_facts_for_distribution_id_and_alias(streaming_distribution_details, facts, distribution_id, aliases)
+        facts_to_set = service_mgr.get_streaming_distribution(distribution_id)
     if streaming_distribution_config:
-        streaming_distribution_config_details = service_mgr.get_streaming_distribution_config(distribution_id)
-        facts = set_facts_for_distribution_id_and_alias(streaming_distribution_config_details, facts, distribution_id, aliases)
+        facts_to_set = service_mgr.get_streaming_distribution_config(distribution_id)
     if list_invalidations:
-        invalidations = service_mgr.list_invalidations(distribution_id)
-        facts = set_facts_for_distribution_id_and_alias(invalidations, facts, distribution_id, aliases)
+        facts_to_set = {'invalidations': service_mgr.list_invalidations(distribution_id) }
+    if 'facts_to_set' in vars():
+        facts = set_facts_for_distribution_id_and_alias(facts_to_set, facts, distribution_id, aliases)
 
     # get list based on options
     if all_lists or list_origin_access_identities:

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -368,12 +368,6 @@ class CloudFrontServiceManager:
             for alias in aliases:
                 keyed_list.update({alias: item})
         return keyed_list
-def to_dict(items, key, value):
-    ''' Transforms a list of items to a Key/Value dictionary '''
-    if items:
-        return dict(zip([i[key] for i in items], [i[value] for i in items]))
-    else:
-        return dict()
 
 def main():
     argument_spec = ec2_argument_spec()
@@ -468,7 +462,6 @@ def main():
         aliases = service_mgr.get_aliases_from_distribution_id(distribution_id)
         for alias in aliases:
             result['cloudfront']['invalidations'].update( { alias: {} } )
-        facts = result['cloudfront']
     elif origin_access_identity_id:
         result = { 'cloudfront': { origin_access_identity_id: {} } }
         facts = result['cloudfront'][origin_access_identity_id]

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -527,9 +527,7 @@ def main():
     origin_access_identity_id = module.params.get('origin_access_identity_id')
     web_acl_id = module.params.get('web_acl_id')
     domain_name_alias = module.params.get('domain_name_alias')
-
     all_lists = module.params.get('all_lists')
-
     distribution = module.params.get('distribution')
     distribution_config = module.params.get('distribution_config')
     origin_access_identity = module.params.get('origin_access_identity')
@@ -537,7 +535,6 @@ def main():
     invalidation = module.params.get('invalidation')
     streaming_distribution = module.params.get('streaming_distribution')
     streaming_distribution_config = module.params.get('streaming_distribution_config')
-
     list_origin_access_identities = module.params.get('list_origin_access_identities')
     list_distributions = module.params.get('list_distributions')
     list_distributions_by_web_acl_id = module.params.get('list_distributions_by_web_acl_id')

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -468,6 +468,7 @@ def main():
         aliases = service_mgr.get_aliases_from_distribution_id(distribution_id)
         for alias in aliases:
             result['cloudfront']['invalidations'].update( { alias: {} } )
+        facts = result['cloudfront']
     elif origin_access_identity_id:
         result = { 'cloudfront': { origin_access_identity_id: {} } }
         facts = result['cloudfront'][origin_access_identity_id]

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -235,56 +235,64 @@ class CloudFrontServiceManager:
         except botocore.exceptions.NoRegionError:
             self.module.fail_json(msg="Region must be specified as a parameter, in AWS_DEFAULT_REGION environment variable or in boto configuration file")
         except Exception as e:
-            self.module.fail_json(msg="Can't establish connection - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Can't establish connection - " + str(e),
+                                  exception=traceback.format_exc(e))
 
     def get_distribution(self, distribution_id):
         try:
             func = partial(self.client.get_distribution,Id=distribution_id)
             return self.paginated_response(func)
         except Exception as e:
-            self.module.fail_json(msg="Error describing distribution - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error describing distribution - " + str(e),
+                                  exception=traceback.format_exc(e))
 
     def get_distribution_config(self, distribution_id):
         try:
             func = partial(self.client.get_distribution_config,Id=distribution_id)
             return self.paginated_response(func)
         except Exception as e:
-            self.module.fail_json(msg="Error describing distribution configuration - " + str(e), exception=traceback.format_exec(e))
+            self.module.fail_json(msg="Error describing distribution configuration - " + str(e),
+                                  exception=traceback.format_exec(e))
 
     def get_origin_access_identity(self, origin_access_identity_id):
         try:
             func = partial(self.client.get_cloud_front_origin_access_identity,Id=origin_access_identity_id)
             return self.paginated_response(func)
         except Exception as e:
-            self.module.fail_json(msg="Error describing origin access identity - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error describing origin access identity - " + str(e),
+                                  exception=traceback.format_exc(e))
 
     def get_origin_access_identity_config(self, origin_access_identity_id):
         try:
             func = partial(self.client.get_cloud_front_origin_access_identity_config,Id=origin_access_identity_id)
             return self.paginated_response(func)
         except Exception as e:
-            self.module.fail_json(msg="Error describing origin access identity configuration - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error describing origin access identity configuration - " + str(e),
+                                  exception=traceback.format_exc(e))
 
     def get_invalidation(self, distribution_id, invalidation_id):
         try:
             func = partial(self.client.get_invalidation,DistributionId=distribution_id,Id=invalidation_id)
             return self.paginated_response(func)
         except Exception as e:
-            self.module.fail_json(msg="Error describing invalidation - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error describing invalidation - " + str(e),
+                                  exception=traceback.format_exc(e))
 
     def get_streaming_distribution(self, distribution_id):
         try:
             func = partial(self.client.get_streaming_distribution,Id=distribution_id)
             return self.paginated_response(func)
         except Exception as e:
-            self.module.fail_json(msg="Error describing streaming distribution - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error describing streaming distribution - " + str(e),
+                                  exception=traceback.format_exc(e))
 
     def get_streaming_distribution_config(self, distribution_id):
         try:
             func = partial(self.client.get_streaming_distribution_config,Id=distribution_id)
             return self.paginated_response(func)
         except Exception as e:
-            self.module.fail_json(msg="Error describing streaming distribution - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error describing streaming distribution - " + str(e),
+                                  exception=traceback.format_exc(e))
 
     def list_origin_access_identities(self):
         try:
@@ -294,7 +302,8 @@ class CloudFrontServiceManager:
               return origin_access_identity_list['Items']
             return {}
         except Exception as e:
-            self.module.fail_json(msg="Error listing cloud front origin access identities - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error listing cloud front origin access identities - " + str(e),
+                                  exception=traceback.format_exc(e))
 
     def list_distributions(self, keyed=True):
         try:
@@ -308,7 +317,8 @@ class CloudFrontServiceManager:
                 return distribution_list
             return self.keyed_list_helper(distribution_list)
         except Exception as e:
-            self.module.fail_json(msg="Error listing distributions - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error listing distributions - " + str(e),
+                                  exception=traceback.format_exc(e))
 
     def list_distributions_by_web_acl_id(self, web_acl_id):
         try:
@@ -320,7 +330,8 @@ class CloudFrontServiceManager:
                 distribution_list = distribution_list['Items']
             return self.keyed_list_helper(distribution_list)
         except Exception as e:
-            self.module.fail_json(msg="Error listing distributions by web acl id - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error listing distributions by web acl id - " + str(e),
+                                  exception=traceback.format_exc(e))
 
     def list_invalidations(self, distribution_id):
         try:
@@ -330,7 +341,8 @@ class CloudFrontServiceManager:
                 return invalidation_list['Items']
             return {}
         except Exception as e:
-            self.module.fail_json(msg="Error listing invalidations - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error listing invalidations - " + str(e),
+                                  exception=traceback.format_exc(e))
 
     def list_streaming_distributions(self, keyed=True):
         try:
@@ -344,7 +356,8 @@ class CloudFrontServiceManager:
                 return streaming_distribution_list
             return self.keyed_list_helper(streaming_distribution_list)
         except Exception as e:
-            self.module.fail_json(msg="Error listing streaming distributions - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error listing streaming distributions - " + str(e),
+                                  exception=traceback.format_exc(e))
 
     def summary(self):
         summary_dict = {}
@@ -364,7 +377,8 @@ class CloudFrontServiceManager:
                 origin_access_identity_list['origin_access_identities'].append( oai_summary )
             return origin_access_identity_list
         except Exception as e:
-            self.module.fail_json(msg="Error generating summary of origin access identities - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error generating summary of origin access identities - " + str(e),
+                                  exception=traceback.format_exc(e))
 
     def summary_get_distribution_list(self, streaming=False):
         try:
@@ -389,7 +403,8 @@ class CloudFrontServiceManager:
                 distribution_list[list_name].append(temp_distribution)
             return distribution_list
         except Exception as e:
-            self.module.fail_json(msg="Error generating summary of distributions - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error generating summary of distributions - " + str(e),
+                                  exception=traceback.format_exc(e))
 
     def get_etag_from_distribution_id(self, distribution_id, streaming):
         distribution = {}
@@ -407,7 +422,8 @@ class CloudFrontServiceManager:
                 invalidation_ids.append(invalidation['Id'])
             return invalidation_ids
         except Exception as e:
-            self.module.fail_json(msg="Error getting list of invalidation ids - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error getting list of invalidation ids - " + str(e),
+                                  exception=traceback.format_exc(e))
 
     def get_distribution_id_from_domain_name(self, domain_name):
         try:
@@ -422,7 +438,8 @@ class CloudFrontServiceManager:
                             break
             return distribution_id
         except Exception as e:
-            self.module.fail_json(msg="Error getting distribution id from domain name - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error getting distribution id from domain name - " + str(e),
+                                  exception=traceback.format_exc(e))
 
     def get_aliases_from_distribution_id(self, distribution_id):
         aliases = []
@@ -435,7 +452,8 @@ class CloudFrontServiceManager:
                     break
             return aliases
         except Exception as e:
-            self.module.fail_json(msg="Error getting list of aliases from distribution_id - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error getting list of aliases from distribution_id - " + str(e),
+                                  exception=traceback.format_exc(e))
 
     def paginated_response(self, func, result_key=""):
         '''

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -537,7 +537,7 @@ def main():
     invalidation = module.params.get('invalidation')
     streaming_distribution = module.params.get('streaming_distribution')
     streaming_distribution_config = module.params.get('streaming_distribution_config')
- 
+
     list_origin_access_identities = module.params.get('list_origin_access_identities')
     list_distributions = module.params.get('list_distributions')
     list_distributions_by_web_acl_id = module.params.get('list_distributions_by_web_acl_id')

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -409,7 +409,7 @@ class CloudFrontServiceManager:
             distributions = self.list_distributions(False)
             distributions += self.list_streaming_distributions(False)
             for dist in distributions:
-		if 'Items' in dist['Aliases']:
+                if 'Items' in dist['Aliases']:
                     for alias in dist['Aliases']['Items']:
                         if str(alias).lower() == domain_name.lower():
                             distribution_id = dist['Id']
@@ -456,7 +456,7 @@ class CloudFrontServiceManager:
         for item in list_to_key:
             distribution_id = item['Id']
             if 'Items' in item['Aliases']:
-	        aliases = item['Aliases']['Items']
+            aliases = item['Aliases']['Items']
                 for alias in aliases:
                     keyed_list.update( { alias: item } )
             keyed_list.update( { distribution_id: item } )

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -201,7 +201,7 @@ streaming_distribution_configuration:
     returned: only if streaming_distribution_configuration is true
     type: dict
 summary:
-    description: Gives a summary of distributions (distribution ids, aliases and invalidation ids), streaming distributions (distribution ids and aliases) and origin access identities (origin access identity ids).
+    description: Gives a summary of distributions, streaming distributions and origin access identities.
     returned: as default or if summary is true
     type: dict
 '''
@@ -292,7 +292,7 @@ class CloudFrontServiceManager:
               return origin_access_identity_list['Items']
             return {}
         except Exception as e:
-            self.module.fail_json(msg="Error listing cloud front origin access identities = " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error listing cloud front origin access identities - " + str(e), exception=traceback.format_exc(e))
 
     def list_distributions(self, keyed=True):
         try:
@@ -306,7 +306,7 @@ class CloudFrontServiceManager:
                 return distribution_list
             return self.keyed_list_helper(distribution_list)
         except Exception as e:
-            self.module.fail_json(msg="Error listing distributions = " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error listing distributions - " + str(e), exception=traceback.format_exc(e))
 
     def list_distributions_by_web_acl_id(self, web_acl_id):
         try:
@@ -318,7 +318,7 @@ class CloudFrontServiceManager:
                 distribution_list = distribution_list['Items']
             return self.keyed_list_helper(distribution_list)
         except Exception as e:
-            self.module.fail_json(msg="Error listing distributions by web acl id = " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error listing distributions by web acl id - " + str(e), exception=traceback.format_exc(e))
 
     def list_invalidations(self, distribution_id):
         try:
@@ -328,7 +328,7 @@ class CloudFrontServiceManager:
                 return invalidation_list['Items']
             return {}
         except Exception as e:
-            self.module.fail_json(msg="Error listing invalidations = " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error listing invalidations - " + str(e), exception=traceback.format_exc(e))
 
     def list_streaming_distributions(self, keyed=True):
         try:
@@ -342,7 +342,7 @@ class CloudFrontServiceManager:
                 return streaming_distribution_list
             return self.keyed_list_helper(streaming_distribution_list)
         except Exception as e:
-            self.module.fail_json(msg="Error listing streaming distributions = " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error listing streaming distributions - " + str(e), exception=traceback.format_exc(e))
 
     def summary(self):
         summary_dict = {}
@@ -359,7 +359,7 @@ class CloudFrontServiceManager:
                 origin_access_identity_list['origin_access_identities'].append(origin_access_identity['Id'])
             return origin_access_identity_list
         except Exception as e:
-            self.module.fail_json(msg="Error generating summary of origin access identities = " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error generating summary of origin access identities - " + str(e), exception=traceback.format_exc(e))
 
     def summary_get_distribution_list(self, streaming=False):
         try:
@@ -391,7 +391,7 @@ class CloudFrontServiceManager:
                 distribution_list[list_name].append(temp_distribution)
             return distribution_list
         except Exception as e:
-            self.module.fail_json(msg="Error generating summary of distributions = " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error generating summary of distributions - " + str(e), exception=traceback.format_exc(e))
 
     def get_list_of_invalidation_ids_from_distribution_id(self, distribution_id):
         try:
@@ -401,12 +401,13 @@ class CloudFrontServiceManager:
                 invalidation_ids.append(invalidation['Id'])
             return invalidation_ids
         except Exception as e:
-            self.module.fail_json(msg="Error getting list of invalidation ids = " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error getting list of invalidation ids - " + str(e), exception=traceback.format_exc(e))
 
     def get_distribution_id_from_domain_name(self, domain_name):
         try:
             distribution_id = ""
             distributions = self.list_distributions(False)
+            distributions += self.list_streaming_distributions(False)
             for dist in distributions:
 		if 'Items' in dist['Aliases']:
                     for alias in dist['Aliases']['Items']:
@@ -415,7 +416,7 @@ class CloudFrontServiceManager:
                             break
             return distribution_id
         except Exception as e:
-            self.module.fail_json(msg="Error getting distribution id from domain name = " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error getting distribution id from domain name - " + str(e), exception=traceback.format_exc(e))
 
     def get_aliases_from_distribution_id(self, distribution_id):
         aliases = []
@@ -428,7 +429,7 @@ class CloudFrontServiceManager:
                     break
             return aliases
         except Exception as e:
-            self.module.fail_json(msg="Error getting list of aliases from distribution_id = " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error getting list of aliases from distribution_id - " + str(e), exception=traceback.format_exc(e))
 
     def paginated_response(self, func, result_key=""):
         '''
@@ -512,6 +513,7 @@ def main():
     streaming_distribution_config     = module.params.get('streaming_distribution_config')
     list_origin_access_identities     = module.params.get('list_origin_access_identities')
     list_distributions                = module.params.get('list_distributions')
+
     list_distributions_by_web_acl_id  = module.params.get('list_distributions_by_web_acl_id');
     list_invalidations                = module.params.get('list_invalidations')
     list_streaming_distributions      = module.params.get('list_streaming_distributions')
@@ -564,7 +566,7 @@ def main():
     elif web_acl_id:
         facts = { web_acl_id: {} }
 
-# get details based on options
+    # get details based on options
     if distribution:
         distribution_details = service_mgr.get_distribution(distribution_id)
         facts = set_facts_for_distribution_id_and_alias(distribution_details, facts, distribution_id, aliases)
@@ -588,6 +590,7 @@ def main():
     if list_invalidations:
         invalidations = service_mgr.list_invalidations(distribution_id)
         facts = set_facts_for_distribution_id_and_alias(invalidations, facts, distribution_id, aliases)
+    
     # get list based on options
     if all_lists or list_origin_access_identities:
         facts['origin_access_identities'] = service_mgr.list_origin_access_identities()


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/cloudfront_facts.py

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 7551821eae)
```

##### SUMMARY
Added Summary functionality for distributions, streaming distributions and origin access identities. Can be called by summary:yes or as default behaviour without parameters.

Distributions contains the following attributes:

- ARN
- Aliases
- Comment
- Domain Name
- Enabled
- Id
- Invalidations
- LastModifiedTime
- PriceClass
- Status
- WebACLId
- ETag

Streaming Distributions lists all Distribution attributes except WebACLId and Invalidations.
Origin Access Identities lists only Id and ETag.

Also fixed various bugs:
- when no CNAME is present for a distribution it would error - have added checking on 'Items' key where relevant.
- would not search for distribution id for a given domain name alias for streaming distributions - have fixed by using both list_distributions and list_streaming_distributions in search criteria.
- error thrown when no items in boto recordset - have added checking where Quantity > 0

Also done:
- refactoring of repeated code into separate methods
- formatting of code
- added to documentation for summary feature