### PR TITLE
add output for meta taks (only for level -vv)

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -913,4 +913,6 @@ class StrategyBase:
         else:
             result['changed'] = False
 
+        display.vv("META: %s" % msg)
+
         return [TaskResult(target_host, task, result)]


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
meta:

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (meta_output c015e0a488) last updated 2017/01/28 22:33:08 (GMT +200)
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
meta: end_play has no output at the moment, i think this is bad,
there is an issue for this: https://github.com/ansible/ansible/issues/19433
this is a quick fix that works for me

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
my test playbook:
```
---

- hosts: localhost
  tasks:
    - debug: msg="test"
    - meta: end_play
    - debug: msg="test2"

```

output diff:
```
 TASK [Gathering Facts] **************************************************************************************************************
 ok: [localhost]
+META: ran handlers
 
 TASK [debug] ************************************************************************************************************************
 task path: /home/hauke/github.com/hloeffler/ansible/test.yml:5
 ok: [localhost] => {
     "msg": "test"
 }
+META: ending play
 
 PLAY RECAP **************************************************************************************************************************

```