### PR TITLE
netconf_config: adding support for no candidate config

### DIFF
--- a/lib/ansible/modules/network/netconf/netconf_config.py
+++ b/lib/ansible/modules/network/netconf/netconf_config.py
@@ -142,7 +142,7 @@ def netconf_edit_config(m, xml, commit, retkwargs):
         m.edit_config(target=datastore, config=xml)
         config_after = m.get_config(source=datastore)
         changed = config_before.data_xml != config_after.data_xml
-        if changed and commit:
+        if changed and commit and ":candidate" in m.server_capabilities:
             if ":confirmed-commit" in m.server_capabilities:
                 m.commit(confirmed=True)
                 m.commit()


### PR DESCRIPTION
commit fails for devices with no candidate config, such as when configuraion is written to running-config store.  Commit is set to True in main's call of netconf_edit_config.  The simple edit is to add the additional logic around sending the commit.  Otherwise you could change commit could be set to (if ":candidate" in m.server_capabilities) in the call of netconf_edit_config.  Either way would work.  I'll defer for the decision of which.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
