### PR TITLE
Added prefix attribute to rabbitmq modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,8 @@ Ansible Changes By Release
 * 'service' tasks can now use async again, we had lost this capability when changed into an action plugin.
 * made any_errors_fatal inheritable from play to task and all other objects in between.
 * many small performance improvements in inventory and variable handling and in task execution.
+* The AWS Lambda module previously ignored changes that only affected one parameter. Existing deployments may have outstanding changes that this bugfix will apply.
+* Added 'prefix' attribute to all the RabbitMQ modules that can support it.
 
 ### Deprecations
 * Specifying --tags (or --skip-tags) multiple times on the command line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Ansible Changes By Release
   Use ignore_errors or failed_when in playbooks if you wish to ignore errors.
 * Experimentally added pmrun become method.
 * Enable the docker connection plugin to use su as a become method
+* Added 'prefix' attribute to all the RabbitMQ modules that can support it.
 
 #### New Inventory scripts:
 - lxd
@@ -225,7 +226,6 @@ Ansible Changes By Release
 * made any_errors_fatal inheritable from play to task and all other objects in between.
 * many small performance improvements in inventory and variable handling and in task execution.
 * The AWS Lambda module previously ignored changes that only affected one parameter. Existing deployments may have outstanding changes that this bugfix will apply.
-* Added 'prefix' attribute to all the RabbitMQ modules that can support it.
 
 ### Deprecations
 * Specifying --tags (or --skip-tags) multiple times on the command line

--- a/lib/ansible/modules/messaging/rabbitmq_parameter.py
+++ b/lib/ansible/modules/messaging/rabbitmq_parameter.py
@@ -68,7 +68,7 @@ options:
     description:
       - Specify a custom install prefix to a RabbitMQ installation
     required: false
-    version_added: "2.3"
+    version_added: "2.4"
     default: null
 '''
 

--- a/lib/ansible/modules/messaging/rabbitmq_parameter.py
+++ b/lib/ansible/modules/messaging/rabbitmq_parameter.py
@@ -64,6 +64,12 @@ options:
     required: false
     default: present
     choices: [ 'present', 'absent']
+  prefix:
+    description:
+      - Specify a custom install prefix to a RabbitMQ installation
+    required: false
+    version_added: "2.3"
+    default: null
 '''
 
 EXAMPLES = """
@@ -86,7 +92,23 @@ class RabbitMqParameter(object):
 
         self._value = None
 
-        self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
+        self._rabbitmqctl = self._get_rmq_exec(module, "rabbitmqctl")
+
+    def _get_rmq_exec(self, module, command):
+        prefix = module.params['prefix']
+        if prefix:
+            if os.path.isdir(os.path.join(prefix, 'bin')):
+                bin_path = os.path.join(prefix, 'bin')
+            elif os.path.isdir(os.path.join(prefix, 'sbin')):
+                bin_path = os.path.join(prefix, 'sbin')
+            else:
+                # No such path exists.
+                raise Exception("No binary folder in prefix %s" % prefix)
+
+            return bin_path + '/' + command
+
+        else:
+            return module.get_bin_path(command, True)
 
     def _exec(self, args, run_in_check_mode=False):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
@@ -127,7 +149,8 @@ def main():
         value=dict(default=None),
         vhost=dict(default='/'),
         state=dict(default='present', choices=['present', 'absent']),
-        node=dict(default='rabbit')
+        node=dict(default='rabbit'),
+        prefix=dict(default=None)
     )
     module = AnsibleModule(
         argument_spec=arg_spec,

--- a/lib/ansible/modules/messaging/rabbitmq_policy.py
+++ b/lib/ansible/modules/messaging/rabbitmq_policy.py
@@ -79,7 +79,7 @@ options:
     description:
       - Specify a custom install prefix to a RabbitMQ installation
     required: false
-    version_added: "2.3"
+    version_added: "2.4"
     default: null
 '''
 

--- a/lib/ansible/modules/messaging/rabbitmq_policy.py
+++ b/lib/ansible/modules/messaging/rabbitmq_policy.py
@@ -75,6 +75,12 @@ options:
       - The state of the policy.
     default: present
     choices: [present, absent]
+  prefix:
+    description:
+      - Specify a custom install prefix to a RabbitMQ installation
+    required: false
+    version_added: "2.3"
+    default: null
 '''
 
 EXAMPLES = '''
@@ -103,7 +109,23 @@ class RabbitMqPolicy(object):
         self._tags = module.params['tags']
         self._priority = module.params['priority']
         self._node = module.params['node']
-        self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
+        self._rabbitmqctl = self._get_rmq_exec(module, "rabbitmqctl")
+
+    def _get_rmq_exec(self, module, command):
+        prefix = module.params['prefix']
+        if prefix:
+            if os.path.isdir(os.path.join(prefix, 'bin')):
+                bin_path = os.path.join(prefix, 'bin')
+            elif os.path.isdir(os.path.join(prefix, 'sbin')):
+                bin_path = os.path.join(prefix, 'sbin')
+            else:
+                # No such path exists.
+                raise Exception("No binary folder in prefix %s" % prefix)
+
+            return bin_path + '/' + command
+
+        else:
+            return module.get_bin_path(command, True)
 
     def _exec(self, args, run_in_check_mode=False):
         if not self._module.check_mode or (self._module.check_mode and run_in_check_mode):
@@ -150,6 +172,7 @@ def main():
         priority=dict(default='0'),
         node=dict(default='rabbit'),
         state=dict(default='present', choices=['present', 'absent']),
+        prefix=dict(default=None)
     )
 
     module = AnsibleModule(

--- a/lib/ansible/modules/messaging/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq_user.py
@@ -107,6 +107,12 @@ options:
     required: false
     default: present
     choices: [present, absent]
+  prefix:
+    description:
+      - Specify a custom install prefix to a RabbitMQ installation
+    required: false
+    version_added: "2.3"
+    default: null
 '''
 
 EXAMPLES = '''
@@ -151,7 +157,23 @@ class RabbitMqUser(object):
 
         self._tags = None
         self._permissions = []
-        self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
+        self._rabbitmqctl = self._get_rmq_exec(module, 'rabbitmqctl')
+
+    def _get_rmq_exec(self, module, command):
+        prefix = module.params['prefix']
+        if prefix:
+            if os.path.isdir(os.path.join(prefix, 'bin')):
+                bin_path = os.path.join(prefix, 'bin')
+            elif os.path.isdir(os.path.join(prefix, 'sbin')):
+                bin_path = os.path.join(prefix, 'sbin')
+            else:
+                # No such path exists.
+                raise Exception("No binary folder in prefix %s" % prefix)
+
+            return bin_path + '/' + command
+
+        else:
+            return module.get_bin_path(command, True)
 
     def _exec(self, args, run_in_check_mode=False):
         if not self.module.check_mode or run_in_check_mode:
@@ -248,7 +270,8 @@ def main():
         read_priv=dict(default='^$'),
         force=dict(default='no', type='bool'),
         state=dict(default='present', choices=['present', 'absent']),
-        node=dict(default=None)
+        node=dict(default=None),
+        prefix=dict(default=None)
     )
     module = AnsibleModule(
         argument_spec=arg_spec,

--- a/lib/ansible/modules/messaging/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq_user.py
@@ -111,7 +111,7 @@ options:
     description:
       - Specify a custom install prefix to a RabbitMQ installation
     required: false
-    version_added: "2.3"
+    version_added: "2.4"
     default: null
 '''
 

--- a/lib/ansible/modules/messaging/rabbitmq_vhost.py
+++ b/lib/ansible/modules/messaging/rabbitmq_vhost.py
@@ -56,6 +56,12 @@ options:
       - The state of vhost
     default: present
     choices: [present, absent]
+  prefix:
+    description:
+      - Specify a custom install prefix to a RabbitMQ installation
+    required: false
+    version_added: "2.3"
+    default: null
 '''
 
 EXAMPLES = '''
@@ -73,7 +79,23 @@ class RabbitMqVhost(object):
         self.node = node
 
         self._tracing = False
-        self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
+        self._rabbitmqctl = self._get_rmq_exec(module, 'rabbitmqctl')
+
+    def _get_rmq_exec(self, module, command):
+        prefix = module.params['prefix']
+        if prefix:
+            if os.path.isdir(os.path.join(prefix, 'bin')):
+                bin_path = os.path.join(prefix, 'bin')
+            elif os.path.isdir(os.path.join(prefix, 'sbin')):
+                bin_path = os.path.join(prefix, 'sbin')
+            else:
+                # No such path exists.
+                raise Exception("No binary folder in prefix %s" % prefix)
+
+            return bin_path + '/' + command
+
+        else:
+            return module.get_bin_path(command, True)
 
     def _exec(self, args, run_in_check_mode=False):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
@@ -120,6 +142,7 @@ def main():
         tracing=dict(default='off', aliases=['trace'], type='bool'),
         state=dict(default='present', choices=['present', 'absent']),
         node=dict(default='rabbit'),
+        prefix=dict(default=None)
     )
 
     module = AnsibleModule(

--- a/lib/ansible/modules/messaging/rabbitmq_vhost.py
+++ b/lib/ansible/modules/messaging/rabbitmq_vhost.py
@@ -60,7 +60,7 @@ options:
     description:
       - Specify a custom install prefix to a RabbitMQ installation
     required: false
-    version_added: "2.3"
+    version_added: "2.4"
     default: null
 '''
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
rabbitmq_parameter
rabbitmq_policy
rabbitmq_user
rabbitmq_vhost

##### ANSIBLE VERSION
```
ansible 2.3.0 (feature/rabbitmq 9494c5c44b) last updated 2017/01/30 14:58:14 (GMT +000)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Added support for RabbitMQ installation on a custom location.
The change adds a prefix attribute, like the one in the module rabbitmq_plugin, to the plugins that use the command rabbitmqctl.

**NOTE:** This is the same pull request as https://github.com/ansible/ansible-modules-extras/pull/3079 that has been closed after the repository merge and https://github.com/ansible/ansible/pull/19843 that lost the reference to my repository.