### PR TITLE
Fix import of urlparse on python3

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -21,10 +21,10 @@ import re
 import json
 import sys
 import copy
-
 from distutils.version import LooseVersion
-from urlparse import urlparse
-from ansible.module_utils.basic import *
+
+from ansible.module_utils.basic import AnsibleModule, BOOLEANS_TRUE, BOOLEANS_FALSE
+from ansible.module_utils.six.moves.urllib.parse import urlparse
 
 HAS_DOCKER_PY = True
 HAS_DOCKER_PY_2 = False


### PR DESCRIPTION
On python3, urlparse has moved to a new location.  Use the bundled six to import urlparse.

Should fix the error reported here:
https://github.com/ansible/ansible/issues/17495#issuecomment-267921719


##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
ansible/module_utils/docker_common.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.2
```
