### PR TITLE
Refactoring Galaxy unit tests for uniformity

### DIFF
--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -168,18 +168,18 @@ class TestGalaxy(unittest.TestCase):
             self.assertIsInstance(galaxycli_obj.parser, ansible.cli.SortedOptParser)
             self.assertIsInstance(galaxycli_obj.galaxy, ansible.galaxy.Galaxy)
             formatted_call = {
-                                'import'    : 'usage: %prog import [options] github_user github_repo',
-                                'delete'    : 'usage: %prog delete [options] github_user github_repo',
-                                'info'      : 'usage: %prog info [options] role_name[,version]',
-                                'init'      : 'usage: %prog init [options] role_name',
-                                'install'   : 'usage: %prog install [options] [-r FILE | role_name(s)[,version] | scm+role_repo_url[,version] | tar_file(s)]',
-                                'list'      : 'usage: %prog list [role_name]',
-                                'login'     : 'usage: %prog login [options]',
-                                'remove'    : 'usage: %prog remove role1 role2 ...',
-                                'search'    : 'usage: %prog search [searchterm1 searchterm2] [--galaxy-tags galaxy_tag1,galaxy_tag2] [--platforms platform1,platform2] [--author username]',
-                                'setup'     : 'usage: %prog setup [options] source github_user github_repo secret',
-                             }
-            
+            'import'    : 'usage: %prog import [options] github_user github_repo',
+            'delete'    : 'usage: %prog delete [options] github_user github_repo',
+            'info'      : 'usage: %prog info [options] role_name[,version]',
+            'init'      : 'usage: %prog init [options] role_name',
+            'install'   : 'usage: %prog install [options] [-r FILE | role_name(s)[,version] | scm+role_repo_url[,version] | tar_file(s)]',
+            'list'      : 'usage: %prog list [role_name]',
+            'login'     : 'usage: %prog login [options]',
+            'remove'    : 'usage: %prog remove role1 role2 ...',
+            'search'    : 'usage: %prog search [searchterm1 searchterm2] [--galaxy-tags galaxy_tag1,galaxy_tag2] [--platforms platform1,platform2] [--author username]',
+            'setup'     : 'usage: %prog setup [options] source github_user github_repo secret',
+            }
+ 
             first_call = 'usage: %prog [delete|import|info|init|install|list|login|remove|search|setup] [--help] [options] ...'
             second_call = formatted_call[action]
             calls = [call(first_call), call(second_call)]

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -168,18 +168,18 @@ class TestGalaxy(unittest.TestCase):
             self.assertIsInstance(galaxycli_obj.parser, ansible.cli.SortedOptParser)
             self.assertIsInstance(galaxycli_obj.galaxy, ansible.galaxy.Galaxy)
             formatted_call = {
-            'import'    : 'usage: %prog import [options] github_user github_repo',
-            'delete'    : 'usage: %prog delete [options] github_user github_repo',
-            'info'      : 'usage: %prog info [options] role_name[,version]',
-            'init'      : 'usage: %prog init [options] role_name',
-            'install'   : 'usage: %prog install [options] [-r FILE | role_name(s)[,version] | scm+role_repo_url[,version] | tar_file(s)]',
-            'list'      : 'usage: %prog list [role_name]',
-            'login'     : 'usage: %prog login [options]',
-            'remove'    : 'usage: %prog remove role1 role2 ...',
-            'search'    : 'usage: %prog search [searchterm1 searchterm2] [--galaxy-tags galaxy_tag1,galaxy_tag2] [--platforms platform1,platform2] [--author username]',
-            'setup'     : 'usage: %prog setup [options] source github_user github_repo secret',
+                'import'    : 'usage: %prog import [options] github_user github_repo',
+                'delete'    : 'usage: %prog delete [options] github_user github_repo',
+                'info'      : 'usage: %prog info [options] role_name[,version]',
+                'init'      : 'usage: %prog init [options] role_name',
+                'install'   : 'usage: %prog install [options] [-r FILE | role_name(s)[,version] | scm+role_repo_url[,version] | tar_file(s)]',
+                'list'      : 'usage: %prog list [role_name]',
+                'login'     : 'usage: %prog login [options]',
+                'remove'    : 'usage: %prog remove role1 role2 ...',
+                'search'    : 'usage: %prog search [searchterm1 searchterm2] [--galaxy-tags galaxy_tag1,galaxy_tag2] [--platforms platform1,platform2] [--author username]',
+                'setup'     : 'usage: %prog setup [options] source github_user github_repo secret',
             }
- 
+
             first_call = 'usage: %prog [delete|import|info|init|install|list|login|remove|search|setup] [--help] [options] ...'
             second_call = formatted_call[action]
             calls = [call(first_call), call(second_call)]

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -32,7 +32,6 @@ import ansible
 from ansible.errors import AnsibleError, AnsibleOptionsError
 
 from ansible.cli.galaxy import GalaxyCLI
-from ansible.utils.display import Display
 
 class TestGalaxy(unittest.TestCase):
     @classmethod

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -131,9 +131,8 @@ class TestGalaxy(unittest.TestCase):
         gc.parse()
         gc.run()
 
-        # checking that installation worked
+        # location where the role was installed
         role_file = os.path.join(self.role_path, self.role_name)
-        self.assertTrue(os.path.exists(role_file))
 
         # removing role
         gc = GalaxyCLI(args=["remove", "-p", role_file, self.role_name])
@@ -144,22 +143,21 @@ class TestGalaxy(unittest.TestCase):
         removed_role = not os.path.exists(role_file)
         self.assertTrue(removed_role)
 
-    def test_exit_without_ignore(self):
-        ''' tests that GalaxyCLI exits with the error specified unless the --ignore-errors flag is used '''
+    def test_exit_without_ignore_without_flag(self):
+        ''' tests that GalaxyCLI exits with the error specified if the --ignore-errors flag is not used '''
         gc = GalaxyCLI(args=["install", "--server=None", "fake_role_name"])
-
-        # testing without --ignore-errors flag
         gc.parse()
         with patch.object(ansible.utils.display.Display, "display", return_value=None) as mocked_display:
             # testing that error expected is raised
             self.assertRaises(AnsibleError, gc.run)
             self.assertTrue(mocked_display.called_once_with("- downloading role 'fake_role_name', owned by "))
 
+    def test_exit_without_ignore_with_flag(self):
+        ''' tests that GalaxyCLI exits without the error specified if the --ignore-errors flag is used  '''
         # testing with --ignore-errors flag
         gc = GalaxyCLI(args=["install", "--server=None", "fake_role_name", "--ignore-errors"])
         gc.parse()
         with patch.object(ansible.utils.display.Display, "display", return_value=None) as mocked_display:
-            # testing that error expected is not raised with --ignore-errors flag in use
             gc.run()
             self.assertTrue(mocked_display.called_once_with("- downloading role 'fake_role_name', owned by "))
 
@@ -170,94 +168,101 @@ class TestGalaxy(unittest.TestCase):
             # checking that the common results of parse() for all possible actions have been created/called
             self.assertIsInstance(galaxycli_obj.parser, ansible.cli.SortedOptParser)
             self.assertIsInstance(galaxycli_obj.galaxy, ansible.galaxy.Galaxy)
-            if action in ['import', 'delete']:
-                formatted_call = 'usage: %prog ' + action + ' [options] github_user github_repo'
-            elif action == 'info':
-                formatted_call = 'usage: %prog ' + action + ' [options] role_name[,version]'
-            elif action == 'init':
-                formatted_call = 'usage: %prog ' + action + ' [options] role_name'
-            elif action == 'install':
-                formatted_call = 'usage: %prog ' + action + ' [options] [-r FILE | role_name(s)[,version] | scm+role_repo_url[,version] | tar_file(s)]'
-            elif action == 'list':
-                formatted_call = 'usage: %prog ' + action + ' [role_name]'
-            elif action == 'login':
-                formatted_call = 'usage: %prog ' + action + ' [options]'
-            elif action == 'remove':
-                formatted_call = 'usage: %prog ' + action + ' role1 role2 ...'
-            elif action == 'search':
-                formatted_call = 'usage: %prog ' + action + ' [searchterm1 searchterm2] [--galaxy-tags galaxy_tag1,galaxy_tag2] [--platforms platform1,platform2] [--author username]'
-            elif action == 'setup':
-                formatted_call = 'usage: %prog ' + action + ' [options] source github_user github_repo secret'
-            calls = [call('usage: %prog [delete|import|info|init|install|list|login|remove|search|setup] [--help] [options] ...'), call(formatted_call)]
+            formatted_call = {
+                                'import'    : 'usage: %prog import [options] github_user github_repo',
+                                'delete'    : 'usage: %prog delete [options] github_user github_repo',
+                                'info'      : 'usage: %prog info [options] role_name[,version]',
+                                'init'      : 'usage: %prog init [options] role_name',
+                                'install'   : 'usage: %prog install [options] [-r FILE | role_name(s)[,version] | scm+role_repo_url[,version] | tar_file(s)]',
+                                'list'      : 'usage: %prog list [role_name]',
+                                'login'     : 'usage: %prog login [options]',
+                                'remove'    : 'usage: %prog remove role1 role2 ...',
+                                'search'    : 'usage: %prog search [searchterm1 searchterm2] [--galaxy-tags galaxy_tag1,galaxy_tag2] [--platforms platform1,platform2] [--author username]',
+                                'setup'     : 'usage: %prog setup [options] source github_user github_repo secret',
+                             }
+            
+            first_call = 'usage: %prog [delete|import|info|init|install|list|login|remove|search|setup] [--help] [options] ...'
+            second_call = formatted_call[action]
+            calls = [call(first_call), call(second_call)]
             mocked_usage.assert_has_calls(calls)
 
-    def test_parse(self):
-        ''' systematically testing that the expected options parser is created '''
-        # testing no action given
-        gc = GalaxyCLI(args=["-c"])
+    def test_parse_no_action(self):
+        ''' testing the options parser when no action is given '''
+        gc = GalaxyCLI(args=[""])
         self.assertRaises(AnsibleOptionsError, gc.parse)
 
-        # testing action that doesn't exist
-        gc = GalaxyCLI(args=["NOT_ACTION", "-c"])
+    def test_parse_invalid_action(self):
+        ''' testing the options parser when an invalid action is given '''
+        gc = GalaxyCLI(args=["NOT_ACTION"])
         self.assertRaises(AnsibleOptionsError, gc.parse)
 
-        # testing action 'delete'
-        gc = GalaxyCLI(args=["delete", "-c"])
+    def test_parse_delete(self):
+        ''' testing the options parser when the action 'delete' is given '''
+        gc = GalaxyCLI(args=["delete"])
         self.run_parse_common(gc, "delete")
         self.assertEqual(gc.options.verbosity, 0)
 
-        # testing action 'import'
-        gc = GalaxyCLI(args=["import", "-c"])
+    def test_parse_import(self):
+        ''' testing the options parser when the action 'import' is given '''
+        gc = GalaxyCLI(args=["import"])
         self.run_parse_common(gc, "import")
         self.assertEqual(gc.options.wait, True)
         self.assertEqual(gc.options.reference, None)
         self.assertEqual(gc.options.check_status, False)
         self.assertEqual(gc.options.verbosity, 0)
 
-        # testing action 'info'
-        gc = GalaxyCLI(args=["info", "-c"])
+    def test_parse_info(self):
+        ''' testing the options parser when the action 'info' is given '''
+        gc = GalaxyCLI(args=["info"])
         self.run_parse_common(gc, "info")
         self.assertEqual(gc.options.offline, False)
 
-        # testing action 'init'
-        gc = GalaxyCLI(args=["init", "-c"])
+    def test_parse_init(self):
+        ''' testing the options parser when the action 'init' is given '''
+        gc = GalaxyCLI(args=["init"])
         self.run_parse_common(gc, "init")
         self.assertEqual(gc.options.offline, False)
         self.assertEqual(gc.options.force, False)
 
-        # testing action 'install'
-        gc = GalaxyCLI(args=["install", "-c"])
+    def test_parse_install(self):
+        ''' testing the options parser when the action 'install' is given '''
+        gc = GalaxyCLI(args=["install"])
         self.run_parse_common(gc, "install")
         self.assertEqual(gc.options.ignore_errors, False)
         self.assertEqual(gc.options.no_deps, False)
         self.assertEqual(gc.options.role_file, None)
         self.assertEqual(gc.options.force, False)
 
-        # testing action 'list'
-        gc = GalaxyCLI(args=["list", "-c"])
+    def test_parse_list(self):
+        ''' testing the options parser when the action 'list' is given '''
+        gc = GalaxyCLI(args=["list"])
         self.run_parse_common(gc, "list")
         self.assertEqual(gc.options.verbosity, 0)
 
-        # testing action 'login'
-        gc = GalaxyCLI(args=["login", "-c"])
+    def test_parse_login(self):
+        ''' testing the options parser when the action 'login' is given '''
+        gc = GalaxyCLI(args=["login"])
         self.run_parse_common(gc, "login")
         self.assertEqual(gc.options.verbosity, 0)
         self.assertEqual(gc.options.token, None)
 
-        # testing action 'remove'
-        gc = GalaxyCLI(args=["remove", "-c"])
+    def test_parse_remove(self):
+        ''' testing the options parser when the action 'remove' is given '''
+        gc = GalaxyCLI(args=["remove"])
         self.run_parse_common(gc, "remove")
         self.assertEqual(gc.options.verbosity, 0)
 
-        # testing action 'search'
-        gc = GalaxyCLI(args=["search", "-c"])
+    def test_parse_search(self):
+        ''' testing the options parswer when the action 'search' is given '''
+        gc = GalaxyCLI(args=["search"])
         self.run_parse_common(gc, "search")
         self.assertEqual(gc.options.platforms, None)
         self.assertEqual(gc.options.galaxy_tags, None)
         self.assertEqual(gc.options.author, None)
 
-        # testing action 'setup'
-        gc = GalaxyCLI(args=["setup", "-c"])
+    def test_parse_setup(self):
+        ''' testing the options parser when the action 'setup' is given '''
+        gc = GalaxyCLI(args=["setup"])
         self.run_parse_common(gc, "setup")
         self.assertEqual(gc.options.verbosity, 0)
         self.assertEqual(gc.options.remove_id, None)


### PR DESCRIPTION
##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
test/units/cli/test_galaxy.py

##### ANSIBLE VERSION
```
(venv) shertel-OSX:ansible shertel$ ansible --version
ansible 2.3.0 (galaxy-unit-tests-uniformity fcaee1c05e) last updated 2017/01/30 11:59:19 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Trying to make the unit tests for GalaxyCLI more uniform to make it easier to add more tests and be consistent.
- Removed unnecessary GalaxyCLI arguments
- Removing unnecessary patches for the command line
- Called GalaxyCLI.parse and GalaxyCLI.run the same way every time (instead of saving the value of GalaxyCLI.parse or calling GalaxyCLI.run by calling super(GalaxyCLI, galaxy_object).run() and then GalaxyAPI(galaxy_object.galaxy))
- Fixing test_execute_remove to use the correct path
- Refactoring so one unittest tests one thing
- Improving readability by using a dictionary instead of lots of elifs

Before:
```
(venv) shertel-OSX:ansible shertel$ pytest -r a --color yes --junit-xml test/results/junit/python3.5-units.xml -v test/units/cli/test_galaxy.py
============================================ test session starts =============================================
platform darwin -- Python 3.5.0, pytest-3.0.6, py-1.4.32, pluggy-0.4.0 -- /Users/shertel/.../ansible/venv/bin/python3.5
cachedir: .cache
rootdir: /Users/shertel/.../ansible, inifile:
collected 7 items

test/units/cli/test_galaxy.py::TestGalaxy::test_display_galaxy_info PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_display_min PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_execute_remove PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_exit_without_ignore PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_init PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_parse PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_run PASSED

---- generated xml file: /Users/shertel/...ansible/test/results/junit/python3.5-units.xml ----
========================================== 7 passed in 1.67 seconds ==========================================
```
After:
```
(venv) shertel-OSX:ansible shertel$ pytest -r a --color yes --junit-xml test/results/junit/python3.5-units.xml -v test/units/cli/test_galaxy.py
============================================ test session starts =============================================
platform darwin -- Python 3.5.0, pytest-3.0.6, py-1.4.32, pluggy-0.4.0 -- /Users/shertel/.../ansible/venv/bin/python3.5
cachedir: .cache
rootdir: /Users/shertel/.../ansible, inifile:
collected 19 items

test/units/cli/test_galaxy.py::TestGalaxy::test_display_galaxy_info PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_display_min PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_execute_remove PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_exit_without_ignore_with_flag PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_exit_without_ignore_without_flag PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_init PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_parse_delete PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_parse_import PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_parse_info PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_parse_init PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_parse_install PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_parse_invalid_action PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_parse_list PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_parse_login PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_parse_no_action PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_parse_remove PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_parse_search PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_parse_setup PASSED
test/units/cli/test_galaxy.py::TestGalaxy::test_run PASSED

---- generated xml file: /Users/shertel/.../ansible/test/results/junit/python3.5-units.xml ----
========================================= 19 passed in 2.86 seconds ==========================================
```
