### PR TITLE
Example of remote usage in znode documentation #20816

### DIFF
--- a/lib/ansible/modules/clustering/znode.py
+++ b/lib/ansible/modules/clustering/znode.py
@@ -100,6 +100,14 @@ EXAMPLES = """
     hosts: 'localhost:2181'
     name: /mypath
     state: absent
+
+# Creating or updating a znode with a given value on a remote Zookeeper
+- znode:
+    hosts: 'my-zookeeper-node:2181'
+    name: /mypath
+    value: myvalue
+    state: present
+  delegate_to: 127.0.0.1
 """
 
 try:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
`znode`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
As mentioned in #20816, the examples doesn't explain clearly the need for `delegate_to:` when running `znode` agains a remote Zookeeper server. Added a section with this example.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
No changes to command, only docs.
```
