### PR TITLE
Unbreak tests:

### DIFF
--- a/lib/ansible/modules/packaging/os/swupd.py
+++ b/lib/ansible/modules/packaging/os/swupd.py
@@ -44,9 +44,9 @@ options:
         description:
             - Indicates the desired bundle state. C(present) ensures the bundle
               is installed while C(absent) ensures the bundle is not installed.
-            required: false
-            default: present
-            choices: ["present", "absent"]
+         required: false
+         default: present
+         choices: ["present", "absent"]
     update:
         description:
             - Updates the OS to the latest version


### PR DESCRIPTION


##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
v2.3
```

##### SUMMARY
This should fix the currently failing Shippable tests:

```
ERROR: DOCUMENTATION is not valid YAML. Line 47 column 13
```
