### PR TITLE
os_network: Allow freeform provider_network_type string

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_network.py
+++ b/lib/ansible/modules/cloud/openstack/os_network.py
@@ -73,7 +73,6 @@ options:
    provider_network_type:
      description:
         - The type of physical network that maps to this network resource.
-     choices: ['flat', 'vlan', 'vxlan', 'gre', 'uplink']
      required: false
      default: None
      version_added: "2.1"
@@ -172,8 +171,7 @@ def main():
         admin_state_up=dict(default=True, type='bool'),
         external=dict(default=False, type='bool'),
         provider_physical_network=dict(required=False),
-        provider_network_type=dict(required=False, default=None,
-                                   choices=['flat', 'vlan', 'vxlan', 'gre', 'uplink']),
+        provider_network_type=dict(required=False),
         provider_segmentation_id=dict(required=False),
         state=dict(default='present', choices=['absent', 'present']),
         project=dict(default=None)


### PR DESCRIPTION
Prescribing types is not necessary as the underlying shade library
does not do so, and the Neutron API will inform us if a disallowed
or non existent type is used.

Fixes #20830

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
os_network

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file =
  configured module search path = ['/etc/ansible/roles/plugins/library']
```

##### SUMMARY
Fixes #20830 by removing prescribed provider network types and allowing the shade library to pass back the Neutron server response if a disallowed or nonexistent network type is specified.

