### PR TITLE
swupd: Return a descriptive message when bundle does not exist.

### DIFF
--- a/lib/ansible/modules/packaging/os/swupd.py
+++ b/lib/ansible/modules/packaging/os/swupd.py
@@ -187,6 +187,9 @@ def swupd_install(module, bundle):
     if rc == 0:
         module.exit_json(changed=True, msg="Bundle %s installed" % bundle, stdout=stdout, stderr=stderr)
 
+    if rc == 18:
+        module.exit_json(Changed=False, msg="Bundle name %s is invalid" % bundle, stdout=stdout, stderr=stderr)
+
     module.fail_json(msg="Unkown Error", stdout=stdout, stderr=stderr)
 
 


### PR DESCRIPTION
Return "Bundle name %s is invalid" message when bundle does not exists
rather than "Unknown Error"

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- swupd.py -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (clearlinux 234556d37a) last updated 2017/01/30 20:01:49 (GMT +000)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
When a non-existeng bundle is specified, swupd.py fails with "Unkown Error"