### PR TITLE
Convert error to the native text type before writing to stderr

### DIFF
--- a/lib/ansible/inventory/script.py
+++ b/lib/ansible/inventory/script.py
@@ -77,11 +77,11 @@ class InventoryScript:
         try:
             self.raw = self._loader.load(self.data)
         except Exception as e:
-            sys.stderr.write(err + "\n")
+            sys.stderr.write(to_native(err) + "\n")
             raise AnsibleError("failed to parse executable inventory script results from {0}: {1}".format(to_native(self.filename), to_native(e)))
 
         if not isinstance(self.raw, Mapping):
-            sys.stderr.write(err + "\n")
+            sys.stderr.write(to_native(err) + "\n")
             raise AnsibleError("failed to parse executable inventory script results from {0}: data needs to be formatted as a json dict".format(to_native(self.filename)))
 
         group = None


### PR DESCRIPTION
Fixes #20588

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
inventory/script

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (bug/20588 b9ae5b35be) last updated 2017/01/30 15:45:59 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

When using external inventory scripts, if the scripts fail we try to write the errors to stderr. On Python 3, this causes:

```
TypeError: write() argument must be str, not bytes
write() argument must be str, not bytes
``` 
Using the _text.to_native function before writing fixes this, and works on Python 2 and 3. 