### PR TITLE
Ensure ssh hostkey checks respect server port

### DIFF
--- a/lib/ansible/module_utils/known_hosts.py
+++ b/lib/ansible/module_utils/known_hosts.py
@@ -86,10 +86,10 @@ def get_fqdn_and_port(repo_url):
         # most likely an user@host:path or user@host/path type URL
         repo_url = repo_url.split("@", 1)[1]
         match = ipv6_re.match(repo_url)
+        # For this type of URL, colon specifies the path, not the port
         if match:
-            fqdn, port = match.groups()
+            fqdn, path = match.groups()
         elif ":" in repo_url:
-            # Here, the colon specifies the path, not the port
             fqdn = repo_url.split(":")[0]
         elif "/" in repo_url:
             fqdn = repo_url.split("/")[0]

--- a/lib/ansible/module_utils/known_hosts.py
+++ b/lib/ansible/module_utils/known_hosts.py
@@ -28,6 +28,7 @@
 
 import os
 import hmac
+import re
 
 try:
     import urlparse
@@ -41,23 +42,26 @@ except ImportError:
 
 HASHED_KEY_MAGIC = "|1|"
 
+
 def add_git_host_key(module, url, accept_hostkey=True, create_dir=True):
 
     """ idempotently add a git url hostkey """
 
     if is_ssh_url(url):
 
-        fqdn = get_fqdn(url)
+        fqdn, port = get_fqdn_and_port(url)
 
         if fqdn:
             known_host = check_hostkey(module, fqdn)
             if not known_host:
                 if accept_hostkey:
-                    rc, out, err = add_host_key(module, fqdn, create_dir=create_dir)
+                    rc, out, err = add_host_key(module, fqdn, port=port, create_dir=create_dir)
                     if rc != 0:
                         module.fail_json(msg="failed to add %s hostkey: %s" % (fqdn, out + err))
                 else:
-                    module.fail_json(msg="%s has an unknown hostkey. Set accept_hostkey to True or manually add the hostkey prior to running the git module" % fqdn)
+                    module.fail_json(msg="%s has an unknown hostkey. Set accept_hostkey to True "
+                                     "or manually add the hostkey prior to running the git module" % fqdn)
+
 
 def is_ssh_url(url):
 
@@ -70,44 +74,50 @@ def is_ssh_url(url):
             return True
     return False
 
-def get_fqdn(repo_url):
 
-    """ chop the hostname out of a url """
+def get_fqdn_and_port(repo_url):
 
-    result = None
+    """ chop the hostname and port out of a url """
+
+    fqdn = None
+    port = None
+    ipv6_re = re.compile('(\[[^]]*\])(?::([0-9]+))?')
     if "@" in repo_url and "://" not in repo_url:
         # most likely an user@host:path or user@host/path type URL
         repo_url = repo_url.split("@", 1)[1]
-        if repo_url.startswith('['):
-            result = repo_url.split(']', 1)[0] + ']'
+        match = ipv6_re.match(repo_url)
+        if match:
+            fqdn, port = match.groups()
         elif ":" in repo_url:
-            result = repo_url.split(":")[0]
+            # Here, the colon specifies the path, not the port
+            fqdn = repo_url.split(":")[0]
         elif "/" in repo_url:
-            result = repo_url.split("/")[0]
+            fqdn = repo_url.split("/")[0]
     elif "://" in repo_url:
         # this should be something we can parse with urlparse
         parts = urlparse.urlparse(repo_url)
         # parts[1] will be empty on python2.4 on ssh:// or git:// urls, so
         # ensure we actually have a parts[1] before continuing.
         if parts[1] != '':
-            result = parts[1]
-            if "@" in result:
-                result = result.split("@", 1)[1]
+            fqdn = parts[1]
+            if "@" in fqdn:
+                fqdn = fqdn.split("@", 1)[1]
+            match = ipv6_re.match(fqdn)
+            if match:
+                fqdn, port = match.groups()
+            elif ":" in fqdn:
+                fqdn, port = fqdn.split(":")[0:2]
+    return fqdn, port
 
-            if result[0].startswith('['):
-                result = result.split(']', 1)[0] + ']'
-            elif ":" in result:
-                result = result.split(":")[0]
-    return result
 
 def check_hostkey(module, fqdn):
     return not not_in_host_file(module, fqdn)
+
 
 # this is a variant of code found in connection_plugins/paramiko.py and we should modify
 # the paramiko code to import and use this.
 
 def not_in_host_file(self, host):
-
 
     if 'USER' in os.environ:
         user_host_file = os.path.expandvars("~${USER}/.ssh/known_hosts")
@@ -159,7 +169,7 @@ def not_in_host_file(self, host):
     return True
 
 
-def add_host_key(module, fqdn, key_type="rsa", create_dir=False):
+def add_host_key(module, fqdn, port=22, key_type="rsa", create_dir=False):
 
     """ use ssh-keyscan to add the hostkey """
 
@@ -184,7 +194,10 @@ def add_host_key(module, fqdn, key_type="rsa", create_dir=False):
     elif not os.path.isdir(user_ssh_dir):
         module.fail_json(msg="%s is not a directory" % user_ssh_dir)
 
-    this_cmd = "%s -t %s %s" % (keyscan_cmd, key_type, fqdn)
+    if port:
+        this_cmd = "%s -t %s -p %s %s" % (keyscan_cmd, key_type, port, fqdn)
+    else:
+        this_cmd = "%s -t %s %s" % (keyscan_cmd, key_type, fqdn)
 
     rc, out, err = module.run_command(this_cmd)
     # ssh-keyscan gives a 0 exit code and prints nothins on timeout
@@ -193,4 +206,3 @@ def add_host_key(module, fqdn, key_type="rsa", create_dir=False):
     module.append_to_file(user_host_file, out)
 
     return rc, out, err
-

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -23,7 +23,6 @@ lib/ansible/module_utils/basic.py
 lib/ansible/module_utils/ec2.py
 lib/ansible/module_utils/f5.py
 lib/ansible/module_utils/facts.py
-lib/ansible/module_utils/known_hosts.py
 lib/ansible/module_utils/mysql.py
 lib/ansible/module_utils/vmware.py
 lib/ansible/modules/cloud/amazon/_ec2_vpc.py

--- a/test/units/module_utils/basic/test_known_hosts.py
+++ b/test/units/module_utils/basic/test_known_hosts.py
@@ -19,28 +19,59 @@
 from ansible.compat.tests import unittest
 from ansible.module_utils import known_hosts
 
+import json
+import ansible.module_utils.basic
+from ansible.compat.tests.mock import Mock
+from units.mock.procenv import swap_stdin_and_argv
+
 class TestAnsibleModuleKnownHosts(unittest.TestCase):
     urls = {
         'ssh://one.example.org/example.git':
-            {'is_ssh_url': True, 'get_fqdn': 'one.example.org'},
+            {'is_ssh_url': True, 'get_fqdn': 'one.example.org',
+             'add_host_key_cmd': " -t rsa one.example.org",
+             'port': known_hosts.SSH_KEYSCAN_DEFAULT_PORT},
         'ssh+git://two.example.org/example.git':
-            {'is_ssh_url': True, 'get_fqdn': 'two.example.org'},
+            {'is_ssh_url': True, 'get_fqdn': 'two.example.org',
+             'add_host_key_cmd': " -t rsa two.example.org", 
+             'port': known_hosts.SSH_KEYSCAN_DEFAULT_PORT},
         'rsync://three.example.org/user/example.git':
-            {'is_ssh_url': False, 'get_fqdn': 'three.example.org'},
+            {'is_ssh_url': False, 'get_fqdn': 'three.example.org', 
+             'add_host_key_cmd': None, # not called for non-ssh urls
+             'port': known_hosts.SSH_KEYSCAN_DEFAULT_PORT},
         'git@four.example.org:user/example.git':
-            {'is_ssh_url': True, 'get_fqdn': 'four.example.org'},
+            {'is_ssh_url': True, 'get_fqdn': 'four.example.org',
+             'add_host_key_cmd': " -t rsa four.example.org", 
+             'port': known_hosts.SSH_KEYSCAN_DEFAULT_PORT},
         'git+ssh://five.example.org/example.git':
-            {'is_ssh_url': True, 'get_fqdn': 'five.example.org'},
-        'ssh://six.example.org:21/example.org':
-            {'is_ssh_url': True, 'get_fqdn': 'six.example.org'},
+            {'is_ssh_url': True, 'get_fqdn': 'five.example.org', 
+             'add_host_key_cmd': " -t rsa five.example.org",
+             'port': known_hosts.SSH_KEYSCAN_DEFAULT_PORT},
+        'ssh://six.example.org:21/example.org': # ssh on FTP Port? 
+            {'is_ssh_url': True, 'get_fqdn': 'six.example.org',
+             'add_host_key_cmd': " -t rsa six.example.org -p 21", # should add port param, since it's different from default
+             'port': "21"},
         'ssh://[2001:DB8::abcd:abcd]/example.git':
-            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]'},
+            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]',
+             'add_host_key_cmd': " -t rsa [2001:DB8::abcd:abcd]",
+             'port': known_hosts.SSH_KEYSCAN_DEFAULT_PORT},
         'ssh://[2001:DB8::abcd:abcd]:22/example.git':
-            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]'},
+            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]',
+             'add_host_key_cmd': " -t rsa [2001:DB8::abcd:abcd]", 
+             # even though it's explicitly specified we do not add port here (for backwards compatibility)'
+             'add_host_key_cmd': " -t rsa [2001:DB8::abcd:abcd]",  
+             'port': "22"},
         'username@[2001:DB8::abcd:abcd]/example.git':
-            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]'},
+            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]',
+             'add_host_key_cmd': " -t rsa [2001:DB8::abcd:abcd]", 
+             'port': known_hosts.SSH_KEYSCAN_DEFAULT_PORT},
         'username@[2001:DB8::abcd:abcd]:22/example.git':
-            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]'},
+            {'is_ssh_url': True, 'get_fqdn': '[2001:DB8::abcd:abcd]',
+             'add_host_key_cmd': " -t rsa [2001:DB8::abcd:abcd]", 
+             'port': "22"},
+        'ssh://internal.git.server:7999/repos/repo.git':
+            {'is_ssh_url': True, 'get_fqdn': 'internal.git.server',
+             'add_host_key_cmd': " -t rsa internal.git.server -p 7999",
+             'port': "7999"}
     }
 
     def test_is_ssh_url(self):
@@ -51,5 +82,32 @@ class TestAnsibleModuleKnownHosts(unittest.TestCase):
         for u in self.urls:
             self.assertEqual(known_hosts.get_fqdn(u), self.urls[u]['get_fqdn'])
 
+    def test_get_fqdn_and_port(self):
+        for u in self.urls:
+            self.assertEqual(known_hosts.get_fqdn_and_port(u), (self.urls[u]['get_fqdn'], self.urls[u]['port']))
+
+    def test_add_host_key(self):
+
+        # Copied
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}))
+        # unittest doesn't have a clean place to use a context manager, so we have to enter/exit manually
+        self.stdin_swap = swap_stdin_and_argv(stdin_data=args)
+        self.stdin_swap.__enter__()
+
+        ansible.module_utils.basic._ANSIBLE_ARGS = None 
+        self.module = ansible.module_utils.basic.AnsibleModule(argument_spec=dict())
+
+        run_command = Mock()
+        run_command.return_value = (0, "Needs output, otherwise thinks ssh-keyscan timed out'", "")
+        self.module.run_command = run_command
+
+        get_bin_path = Mock()
+        get_bin_path.return_value = keyscan_cmd = "/custom/path/ssh-keyscan"
+        self.module.get_bin_path = get_bin_path
+
+        for u in self.urls:
+            if self.urls[u]['is_ssh_url']:
+                known_hosts.add_host_key(self.module, self.urls[u]['get_fqdn'], port=self.urls[u]['port'])
+                run_command.assert_called_with(keyscan_cmd + self.urls[u]['add_host_key_cmd'])
 
 

--- a/test/units/module_utils/test_known_hosts.py
+++ b/test/units/module_utils/test_known_hosts.py
@@ -86,21 +86,20 @@ class TestAnsibleModuleKnownHosts(unittest.TestCase):
         # Copied
         args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}))
         # unittest doesn't have a clean place to use a context manager, so we have to enter/exit manually
-        self.stdin_swap = swap_stdin_and_argv(stdin_data=args)
-        self.stdin_swap.__enter__()
 
-        ansible.module_utils.basic._ANSIBLE_ARGS = None
-        self.module = ansible.module_utils.basic.AnsibleModule(argument_spec=dict())
+        with swap_stdin_and_argv(stdin_data=args):
+            ansible.module_utils.basic._ANSIBLE_ARGS = None
+            self.module = ansible.module_utils.basic.AnsibleModule(argument_spec=dict())
 
-        run_command = Mock()
-        run_command.return_value = (0, "Needs output, otherwise thinks ssh-keyscan timed out'", "")
-        self.module.run_command = run_command
+            run_command = Mock()
+            run_command.return_value = (0, "Needs output, otherwise thinks ssh-keyscan timed out'", "")
+            self.module.run_command = run_command
 
-        get_bin_path = Mock()
-        get_bin_path.return_value = keyscan_cmd = "/custom/path/ssh-keyscan"
-        self.module.get_bin_path = get_bin_path
+            get_bin_path = Mock()
+            get_bin_path.return_value = keyscan_cmd = "/custom/path/ssh-keyscan"
+            self.module.get_bin_path = get_bin_path
 
-        for u in self.urls:
-            if self.urls[u]['is_ssh_url']:
-                known_hosts.add_host_key(self.module, self.urls[u]['get_fqdn'], port=self.urls[u]['port'])
-                run_command.assert_called_with(keyscan_cmd + self.urls[u]['add_host_key_cmd'])
+            for u in self.urls:
+                if self.urls[u]['is_ssh_url']:
+                    known_hosts.add_host_key(self.module, self.urls[u]['get_fqdn'], port=self.urls[u]['port'])
+                    run_command.assert_called_with(keyscan_cmd + self.urls[u]['add_host_key_cmd'])


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/known_hosts

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 462ab6b1db) last updated 2017/01/31 10:02:44 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides
```

Also affects 2.2.1, but not 2.2.0

##### SUMMARY
ssh-keyscan will default to getting the host key for port 22.
If the ssh service is running on a different port, ssh-keyscan
will need to know this.

Tidy up minor flake8 issues
