### PR TITLE
Use a -short- custom hash for controlpersist path by default 

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -310,16 +310,14 @@
 # control_path_dir = /tmp/.ansible/cp
 #control_path_dir = ~/.ansible/cp
 
-# The path to use for the ControlPath sockets. This defaults to
-# "%(directory)s/ansible-ssh-%%h-%%p-%%r", however on some systems with
-# very long hostnames or very long path names (caused by long user names or
-# deeply nested home directories) this can exceed the character limit on
-# file socket names (108 characters for most platforms). In that case, you
-# may wish to shorten the string below.
+# The path to use for the ControlPath sockets. This defaults to a hashed string of the hostname, 
+# port and username (empty string in the config). The hash mitigates a common problem users 
+# found with long hostames and the conventional %(directory)s/ansible-ssh-%%h-%%p-%%r format. 
+# In those cases, a "too long for Unix domain socket" ssh error would occur.
 #
 # Example:
 # control_path = %(directory)s/%%h-%%r
-#control_path = %(directory)s/ansible-ssh-%%h-%%p-%%r
+#control_path =
 
 # Enabling pipelining reduces the number of SSH operations required to
 # execute a module on the remote server. This can result in a significant

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -333,6 +333,7 @@ ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'AN
 # that it may be a security risk to do so.
 ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', u"%(directory)s/ansible-ssh-%%h-%%p-%%r")
 ANSIBLE_SSH_CONTROL_PATH_DIR   = get_config(p, 'ssh_connection', 'control_path_dir', 'ANSIBLE_SSH_CONTROL_PATH_DIR', u'~/.ansible/cp')
+ANSIBLE_SSH_CONTROL_PATH_FIX   = get_config(p, 'ssh_connection', 'control_path_fix', 'ANSIBLE_SSH_CONTROL_PATH_FIX', False, value_type='boolean')
 ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', False, value_type='boolean')
 ANSIBLE_SSH_RETRIES            = get_config(p, 'ssh_connection', 'retries', 'ANSIBLE_SSH_RETRIES', 0, value_type='integer')
 ANSIBLE_SSH_EXECUTABLE         = get_config(p, 'ssh_connection', 'ssh_executable', 'ANSIBLE_SSH_EXECUTABLE', 'ssh')

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -331,7 +331,7 @@ ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'AN
 # to .format() in the future.  be sure to read this:
 # http://lucumr.pocoo.org/2016/12/29/careful-with-str-format/ and understand
 # that it may be a security risk to do so.
-ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', u"%(directory)s/ansible-ssh-%%h-%%p-%%r")
+ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', None)
 ANSIBLE_SSH_CONTROL_PATH_DIR   = get_config(p, 'ssh_connection', 'control_path_dir', 'ANSIBLE_SSH_CONTROL_PATH_DIR', u'~/.ansible/cp')
 ANSIBLE_SSH_CONTROL_PATH_FIX   = get_config(p, 'ssh_connection', 'control_path_fix', 'ANSIBLE_SSH_CONTROL_PATH_FIX', False, value_type='boolean')
 ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', False, value_type='boolean')

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -333,7 +333,6 @@ ANSIBLE_SSH_ARGS               = get_config(p, 'ssh_connection', 'ssh_args', 'AN
 # that it may be a security risk to do so.
 ANSIBLE_SSH_CONTROL_PATH       = get_config(p, 'ssh_connection', 'control_path', 'ANSIBLE_SSH_CONTROL_PATH', None)
 ANSIBLE_SSH_CONTROL_PATH_DIR   = get_config(p, 'ssh_connection', 'control_path_dir', 'ANSIBLE_SSH_CONTROL_PATH_DIR', u'~/.ansible/cp')
-ANSIBLE_SSH_CONTROL_PATH_FIX   = get_config(p, 'ssh_connection', 'control_path_fix', 'ANSIBLE_SSH_CONTROL_PATH_FIX', False, value_type='boolean')
 ANSIBLE_SSH_PIPELINING         = get_config(p, 'ssh_connection', 'pipelining', 'ANSIBLE_SSH_PIPELINING', False, value_type='boolean')
 ANSIBLE_SSH_RETRIES            = get_config(p, 'ssh_connection', 'retries', 'ANSIBLE_SSH_RETRIES', 0, value_type='integer')
 ANSIBLE_SSH_EXECUTABLE         = get_config(p, 'ssh_connection', 'ssh_executable', 'ANSIBLE_SSH_EXECUTABLE', 'ssh')

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -77,7 +77,7 @@ class Connection(ConnectionBase):
         '''Make a hash for the controlpath based on con attributes'''
         pstring = '%s-%s-%s' % (host, port, user)
         m = hashlib.sha1()
-        m.update(pstring)
+        m.update(to_text(pstring))
         digest = m.hexdigest()
         cpath = '%(directory)s/' + digest[:10]
         return cpath

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -77,7 +77,7 @@ class Connection(ConnectionBase):
         '''Make a hash for the controlpath based on con attributes'''
         pstring = '%s-%s-%s' % (host, port, user)
         m = hashlib.sha1()
-        m.update(to_text(pstring))
+        m.update(to_bytes(pstring))
         digest = m.hexdigest()
         cpath = '%(directory)s/' + digest[:10]
         return cpath

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -64,7 +64,6 @@ class Connection(ConnectionBase):
         self.user = self._play_context.remote_user
         self.control_path = C.ANSIBLE_SSH_CONTROL_PATH
         self.control_path_dir = C.ANSIBLE_SSH_CONTROL_PATH_DIR
-        self.control_path_success = False
 
     # The connection is created by running ssh/scp/sftp from the exec_command,
     # put_file, and fetch_file methods, so we don't need to do any connection

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -59,6 +59,9 @@ class Connection(ConnectionBase):
         super(Connection, self).__init__(*args, **kwargs)
 
         self.host = self._play_context.remote_addr
+        self.control_path = C.ANSIBLE_SSH_CONTROL_PATH
+        self.control_path_dir = C.ANSIBLE_SSH_CONTROL_PATH_DIR
+        self.control_path_success = False
 
     # The connection is created by running ssh/scp/sftp from the exec_command,
     # put_file, and fetch_file methods, so we don't need to do any connection
@@ -228,7 +231,7 @@ class Connection(ConnectionBase):
             self._persistent = True
 
             if not controlpath:
-                cpdir = unfrackpath(C.ANSIBLE_SSH_CONTROL_PATH_DIR)
+                cpdir = unfrackpath(self.control_path_dir)
                 b_cpdir = to_bytes(cpdir, errors='surrogate_or_strict')
 
                 # The directory must exist and be writable.
@@ -236,7 +239,7 @@ class Connection(ConnectionBase):
                 if not os.access(b_cpdir, os.W_OK):
                     raise AnsibleError("Cannot write to ControlPath %s" % to_native(cpdir))
 
-                b_args = (b"-o", b"ControlPath=" + to_bytes(C.ANSIBLE_SSH_CONTROL_PATH % dict(directory=cpdir), errors='surrogate_or_strict'))
+                b_args = (b"-o", b"ControlPath=" + to_bytes(self.control_path % dict(directory=cpdir), errors='surrogate_or_strict'))
                 self._add_args(b_command, b_args, u"found only ControlPersist; added ControlPath")
 
         # Finally, we add any caller-supplied extras.
@@ -244,6 +247,63 @@ class Connection(ConnectionBase):
             b_command += [to_bytes(a) for a in other_args]
 
         return b_command
+
+    def _test_control_persist(self, ssh_executable, hostname):
+        '''Test ssh with control persist and alter the path to fix it'''
+        # https://github.com/ansible/ansible/issues/11536#issuecomment-188892237
+
+        if self.control_path_success:
+            return self.control_path_success
+
+        display.debug('validating ssh controlpath %s' % self.control_path)
+        count = 0
+        while count <= 3:
+            # try a simple echo
+            test_args = (ssh_executable, self.host, 'echo')
+            # _build_command adds the controlpersist args
+            test_cmd = self._build_command(*test_args)
+            (rc, so, se) = self._run(test_cmd, None, checkrc=False)
+
+            if 'too long for unix domain socket' not in se.lower():
+                # presume no failure because we don't care about anything
+                # besides the domain socket length error
+                self.control_path_success = True
+                break
+            else:
+                # Alter the args incrementally and re-test
+                cp_parts = self.control_path.split('/')
+                if not cp_parts:
+                    # give up if nothing left
+                    break
+                if '%%C' not in cp_parts:
+                    # try the hashing function first
+                    cp_parts[-1] = to_bytes('%%C')
+                else:
+                    cp_final = cp_parts[-1].split('-')
+                    if 'ansible' in cp_final or 'ssh' in cp_final:
+                        # remove ansible specific fields
+                        if 'ansible' in cp_final:
+                            cp_final.remove('ansible')
+                        if 'ssh' in cp_final:
+                            cp_final.remove('ssh')
+                    elif '%%r' in cp_final:
+                        # remove username
+                        cp_final.remove('%%r')
+                    elif '%%p' in cp_final:
+                        # remove port
+                        cp_final.remove('%%p')
+                    elif '%%h' in cp_final:
+                        # remove hostname
+                        cp_final.remove('%%h')
+
+                    # use /tmp as a last resort ...
+                    if not cp_final:
+                        cp_parts = ['/tmp', '%%h-%%p-%%r']
+
+                self.control_path = '/'.join(cp_parts)
+                display.warning('ssh control path is too long, re-trying with %s' % self.control_path)
+
+        return self.control_path_success
 
     def _send_initial_data(self, fh, in_data):
         '''
@@ -594,6 +654,10 @@ class Connection(ConnectionBase):
             args = (ssh_executable, '-tt', self.host, cmd)
         else:
             args = (ssh_executable, self.host, cmd)
+
+        # validate and alter the control path
+        if C.ANSIBLE_SSH_CONTROL_PATH_FIX:
+            self._test_control_persist(ssh_executable, self.host)
 
         cmd = self._build_command(*args)
         (returncode, stdout, stderr) = self._run(cmd, in_data, sudoable=sudoable)

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -259,7 +259,7 @@ class Connection(ConnectionBase):
         count = 0
         while count <= 3:
             # try a simple echo
-            test_args = (ssh_executable, self.host, 'echo')
+            test_args = (ssh_executable, hostname, 'echo')
             # _build_command adds the controlpersist args
             test_cmd = self._build_command(*test_args)
             (rc, so, se) = self._run(test_cmd, None, checkrc=False)


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
lib/ansible/plugins/connection/ssh.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```

##### SUMMARY

Fixes https://github.com/ansible/ansible/issues/11536