### PR TITLE
Fixing nxos_portchannel bug caused by wrong regex

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_portchannel.py
+++ b/lib/ansible/modules/network/nxos/nxos_portchannel.py
@@ -303,7 +303,7 @@ def get_value(arg, config, module):
 
 def check_interface(module, netcfg):
     config = str(netcfg)
-    REGEX = re.compile(r'\s+interface port-channel{0}*$'.format(module.params['group']), re.M)
+    REGEX = re.compile(r'\s+interface port-channel{0}$'.format(module.params['group']), re.M)
     value = False
     try:
         if REGEX.search(config):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_portchannel

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Solves #20684 . This only need to be backported to 2.2 . 
