### PR TITLE
Add installation of PPA signing key to intro_installation.rst

### DIFF
--- a/docs/docsite/rst/intro_installation.rst
+++ b/docs/docsite/rst/intro_installation.rst
@@ -178,6 +178,7 @@ Then run these commands:
 
 .. code-block:: bash
 
+    $ sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 93C4A3FD7BB9C367
     $ sudo apt-get update
     $ sudo apt-get install ansible
 


### PR DESCRIPTION
Added command to install the repository key to prevent errors

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

 docs/docsite/rst/intro_installation.rst 

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
n/a
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Added the repository key import for the Debian installation manual as without it, apt generates errors about an unknown key.


