### PR TITLE
ec2: `assign_public_ip` should be `None` field by default

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_lc.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_lc.py
@@ -181,19 +181,12 @@ def create_launch_config(connection, module):
     instance_monitoring = module.params.get('instance_monitoring')
     kernel_id = module.params.get('kernel_id')
     ramdisk_id = module.params.get('ramdisk_id')
+    assign_public_ip = module.params.get('assign_public_ip')
     instance_profile_name = module.params.get('instance_profile_name')
     ebs_optimized = module.params.get('ebs_optimized')
     classic_link_vpc_id = module.params.get('classic_link_vpc_id')
     classic_link_vpc_security_groups = module.params.get('classic_link_vpc_security_groups')
     bdm = BlockDeviceMapping()
-    
-    if module.params.get('assign_public_ip'):
-        if module.params.get('assign_public_ip') == 'yes':
-            assign_public_ip = True
-        else:
-            assign_public_ip = False
-    else:
-        assign_public_ip = None
     
     if volumes:
         for volume in volumes:

--- a/lib/ansible/modules/cloud/amazon/ec2_lc.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_lc.py
@@ -179,7 +179,6 @@ def create_launch_config(connection, module):
     instance_type = module.params.get('instance_type')
     spot_price = module.params.get('spot_price')
     instance_monitoring = module.params.get('instance_monitoring')
-    assign_public_ip = module.params.get('assign_public_ip')
     kernel_id = module.params.get('kernel_id')
     ramdisk_id = module.params.get('ramdisk_id')
     instance_profile_name = module.params.get('instance_profile_name')
@@ -187,7 +186,15 @@ def create_launch_config(connection, module):
     classic_link_vpc_id = module.params.get('classic_link_vpc_id')
     classic_link_vpc_security_groups = module.params.get('classic_link_vpc_security_groups')
     bdm = BlockDeviceMapping()
-
+    
+    if module.params.get('assign_public_ip'):
+        if module.params.get('assign_public_ip') == 'yes':
+            assign_public_ip = True
+        else:
+            assign_public_ip = False
+    else:
+        assign_public_ip = None
+    
     if volumes:
         for volume in volumes:
             if 'device_name' not in volume:
@@ -287,7 +294,7 @@ def main():
             ebs_optimized=dict(default=False, type='bool'),
             associate_public_ip_address=dict(type='bool'),
             instance_monitoring=dict(default=False, type='bool'),
-            assign_public_ip=dict(type='bool'),
+            assign_public_ip=dict(default=None, type='bool'),
             classic_link_vpc_security_groups=dict(type='list'),
             classic_link_vpc_id=dict(type='str')
         )


### PR DESCRIPTION
This issue was addressed in the `ansible-modules-core` but wasn't reflected here.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
`assign_public_ip` should be a None type field as default. This issue was addressed in `ansible-modules-core` but change wasn't reflected here.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
