### PR TITLE
Fix import of urlparse on python3. Fixes #20820.

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3.py
+++ b/lib/ansible/modules/cloud/amazon/s3.py
@@ -415,7 +415,7 @@ def get_download_url(module, s3, bucket, obj, expiry, changed=True):
 def is_fakes3(s3_url):
     """ Return True if s3_url has scheme fakes3:// """
     if s3_url is not None:
-        return urlparse.urlparse(s3_url).scheme in ('fakes3', 'fakes3s')
+        return urlparse(s3_url).scheme in ('fakes3', 'fakes3s')
     else:
         return False
 
@@ -424,7 +424,7 @@ def is_walrus(s3_url):
 
     We assume anything other than *.amazonaws.com is Walrus"""
     if s3_url is not None:
-        o = urlparse.urlparse(s3_url)
+        o = urlparse(s3_url)
         return not o.hostname.endswith('amazonaws.com')
     else:
         return False
@@ -513,12 +513,11 @@ def main():
     # for more details.
     if '.' in bucket:
         aws_connect_kwargs['calling_format'] = OrdinaryCallingFormat()
-
     # Look at s3_url and tweak connection settings
     # if connecting to RGW, Walrus or fakes3
     try:
         if s3_url and rgw:
-            rgw = urlparse.urlparse(s3_url)
+            rgw = urlparse(s3_url)
             s3 = boto.connect_s3(
                 is_secure=rgw.scheme == 'https',
                 host=rgw.hostname,
@@ -527,7 +526,7 @@ def main():
                 **aws_connect_kwargs
             )
         elif is_fakes3(s3_url):
-            fakes3 = urlparse.urlparse(s3_url)
+            fakes3 = urlparse(s3_url)
             s3 = S3Connection(
                 is_secure=fakes3.scheme == 'fakes3s',
                 host=fakes3.hostname,
@@ -536,7 +535,7 @@ def main():
                 **aws_connect_kwargs
             )
         elif is_walrus(s3_url):
-            walrus = urlparse.urlparse(s3_url).hostname
+            walrus = urlparse(s3_url).hostname
             s3 = boto.connect_walrus(walrus, **aws_connect_kwargs)
         else:
             aws_connect_kwargs['is_secure'] = True


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/s3.py

##### ANSIBLE VERSION
```
ansible 2.3.0 (s3-option-urlparse 9e49040e4a) last updated 2017/01/31 09:20:37 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
- Fix the way urlparse is imported
- Reflect this change where urlparse is used in the code
- Fixes #20820 

Playbook
```
---
- hosts: localhost
  connection: local
  tasks:
    - name: download file from s3
      s3:
        profile: myprofile
        bucket: mybucket
        object: "/testing.txt"
        dest: "/tmp/testing.txt"
        rgw: True
        s3_url: "https://s3.amazonaws.com"
        mode: get
```

Before:
```
PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [localhost]

TASK [download file from s3] ***************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to connect to S3: 'function' object has no attribute 'urlparse'"}
	to retry, use: --limit @/Users/shertel/.../ansible/my_playbooks/s3-test.retry

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1
```
After:
```
PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [localhost]

TASK [download file from s3] ***************************************************
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0
```