### PR TITLE
unicode is absent in case of python3 - fix it

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -52,7 +52,7 @@ try:
 except:
     HAS_LOOSE_VERSION = False
 
-from ansible.module_utils.six import string_types
+from ansible.module_utils.six import string_types, binary_type, text_type
 
 class AnsibleAWSError(Exception):
     pass
@@ -232,8 +232,8 @@ def get_aws_connection_info(module, boto3=False):
         boto_params['validate_certs'] = validate_certs
 
     for param, value in boto_params.items():
-        if isinstance(value, str):
-            boto_params[param] = unicode(value, 'utf-8', 'strict')
+        if isinstance(value, binary_type):
+            boto_params[param] = text_type(value, 'utf-8', 'strict')
 
     return region, ec2_url, boto_params
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - module_utils

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Fix bug raised in python3

Before diff:
```
TASK [Delete ASG] **************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: NameError: name 'unicode' is not defined
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/var/folders/kn/680ym7414kd1tkzq6jsrx_1c0000gn/T/ansible_rg8z67g0/ansible_module_ec2_asg.py\", line 875, in <module>\n    main()\n  File \"/var/folders/kn/680ym7414kd1tkzq6jsrx_1c0000gn/T/ansible_rg8z67g0/ansible_module_ec2_asg.py\", line 854, in main\n    region, ec2_url, aws_connect_params = get_aws_connection_info(module)\n  File \"/var/folders/kn/680ym7414kd1tkzq6jsrx_1c0000gn/T/ansible_rg8z67g0/ansible_modlib.zip/ansible/module_utils/ec2.py\", line 236, in get_aws_connection_info\nNameError: name 'unicode' is not defined\n", "module_stdout": "", "msg": "MODULE FAILURE"}
	to retry, use: --limit @/Users/heni/repos/Web/cm/ansible/stop-spark-workers.retry
```

After diff:
```
TASK [Delete ASG] **************************************************************
ok: [localhost]
```
