### PR TITLE
Fix 'touch' mode so it creates zero size files.

### DIFF
--- a/lib/ansible/modules/windows/win_file.ps1
+++ b/lib/ansible/modules/windows/win_file.ps1
@@ -35,7 +35,7 @@ if ($state -eq "touch") {
         if (Test-Path $path) {
             (Get-ChildItem $path).LastWriteTime = Get-Date
         } else {
-            echo $null > $path
+            Write-Output $null | Out-File -FilePath $path -Encoding ASCII
         }
     }
     $result.changed = $true

--- a/test/integration/targets/win_file/tasks/main.yml
+++ b/test/integration/targets/win_file/tasks/main.yml
@@ -52,6 +52,16 @@
 #      - "file3_result.state == 'file'"
 #      - "file3_result.mode == '0644'"
 
+- name: stat the touched file
+  win_stat: path={{win_output_dir}}/baz.txt state=touch
+  register: file3_stat_result
+
+- name: verify that the touched file exists and is size 0
+  assert:
+    that:
+      - "file3_stat_result.changed == false"
+      - "file3_stat_result.stat.size == 0"
+      - "file3_stat_result.stat.exists == true"
 #- name: change file mode
 #  win_file: path={{win_output_dir}}/baz.txt mode=0600
 #  register: file4_result


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_file
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (win_file_touch_fix 1c35b6ae37) last updated 2017/01/31 17:55:20 (GMT +100)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fix for https://github.com/ansible/ansible-modules-core/issues/5345
prerviously a two-byte file was created containing the UTF-16 LE Byte order mark (0xff 0xfe)
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
