### PR TITLE
iosxr tests: Initial work for 2.3

### DIFF
--- a/test/integration/iosxr.yaml
+++ b/test/integration/iosxr.yaml
@@ -1,7 +1,6 @@
 ---
 - hosts: iosxr
   gather_facts: no
-  connection: local
 
   vars:
     limit_to: "*"

--- a/test/integration/targets/ios_facts/meta/main.yml
+++ b/test/integration/targets/ios_facts/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_ios_tests

--- a/test/integration/targets/iosxr_command/meta/main.yml
+++ b/test/integration/targets/iosxr_command/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_iosxr_tests

--- a/test/integration/targets/iosxr_command/tasks/cli.yaml
+++ b/test/integration/targets/iosxr_command/tasks/cli.yaml
@@ -4,6 +4,7 @@
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
   register: test_cases
+  delegate_to: localhost
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/test/integration/targets/iosxr_command/tests/cli/bad_operator.yaml
+++ b/test/integration/targets/iosxr_command/tests/cli/bad_operator.yaml
@@ -8,7 +8,6 @@
       - show interfaces GigabitEthernet 0/0
     wait_for:
       - "result[0] contains 'Description: Foo'"
-    provider: "{{ cli }}"
   register: result
   ignore_errors: yes
 

--- a/test/integration/targets/iosxr_command/tests/cli/contains.yaml
+++ b/test/integration/targets/iosxr_command/tests/cli/contains.yaml
@@ -9,7 +9,6 @@
     wait_for:
       - "result[0] contains 6.0.0"
       - "result[1] contains GigabitEthernet0/0/0/1"
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/iosxr_command/tests/cli/invalid.yaml
+++ b/test/integration/targets/iosxr_command/tests/cli/invalid.yaml
@@ -4,7 +4,6 @@
 - name: run invalid command
   iosxr_command:
     commands: ['show foo']
-    provider: "{{ cli }}"
   register: result
   ignore_errors: yes
 
@@ -17,7 +16,6 @@
     commands:
       - show version
       - show foo
-    provider: "{{ cli }}"
   register: result
   ignore_errors: yes
 

--- a/test/integration/targets/iosxr_command/tests/cli/output.yaml
+++ b/test/integration/targets/iosxr_command/tests/cli/output.yaml
@@ -4,7 +4,6 @@
 - name: get output for single command
   iosxr_command:
     commands: ['show version']
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -17,7 +16,6 @@
     commands:
       - show version
       - show interfaces
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/iosxr_command/tests/cli/timeout.yaml
+++ b/test/integration/targets/iosxr_command/tests/cli/timeout.yaml
@@ -7,7 +7,6 @@
       - show version
     wait_for:
       - "result[0] contains bad_value_string"
-    provider: "{{ cli }}"
   register: result
   ignore_errors: yes
 

--- a/test/integration/targets/iosxr_config/meta/main.yml
+++ b/test/integration/targets/iosxr_config/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_iosxr_tests

--- a/test/integration/targets/iosxr_config/tasks/cli.yaml
+++ b/test/integration/targets/iosxr_config/tasks/cli.yaml
@@ -4,6 +4,7 @@
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
   register: test_cases
+  delegate_to: localhost
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/test/integration/targets/iosxr_config/tests/cli/backup.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/backup.yaml
@@ -9,7 +9,6 @@
     parents:
       - interface Loopback999
     match: none
-    provider: "{{ cli }}"
 
 - name: collect any backup files
   find:
@@ -28,7 +27,6 @@
   iosxr_config:
     src: basic/config.j2
     backup: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/iosxr_config/tests/cli/comment-too-long.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/comment-too-long.yaml
@@ -9,13 +9,11 @@
     parents:
       - interface Loopback999
     match: none
-    provider: "{{ cli }}"
 
 # Defend against https://github.com/ansible/ansible-modules-core/issues/5146
 - name: Commit message too long
   iosxr_config:
     src: basic/config.j2
-    provider: "{{ cli }}"
     comment: "this is a really long message  aaaaabbbbbbcdde end-of-message"
   register: result
   ignore_errors: true

--- a/test/integration/targets/iosxr_config/tests/cli/comment.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/comment.yaml
@@ -9,12 +9,10 @@
     parents:
       - interface Loopback999
     match: none
-    provider: "{{ cli }}"
 
 - name: configure device with comment
   iosxr_config:
     src: basic/config.j2
-    provider: "{{ cli }}"
     comment: "this is sensible commit message"
   register: result
 
@@ -26,7 +24,6 @@
 - name: check device with config
   iosxr_config:
     src: basic/config.j2
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/iosxr_config/tests/cli/src_basic.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/src_basic.yaml
@@ -9,12 +9,10 @@
     parents:
       - interface Loopback999
     match: none
-    provider: "{{ cli }}"
 
 - name: configure device with config
   iosxr_config:
     src: basic/config.j2
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -26,7 +24,6 @@
 - name: check device with config
   iosxr_config:
     src: basic/config.j2
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/iosxr_config/tests/cli/src_invalid.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/src_invalid.yaml
@@ -6,7 +6,6 @@
 - name: configure with invalid src
   iosxr_config:
     src: basic/foobar.j2
-    provider: "{{ cli }}"
   register: result
   ignore_errors: yes
 

--- a/test/integration/targets/iosxr_config/tests/cli/src_match_none.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/src_match_none.yaml
@@ -9,12 +9,10 @@
     parents:
       - interface Loopback999
     match: none
-    provider: "{{ cli }}"
 
 - name: configure device with config
   iosxr_config:
     src: basic/config.j2
-    provider: "{{ cli }}"
     match: none
   register: result
 
@@ -27,7 +25,6 @@
 - name: check device with config
   iosxr_config:
     src: basic/config.j2
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/iosxr_config/tests/cli/sublevel.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/sublevel.yaml
@@ -4,7 +4,6 @@
 - name: setup
   iosxr_config:
     commands: ['no ipv4 access-list test']
-    provider: "{{ cli }}"
     match: none
   ignore_errors: yes
 
@@ -12,7 +11,6 @@
   iosxr_config:
     commands: ['10 permit ipv4 any any log']
     parents: ['ipv4 access-list test']
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -25,7 +23,6 @@
   iosxr_config:
     commands: ['10 permit ipv4 any any log']
     parents: ['ipv4 access-list test']
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -35,7 +32,6 @@
 - name: teardown
   iosxr_config:
     commands: ['no ipv4 access-list test']
-    provider: "{{ cli }}"
     match: none
 
 - debug: msg="END cli/sublevel.yaml"

--- a/test/integration/targets/iosxr_config/tests/cli/sublevel_block.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/sublevel_block.yaml
@@ -10,7 +10,6 @@
     parents: ['ipv4 access-list test']
     before: ['no ipv4 access-list test']
     after: ['exit']
-    provider: "{{ cli }}"
     match: none
 
 - name: configure sub level command using block resplace
@@ -23,7 +22,6 @@
     parents: ['ipv4 access-list test']
     replace: block
     after: ['exit']
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -45,7 +43,6 @@
     parents: ['ipv4 access-list test']
     replace: block
     after: ['exit']
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -55,7 +52,6 @@
 - name: teardown
   iosxr_config:
     commands: ['no ipv4 access-list test']
-    provider: "{{ cli }}"
     match: none
 
 - debug: msg="END cli/sublevel_block.yaml"

--- a/test/integration/targets/iosxr_config/tests/cli/sublevel_exact.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/sublevel_exact.yaml
@@ -13,7 +13,6 @@
     before: ['no ipv4 access-list test']
     after: ['exit']
     match: none
-    provider: "{{ cli }}"
 
 - name: configure sub level command using exact match
   iosxr_config:
@@ -25,7 +24,6 @@
     parents: ['ipv4 access-list test']
     after: ['exit']
     match: exact
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -49,7 +47,6 @@
     parents: ['ipv4 access-list test']
     after: ['exit']
     match: exact
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -59,7 +56,6 @@
 - name: teardown
   iosxr_config:
     commands: ['no ipv4 access-list test']
-    provider: "{{ cli }}"
     match: none
 
 - debug: msg="END cli/sublevel_exact.yaml"

--- a/test/integration/targets/iosxr_config/tests/cli/sublevel_strict.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/sublevel_strict.yaml
@@ -13,7 +13,6 @@
     before: ['no ipv4 access-list test']
     after: ['exit']
     match: none
-    provider: "{{ cli }}"
 
 - name: configure sub level command using strict match
   iosxr_config:
@@ -27,7 +26,6 @@
     after: ['exit']
     match: strict
     replace: block
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -50,7 +48,6 @@
     parents: ['ipv4 access-list test']
     after: ['exit']
     match: strict
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -61,6 +58,5 @@
   iosxr_config:
     commands: ['no ipv4 access-list test']
     match: none
-    provider: "{{ cli }}"
 
 - debug: msg="END cli/sublevel_strict.yaml"

--- a/test/integration/targets/iosxr_config/tests/cli/toplevel.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/toplevel.yaml
@@ -4,13 +4,11 @@
 - name: setup
   iosxr_config:
     commands: ['hostname {{ inventory_hostname_short }}']
-    provider: "{{ cli }}"
     match: none
 
 - name: configure top level command
   iosxr_config:
     commands: ['hostname foo']
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -21,7 +19,6 @@
 - name: configure top level command idempotent check
   iosxr_config:
     commands: ['hostname foo']
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -31,7 +28,6 @@
 - name: teardown
   iosxr_config:
     commands: ['hostname {{ inventory_hostname_short }}']
-    provider: "{{ cli }}"
     match: none
 
 - debug: msg="END cli/toplevel.yaml"

--- a/test/integration/targets/iosxr_config/tests/cli/toplevel_after.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/toplevel_after.yaml
@@ -6,14 +6,12 @@
     commands:
       - "no cdp"
       - "hostname {{ inventory_hostname_short }}"
-    provider: "{{ cli }}"
     match: none
 
 - name: configure top level command with before
   iosxr_config:
     commands: ['hostname foo']
     after: ['cdp']
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -26,7 +24,6 @@
   iosxr_config:
     commands: ['hostname foo']
     after: ['no cdp']
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -38,7 +35,6 @@
     commands:
       - "no cdp"
       - "hostname {{ inventory_hostname_short }}"
-    provider: "{{ cli }}"
     match: none
 
 - debug: msg="END cli/toplevel_after.yaml"

--- a/test/integration/targets/iosxr_config/tests/cli/toplevel_before.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/toplevel_before.yaml
@@ -6,14 +6,12 @@
     commands:
       - "no cdp"
       - "hostname {{ inventory_hostname_short }}"
-    provider: "{{ cli }}"
     match: none
 
 - name: configure top level command with before
   iosxr_config:
     commands: ['hostname foo']
     before: ['cdp']
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -26,7 +24,6 @@
   iosxr_config:
     commands: ['hostname foo']
     before: ['cdp']
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -38,7 +35,6 @@
     commands:
       - "no cdp"
       - "hostname {{ inventory_hostname_short }}"
-    provider: "{{ cli }}"
     match: none
 
 - debug: msg="END cli/toplevel_before.yaml"

--- a/test/integration/targets/iosxr_config/tests/cli/toplevel_nonidempotent.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/toplevel_nonidempotent.yaml
@@ -4,13 +4,11 @@
 - name: setup
   iosxr_config:
     commands: ['hostname {{ inventory_hostname_short }}']
-    provider: "{{ cli }}"
     match: none
 
 - name: configure top level command
   iosxr_config:
     commands: ['hostname foo']
-    provider: "{{ cli }}"
     match: strict
   register: result
 
@@ -22,7 +20,6 @@
 - name: configure top level command idempotent check
   iosxr_config:
     commands: ['hostname foo']
-    provider: "{{ cli }}"
     match: strict
   register: result
 
@@ -33,7 +30,6 @@
 - name: teardown
   iosxr_config:
     commands: ['hostname {{ inventory_hostname_short }}']
-    provider: "{{ cli }}"
     match: none
 
 - debug: msg="END cli/toplevel_nonidempotent.yaml"

--- a/test/integration/targets/iosxr_facts/meta/main.yml
+++ b/test/integration/targets/iosxr_facts/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_iosxr_tests

--- a/test/integration/targets/iosxr_facts/tasks/cli.yaml
+++ b/test/integration/targets/iosxr_facts/tasks/cli.yaml
@@ -4,6 +4,7 @@
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
   register: test_cases
+  delegate_to: localhost
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/test/integration/targets/iosxr_facts/tests/cli/all_facts.yaml
+++ b/test/integration/targets/iosxr_facts/tests/cli/all_facts.yaml
@@ -4,7 +4,6 @@
 
 - name: test getting all facts
   iosxr_facts:
-    provider: "{{ cli }}"
     gather_subset:
       - all
   register: result

--- a/test/integration/targets/iosxr_facts/tests/cli/default_facts.yaml
+++ b/test/integration/targets/iosxr_facts/tests/cli/default_facts.yaml
@@ -4,7 +4,6 @@
 
 - name: test getting default facts
   iosxr_facts:
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/iosxr_facts/tests/cli/invalid_subset.yaml
+++ b/test/integration/targets/iosxr_facts/tests/cli/invalid_subset.yaml
@@ -4,7 +4,6 @@
 
 - name: test invalid subset (foobar)
   iosxr_facts:
-    provider: "{{ cli }}"
     gather_subset:
       - "foobar"
   register: result
@@ -26,7 +25,6 @@
 
 - name: test subset specified multiple times
   iosxr_facts:
-    provider: "{{ cli }}"
     gather_subset:
       - "!hardware"
       - "hardware"

--- a/test/integration/targets/iosxr_facts/tests/cli/not_hardware.yaml
+++ b/test/integration/targets/iosxr_facts/tests/cli/not_hardware.yaml
@@ -4,7 +4,6 @@
 
 - name: test not hardware
   iosxr_facts:
-    provider: "{{ cli }}"
     gather_subset:
       - "!hardware"
   register: result

--- a/test/integration/targets/iosxr_template/meta/main.yml
+++ b/test/integration/targets/iosxr_template/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_iosxr_tests

--- a/test/integration/targets/iosxr_template/tasks/cli.yaml
+++ b/test/integration/targets/iosxr_template/tasks/cli.yaml
@@ -4,6 +4,7 @@
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
   register: test_cases
+  delegate_to: localhost
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/test/integration/targets/iosxr_template/tests/cli/backup.yaml
+++ b/test/integration/targets/iosxr_template/tests/cli/backup.yaml
@@ -6,7 +6,6 @@
     commands:
       - no interface Loopback999
     match: none
-    provider: "{{ cli }}"
   ignore_errors: yes
 
 - name: collect any backup files
@@ -26,7 +25,6 @@
   iosxr_template:
     src: basic/config.j2
     backup: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -50,6 +48,5 @@
     commands:
       - no interface Loopback999
     match: none
-    provider: "{{ cli }}"
 
 - debug: msg="END cli/backup.yaml"

--- a/test/integration/targets/iosxr_template/tests/cli/basic.yaml
+++ b/test/integration/targets/iosxr_template/tests/cli/basic.yaml
@@ -6,12 +6,10 @@
     commands:
       - no interface Loopback999
     match: none
-    provider: "{{ cli }}"
 
 - name: configure device with config
   iosxr_template:
     src: basic/config.j2
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -22,7 +20,6 @@
 - name: check device with config
   iosxr_template:
     src: basic/config.j2
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -35,6 +32,5 @@
     commands:
       - no interface Loopback999
     match: none
-    provider: "{{ cli }}"
 
 - debug: msg="END cli/basic.yaml"

--- a/test/integration/targets/iosxr_template/tests/cli/force.yaml
+++ b/test/integration/targets/iosxr_template/tests/cli/force.yaml
@@ -6,12 +6,10 @@
     commands:
       - no interface Loopback999
     match: none
-    provider: "{{ cli }}"
 
 - name: configure device with config
   iosxr_template:
     src: basic/config.j2
-    provider: "{{ cli }}"
     force: yes
   register: result
 
@@ -23,7 +21,6 @@
 - name: check device with config
   iosxr_template:
     src: basic/config.j2
-    provider: "{{ cli }}"
     force: yes
   register: result
 
@@ -37,6 +34,5 @@
     commands:
       - no interface Loopback999
     match: none
-    provider: "{{ cli }}"
 
 - debug: msg="END cli/force.yaml"

--- a/test/integration/targets/prepare_iosxr_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_iosxr_tests/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Ensure we have loopback 888 for testing
+  iosxr_config:
+    src: config.j2
+
+
+# Some AWS hostnames can be longer than those allowed by the system we are testing
+# Truncate the hostname
+# http://jinja.pocoo.org/docs/2.9/templates/#truncate
+- set_fact:
+    shorter_hostname: '{{ inventory_hostname_short| truncate(10, True, "") }}'

--- a/test/integration/targets/prepare_iosxr_tests/templates/config.j2
+++ b/test/integration/targets/prepare_iosxr_tests/templates/config.j2
@@ -1,0 +1,4 @@
+interface Loopback888
+ description test for ansible
+ shutdown
+


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request


##### SUMMARY
* Ensure a loopback device exists for testing
* Remove `provider:`
* Default is to run task on Network, device, use `delegate_to: localhost` for local tasks.

Note: Further updates will be needed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/20883)
<!-- Reviewable:end -->
