### PR TITLE
os_auth: display proper error message for exceptions

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_auth.py
+++ b/lib/ansible/modules/cloud/openstack/os_auth.py
@@ -66,8 +66,8 @@ def main():
             ansible_facts=dict(
                 auth_token=cloud.auth_token,
                 service_catalog=cloud.service_catalog))
-    except shade.OpenStackCloudException as e:
-        module.fail_json(msg=str(e))
+    except Exception as e:
+        module.fail_json(msg=str(e), exception=traceback.format_exc())
 
 # this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import *


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
os_auth

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 1fcb2a884e) last updated 2017/01/31 14:21:37 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
The exception shade.OpenStackCloudException is not the one that's getting raised during authentication, it's actually keystoneauth1.exceptions.http.Unauthorized. This results in unhandled exception and unhelpful message that says `MODULE FAILURE`. Instead of trying to figure out exact type, do what other os_ modules do and catch generic Exception and provide helpful helpful error message.

Verbose error before changes

```
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_SDMpFL/ansible_module_os_auth.py", line 76, in <module>
    main()
  File "/tmp/ansible_SDMpFL/ansible_module_os_auth.py", line 67, in main
    auth_token=cloud.auth_token,
  File "/usr/lib/python2.7/site-packages/shade/openstackcloud.py", line 494, in auth_token
    return self.keystone_session.get_token()
  File "/usr/lib/python2.7/site-packages/keystoneauth1/session.py", line 809, in get_token
    return (self.get_auth_headers(auth) or {}).get('X-Auth-Token')
  File "/usr/lib/python2.7/site-packages/keystoneauth1/session.py", line 787, in get_auth_headers
    return auth.get_headers(self, **kwargs)
  File "/usr/lib/python2.7/site-packages/keystoneauth1/plugin.py", line 90, in get_headers
    token = self.get_token(session)
  File "/usr/lib/python2.7/site-packages/keystoneauth1/identity/base.py", line 90, in get_token
    return self.get_access(session).auth_token
  File "/usr/lib/python2.7/site-packages/keystoneauth1/identity/base.py", line 136, in get_access
    self.auth_ref = self.get_auth_ref(session)
  File "/usr/lib/python2.7/site-packages/keystoneauth1/identity/generic/base.py", line 198, in get_auth_ref
    return self._plugin.get_auth_ref(session, **kwargs)
  File "/usr/lib/python2.7/site-packages/keystoneauth1/identity/v2.py", line 65, in get_auth_ref
    authenticated=False, log=False)
  File "/usr/lib/python2.7/site-packages/keystoneauth1/session.py", line 735, in post
    return self.request(url, 'POST', **kwargs)
  File "/usr/lib/python2.7/site-packages/positional/__init__.py", line 101, in inner
    return wrapped(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/keystoneauth1/session.py", line 624, in request
    raise exceptions.from_response(resp, method, url)
keystoneauth1.exceptions.http.Unauthorized: The request you have made requires authentication. (HTTP 401) (Request-ID: req-441937cd-c9e4-4eb0-ad7b-5abd84aa3010)

fatal: [localhost]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_name": "os_auth"
    },
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_SDMpFL/ansible_module_os_auth.py\", line 76, in <module>\n    main()\n  File \"/tmp/ansible_SDMpFL/ansible_module_os_auth.py\", line 67, in main\n    auth_token=cloud.auth_token,\n  File \"/usr/lib/python2.7/site-packages/shade/openstackcloud.py\", line 494, in auth_token\n    return self.keystone_session.get_token()\n  File \"/usr/lib/python2.7/site-packages/keystoneauth1/session.py\", line 809, in get_token\n    return (self.get_auth_headers(auth) or {}).get('X-Auth-Token')\n  File \"/usr/lib/python2.7/site-packages/keystoneauth1/session.py\", line 787, in get_auth_headers\n    return auth.get_headers(self, **kwargs)\n  File \"/usr/lib/python2.7/site-packages/keystoneauth1/plugin.py\", line 90, in get_headers\n    token = self.get_token(session)\n  File \"/usr/lib/python2.7/site-packages/keystoneauth1/identity/base.py\", line 90, in get_token\n    return self.get_access(session).auth_token\n  File \"/usr/lib/python2.7/site-packages/keystoneauth1/identity/base.py\", line 136, in get_access\n    self.auth_ref = self.get_auth_ref(session)\n  File \"/usr/lib/python2.7/site-packages/keystoneauth1/identity/generic/base.py\", line 198, in get_auth_ref\n    return self._plugin.get_auth_ref(session, **kwargs)\n  File \"/usr/lib/python2.7/site-packages/keystoneauth1/identity/v2.py\", line 65, in get_auth_ref\n    authenticated=False, log=False)\n  File \"/usr/lib/python2.7/site-packages/keystoneauth1/session.py\", line 735, in post\n    return self.request(url, 'POST', **kwargs)\n  File \"/usr/lib/python2.7/site-packages/positional/__init__.py\", line 101, in inner\n    return wrapped(*args, **kwargs)\n  File \"/usr/lib/python2.7/site-packages/keystoneauth1/session.py\", line 624, in request\n    raise exceptions.from_response(resp, method, url)\nkeystoneauth1.exceptions.http.Unauthorized: The request you have made requires authentication. (HTTP 401) (Request-ID: req-441937cd-c9e4-4eb0-ad7b-5abd84aa3010)\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE",
    "rc": 1
}
```

Verbose error after changes. Notice how msg is now populated.
```
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_8T1Wo2/ansible_module_os_auth.py", line 67, in main
    auth_token=cloud.auth_token,
  File "/usr/lib/python2.7/site-packages/shade/openstackcloud.py", line 494, in auth_token
    return self.keystone_session.get_token()
  File "/usr/lib/python2.7/site-packages/keystoneauth1/session.py", line 809, in get_token
    return (self.get_auth_headers(auth) or {}).get('X-Auth-Token')
  File "/usr/lib/python2.7/site-packages/keystoneauth1/session.py", line 787, in get_auth_headers
    return auth.get_headers(self, **kwargs)
  File "/usr/lib/python2.7/site-packages/keystoneauth1/plugin.py", line 90, in get_headers
    token = self.get_token(session)
  File "/usr/lib/python2.7/site-packages/keystoneauth1/identity/base.py", line 90, in get_token
    return self.get_access(session).auth_token
  File "/usr/lib/python2.7/site-packages/keystoneauth1/identity/base.py", line 136, in get_access
    self.auth_ref = self.get_auth_ref(session)
  File "/usr/lib/python2.7/site-packages/keystoneauth1/identity/generic/base.py", line 198, in get_auth_ref
    return self._plugin.get_auth_ref(session, **kwargs)
  File "/usr/lib/python2.7/site-packages/keystoneauth1/identity/v2.py", line 65, in get_auth_ref
    authenticated=False, log=False)
  File "/usr/lib/python2.7/site-packages/keystoneauth1/session.py", line 735, in post
    return self.request(url, 'POST', **kwargs)
  File "/usr/lib/python2.7/site-packages/positional/__init__.py", line 101, in inner
    return wrapped(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/keystoneauth1/session.py", line 624, in request
    raise exceptions.from_response(resp, method, url)
Unauthorized: The request you have made requires authentication. (HTTP 401) (Request-ID: req-58c1b0b4-59e9-41a1-b011-1ecc44fc6bab)

fatal: [localhost]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_args": {
            "api_timeout": null,
            "auth": {
                "auth_url": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "password": "",
                "project_name": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
            },
            "auth_type": null,
            "availability_zone": null,
            "cacert": null,
            "cert": null,
            "cloud": null,
            "endpoint_type": "public",
            "key": null,
            "region_name": null,
            "timeout": 180,
            "validate_certs": false,
            "verify": false,
            "wait": true
        },
        "module_name": "os_auth"
    },
    "msg": "The request you have made requires authentication. (HTTP 401) (Request-ID: req-58c1b0b4-59e9-41a1-b011-1ecc44fc6bab)"
}
```