### PR TITLE
Refactor E-Series Snapshot Images module to use module_utils

### DIFF
--- a/lib/ansible/module_utils/netapp.py
+++ b/lib/ansible/module_utils/netapp.py
@@ -1,5 +1,6 @@
 #
 # (c) 2016, Sumit Kumar <sumit4@netapp.com>
+# (c) 2016, Michael Price <michael.price@netapp.com>
 #
 # This file is part of Ansible
 #
@@ -15,6 +16,13 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+
+from ansible.module_utils.six.moves.urllib.error import HTTPError
+
+from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils.urls import open_url
 
 HAS_NETAPP_LIB = False
 try:
@@ -88,3 +96,55 @@ def setup_ontap_zapi(module, vserver=None):
         return server
     else:
         module.fail_json(msg="the python NetApp-Lib module is required")
+
+
+def eseries_host_argument_spec():
+    """Retrieve a base argument specifiation common to all NetApp E-Series modules"""
+    argument_spec = basic_auth_argument_spec()
+    argument_spec.update(dict(
+        api_username=dict(type='str', required=True),
+        api_password=dict(type='str', required=True, no_log=True),
+        api_url=dict(type='str', required=True),
+        ssid=dict(type='str', required=True),
+        validate_certs=dict(required=False, default=True),
+    ))
+    return argument_spec
+
+def request(url, data=None, headers=None, method='GET', use_proxy=True,
+            force=False, last_mod_time=None, timeout=10, validate_certs=True,
+            url_username=None, url_password=None, http_agent=None, force_basic_auth=True, ignore_errors=False):
+    """Issue an HTTP request to a url, retrieving an optional JSON response."""
+
+    if headers is None:
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    try:
+        r = open_url(url=url, data=data, headers=headers, method=method, use_proxy=use_proxy,
+                     force=force, last_mod_time=last_mod_time, timeout=timeout, validate_certs=validate_certs,
+                     url_username=url_username, url_password=url_password, http_agent=http_agent,
+                     force_basic_auth=force_basic_auth)
+    except HTTPError:
+        err = get_exception()
+        r = err.fp
+
+    try:
+        raw_data = r.read()
+        if raw_data:
+            data = json.loads(raw_data)
+        else:
+            raw_data = None
+    except:
+        if ignore_errors:
+            pass
+        else:
+            raise Exception(raw_data)
+
+    resp_code = r.getcode()
+
+    if resp_code >= 400 and not ignore_errors:
+        raise Exception(resp_code, data)
+    else:
+        return resp_code, data

--- a/lib/ansible/modules/storage/netapp/netapp_e_snapshot_images.py
+++ b/lib/ansible/modules/storage/netapp/netapp_e_snapshot_images.py
@@ -31,26 +31,9 @@ description:
     - "Related: Snapshot volumes are created from snapshot images."
 version_added: '2.2'
 author: Kevin Hulquest (@hulquest)
+extends_documentation_fragment:
+    - netapp.eseries
 options:
-    api_username:
-        required: true
-        description:
-        - The username to authenticate with the SANtricity WebServices Proxy or embedded REST API.
-    api_password:
-        required: true
-        description:
-        - The password to authenticate with the SANtricity WebServices Proxy or embedded REST API.
-    api_url:
-        required: true
-        description:
-        - The url to the SANtricity WebServices Proxy or embedded REST API.
-        example:
-        - https://prod-1.wahoo.acme.com/devmgr/v2
-    validate_certs:
-        required: false
-        default: true
-        description:
-        - Should https certificates be validated?
     snapshot_group:
         description:
             - The name of the snapshot group in which you want to create a snapshot image.
@@ -85,44 +68,9 @@ HEADERS = {
 }
 import json
 
-from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule
-
+from ansible.module_utils.netapp import request, eseries_host_argument_spec
 from ansible.module_utils.pycompat24 import get_exception
-from ansible.module_utils.urls import open_url
-from ansible.module_utils.six.moves.urllib.error import HTTPError
-
-
-def request(url, data=None, headers=None, method='GET', use_proxy=True,
-            force=False, last_mod_time=None, timeout=10, validate_certs=True,
-            url_username=None, url_password=None, http_agent=None, force_basic_auth=True, ignore_errors=False):
-    try:
-        r = open_url(url=url, data=data, headers=headers, method=method, use_proxy=use_proxy,
-                     force=force, last_mod_time=last_mod_time, timeout=timeout, validate_certs=validate_certs,
-                     url_username=url_username, url_password=url_password, http_agent=http_agent,
-                     force_basic_auth=force_basic_auth)
-    except HTTPError:
-        err = get_exception()
-        r = err.fp
-
-    try:
-        raw_data = r.read()
-        if raw_data:
-            data = json.loads(raw_data)
-        else:
-            raw_data = None
-    except:
-        if ignore_errors:
-            pass
-        else:
-            raise Exception(raw_data)
-
-    resp_code = r.getcode()
-
-    if resp_code >= 400 and not ignore_errors:
-        raise Exception(resp_code, data)
-    else:
-        return resp_code, data
 
 
 def snapshot_group_from_name(module, ssid, api_url, api_pwd, api_usr, name):
@@ -207,14 +155,9 @@ def delete_image(module, ssid, api_url, pwd, user, snapshot_group):
 
 
 def main():
-    argument_spec = basic_auth_argument_spec()
+    argument_spec = eseries_host_argument_spec()
     argument_spec.update(dict(
         snapshot_group=dict(required=True, type='str'),
-        ssid=dict(required=True, type='str'),
-        api_url=dict(required=True),
-        api_username=dict(required=False),
-        api_password=dict(required=False, no_log=True),
-        validate_certs=dict(required=False, default=True),
         state=dict(required=True, choices=['create', 'remove'], type='str'),
     ))
     module = AnsibleModule(argument_spec)

--- a/lib/ansible/utils/module_docs_fragments/netapp.py
+++ b/lib/ansible/utils/module_docs_fragments/netapp.py
@@ -78,3 +78,32 @@ notes:
   - The modules prefixed with C(sf\_) are built to support the SolidFire storage platform.
 
 """
+
+
+# Documentation fragment for E-Series
+    ESERIES = """
+options:
+  api_username:
+    required: true
+    description:
+    - The username to authenticate with the SANtricity WebServices Proxy or embedded REST API.
+  api_password:
+    required: true
+    description:
+    - The password to authenticate with the SANtricity WebServices Proxy or embedded REST API.
+  api_url:
+    required: true
+    description:
+    - The url to the SANtricity WebServices Proxy or embedded REST API.
+    example:
+    - https://prod-1.wahoo.acme.com/devmgr/v2
+  validate_certs:
+    required: false
+    default: true
+    description:
+    - Should https certificates be validated?
+  ssid:
+    required: true
+    description:
+    - The ID of the array to manage. This value must be unique for each array.
+    """


### PR DESCRIPTION
Refactor the NetApp E-Series module to utilize the common module_utils
and doc_fragments.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
netapp_e_snapshot_images

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = /home/lorenp/ansible/lib/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
This patch is intended to bring the NetApp E-Series modules more in line with the other NetApp modules and with the updated best practices by utilizing doc_fragments and module_utils for common code. This patch is not intended to change any existing functionality or output.

This patch is a simplification of my original PR (#20764); I was asked to split it into one PR per module.