### PR TITLE
Refactor E-Series Storage-Pool to use module_utils

### DIFF
--- a/lib/ansible/modules/storage/netapp/netapp_e_storagepool.py
+++ b/lib/ansible/modules/storage/netapp/netapp_e_storagepool.py
@@ -19,28 +19,9 @@ short_description: Manage disk groups and disk pools
 version_added: '2.2'
 description:
     - Create or remove disk groups and disk pools for NetApp E-series storage arrays.
+extends_documentation_fragment:
+    - netapp.eseries
 options:
-  api_username:
-      required: true
-      description:
-      - The username to authenticate with the SANtricity WebServices Proxy or embedded REST API.
-  api_password:
-      required: true
-      description:
-      - The password to authenticate with the SANtricity WebServices Proxy or embedded REST API.
-  api_url:
-      required: true
-      description:
-      - The url to the SANtricity WebServices Proxy or embedded REST API.
-  validate_certs:
-      required: false
-      default: true
-      description:
-      - Should https certificates be validated?
-  ssid:
-    required: true
-    description:
-    - The ID of the array to manage (as configured on the web services proxy).
   state:
     required: true
     description:
@@ -126,43 +107,9 @@ import json
 import logging
 from traceback import format_exc
 
-from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.netapp import request, eseries_host_argument_spec
 from ansible.module_utils.pycompat24 import get_exception
-from ansible.module_utils.urls import open_url
-from ansible.module_utils.six.moves.urllib.error import HTTPError
-
-
-def request(url, data=None, headers=None, method='GET', use_proxy=True,
-            force=False, last_mod_time=None, timeout=10, validate_certs=True,
-            url_username=None, url_password=None, http_agent=None, force_basic_auth=True, ignore_errors=False):
-    try:
-        r = open_url(url=url, data=data, headers=headers, method=method, use_proxy=use_proxy,
-                     force=force, last_mod_time=last_mod_time, timeout=timeout, validate_certs=validate_certs,
-                     url_username=url_username, url_password=url_password, http_agent=http_agent,
-                     force_basic_auth=force_basic_auth)
-    except HTTPError:
-        err = get_exception()
-        r = err.fp
-
-    try:
-        raw_data = r.read()
-        if raw_data:
-            data = json.loads(raw_data)
-        else:
-            raw_data = None
-    except:
-        if ignore_errors:
-            pass
-        else:
-            raise Exception(raw_data)
-
-    resp_code = r.getcode()
-
-    if resp_code >= 400 and not ignore_errors:
-        raise Exception(resp_code, data)
-    else:
-        return resp_code, data
 
 
 def select(predicate, iterable):
@@ -174,7 +121,7 @@ def select(predicate, iterable):
             yield x
 
 
-class groupby(object):
+class GroupBy(object):
     # python 2, 3 generic grouping.
     def __init__(self, iterable, key=None):
         if key is None:
@@ -217,13 +164,10 @@ class NetAppESeriesStoragePool(object):
             yb=1024 ** 8
         )
 
-        argument_spec = basic_auth_argument_spec()
+        argument_spec = eseries_host_argument_spec()
         argument_spec.update(dict(
-            api_username=dict(type='str', required=True),
-            api_password=dict(type='str', required=True, no_log=True),
             api_url=dict(type='str', required=True),
             state=dict(required=True, choices=['present', 'absent'], type='str'),
-            ssid=dict(required=True, type='str'),
             name=dict(required=True, type='str'),
             criteria_size_unit=dict(default='gb', type='str'),
             criteria_drive_count=dict(type='int'),
@@ -349,10 +293,10 @@ class NetAppESeriesStoragePool(object):
 
         # initial implementation doesn't have a preference for any of these values...
         # just return the first set we find that matches the requested disk count and/or minimum total capacity
-        for (cur_capacity, drives_by_capacity) in groupby(drives, lambda d: int(d['rawCapacity'])):
-            for (cur_interface_type, drives_by_interface_type) in groupby(drives_by_capacity,
+        for (cur_capacity, drives_by_capacity) in GroupBy(drives, lambda d: int(d['rawCapacity'])):
+            for (cur_interface_type, drives_by_interface_type) in GroupBy(drives_by_capacity,
                                                                           lambda d: d['phyDriveType']):
-                for (cur_drive_type, drives_by_drive_type) in groupby(drives_by_interface_type,
+                for (cur_drive_type, drives_by_drive_type) in GroupBy(drives_by_interface_type,
                                                                       lambda d: d['driveMediaType']):
                     # listify so we can consume more than once
                     drives_by_drive_type = list(drives_by_drive_type)


### PR DESCRIPTION
Refactor the NetApp E-Series module to utilize the common module_utils
and doc_fragments.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
netapp_e_storagepool

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = /home/lorenp/ansible/lib/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
This patch is intended to bring the NetApp E-Series modules more in line with the other NetApp modules and with the updated best practices by utilizing doc_fragments and module_utils for common code. This patch is not intended to change any existing functionality or output.

This patch is a simplification of my original PR (#20764); I was asked to split it into one PR per module.