### PR TITLE
Refactor E-Series Volume to use module_utils

### DIFF
--- a/lib/ansible/module_utils/netapp.py
+++ b/lib/ansible/module_utils/netapp.py
@@ -22,8 +22,8 @@ try:
 except ImportError:
     import simplejson as json
 
+from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.six.moves.urllib.error import HTTPError
-
 from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.api import basic_auth_argument_spec
@@ -124,7 +124,7 @@ def eseries_host_argument_spec():
         api_password=dict(type='str', required=True, no_log=True),
         api_url=dict(type='str', required=True),
         ssid=dict(type='str', required=True),
-        validate_certs=dict(required=False, default=True),
+        validate_certs=dict(type='bool', required=False, default=True),
     ))
     return argument_spec
 

--- a/lib/ansible/modules/storage/netapp/netapp_e_volume.py
+++ b/lib/ansible/modules/storage/netapp/netapp_e_volume.py
@@ -11,7 +11,6 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
-
 DOCUMENTATION = '''
 ---
 module: netapp_e_volume
@@ -19,28 +18,9 @@ version_added: "2.2"
 short_description: Manage storage volumes (standard and thin)
 description:
     - Create or remove volumes (standard and thin) for NetApp E/EF-series storage arrays.
+extends_documentation_fragment:
+    - netapp.eseries
 options:
-  api_username:
-      required: true
-      description:
-      - The username to authenticate with the SANtricity WebServices Proxy or embedded REST API.
-  api_password:
-      required: true
-      description:
-      - The password to authenticate with the SANtricity WebServices Proxy or embedded REST API.
-  api_url:
-      required: true
-      description:
-      - The url to the SANtricity WebServices Proxy or embedded REST API.
-  validate_certs:
-      required: false
-      default: true
-      description:
-      - Should https certificates be validated?
-  ssid:
-    required: true
-    description:
-    - The ID of the array to manage (as configured on the web services proxy).
   state:
     required: true
     description:
@@ -136,42 +116,13 @@ import time
 from traceback import format_exc
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.netapp import request, eseries_host_argument_spec
 from ansible.module_utils.pycompat24 import get_exception
-from ansible.module_utils.urls import open_url
-from ansible.module_utils.six.moves.urllib.error import HTTPError
-from ansible.module_utils.api import basic_auth_argument_spec
 
-
-def request(url, data=None, headers=None, method='GET', use_proxy=True,
-            force=False, last_mod_time=None, timeout=10, validate_certs=True,
-            url_username=None, url_password=None, http_agent=None, force_basic_auth=True, ignore_errors=False):
-    try:
-        r = open_url(url=url, data=data, headers=headers, method=method, use_proxy=use_proxy,
-                     force=force, last_mod_time=last_mod_time, timeout=timeout, validate_certs=validate_certs,
-                     url_username=url_username, url_password=url_password, http_agent=http_agent,
-                     force_basic_auth=force_basic_auth)
-    except HTTPError:
-        err = get_exception()
-        r = err.fp
-
-    try:
-        raw_data = r.read()
-        if raw_data:
-            data = json.loads(raw_data)
-        else:
-            raw_data is None
-    except:
-        if ignore_errors:
-            pass
-        else:
-            raise Exception(raw_data)
-
-    resp_code = r.getcode()
-
-    if resp_code >= 400 and not ignore_errors:
-        raise Exception(resp_code, data)
-    else:
-        return resp_code, data
+HEADERS = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+}
 
 
 def ifilter(predicate, iterable):
@@ -198,13 +149,9 @@ class NetAppESeriesVolume(object):
             yb=1024 ** 8
         )
 
-        self._post_headers = dict(Accept="application/json")
-        self._post_headers['Content-Type'] = 'application/json'
-
-        argument_spec = basic_auth_argument_spec()
+        argument_spec = eseries_host_argument_spec()
         argument_spec.update(dict(
             state=dict(required=True, choices=['present', 'absent']),
-            ssid=dict(required=True, type='str'),
             name=dict(required=True, type='str'),
             storage_pool_name=dict(type='str'),
             size_unit=dict(default='gb', choices=['bytes', 'b', 'kb', 'mb', 'gb', 'tb', 'pb', 'eb', 'zb', 'yb'],
@@ -218,10 +165,6 @@ class NetAppESeriesVolume(object):
             thin_volume_max_repo_size=dict(type='int'),
             # TODO: add cache, owning controller support, thin expansion policy, etc
             log_path=dict(type='str'),
-            api_url=dict(type='str'),
-            api_username=dict(type='str'),
-            api_password=dict(type='str', no_log=True),
-            validate_certs=dict(type='bool'),
         ))
 
         self.module = AnsibleModule(argument_spec=argument_spec,
@@ -337,7 +280,7 @@ class NetAppESeriesVolume(object):
         self.debug("creating volume '%s'" % name)
         try:
             (rc, resp) = request(self.api_url + "/storage-systems/%s/volumes" % (self.ssid),
-                                 data=json.dumps(volume_add_req), headers=self._post_headers, method='POST',
+                                 data=json.dumps(volume_add_req), headers=HEADERS, method='POST',
                                  url_username=self.api_usr, url_password=self.api_pwd,
                                  validate_certs=self.validate_certs,
                                  timeout=120)
@@ -362,7 +305,7 @@ class NetAppESeriesVolume(object):
         self.debug("creating thin-volume '%s'" % name)
         try:
             (rc, resp) = request(self.api_url + "/storage-systems/%s/thin-volumes" % (self.ssid),
-                                 data=json.dumps(thin_volume_add_req), headers=self._post_headers, method='POST',
+                                 data=json.dumps(thin_volume_add_req), headers=HEADERS, method='POST',
                                  url_username=self.api_usr, url_password=self.api_pwd,
                                  validate_certs=self.validate_certs,
                                  timeout=120)
@@ -420,7 +363,7 @@ class NetAppESeriesVolume(object):
             (rc, resp) = request(
                 self.api_url + "/storage-systems/%s/%s/%s/" % (self.ssid, self.volume_resource_name,
                                                                self.volume_detail['id']),
-                data=json.dumps(update_volume_req), headers=self._post_headers, method='POST',
+                data=json.dumps(update_volume_req), headers=HEADERS, method='POST',
                 url_username=self.api_usr, url_password=self.api_pwd, validate_certs=self.validate_certs,
                 timeout=120)
         except Exception:
@@ -453,7 +396,7 @@ class NetAppESeriesVolume(object):
                 (rc, resp) = request(self.api_url + "/storage-systems/%s/thin-volumes/%s/expand" % (self.ssid,
                                                                                                     self.volume_detail[
                                                                                                         'id']),
-                                     data=json.dumps(thin_volume_expand_req), headers=self._post_headers, method='POST',
+                                     data=json.dumps(thin_volume_expand_req), headers=HEADERS, method='POST',
                                      url_username=self.api_usr, url_password=self.api_pwd,
                                      validate_certs=self.validate_certs, timeout=120)
             except Exception:
@@ -474,7 +417,7 @@ class NetAppESeriesVolume(object):
                 (rc, resp) = request(
                     self.api_url + "/storage-systems/%s/volumes/%s/expand" % (self.ssid,
                                                                               self.volume_detail['id']),
-                    data=json.dumps(volume_expand_req), headers=self._post_headers, method='POST',
+                    data=json.dumps(volume_expand_req), headers=HEADERS, method='POST',
                     url_username=self.api_usr, url_password=self.api_pwd, validate_certs=self.validate_certs,
                     timeout=120)
             except Exception:


### PR DESCRIPTION
Refactor the NetApp E-Series module to utilize the common module_utils
and doc_fragments.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
netapp_e_volume

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = /home/lorenp/ansible/lib/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
This patch is intended to bring the NetApp E-Series modules more in line with the other NetApp modules and with the updated best practices by utilizing doc_fragments and module_utils for common code. This patch is not intended to change any existing functionality or output.

This patch is a simplification of my original PR (#20764); I was asked to split it into one PR per module.