### PR TITLE
Refactor E-Series VolumeCopy to use module_utils

### DIFF
--- a/lib/ansible/module_utils/netapp.py
+++ b/lib/ansible/module_utils/netapp.py
@@ -22,8 +22,8 @@ try:
 except ImportError:
     import simplejson as json
 
+from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.six.moves.urllib.error import HTTPError
-
 from ansible.module_utils.api import basic_auth_argument_spec
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.api import basic_auth_argument_spec
@@ -124,7 +124,7 @@ def eseries_host_argument_spec():
         api_password=dict(type='str', required=True, no_log=True),
         api_url=dict(type='str', required=True),
         ssid=dict(type='str', required=True),
-        validate_certs=dict(required=False, default=True),
+        validate_certs=dict(type='bool', required=False, default=True),
     ))
     return argument_spec
 

--- a/lib/ansible/modules/storage/netapp/netapp_e_volume_copy.py
+++ b/lib/ansible/modules/storage/netapp/netapp_e_volume_copy.py
@@ -20,6 +20,8 @@ description:
     - Create and delete snapshots images on volume groups for NetApp E-series storage arrays.
 version_added: '2.2'
 author: Kevin Hulquest (@hulquest)
+extends_documentation_fragment:
+    - netapp.eseries
 options:
     api_username:
         required: true
@@ -97,45 +99,12 @@ import json
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
-from ansible.module_utils.urls import open_url
-from ansible.module_utils.six.moves.urllib.error import HTTPError
+from ansible.module_utils.netapp import request
 
 HEADERS = {
     "Content-Type": "application/json",
     "Accept": "application/json",
 }
-
-
-def request(url, data=None, headers=None, method='GET', use_proxy=True,
-            force=False, last_mod_time=None, timeout=10, validate_certs=True,
-            url_username=None, url_password=None, http_agent=None, force_basic_auth=True, ignore_errors=False):
-    try:
-        r = open_url(url=url, data=data, headers=headers, method=method, use_proxy=use_proxy,
-                     force=force, last_mod_time=last_mod_time, timeout=timeout, validate_certs=validate_certs,
-                     url_username=url_username, url_password=url_password, http_agent=http_agent,
-                     force_basic_auth=force_basic_auth)
-    except HTTPError:
-        err = get_exception()
-        r = err.fp
-
-    try:
-        raw_data = r.read()
-        if raw_data:
-            data = json.loads(raw_data)
-        else:
-            raw_data = None
-    except:
-        if ignore_errors:
-            pass
-        else:
-            raise Exception(raw_data)
-
-    resp_code = r.getcode()
-
-    if resp_code >= 400 and not ignore_errors:
-        raise Exception(resp_code, data)
-    else:
-        return resp_code, data
 
 
 def find_volume_copy_pair_id_from_source_volume_id_and_destination_volume_id(params):


### PR DESCRIPTION
Refactor the NetApp E-Series module to utilize the common module_utils
and doc_fragments.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
netapp_e_volume_copy

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = /home/lorenp/ansible/lib/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
This patch is intended to bring the NetApp E-Series modules more in line with the other NetApp modules and with the updated best practices by utilizing doc_fragments and module_utils for common code. This patch is not intended to change any existing functionality or output.

This patch is a simplification of my original PR (#20764); I was asked to split it into one PR per module.