### PR TITLE
Update AWS module guidelines to meet modern requirements

### DIFF
--- a/lib/ansible/modules/cloud/amazon/GUIDELINES.md
+++ b/lib/ansible/modules/cloud/amazon/GUIDELINES.md
@@ -15,6 +15,32 @@ If you are writing a bugfix for a module that uses boto, you should continue to 
 If you are adding new functionality to an existing module that uses boto but the new functionality requires boto3, you
 must maintain backward compatibility of the module and ensure the module still works without boto3.
 
+## Coding standards
+
+All new modules are expected to meet the Ansible project's flake8 standards.
+This is basically normal flake8, but with a 120 line length.
+
+To test flake8 compatibility, use
+
+```
+pip install flake8
+flake8 your_module
+```
+
+The section below on module imports will help meet most flake8 complaints such
+as this anonymized flake8 result:
+
+```
+F401 'boto3' imported but unused
+F999 ec2_argument_spec may be undefined, or defined from star imports: ansible.module_utils.basic, ansible.module_utils.ec2
+F999 AnsibleModule may be undefined, or defined from star imports: ansible.module_utils.basic, ansible.module_utils.ec2
+E402 module level import not at top of file
+F403 'from ansible.module_utils.basic import *' used; unable to detect undefined names
+E402 module level import not at top of file
+F403 'from ansible.module_utils.ec2 import *' used; unable to detect undefined names
+```
+
+
 ## Naming your module
 
 Base the name of the module on the part of AWS that
@@ -46,21 +72,33 @@ else:
         module.fail_json(msg="instance_profile_name parameter requires boto version 2.5.0 or higher")
 ```
 
-## Using boto and boto3
+## Module imports
 
-### Importing
+Now that Ansible 2.2 is released, all modules should Use the modern module import style.
+
+```python
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import ec2_argument_spec, boto3_conn, HAS_BOTO3
+from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+```
+
+You will need to vary the imports depending on what methods from
+`module_utils.ec2` you actually use.
+
+### boto and boto3
 
 Wrap import statements in a try block and fail the module later if the import fails
 
 #### boto
 
 ```python
+from ansible.module_utils.ec2 import HAS_BOTO
+
 try:
     import boto.ec2
     from boto.exception import BotoServerError
-    HAS_BOTO = True
 except ImportError:
-    HAS_BOTO = False
+    pass  # caught by imported HAS_BOTO
 
 def main():
 
@@ -71,17 +109,21 @@ def main():
 #### boto3
 
 ```python
+from ansible.module_utils.ec2 import HAS_BOTO3
+
 try:
-    import boto3
-    HAS_BOTO3 = True
+    from botocore.exceptions import ClientError
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # caught by imported HAS_BOTO3
 
 def main():
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 required for this module')
 ```
+
+Note that you almost never need to import boto3 directly,
+the `boto3_conn` routine takes care of that.
 
 #### boto and boto3 combined
 
@@ -90,6 +132,8 @@ Ensure that you clearly document if a new parameter requires boto3. Import boto3
 module as normal and then use the HAS_BOTO3 bool when necessary, before the new feature.
 
 ```python
+from ansible.module_utils.ec2 import HAS_BOTO3
+
 try:
     import boto
     HAS_BOTO = True
@@ -97,12 +141,11 @@ except ImportError:
     HAS_BOTO = False
 
 try:
-    import boto3
-    HAS_BOTO3 = True
+    from botocore.exceptions import ClientError
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # captured by imported HAS_BOTO3
 
-if my_new_feauture_Parameter_is_set:
+if my_new_feature_parameter_is_set:
     if HAS_BOTO3:
         # do feature
     else:
@@ -183,9 +226,8 @@ Boto3 provides lots of useful info when an exception is thrown so pass this to t
 # Import ClientError from botocore
 try:
     from botocore.exceptions import ClientError
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # importing HAS_BOTO3 will catch this
 
 # Connect to AWS
 ...
@@ -290,7 +332,7 @@ Pass this function a list of security group names or combination of security gro
 return a list of IDs.  You should also pass the VPC ID if known because security group names are not necessarily unique
 across VPCs.
 
-### sort_json_policy_dict
+#### sort_json_policy_dict
 
 Pass any JSON policy dict to this function in order to sort any list contained therein. This is useful
 because AWS rarely return lists in the same order that they were submitted so without this function, comparison


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
modules/cloud/amazon/GUIDELINES.md

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel bbe2903d63) last updated 2017/02/01 11:14:08 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Update module import guidelines

Document that flake8 should be used, and more importantly,
how to fix the less obvious complaints.

Some of this might be better in the developer docs.