### PR TITLE
Feature: adding route53_hostnames option to set the hostnames from route 53

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -56,8 +56,13 @@ vpc_destination_variable = ip_address
 #destination_format_tags = Name,environment
 
 # To tag instances on EC2 with the resource records that point to them from
-# Route53, uncomment and set 'route53' to True.
+# Route53, set 'route53' to True.
 route53 = False
+
+# To use Route53 records as the inventory hostnames, uncomment and set
+# to equal the domain name you wish to use. You must also have 'route53' (above)
+# set to True.
+# route53_hostnames = .example.com
 
 # To exclude RDS instances from the inventory, uncomment and set to False.
 #rds = False

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -267,7 +267,8 @@ class Ec2Inventory(object):
 
         # Route53
         self.route53_enabled = config.getboolean('ec2', 'route53')
-        self.route53_hostnames = config.get('ec2', 'route53_hostnames')
+        if config.has_option('ec2', 'route53_hostnames'):
+            self.route53_hostnames = config.get('ec2', 'route53_hostnames')
         self.route53_excluded_zones = []
         if config.has_option('ec2', 'route53_excluded_zones'):
             self.route53_excluded_zones.extend(

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -269,6 +269,8 @@ class Ec2Inventory(object):
         self.route53_enabled = config.getboolean('ec2', 'route53')
         if config.has_option('ec2', 'route53_hostnames'):
             self.route53_hostnames = config.get('ec2', 'route53_hostnames')
+        else:
+            self.route53_hostnames = None
         self.route53_excluded_zones = []
         if config.has_option('ec2', 'route53_excluded_zones'):
             self.route53_excluded_zones.extend(

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -803,8 +803,8 @@ class Ec2Inventory(object):
         # If we can't get a nice hostname, use the destination address
         if not hostname:
             hostname = dest
-        # to_safe strips hostname characters like dots, so don't strip if using route53 hostnames
-        elif self.route53_enabled and self.route53_hostnames:
+        # to_safe strips hostname characters like dots, so don't strip route53 hostnames
+        elif self.route53_enabled and self.route53_hostnames and hostname.endswith(self.route53_hostnames):
             hostname = hostname.lower()
         else:
             hostname = self.to_safe(hostname).lower()

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -803,8 +803,11 @@ class Ec2Inventory(object):
         # If we can't get a nice hostname, use the destination address
         if not hostname:
             hostname = dest
-        else:
+        # to_safe strips hostname characters like dots, so don't strip if using route53 hostnames
+        elif self.route53_enabled and self.route53_hostnames:
             hostname = hostname.lower()
+        else:
+            hostname = self.to_safe(hostname).lower()
 
         # if we only want to include hosts that match a pattern, skip those that don't
         if self.pattern_include and not self.pattern_include.match(hostname):


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
EC2 dynamic external inventory script (ec2.py)

##### ANSIBLE VERSION
2.2.1.0

##### SUMMARY
It is common to use Route53 with EC2 instances. The current inventory script can tag EC2 instances from Route53 records, but it doesn't have a way to actually set the hostnames.

This PR adds an option, `route53_hostnames`. When set to a domain name, the inventory hostnames will be generated from Route53 records.

This PR is being used in production.

The only risky part of this change is the removal of the use of `to_safe` on line 796 when generating the hostname. `to_safe` seems to be intended for tags, not hostnames, since it strips common hostname characters like `-` and `.`, so it didn't seem to be useful there. If for some reason this causes an issue, I'd be happy to change it to only skip `to_safe` when the `route53_hostnames` option is in use.