### PR TITLE
fix urlparse usage in cloud.amazon module to be compatible with python3

### DIFF
--- a/lib/ansible/modules/cloud/amazon/_ec2_ami_search.py
+++ b/lib/ansible/modules/cloud/amazon/_ec2_ami_search.py
@@ -95,7 +95,7 @@ EXAMPLES = '''
 
 import csv
 import json
-import ansible.module_utils.six.moves.urllib_parse as urlparse
+import ansible.module_utils.six.moves.urllib.parse as urlparse
 
 SUPPORTED_DISTROS = ['ubuntu']
 

--- a/lib/ansible/modules/cloud/amazon/_ec2_ami_search.py
+++ b/lib/ansible/modules/cloud/amazon/_ec2_ami_search.py
@@ -95,7 +95,7 @@ EXAMPLES = '''
 
 import csv
 import json
-import urlparse
+import ansible.module_utils.six.moves.urllib_parse as urlparse
 
 SUPPORTED_DISTROS = ['ubuntu']
 

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -112,7 +112,7 @@ EXAMPLES = '''
 
 import os
 import xml.etree.ElementTree as ET
-import urlparse
+import ansible.module_utils.six.moves.urllib_parse as urlparse
 
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -112,7 +112,7 @@ EXAMPLES = '''
 
 import os
 import xml.etree.ElementTree as ET
-import ansible.module_utils.six.moves.urllib_parse as urlparse
+import ansible.module_utils.six.moves.urllib.parse as urlparse
 
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import *


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - cloud.amazon module; s3_bucket task

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
fix urlparse import

Before diff:
```
TASK [Create S3 bucket for configuration] **************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ImportError: No module named 'urlparse'
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/var/folders/kn/680ym7414kd1tkzq6jsrx_1c0000gn/T/ansible_4gyw_j9t/ansible_module_s3_bucket.py\", line 111, in <module>\n    import urlparse\nImportError: No module named 'urlparse'\n", "module_stdout": "", "msg": "MODULE FAILURE"}
	to retry, use: --limit @sample-configuration.retry
```

After diff:
```
TASK [Create S3 bucket for configuration] **************************************
ok: [localhost]
```