### PR TITLE
allow server facts to be retrieved by nova UUID

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_server_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_facts.py
@@ -88,7 +88,7 @@ def main():
             # filter servers by name
             pattern = module.params['server']
             openstack_servers = [server for server in openstack_servers
-                                 if fnmatch.fnmatch(server['name'], pattern)]
+                                 if fnmatch.fnmatch(server['name'], pattern) or fnmatch.fnmatch(server['id'], pattern)]
         module.exit_json(changed=False, ansible_facts=dict(
             openstack_servers=openstack_servers))
 

--- a/lib/ansible/modules/cloud/openstack/os_server_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_facts.py
@@ -44,7 +44,7 @@ requirements:
 options:
    server:
      description:
-       - restrict results to servers with names matching
+       - restrict results to servers with names or UUID matching
          this glob expression (e.g., C<web*>).
      required: false
      default: None


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
os_server_facts.py module

##### ANSIBLE VERSION
ansible --version
ansible 2.2.1.0
config file = /etc/ansible/ansible.cfg
configured module search path = Default w/o overrides

##### SUMMARY
Allows os_server_facts module to retrieve facts for a server from Nova by searching via UUID. Currently can only search by name, which doesn't really align with shade where the name_or_id parameter is commonplace.

This is particularly useful for mapping between servers that are deployed in Nova and Ironic, as it is the Nova UUID that provides the link between the two.

```
    - os_server_facts:
        cloud: "{{ cloud }}"
        server: "54bcd962-952e-41e8-bfa1-50d7cdf26375"
      run_once: yes

    - debug: var=openstack_servers
      run_once: yes
```

Before change:

```
TASK [os_server_facts] *********************************************************
ok: [*]

TASK [debug] *******************************************************************
ok: [*] => {
    "openstack_servers": []
}
```

After change:

```
TASK [os_server_facts] *********************************************************
ok: [*]

TASK [debug] *******************************************************************
ok: [*] => {
    "openstack_servers": [
        {
            "OS-DCF:diskConfig": "MANUAL",
            "OS-EXT-AZ:availability_zone": "nova",
            "OS-EXT-SRV-ATTR:host": "*",
            "OS-EXT-SRV-ATTR:hypervisor_hostname": "*",
            "OS-EXT-SRV-ATTR:instance_name": "*",
            "OS-EXT-STS:power_state": 1,
            "OS-EXT-STS:task_state": null,
            "OS-EXT-STS:vm_state": "active",
            "OS-SRV-USG:launched_at": "2016-07-06T15:17:07.000000",
            "OS-SRV-USG:terminated_at": null,
            "accessIPv4": "*",
            "accessIPv6": "",
            "addresses": {
                "ctlplane": [
                    {
                        "OS-EXT-IPS-MAC:mac_addr": "*",
                        "OS-EXT-IPS:type": "fixed",
                        "addr": "*",
                        "version": 4
                    }
                ]
            },
            "adminPass": null,
            "az": "nova",
            "cloud": "*",
            "config_drive": "True",
            "created": "2016-07-06T15:10:00Z",
            "disk_config": "MANUAL",
            "flavor": {
                "id": "*"
            },
            "has_config_drive": true,
            "hostId": "*",
            "host_id": "*",
            "id": "54bcd962-952e-41e8-bfa1-50d7cdf26375",
            "image": {
                "id": "*"
            },
            "interface_ip": "*",
            "key_name": "default",
            "launched_at": "2016-07-06T15:17:07.000000",
            "location": {
                "cloud": "*",
                "project": {
                    "domain_id": null,
                    "domain_name": null,
                    "id": "*",
                    "name": "admin"
                },
                "region_name": "",
                "zone": "nova"
            },
            "metadata": {
                "group": "*"
            },
            "name": "*",
            "networks": {
                "ctlplane": [
                    "*"
                ]
            },
            "os-extended-volumes:volumes_attached": [],
            "power_state": 1,
            "private_v4": "",
            "progress": 0,
            "project_id": "*",
            "properties": {
                "OS-DCF:diskConfig": "MANUAL",
                "OS-EXT-AZ:availability_zone": "nova",
                "OS-EXT-SRV-ATTR:host": "*",
                "OS-EXT-SRV-ATTR:hypervisor_hostname": "*",
                "OS-EXT-SRV-ATTR:instance_name": "*",
                "OS-EXT-STS:power_state": 1,
                "OS-EXT-STS:task_state": null,
                "OS-EXT-STS:vm_state": "active",
                "OS-SRV-USG:launched_at": "2016-07-06T15:17:07.000000",
                "OS-SRV-USG:terminated_at": null,
                "os-extended-volumes:volumes_attached": [],
                "request_ids": []
            },
            "public_v4": "*",
            "public_v6": "",
            "region": "",
            "request_ids": [],
            "security_groups": [
                {
                    "name": "default"
                }
            ],
            "status": "ACTIVE",
            "task_state": null,
            "tenant_id": "*",
            "terminated_at": null,
            "updated": "2016-08-26T08:35:41Z",
            "user_id": "*",
            "vm_state": "active",
            "volumes": []
        }
    ]
}
```
