### PR TITLE
win_lineinfile backrefs bug fix and updated examples.

### DIFF
--- a/lib/ansible/modules/windows/win_lineinfile.ps1
+++ b/lib/ansible/modules/windows/win_lineinfile.ps1
@@ -101,8 +101,8 @@ function WriteLines($outlines, $path, $linesep, $encodingobj, $validate) {
 	Try {
 		Copy-Item $temppath $cleanpath -force;
 	}
-	catch {
-		Fail-Json "Cannot write to: $cleanpath"
+	Catch {
+		Fail-Json ("Cannot write to: $cleanpath (" + $_.Exception.Message + ")")
 	}
 
 	Remove-Item $temppath -force;

--- a/lib/ansible/modules/windows/win_lineinfile.ps1
+++ b/lib/ansible/modules/windows/win_lineinfile.ps1
@@ -29,7 +29,7 @@ $path= Get-Attr $params "path" $FALSE;
 $regexp = Get-Attr $params "regexp" $FALSE;
 $state = Get-Attr $params "state" "present";
 $line = Get-Attr $params "line" $FALSE;
-$backrefs = Get-Attr $params "backrefs" "no";
+$backrefs = ConvertTo-Bool (Get-AnsibleParam -obj $params -name "backrefs" -default "no")
 $insertafter = Get-Attr $params "insertafter" $FALSE;
 $insertbefore = Get-Attr $params "insertbefore" $FALSE;
 $create = Get-Attr $params "create" "no";
@@ -63,30 +63,30 @@ If (Test-Path $path -pathType container) {
 }
 
 
-# Write lines to a file using the specified line separator and encoding, 
+# Write lines to a file using the specified line separator and encoding,
 # performing validation if a validation command was specified.
 
 function WriteLines($outlines, $path, $linesep, $encodingobj, $validate) {
 	$temppath = [System.IO.Path]::GetTempFileName();
 	$joined = $outlines -join $linesep;
 	[System.IO.File]::WriteAllText($temppath, $joined, $encodingobj);
-	
+
 	If ($validate -ne $FALSE) {
-		
+
 		If (!($validate -like "*%s*")) {
 			Fail-Json (New-Object psobject) "validate must contain %s: $validate";
 		}
 
-		$validate = $validate.Replace("%s", $temppath);		
-		
+		$validate = $validate.Replace("%s", $temppath);
+
 		$parts = [System.Collections.ArrayList] $validate.Split(" ");
 		$cmdname = $parts[0];
-		
+
 		$cmdargs = $validate.Substring($cmdname.Length + 1);
-		
+
 		$process = [Diagnostics.Process]::Start($cmdname, $cmdargs);
 		$process.WaitForExit();
-		
+
 		If ($process.ExitCode -ne 0) {
 			[string] $output = $process.StandardOutput.ReadToEnd();
 			[string] $error = $process.StandardError.ReadToEnd();
@@ -95,10 +95,10 @@ function WriteLines($outlines, $path, $linesep, $encodingobj, $validate) {
 		}
 
 	}
-	
+
 	# Commit changes to the path
 	$cleanpath = $path.Replace("/", "\");
-	Copy-Item $temppath $cleanpath -force;	
+	Copy-Item $temppath $cleanpath -force;
 	Remove-Item $temppath -force;
 }
 
@@ -117,7 +117,7 @@ function BackupFile($path) {
 
 function Present($path, $regexp, $line, $insertafter, $insertbefore, $create, $backup, $backrefs, $validate, $encodingobj, $linesep) {
 
-	# Note that we have to clean up the path because ansible wants to treat / and \ as 
+	# Note that we have to clean up the path because ansible wants to treat / and \ as
 	# interchangeable in windows pathnames, but .NET framework internals do not support that.
 	$cleanpath = $path.Replace("/", "\");
 
@@ -139,16 +139,16 @@ function Present($path, $regexp, $line, $insertafter, $insertbefore, $create, $b
 	Else {
 		$lines = [System.Collections.ArrayList] $content;
 	}
-	
+
 	# Compile the regex specified, if provided
 	$mre = $FALSE;
 	If ($regexp -ne $FALSE) {
 		$mre = New-Object Regex $regexp, 'Compiled';
 	}
-	
+
 	# Compile the regex for insertafter or insertbefore, if provided
 	$insre = $FALSE;
-	
+
 	If ($insertafter -ne $FALSE -and $insertafter -ne "BOF" -and $insertafter -ne "EOF") {
 		$insre = New-Object Regex $insertafter, 'Compiled';
 	}
@@ -160,7 +160,7 @@ function Present($path, $regexp, $line, $insertafter, $insertbefore, $create, $b
     # index[1] is the line num where insertafter/inserbefore has been found
 	$index = -1, -1;
 	$lineno = 0;
-	
+
 	# The latest match object and matched line
 	$matched_line = "";
 	$m = $FALSE;
@@ -186,16 +186,16 @@ function Present($path, $regexp, $line, $insertafter, $insertbefore, $create, $b
 			}
 			If ($insertbefore -ne $FALSE) {
 				$index[1] = $lineno;
-			}	
+			}
 		}
 		$lineno = $lineno + 1;
 	}
-	
+
 	$changed = $FALSE;
 	$msg = "";
 
 	If ($index[0] -ne -1) {
-		If ($backrefs -ne "no") {
+		If ($backrefs) {
 		    $new_line = [regex]::Replace($matched_line, $regexp, $line);
 		}
 		Else {
@@ -207,7 +207,7 @@ function Present($path, $regexp, $line, $insertafter, $insertbefore, $create, $b
 			$changed = $TRUE;
 		}
 	}
-	ElseIf ($backrefs -ne "no") {
+	ElseIf ($backrefs) {
 		# No matches - no-op
 	}
 	ElseIf ($insertbefore -eq "BOF" -or $insertafter -eq "BOF") {
@@ -232,7 +232,7 @@ function Present($path, $regexp, $line, $insertafter, $insertbefore, $create, $b
 	If ($changed -eq $TRUE -and $backup -eq "yes") {
 		$backuppath = BackupFile $path;
 	}
-	
+
 	# Write changes to the path if changes were made
 	If ($changed) {
 		WriteLines $lines $path $linesep $encodingobj $validate;
@@ -247,7 +247,7 @@ function Present($path, $regexp, $line, $insertafter, $insertbefore, $create, $b
 		backup = $backuppath
 		encoding = $encodingstr
 	}
-	
+
 	Exit-Json $result;
 }
 
@@ -262,9 +262,9 @@ function Absent($path, $regexp, $line, $backup, $validate, $encodingobj, $linese
 	}
 
 	# Read the dest file lines using the indicated encoding into a mutable ArrayList. Note
-	# that we have to clean up the path because ansible wants to treat / and \ as 
+	# that we have to clean up the path because ansible wants to treat / and \ as
 	# interchangeable in windows pathnames, but .NET framework internals do not support that.
-	 
+
 	$cleanpath = $path.Replace("/", "\");
     $content = [System.IO.File]::ReadAllLines($cleanpath, $encodingobj);
     If ($content -eq $null) {
@@ -273,7 +273,7 @@ function Absent($path, $regexp, $line, $backup, $validate, $encodingobj, $linese
 	Else {
 		$lines = [System.Collections.ArrayList] $content;
 	}
-	
+
 	# Initialize message to be returned on success
 	$msg = "";
 
@@ -310,7 +310,7 @@ function Absent($path, $regexp, $line, $backup, $validate, $encodingobj, $linese
 	If ($changed -eq $TRUE -and $backup -eq "yes") {
 		$backuppath = BackupFile $path;
 	}
-	
+
 	# Write changes to the path if changes were made
 	If ($changed) {
 		WriteLines $left $path $linesep $encodingobj $validate;
@@ -328,7 +328,7 @@ function Absent($path, $regexp, $line, $backup, $validate, $encodingobj, $linese
 		found = $fcount
 		encoding = $encodingstr
 	}
-	
+
 	Exit-Json $result;
 }
 
@@ -362,7 +362,7 @@ If ($encoding -ne "auto") {
 }
 
 # Otherwise see if we can determine the current encoding of the target file.
-# If the file doesn't exist yet (create == 'yes') we use the default or 
+# If the file doesn't exist yet (create == 'yes') we use the default or
 # explicitly specified encoding set above.
 Elseif (Test-Path $path) {
 
@@ -382,11 +382,11 @@ Elseif (Test-Path $path) {
 	}
 
 	# Get the first N bytes from the file, where N is the max preamble length we saw
-	
+
 	[Byte[]]$bom = Get-Content -Encoding Byte -ReadCount $max_preamble_len -TotalCount $max_preamble_len -Path $path;
-  
+
 	# Iterate through the sorted encodings, looking for a full match.
-	
+
 	$found = $FALSE;
 	Foreach ($encoding in $sortedlist.GetValueList()) {
 		$preamble = $encoding.GetPreamble();
@@ -411,19 +411,19 @@ Elseif (Test-Path $path) {
 }
 
 
-# Main dispatch - based on the value of 'state', perform argument validation and 
+# Main dispatch - based on the value of 'state', perform argument validation and
 # call the appropriate handler function.
 
 If ($state -eq "present") {
 
-	If ( $backrefs -ne "no" -and $regexp -eq $FALSE ) {
+	If ( $backrefs -and $regexp -eq $FALSE ) {
 	    Fail-Json (New-Object psobject) "regexp= is required with backrefs=true";
 	}
-	
+
 	If ($line -eq $FALSE) {
 		Fail-Json (New-Object psobject) "line= is required with state=present";
 	}
-	
+
 	If ($insertbefore -eq $FALSE -and $insertafter -eq $FALSE) {
 		$insertafter = "EOF";
 	}
@@ -436,6 +436,6 @@ Else {
 	If ($regexp -eq $FALSE -and $line -eq $FALSE) {
 		Fail-Json (New-Object psobject) "one of line= or regexp= is required with state=absent";
 	}
-	
+
 	Absent $path $regexp $line $backup $validate $encodingobj $linesep;
 }

--- a/lib/ansible/modules/windows/win_lineinfile.ps1
+++ b/lib/ansible/modules/windows/win_lineinfile.ps1
@@ -67,7 +67,12 @@ If (Test-Path $path -pathType container) {
 # performing validation if a validation command was specified.
 
 function WriteLines($outlines, $path, $linesep, $encodingobj, $validate) {
-	$temppath = [System.IO.Path]::GetTempFileName();
+	Try {
+		$temppath = [System.IO.Path]::GetTempFileName();
+	}
+	Catch {
+		Fail-Json ("Cannot create temporary file! (" + $_.Exception.Message + ")")
+	}
 	$joined = $outlines -join $linesep;
 	[System.IO.File]::WriteAllText($temppath, $joined, $encodingobj);
 
@@ -99,13 +104,18 @@ function WriteLines($outlines, $path, $linesep, $encodingobj, $validate) {
 	# Commit changes to the path
 	$cleanpath = $path.Replace("/", "\");
 	Try {
-		Copy-Item $temppath $cleanpath -force;
+		Copy-Item $temppath $cleanpath -force -ErrorAction Stop;
 	}
 	Catch {
 		Fail-Json ("Cannot write to: $cleanpath (" + $_.Exception.Message + ")")
 	}
 
-	Remove-Item $temppath -force;
+	Try {
+		Remove-Item $temppath -force -ErrorAction Stop;
+	}
+	Catch {
+		Fail-Json ("Cannot remove temporary file: $temppath (" + $_.Exception.Message + ")")
+	}
 
 }
 

--- a/lib/ansible/modules/windows/win_lineinfile.py
+++ b/lib/ansible/modules/windows/win_lineinfile.py
@@ -147,4 +147,11 @@ EXAMPLES = r'''
     path: C:\temp\testfile.txt
     line: Line added to file
     newline: unix
+
+# Update a line using backrefs
+- win_lineinfile:
+    path: C:\temp\example.conf
+    backrefs: yes
+    regexp: '(^name=)'
+    line: '$1JohnDoe'
 '''


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_lineinfile

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel ba39d1158c) last updated 2017/02/01 11:36:04 (GMT +100)
  config file = /home/js/.ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
A small fix to win_lineinfile to help it be idempotent. Also updated the docs to give an example of using **backrefs**.

- changed $backrefs to a bool so it works with true/false/yes/no.

This is based on an issue reported in the old core modules repository: https://github.com/ansible/ansible-modules-core/issues/3381