### PR TITLE
Making the decoration more clear

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
@@ -46,7 +46,7 @@ The complete module metadata specification is here: https://github.com/ansible/p
     * For password / secret arguments no_log=True should be set.
     * Requirements should be documented, using the `requirements=[]` field.
     * Author should be set, with their name and their github id, at the least.
-    * Ensure that you make use of U() for urls, C() for files and options, I() for params, M() for modules.
+    * Ensure that you make use of `U()` for URLs, `I()` for option names, `C()` for files and option values, `M()` for module names.
     * If an optional parameter is sometimes required this need to be reflected in the documentation, e.g. "Required when C(state=present)."
     * Verify that a GPL 3 License header is included.
     * Does module use check_mode? Could it be modified to use it? Document it. Documentation is everyone's friend.


### PR DESCRIPTION
##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

The [`developing_modules_checklist`](http://docs.ansible.com/ansible/dev_guide/developing_modules_checklist.html) page.

##### ANSIBLE VERSION

```
ansible 2.2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

This doc PR is making the decoration option names and values more clear. Before it wasn't clear what's option and what's parameter.