### PR TITLE
use require_if to check for username or AK instead of custom code

### DIFF
--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -488,6 +488,7 @@ def main():
             ),
         required_together = [ ['username', 'password'], ['activationkey', 'org_id'] ],
         mutually_exclusive = [ ['username', 'activationkey'] ],
+        required_if = [ [ 'state', 'present', ['username', 'activationkey'], True ] ],
         )
 
     rhsm.module = module
@@ -512,10 +513,6 @@ def main():
 
     # Ensure system is registered
     if state == 'present':
-
-        # Check for missing parameters ...
-        if not (activationkey or org_id or username or password):
-            module.fail_json(msg="Missing arguments, must supply an activationkey (%s) and Organization ID (%s) or username (%s) and password (%s)" % (activationkey, org_id, username, password))
 
         # Register system
         if rhsm.is_registered and not force_register:


### PR DESCRIPTION
the logical or parameter to require_if was introduced in #20220

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
redhat_subscription

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 86db15b105) last updated 2017/02/01 22:14:59 (GMT +300)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

previously redhat_subscription would have own code to check of all the needed params were given, given #20220 is merged, we can use that instead

```
before:  "msg": "Missing arguments, must supply an activationkey (None) and Organization ID (None) or username (None) and password (None)"
after:   "msg": "state is present but the following are missing: username,activationkey"

```
