### PR TITLE
Added support for specifying zone for gce.py dynamic inventory

### DIFF
--- a/contrib/inventory/gce.ini
+++ b/contrib/inventory/gce.ini
@@ -37,13 +37,14 @@
 # statement in the inventory script.  However, you can specify an absolute
 # path to the secrets.py file with 'libcloud_secrets' parameter.
 # This option will be deprecated in a future release.
-libcloud_secrets = 
+libcloud_secrets =
 
 # If you are not going to use a 'secrets.py' file, you can set the necessary
 # authorization parameters here.
-gce_service_account_email_address = 
-gce_service_account_pem_file_path = 
-gce_project_id = 
+gce_service_account_email_address =
+gce_service_account_pem_file_path =
+gce_project_id =
+gce_zone =
 
 # Filter inventory based on on state. Leave undefined to return instances regardless of state.
 # example: Uncomment to only return inventory in the running or provisioning state

--- a/contrib/inventory/gce.py
+++ b/contrib/inventory/gce.py
@@ -217,6 +217,7 @@ class GceInventory(object):
             'gce_service_account_email_address': '',
             'gce_service_account_pem_file_path': '',
             'gce_project_id': '',
+            'gce_zone': '',
             'libcloud_secrets': '',
             'inventory_ip_type': '',
             'cache_path': '~/.ansible/tmp',
@@ -296,13 +297,15 @@ class GceInventory(object):
                 self.config.get('gce','gce_service_account_email_address'),
                 self.config.get('gce','gce_service_account_pem_file_path')
             ]
-            kwargs = {'project': self.config.get('gce', 'gce_project_id')}
+            kwargs = {'project': self.config.get('gce', 'gce_project_id'),
+                      'datacenter': self.config.get('gce', 'gce_zone')}
 
         # If the appropriate environment variables are set, they override
         # other configuration; process those into our args and kwargs.
         args[0] = os.environ.get('GCE_EMAIL', args[0])
         args[1] = os.environ.get('GCE_PEM_FILE_PATH', args[1])
         kwargs['project'] = os.environ.get('GCE_PROJECT', kwargs['project'])
+        kwargs['datacenter'] = os.environ.get('GCE_ZONE', kwargs['datacenter'])
 
         # Retrieve and return the GCE driver.
         gce = get_driver(Provider.GCE)(*args, **kwargs)


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
gce.py

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
When dealing with large amount of servers within different zones in GCE it is quite nice to be able to just generate an inventory for a specific zone. This pull requests adds both an environment variable `GCE_ZONE` and the possibility to specify the zone from the ini-file.