### PR TITLE
Fixes to test-module for running debugger and to test-module documentation.

### DIFF
--- a/hacking/README.md
+++ b/hacking/README.md
@@ -29,7 +29,7 @@ a module outside of the ansible program, locally, on the current machine.
 
 Example:
 
-    $ ./hacking/test-module -m lib/ansible/modules/commands/shell -a "echo hi"
+    $ ./hacking/test-module -m lib/ansible/modules/commands/command.py -a "echo hi"
 
 This is a good way to insert a breakpoint into a module, for instance.
 
@@ -60,5 +60,3 @@ Authors
 -------
 'authors' is a simple script that generates a list of everyone who has
 contributed code to the ansible repository.
-
-

--- a/hacking/test-module
+++ b/hacking/test-module
@@ -23,11 +23,10 @@
 # modules
 #
 # example:
-#    test-module -m ../library/commands/command -a "/bin/sleep 3"
-#    test-module -m ../library/system/service -a "name=httpd ensure=restarted"
-#    test-module -m ../library/system/service -a "name=httpd ensure=restarted" --debugger /usr/bin/pdb
-#    test-module -m ../library/file/lineinfile -a "dest=/etc/exports line='/srv/home hostname1(rw,sync)'" --check
-#    test-module -m ../library/commands/command -a "echo hello" -n -o "test_hello"
+#    ./hacking/test-module -m lib/ansible/modules/commands/command.py -a "/bin/sleep 3"
+#    ./hacking/test-module -m lib/ansible/modules/commands/command.py -a "/bin/sleep 3" --debugger /usr/bin/pdb
+#    ./hacking/test-module -m lib/ansible/modules/files/lineinfile.py -a "dest=/etc/exports line='/srv/home hostname1(rw,sync)'" --check
+#    ./hacking/test-module -m lib/ansible/modules/commands/command.py -a "echo hello" -n -o "test_hello"
 
 import optparse
 import os
@@ -228,11 +227,11 @@ def runtest(modfile, argspath, modname, module_style, interpreters):
     print(jsonify(results,format=True))
 
 
-def rundebug(debugger, modfile, argspath, modname, module_style):
+def rundebug(debugger, modfile, argspath, modname, module_style, interpreters):
     """Run interactively with console debugger."""
 
     if module_style == 'ansiballz':
-        modfile, argspath = ansiballz_setup(modfile, modname)
+        modfile, argspath = ansiballz_setup(modfile, modname, interpreters)
 
     if argspath is not None:
         subprocess.call("%s %s %s" % (debugger, modfile, argspath), shell=True)
@@ -257,7 +256,7 @@ def main():
 
     if options.execute:
         if options.debugger:
-            rundebug(options.debugger, modfile, argspath, modname, module_style)
+            rundebug(options.debugger, modfile, argspath, modname, module_style, interpreters)
         else:
             runtest(modfile, argspath, modname, module_style, interpreters)
 


### PR DESCRIPTION
bring comments and docs up-to-date for invoking hacking/test-module
inside test-module, rundebug also needs to know interpreters

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- hacking/test-module -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel 5432f08c78) last updated 2017/02/01 14:56:35 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Update path to module file in docs to current conventions. In particular, use command.py for examples, not shell.py.

Add interpreters parameter all the way to the call to ansiballz_setup in rundebug.