### PR TITLE
update code-smells shell scripts to check files known to git 

### DIFF
--- a/test/sanity/code-smell/boilerplate.sh
+++ b/test/sanity/code-smell/boilerplate.sh
@@ -1,23 +1,18 @@
 #!/bin/sh
 
-metaclass1=$(find ./bin -type f -exec grep -HL '__metaclass__ = type' '{}' '+')
-future1=$(find ./bin -type f -exec grep -HL 'from __future__ import (absolute_import, division, print_function)' '{}' '+')
+metaclass1=$(git ls-files bin/ | xargs grep -HL '__metaclass__ = type')
+future1=$(git ls-files bin/ | xargs grep -HL 'from __future__ import (absolute_import, division, print_function)')
 
-metaclass2=$(find ./lib/ansible -path ./lib/ansible/modules -prune \
-        -o -path ./lib/ansible/modules/__init__.py \
-        -o -path ./lib/ansible/module_utils -prune \
-        -o -path ./lib/ansible/compat/six/_six.py -prune \
-        -o -path ./lib/ansible/compat/selectors/_selectors2.py -prune \
-        -o -path ./lib/ansible/utils/module_docs_fragments -prune \
-        -o -name '*.py' -exec grep -HL '__metaclass__ = type' '{}' '+')
+py_files=$(git ls-files lib/ansible | grep '.*\.py$'| \
+           grep -v \
+           -e 'lib/ansible/modules/' \
+           -e 'lib/ansible/utils/module_docs' \
+           -e 'lib/ansible/module_utils/' \
+           -e 'lib/ansible/compat/selectors/_selectors2.py' \
+           -e 'lib/ansible/compat/six')
 
-future2=$(find ./lib/ansible -path ./lib/ansible/modules -prune \
-        -o -path ./lib/ansible/modules/__init__.py \
-        -o -path ./lib/ansible/module_utils -prune \
-        -o -path ./lib/ansible/compat/six/_six.py -prune \
-        -o -path ./lib/ansible/compat/selectors/_selectors2.py -prune \
-        -o -path ./lib/ansible/utils/module_docs_fragments -prune \
-        -o -name '*.py' -exec grep -HL 'from __future__ import (absolute_import, division, print_function)' '{}' '+')
+metaclass2=$(echo "${py_files}" | xargs grep -HL '__metaclass__ = type')
+future2=$(echo "${py_files}" | xargs grep -HL 'from __future__ import (absolute_import, division, print_function)')
 
 ### TODO:
 ### - contrib/

--- a/test/sanity/code-smell/inappropriately-private.sh
+++ b/test/sanity/code-smell/inappropriately-private.sh
@@ -15,4 +15,4 @@
 # that violate this.
 #
 # 23-10-2015: Count was 508 lines
-grep -Pri '(?<!self)\._(?!_)' "$1" | grep -v modules
+git grep -Pi '(?<!self)\._(?!_)' "$1" | grep -v modules

--- a/test/sanity/code-smell/line-endings.sh
+++ b/test/sanity/code-smell/line-endings.sh
@@ -1,10 +1,7 @@
 #!/bin/sh
 
-grep -rIPl '\r' . \
-    --exclude-dir .git \
-    --exclude-dir .tox \
-    | grep -v -F \
-    -e './test/integration/targets/win_regmerge/templates/win_line_ending.j2'
+git grep -IPl '\r' . \
+    | grep -v -F 'test/integration/targets/win_regmerge/templates/win_line_ending.j2'
 
 if [ $? -ne 1 ]; then
     printf 'One or more file(s) listed above have invalid line endings.\n'

--- a/test/sanity/code-smell/no-basestring.sh
+++ b/test/sanity/code-smell/no-basestring.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 
-BASESTRING_USERS=$(grep -r basestring . \
-    --exclude-dir .git \
-    --exclude-dir .tox \
+BASESTRING_USERS=$(git grep basestring  \
     | grep isinstance \
     | grep -v \
     -e test/results/ \

--- a/test/sanity/code-smell/no-dict-iteritems.sh
+++ b/test/sanity/code-smell/no-dict-iteritems.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 
-ITERITEMS_USERS=$(grep -rI '\.iteritems' . \
-    --exclude-dir .git \
-    --exclude-dir .tox \
-    --exclude-dir docsite \
+ITERITEMS_USERS=$(git grep -I '\.iteritems' \
     | grep -v \
     -e 'six\.iteritems' \
     -e lib/ansible/compat/six/_six.py \

--- a/test/sanity/code-smell/no-dict-itervalues.sh
+++ b/test/sanity/code-smell/no-dict-itervalues.sh
@@ -1,9 +1,6 @@
 #!/bin/sh
 
-ITERVALUES_USERS=$(grep -rI '\.itervalues' . \
-    --exclude-dir .git \
-    --exclude-dir .tox \
-    --exclude-dir docsite \
+ITERVALUES_USERS=$(git grep -I '\.itervalues' \
     | grep -v \
     -e 'six\.itervalues' \
     -e lib/ansible/compat/six/_six.py \

--- a/test/sanity/code-smell/no-iterkeys.sh
+++ b/test/sanity/code-smell/no-iterkeys.sh
@@ -1,13 +1,11 @@
 #!/bin/sh
 
-ITERKEYS_USERS=$(grep -r -I iterkeys . \
-    --exclude-dir .git \
-    --exclude-dir .tox \
-    --exclude-dir docsite \
+ITERKEYS_USERS=$(git grep -I iterkeys  \
     | grep -v \
     -e lib/ansible/compat/six/_six.py \
     -e lib/ansible/module_utils/six.py \
     -e test/sanity/code-smell/no-iterkeys.sh \
+    docs/docsite/ \
     -e '^[^:]*:#'
     )
 

--- a/test/sanity/code-smell/replace-urlopen.sh
+++ b/test/sanity/code-smell/replace-urlopen.sh
@@ -1,10 +1,9 @@
 #!/bin/sh
-
-urllib_users=$(find . -name '*.py' -exec grep -H urlopen '{}' '+' | grep -v \
+urllib_users=$(git ls-files | grep '.*\.py$' | xargs grep -H urlopen | grep -v \
     -e '^[^:]*/.tox/' \
-    -e '^\./lib/ansible/module_utils/urls.py:' \
-    -e '^\./lib/ansible/module_utils/six.py:' \
-    -e '^\./lib/ansible/compat/six/_six.py:' \
+    -e '^lib/ansible/module_utils/urls.py:' \
+    -e '^lib/ansible/module_utils/six.py:' \
+    -e '^lib/ansible/compat/six/_six.py:' \
     -e '^[^:]*:#'
 )
 

--- a/test/sanity/code-smell/required-and-default-attributes.sh
+++ b/test/sanity/code-smell/required-and-default-attributes.sh
@@ -1,8 +1,7 @@
 #!/bin/sh
 
 BASEDIR=${1-"lib/ansible"}
-cd "$BASEDIR"
-grep -r FieldAttribute . |grep 'default' | grep 'required'
+git grep  FieldAttribute "${BASEDIR}" |grep 'default' | grep 'required'
 if test $? -eq 0 ; then
     exit 1
 fi

--- a/test/sanity/code-smell/shebang.sh
+++ b/test/sanity/code-smell/shebang.sh
@@ -1,16 +1,14 @@
 #!/bin/sh
 
-grep '^#!' -rIn . \
-    --exclude-dir .git \
-    --exclude-dir .tox \
-    | grep ':1:' | sed 's/:1:/:/' | grep -v -E \
-    -e '^\./lib/ansible/modules/' \
-    -e '^\./test/integration/targets/[^/]*/library/[^/]*:#!powershell$' \
-    -e '^\./test/integration/targets/[^/]*/library/[^/]*:#!/usr/bin/python$' \
-    -e '^\./test/sanity/validate-modules/validate-modules:#!/usr/bin/env python2$' \
-    -e '^\./hacking/cherrypick.py:#!/usr/bin/env python3$' \
+git grep -In '^#!' \
+    | grep ':1:' | sed 's/:1:/:/' | grep -v  \
+    -e '^lib/ansible/modules/' \
+    -e '^test/integration/targets/[^/]*/library/[^/]*:#!powershell$' \
+    -e '^test/integration/targets/[^/]*/library/[^/]*:#!/usr/bin/python$' \
+    -e '^test/sanity/validate-modules/validate-modules:#!/usr/bin/env python2$' \
+    -e '^hacking/cherrypick.py:#!/usr/bin/env python3$' \
     -e ':#!/bin/sh$' \
-    -e ':#!/bin/bash( -[eux]|$)' \
+    -e ':#!/bin/bash -[eux]' \
     -e ':#!/usr/bin/make -f$' \
     -e ':#!/usr/bin/env python$' \
     -e ':#!/usr/bin/env bash$' \

--- a/test/sanity/code-smell/use-compat-six.sh
+++ b/test/sanity/code-smell/use-compat-six.sh
@@ -8,7 +8,7 @@ BASEDIR=${1-"lib"}
 #   message
 WHITELIST='(lib/ansible/modules/cloud/digital_ocean/digital_ocean.py)'
 
-SIX_USERS=$(find "$BASEDIR" -name '*.py' -exec grep -wH six '{}' '+' \
+SIX_USERS=$(git ls-files "${BASEDIR}" | grep '.*\.py$' | xargs grep -wH six \
     | grep import \
     | grep -v ansible.compat \
     | grep -v ansible.module_utils.six \


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 - Tests Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
test/runner/ansible-test

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (boilerplate b4ea24e9b1) last updated 2017/02/01 16:23:25 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules', u'/home/adrian/ansible/lib/modules/']

```

##### SUMMARY
Change code-smell shell scripts to use git ls-files and git grep instead of 'find' or 'grep -r' so that the tests will avoid uncommitted files. Otherwise any local test or util script will cause ansible-test to fail.