### PR TITLE
Split on newlines when checking for prompt matches

### DIFF
--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -254,7 +254,10 @@ class ConnectionBase(with_metaclass(ABCMeta, object)):
             return False
         elif isinstance(self._play_context.prompt, string_types):
             b_prompt = to_bytes(self._play_context.prompt)
-            return b_output.startswith(b_prompt)
+            b_lines = b_output.splitlines(True)
+            if not b_lines:
+                return False
+            return b_lines[-1].startswith(b_prompt)
         else:
             return self._play_context.prompt(b_output)
 

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -254,10 +254,7 @@ class ConnectionBase(with_metaclass(ABCMeta, object)):
             return False
         elif isinstance(self._play_context.prompt, string_types):
             b_prompt = to_bytes(self._play_context.prompt)
-            b_lines = b_output.splitlines(True)
-            if not b_lines:
-                return False
-            return b_lines[-1].startswith(b_prompt)
+            return b_prompt in b_output
         else:
             return self._play_context.prompt(b_output)
 


### PR DESCRIPTION
sudo sometimes spits out warnings to stdout before getting to the
password prompt.  Account for that when trying to match a password
prompt.

Fixes #20858

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/connection/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.2
```