### PR TITLE
add tagging to dynamodb_table.py

### DIFF
--- a/lib/ansible/modules/cloud/amazon/dynamodb_table.py
+++ b/lib/ansible/modules/cloud/amazon/dynamodb_table.py
@@ -30,7 +30,7 @@ description:
 author: Alan Loi (@loia)
 requirements:
   - "boto >= 2.37.0"
-  - "boto3 >= 1.4.4" (for tagging)
+  - "boto3 >= 1.4.4 (for tagging)"
 options:
   state:
     description:

--- a/lib/ansible/modules/cloud/amazon/dynamodb_table.py
+++ b/lib/ansible/modules/cloud/amazon/dynamodb_table.py
@@ -30,6 +30,7 @@ description:
 author: Alan Loi (@loia)
 requirements:
   - "boto >= 2.37.0"
+  - "boto3 >= 1.4.4" (for tagging)
 options:
   state:
     description:
@@ -83,6 +84,18 @@ options:
     required: false
     default: []
     version_added: "2.1"
+  tags:
+    version_added: "2.3"
+    description:
+      - a hash/dictionary of tags to add to the new instance or for starting/stopping instance by tag; '{"key":"value"}' and '{"key":"value","key":"value"}'
+    required: false
+    default: null
+  wait_for_active_timeout:
+    version_added: "2.3"
+    description:
+      - how long before wait gives up, in seconds. only used when tags is set
+    required: false
+    default: 60
 extends_documentation_fragment:
     - aws
     - ec2
@@ -99,6 +112,8 @@ EXAMPLES = '''
     range_key_type: NUMBER
     read_capacity: 2
     write_capacity: 2
+    tags:
+      tag_name: tag_value
 
 # Update capacity on existing dynamo table
 - dynamodb_table:
@@ -137,6 +152,7 @@ table_status:
     sample: ACTIVE
 '''
 
+import time
 import traceback
 
 try:
@@ -158,6 +174,13 @@ try:
 except ImportError:
     HAS_BOTO = False
 
+try:
+    import botocore
+    from ansible.module_utils.ec2 import ansible_dict_to_boto3_tag_list, boto3_conn
+    HAS_BOTO3 = True
+except ImportError:
+    HAS_BOTO3 = False
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import AnsibleAWSError, connect_to_aws, ec2_argument_spec, get_aws_connection_info
 
@@ -168,7 +191,7 @@ INDEX_OPTIONS = INDEX_REQUIRED_OPTIONS + ['hash_key_type', 'range_key_name', 'ra
 INDEX_TYPE_OPTIONS = ['all', 'global_all', 'global_include', 'global_keys_only', 'include', 'keys_only']
 
 
-def create_or_update_dynamo_table(connection, module):
+def create_or_update_dynamo_table(connection, module, boto3_dynamodb=None, boto3_iam=None):
     table_name = module.params.get('name')
     hash_key_name = module.params.get('hash_key_name')
     hash_key_type = module.params.get('hash_key_type')
@@ -177,6 +200,9 @@ def create_or_update_dynamo_table(connection, module):
     read_capacity = module.params.get('read_capacity')
     write_capacity = module.params.get('write_capacity')
     all_indexes = module.params.get('indexes')
+    region = module.params.get('region')
+    tags = module.params.get('tags')
+    wait_for_active_timeout = module.params.get('wait_for_active_timeout')
 
     for index in all_indexes:
         validate_index(index, module)
@@ -191,7 +217,7 @@ def create_or_update_dynamo_table(connection, module):
     indexes, global_indexes = get_indexes(all_indexes)
 
     result = dict(
-        region=module.params.get('region'),
+        region=region,
         table_name=table_name,
         hash_key_name=hash_key_name,
         hash_key_type=hash_key_type,
@@ -216,11 +242,31 @@ def create_or_update_dynamo_table(connection, module):
         if not module.check_mode:
             result['table_status'] = table.describe()['Table']['TableStatus']
 
+        if tags:
+            # only tables which are active can be tagged
+            wait_until_table_active(module, boto3_dynamodb, table, wait_for_active_timeout)
+            account_id = get_account_id(boto3_iam)
+            boto3_dynamodb.tag_resource(ResourceArn='arn:aws:dynamodb:' + region + ':' + account_id + ':table/' + table_name, Tags=ansible_dict_to_boto3_tag_list(tags))
+
     except BotoServerError:
         result['msg'] = 'Failed to create/update dynamo table due to error: ' + traceback.format_exc()
         module.fail_json(**result)
     else:
         module.exit_json(**result)
+
+
+def get_account_id(boto3_iam):
+    users = boto3_iam.list_users(MaxItems=1)
+    return users['Users'][0]['Arn'].split(':')[4]
+
+
+def wait_until_table_active(module, boto3_dynamodb, table, wait_timeout):
+    max_wait_time = time.time() + wait_timeout
+    while (max_wait_time > time.time()) and (table.describe()['Table']['TableStatus'] != 'ACTIVE'):
+        time.sleep(5)
+    if max_wait_time <= time.time():
+        # waiting took too long
+        module.fail_json(msg="timed out waiting for table to exist")
 
 
 def delete_dynamo_table(connection, module):
@@ -393,6 +439,8 @@ def main():
         read_capacity=dict(default=1, type='int'),
         write_capacity=dict(default=1, type='int'),
         indexes=dict(default=[], type='list'),
+        tags = dict(type='dict'),
+        wait_for_active_timeout = dict(default=60, type='int'),
     ))
 
     module = AnsibleModule(
@@ -401,6 +449,9 @@ def main():
 
     if not HAS_BOTO:
         module.fail_json(msg='boto required for this module')
+
+    if not HAS_BOTO3 and module.params.get('tags'):
+        module.fail_json(msg='boto3 required when using tags for this module')
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module)
     if not region:
@@ -411,9 +462,20 @@ def main():
     except (NoAuthHandlerFound, AnsibleAWSError) as e:
         module.fail_json(msg=str(e))
 
+    if module.params.get('tags'):
+        try:
+            region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+            boto3_dynamodb = boto3_conn(module, conn_type='client', resource='dynamodb', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+            boto3_iam = boto3_conn(module, conn_type='client', resource='iam', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+        except botocore.exceptions.NoCredentialsError as e:
+            module.fail_json(msg='cannot connect to AWS', exception=traceback.format_exc(e))
+    else:
+        boto3_dynamodb = None
+        boto3_iam = None
+
     state = module.params.get('state')
     if state == 'present':
-        create_or_update_dynamo_table(connection, module)
+        create_or_update_dynamo_table(connection, module, boto3_dynamodb, boto3_iam)
     elif state == 'absent':
         delete_dynamo_table(connection, module)
 

--- a/lib/ansible/modules/cloud/amazon/dynamodb_table.py
+++ b/lib/ansible/modules/cloud/amazon/dynamodb_table.py
@@ -466,6 +466,8 @@ def main():
         try:
             region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
             boto3_dynamodb = boto3_conn(module, conn_type='client', resource='dynamodb', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+            if not hasattr(boto3_dynamodb, 'tag_resource'):
+                module.fail_json(msg='boto3 connection does not have tag_resource(), likely due to using an old version')
             boto3_sts = boto3_conn(module, conn_type='client', resource='sts', region=region, endpoint=ec2_url, **aws_connect_kwargs)
         except botocore.exceptions.NoCredentialsError as e:
             module.fail_json(msg='cannot connect to AWS', exception=traceback.format_exc(e))


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
dynamodb_table

##### ANSIBLE VERSION
```
> ansible --version
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Added tagging support to dynamodb_table.py.

Tested with:

```
#~/ansible/ansible_test.yml
- hosts: localhost
  tasks:
  - name: create no tag table
    dynamodb_table:
      name: "corey_no_tag_test"
      region: "us-east-1"
      hash_key_name: "test_key"

  - name: create tag table
    dynamodb_table:
      name: "corey_tag_test"
      region: "us-east-1"
      hash_key_name: "test_key"
      tags:
        Name: "corey_test"
        Environment: "test"
```

test command:
```
ansible-playbook -i ~/dataxu/dxansible/hosts_local -vvvv ~/ansible/ansible_test.yml
```

test output:
```
No config file found; using defaults
Loading callback plugin default of type stdout, v2.0 from /Users/cchristous/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.3.0-py2.7.egg/ansible/plugins/callback/__init__.pyc

PLAYBOOK: ansible_test.yml ********************************************************************************************************************************************************************************************************
1 plays in /Users/cchristous/ansible/ansible_test.yml

PLAY [localhost] ******************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ************************************************************************************************************************************************************************************************************
Using module file /Users/cchristous/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.3.0-py2.7.egg/ansible/modules/system/setup.py
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: cchristous
<localhost> EXEC /bin/sh -c 'echo ~ && sleep 0'
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/cchristous/.ansible/tmp/ansible-tmp-1485984882.43-258841138288613 `" && echo ansible-tmp-1485984882.43-258841138288613="` echo /Users/cchristous/.ansible/tmp/ansible-tmp-1485984882.43-258841138288613 `" ) && sleep 0'
<localhost> PUT /var/folders/09/lfjb6xns62b5nm3vf_7th6cc0000gp/T/tmpZuZ7Cu TO /Users/cchristous/.ansible/tmp/ansible-tmp-1485984882.43-258841138288613/setup.py
<localhost> EXEC /bin/sh -c 'chmod u+x /Users/cchristous/.ansible/tmp/ansible-tmp-1485984882.43-258841138288613/ /Users/cchristous/.ansible/tmp/ansible-tmp-1485984882.43-258841138288613/setup.py && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/env python /Users/cchristous/.ansible/tmp/ansible-tmp-1485984882.43-258841138288613/setup.py; rm -rf "/Users/cchristous/.ansible/tmp/ansible-tmp-1485984882.43-258841138288613/" > /dev/null 2>&1 && sleep 0'
ok: [localhost]
META: ran handlers

TASK [create no tag table] **********************************************************************************************************************************************************************************************************
task path: /Users/cchristous/ansible/ansible_test.yml:5
Using module file /Users/cchristous/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.3.0-py2.7.egg/ansible/modules/cloud/amazon/dynamodb_table.py
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: cchristous
<localhost> EXEC /bin/sh -c 'echo ~ && sleep 0'
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/cchristous/.ansible/tmp/ansible-tmp-1485984883.63-102965495980308 `" && echo ansible-tmp-1485984883.63-102965495980308="` echo /Users/cchristous/.ansible/tmp/ansible-tmp-1485984883.63-102965495980308 `" ) && sleep 0'
<localhost> PUT /var/folders/09/lfjb6xns62b5nm3vf_7th6cc0000gp/T/tmpjbsv1a TO /Users/cchristous/.ansible/tmp/ansible-tmp-1485984883.63-102965495980308/dynamodb_table.py
<localhost> EXEC /bin/sh -c 'chmod u+x /Users/cchristous/.ansible/tmp/ansible-tmp-1485984883.63-102965495980308/ /Users/cchristous/.ansible/tmp/ansible-tmp-1485984883.63-102965495980308/dynamodb_table.py && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/env python /Users/cchristous/.ansible/tmp/ansible-tmp-1485984883.63-102965495980308/dynamodb_table.py; rm -rf "/Users/cchristous/.ansible/tmp/ansible-tmp-1485984883.63-102965495980308/" > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true, 
    "hash_key_name": "test_key", 
    "hash_key_type": "STRING", 
    "indexes": [], 
    "invocation": {
        "module_args": {
            "aws_access_key": null, 
            "aws_secret_key": null, 
            "ec2_url": null, 
            "hash_key_name": "test_key", 
            "hash_key_type": "STRING", 
            "indexes": [], 
            "name": "corey_no_tag_test", 
            "profile": null, 
            "range_key_name": null, 
            "range_key_type": "STRING", 
            "read_capacity": 1, 
            "region": "us-east-1", 
            "security_token": null, 
            "state": "present", 
            "tags": null, 
            "validate_certs": true, 
            "wait_for_active_timeout": 60, 
            "write_capacity": 1
        }, 
        "module_name": "dynamodb_table"
    }, 
    "range_key_name": null, 
    "range_key_type": "STRING", 
    "read_capacity": 1, 
    "region": "us-east-1", 
    "table_name": "corey_no_tag_test", 
    "table_status": "CREATING", 
    "write_capacity": 1
}

TASK [create tag table] **********************************************************************************************************************************************************************************************************
task path: /Users/cchristous/ansible/ansible_test.yml:11
Using module file /Users/cchristous/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.3.0-py2.7.egg/ansible/modules/cloud/amazon/dynamodb_table.py
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: cchristous
<localhost> EXEC /bin/sh -c 'echo ~ && sleep 0'
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/cchristous/.ansible/tmp/ansible-tmp-1485984885.76-82138804988925 `" && echo ansible-tmp-1485984885.76-82138804988925="` echo /Users/cchristous/.ansible/tmp/ansible-tmp-1485984885.76-82138804988925 `" ) && sleep 0'
<localhost> PUT /var/folders/09/lfjb6xns62b5nm3vf_7th6cc0000gp/T/tmpo4R4UG TO /Users/cchristous/.ansible/tmp/ansible-tmp-1485984885.76-82138804988925/dynamodb_table.py
<localhost> EXEC /bin/sh -c 'chmod u+x /Users/cchristous/.ansible/tmp/ansible-tmp-1485984885.76-82138804988925/ /Users/cchristous/.ansible/tmp/ansible-tmp-1485984885.76-82138804988925/dynamodb_table.py && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/env python /Users/cchristous/.ansible/tmp/ansible-tmp-1485984885.76-82138804988925/dynamodb_table.py; rm -rf "/Users/cchristous/.ansible/tmp/ansible-tmp-1485984885.76-82138804988925/" > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true, 
    "hash_key_name": "test_key", 
    "hash_key_type": "STRING", 
    "indexes": [], 
    "invocation": {
        "module_args": {
            "aws_access_key": null, 
            "aws_secret_key": null, 
            "ec2_url": null, 
            "hash_key_name": "test_key", 
            "hash_key_type": "STRING", 
            "indexes": [], 
            "name": "corey_tag_test", 
            "profile": null, 
            "range_key_name": null, 
            "range_key_type": "STRING", 
            "read_capacity": 1, 
            "region": "us-east-1", 
            "security_token": null, 
            "state": "present", 
            "tags": {
                "Environment": "test", 
                "Name": "corey_test"
            }, 
            "validate_certs": true, 
            "wait_for_active_timeout": 60, 
            "write_capacity": 1
        }, 
        "module_name": "dynamodb_table"
    }, 
    "range_key_name": null, 
    "range_key_type": "STRING", 
    "read_capacity": 1, 
    "region": "us-east-1", 
    "table_name": "corey_tag_test", 
    "table_status": "CREATING", 
    "write_capacity": 1
}
META: ran handlers
META: ran handlers

PLAY RECAP ************************************************************************************************************************************************************************************************************************
localhost                  : ok=3    changed=2    unreachable=0    failed=0 
```