### PR TITLE
adds the cli transport back to the ios modules

### DIFF
--- a/lib/ansible/module_utils/ios_cli.py
+++ b/lib/ansible/module_utils/ios_cli.py
@@ -46,15 +46,12 @@ ios_cli_argument_spec = {
     'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
     'password': dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), no_log=True),
 
-    'authorize': dict(default=False, fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
-    'auth_pass': dict(no_log=True, fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS'])),
+    'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
+    'auth_pass': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS']), no_log=True),
 
     'timeout': dict(type='int', default=10),
 
     'provider': dict(type='dict'),
-
-    # deprecated in Ansible 2.3
-    'transport': dict(),
 }
 
 def check_args(module):
@@ -78,8 +75,6 @@ class Cli(CliBase):
         re.compile(r"connection timed out", re.I),
         re.compile(r"[^\r\n]+ not found", re.I),
     ]
-
-    NET_PASSWD_RE = re.compile(r"[\r\n]?password: $", re.I)
 
     def __init__(self, module):
         self._module = module
@@ -106,7 +101,12 @@ class Cli(CliBase):
 
     def authorize(self):
         passwd = self._module.params['auth_pass']
-        self.execute(Command('enable', prompt=self.NET_PASSWD_RE, response=passwd))
+        if passwd:
+            prompt = "[\r\n]?Password: $"
+            self.exec_command(dict(command='enable', prompt=prompt, response=passwd))
+        else:
+            self.exec_command('enable')
+
 
 
 def connection(module):

--- a/lib/ansible/modules/network/ios/ios_command.py
+++ b/lib/ansible/modules/network/ios/ios_command.py
@@ -35,9 +35,7 @@ description:
     before returning or timing out if the condition is not met.
   - This module does not support running commands in configuration mode.
     Please use M(ios_config) to configure IOS devices.
-notes:
-  - Provider arguments are no longer supported.  Network tasks should now
-    specify connection plugin network_cli instead.
+extends_documentation_fragment: ios
 options:
   commands:
     description:
@@ -149,13 +147,33 @@ delta:
 """
 import time
 
+from functools import partial
+
+from ansible.module_utils import ios
+from ansible.module_utils import ios_cli
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.local import LocalAnsibleModule
-from ansible.module_utils.ios import run_commands
 from ansible.module_utils.network_common import ComplexList
 from ansible.module_utils.netcli import Conditional
 from ansible.module_utils.six import string_types
 
-VALID_KEYS = ['command', 'output']
+SHARED_LIB = 'ios'
+
+def get_ansible_module():
+    if SHARED_LIB == 'ios':
+        return LocalAnsibleModule
+    return AnsibleModule
+
+def invoke(name, *args, **kwargs):
+    obj = globals().get(SHARED_LIB)
+    func = getattr(obj, name)
+    return func(*args, **kwargs)
+
+run_commands = partial(invoke, 'run_commands')
+
+def check_args(module, warnings):
+    if SHARED_LIB == 'ios_cli':
+        ios_cli.check_args(module)
 
 def to_lines(stdout):
     for item in stdout:
@@ -186,7 +204,9 @@ def parse_commands(module, warnings):
     return commands
 
 def main():
-    spec = dict(
+    """main entry point for module execution
+    """
+    argument_spec = dict(
         # { command: <str>, prompt: <str>, response: <str> }
         commands=dict(type='list', required=True),
 
@@ -197,10 +217,16 @@ def main():
         interval=dict(default=1, type='int')
     )
 
-    module = LocalAnsibleModule(argument_spec=spec,
-                                supports_check_mode=True)
+    argument_spec.update(ios_cli.ios_cli_argument_spec)
+
+    cls = get_ansible_module()
+    module = cls(argument_spec=argument_spec, supports_check_mode=True)
 
     warnings = list()
+    check_args(module, warnings)
+
+    result = {'changed': False}
+
     commands = parse_commands(module, warnings)
 
     wait_for = module.params['wait_for'] or list()
@@ -243,4 +269,5 @@ def main():
 
 
 if __name__ == '__main__':
+    SHARED_LIB = 'ios_cli'
     main()


### PR DESCRIPTION
the cli transport was initially removed to aid in the transition to
network_cli.  This adds the function back to the provider can be
specified.
