### PR TITLE
Fixes #20951 fixed multi_ok (var multi usage in vpc_exists function)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
@@ -118,9 +118,9 @@ def boto_exception(err):
     return error
 
 def vpc_exists(module, vpc, name, cidr_block, multi):
-    """Returns True or False in regards to the existence of a VPC. When supplied
+    """Returns None or a vpc object depending on the existence of a VPC. When supplied
     with a CIDR, it will check for matching tags to determine if it is a match
-    otherwise it will assume the VPC does not exist and thus return false.
+    otherwise it will assume the VPC does not exist and thus return None.
     """
     matched_vpc = None
 
@@ -130,11 +130,12 @@ def vpc_exists(module, vpc, name, cidr_block, multi):
         e_msg=boto_exception(e)
         module.fail_json(msg=e_msg)
 
-    if len(matching_vpcs) == 1:
+    if multi:
+        return None
+    elif len(matching_vpcs) == 1:
         matched_vpc = matching_vpcs[0]
     elif len(matching_vpcs) > 1:
-        if multi:
-            module.fail_json(msg='Currently there are %d VPCs that have the same name and '
+        module.fail_json(msg='Currently there are %d VPCs that have the same name and '
                              'CIDR block you specified. If you would like to create '
                              'the VPC anyway please pass True to the multi_ok param.' % len(matching_vpcs))
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
/modules/cloud/amazon/ec2_vpc_net.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel 64f98f855d) last updated 2017/02/02 00:25:11 (GMT +200)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Changed the description to match return value (None or object). Changed the if branches to return None if var multi is True. Changed the last if branch to return error message whatever value the var multi has.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
Changed True appears as the result of the execution of the ec2_vpc_net module when creating a vpc with the same cidr_block and tag Name than another already existing vpc within the same AWS account.
```
