### PR TITLE
Convert nat gateway facts to ansible format

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway_facts.py
@@ -81,7 +81,7 @@ EXAMPLES = '''
 
 RETURN = '''
 result:
-  description: The result of the describe.
+  description: The result of the describe, converted to ansible snake case style.
     See http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_nat_gateways for the response.
   returned: success
   type: list
@@ -114,7 +114,7 @@ def get_nat_gateways(client, module, nat_gateway_id=None):
     except Exception as e:
         module.fail_json(msg=str(e.message))
 
-    return result['NatGateways']
+    return [camel_dict_to_snake_dict(gateway) for gateway in result['NatGateways']]
 
 
 def main():


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc_nat_gateway_facts

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel e19c2f6a6d) last updated 2017/02/02 14:50:03 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Use `camel_dict_to_snake_dict` for returning NAT gateway facts in ansible format

Requested by @wimnat as part of review for #20214, but after it was already merged.