### PR TITLE
ecs_service: fixed type mapper and added tests

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -618,5 +618,5 @@ def map_complex_type(complex_type, type_map):
                 complex_type[i],
                 type_map))
     elif type_map:
-        return vars(globals()['__builtins__'])[type_map](complex_type)
+        return globals()['__builtins__'][type_map](complex_type)
     return new_type

--- a/test/units/modules/cloud/amazon/test_ec2_utils.py
+++ b/test/units/modules/cloud/amazon/test_ec2_utils.py
@@ -1,0 +1,12 @@
+import unittest
+
+from ansible.module_utils.ec2 import map_complex_type
+
+
+class Ec2Utils(unittest.TestCase):
+    def test_map_complex_type_over_dict(self):
+        complex_type = {'minimum_healthy_percent': "75", 'maximum_percent': "150"}
+        type_map = {'minimum_healthy_percent': 'int', 'maximum_percent': 'int'}
+        complex_type_mapped = map_complex_type(complex_type, type_map)
+        complex_type_expected = {'minimum_healthy_percent': 75, 'maximum_percent': 150}
+        self.assertEqual(complex_type_mapped, complex_type_expected)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ecs_service

##### ANSIBLE VERSION
```
$ ansible --version
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
I almost lost my sanity on this one. I may have hit a python bug with `globals()['__builtins__']` losing its dictionary attribute `__dict__` and therefore `vars()` was returning `None`. 
This made the `ecs_service` module fail if `deployment_configuration` was provided.

The bug was triggered after a refactor of putting the function `map_complex_type` in the `ec2.py` module. Somehow it worked before when it was collocated with its caller. 

Before
```
---
- hosts: localhost
  connection: localhost
  gather_facts: no
  tasks:
    - name: test ecs service
      ecs_service:
        profile: "default"
        region: "ap-southeast-2"
        state: present
        name: "test"
        cluster: "test"
        task_definition: "test:16"
        desired_count: "0"
        deployment_configuration:
          minimum_healthy_percent: 75
          maximum_percent: 150


An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/var/folders/x5/gcz23y8x62v7v2bx49rt00wr0000gn/T/ansible_5bFihl/ansible_module_ecs_service.py", line 462, in <module>
    main()
  File "/var/folders/x5/gcz23y8x62v7v2bx49rt00wr0000gn/T/ansible_5bFihl/ansible_module_ecs_service.py", line 364, in main
    DEPLOYMENT_CONFIGURATION_TYPE_MAP)
  File "/var/folders/x5/gcz23y8x62v7v2bx49rt00wr0000gn/T/ansible_5bFihl/ansible_modlib.zip/ansible/module_utils/ec2.py", line 612,

 in map_complex_type
  File "/var/folders/x5/gcz23y8x62v7v2bx49rt00wr0000gn/T/ansible_5bFihl/ansible_modlib.zip/ansible/module_utils/ec2.py", line 621,
 in map_complex_type
TypeError: vars() argument must have __dict__ attribute
```

After 

```
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "aws_access_key": null,
            "aws_secret_key": null,
            "client_token": "",
            "cluster": "test",
            "delay": 10,
            "deployment_configuration": {

                "maximum_percent": 150,
                "minimum_healthy_percent": 75
            },
... etc
```

I have added a test to prevent to run into this issue in the future. 