### PR TITLE
Revert "clean up unused doc fragments"

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/eapi.py
+++ b/lib/ansible/utils/module_docs_fragments/eapi.py
@@ -1,0 +1,97 @@
+#
+# (c) 2015, Peter Sprygada <psprygada@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class ModuleDocFragment(object):
+
+    # Standard files documentation fragment
+    DOCUMENTATION = """
+options:
+  host:
+    description:
+      - Specifies the DNS host name or address for connecting to the remote
+        device over the specified transport.  The value of host is used as
+        the destination address for the transport.
+    required: true
+  port:
+    description:
+      - Specifies the port to use when building the connection to the remote
+        device.  The port value will default to the appropriate transport
+        common port if none is provided in the task.  (http=80, https=443).
+    required: false
+    default: null
+  url_username:
+    description:
+      - Configures the username to use to authenticate the connection to
+        the remote device.  This value is used to authenticate
+        the eAPI authentication depending on which transport is used. If
+        the value is not specified in the task, the value of environment
+        variable C(ANSIBLE_NET_USERNAME) will be used instead.
+    required: false
+    default: null
+    aliases: ['username']
+  url_password:
+    description:
+      - Specifies the password to use to authenticate the connection to
+        the remote device.  This is a common argument used for the I(eapi)
+        transport. If the value is not specified in the task, the value of
+        environment variable C(ANSIBLE_NET_PASSWORD) will be used instead.
+    required: false
+    default: null
+    aliases: ['password']
+  timeout:
+    description:
+      - Specifies the timeout in seconds for communicating with the network device
+        for either connecting or sending commands.  If the timeout is
+        exceeded before the operation is completed, the module will error.
+    require: false
+    default: 10
+  authorize:
+    description:
+      - Instructs the module to enter privileged mode on the remote device
+        before sending any commands.  If not specified, the device will
+        attempt to execute all commands in non-privileged mode. If the value
+        is not specified in the task, the value of environment variable
+        C(ANSIBLE_NET_AUTHORIZE) will be used instead.
+    required: false
+    default: no
+    choices: ['true', 'false']
+  auth_pass:
+    description:
+      - Specifies the password to use if required to enter privileged mode
+        on the remote device.  If I(authorize) is false, then this argument
+        does nothing. If the value is not specified in the task, the value of
+        environment variable C(ANSIBLE_NET_AUTH_PASS) will be used instead.
+    required: false
+    default: none
+  use_ssl:
+    description:
+      - Configures the I(transport) to use SSL if set to true only when the
+        C(transport=eapi).  If the transport
+        argument is not eapi, this value is ignored.
+    required: false
+    default: yes
+    choices: ['true', 'false']
+  provider:
+    description:
+      - Convenience method that allows all I(eos) arguments to be passed as
+        a dict object.  All constraints (required, choices, etc) must be
+        met either by individual arguments or values in this dict.
+    required: false
+    default: null
+"""

--- a/lib/ansible/utils/module_docs_fragments/eos.py
+++ b/lib/ansible/utils/module_docs_fragments/eos.py
@@ -1,0 +1,112 @@
+#
+# (c) 2015, Peter Sprygada <psprygada@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class ModuleDocFragment(object):
+
+    # Standard files documentation fragment
+    DOCUMENTATION = """
+options:
+  host:
+    description:
+      - Specifies the DNS host name or address for connecting to the remote
+        device over the specified transport.  The value of host is used as
+        the destination address for the transport.
+    required: true
+  port:
+    description:
+      - Specifies the port to use when building the connection to the remote
+        device.  This value applies to either I(cli) or I(eapi).  The port
+        value will default to the appropriate transport common port if
+        none is provided in the task.  (cli=22, http=80, https=443).
+    required: false
+    default: 0 (use common port)
+  username:
+    description:
+      - Configures the username to use to authenticate the connection to
+        the remote device.  This value is used to authenticate
+        either the CLI login or the eAPI authentication depending on which
+        transport is used. If the value is not specified in the task, the
+        value of environment variable C(ANSIBLE_NET_USERNAME) will be used instead.
+    required: false
+  password:
+    description:
+      - Specifies the password to use to authenticate the connection to
+        the remote device.  This is a common argument used for either I(cli)
+        or I(eapi) transports. If the value is not specified in the task, the
+        value of environment variable C(ANSIBLE_NET_PASSWORD) will be used instead.
+    required: false
+    default: null
+  timeout:
+    description:
+      - Specifies the timeout in seconds for communicating with the network device
+        for either connecting or sending commands.  If the timeout is
+        exceeded before the operation is completed, the module will error.
+    require: false
+    default: 10
+  ssh_keyfile:
+    description:
+      - Specifies the SSH keyfile to use to authenticate the connection to
+        the remote device.  This argument is only used for I(cli) transports.
+        If the value is not specified in the task, the value of environment
+        variable C(ANSIBLE_NET_SSH_KEYFILE) will be used instead.
+    required: false
+  authorize:
+    description:
+      - Instructs the module to enter privileged mode on the remote device
+        before sending any commands.  If not specified, the device will
+        attempt to execute all commands in non-privileged mode. If the value
+        is not specified in the task, the value of environment variable
+        C(ANSIBLE_NET_AUTHORIZE) will be used instead.
+    required: false
+    default: no
+    choices: ['yes', 'no']
+  auth_pass:
+    description:
+      - Specifies the password to use if required to enter privileged mode
+        on the remote device.  If I(authorize) is false, then this argument
+        does nothing. If the value is not specified in the task, the value of
+        environment variable C(ANSIBLE_NET_AUTH_PASS) will be used instead.
+    required: false
+    default: none
+  transport:
+    description:
+      - Configures the transport connection to use when connecting to the
+        remote device.
+    required: true
+    choices:
+        - eapi
+        - cli
+    default: cli
+  use_ssl:
+    description:
+      - Configures the I(transport) to use SSL if set to true only when the
+        C(transport=eapi).  If the transport
+        argument is not eapi, this value is ignored.
+    required: false
+    default: yes
+    choices: ['yes', 'no']
+  provider:
+    description:
+      - Convenience method that allows all I(eos) arguments to be passed as
+        a dict object.  All constraints (required, choices, etc) must be
+        met either by individual arguments or values in this dict.
+    required: false
+    default: null
+
+"""


### PR DESCRIPTION

##### ISSUE TYPE
 - Bugfix Pull Request
 
##### COMPONENT NAME
tests

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel e19c2f6a6d) last updated 2017/02/02 14:50:03 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Those "unused" doc fragments are still referenced

lib/ansible/modules/network/eos/eos_config.py:extends_documentation_fragment: eapi
lib/ansible/modules/network/eos/eos_facts.py:extends_documentation_fragment: eos

This reverts commit 246cd041d8e68045c64db7a2d8c1d14b9e7e4233 from a seemingly direct, untested push by @privateip to devel (at least I can't see an associated PR)

