### PR TITLE
Make a generalized OpenStack cloud constructor

### DIFF
--- a/contrib/inventory/openstack.yml
+++ b/contrib/inventory/openstack.yml
@@ -1,18 +1,10 @@
 clouds:
-  mordred:
-    cloud: hp
+  vexxhost:
+    profile: vexxhost
     auth:
-      username: mordred@example.com
-      password: my-wonderful-password
-      project_name: mordred-tenant
-    region_name: region-b.geo-1
-  monty:
-    cloud: hp
-    auth:
-      username: monty.taylor@example.com
-      password: another-wonderful-password
-      project_name: monty.taylor@example.com-default-tenant
-    region_name: region-b.geo-1
+      project_name: 39e296b2-fc96-42bf-8091-cb742fa13da9
+      username: fb886a9b-c37b-442a-9be3-964bed961e04
+      password: fantastic-password1
   rax:
     cloud: rackspace
     auth:
@@ -22,7 +14,7 @@ clouds:
     region_name: DFW,ORD,IAD
   devstack:
     auth:
-      auth_url: http://127.0.0.1:35357/v2.0/
+      auth_url: https://devstack.example.com
       username: stack
       password: stack
       project_name: stack

--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -76,7 +76,7 @@ def openstack_find_nova_addresses(addresses, ext_tag, key_name=None):
 
 def openstack_full_argument_spec(**kwargs):
     spec = dict(
-        cloud=dict(default=None),
+        cloud=dict(default=None, type='raw'),
         auth_type=dict(default=None),
         auth=dict(default=None, type='dict', no_log=True),
         region_name=dict(default=None),
@@ -88,12 +88,9 @@ def openstack_full_argument_spec(**kwargs):
         wait=dict(default=True, type='bool'),
         timeout=dict(default=180, type='int'),
         api_timeout=dict(default=None, type='int'),
-        endpoint_type=dict(
-            default='public', choices=['public', 'internal', 'admin']
-        ),
-        identity_api_version=dict(
-            default=None, choices=['2.0', '3']
-        )
+        interface=dict(
+            default='public', choices=['public', 'internal', 'admin'],
+            aliases=['endpoint_type']),
     )
     spec.update(kwargs)
     return spec
@@ -109,3 +106,46 @@ def openstack_module_kwargs(**kwargs):
                 ret[key] = kwargs[key]
 
     return ret
+
+
+def openstack_cloud_from_module(module, min_version=None):
+    from distutils.version import StrictVersion
+    try:
+        import shade
+    except ImportError:
+        module.fail_json(msg='shade is required for this module')
+
+    if min_version:
+        if StrictVersion(shade.__version__) < StrictVersion(min_version):
+            module.fail_json(
+                msg="To utilize this module, the installed version of"
+                    "the shade library MUST be >={min_version}".format(
+                        min_version=min_version))
+
+    cloud_config = module.params.pop('cloud', None)
+    if isinstance(cloud_config, dict):
+        fail_message = (
+            "A cloud config dict was provided to the cloud parameter"
+            " but also a value was provided for {param}. If a cloud"
+            " config dict is provided, {param} should be"
+            " excluded.")
+        for param in (
+                'auth', 'region_name', 'verify',
+                'cacert', 'key', 'api_timeout', 'interface'):
+            if module.params[param] is not None:
+                module.fail_json(fail_message.format(param=param))
+        if module.params['auth_type'] != 'password':
+            module.fail_json(fail_message.format(param='auth_type'))
+        return shade, shade.operator_cloud(**cloud_config)
+    else:
+        return shade, shade.operator_cloud(
+            cloud=cloud_config,
+            auth_type=module.params['auth_type'],
+            auth=module.params['auth'],
+            region_name=module.params['region_name'],
+            verify=module.params['verify'],
+            cacert=module.params['cacert'],
+            key=module.params['key'],
+            api_timeout=module.params['api_timeout'],
+            interface=module.params['interface'],
+        )

--- a/lib/ansible/modules/cloud/openstack/os_auth.py
+++ b/lib/ansible/modules/cloud/openstack/os_auth.py
@@ -43,15 +43,8 @@ EXAMPLES = '''
 
 import traceback
 
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
-# this is magic, see lib/ansible/module_common.py
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def main():
@@ -60,11 +53,8 @@ def main():
     module_kwargs = openstack_module_kwargs()
     module = AnsibleModule(argument_spec, **module_kwargs)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-
+    shade, cloud = openstack_cloud_from_module(module)
     try:
-        cloud = shade.openstack_cloud(**module.params)
         module.exit_json(
             changed=False,
             ansible_facts=dict(

--- a/lib/ansible/modules/cloud/openstack/os_group.py
+++ b/lib/ansible/modules/cloud/openstack/os_group.py
@@ -99,14 +99,8 @@ group:
             sample: "default"
 '''
 
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def _system_state_change(state, description, group):
@@ -132,16 +126,14 @@ def main():
                            supports_check_mode=True,
                            **module_kwargs)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
+    name = module.params.get('name')
+    description = module.params.get('description')
+    state = module.params.get('state')
 
-    name = module.params.pop('name')
-    description = module.params.pop('description')
     domain_id = module.params.pop('domain_id')
-    state = module.params.pop('state')
 
+    shade, cloud = openstack_cloud_from_module(module)
     try:
-        cloud = shade.operator_cloud(**module.params)
         if domain_id:
             group = cloud.get_group(name, filters={'domain_id': domain_id})
         else:

--- a/lib/ansible/modules/cloud/openstack/os_image.py
+++ b/lib/ansible/modules/cloud/openstack/os_image.py
@@ -108,7 +108,7 @@ EXAMPLES = '''
 # Upload an image from a local file named cirros-0.3.0-x86_64-disk.img
 - os_image:
     auth:
-      auth_url: http://localhost/auth/v2.0
+      auth_url: https://identity.example.com
       username: admin
       password: passme
       project_name: admin
@@ -124,14 +124,8 @@ EXAMPLES = '''
       distro: ubuntu
 '''
 
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def main():
@@ -155,11 +149,8 @@ def main():
     module_kwargs = openstack_module_kwargs()
     module = AnsibleModule(argument_spec, **module_kwargs)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-
+    shade, cloud = openstack_cloud_from_module(module)
     try:
-        cloud = shade.openstack_cloud(**module.params)
 
         changed = False
         if module.params['checksum']:

--- a/lib/ansible/modules/cloud/openstack/os_image_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_image_facts.py
@@ -40,7 +40,7 @@ EXAMPLES = '''
 - name: Gather facts about a previously created image named image1
   os_image_facts:
     auth:
-      auth_url: https://your_api_url.com:9000/v2.0
+      auth_url: https://identity.example.com
       username: user
       password: password
       project_name: someproject
@@ -127,14 +127,8 @@ openstack_image:
             type: int
 '''
 
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def main():
@@ -145,11 +139,8 @@ def main():
     module_kwargs = openstack_module_kwargs()
     module = AnsibleModule(argument_spec, **module_kwargs)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-
+    shade, cloud = openstack_cloud_from_module(module)
     try:
-        cloud = shade.openstack_cloud(**module.params)
         image = cloud.get_image(module.params['image'])
         module.exit_json(changed=False, ansible_facts=dict(
             openstack_image=image))

--- a/lib/ansible/modules/cloud/openstack/os_ironic_inspect.py
+++ b/lib/ansible/modules/cloud/openstack/os_ironic_inspect.py
@@ -89,16 +89,8 @@ EXAMPLES = '''
     name: "testnode1"
 '''
 
-from distutils.version import StrictVersion
-
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def _choose_id_value(module):
@@ -121,12 +113,6 @@ def main():
     module_kwargs = openstack_module_kwargs()
     module = AnsibleModule(argument_spec, **module_kwargs)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-    if StrictVersion(shade.__version__) < StrictVersion('1.0.0'):
-        module.fail_json(msg="To utilize this module, the installed version of"
-                             "the shade library MUST be >=1.0.0")
-
     if (module.params['auth_type'] in [None, 'None'] and
             module.params['ironic_url'] is None):
         module.fail_json(msg="Authentication appears to be disabled, "
@@ -138,8 +124,9 @@ def main():
             endpoint=module.params['ironic_url']
         )
 
+    shade, cloud = openstack_cloud_from_module(
+        module, min_version='1.0.0')
     try:
-        cloud = shade.operator_cloud(**module.params)
 
         if module.params['name'] or module.params['uuid']:
             server = cloud.get_machine(_choose_id_value(module))

--- a/lib/ansible/modules/cloud/openstack/os_keypair.py
+++ b/lib/ansible/modules/cloud/openstack/os_keypair.py
@@ -88,14 +88,8 @@ private_key:
     type: string
 '''
 
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def _system_state_change(module, keypair):
@@ -123,9 +117,6 @@ def main():
                            supports_check_mode=True,
                            **module_kwargs)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-
     state = module.params['state']
     name = module.params['name']
     public_key = module.params['public_key']
@@ -134,8 +125,8 @@ def main():
         public_key = open(module.params['public_key_file']).read()
         public_key = public_key.rstrip()
 
+    shade, cloud = openstack_cloud_from_module(module)
     try:
-        cloud = shade.openstack_cloud(**module.params)
         keypair = cloud.get_keypair(name)
 
         if module.check_mode:

--- a/lib/ansible/modules/cloud/openstack/os_keystone_domain.py
+++ b/lib/ansible/modules/cloud/openstack/os_keystone_domain.py
@@ -98,14 +98,8 @@ id:
     sample: "474acfe5-be34-494c-b339-50f06aa143e4"
 '''
 
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def _needs_update(module, domain):
@@ -143,16 +137,13 @@ def main():
                            supports_check_mode=True,
                            **module_kwargs)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-
     name = module.params['name']
     description = module.params['description']
     enabled = module.params['enabled']
     state = module.params['state']
 
+    shade, cloud = openstack_cloud_from_module(module)
     try:
-        cloud = shade.operator_cloud(**module.params)
 
         domains = cloud.search_domains(filters=dict(name=name))
 

--- a/lib/ansible/modules/cloud/openstack/os_keystone_domain_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_keystone_domain_facts.py
@@ -89,14 +89,8 @@ openstack_domains:
             type: bool
 '''
 
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def main():
@@ -112,14 +106,10 @@ def main():
     )
     module = AnsibleModule(argument_spec, **module_kwargs)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-
+    shade, opcloud = openstack_cloud_from_module(module)
     try:
         name = module.params['name']
         filters = module.params['filters']
-
-        opcloud = shade.operator_cloud(**module.params)
 
         if name:
             # Let's suppose user is passing domain ID

--- a/lib/ansible/modules/cloud/openstack/os_keystone_role.py
+++ b/lib/ansible/modules/cloud/openstack/os_keystone_role.py
@@ -69,14 +69,8 @@ role:
             sample: "demo"
 '''
 
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def _system_state_change(state, role):
@@ -98,14 +92,11 @@ def main():
                            supports_check_mode=True,
                            **module_kwargs)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
+    name = module.params.get('name')
+    state = module.params.get('state')
 
-    name = module.params.pop('name')
-    state = module.params.pop('state')
-
+    shade, cloud = openstack_cloud_from_module(module)
     try:
-        cloud = shade.operator_cloud(**module.params)
 
         role = cloud.get_role(name)
 

--- a/lib/ansible/modules/cloud/openstack/os_keystone_service.py
+++ b/lib/ansible/modules/cloud/openstack/os_keystone_service.py
@@ -104,16 +104,8 @@ id:
     sample: "3292f020780b4d5baf27ff7e1d224c44"
 '''
 
-from distutils.version import StrictVersion
-
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def _needs_update(module, service):
@@ -152,21 +144,14 @@ def main():
                            supports_check_mode=True,
                            **module_kwargs)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-    if StrictVersion(shade.__version__) < StrictVersion('1.6.0'):
-        module.fail_json(msg="To utilize this module, the installed version of"
-                             "the shade library MUST be >=1.6.0")
-
     description = module.params['description']
     enabled = module.params['enabled']
     name = module.params['name']
     state = module.params['state']
     service_type = module.params['service_type']
 
+    shade, cloud = openstack_cloud_from_module(module, min_version='1.6.0')
     try:
-        cloud = shade.operator_cloud(**module.params)
-
         services = cloud.search_services(name_or_id=name,
                                          filters=dict(type=service_type))
 

--- a/lib/ansible/modules/cloud/openstack/os_networks_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_networks_facts.py
@@ -44,7 +44,7 @@ EXAMPLES = '''
 - name: Gather facts about previously created networks
   os_networks_facts:
     auth:
-      auth_url: https://your_api_url.com:9000/v2.0
+      auth_url: https://identity.example.com
       username: user
       password: password
       project_name: someproject
@@ -56,7 +56,7 @@ EXAMPLES = '''
 - name: Gather facts about a previously created network by name
   os_networks_facts:
     auth:
-      auth_url: https://your_api_url.com:9000/v2.0
+      auth_url: https://identity.example.com
       username: user
       password: password
       project_name: someproject
@@ -70,7 +70,7 @@ EXAMPLES = '''
   # Note: name and filters parameters are Not mutually exclusive
   os_networks_facts:
     auth:
-      auth_url: https://your_api_url.com:9000/v2.0
+      auth_url: https://identity.example.com
       username: user
       password: password
       project_name: someproject
@@ -117,14 +117,8 @@ openstack_networks:
             type: boolean
 '''
 
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_cloud_from_module
 
 
 def main():
@@ -135,11 +129,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-
+    shade, cloud = openstack_cloud_from_module(module)
     try:
-        cloud = shade.openstack_cloud(**module.params)
         networks = cloud.search_networks(module.params['name'],
                                          module.params['filters'])
         module.exit_json(changed=False, ansible_facts=dict(

--- a/lib/ansible/modules/cloud/openstack/os_nova_flavor.py
+++ b/lib/ansible/modules/cloud/openstack/os_nova_flavor.py
@@ -173,14 +173,8 @@ flavor:
                 "aggregate_instance_extra_specs:pinned": false
 '''
 
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def _system_state_change(module, flavor):
@@ -220,15 +214,12 @@ def main():
         ],
         **module_kwargs)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-
     state = module.params['state']
     name = module.params['name']
     extra_specs = module.params['extra_specs'] or {}
 
+    shade, cloud = openstack_cloud_from_module(module)
     try:
-        cloud = shade.operator_cloud(**module.params)
         flavor = cloud.get_flavor(name)
 
         if module.check_mode:

--- a/lib/ansible/modules/cloud/openstack/os_object.py
+++ b/lib/ansible/modules/cloud/openstack/os_object.py
@@ -69,14 +69,8 @@ EXAMPLES = '''
     container: config
 '''
 
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def process_object(
@@ -118,12 +112,8 @@ def main():
     module_kwargs = openstack_module_kwargs()
     module = AnsibleModule(argument_spec, **module_kwargs)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-
+    shade, cloud = openstack_cloud_from_module(module)
     try:
-        cloud = shade.openstack_cloud(**module.params)
-
         changed = process_object(cloud, **module.params)
 
         module.exit_json(changed=changed)

--- a/lib/ansible/modules/cloud/openstack/os_port.py
+++ b/lib/ansible/modules/cloud/openstack/os_port.py
@@ -105,7 +105,7 @@ EXAMPLES = '''
 - os_port:
     state: present
     auth:
-      auth_url: https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/
+      auth_url: https://identity.example.com
       username: admin
       password: admin
       project_name: admin
@@ -116,7 +116,7 @@ EXAMPLES = '''
 - os_port:
     state: present
     auth:
-      auth_url: https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/
+      auth_url: https://identity.example.com
       username: admin
       password: admin
       project_name: admin
@@ -129,7 +129,7 @@ EXAMPLES = '''
 - os_port:
     state: present
     auth:
-      auth_url: https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/
+      auth_url: https://identity.example.com
       username: admin
       password: admin
       project_name: admin
@@ -141,7 +141,7 @@ EXAMPLES = '''
 - os_port:
     state: present
     auth:
-      auth_url: https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/d
+      auth_url: https://identity.example.com
       username: admin
       password: admin
       project_name: admin
@@ -152,7 +152,7 @@ EXAMPLES = '''
 - os_port:
     state: present
     auth:
-      auth_url: https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/d
+      auth_url: https://identity.example.com
       username: admin
       password: admin
       project_name: admin
@@ -201,14 +201,8 @@ admin_state_up:
     type: bool
 '''
 
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def _needs_update(module, port, cloud):
@@ -329,13 +323,11 @@ def main():
                            supports_check_mode=True,
                            **module_kwargs)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
     name = module.params['name']
     state = module.params['state']
 
+    shade, cloud = openstack_cloud_from_module(module)
     try:
-        cloud = shade.openstack_cloud(**module.params)
         if module.params['security_groups']:
             # translate security_groups to UUID's if names where provided
             module.params['security_groups'] = [

--- a/lib/ansible/modules/cloud/openstack/os_port_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_port_facts.py
@@ -189,14 +189,8 @@ openstack_ports:
             sample: "51fce036d7984ba6af4f6c849f65ef00"
 '''
 
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def main():
@@ -207,14 +201,11 @@ def main():
     module_kwargs = openstack_module_kwargs()
     module = AnsibleModule(argument_spec, **module_kwargs)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
+    port = module.params.get('port')
+    filters = module.params.get('filters')
 
-    port = module.params.pop('port')
-    filters = module.params.pop('filters')
-
+    shade, cloud = openstack_cloud_from_module(module)
     try:
-        cloud = shade.openstack_cloud(**module.params)
         ports = cloud.search_ports(port, filters)
         module.exit_json(changed=False, ansible_facts=dict(
             openstack_ports=ports))

--- a/lib/ansible/modules/cloud/openstack/os_project.py
+++ b/lib/ansible/modules/cloud/openstack/os_project.py
@@ -102,16 +102,8 @@ project:
             sample: True
 '''
 
-from distutils.version import StrictVersion
-
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def _needs_update(module, project):
@@ -159,36 +151,34 @@ def main():
         **module_kwargs
     )
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-
     name = module.params['name']
     description = module.params['description']
-    domain = module.params.pop('domain_id')
+    domain = module.params.get('domain_id')
     enabled = module.params['enabled']
     state = module.params['state']
 
-    if domain and StrictVersion(shade.__version__) < StrictVersion('1.8.0'):
-        module.fail_json(msg="The domain argument requires shade >=1.8.0")
+    if domain:
+        min_version = '1.8.0'
+    else:
+        min_version = None
 
+    shade, cloud = openstack_cloud_from_module(
+        module, min_version=min_version)
     try:
         if domain:
-            opcloud = shade.operator_cloud(**module.params)
             try:
                 # We assume admin is passing domain id
-                dom = opcloud.get_domain(domain)['id']
+                dom = cloud.get_domain(domain)['id']
                 domain = dom
             except:
                 # If we fail, maybe admin is passing a domain name.
                 # Note that domains have unique names, just like id.
                 try:
-                    dom = opcloud.search_domains(filters={'name': domain})[0]['id']
+                    dom = cloud.search_domains(filters={'name': domain})[0]['id']
                     domain = dom
                 except:
                     # Ok, let's hope the user is non-admin and passing a sane id
                     pass
-
-        cloud = shade.openstack_cloud(**module.params)
 
         if domain:
             project = cloud.get_project(name, domain_id=domain)

--- a/lib/ansible/modules/cloud/openstack/os_project_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_project_facts.py
@@ -107,14 +107,8 @@ openstack_projects:
             type: bool
 '''
 
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_cloud_from_module
 
 
 def main():
@@ -127,15 +121,11 @@ def main():
 
     module = AnsibleModule(argument_spec)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-
+    shade, opcloud = openstack_cloud_from_module(module)
     try:
         name = module.params['name']
         domain = module.params['domain']
         filters = module.params['filters']
-
-        opcloud = shade.operator_cloud(**module.params)
 
         if domain:
             try:

--- a/lib/ansible/modules/cloud/openstack/os_recordset.py
+++ b/lib/ansible/modules/cloud/openstack/os_recordset.py
@@ -127,16 +127,8 @@ recordset:
             sample: ['10.0.0.1']
 '''
 
-from distutils.version import StrictVersion
-
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def _system_state_change(state, records, description, ttl, zone, recordset):
@@ -173,18 +165,12 @@ def main():
                            supports_check_mode=True,
                            **module_kwargs)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-    if StrictVersion(shade.__version__) <= StrictVersion('1.8.0'):
-        module.fail_json(msg="To utilize this module, the installed version of "
-                             "the shade library MUST be >1.8.0")
-
     zone = module.params.get('zone')
     name = module.params.get('name')
     state = module.params.get('state')
 
+    shade, cloud = openstack_cloud_from_module(module, min_version='1.9.0')
     try:
-        cloud = shade.openstack_cloud(**module.params)
         recordset_type = module.params.get('recordset_type')
         recordset_filter = {'type': recordset_type}
 

--- a/lib/ansible/modules/cloud/openstack/os_security_group.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group.py
@@ -60,14 +60,8 @@ EXAMPLES = '''
     description: updated description for the foo security group
 '''
 
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def _needs_update(module, secgroup):
@@ -103,15 +97,12 @@ def main():
                            supports_check_mode=True,
                            **module_kwargs)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-
     name = module.params['name']
     state = module.params['state']
     description = module.params['description']
 
+    shade, cloud = openstack_cloud_from_module(module)
     try:
-        cloud = shade.openstack_cloud(**module.params)
         secgroup = cloud.get_security_group(name)
 
         if module.check_mode:

--- a/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
@@ -167,14 +167,8 @@ security_group_id:
   returned: state == present
 '''
 
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def _ports_match(protocol, module_min, module_max, rule_min, rule_max):
@@ -297,16 +291,13 @@ def main():
                            supports_check_mode=True,
                            **module_kwargs)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-
     state = module.params['state']
     security_group = module.params['security_group']
     remote_group = module.params['remote_group']
     changed = False
 
+    shade, cloud = openstack_cloud_from_module(module)
     try:
-        cloud = shade.openstack_cloud(**module.params)
         secgroup = cloud.get_security_group(security_group)
 
         if remote_group:

--- a/lib/ansible/modules/cloud/openstack/os_server_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_facts.py
@@ -57,14 +57,8 @@ EXAMPLES = '''
 
 import fnmatch
 
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def main():
@@ -76,17 +70,15 @@ def main():
     module_kwargs = openstack_module_kwargs()
     module = AnsibleModule(argument_spec, **module_kwargs)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-
+    shade, cloud = openstack_cloud_from_module(module)
     try:
-        cloud = shade.openstack_cloud(**module.params)
         openstack_servers = cloud.list_servers(
             detailed=module.params['detailed'])
 
         if module.params['server']:
             # filter servers by name
             pattern = module.params['server']
+            # TODO(mordred) This is handled by shade now
             openstack_servers = [server for server in openstack_servers
                                  if fnmatch.fnmatch(server['name'], pattern) or fnmatch.fnmatch(server['id'], pattern)]
         module.exit_json(changed=False, ansible_facts=dict(

--- a/lib/ansible/modules/cloud/openstack/os_server_group.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_group.py
@@ -54,7 +54,7 @@ EXAMPLES = '''
 - os_server_group:
     state: present
     auth:
-      auth_url: https://api.cloud.catalyst.net.nz:5000/v2.0
+      auth_url: https://identity.example.com
       username: admin
       password: admin
       project_name: admin
@@ -66,7 +66,7 @@ EXAMPLES = '''
 - os_server_group:
     state: absent
     auth:
-      auth_url: https://api.cloud.catalyst.net.nz:5000/v2.0
+      auth_url: https://identity.example.com
       username: admin
       password: admin
       project_name: admin
@@ -104,14 +104,8 @@ user_id:
     type: string
 '''
 
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def _system_state_change(state, server_group):
@@ -136,15 +130,12 @@ def main():
         **module_kwargs
     )
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-
     name = module.params['name']
     policies = module.params['policies']
     state = module.params['state']
 
+    shade, cloud = openstack_cloud_from_module(module)
     try:
-        cloud = shade.openstack_cloud(**module.params)
         server_group = cloud.get_server_group(name)
 
         if module.check_mode:

--- a/lib/ansible/modules/cloud/openstack/os_server_volume.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_volume.py
@@ -65,15 +65,8 @@ EXAMPLES = '''
       device: /dev/vdb
 '''
 
-try:
-    import shade
-    from shade import meta
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def _system_state_change(state, device):
@@ -102,15 +95,12 @@ def main():
                            supports_check_mode=True,
                            **module_kwargs)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-
     state = module.params['state']
     wait = module.params['wait']
     timeout = module.params['timeout']
 
+    shade, cloud = openstack_cloud_from_module(module)
     try:
-        cloud = shade.openstack_cloud(**module.params)
         server = cloud.get_server(module.params['server'])
         volume = cloud.get_volume(module.params['volume'])
         dev = cloud.get_volume_attach_device(volume, server.id)
@@ -128,7 +118,7 @@ def main():
 
             server = cloud.get_server(module.params['server'])  # refresh
             volume = cloud.get_volume(module.params['volume'])  # refresh
-            hostvars = meta.get_hostvars_from_server(cloud, server)
+            hostvars = cloud.get_openstack_vars(server)
 
             module.exit_json(
                 changed=True,

--- a/lib/ansible/modules/cloud/openstack/os_subnets_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_subnets_facts.py
@@ -44,7 +44,7 @@ EXAMPLES = '''
 - name: Gather facts about previously created subnets
   os_subnets_facts:
     auth:
-      auth_url: https://your_api_url.com:9000/v2.0
+      auth_url: https://identity.example.com
       username: user
       password: password
       project_name: someproject
@@ -56,7 +56,7 @@ EXAMPLES = '''
 - name: Gather facts about a previously created subnet by name
   os_subnets_facts:
     auth:
-      auth_url: https://your_api_url.com:9000/v2.0
+      auth_url: https://identity.example.com
       username: user
       password: password
       project_name: someproject
@@ -70,7 +70,7 @@ EXAMPLES = '''
   # Note: name and filters parameters are not mutually exclusive
   os_subnets_facts:
     auth:
-      auth_url: https://your_api_url.com:9000/v2.0
+      auth_url: https://identity.example.com
       username: user
       password: password
       project_name: someproject
@@ -130,14 +130,8 @@ openstack_subnets:
             type: list of dicts
 '''
 
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def main():
@@ -148,11 +142,8 @@ def main():
     )
     module = AnsibleModule(argument_spec)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-
+    shade, cloud = openstack_cloud_from_module(module)
     try:
-        cloud = shade.openstack_cloud(**module.params)
         subnets = cloud.search_subnets(module.params['name'],
                                        module.params['filters'])
         module.exit_json(changed=False, ansible_facts=dict(

--- a/lib/ansible/modules/cloud/openstack/os_user_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_user_facts.py
@@ -115,14 +115,8 @@ openstack_users:
             type: string
 '''
 
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def main():
@@ -135,15 +129,11 @@ def main():
 
     module = AnsibleModule(argument_spec)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-
+    shade, opcloud = openstack_cloud_from_module(module)
     try:
         name = module.params['name']
         domain = module.params['domain']
         filters = module.params['filters']
-
-        opcloud = shade.operator_cloud(**module.params)
 
         if domain:
             try:

--- a/lib/ansible/modules/cloud/openstack/os_user_group.py
+++ b/lib/ansible/modules/cloud/openstack/os_user_group.py
@@ -51,14 +51,8 @@ EXAMPLES = '''
   group: demo
 '''
 
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def _system_state_change(state, in_group):
@@ -81,16 +75,12 @@ def main():
                            supports_check_mode=True,
                            **module_kwargs)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-
     user = module.params['user']
     group = module.params['group']
     state = module.params['state']
 
+    shade, cloud = openstack_cloud_from_module(module)
     try:
-        cloud = shade.operator_cloud(**module.params)
-
         in_group = cloud.is_user_in_group(user, group)
 
         if module.check_mode:

--- a/lib/ansible/modules/cloud/openstack/os_zone.py
+++ b/lib/ansible/modules/cloud/openstack/os_zone.py
@@ -126,16 +126,8 @@ zone:
             sample: []
 '''
 
-from distutils.version import StrictVersion
-
-try:
-    import shade
-    HAS_SHADE = True
-except ImportError:
-    HAS_SHADE = False
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs
+from ansible.module_utils.openstack import openstack_full_argument_spec, openstack_module_kwargs, openstack_cloud_from_module
 
 
 def _system_state_change(state, email, description, ttl, masters, zone):
@@ -171,17 +163,11 @@ def main():
                            supports_check_mode=True,
                            **module_kwargs)
 
-    if not HAS_SHADE:
-        module.fail_json(msg='shade is required for this module')
-    if StrictVersion(shade.__version__) < StrictVersion('1.8.0'):
-        module.fail_json(msg="To utilize this module, the installed version of"
-                             "the shade library MUST be >=1.8.0")
-
     name = module.params.get('name')
     state = module.params.get('state')
 
+    shade, cloud = openstack_cloud_from_module(module, min_version='1.8.0')
     try:
-        cloud = shade.openstack_cloud(**module.params)
         zone = cloud.get_zone(name)
 
         if state == 'present':

--- a/lib/ansible/utils/module_docs_fragments/openstack.py
+++ b/lib/ansible/utils/module_docs_fragments/openstack.py
@@ -23,9 +23,13 @@ class ModuleDocFragment(object):
 options:
   cloud:
     description:
-      - Named cloud to operate against. Provides default values for I(auth) and
-        I(auth_type). This parameter is not needed if I(auth) is provided or if
-        OpenStack OS_* environment variables are present.
+      - Named cloud or cloud config to operate against.
+        If I(cloud) is a string, it references a named cloud config as defined
+        in an OpenStack clouds.yaml file. Provides default values for I(auth)
+        and I(auth_type). This parameter is not needed if I(auth) is provided
+        or if OpenStack OS_* environment variables are present.
+        If I(cloud) is a dict, it contains a complete cloud configuration like
+        would be in a section of clouds.yaml.
     required: false
   auth:
     description:
@@ -87,18 +91,14 @@ options:
       - A path to a client key to use as part of the SSL transaction.
     required: false
     default: None
-  endpoint_type:
+  interface:
     description:
         - Endpoint URL type to fetch from the service catalog.
     choices: [public, internal, admin]
     required: false
     default: public
-  identity_api_version:
-    description:
-        - The identity API version
-    choices: [2.0, 3]
-    required: false
-    default: None
+    aliases: ['endpoint_type']
+    version_added: "2.3"
 requirements:
   - python >= 2.7
   - shade

--- a/test/units/modules/cloud/openstack/test_os_server.py
+++ b/test/units/modules/cloud/openstack/test_os_server.py
@@ -81,6 +81,9 @@ class FakeCloud (object):
     def get_network(self, name):
         return self._find(self.networks, name)
 
+    def get_openstack_vars(self, server):
+        return server
+
     create_server = mock.MagicMock()
 
 


### PR DESCRIPTION
Creating the shade object correctly from the ansible module parameters is complex, especially as special cases arise. There have been several bugs about parameters conflicting or how to pass in more complicated cloud config.

Centralize those functions into module_utils. We also add the ability to pass a fully formed cloud config structure for scenarios when having a clouds.yaml file is not possible but more complex cloud config needs to be provided. Finally, we also centralize the min_version code so that it doesn't have to be copied around like a cantrip everywhere.

Depends-On: https://review.openstack.org/539563
Depends-On: https://github.com/ansible/ansible/pull/34925