### PR TITLE
wait_for: change file check to handle directories and sockets

### DIFF
--- a/lib/ansible/modules/utilities/logic/wait_for.py
+++ b/lib/ansible/modules/utilities/logic/wait_for.py
@@ -100,6 +100,12 @@ options:
       - This overrides the normal error message from a failure to meet the required conditions.
 notes:
   - The ability to use search_regex with a port connection was added in 1.7.
+  - Prior to 2.4, testing for the absense of a directory or UNIX socket did not work correctly.
+  - Prior to 2.4, testing for the presence of a file did not work correctly if the remote user did not have read access to that file.
+  - Under some circumstances when using mandatory access control, a path may always be treated as being absent even if it exists, but
+    can't be modified or created by the remote user either.
+  - When waiting for a path, symbolic links will be followed.  Many other modules that manipulate files do not follow symbolic links,
+    so operations on the path using other modules may not work exactly as expected.
   - This module is also supported for Windows targets.
   - See also M(wait_for_connection)
 author:
@@ -489,9 +495,11 @@ def main():
         while datetime.datetime.utcnow() < end:
             if path:
                 try:
-                    f = open(path)
-                    f.close()
+                    if not os.access(path, os.F_OK):
+                        break
                 except IOError:
+                    break
+                except OSError:
                     break
             elif port:
                 try:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
wait_for

##### ANSIBLE VERSION
Based on: 8d5f4dda06d876a380f25afc2958f951544ff4ca
Originally discovered with:
```
ansible 2.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
open(path) throws an error when called on a directory or UNIX socket,
and therefore a check to ensure that the path is absent will always
succeed when there is a directory or file located there.

This updates the check to use os.access(path, os.F_OK) instead, which
instead just checks that the path exists instead of trying to open it as
a file, and therefore properly handles directories and sockets.

This causes a slight semantic change in how permissions are handled.
The existing code will fail to work correctly if the user running the
module on the managed host has no read access to the path specified.
The new code will work correctly in that situation.
Both versions fail if the user can't traverse the parent directory.

Fixes: #20870 

I've also added a check to the try block to catch OSError.  I've seen this call fail with an OSError on rare occasion in the face of odd extended permissions (usually MAC configuration) in cases where it should technically return False.  In such cases, the file is functionally inaccessible to the user making the call, so it's essentially not there, but it can't be created by them either.  This particular issue also technically affected the original code too, and should probably be documented somewhere.  I can make a pull request to add this to the documentation if desired.