### PR TITLE
Update loop docs to also describe register:'s value when inside loop.

### DIFF
--- a/docs/docsite/rst/playbooks_loops.rst
+++ b/docs/docsite/rst/playbooks_loops.rst
@@ -463,7 +463,7 @@ That's how!
 Using register with a loop
 ``````````````````````````
 
-When using ``register`` with a loop, the data structure placed in the variable will contain a ``results`` attribute that is a list of all responses from the module.
+After using ``register`` with a loop, the data structure placed in the variable will contain a ``results`` attribute that is a list of all responses from the module.
 
 Here is an example of using ``register`` with ``with_items``::
 
@@ -519,6 +519,15 @@ Subsequent loops over the registered variable to inspect the results may look li
         msg: "The command ({{ item.cmd }}) did not have a 0 return code"
       when: item.rc != 0
       with_items: "{{ echo.results }}"
+
+During iteration, the result of the current item will be placed in the variable:
+
+    - shell: echo "{{ item }}"
+      with_items:
+        - one
+        - two
+      register: echo
+      changed_when: echo.stdout != "one"
 
 
 


### PR DESCRIPTION
##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME
playbooks_loops.rst

##### ANSIBLE VERSION

```
2.1.1.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Currently says that when using a loop, the register: variable will contain a `results` list.

However this list-ified result happens _after_ the loop. During the loop, the register variable contains the results for that item.