### PR TITLE
win_scheduled_task, added hourly and interval options, update bug fix

### DIFF
--- a/lib/ansible/modules/windows/win_scheduled_task.py
+++ b/lib/ansible/modules/windows/win_scheduled_task.py
@@ -69,8 +69,12 @@ options:
   frequency:
     description:
       - The frequency of the command, not idempotent
+      - C(interval) added in Ansible 2.4
+      - C(hourly) added in Ansible 2.4
     choices:
       - once
+      - interval
+      - hourly
       - daily
       - weekly
   time:
@@ -79,6 +83,17 @@ options:
   days_of_week:
     description:
       - Days of the week to run a weekly task, not idempotent
+    required: false
+  interval:
+    description:
+      - When frequency is set to interval, time between executions, units are set by "interval_unit"
+    required: false
+    version_added: "2.4"
+  interval_unit:
+    description:
+      - Unit of time between interval, can be seconds, minutes, hours, days
+    default: minutes
+    version_added: "2.4"
   path:
     description:
       - Task folder in which this task will be stored - creates a non-existent path when C(state) is C(present),
@@ -99,4 +114,17 @@ EXAMPLES = r'''
     state: present
     enabled: yes
     user: SYSTEM
+
+# create an interval task to run every 12 minutes starting at 2pm
+- win_scheduled_task:
+    name: IntervalTask
+    execute: cmd
+    frequency: interval
+    interval: 12
+    time: 2pm
+    path: example
+    enable: yes
+    state: present
+    user: SYSTEM
+
 '''


### PR DESCRIPTION
- frequency can be set to "hourly" and "interval"
- hourly will execute once an hour
- interval lets user specify an interval between executions, user can
specify units of interval
- powershell script had some code that couldn't get executed, if ever got activated would have been missing the check to see if trigger changed

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
win_scheduled_task

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file =
  configured module search path = ['/Users/cheinzma/ansible-library', '/Users/cheinzma/Documents/ansible/lib/modules']
```

##### SUMMARY
Adding interval ability for windows scheduled tasks.  Added "hourly" and "interval" options for frequency, "interval" optional argument and "interval_unit" optional argument.

The "hourly" frequency option allows a task to be executed once an hour.  The time argument specifies when it should run, the next executions will happen once an hour.

The "interval" frequency option allows a task to be executed at a user-supplied interval.  The "interval" argument is the amount of time between executions, and the "interval_unit" is the units that number is in.  Supported units are "seconds", "minutes", "hours", and "days".  The powershell script checks to make sure that "interval_unit" is set to those four.

fixes issue #20056