### PR TITLE
ios_cli: fix load_config exec_command

### DIFF
--- a/lib/ansible/module_utils/ios_cli.py
+++ b/lib/ansible/module_utils/ios_cli.py
@@ -150,7 +150,7 @@ def load_config(module, commands):
     for command in to_list(commands):
         if command == 'end':
             continue
-        rc, out, err = module.exec_command(command)
+        rc, out, err = conn.exec_command(command)
         if rc != 0:
             module.fail_json(msg=err, command=command, rc=rc)
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ios_cli.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```

##### SUMMARY
fixes AttributeError: 'AnsibleModule' object has no attribute 'exec_command'
