### PR TITLE
apk: Fix regex search patterns

### DIFF
--- a/lib/ansible/modules/packaging/os/apk.py
+++ b/lib/ansible/modules/packaging/os/apk.py
@@ -136,7 +136,7 @@ def query_package(module, name):
 def query_latest(module, name):
     cmd = "%s version %s" % (APK_PATH, name)
     rc, stdout, stderr = module.run_command(cmd, check_rc=False)
-    search_pattern = "(%s)-[\d\.\w]+-[\d\w]+\s+(.)\s+[\d\.\w]+-[\d\w]+\s+" % (name)
+    search_pattern = r"(%s)-[\d\.\w]+-[\d\w]+\s+(.)\s+[\d\.\w]+-[\d\w]+\s+" % (re.escape(name))
     match = re.search(search_pattern, stdout)
     if match and match.group(2) == "<":
         return False
@@ -145,7 +145,7 @@ def query_latest(module, name):
 def query_virtual(module, name):
     cmd = "%s -v info --description %s" % (APK_PATH, name)
     rc, stdout, stderr = module.run_command(cmd, check_rc=False)
-    search_pattern = "^%s: virtual meta package" % (name)
+    search_pattern = r"^%s: virtual meta package" % (re.escape(name))
     if re.search(search_pattern, stdout):
         return True
     return False
@@ -167,7 +167,7 @@ def upgrade_packages(module):
     rc, stdout, stderr = module.run_command(cmd, check_rc=False)
     if rc != 0:
         module.fail_json(msg="failed to upgrade packages")
-    if re.search('^OK', stdout):
+    if re.search(r'^OK', stdout):
         module.exit_json(changed=False, msg="packages already upgraded")
     module.exit_json(changed=True, msg="upgraded packages")
 

--- a/test/units/modules/packaging/os/test_apk.py
+++ b/test/units/modules/packaging/os/test_apk.py
@@ -1,0 +1,31 @@
+from ansible.compat.tests import mock
+from ansible.compat.tests import unittest
+
+from ansible.modules.packaging.os import apk
+
+
+class TestApkQueryLatest(unittest.TestCase):
+
+    def setUp(self):
+        self.module_names = [
+            'bash',
+            'g++',
+        ]
+
+    @mock.patch('ansible.modules.packaging.os.apk.AnsibleModule')
+    def test_not_latest(self, mock_module):
+        apk.APK_PATH = ""
+        for module_name in self.module_names:
+            command_output = module_name + '-2.0.0-r1 < 3.0.0-r2 '
+            mock_module.run_command.return_value = (0, command_output, None)
+            command_result = apk.query_latest(mock_module, module_name)
+            self.assertFalse(command_result)
+
+    @mock.patch('ansible.modules.packaging.os.apk.AnsibleModule')
+    def test_latest(self, mock_module):
+        apk.APK_PATH = ""
+        for module_name in self.module_names:
+            command_output = module_name + '-2.0.0-r1 = 2.0.0-r1 '
+            mock_module.run_command.return_value = (0, command_output, None)
+            command_result = apk.query_latest(mock_module, module_name)
+            self.assertTrue(command_result)


### PR DESCRIPTION
Regex patterns were not being escaped properly so package names
containing characters that could be interpreted as regex symbols
were causing failures.

Fixes: #19714

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
apk

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Regex patterns were not being escaped properly so
package names containing regex symbols would fail.

Before:
```
failed: [default] (item=[u'g++']) => {
    "failed": true, 
    "invocation": {
        "module_name": "apk"
    }, 
    "item": [
        "g++"
    ], 
    "module_stderr": "Shared connection to 127.0.0.1 closed.\r\n", 
    "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_uZKdwM/ansible_module_apk.py\", line 272, in <module>\r\n    main()\r\n  File \"/tmp/ansible_uZKdwM/ansible_module_apk.py\", line 265, in main\r\n    install_packages(module, p['name'], p['state'])\r\n  File \"/tmp/ansible_uZKdwM/ansible_module_apk.py\", line 178, in install_packages\r\n    if query_virtual(module, name):\r\n  File \"/tmp/ansible_uZKdwM/ansible_module_apk.py\", line 147, in query_virtual\r\n    if re.search(search_pattern, stdout):\r\n  File \"/usr/lib/python2.7/re.py\", line 146, in search\r\n    return _compile(pattern, flags).search(string)\r\n  File \"/usr/lib/python2.7/re.py\", line 251, in _compile\r\n    raise error, v # invalid expression\r\nsre_constants.error: multiple repeat\r\n", 
    "msg": "MODULE FAILURE"
}
```

After:
```
changed: [default] => (item=[u'g++']) => {
    "changed": true, 
    "invocation": {
        "module_args": {
            "name": [
                "g++"
            ], 
            "state": "present", 
            "update_cache": false, 
            "upgrade": false
        }, 
        "module_name": "apk"
    }, 
    "item": [
        "g++"
    ], 
    "msg": "installed g++ package(s)"
}
```