### PR TITLE
Adding modules to manage Cloudera Manager cluster.  http://www.cloudera.com/

### DIFF
--- a/lib/ansible/module_utils/cloudera.py
+++ b/lib/ansible/module_utils/cloudera.py
@@ -146,8 +146,10 @@ class Cloudera(object):
 
 ### Reverses dict { key:value } to { value:key }
     def reversed_dictionary(self, dictionary):
-        dictionary = { value:key for key,value in dictionary.items() }
-        return dictionary
+        rev = {}
+        for item in dictionary.iteritems():
+          rev[item[1]] = item[0]
+        return rev
 
 ### Removes specific keys from dict
     def filter_dictionary(self, dictionary, keys):

--- a/lib/ansible/module_utils/cloudera.py
+++ b/lib/ansible/module_utils/cloudera.py
@@ -34,8 +34,8 @@ except ImportError:
 class Cloudera(object):
     def __init__(self, module, host, port, username, password, api_version, use_tls):
         self.module = module
-        self.host = hos
-        self.port = por
+        self.host = host
+        self.port = port
         self.username = username
         self.password = password
         self.api_version = api_version

--- a/lib/ansible/module_utils/cloudera.py
+++ b/lib/ansible/module_utils/cloudera.py
@@ -1,0 +1,175 @@
+#
+# (c) 2017 Serghei Anicheev, <serghei.anicheev@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import json
+import os
+from time import sleep
+
+try:
+    from cm_api.endpoints.cms import *
+    from cm_api.endpoints.clusters import *
+    from cm_api.endpoints.services import *
+    from cm_api.endpoints.types import *
+    from cm_api.api_client import *
+    python_cm_installed = True
+except ImportError:
+    python_cm_installed = False
+
+class Cloudera(object):
+    def __init__(self, module, host, port, username, password, api_version, use_tls):
+        self.module = module
+        self.host = host
+        self.port = port
+        self.username = username
+        self.password = password
+        self.api_version = api_version
+        self.use_tls = use_tls
+
+### Checks if service type available
+    def validate_service_type(self, cluster_obj, service_type):
+        if service_type not in cluster_obj.get_service_types():
+            raise Exception('Not valid service type - %s' % service_type)
+
+### Checks if role type available
+    def validate_role_type(self, service_obj, role_type):
+        if role_type not in service_obj.get_role_types():
+            raise Exception('Not valid role type - %s' % role_type)
+
+### Reads configuration file specified by config_path and returns its content.
+### File should be in JSON format.
+    def load_config(self, config_path):
+        config_content = None
+        if os.path.exists(config_path):
+            fd = open(config_path, 'r')
+            config_content = json.load(fd)
+            fd.close()
+        else:
+            self.module.log('No such configuration file -  %s or there are no read permissions' % config_path)
+        return config_content
+
+### Checks if existing config is up-to-date
+    def update_config(self, obj, current_config, config_path):
+        updated_config = self.load_config(config_path)
+        updated = False
+        if updated_config is not None:
+            if all(prop in current_config.items() for prop in updated_config.items()):
+                self.module.log('Already have up-to-date config. Nothing to do')
+            else:
+                obj.update_config(updated_config)
+                updated = True
+        return updated
+
+### Returns license info
+    def license_state(self, cm):
+        license = None
+        try:
+            license = cm.get_license()
+        except Exception:
+            self.module.log('Cloudera Manager is in express state!')
+        return license
+
+### Returns connection object
+    def connect(self):
+        connection = ApiResource(
+            self.host, server_port = self.port, username = self.username, password = self.password,
+            use_tls = self.use_tls, version = self.api_version
+        )
+        return connection
+
+### Returns instance of cloudera manager
+    def cloudera_manager(self, connection):
+        cm = connection.get_cloudera_manager()
+        return cm
+
+### Returns cluster object
+    def get_cluster(self, connection, cluster_name):
+        cluster = None
+        try:
+            cluster = connection.get_cluster(cluster_name)
+        except Exception:
+            self.module.log('No cluster found with name - %s' % cluster_name)
+        return cluster
+
+### Returns service object if found.
+    def get_service_by_type(self, obj, service_type):
+        all_services = obj.get_all_services()
+        service_info = filter(lambda svc: svc.type == service_type, all_services)
+        if len(service_info) == 0:
+            raise Exception('No service found with type - %s' % service_type)
+        return service_info[0]
+
+### Return list of host_ids for specific role_type
+    def get_hostid_by_role_type(self, service_obj, role_type):
+        role_objects_list = service_obj.get_roles_by_type(role_type)
+        if len(role_objects_list) == 0:
+            raise 'No existing role types found!'
+        host_ids = map(lambda role_obj: role_obj.hostRef.hostId, role_objects_list)
+        return host_ids
+
+### Return host_id for specific hostname
+    def get_hostid_by_hostname(self, connection, hostname):
+        try:
+            host_id = connection.get_host(hostname).hostId
+        except Exception:
+            raise Exception('No host found for hostname - %s' % hostname)
+        return host_id
+
+### Returnds dict of all provisioned hosts in form : { hostId : hostname }
+    def get_hostid_hostname_mapping(self, connection):
+        existing_host_ids = connection.get_all_hosts()
+        mapping = {}
+        for host_id in existing_host_ids:
+            mapping[host_id.hostId] = host_id.hostname
+        return mapping
+
+### Returns host_ids of all hosts in cluster
+    def list_cluster_member_ids(self, cluster_obj):
+        cluster_members = cluster_obj.list_hosts()
+        host_ids = map(lambda host_ref: host_ref.hostId, cluster_members)
+        return host_ids
+
+### Reverses dict { key:value } to { value:key }
+    def reversed_dictionary(self, dictionary):
+        dictionary = { value:key for key,value in dictionary.items() }
+        return dictionary
+
+### Removes specific keys from dict
+    def filter_dictionary(self, dictionary, keys):
+        filtered = filter(lambda key: dictionary.pop(key, None), keys) 
+        return filtered
+
+### 
+    def installed_hosts_globally(self, connection, hostnames):
+        mapping = self.get_hostid_hostname_mapping(connection)
+        reversed_mapping = self.reversed_dictionary(mapping)
+        installed_hosts = filter(lambda hostname: reversed_mapping.pop(hostname, None), hostnames)
+        return installed_hosts
+
+### Returns host_ids which is provisioned but not in the cluster    
+    def installed_hosts_not_in_cluster(self, connection, cluster_obj):
+        mapping = self.get_hostid_hostname_mapping(connection)
+        host_ids = self.list_cluster_member_ids(cluster_obj)
+        for host_id in host_ids:
+            mapping.pop(host_id, None)
+        return mapping
+
+### Returns service setup info
+    def get_service_setup_info(self, service_name, service_type):
+        service_info = ApiServiceSetupInfo(name=service_name, type=service_type)
+        return service_info

--- a/lib/ansible/module_utils/cloudera.py
+++ b/lib/ansible/module_utils/cloudera.py
@@ -34,8 +34,8 @@ except ImportError:
 class Cloudera(object):
     def __init__(self, module, host, port, username, password, api_version, use_tls):
         self.module = module
-        self.host = host
-        self.port = port
+        self.host = hos
+        self.port = por
         self.username = username
         self.password = password
         self.api_version = api_version
@@ -61,7 +61,7 @@ class Cloudera(object):
             fd.close()
         else:
             self.module.log('No such configuration file -  %s or there are no read permissions' % config_path)
-        return config_content
+        return config_conten
 
 ### Checks if existing config is up-to-date
     def update_config(self, obj, current_config, config_path):
@@ -84,7 +84,7 @@ class Cloudera(object):
             self.module.log('Cloudera Manager is in express state!')
         return license
 
-### Returns connection object
+### Returns connection objec
     def connect(self):
         connection = ApiResource(
             self.host, server_port = self.port, username = self.username, password = self.password,
@@ -97,7 +97,7 @@ class Cloudera(object):
         cm = connection.get_cloudera_manager()
         return cm
 
-### Returns cluster object
+### Returns cluster objec
     def get_cluster(self, connection, cluster_name):
         cluster = None
         try:
@@ -148,22 +148,22 @@ class Cloudera(object):
     def reversed_dictionary(self, dictionary):
         rev = {}
         for key, value in dictionary.items():
-          rev[value] = key
+            rev[value] = key
         return rev
 
-### Removes specific keys from dict
+### Removes specific keys from dic
     def filter_dictionary(self, dictionary, keys):
-        filtered = filter(lambda key: dictionary.pop(key, None), keys) 
+        filtered = filter(lambda key: dictionary.pop(key, None), keys)
         return filtered
 
-### 
+###
     def installed_hosts_globally(self, connection, hostnames):
         mapping = self.get_hostid_hostname_mapping(connection)
         reversed_mapping = self.reversed_dictionary(mapping)
         installed_hosts = filter(lambda hostname: reversed_mapping.pop(hostname, None), hostnames)
         return installed_hosts
 
-### Returns host_ids which is provisioned but not in the cluster    
+### Returns host_ids which is provisioned but not in the cluster
     def installed_hosts_not_in_cluster(self, connection, cluster_obj):
         mapping = self.get_hostid_hostname_mapping(connection)
         host_ids = self.list_cluster_member_ids(cluster_obj)

--- a/lib/ansible/module_utils/cloudera.py
+++ b/lib/ansible/module_utils/cloudera.py
@@ -147,8 +147,8 @@ class Cloudera(object):
 ### Reverses dict { key:value } to { value:key }
     def reversed_dictionary(self, dictionary):
         rev = {}
-        for item in dictionary.iteritems():
-          rev[item[1]] = item[0]
+        for key, value in dictionary.items():
+          rev[value] = key
         return rev
 
 ### Removes specific keys from dict

--- a/lib/ansible/module_utils/cloudera.py
+++ b/lib/ansible/module_utils/cloudera.py
@@ -156,7 +156,7 @@ class Cloudera(object):
         filtered = filter(lambda key: dictionary.pop(key, None), keys)
         return filtered
 
-###
+####
     def installed_hosts_globally(self, connection, hostnames):
         mapping = self.get_hostid_hostname_mapping(connection)
         reversed_mapping = self.reversed_dictionary(mapping)

--- a/lib/ansible/modules/clustering/cloudera/cloudera_cluster.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_cluster.py
@@ -1,0 +1,156 @@
+#!/usr/bin/python
+#
+# (c) 2017, Serghei Anicheev <serghei.anicheev@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+DOCUMENTATION = '''
+---
+module: cloudera_cluster
+author: "Serghei Anicheev (@sanicheev) <serghei.anicheev@gmail.com>"
+version_added: '2.2.0.2'
+short_description: Manage Cloudera cluster.
+description:
+    - This module can create/delete Cloudera cluster.
+options:
+    host:
+        description:
+            - Cloudera Manager API host.
+        required: true
+    port:
+        description:
+            - Cloudera Manager API port.
+        required: false
+        default: 7180
+    username:
+        description:
+            - Username to connect to Cloudera Manager API.
+        required: false
+        default: admin
+    password:
+        description:
+            - Password to connect to Cloudera Manager API.
+        required: false
+        default: admin
+    api_version:
+        description:
+            - Cloudera API version(Older API versions cannot use calls like 'configure_for_kerberos' for example).
+        required: false
+        default: 12
+    cdh_version:
+        description:
+            - CDH version to use
+        required: false
+        default: CDH5
+    use_tls:
+        description:
+            - Enable TLS(In this case port 7183 should be used!).
+        required: false
+        default: false
+    cluster_name:
+        description:
+            - Cloudera cluster name to use.
+        required: true
+    state:
+        description:
+          - The desired action to perform with the cluster.
+        required: false
+        default: create
+        choices: ['create', 'delete']
+'''
+
+EXAMPLES = '''
+# Create Cloudera cluster
+- name: Create Cloudera cluster
+  cloudera_cluster:
+    host: 123.123.123.123
+    username: admin
+    password: admin
+    cluster_name: MyCluster
+    state: create
+
+# Delete Cloudera cluster
+- name: Delete Cloudera cluster
+  cloudera_cluster:
+    host: 123.123.123.123
+    username: admin
+    password: admin
+    cluster_name: MyCluster
+    state: delete
+'''
+
+def create_cluster(connection, cluster_name, cdh_version):
+    connection.create_cluster(cluster_name, version=cdh_version).wait()
+
+def delete_cluster(connection, cluster_name):
+    connection.delete_cluster(cluster_name).wait()
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            host=dict(required=True, type='str'),
+            port=dict(default=7180, type='int'),
+            username=dict(default='admin', type='str'),
+            password=dict(default='admin', no_log=True, type='str'),
+            api_version=dict(default=12, type='int'),
+            cdh_version=dict(default='CDH5', type='str'),
+            use_tls=dict(default=False, type='bool'),
+            cluster_name=dict(required=True, type='str'),
+            state=dict(default='create', choices=['create', 'delete'])
+        ),
+        supports_check_mode=True
+    )
+
+    host = module.params['host']
+    port = module.params['port']
+    username = module.params['username']
+    password = module.params['password']
+    api_version = module.params['api_version']
+    cdh_version = module.params['cdh_version']
+    use_tls = module.params['use_tls']
+    cluster_name = module.params['cluster_name']
+    state = module.params['state']
+    changed=False
+
+    if module.check_mode:
+        module.exit_json(changed=True)
+
+    cloudera = Cloudera(module, host, port, username, password, api_version, use_tls)
+    connection = cloudera.connect()
+    cluster = cloudera.get_cluster(connection, cluster_name)
+
+    if state == 'create':
+        if cluster:
+            module.log('Cluster with name - %s already exists! Nothing to do!' % cluster_name)
+            changed = False
+        else:
+            create_cluster(connection, cluster_name, cdh_version)
+            changed = True
+    elif state == 'delete':
+        if cluster:
+            delete_cluster(connection, cluster_name).wait()
+            changed = True
+        else:
+            module.log('Cluster with name - %s does not exists! Nothing to do!' % cluster_name)
+            changed = False
+
+    module.exit_json(changed=changed)
+
+if __name__ == '__main__':
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.cloudera import *
+    main()

--- a/lib/ansible/modules/clustering/cloudera/cloudera_cluster.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_cluster.py
@@ -17,6 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
 
 DOCUMENTATION = '''
 ---

--- a/lib/ansible/modules/clustering/cloudera/cloudera_hdfs_ha.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_hdfs_ha.py
@@ -66,34 +66,34 @@ options:
         required: true
     standby_host_role_type:
         description:
-            - Role type in HDFS service. It will be used to find host ID where this role has been applied. Default is : SECONDARYNAMENODE.      
+            - Role type in HDFS service. It will be used to find host ID where this role has been applied. Default is : SECONDARYNAMENODE.
         required: false
         default: SECONDARYNAMENODE
     nameservice:
         description:
             - Nameservice for HDFS HA
         required: false
-        default: HDFS-HA-NAMESERVICE    
+        default: HDFS-HA-NAMESERVICE
     jns:
         description:
             - Journal node list:
-            - { 'journal_role_name': 'JOURNALNODE1', 'host': "123.123.123.124" } 
+            - { 'journal_role_name': 'JOURNALNODE1', 'host': "123.123.123.124" }
             - { 'journal_role_name': 'JOURNALNODE2', 'host': "123.123.123.125" }
             - { 'journal_role_name': 'JOURNALNODE3', 'host': "123.123.123.126" }
             - In this example 'journal_role_name' - role name which will be used when creating JOURNALNODE role type on specific host.
             - 'host' is a hostname where journal role will be applied. This 'host' MUST BE in cluster.
-        required: true    
+        required: true
     standby_role_name:
         description:
             - Role name to use for NAMENODE-STANDBY role type.
         required: false
-        default: NAMENODE-STANDBY    
+        default: NAMENODE-STANDBY
     state:
         description:
             - Enable HDFS HA state.
         required: false
         default: 'enable_hdfs_ha'
-        choices: ['enable_hdfs_ha']        
+        choices: ['enable_hdfs_ha']
 '''
 
 EXAMPLES = '''
@@ -129,7 +129,10 @@ def enable_hdfs_ha(cloudera, connection, cluster_name, active_role_name, standby
     standby_host_id = cloudera.get_hostid_by_role_type(service, standby_host_role_type)[0]
     zookeeper_service_name = cloudera.get_service_by_type(cluster, 'ZOOKEEPER').name
     journal_nodes_info = compose_journal_nodes_info(cloudera, connection, jns)
-    service.enable_nn_ha(active_name=active_role_name, standby_host_id=standby_host_id, nameservice=nameservice, jns=journal_nodes_info, standby_name=standby_role_name, zk_service_name=zookeeper_service_name).wait()
+    service.enable_nn_ha(
+        active_name=active_role_name, standby_host_id=standby_host_id, nameservice=nameservice, jns=journal_nodes_info,
+        standby_name=standby_role_name, zk_service_name=zookeeper_service_name
+    ).wait()
     return True
 
 def main():

--- a/lib/ansible/modules/clustering/cloudera/cloudera_hdfs_ha.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_hdfs_ha.py
@@ -17,6 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
 
 DOCUMENTATION = '''
 ---
@@ -58,7 +61,7 @@ options:
         default: false
     cluster_name:
         description:
-            - Cloudera cluster name to search for HDFS service type in.  .
+            - Cloudera cluster name to search for HDFS service type in.
         required: true
     active_role_name:
         description:
@@ -66,7 +69,7 @@ options:
         required: true
     standby_host_role_type:
         description:
-            - Role type in HDFS service. It will be used to find host ID where this role has been applied. Default is : SECONDARYNAMENODE.
+            - Role type in HDFS service. It will be used to find host ID where this role has been applied. Default is SECONDARYNAMENODE.
         required: false
         default: SECONDARYNAMENODE
     nameservice:
@@ -76,12 +79,9 @@ options:
         default: HDFS-HA-NAMESERVICE
     jns:
         description:
-            - Journal node list:
-            - { 'journal_role_name': 'JOURNALNODE1', 'host': "123.123.123.124" }
-            - { 'journal_role_name': 'JOURNALNODE2', 'host': "123.123.123.125" }
-            - { 'journal_role_name': 'JOURNALNODE3', 'host': "123.123.123.126" }
-            - In this example 'journal_role_name' - role name which will be used when creating JOURNALNODE role type on specific host.
-            - 'host' is a hostname where journal role will be applied. This 'host' MUST BE in cluster.
+            - Journal node list.
+              'journal_role_name' - role name which will be used when creating JOURNALNODE role type on specific host.
+              'host' is a hostname where journal role will be applied. This 'host' MUST BE in cluster.
         required: true
     standby_role_name:
         description:

--- a/lib/ansible/modules/clustering/cloudera/cloudera_hdfs_ha.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_hdfs_ha.py
@@ -1,0 +1,184 @@
+#!/usr/bin/python
+#
+# (c) 2017, Serghei Anicheev <serghei.anicheev@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+DOCUMENTATION = '''
+---
+module: cloudera_hdfs_ha
+author: "Serghei Anicheev (@sanicheev) <serghei.anicheev@gmail.com>"
+version_added: '2.2.0.2'
+short_description: Cloudera Manager enable HA for HDFS.
+description:
+    - This module will enable HA for HDFS. Please take in consideration that ZOOKEEPER service should be up and running!
+options:
+    host:
+        description:
+            - Cloudera Manager API host.
+        required: true
+    port:
+        description:
+            - Cloudera Manager API port.
+        required: false
+        default: 7180
+    username:
+        description:
+            - Username to connect to Cloudera Manager API.
+        required: false
+        default: admin
+    password:
+        description:
+            - Password to connect to Cloudera Manager API.
+        required: false
+        default: admin
+    api_version:
+        description:
+            - Cloudera API version(Older API versions cannot use calls like 'configure_for_kerberos' for example).
+        required: false
+        default: 12
+    use_tls:
+        description:
+            - Enable TLS(In this case port 7183 should be used!).
+        required: false
+        default: false
+    cluster_name:
+        description:
+            - Cloudera cluster name to search for HDFS service type in.  .
+        required: true
+    active_role_name:
+        description:
+            - Role name of currently existing NAMENODE type.
+        required: true
+    standby_host_role_type:
+        description:
+            - Role type in HDFS service. It will be used to find host ID where this role has been applied. Default is : SECONDARYNAMENODE.      
+        required: false
+        default: SECONDARYNAMENODE
+    nameservice:
+        description:
+            - Nameservice for HDFS HA
+        required: false
+        default: HDFS-HA-NAMESERVICE    
+    jns:
+        description:
+            - Journal node list:
+            - { 'journal_role_name': 'JOURNALNODE1', 'host': "123.123.123.124" } 
+            - { 'journal_role_name': 'JOURNALNODE2', 'host': "123.123.123.125" }
+            - { 'journal_role_name': 'JOURNALNODE3', 'host': "123.123.123.126" }
+            - In this example 'journal_role_name' - role name which will be used when creating JOURNALNODE role type on specific host.
+            - 'host' is a hostname where journal role will be applied. This 'host' MUST BE in cluster.
+        required: true    
+    standby_role_name:
+        description:
+            - Role name to use for NAMENODE-STANDBY role type.
+        required: false
+        default: NAMENODE-STANDBY    
+    state:
+        description:
+            - Enable HDFS HA state.
+        required: false
+        default: 'enable_hdfs_ha'
+        choices: ['enable_hdfs_ha']        
+'''
+
+EXAMPLES = '''
+# Enable HDFS HA
+- name: Enable HDFS HA
+  cloudera_hdfs_ha:
+    host: 123.123.123.123
+    port: 7180
+    username: admin
+    password: admin
+    cluster_name: MyCluster
+    active_role_name: "NAMENODE"
+    standby_host_role_type: "SECONDARYNAMENODE"
+    nameservice: "HDFS-HA-NAMESERVICE"
+    jns:
+      - { 'journal_role_name': 'JOURNALNODE1', 'host': "123.123.123.124" }
+      - { 'journal_role_name': 'JOURNALNODE2', 'host': "123.123.123.125" }
+      - { 'journal_role_name': 'JOURNALNODE3', 'host': "123.123.123.126" }
+    standby_role_name: "NAMENODE-STANDBY"
+    state: "enable_hdfs_ha"
+'''
+def compose_journal_nodes_info(cloudera, connection, jns):
+    journal_nodes_info = []
+    for journal_node in jns:
+        host_id = cloudera.get_hostid_by_hostname(connection, journal_node['host'])
+        entry = { 'jnHostId': host_id, 'jnName': journal_node['journal_role_name'] }
+        journal_nodes_info.append(entry)
+    return journal_nodes_info
+
+def enable_hdfs_ha(cloudera, connection, cluster_name, active_role_name, standby_host_role_type, nameservice, jns, standby_role_name):
+    cluster = connection.get_cluster(cluster_name)
+    service = cloudera.get_service_by_type(cluster, 'HDFS')
+    standby_host_id = cloudera.get_hostid_by_role_type(service, standby_host_role_type)[0]
+    zookeeper_service_name = cloudera.get_service_by_type(cluster, 'ZOOKEEPER').name
+    journal_nodes_info = compose_journal_nodes_info(cloudera, connection, jns)
+    service.enable_nn_ha(active_name=active_role_name, standby_host_id=standby_host_id, nameservice=nameservice, jns=journal_nodes_info, standby_name=standby_role_name, zk_service_name=zookeeper_service_name).wait()
+    return True
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            host=dict(required=True, type='str'),
+            port=dict(default=7180, type='int'),
+            username=dict(default='admin', type='str'),
+            password=dict(default='admin', no_log=True, type='str'),
+            api_version=dict(default=12, type='int'),
+            use_tls=dict(default=False, type='bool'),
+            cluster_name=dict(required=True, type='str'),
+            active_role_name=dict(default='NAMENODE', type='str'),
+            standby_host_role_type=dict(default='SECONDARYNAMENODE', type='str'),
+            nameservice=dict(default='HDFS-HA-NAMESERVICE', type='str'),
+            jns=dict(default=None, type='list'),
+            standby_role_name=dict(default='NAMENODE-STANDBY', type='str'),
+            state=dict(default='enable_hdfs_ha', choices=['enable_hdfs_ha'])
+        ),
+        supports_check_mode=True
+    )
+
+    host = module.params['host']
+    port = module.params['port']
+    username = module.params['username']
+    password = module.params['password']
+    api_version = module.params['api_version']
+    use_tls = module.params['use_tls']
+    cluster_name = module.params['cluster_name']
+    active_role_name = module.params['active_role_name']
+    standby_host_role_type = module.params['standby_host_role_type']
+    nameservice = module.params['nameservice']
+    jns = module.params['jns']
+    standby_role_name = module.params['standby_role_name']
+    state = module.params['state']
+    changed=False
+
+    cloudera = Cloudera(module, host, port, username, password, api_version, use_tls)
+    connection = cloudera.connect()
+
+    if module.check_mode:
+        module.exit_json(changed=True)
+
+    if state == 'enable_hdfs_ha':
+        changed = enable_hdfs_ha(cloudera, connection, cluster_name, active_role_name, standby_host_role_type, nameservice, jns, standby_role_name)
+
+    module.exit_json(changed=changed)
+
+if __name__ == '__main__':
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.cloudera import *
+    main()

--- a/lib/ansible/modules/clustering/cloudera/cloudera_host.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_host.py
@@ -1,0 +1,206 @@
+#!/usr/bin/python
+#
+# (c) 2017, Serghei Anicheev <serghei.anicheev@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+DOCUMENTATION = '''
+---
+module: cloudera_host
+author: "Serghei Anicheev (@sanicheev) <serghei.anicheev@gmail.com>"
+version_added: '2.2.0.2'
+short_description: Module for Cloudera Manager hosts.
+description:
+    - This module can be used to provision hosts or adding them to cluster.
+options:
+    host:
+        description:
+            - Cloudera Manager API host.
+        required: true
+    port:
+        description:
+            - Cloudera Manager API port.
+        required: false
+        default: 7180
+    username:
+        description:
+            - Username to connect to Cloudera Manager API.
+        required: false
+        default: admin
+    password:
+        description:
+            - Password to connect to Cloudera Manager API.
+        required: false
+        default: admin
+    api_version:
+        description:
+            - Cloudera API version(Older API versions cannot use calls like 'configure_for_kerberos' for example).
+        required: false
+        default: 12
+    use_tls:
+        description:
+            - Enable TLS(In this case port 7183 should be used!).
+        required: false
+        default: false
+    cluster_name:
+        description:
+            - Cloudera cluster name to use. This parameter should be present during 'add_to_cluster' state.
+        default: None    .
+        required: false
+    host_username:
+        description:
+            - Username to use for connection from Cloudera Manager to agent node during 'install'.
+        required: false
+        default: root
+    private_key:
+        description:
+            - Private ssh key to use for connection from Cloudera Manager to agent node during 'install'.
+        required: false
+        default: /var/lib/cloudera-scm-server/.ssh/id_rsa
+    cm_repo_url:
+        description:
+            - Repo URL to use for the package installation
+        required: false
+        default: http://archive.cloudera.com/cm5/redhat/7/x86_64/cm/5/
+    gpg_key_custom_url:
+        description:
+            - GPG key URL to validate package signatures
+        required: false
+        default: https://archive.cloudera.com/cm5/redhat/7/x86_64/cm/RPM-GPG-KEY-cloudera
+    hostnames:
+        description:
+            - List of hostnames to install or add to cluster.
+        required: true
+    state:
+        description:
+            - The desired action to take upon selected hosts. You can provision them using 'install' state or add to cluster using 'add_to_cluster state'.
+        required: false
+        default: install
+        choices: ['install', 'add_to_cluster']
+'''
+
+EXAMPLES = '''
+# Install new hosts.
+- name: Install new hosts
+  cloudera_host:
+    host: 123.123.123.123
+    username: admin
+    password: admin
+    private_key: /home/deploy/.ssh/id_rsa
+    host_names:
+      - host1
+      - host2
+    state: install
+
+# Add hosts to cluster
+- name: Add hosts into cluster
+  cloudera_host:
+    host: 123.123.123.123
+    username: admin
+    password: admin
+    cluster_name: MyCluster
+    host_names:
+      - host1
+      - host2
+    state: add_to_cluster
+'''
+from time import sleep
+
+def install_hosts(cloudera, connection, host_username, private_key, cm_repo_url, gpg_key_custom_url, hostnames):
+    installed_hosts = cloudera.installed_hosts_globally(connection, hostnames)
+    hosts_to_install = list(set(hostnames).difference(set(installed_hosts)))
+    cloudera_manager = cloudera.cloudera_manager(connection)
+    changed = False
+    if len(hosts_to_install) != 0:
+        status = cloudera_manager.host_install(
+            host_username, hosts_to_install, private_key=private_key, cm_repo_url=cm_repo_url,
+            gpg_key_custom_url=gpg_key_custom_url
+        )
+        while status.success == None:
+          sleep(5)
+          status = status.fetch()
+        if status.success != True:
+            raise Exception('Host install failed with error: ' + cmd.resultMessage)
+        changed = True
+    return changed
+
+def add_hosts_to_cluster(module, cloudera, connection, cluster_name, hostnames):
+    cluster = cloudera.get_cluster(connection, cluster_name)
+    installed_hosts_not_in_cluster = cloudera.installed_hosts_not_in_cluster(connection, cluster).values()
+    changed = False
+    if len(installed_hosts_not_in_cluster) == 0:
+        module.log('No available hosts to add into cluster - %s!' % cluster_name)
+    else:
+        missing_hosts = list(set(installed_hosts_not_in_cluster).intersection(set(hostnames)))
+        if len(missing_hosts) != 0:
+            cluster.add_hosts(missing_hosts)
+        else:
+            raise Exception('Hosts - %s you are trying to add have not been installed yet!' % hostnames)
+        changed = True
+    return changed
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            host=dict(required=True, type='str'),
+            port=dict(default=7180, type='int'),
+            username=dict(default='admin', type='str'),
+            password=dict(default='admin', no_log=True, type='str'),
+            api_version=dict(default=12, type='int'),
+            use_tls=dict(default=False, type='bool'),
+            cluster_name=dict(default=None, type='str', required=False),
+            host_username=dict(default='root', type='str'),
+            private_key=dict(default='/var/lib/cloudera-scm-server/.ssh/id_rsa', type='path'),
+            cm_repo_url=dict(default='http://archive.cloudera.com/cm5/redhat/7/x86_64/cm/5/', type='str'),
+            gpg_key_custom_url=dict(default='https://archive.cloudera.com/cm5/redhat/7/x86_64/cm/RPM-GPG-KEY-cloudera', type='str'),
+            hostnames=dict(required=True, type='list'),
+            state=dict(default='install', choices=['install', 'add_to_cluster'])
+        ),
+        supports_check_mode=True
+    )
+
+    host = module.params['host']
+    port = module.params['port']
+    username = module.params['username']
+    password = module.params['password']
+    api_version = module.params['api_version']
+    use_tls = module.params['use_tls']
+    cluster_name = module.params['cluster_name']
+    host_username = module.params['host_username']
+    private_key = module.params['private_key']
+    cm_repo_url = module.params['cm_repo_url']
+    gpg_key_custom_url = module.params['gpg_key_custom_url']
+    hostnames = module.params['hostnames']
+    state = module.params['state']
+    changed=False
+
+    if module.check_mode:
+        module.exit_json(changed=True)
+
+    cloudera = Cloudera(module, host, port, username, password, api_version, use_tls)
+    connection = cloudera.connect()
+    if state == 'install':
+        changed = install_hosts(cloudera, connection, host_username, private_key, cm_repo_url, gpg_key_custom_url, hostnames)
+    if state == 'add_to_cluster' and cluster_name:
+        changed = add_hosts_to_cluster(module, cloudera, connection, cluster_name, hostnames)
+
+    module.exit_json(changed=changed)
+
+if __name__ == '__main__':
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.cloudera import *
+    main()

--- a/lib/ansible/modules/clustering/cloudera/cloudera_host.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_host.py
@@ -17,6 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
 
 DOCUMENTATION = '''
 ---

--- a/lib/ansible/modules/clustering/cloudera/cloudera_host.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_host.py
@@ -20,7 +20,7 @@
 
 DOCUMENTATION = '''
 ---
-module: cloudera_host
+module: cloudera_hos
 author: "Serghei Anicheev (@sanicheev) <serghei.anicheev@gmail.com>"
 version_added: '2.2.0.2'
 short_description: Module for Cloudera Manager hosts.
@@ -65,7 +65,7 @@ options:
         description:
             - Username to use for connection from Cloudera Manager to agent node during 'install'.
         required: false
-        default: root
+        default: roo
     private_key:
         description:
             - Private ssh key to use for connection from Cloudera Manager to agent node during 'install'.
@@ -130,10 +130,10 @@ def install_hosts(cloudera, connection, host_username, private_key, cm_repo_url,
             host_username, hosts_to_install, private_key=private_key, cm_repo_url=cm_repo_url,
             gpg_key_custom_url=gpg_key_custom_url
         )
-        while status.success == None:
-          sleep(5)
-          status = status.fetch()
-        if status.success != True:
+        while status.success is None:
+            sleep(5)
+            status = status.fetch()
+        if status.success is not True:
             raise Exception('Host install failed with error: ' + cmd.resultMessage)
         changed = True
     return changed

--- a/lib/ansible/modules/clustering/cloudera/cloudera_kerberos.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_kerberos.py
@@ -1,0 +1,151 @@
+#!/usr/bin/python
+#
+# (c) 2017, Serghei Anicheev <serghei.anicheev@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+DOCUMENTATION = '''
+---
+module: cloudera_kerberos
+author: "Serghei Anicheev (@sanicheev) <serghei.anicheev@gmail.com>"
+version_added: '2.2.0.2'
+short_description: Cloudera Manager configure kerberos.
+description:
+    - This module is used to configure all services to use kerberos.
+options:
+    host:
+        description:
+            - Cloudera Manager API host.
+        required: true
+    port:
+        description:
+            - Cloudera Manager API port.
+        required: false
+        default: 7180
+    username:
+        description:
+            - Username to connect to Cloudera Manager API.
+        required: false
+        default: admin
+    password:
+        description:
+            - Password to connect to Cloudera Manager API.
+        required: false
+        default: admin
+    api_version:
+        description:
+            - Cloudera API version(Older API versions cannot use calls like 'configure_for_kerberos' for example).
+        required: false
+        default: 12
+    use_tls:
+        description:
+            - Enable TLS(In this case port 7183 should be used!).
+        required: false
+        default: false
+    cluster_name:
+        description:
+            - Cloudera cluster name to kerberize services in.
+        default: MyCluster    .
+        required: false
+    kdc_user:
+        description:
+            - Username to use during generation of admin principal
+        required: false
+        default: Administrator
+    kdc_password:
+        description:
+            - Password to use during generation of admin principal
+        required: true    
+    state:
+        description:
+            - Kerberize services in cluster.
+        required: false
+        default: 'kerberize'
+        choices: ['kerberize']        
+'''
+
+EXAMPLES = '''
+# Prepare all services in cluster for kerberos
+- name: Kerberize all services in the cluster
+  cloudera_kerberos:
+    host: 123.123.123.123
+    username: admin
+    password: admin
+    cluster_name: MyCluster
+    kdc_user: Administrator@MY.REALM
+    kdc_password: secret
+    state: "kerberize"
+'''
+
+def kerberize(cloudera, connection, cluster_name, kdc_user, kdc_password):
+    cluster = connection.get_cluster(cluster_name)
+    cloudera_manager = connection.get_cloudera_manager()
+    cloudera_manager_service = cloudera_manager.get_service()
+    cluster.stop().wait()
+    cloudera_manager_service.stop().wait()
+    cloudera_manager.import_admin_credentials(kdc_user, kdc_password).wait()
+    cluster.configure_for_kerberos().wait()
+    cluster.deploy_client_config().wait()
+    cluster.deploy_cluster_client_config().wait()
+    cloudera_manager_service.start().wait()
+    cluster.start().wait()
+    return True
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            host=dict(required=True, type='str'),
+            port=dict(default=7180, type='int'),
+            username=dict(default='admin', type='str'),
+            password=dict(default='admin', no_log=True, type='str'),
+            api_version=dict(default=12, type='int'),
+            use_tls=dict(default=False, type='bool'),
+            cluster_name=dict(required=True, type='str'),
+            kdc_user=dict(default='Administrator', required=False, type='str'),
+            kdc_password=dict(required=True, no_log=True, type='str'),
+            state=dict(default='kerberize', choices=['kerberize'])
+        ),
+        supports_check_mode=True
+    )
+
+    host = module.params['host']
+    port = module.params['port']
+    username = module.params['username']
+    password = module.params['password']
+    api_version = module.params['api_version']
+    use_tls = module.params['use_tls']
+    cluster_name = module.params['cluster_name']
+    kdc_user = module.params['kdc_user']
+    kdc_password = module.params['kdc_password']
+    state = module.params['state']
+    changed=False
+
+    if module.check_mode:
+      module.exit_json(changed=True)
+
+    cloudera = Cloudera(module, host, port, username, password, api_version, use_tls)
+    connection = cloudera.connect()
+
+    if state == 'kerberize':
+        changed = kerberize(cloudera, connection, cluster_name, kdc_user, kdc_password)
+
+    module.exit_json(changed=changed)
+
+if __name__ == '__main__':
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.cloudera import *
+    main()

--- a/lib/ansible/modules/clustering/cloudera/cloudera_kerberos.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_kerberos.py
@@ -17,6 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
 
 DOCUMENTATION = '''
 ---

--- a/lib/ansible/modules/clustering/cloudera/cloudera_kerberos.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_kerberos.py
@@ -69,13 +69,13 @@ options:
     kdc_password:
         description:
             - Password to use during generation of admin principal
-        required: true    
+        required: true
     state:
         description:
             - Kerberize services in cluster.
         required: false
         default: 'kerberize'
-        choices: ['kerberize']        
+        choices: ['kerberize']
 '''
 
 EXAMPLES = '''
@@ -87,7 +87,7 @@ EXAMPLES = '''
     password: admin
     cluster_name: MyCluster
     kdc_user: Administrator@MY.REALM
-    kdc_password: secret
+    kdc_password: secre
     state: "kerberize"
 '''
 
@@ -135,7 +135,7 @@ def main():
     changed=False
 
     if module.check_mode:
-      module.exit_json(changed=True)
+        module.exit_json(changed=True)
 
     cloudera = Cloudera(module, host, port, username, password, api_version, use_tls)
     connection = cloudera.connect()

--- a/lib/ansible/modules/clustering/cloudera/cloudera_license.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_license.py
@@ -58,7 +58,7 @@ options:
         default: false
     trial:
         description:
-            - Begin trial period. This option is mutually exclusive with options: license_body or license_owner. 
+            - Begin trial period. This option is mutually exclusive with options: license_body or license_owner.
         required: false
         default: false
     license_body:
@@ -69,7 +69,7 @@ options:
         description:
             - Owner of the license. This option is mutually exclusive with option: trial. Required together with option: license_body.
         required: false
-        default: Trial License                
+        default: Trial License
     state:
         description:
             - The desired action to perform with the license.
@@ -162,7 +162,7 @@ def main():
         else:
             install_license(cloudera_manager, license_body)
             changed = True
-            
+
     module.exit_json(changed=changed)
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/clustering/cloudera/cloudera_license.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_license.py
@@ -17,6 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
 
 DOCUMENTATION = '''
 ---
@@ -58,16 +61,16 @@ options:
         default: false
     trial:
         description:
-            - Begin trial period. This option is mutually exclusive with options: license_body or license_owner.
+            - Begin trial period. This option is mutually exclusive with options license_body or license_owner.
         required: false
         default: false
     license_body:
         description:
-            - License body to install. This option is mutually exclusive with option: trial. Required together with option: license_owner.
+            - License body to install. This option is mutually exclusive with option trial. Required together with option license_owner.
         required: false
     license_owner:
         description:
-            - Owner of the license. This option is mutually exclusive with option: trial. Required together with option: license_body.
+            - Owner of the license. This option is mutually exclusive with option trial. Required together with option license_body.
         required: false
         default: Trial License
     state:

--- a/lib/ansible/modules/clustering/cloudera/cloudera_license.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_license.py
@@ -1,0 +1,171 @@
+#!/usr/bin/python
+#
+# (c) 2017, Serghei Anicheev <serghei.anicheev@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+DOCUMENTATION = '''
+---
+module: cloudera_license
+author: "Serghei Anicheev (@sanicheev) <serghei.anicheev@gmail.com>"
+version_added: '2.2.0.2'
+short_description: Cloudera Manager license.
+description:
+    - This module can update Cloudera Manager license status.
+options:
+    host:
+        description:
+            - Cloudera Manager API host.
+        required: true
+    port:
+        description:
+            - Cloudera Manager API port.
+        required: false
+        default: 7180
+    username:
+        description:
+            - Username to connect to Cloudera Manager API.
+        required: false
+        default: admin
+    password:
+        description:
+            - Password to connect to Cloudera Manager API.
+        required: false
+        default: admin
+    api_version:
+        description:
+            - Cloudera API version(Older API versions cannot use calls like 'configure_for_kerberos' for example).
+        required: false
+        default: 12
+    use_tls:
+        description:
+            - Enable TLS(In this case port 7183 should be used!).
+        required: false
+        default: false
+    trial:
+        description:
+            - Begin trial period. This option is mutually exclusive with options: license_body or license_owner. 
+        required: false
+        default: false
+    license_body:
+        description:
+            - License body to install. This option is mutually exclusive with option: trial. Required together with option: license_owner.
+        required: false
+    license_owner:
+        description:
+            - Owner of the license. This option is mutually exclusive with option: trial. Required together with option: license_body.
+        required: false
+        default: Trial License                
+    state:
+        description:
+            - The desired action to perform with the license.
+        required: false
+        default: install
+        choices: ['install']
+'''
+
+EXAMPLES = '''
+# Upload new license if it does not exists.
+- name: Upload new license
+  cloudera_license:
+    host: 123.123.123.123
+    username: admin
+    password: admin
+    license_body: {{ license_body }}
+    license_owner: My Company
+    state: install
+
+# Install trial license
+- name: Begin trial
+  cloudera_license:
+    host: 123.123.123.123
+    username: admin
+    password: admin
+    trial: true
+'''
+
+def begin_trial(cloudera_manager):
+    cloudera_manager.begin_trial()
+
+def install_license(cloudera_manager, license_body):
+    cloudera_manager.update_license(license_body)
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            host=dict(required=True, type='str'),
+            port=dict(default=7180, type='int'),
+            username=dict(default='admin', type='str'),
+            password=dict(default='admin', no_log=True, type='str'),
+            api_version=dict(default=12, type='int'),
+            use_tls=dict(default=False, type='bool'),
+            trial=dict(default=False, type='bool'),
+            license_body=dict(default=None, type='str'),
+            license_owner=dict(default='Trial License', type='str'),
+            state=dict(default='install', choices=['install'])
+        ),
+        required_together=(
+            ['license_body', 'license_owner']
+        ),
+        mutually_exclusive=(
+            ['license_body', 'trial'],
+            ['license_owner', 'trial']
+        ),
+        supports_check_mode=True
+    )
+
+    host = module.params['host']
+    port = module.params['port']
+    username = module.params['username']
+    password = module.params['password']
+    api_version = module.params['api_version']
+    use_tls = module.params['use_tls']
+    trial = module.params['trial']
+    license_body = module.params['license_body']
+    license_owner = module.params['license_owner']
+    state = module.params['state']
+    changed=False
+
+    if module.check_mode:
+        module.exit_json(changed=True)
+
+    cloudera = Cloudera(module, host, port, username, password, api_version, use_tls)
+    connection = cloudera.connect()
+    cloudera_manager = cloudera.cloudera_manager(connection)
+    license = cloudera.license_state(cloudera_manager)
+
+    if trial and state == 'install':
+        if license is not None and license.owner == license_owner:
+            module.log('Already in trial state!')
+            changed = False
+        else:
+            begin_trial(cloudera_manager)
+            changed = True
+    else:
+        if license is not None and license.owner == license_owner:
+            module.log('License for - %s already in place. Nothing to do.' % license_owner)
+            changed = False
+        else:
+            install_license(cloudera_manager, license_body)
+            changed = True
+            
+    module.exit_json(changed=changed)
+
+if __name__ == '__main__':
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.cloudera import *
+    main()

--- a/lib/ansible/modules/clustering/cloudera/cloudera_misc.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_misc.py
@@ -1,0 +1,310 @@
+#!/usr/bin/python
+#
+# (c) 2017, Serghei Anicheev <serghei.anicheev@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+DOCUMENTATION = '''
+---
+module: cloudera_misc
+author: "Serghei Anicheev (@sanicheev) <serghei.anicheev@gmail.com>"
+version_added: '2.2.0.2'
+short_description: Cloudera Manager miscellaneous.
+description:
+    - This module can be used to run post actions for service before first run such as: 'create_sentry_database, create_yarn_job_history_dir', or stop,start services or re-deploy service configuration.
+options:
+    host:
+        description:
+            - Cloudera Manager API host.
+        required: true
+    port:
+        description:
+            - Cloudera Manager API port.
+        required: false
+        default: 7180
+    username:
+        description:
+            - Username to connect to Cloudera Manager API.
+        required: false
+        default: admin
+    password:
+        description:
+            - Password to connect to Cloudera Manager API.
+        required: false
+        default: admin
+    api_version:
+        description:
+            - Cloudera API version(Older API versions cannot use calls like 'configure_for_kerberos' for example).
+        required: false
+        default: 12
+    use_tls:
+        description:
+            - Enable TLS(In this case port 7183 should be used!).
+        required: false
+        default: false
+    cluster_name:
+        description:
+            - Cloudera cluster name to use.
+        default: MyCluster    .
+        required: false
+    service_type:
+        description:
+            - Service type to run desired miscellaneous action.
+        required: true
+    force:
+        description:
+            - Enable this if you would like to skip service status check before running stop or start action on desired service type.  
+        required: false
+        default: false    
+    state:
+        description:
+            - Action to apply on desired service_type.
+        required: false
+        default: 'start'
+        choices: [ 'start', 'stop', 'restart', 'init_zk', 'init_hive', 'init_impala', 'init_sqoop', 'init_hbase', 'init_solr', 'init_yarn', 'init_sentry', 'deploy_service_config', 'init_oozie', 'init_hdfs']       
+'''
+
+EXAMPLES = '''
+# Start MGMT service.
+- name: Start MGMT service
+  cloudera_misc:
+    host: 123.123.123.123
+    port: 7180
+    username: admin
+    password: admin
+    service_type: "MGMT"
+    state: "start"
+
+# Run required action on HDFS service type before first start    
+- name: Init HDFS
+  cloudera_misc:
+    host: 123.123.123.123
+    port: 7180
+    username: admin
+    password: admin
+    cluster_name: MyCluster
+    service_type: "HDFS"
+    state: "init_hdfs"
+
+# Start HDFS service and skipping any service status checks    
+- name: Start HDFS service
+  cloudera_misc:
+    host: 123.123.123.123
+    username: admin
+    password: admin
+    cluster_name: MyCluster
+    service_type: "HDFS"
+    force: true
+    state: "start"
+    
+# Run required action on ZOOKEEPER service type before first start   
+ - name: Init ZOOKEEPER
+  cloudera_misc:
+    host: 123.123.123.123
+    port: 7180
+    username: admin
+    password: admin
+    cluster_name: MyCluster
+    service_type: "ZOOKEEPER"
+    state: "init_zk"
+    
+# Re-Deploy service configuration for SENTRY service type.   
+ - name: Re-Deploy SENTRY service configuration
+  cloudera_misc:
+    host: 123.123.123.123
+    port: 7180
+    username: admin
+    password: admin
+    cluster_name: MyCluster
+    service_type: "SENTRY"
+    state: "deploy_service_config"          
+'''
+import time
+
+def process_service(service_obj, force, action):
+    state = service_obj.serviceState
+    changed = False
+    if state == 'STARTED' and action == 'start' and not force:
+        pass
+    elif state == 'STOPPED' and action == 'stop' and not force:
+        pass
+    else:
+        eval("service_obj.{0}().wait()".format(action))
+        changed = True
+    return changed
+
+def get_svc(cloudera, connection, cluster_name, service_type):
+    cluster = connection.get_cluster(cluster_name)
+    service = cloudera.get_service_by_type(cluster, service_type)
+    return service
+
+def service_control(cloudera, connection, cluster_name, service_type, force, action='start'):
+    changed = False
+    if service_type == 'MGMT':
+        cloudera_manager = cloudera.cloudera_manager(connection) 
+        mgmt_service = cloudera_manager.get_service()
+        changed = process_service(mgmt_service, force, action)
+    else:
+        cluster = connection.get_cluster(cluster_name)
+        if service_type:
+            service = cloudera.get_service_by_type(cluster, service_type)
+            changed = process_service(service, force, action)
+        else:
+            eval("cluster.{0}().wait()".format(action))
+            changed = True
+    return changed
+
+def init_zk(cloudera, connection, cluster_name, service_type):
+    service = get_svc(cloudera, connection, cluster_name, service_type)
+    service.init_zookeeper().wait()
+    return True
+
+def deploy_service_config(cloudera, connection, cluster_name, service_type):
+    service = get_svc(cloudera, connection, cluster_name, service_type)
+    changed = False
+    if service.clientConfigStalenessStatus != 'FRESH':
+        service.deploy_client_config().wait()
+        changed = True
+    return changed
+
+def init_hive(cloudera, connection, cluster_name, service_type):
+    service = get_svc(cloudera, connection, cluster_name, service_type)
+    service.create_hive_metastore_database().wait()
+    service.create_hive_metastore_tables().wait()
+    service.create_hive_warehouse().wait()
+    return True
+
+def init_impala(cloudera, connection, cluster_name, service_type):
+    service = get_svc(cloudera, connection, cluster_name, service_type)
+    service.create_impala_catalog_database_tables().wait()
+    service.create_impala_user_dir().wait()
+    return True
+
+def init_sqoop(cloudera, connection, cluster_name, service_type):
+    service = get_svc(cloudera, connection, cluster_name, service_type)
+    service.create_sqoop_database_tables().wait()
+    service.create_sqoop_user_dir().wait()
+    return True
+
+def init_hbase(cloudera, connection, cluster_name, service_type):
+    service = get_svc(cloudera, connection, cluster_name, service_type)
+    service.create_hbase_root().wait()
+    return True
+
+def init_solr(cloudera, connection, cluster_name, service_type):
+    service = get_svc(cloudera, connection, cluster_name, service_type)
+    service.init_solr().wait()
+    service.create_solr_hdfs_home_dir().wait()
+    return True
+
+def init_yarn(cloudera, connection, cluster_name, service_type):
+    service = get_svc(cloudera, connection, cluster_name, service_type)
+    service.create_yarn_job_history_dir().wait()
+    service.create_yarn_node_manager_remote_app_log_dir().wait()
+    return True
+
+def init_sentry(cloudera, connection, cluster_name, service_type):
+    service = get_svc(cloudera, connection, cluster_name, service_type)
+    service.create_sentry_database_tables().wait()
+    return True
+
+def init_oozie(cloudera, connection, cluster_name, service_type):
+    service = get_svc(cloudera, connection, cluster_name, service_type)
+    service.create_oozie_db().wait()
+    service.install_oozie_sharelib().wait()
+    return True
+
+def init_hdfs(cloudera, connection, cluster_name, service_type):
+    service = get_svc(cloudera, connection, cluster_name, service_type)
+    namenode_role_name = service.get_roles_by_type('NAMENODE')[0].name
+    service.format_hdfs(namenode_role_name)[0].wait()
+    service.init_hdfs_shared_dir(namenode_role_name)
+    service.create_hdfs_tmp().wait()
+    return True
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            host=dict(required=True, type='str'),
+            port=dict(default=7180, type='int'),
+            username=dict(default='admin', type='str'),
+            password=dict(default='admin', no_log=True, type='str'),
+            api_version=dict(default=12, type='int'),
+            use_tls=dict(default=False, type='bool'),
+            cluster_name=dict(default='MyCluster', required=False, type='str'),
+            service_type=dict(required=True, type='str'),
+            force=dict(default=False, type='bool'),
+            state=dict(default='start', choices=['start', 'stop', 'restart', 'init_zk', 'init_hive', 'init_impala', 'init_sqoop', 'init_hbase', 'init_solr', 'init_yarn', 'init_sentry', 'deploy_service_config', 'init_oozie', 'init_hdfs'])
+        ),
+        supports_check_mode=True
+    )
+
+    host = module.params['host']
+    port = module.params['port']
+    username = module.params['username']
+    password = module.params['password']
+    api_version = module.params['api_version']
+    use_tls = module.params['use_tls']
+    cluster_name = module.params['cluster_name']
+    service_type = module.params['service_type'].upper()
+    force = module.params['force']
+    state = module.params['state']
+    changed=False
+
+    cloudera = Cloudera(module, host, port, username, password, api_version, use_tls)
+    connection = cloudera.connect()
+
+    if module.check_mode:
+        module.exit_json(changed=True)
+
+    if state == 'start':
+        changed = service_control(cloudera, connection, cluster_name, service_type, force, action='start')
+    elif state == 'stop':
+        changed = service_control(cloudera, connection, cluster_name, service_type, force, action='stop')
+    elif state == 'restart':
+        changed = service_control(cloudera, connection, cluster_name, service_type, force, action='restart')
+    elif state == 'deploy_service_config':
+        changed = deploy_service_config(cloudera, connection, cluster_name, service_type)
+    elif state == 'init_zk':
+        changed = init_zk(cloudera, connection, cluster_name, service_type)
+    elif state == 'init_hive':
+        changed = init_hive(cloudera, connection, cluster_name, service_type)
+    elif state == 'init_impala':
+        changed = init_impala(cloudera, connection, cluster_name, service_type)
+    elif state == 'init_sqoop':
+        changed = init_sqoop(cloudera, connection, cluster_name, service_type)
+    elif state == 'init_hbase':
+        changed = init_hbase(cloudera, connection, cluster_name, service_type)
+    elif state == 'init_solr':
+        changed = init_solr(cloudera, connection, cluster_name, service_type)
+    elif state == 'init_yarn':
+        changed = init_yarn(cloudera, connection, cluster_name, service_type)
+    elif state == 'init_sentry':
+        changed = init_sentry(cloudera, connection, cluster_name, service_type)
+    elif state == 'init_oozie':
+        changed = init_oozie(cloudera, connection, cluster_name, service_type)
+    elif state == 'init_hdfs':
+        changed = init_hdfs(cloudera, connection, cluster_name, service_type)
+    elif state == 'deploy_service_config':
+        changed = deploy_service_config(cloudera, connection, cluster_name, service_type)
+
+    module.exit_json(changed=changed)
+
+if __name__ == '__main__':
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.cloudera import *
+    main()

--- a/lib/ansible/modules/clustering/cloudera/cloudera_misc.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_misc.py
@@ -17,6 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
 
 DOCUMENTATION = '''
 ---
@@ -25,8 +28,8 @@ author: "Serghei Anicheev (@sanicheev) <serghei.anicheev@gmail.com>"
 version_added: '2.2.0.2'
 short_description: Cloudera Manager miscellaneous.
 description:
-    - This module can be used to run post actions for service before first run such as: 'create_sentry_database, create_yarn_job_history_dir',
-    - or stop,start services or re-deploy service configuration.
+    - This module can be used to run post actions for service before first run such as - 'create_sentry_database, create_yarn_job_history_dir'
+      or stop,start services or re-deploy service configuration.
 options:
     host:
         description:
@@ -60,7 +63,7 @@ options:
     cluster_name:
         description:
             - Cloudera cluster name to use.
-        default: MyCluster    .
+        default: MyCluster
         required: false
     service_type:
         description:
@@ -77,7 +80,7 @@ options:
         required: false
         default: 'start'
         choices: [ 'start', 'stop', 'restart', 'init_zk', 'init_hive', 'init_impala', 'init_sqoop', 'init_hbase',
-                   'init_solr', 'init_yarn', 'init_sentry', 'deploy_service_config', 'init_oozie', 'init_hdfs']
+        'init_solr', 'init_yarn', 'init_sentry', 'deploy_service_config', 'init_oozie', 'init_hdfs']
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/clustering/cloudera/cloudera_misc.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_misc.py
@@ -25,7 +25,8 @@ author: "Serghei Anicheev (@sanicheev) <serghei.anicheev@gmail.com>"
 version_added: '2.2.0.2'
 short_description: Cloudera Manager miscellaneous.
 description:
-    - This module can be used to run post actions for service before first run such as: 'create_sentry_database, create_yarn_job_history_dir', or stop,start services or re-deploy service configuration.
+    - This module can be used to run post actions for service before first run such as: 'create_sentry_database, create_yarn_job_history_dir',
+    - or stop,start services or re-deploy service configuration.
 options:
     host:
         description:
@@ -67,15 +68,16 @@ options:
         required: true
     force:
         description:
-            - Enable this if you would like to skip service status check before running stop or start action on desired service type.  
+            - Enable this if you would like to skip service status check before running stop or start action on desired service type.
         required: false
-        default: false    
+        default: false
     state:
         description:
             - Action to apply on desired service_type.
         required: false
         default: 'start'
-        choices: [ 'start', 'stop', 'restart', 'init_zk', 'init_hive', 'init_impala', 'init_sqoop', 'init_hbase', 'init_solr', 'init_yarn', 'init_sentry', 'deploy_service_config', 'init_oozie', 'init_hdfs']       
+        choices: [ 'start', 'stop', 'restart', 'init_zk', 'init_hive', 'init_impala', 'init_sqoop', 'init_hbase',
+                   'init_solr', 'init_yarn', 'init_sentry', 'deploy_service_config', 'init_oozie', 'init_hdfs']
 '''
 
 EXAMPLES = '''
@@ -89,7 +91,7 @@ EXAMPLES = '''
     service_type: "MGMT"
     state: "start"
 
-# Run required action on HDFS service type before first start    
+# Run required action on HDFS service type before first star
 - name: Init HDFS
   cloudera_misc:
     host: 123.123.123.123
@@ -100,7 +102,7 @@ EXAMPLES = '''
     service_type: "HDFS"
     state: "init_hdfs"
 
-# Start HDFS service and skipping any service status checks    
+# Start HDFS service and skipping any service status checks
 - name: Start HDFS service
   cloudera_misc:
     host: 123.123.123.123
@@ -110,8 +112,8 @@ EXAMPLES = '''
     service_type: "HDFS"
     force: true
     state: "start"
-    
-# Run required action on ZOOKEEPER service type before first start   
+
+# Run required action on ZOOKEEPER service type before first star
  - name: Init ZOOKEEPER
   cloudera_misc:
     host: 123.123.123.123
@@ -121,8 +123,8 @@ EXAMPLES = '''
     cluster_name: MyCluster
     service_type: "ZOOKEEPER"
     state: "init_zk"
-    
-# Re-Deploy service configuration for SENTRY service type.   
+
+# Re-Deploy service configuration for SENTRY service type.
  - name: Re-Deploy SENTRY service configuration
   cloudera_misc:
     host: 123.123.123.123
@@ -131,7 +133,7 @@ EXAMPLES = '''
     password: admin
     cluster_name: MyCluster
     service_type: "SENTRY"
-    state: "deploy_service_config"          
+    state: "deploy_service_config"
 '''
 import time
 
@@ -155,7 +157,7 @@ def get_svc(cloudera, connection, cluster_name, service_type):
 def service_control(cloudera, connection, cluster_name, service_type, force, action='start'):
     changed = False
     if service_type == 'MGMT':
-        cloudera_manager = cloudera.cloudera_manager(connection) 
+        cloudera_manager = cloudera.cloudera_manager(connection)
         mgmt_service = cloudera_manager.get_service()
         changed = process_service(mgmt_service, force, action)
     else:
@@ -248,7 +250,10 @@ def main():
             cluster_name=dict(default='MyCluster', required=False, type='str'),
             service_type=dict(required=True, type='str'),
             force=dict(default=False, type='bool'),
-            state=dict(default='start', choices=['start', 'stop', 'restart', 'init_zk', 'init_hive', 'init_impala', 'init_sqoop', 'init_hbase', 'init_solr', 'init_yarn', 'init_sentry', 'deploy_service_config', 'init_oozie', 'init_hdfs'])
+            state=dict(default='start', choices=[
+                'start', 'stop', 'restart', 'init_zk', 'init_hive', 'init_impala', 'init_sqoop', 'init_hbase', 'init_solr',
+                'init_yarn', 'init_sentry', 'deploy_service_config', 'init_oozie', 'init_hdfs'
+            ])
         ),
         supports_check_mode=True
     )

--- a/lib/ansible/modules/clustering/cloudera/cloudera_oozie_ha.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_oozie_ha.py
@@ -63,7 +63,7 @@ options:
     load_balancer_host:
         description:
             - Hostname where secondary Load Balancer will be created. Host MUST BE in cluster!
-        required: true    
+        required: true
     load_balancer_port:
         description:
             - Port number to use for Load Balancer.
@@ -73,13 +73,13 @@ options:
         description:
             - List of hostnames where additional OOZIE roles will be applied. They MUST be in cluster!
             - 123.123.123.124
-            - 123.123.123.125 
+            - 123.123.123.125
     state:
         description:
             - Enable OOZIE HA state.
         required: false
         default: 'enable_oozie_ha'
-        choices: ['enable_oozie_ha']        
+        choices: ['enable_oozie_ha']
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/clustering/cloudera/cloudera_oozie_ha.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_oozie_ha.py
@@ -1,0 +1,159 @@
+#!/usr/bin/python
+#
+# (c) 2017, Serghei Anicheev <serghei.anicheev@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+DOCUMENTATION = '''
+---
+module: cloudera_oozie_ha
+author: "Serghei Anicheev (@sanicheev) <serghei.anicheev@gmail.com>"
+version_added: '2.2.0.2'
+short_description: Cloudera Manager enable HA for OOZIE.
+description:
+    - This module will enable HA for OOZIE. Please take in consideration that ZOOKEEPER service should be up and running!
+options:
+    host:
+        description:
+            - Cloudera Manager API host.
+        required: true
+    port:
+        description:
+            - Cloudera Manager API port.
+        required: false
+        default: 7180
+    username:
+        description:
+            - Username to connect to Cloudera Manager API.
+        required: false
+        default: admin
+    password:
+        description:
+            - Password to connect to Cloudera Manager API.
+        required: false
+        default: admin
+    api_version:
+        description:
+            - Cloudera API version(Older API versions cannot use calls like 'configure_for_kerberos' for example).
+        required: false
+        default: 12
+    use_tls:
+        description:
+            - Enable TLS(In this case port 7183 should be used!).
+        required: false
+        default: false
+    cluster_name:
+        description:
+            - Cloudera cluster name to search for OOZIE service type in.   .
+        required: true
+    load_balancer_host:
+        description:
+            - Hostname where secondary Load Balancer will be created. Host MUST BE in cluster!
+        required: true    
+    load_balancer_port:
+        description:
+            - Port number to use for Load Balancer.
+        required: false
+        default: 21054
+    oozie_hosts:
+        description:
+            - List of hostnames where additional OOZIE roles will be applied. They MUST be in cluster!
+            - 123.123.123.124
+            - 123.123.123.125 
+    state:
+        description:
+            - Enable OOZIE HA state.
+        required: false
+        default: 'enable_oozie_ha'
+        choices: ['enable_oozie_ha']        
+'''
+
+EXAMPLES = '''
+# Enable OOZIE HA
+- name: Enable OOZIE HA
+  cloudera_oozie_ha:
+    host: 123.123.123.123
+    port: 7180
+    username: admin
+    password: admin
+    cluster_name: MyCluster
+    load_balancer_host: "123.123.123.124"
+    load_balancer_port: 21054
+    oozie_hosts:
+      - "123.123.123.125"
+      - "123.123.123.126"
+    state: "enable_oozie_ha"
+'''
+
+def enable_oozie_ha(cloudera, connection, cluster_name, load_balancer_host, load_balancer_port, oozie_hosts):
+    cluster = connection.get_cluster(cluster_name)
+    service = cloudera.get_service_by_type(cluster, 'OOZIE')
+    oozie_host_ids = []
+    for oozie_host in oozie_hosts:
+        host_id = cloudera.get_hostid_by_hostname(connection, oozie_host)
+        oozie_host_ids.append(host_id)
+    zookeeper_service_name = cloudera.get_service_by_type(cluster, 'ZOOKEEPER').name
+    load_balancer_info = "%s:%s" % (load_balancer_host, load_balancer_port)
+    service.enable_oozie_ha(new_oozie_server_host_ids=oozie_host_ids, zk_service_name=zookeeper_service_name, load_balancer_host_port=load_balancer_info).wait()
+    return True
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            host=dict(required=True, type='str'),
+            port=dict(default=7180, type='int'),
+            username=dict(default='admin', type='str'),
+            password=dict(default='admin', no_log=True, type='str'),
+            api_version=dict(default=12, type='int'),
+            use_tls=dict(default=False, type='bool'),
+            cluster_name=dict(required=True, type='str'),
+            load_balancer_host=dict(required=True, type='str'),
+            load_balancer_port=dict(default=21054, type='int'),
+            oozie_hosts=dict(required=True, type='list'),
+            state=dict(default='enable_oozie_ha', choices=['enable_oozie_ha'])
+        ),
+        supports_check_mode=True
+    )
+
+    host = module.params['host']
+    port = module.params['port']
+    username = module.params['username']
+    password = module.params['password']
+    api_version = module.params['api_version']
+    use_tls = module.params['use_tls']
+    cluster_name = module.params['cluster_name']
+    load_balancer_host = module.params['load_balancer_host']
+    load_balancer_port = module.params['load_balancer_port']
+    oozie_hosts = module.params['oozie_hosts']
+    state = module.params['state']
+    changed=False
+
+    cloudera = Cloudera(module, host, port, username, password, api_version, use_tls)
+    connection = cloudera.connect()
+
+    if module.check_mode:
+        module.exit_json(changed=True)
+
+    elif state == 'enable_oozie_ha':
+        changed = enable_oozie_ha(cloudera, connection, cluster_name, load_balancer_host, load_balancer_port, oozie_hosts)
+
+    module.exit_json(changed=changed)
+
+if __name__ == '__main__':
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.cloudera import *
+    main()

--- a/lib/ansible/modules/clustering/cloudera/cloudera_oozie_ha.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_oozie_ha.py
@@ -17,6 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
 
 DOCUMENTATION = '''
 ---

--- a/lib/ansible/modules/clustering/cloudera/cloudera_parcel.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_parcel.py
@@ -1,0 +1,166 @@
+#!/usr/bin/python
+#
+# (c) 2017, Serghei Anicheev <serghei.anicheev@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+DOCUMENTATION = '''
+---
+module: cloudera_license
+author: "Serghei Anicheev (@sanicheev) <serghei.anicheev@gmail.com>"
+version_added: '2.2.0.2'
+short_description: Cloudera Manager parcel.
+description:
+    - This module can install,distribute and activate cluster packages.
+options:
+    host:
+        description:
+            - Cloudera Manager API host.
+        required: true
+    port:
+        description:
+            - Cloudera Manager API port.
+        required: false
+        default: 7180
+    username:
+        description:
+            - Username to connect to Cloudera Manager API.
+        required: false
+        default: admin
+    password:
+        description:
+            - Password to connect to Cloudera Manager API.
+        required: false
+        default: admin
+    api_version:
+        description:
+            - Cloudera API version(Older API versions cannot use calls like 'configure_for_kerberos' for example).
+        required: false
+        default: 12
+    use_tls:
+        description:
+            - Enable TLS(In this case port 7183 should be used!).
+        required: false
+        default: false
+    cluster_name:
+        description:
+            - Cloudera cluster name to use.   .
+        required: true
+    parcel_name:
+        description:
+            - Parcel name to use
+        required: false
+        default: CDH5
+    parcel_version:
+        description:
+            - Parcel version to use
+        required: true
+    state:
+        description:
+            - The desired action to take on selected parcel in cluster.
+        required: false
+        default: activate
+        choices: ['activate']
+'''
+
+EXAMPLES = '''
+# Distribute parcels.
+- name: Distribute parcels
+  cloudera_parcel:
+    host: 123.123.123.123
+    username: admin
+    password: admin
+    cluster_name: MyCluster
+    parcel_name: CDH5
+    parcel_version: 5.9.1-1.cdh5.9.1.p0.4
+    state: activate
+'''
+
+from time import sleep
+
+def deploy_parcel(module, cluster, parcel_name, parcel_version):
+    all_parcels = cluster.get_all_parcels()
+    parcel = filter(lambda parcel: parcel.product == parcel_name and parcel.version == parcel_version, all_parcels)
+    changed = False
+    if len(parcel) == 0:
+        raise Exception('No such parcel version - %s, for parcel name - %s!' % (parcel_version, parcel_name))
+    elif parcel[0].stage == 'ACTIVATED':
+        print 'Already activated!'
+    else:
+        parcel_obj = parcel[0]
+        
+        download = parcel_obj.start_download()
+        while parcel_obj.stage != 'DOWNLOADED':
+            sleep(5)
+            parcel_obj = cluster.get_parcel(parcel_name, parcel_version)
+
+        parcel_obj.start_distribution()       
+        while parcel_obj.stage != "DISTRIBUTED":
+            sleep(5)
+            parcel_obj = cluster.get_parcel(parcel_name, parcel_version)
+
+        parcel_obj.activate()
+        while parcel_obj.stage != "ACTIVATED":
+            sleep(5)
+            parcel_obj = cluster.get_parcel(parcel_name, parcel_version)
+        changed = True
+    return changed
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            host=dict(required=True, type='str'),
+            port=dict(default=7180, type='int'),
+            username=dict(default='admin', type='str'),
+            password=dict(default='admin', no_log=True, type='str'),
+            api_version=dict(default=12, type='int'),
+            use_tls=dict(default=False, type='bool'),
+            cluster_name=dict(required=True, type='str'),
+            parcel_name=dict(required=False, default='CDH5', type='str'),
+            parcel_version=dict(required=True, type='str'),
+            state=dict(default='activate', choices=['activate'])
+        ),
+        supports_check_mode=True
+    )
+    host = module.params['host']
+    port = module.params['port']
+    username = module.params['username']
+    password = module.params['password']
+    api_version = module.params['api_version']
+    use_tls = module.params['use_tls']
+    cluster_name = module.params['cluster_name']
+    parcel_name = module.params['parcel_name']
+    parcel_version = module.params['parcel_version']
+    state = module.params['state']
+    changed=False
+
+    if module.check_mode:
+        module.exit_json(changed=True)
+
+    cloudera = Cloudera(module, host, port, username, password, api_version, use_tls)
+    connection = cloudera.connect()
+    cluster = cloudera.get_cluster(connection, cluster_name)
+
+    if state == 'activate':
+        changed = deploy_parcel(module, cluster, parcel_name, parcel_version)
+
+    module.exit_json(changed=changed, state=state)
+
+if __name__ == '__main__':
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.cloudera import *
+    main()

--- a/lib/ansible/modules/clustering/cloudera/cloudera_parcel.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_parcel.py
@@ -99,7 +99,7 @@ def deploy_parcel(module, cluster, parcel_name, parcel_version):
     if len(parcel) == 0:
         raise Exception('No such parcel version - %s, for parcel name - %s!' % (parcel_version, parcel_name))
     elif parcel[0].stage == 'ACTIVATED':
-        print 'Already activated!'
+        module.log('Parcel %s already activated!' % parcel_version)
     else:
         parcel_obj = parcel[0]
         

--- a/lib/ansible/modules/clustering/cloudera/cloudera_parcel.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_parcel.py
@@ -102,13 +102,13 @@ def deploy_parcel(module, cluster, parcel_name, parcel_version):
         module.log('Parcel %s already activated!' % parcel_version)
     else:
         parcel_obj = parcel[0]
-        
+
         download = parcel_obj.start_download()
         while parcel_obj.stage != 'DOWNLOADED':
             sleep(5)
             parcel_obj = cluster.get_parcel(parcel_name, parcel_version)
 
-        parcel_obj.start_distribution()       
+        parcel_obj.start_distribution()
         while parcel_obj.stage != "DISTRIBUTED":
             sleep(5)
             parcel_obj = cluster.get_parcel(parcel_name, parcel_version)

--- a/lib/ansible/modules/clustering/cloudera/cloudera_parcel.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_parcel.py
@@ -17,6 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
 
 DOCUMENTATION = '''
 ---

--- a/lib/ansible/modules/clustering/cloudera/cloudera_role.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_role.py
@@ -147,7 +147,7 @@ def create_role(module, cloudera, service_obj, role_name, role_type, role_host, 
         role_changed = True
         configuration_changed = update_role_config_group(cloudera, service_obj, role_type, configuration_file)
     result = role_changed | configuration_changed
-    return resul
+    return result
 
 def update_role_config_group(cloudera, service_obj, role_type, configuration_file):
     configuration_changed = False

--- a/lib/ansible/modules/clustering/cloudera/cloudera_role.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_role.py
@@ -65,7 +65,7 @@ options:
         description:
             - Service type to create role in.
         required: false
-        default: MGMT        
+        default: MGMT
     role_type:
         description:
             - Role type to create or search role_config_group in.
@@ -73,21 +73,22 @@ options:
     role_name:
         description:
             - Role name to create. This should be present for state: 'create'.
-        required: false    
-    role_host:    
+        required: false
+    role_host:
         description:
             - Host(hostname as listed in cluster) to apply role on.
-        required: false    
+        required: false
     configuration_file:
         description:
-            - Path to the configuration file to use for the desired role. Should be in JSON format only!. If configuration file is inaccessible warning message will be shown.
+            - Path to the configuration file to use for the desired role. Should be in JSON format only!.
+            - If configuration file is inaccessible warning message will be shown.
         required: false
     state:
         description:
             - Action to apply on desired role_type.
         required: false
         default: 'create'
-        choices: ['create', 'update_role_group']        
+        choices: ['create', 'update_role_group']
 '''
 
 EXAMPLES = '''
@@ -142,7 +143,7 @@ def create_role(module, cloudera, service_obj, role_name, role_type, role_host, 
         role_changed = True
         configuration_changed = update_role_config_group(cloudera, service_obj, role_type, configuration_file)
     result = role_changed | configuration_changed
-    return result
+    return resul
 
 def update_role_config_group(cloudera, service_obj, role_type, configuration_file):
     configuration_changed = False

--- a/lib/ansible/modules/clustering/cloudera/cloudera_role.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_role.py
@@ -18,6 +18,10 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
 DOCUMENTATION = '''
 ---
 module: cloudera_role
@@ -72,7 +76,7 @@ options:
         required: true
     role_name:
         description:
-            - Role name to create. This should be present for state: 'create'.
+            - Role name to create. This should be present for state - 'create'.
         required: false
     role_host:
         description:

--- a/lib/ansible/modules/clustering/cloudera/cloudera_role.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_role.py
@@ -1,0 +1,215 @@
+#!/usr/bin/python
+#
+# (c) 2017, Serghei Anicheev <serghei.anicheev@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+DOCUMENTATION = '''
+---
+module: cloudera_role
+author: "Serghei Anicheev (@sanicheev) <serghei.anicheev@gmail.com>"
+version_added: '2.2.0.2'
+short_description: Cloudera Manager role.
+description:
+    - This module can create and configure Cloudera Manager role or update role_config_group.
+options:
+    host:
+        description:
+            - Cloudera Manager API host.
+        required: true
+    port:
+        description:
+            - Cloudera Manager API port.
+        required: false
+        default: 7180
+    username:
+        description:
+            - Username to connect to Cloudera Manager API.
+        required: false
+        default: admin
+    password:
+        description:
+            - Password to connect to Cloudera Manager API.
+        required: false
+        default: admin
+    api_version:
+        description:
+            - Cloudera API version(Older API versions cannot use calls like 'configure_for_kerberos' for example).
+        required: false
+        default: 12
+    use_tls:
+        description:
+            - Enable TLS(In this case port 7183 should be used!).
+        required: false
+        default: false
+    cluster_name:
+        description:
+            - Cloudera cluster name to create service in. This parameter should be present for non-mgmt role types.
+        default: MyCluster    .
+        required: false
+    service_type:
+        description:
+            - Service type to create role in.
+        required: false
+        default: MGMT        
+    role_type:
+        description:
+            - Role type to create or search role_config_group in.
+        required: true
+    role_name:
+        description:
+            - Role name to create. This should be present for state: 'create'.
+        required: false    
+    role_host:    
+        description:
+            - Host(hostname as listed in cluster) to apply role on.
+        required: false    
+    configuration_file:
+        description:
+            - Path to the configuration file to use for the desired role. Should be in JSON format only!. If configuration file is inaccessible warning message will be shown.
+        required: false
+    state:
+        description:
+            - Action to apply on desired role_type.
+        required: false
+        default: 'create'
+        choices: ['create', 'update_role_group']        
+'''
+
+EXAMPLES = '''
+# Create ACTIVITYMONITOR role and configure it.
+- name: Create ACTIVITYMONITOR role
+  cloudera_role:
+    host: 123.123.123.123
+    username: admin
+    password: admin
+    service_type: MGMT
+    role_name: ACTIVITYMONITOR
+    role_type: ACTIVITYMONITOR
+    role_host: 123.123.123.124
+    configuration_file: 'activitymonitor.conf'
+    state: create
+
+# Create RESOURCEMANAGER role
+- name: Create RESOURCEMANAGER role
+  cloudera_role:
+    host: 123.123.123.123
+    username: admin
+    password: admin
+    cluster_name: MyCluster
+    service_type: YARN
+    role_name: RESOURCEMANAGER
+    role_type: RESOURCEMANAGER
+    role_host: 123.123.123.125
+    state: create
+
+# Update JOURNALNODE role_config_group
+- name: Update JOURNALNODE role_config_group
+  cloudera_role:
+    host: 123.123.123.123
+    username: admin
+    password: admin
+    cluster_name: MyCluster
+    service_type: HDFS
+    role_type: JOURNALNODE
+    configuration_file: 'journalnode.conf'
+    state: update_role_group
+'''
+
+def create_role(module, cloudera, service_obj, role_name, role_type, role_host, configuration_file):
+    cloudera.validate_role_type(service_obj, role_type)
+    role_changed = False
+    configuration_changed = False
+    role = filter(lambda role: role.name == role_name, service_obj.get_all_roles())
+    if len(role) != 0:
+        module.log('Role with name - %s already exists' % role_name)
+    else:
+        service_obj.create_role(role_name, role_type, role_host)
+        role_changed = True
+        configuration_changed = update_role_config_group(cloudera, service_obj, role_type, configuration_file)
+    result = role_changed | configuration_changed
+    return result
+
+def update_role_config_group(cloudera, service_obj, role_type, configuration_file):
+    configuration_changed = False
+    service_name = service_obj.name
+    if configuration_file is not None:
+        config_group = service_obj.get_role_config_group("{0}-{1}-BASE".format(service_name, role_type))
+        current_config = config_group.get_config()
+        configuration_changed = cloudera.update_config(config_group, current_config, configuration_file)
+    return configuration_changed
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            host=dict(required=True, type='str'),
+            port=dict(default=7180, type='int'),
+            username=dict(default='admin', type='str'),
+            password=dict(default='admin', no_log=True, type='str'),
+            api_version=dict(default=12, type='int'),
+            use_tls=dict(default=False, type='bool'),
+            cluster_name=dict(default='MyCluster', required=False, type='str'),
+            service_type=dict(required=False, type='str', default='MGMT'),
+            role_name=dict(required=False, type='str'),
+            role_type=dict(required=True, type='str'),
+            role_host=dict(required=False, type='str'),
+            configuration_file=dict(required=False, type='path'),
+            state=dict(default='create', choices=['create', 'update_role_group'])
+        ),
+        supports_check_mode=True,
+    )
+
+    host = module.params['host']
+    port = module.params['port']
+    username = module.params['username']
+    password = module.params['password']
+    api_version = module.params['api_version']
+    use_tls = module.params['use_tls']
+    cluster_name = module.params['cluster_name']
+    service_type = module.params['service_type'].upper()
+    role_name = module.params['role_name']
+    role_type = module.params['role_type'].upper()
+    role_host = module.params['role_host']
+    configuration_file = module.params['configuration_file']
+    state = module.params['state']
+    changed=False
+
+    if module.check_mode:
+        module.exit_json(changed=True)
+
+    cloudera = Cloudera(module, host, port, username, password, api_version, use_tls)
+    connection = cloudera.connect()
+
+    if state == 'create' and service_type == 'MGMT':
+        cloudera_manager = cloudera.cloudera_manager(connection)
+        service = cloudera_manager.get_service()
+        changed = create_role(module, cloudera, service, role_name, role_type, role_host, configuration_file)
+    else:
+        cluster = cloudera.get_cluster(connection, cluster_name)
+        cloudera.validate_service_type(cluster, service_type)
+        service = cluster.get_service(service_type)
+        if state == 'update_role_group':
+            changed = update_role_config_group(cloudera, service, role_type, configuration_file)
+        else:
+            changed = create_role(module, cloudera, service, role_name, role_type, role_host, configuration_file)
+
+    module.exit_json(changed=changed)
+
+if __name__ == '__main__':
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.cloudera import *
+    main()

--- a/lib/ansible/modules/clustering/cloudera/cloudera_service.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_service.py
@@ -17,6 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
 
 DOCUMENTATION = '''
 ---

--- a/lib/ansible/modules/clustering/cloudera/cloudera_service.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_service.py
@@ -118,7 +118,7 @@ def create_mgmt_service(cloudera, connection, service_type, configuration_file):
         cloudera_manager.create_mgmt_service(service_info)
         service_changed = True
     result = service_changed | configuration_changed
-    return resul
+    return result
 
 def create_general_service(cloudera, connection, cluster_name, service_type, configuration_file):
     cluster = cloudera.get_cluster(connection, cluster_name)
@@ -137,7 +137,7 @@ def create_general_service(cloudera, connection, cluster_name, service_type, con
         current_config = service.get_config()[0]
         configuration_changed = cloudera.update_config(service, current_config, configuration_file)
     result = service_changed | configuration_changed
-    return resul
+    return result
 
 def main():
     module = AnsibleModule(

--- a/lib/ansible/modules/clustering/cloudera/cloudera_service.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_service.py
@@ -67,14 +67,15 @@ options:
         required: true
     configuration_file:
         description:
-            - Path to the configuration file to use for the desired service. Should be in JSON format only!. If configuration file is inaccessible warning message will be shown.
+            - Path to the configuration file to use for the desired service. Should be in JSON format only!.
+            - If configuration file is inaccessible warning message will be shown.
         required: false
     state:
         description:
             - Action to apply on desired service_type.
         required: false
         default: 'create'
-        choices: ['create']        
+        choices: ['create']
 '''
 
 EXAMPLES = '''
@@ -88,7 +89,7 @@ EXAMPLES = '''
     configuration_file: 'service.conf'
     state: create
 
-# Create Zookeeper service and configure it
+# Create Zookeeper service and configure i
 - name: Create Zookeeper service
   cloudera_service:
     host: 123.123.123.123
@@ -114,8 +115,8 @@ def create_mgmt_service(cloudera, connection, service_type, configuration_file):
         cloudera_manager.create_mgmt_service(service_info)
         service_changed = True
     result = service_changed | configuration_changed
-    return result  
-    
+    return resul
+
 def create_general_service(cloudera, connection, cluster_name, service_type, configuration_file):
     cluster = cloudera.get_cluster(connection, cluster_name)
     cloudera.validate_service_type(cluster, service_type)
@@ -133,7 +134,7 @@ def create_general_service(cloudera, connection, cluster_name, service_type, con
         current_config = service.get_config()[0]
         configuration_changed = cloudera.update_config(service, current_config, configuration_file)
     result = service_changed | configuration_changed
-    return result
+    return resul
 
 def main():
     module = AnsibleModule(

--- a/lib/ansible/modules/clustering/cloudera/cloudera_service.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_service.py
@@ -1,0 +1,184 @@
+#!/usr/bin/python
+#
+# (c) 2017, Serghei Anicheev <serghei.anicheev@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+DOCUMENTATION = '''
+---
+module: cloudera_service
+author: "Serghei Anicheev (@sanicheev) <serghei.anicheev@gmail.com>"
+version_added: '2.2.0.2'
+short_description: Cloudera Manager service.
+description:
+    - This module can create and configure Cloudera Manager role.
+options:
+    host:
+        description:
+            - Cloudera Manager API host.
+        required: true
+    port:
+        description:
+            - Cloudera Manager API port.
+        required: false
+        default: 7180
+    username:
+        description:
+            - Username to connect to Cloudera Manager API.
+        required: false
+        default: admin
+    password:
+        description:
+            - Password to connect to Cloudera Manager API.
+        required: false
+        default: admin
+    api_version:
+        description:
+            - Cloudera API version(Older API versions cannot use calls like 'configure_for_kerberos' for example).
+        required: false
+        default: 12
+    use_tls:
+        description:
+            - Enable TLS(In this case port 7183 should be used!).
+        required: false
+        default: false
+    cluster_name:
+        description:
+            - Cloudera cluster name to create service in. This parameter should be present for non-mgmt service types.
+        default: MyCluster    .
+        required: false
+    service_type:
+        description:
+            - Service type to create.
+        required: true
+    configuration_file:
+        description:
+            - Path to the configuration file to use for the desired service. Should be in JSON format only!. If configuration file is inaccessible warning message will be shown.
+        required: false
+    state:
+        description:
+            - Action to apply on desired service_type.
+        required: false
+        default: 'create'
+        choices: ['create']        
+'''
+
+EXAMPLES = '''
+# Create Cloudera management service and configure it.
+- name: Create MGMT service
+  cloudera_service:
+    host: 123.123.123.123
+    username: admin
+    password: admin
+    service_type: MGMT
+    configuration_file: 'service.conf'
+    state: create
+
+# Create Zookeeper service and configure it
+- name: Create Zookeeper service
+  cloudera_service:
+    host: 123.123.123.123
+    username: admin
+    password: admin
+    cluster_name: MyCluster
+    service_type: ZOOKEEPER
+    configuration_file: 'service.conf'
+    state: create
+'''
+
+def create_mgmt_service(cloudera, connection, service_type, configuration_file):
+    cloudera_manager = cloudera.cloudera_manager(connection)
+    service_changed = False
+    configuration_changed = False
+    if configuration_file is not None:
+        current_config = cloudera_manager.get_config()
+        configuration_changed = cloudera.update_config(cloudera_manager, current_config, configuration_file)
+    try:
+        cloudera_manager.get_service()
+    except:
+        service_info = cloudera.get_service_setup_info(service_type, service_type)
+        cloudera_manager.create_mgmt_service(service_info)
+        service_changed = True
+    result = service_changed | configuration_changed
+    return result  
+    
+def create_general_service(cloudera, connection, cluster_name, service_type, configuration_file):
+    cluster = cloudera.get_cluster(connection, cluster_name)
+    cloudera.validate_service_type(cluster, service_type)
+    if cluster is None:
+        raise Exception('No cluster found with name - %s' % cluster_name)
+    service_changed = False
+    configuration_changed = False
+    try:
+        cluster.get_service(service_type)
+    except:
+        cluster.create_service(service_type, service_type)
+        service_changed = True
+    if configuration_file is not None:
+        service = cluster.get_service(service_type)
+        current_config = service.get_config()[0]
+        configuration_changed = cloudera.update_config(service, current_config, configuration_file)
+    result = service_changed | configuration_changed
+    return result
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            host=dict(required=True, type='str'),
+            port=dict(default=7180, type='int'),
+            username=dict(default='admin', type='str'),
+            password=dict(default='admin', no_log=True, type='str'),
+            api_version=dict(default=12, type='int'),
+            use_tls=dict(default=False, type='bool'),
+            cluster_name=dict(default='MyCluster', required=False, type='str'),
+            service_type=dict(required=True, type='str'),
+            configuration_file=dict(required=False, default=None, type='path'),
+            state=dict(default='create', choices=['create'])
+        ),
+        supports_check_mode=True,
+    )
+
+    host = module.params['host']
+    port = module.params['port']
+    username = module.params['username']
+    password = module.params['password']
+    api_version = module.params['api_version']
+    use_tls = module.params['use_tls']
+    cluster_name = module.params['cluster_name']
+    service_type = module.params['service_type'].upper()
+    configuration_file = module.params['configuration_file']
+    state = module.params['state']
+    changed=False
+
+    if module.check_mode:
+        module.exit_json(changed=True)
+
+    cloudera = Cloudera(module, host, port, username, password, api_version, use_tls)
+    connection = cloudera.connect()
+
+    if state == 'create':
+        if service_type == 'MGMT':
+            changed = create_mgmt_service(cloudera, connection, service_type, configuration_file)
+        else:
+            changed = create_general_service(cloudera, connection, cluster_name, service_type, configuration_file)
+
+    module.exit_json(changed=changed)
+
+if __name__ == '__main__':
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.cloudera import *
+    main()

--- a/lib/ansible/modules/clustering/cloudera/cloudera_yarn_ha.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_yarn_ha.py
@@ -1,0 +1,139 @@
+#!/usr/bin/python
+#
+# (c) 2017, Serghei Anicheev <serghei.anicheev@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+DOCUMENTATION = '''
+---
+module: cloudera_yarn_ha
+author: "Serghei Anicheev (@sanicheev) <serghei.anicheev@gmail.com>"
+version_added: '2.2.0.2'
+short_description: Cloudera Manager enable HA for YARN.
+description:
+    - This module will enable HA for YARN. Please take in consideration that ZOOKEEPER service should be up and running!
+options:
+    host:
+        description:
+            - Cloudera Manager API host.
+        required: true
+    port:
+        description:
+            - Cloudera Manager API port.
+        required: false
+        default: 7180
+    username:
+        description:
+            - Username to connect to Cloudera Manager API.
+        required: false
+        default: admin
+    password:
+        description:
+            - Password to connect to Cloudera Manager API.
+        required: false
+        default: admin
+    api_version:
+        description:
+            - Cloudera API version(Older API versions cannot use calls like 'configure_for_kerberos' for example).
+        required: false
+        default: 12
+    use_tls:
+        description:
+            - Enable TLS(In this case port 7183 should be used!).
+        required: false
+        default: false
+    cluster_name:
+        description:
+            - Cloudera cluster name to search for YARN service type in.   .
+        required: true
+    secondary_host:
+        description:
+            - Hostname where secondary YARN will be created. Host MUST BE in cluster!
+        required: true    
+    state:
+        description:
+            - Enable YARN HA state.
+        required: false
+        default: 'enable_yarn_ha'
+        choices: ['enable_yarn_ha']        
+'''
+
+EXAMPLES = '''
+# Enable YARN HA
+- name: Enable YARN HA
+  cloudera_yarn_ha:
+    host: 123.123.123.123
+    port: 7180
+    username: admin
+    password: admin
+    cluster_name: MyCluster
+    secondary_host: 123.123.123.124
+    state: "enable_yarn_ha"
+'''
+
+def enable_yarn_ha(cloudera, connection, cluster_name, secondary_host):
+    cluster = connection.get_cluster(cluster_name)
+    service = cloudera.get_service_by_type(cluster, 'YARN')
+    secondary_host_id = cloudera.get_hostid_by_hostname(connection, secondary_host)
+    zookeeper_service_name = cloudera.get_service_by_type(cluster, 'ZOOKEEPER').name  
+    service.enable_rm_ha(secondary_host_id, zookeeper_service_name).wait()
+    service.create_yarn_job_history_dir().wait()
+    service.create_yarn_node_manager_remote_app_log_dir().wait()
+    return True
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            host=dict(required=True, type='str'),
+            port=dict(default=7180, type='int'),
+            username=dict(default='admin', type='str'),
+            password=dict(default='admin', no_log=True, type='str'),
+            api_version=dict(default=12, type='int'),
+            use_tls=dict(default=False, type='bool'),
+            cluster_name=dict(required=True, type='str'),
+            secondary_host=dict(required=True, type='str'),
+            state=dict(default='enable_yarn_ha', choices=['enable_yarn_ha'])
+        ),
+        supports_check_mode=True
+    )
+
+    host = module.params['host']
+    port = module.params['port']
+    username = module.params['username']
+    password = module.params['password']
+    api_version = module.params['api_version']
+    use_tls = module.params['use_tls']
+    cluster_name = module.params['cluster_name']
+    secondary_host = module.params['secondary_host']
+    state = module.params['state']
+    changed=False
+
+    cloudera = Cloudera(module, host, port, username, password, api_version, use_tls)
+    connection = cloudera.connect()
+
+    if module.check_mode:
+        module.exit_json(changed=True)
+
+    if state == 'enable_yarn_ha':
+        changed = enable_yarn_ha(cloudera, connection, cluster_name, secondary_host)
+
+    module.exit_json(changed=changed)
+
+if __name__ == '__main__':
+    from ansible.module_utils.basic import *
+    from ansible.module_utils.cloudera import *
+    main()

--- a/lib/ansible/modules/clustering/cloudera/cloudera_yarn_ha.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_yarn_ha.py
@@ -63,13 +63,13 @@ options:
     secondary_host:
         description:
             - Hostname where secondary YARN will be created. Host MUST BE in cluster!
-        required: true    
+        required: true
     state:
         description:
             - Enable YARN HA state.
         required: false
         default: 'enable_yarn_ha'
-        choices: ['enable_yarn_ha']        
+        choices: ['enable_yarn_ha']
 '''
 
 EXAMPLES = '''
@@ -89,7 +89,7 @@ def enable_yarn_ha(cloudera, connection, cluster_name, secondary_host):
     cluster = connection.get_cluster(cluster_name)
     service = cloudera.get_service_by_type(cluster, 'YARN')
     secondary_host_id = cloudera.get_hostid_by_hostname(connection, secondary_host)
-    zookeeper_service_name = cloudera.get_service_by_type(cluster, 'ZOOKEEPER').name  
+    zookeeper_service_name = cloudera.get_service_by_type(cluster, 'ZOOKEEPER').name
     service.enable_rm_ha(secondary_host_id, zookeeper_service_name).wait()
     service.create_yarn_job_history_dir().wait()
     service.create_yarn_node_manager_remote_app_log_dir().wait()

--- a/lib/ansible/modules/clustering/cloudera/cloudera_yarn_ha.py
+++ b/lib/ansible/modules/clustering/cloudera/cloudera_yarn_ha.py
@@ -17,6 +17,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
 
 DOCUMENTATION = '''
 ---


### PR DESCRIPTION
##### ISSUE TYPE
 - New Module Pull Request


##### COMPONENT NAME
module_utils/cloudera.py
modules/clustering/cloudera/cloudera_cluster.py
modules/clustering/cloudera/cloudera_hdfs_ha.py
modules/clustering/cloudera/cloudera_host.py
modules/clustering/cloudera/cloudera_kerberos.py
modules/clustering/cloudera/cloudera_license.py
modules/clustering/cloudera/cloudera_misc.py
modules/clustering/cloudera/cloudera_oozie_ha.py
modules/clustering/cloudera/cloudera_parcel.py
modules/clustering/cloudera/cloudera_role.py
modules/clustering/cloudera/cloudera_service.py
modules/clustering/cloudera/cloudera_yarn_ha.py

##### ANSIBLE VERSION
```
2.1.2.0
```

##### SUMMARY
```
Ansible changes were made by a http://www.contexti.com
Added library helper in module_utils : cloudera.py
Added cloudera_cluster.py in clustering module section to manage cloudera cluster
Added cloudera_hdfs_ha.py in clustering module section to enable HDFS HA
Added cloudera_host.py in clustering module section to provision and add hosts into cloudera cluster
Added cloudera_kerberos.py in clustering module section to configure services for kerberos
Added cloudera_license.py in clustering module section to manage cloudera license
Added cloudera_misc.py in clustering module section to perform misc actions such as: start,restart, deploy service configuration and etc.
Added cloudera_oozie_ha.py in clustering module section to enable HA for OOZIE
Added cloudera_parcel.py in clustering module section to install and activate parcel in cluster
Added cloudera_role.py in clustering module section to manage cloudera service
Added cloudera_service.py in clustering module section to manage cloudera role
Added cloudera_yarn_ha.py in clustering module section to enable HA for YARN

Modules are using cm_api client package built by http://www.cloudera.com/.
Link to its repo : https://github.com/cloudera/cm_api
```
