### PR TITLE
Fix exception in module validator.

### DIFF
--- a/test/sanity/validate-modules/validate-modules
+++ b/test/sanity/validate-modules/validate-modules
@@ -428,9 +428,15 @@ class ModuleValidator(Validator):
 
         for error in errors:
             path = [str(p) for p in error.path]
+
+            if isinstance(error.data, dict):
+                error_message = humanize_error(error.data, error)
+            else:
+                error_message = error
+
             self.errors.append('%s.%s: %s' %
                                (name, '.'.join(path),
-                                humanize_error(error.data, error)))
+                                error_message))
 
     def _validate_docs(self):
         doc_info = self._get_docs()


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

validate-modules

##### ANSIBLE VERSION

```
ansible 2.3.0 (validate-fix 01ddbe7cb5) last updated 2017/02/02 17:25:48 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Fix exception in module validator when trying to validate PR #20849:

```
2017-02-02 22:41:25 Traceback (most recent call last):
2017-02-02 22:41:25   File "test/sanity/validate-modules/validate-modules", line 745, in <module>
2017-02-02 22:41:25     main()
2017-02-02 22:41:25   File "test/sanity/validate-modules/validate-modules", line 737, in main
2017-02-02 22:41:25     mv.validate()
2017-02-02 22:41:25   File "test/sanity/validate-modules/validate-modules", line 625, in validate
2017-02-02 22:41:25     doc_info = self._validate_docs()
2017-02-02 22:41:25   File "test/sanity/validate-modules/validate-modules", line 462, in _validate_docs
2017-02-02 22:41:25     self._validate_docs_schema(doc, doc_schema, 'DOCUMENTATION')
2017-02-02 22:41:25   File "test/sanity/validate-modules/validate-modules", line 433, in _validate_docs_schema
2017-02-02 22:41:25     humanize_error(error.data, error)))
2017-02-02 22:41:25   File "/root/src/github.com/ansible/ansible/test/runner/.tox/py27/local/lib/python2.7/site-packages/voluptuous/humanize.py", line 29, in humanize_error
2017-02-02 22:41:25     offending_item_summary = repr(_nested_getitem(data, validation_error.path))
2017-02-02 22:41:25   File "/root/src/github.com/ansible/ansible/test/runner/.tox/py27/local/lib/python2.7/site-packages/voluptuous/humanize.py", line 11, in _nested_getitem
2017-02-02 22:41:25     data = data[item_index]
2017-02-02 22:41:25 TypeError: 'NoneType' object has no attribute '__getitem__'
```

