### PR TITLE
Update tox.ini to match current standards

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,17 +24,37 @@ passenv =
 
 [flake8]
 # These are things that the devs don't agree make the code more readable
+# https://github.com/ansible/proposals/issues/50
+# E123 closing bracket does not match indentation of opening bracket's line
+# E124 closing bracket does not match visual indentation
+# E127 continuation line over-indented for visual indent
 # E128 continuation line under-indented for visual indent
 # E201 whitespace after '['
 # E202 whitespace before ']'
 # E203 whitespace before ','
 # E221 multiple spaces before operator
+# E222 multiple spaces after operator
 # E225 missing whitespace around operator
 # E226 missing whitespace around arithmetic operator
+# E227 missing whitespace around bitwise or shift operator
+# E228 missing whitespace around modulo operator
 # E231 missing whitespace after ','
 # E241 multiple spaces after ','
 # E251 unexpected spaces around keyword / parameter equals
-ignore = E128,E201,E202,E203,E221,E225,E226,E231,E241,E251
+# E261 at least two spaces before inline comment
+# E262 inline comment should start with '# '
+# E265 block comment should start with '# '
+# E266 too many leading '#' for block comment
+# E301 expected 1 blank line, found 0
+# E302 expected 2 blank lines, found 1
+# E303 too many blank lines (3)
+# E402 module level import not at top of file
+# E502 the backslash is redundant between brackets
+# E713 test for membership should be 'not in'
+# E731 do not assign a lambda expression, use a def
+# W391 blank line at end of file
+# W503 line break before binary operator
+ignore = E123,E124,E127,E128,E201,E202,E203,E211,E221,E222,E225,E226,E228,E227,E231,E241,E251,E261,E262,E265,E266,E301,E302,E303,E402,E502,E713,E731,W391,W503
 # not all the devs believe in 80 column line length
 max-line-length = 160
 # Not going to worry about style in the test suite


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
tox.ini

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 1df14ed121) last updated 2017/02/03 14:52:00 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

tox.ini is used for flake8 configuration in addition to tox
configuration. Update the flake8 configuration to match the
latest standards as documented in ansible/proposals#50
