### PR TITLE
Add Check Mode capability to kernel_blacklist module

### DIFF
--- a/lib/ansible/modules/system/kernel_blacklist.py
+++ b/lib/ansible/modules/system/kernel_blacklist.py
@@ -118,7 +118,7 @@ def main():
                        default='present'),
             blacklist_file=dict(required=False, default=None)
         ),
-        supports_check_mode=False,
+        supports_check_mode=True,
     )
 
     args = dict(changed=False, failed=False,
@@ -128,6 +128,9 @@ def main():
 
     if module.params['blacklist_file']:
         filename = module.params['blacklist_file']
+
+    if module.check_mode:
+        filename = '/dev/null'
 
     blacklist = Blacklist(args['name'], filename)
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
modules/system/kernel_blacklist

##### ANSIBLE VERSION
```
ansible 2.3.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added the ability for the kernel_blacklist module to run under Check Mode.

Simply redirect writes to /dev/null

Module will not make any changes to the local system but will report changes if there are any that it would have made.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
