### PR TITLE
Add missing support for -CertValidityDays

### DIFF
--- a/examples/scripts/ConfigureRemotingForAnsible.ps1
+++ b/examples/scripts/ConfigureRemotingForAnsible.ps1
@@ -193,7 +193,7 @@ If (!($listeners | Where {$_.Keys -like "TRANSPORT=HTTPS"}))
     # HTTPS-based endpoint does not exist.
     If (Get-Command "New-SelfSignedCertificate" -ErrorAction SilentlyContinue)
     {
-        $cert = New-SelfSignedCertificate -DnsName $SubjectName -CertStoreLocation "Cert:\LocalMachine\My" -ValidDays $CertValidityDays
+        $cert = New-SelfSignedCertificate -DnsName $SubjectName -CertStoreLocation "Cert:\LocalMachine\My" -NotAfter (Get-Date).AddDays($CertValidityDays)
         $thumbprint = $cert.Thumbprint
         Write-HostLog "Self-signed SSL certificate generated; thumbprint: $thumbprint"
     }
@@ -229,7 +229,7 @@ Else
         # Create the new cert.
         If (Get-Command "New-SelfSignedCertificate" -ErrorAction SilentlyContinue)
         {
-            $cert = New-SelfSignedCertificate -DnsName $SubjectName -CertStoreLocation "Cert:\LocalMachine\My" -ValidDays $CertValidityDays
+            $cert = New-SelfSignedCertificate -DnsName $SubjectName -CertStoreLocation "Cert:\LocalMachine\My" -NotAfter (Get-Date).AddDays($CertValidityDays)
             $thumbprint = $cert.Thumbprint
             Write-HostLog "Self-signed SSL certificate generated; thumbprint: $thumbprint"
         }

--- a/examples/scripts/ConfigureRemotingForAnsible.ps1
+++ b/examples/scripts/ConfigureRemotingForAnsible.ps1
@@ -190,18 +190,9 @@ Else
 $listeners = Get-ChildItem WSMan:\localhost\Listener
 If (!($listeners | Where {$_.Keys -like "TRANSPORT=HTTPS"}))
 {
-    # HTTPS-based endpoint does not exist.
-    If (Get-Command "New-SelfSignedCertificate" -ErrorAction SilentlyContinue)
-    {
-        $cert = New-SelfSignedCertificate -DnsName $SubjectName -CertStoreLocation "Cert:\LocalMachine\My" -NotAfter (Get-Date).AddDays($CertValidityDays)
-        $thumbprint = $cert.Thumbprint
-        Write-HostLog "Self-signed SSL certificate generated; thumbprint: $thumbprint"
-    }
-    Else
-    {
-        $thumbprint = New-LegacySelfSignedCert -SubjectName $SubjectName -ValidDays $CertValidityDays
-        Write-HostLog "(Legacy) Self-signed SSL certificate generated; thumbprint: $thumbprint"
-    }
+    # We cannot use New-SelfSignedCertificate on 2012R2 and earlier
+    $thumbprint = New-LegacySelfSignedCert -SubjectName $SubjectName -ValidDays $CertValidityDays
+    Write-HostLog "Self-signed SSL certificate generated; thumbprint: $thumbprint"
 
     # Create the hashtables of settings to be used.
     $valueset = @{
@@ -226,18 +217,9 @@ Else
     If ($ForceNewSSLCert)
     {
 
-        # Create the new cert.
-        If (Get-Command "New-SelfSignedCertificate" -ErrorAction SilentlyContinue)
-        {
-            $cert = New-SelfSignedCertificate -DnsName $SubjectName -CertStoreLocation "Cert:\LocalMachine\My" -NotAfter (Get-Date).AddDays($CertValidityDays)
-            $thumbprint = $cert.Thumbprint
-            Write-HostLog "Self-signed SSL certificate generated; thumbprint: $thumbprint"
-        }
-        Else
-        {
-            $thumbprint = New-LegacySelfSignedCert -SubjectName $SubjectName -ValidDays $CertValidityDays
-            Write-HostLog "(Legacy) Self-signed SSL certificate generated; thumbprint: $thumbprint"
-        }
+        # We cannot use New-SelfSignedCertificate on 2012R2 and earlier
+        $thumbprint = New-LegacySelfSignedCert -SubjectName $SubjectName -ValidDays $CertValidityDays
+        Write-HostLog "Self-signed SSL certificate generated; thumbprint: $thumbprint"
 
         $valueset = @{
             CertificateThumbprint = $thumbprint


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ConfigureRemotingForAnsible

##### ANSIBLE VERSION
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
For some reason the -CertValidityDays option was not being used in the certificates we created.

This fixes #10439