### PR TITLE
Add ConfigMap support to kubernetes module

### DIFF
--- a/lib/ansible/modules/clustering/kubernetes.py
+++ b/lib/ansible/modules/clustering/kubernetes.py
@@ -202,6 +202,7 @@ except ImportError:
 
 KIND_URL = {
     "binding": "/api/v1/namespaces/{namespace}/bindings",
+    "configmap": "/api/v1/namespaces/{namespace}/configmaps",
     "endpoints": "/api/v1/namespaces/{namespace}/endpoints",
     "limitrange": "/api/v1/namespaces/{namespace}/limitranges",
     "namespace": "/api/v1/namespaces",


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- `kubernetes` module

##### ANSIBLE VERSION

- Tested on 2.1.4.0 and 2.2.1.0

##### SUMMARY

The module was failing when trying to create a `ConfigMap`, as there was no support. The code itself seems extremely modular, all it took was adding a single line to correctly match resource type with API endpoints.
