### PR TITLE
Make configparser imports python3 ready

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -18,7 +18,6 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import ConfigParser
 import json
 import os
 import re
@@ -29,7 +28,9 @@ import inspect
 
 from distutils.version import LooseVersion
 from os.path import expanduser
-from ansible.module_utils.basic import *
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six.moves import configparser
 
 AZURE_COMMON_ARGS = dict(
     profile=dict(type='str'),
@@ -299,7 +300,7 @@ class AzureRMModuleBase(object):
     def _get_profile(self, profile="default"):
         path = expanduser("~/.azure/credentials")
         try:
-            config = ConfigParser.ConfigParser()
+            config = configparser.ConfigParser()
             config.read(path)
         except Exception as exc:
             self.fail("Failed to access {0}. Check that the file exists and you have read "

--- a/lib/ansible/module_utils/exoscale.py
+++ b/lib/ansible/module_utils/exoscale.py
@@ -36,12 +36,12 @@ except ImportError:
         # Let snippet from module_utils/basic.py return a proper error in this case
         pass
 
-import urllib
-from ConfigParser import ConfigParser, NoSectionError
+import os
 
 # import module snippets
-from ansible.module_utils.urls import *
-from ansible.module_utils.basic import *
+from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils.six.moves import configparser
+from ansible.module_utils.urls import fetch_url
 
 EXO_DNS_BASEURL="https://api.exoscale.ch/dns/v1"
 
@@ -115,7 +115,7 @@ class ExoDns(object):
             raise SystemExit("Config file not found. Tried {0}".format(
                 ", ".join(paths)))
 
-        conf = ConfigParser()
+        conf = configparser.ConfigParser()
         conf.read(paths)
         return dict(conf.items(ini_group))
 

--- a/lib/ansible/module_utils/redhat.py
+++ b/lib/ansible/module_utils/redhat.py
@@ -29,7 +29,8 @@
 import os
 import re
 import types
-import ConfigParser
+
+from ansible.module_utils.six.moves import configparser
 
 
 class RegistrationBase(object):
@@ -59,7 +60,7 @@ class RegistrationBase(object):
     def update_plugin_conf(self, plugin, enabled=True):
         plugin_conf = '/etc/yum/pluginconf.d/%s.conf' % plugin
         if os.path.isfile(plugin_conf):
-            cfg = ConfigParser.ConfigParser()
+            cfg = configparser.ConfigParser()
             cfg.read([plugin_conf])
             if enabled:
                 cfg.set('main', 'enabled', 1)
@@ -87,7 +88,7 @@ class Rhsm(RegistrationBase):
         '''
 
         # Read RHSM defaults ...
-        cp = ConfigParser.ConfigParser()
+        cp = configparser.ConfigParser()
         cp.read(rhsm_conf)
 
         # Add support for specifying a default value w/o having to standup some configuration
@@ -99,7 +100,7 @@ class Rhsm(RegistrationBase):
             else:
                 return default
 
-        cp.get_option = types.MethodType(get_option_default, cp, ConfigParser.ConfigParser)
+        cp.get_option = types.MethodType(get_option_default, cp, configparser.ConfigParser)
 
         return cp
 

--- a/lib/ansible/modules/database/misc/mongodb_parameter.py
+++ b/lib/ansible/modules/database/misc/mongodb_parameter.py
@@ -113,7 +113,7 @@ after:
     type: string
 '''
 
-import ConfigParser
+import os
 
 try:
     from pymongo.errors import ConnectionFailure
@@ -130,13 +130,17 @@ except ImportError:
 else:
     pymongo_found = True
 
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils.six.moves import configparser
+
 
 # =========================================
 # MongoDB module specific support methods.
 #
 
 def load_mongocnf():
-    config = ConfigParser.RawConfigParser()
+    config = configparser.RawConfigParser()
     mongocnf = os.path.expanduser('~/.mongodb.cnf')
 
     try:
@@ -145,7 +149,7 @@ def load_mongocnf():
             user=config.get('client', 'user'),
             password=config.get('client', 'pass')
         )
-    except (ConfigParser.NoOptionError, IOError):
+    except (configparser.NoOptionError, IOError):
         return False
 
     return creds
@@ -230,10 +234,6 @@ def main():
         module.exit_json(changed=(value != after_value["was"]), before=after_value["was"],
                          after=value)
 
-
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.pycompat24 import get_exception
 
 if __name__ ==  '__main__':
     main()

--- a/lib/ansible/modules/database/misc/mongodb_user.py
+++ b/lib/ansible/modules/database/misc/mongodb_user.py
@@ -189,9 +189,10 @@ EXAMPLES = '''
 
 '''
 
+import os
 import ssl as ssl_lib
-import ConfigParser
 from distutils.version import LooseVersion
+
 try:
     from pymongo.errors import ConnectionFailure
     from pymongo.errors import OperationFailure
@@ -206,6 +207,11 @@ except ImportError:
         pymongo_found = True
 else:
     pymongo_found = True
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils.six.moves import configparser
+
 
 # =========================================
 # MongoDB module specific support methods.
@@ -279,7 +285,7 @@ def user_remove(module, client, db_name, user):
         module.exit_json(changed=False, user=user)
 
 def load_mongocnf():
-    config = ConfigParser.RawConfigParser()
+    config = configparser.RawConfigParser()
     mongocnf = os.path.expanduser('~/.mongodb.cnf')
 
     try:
@@ -288,7 +294,7 @@ def load_mongocnf():
             user=config.get('client', 'user'),
             password=config.get('client', 'pass')
         )
-    except (ConfigParser.NoOptionError, IOError):
+    except (configparser.NoOptionError, IOError):
         return False
 
     return creds
@@ -446,9 +452,6 @@ def main():
 
     module.exit_json(changed=True, user=user)
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.pycompat24 import get_exception
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/monitoring/nagios.py
+++ b/lib/ansible/modules/monitoring/nagios.py
@@ -196,13 +196,14 @@ EXAMPLES = '''
     command: DISABLE_FAILURE_PREDICTION
 '''
 
-import ConfigParser
 import types
 import time
 import os.path
 
-######################################################################
+from ansible.module_utils.basic import AnsibleModule
 
+
+######################################################################
 
 def which_cmdfile():
     locations = [
@@ -1079,9 +1080,6 @@ class Nagios(object):
         self.module.exit_json(nagios_commands=self.command_results,
                               changed=True)
 
-######################################################################
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -160,8 +160,10 @@ EXAMPLES = '''
 import os
 import re
 import types
-import ConfigParser
-import shlex
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils.six.moves import configparser
 
 
 class RegistrationBase(object):
@@ -191,7 +193,7 @@ class RegistrationBase(object):
     def update_plugin_conf(self, plugin, enabled=True):
         plugin_conf = '/etc/yum/pluginconf.d/%s.conf' % plugin
         if os.path.isfile(plugin_conf):
-            cfg = ConfigParser.ConfigParser()
+            cfg = configparser.ConfigParser()
             cfg.read([plugin_conf])
             if enabled:
                 cfg.set('main', 'enabled', 1)
@@ -219,7 +221,7 @@ class Rhsm(RegistrationBase):
         '''
 
         # Read RHSM defaults ...
-        cp = ConfigParser.ConfigParser()
+        cp = configparser.ConfigParser()
         cp.read(rhsm_conf)
 
         # Add support for specifying a default value w/o having to standup some configuration
@@ -231,7 +233,7 @@ class Rhsm(RegistrationBase):
             else:
                 return default
 
-        cp.get_option = types.MethodType(get_option_default, cp, ConfigParser.ConfigParser)
+        cp.get_option = types.MethodType(get_option_default, cp, configparser.ConfigParser)
 
         return cp
 
@@ -558,9 +560,6 @@ def main():
             else:
                 module.exit_json(changed=True, msg="System successfully unregistered from %s." % server_hostname)
 
-
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/plugins/lookup/ini.py
+++ b/lib/ansible/plugins/lookup/ini.py
@@ -21,13 +21,7 @@ from io import StringIO
 import os
 import re
 
-try:
-    # python2
-    import ConfigParser as configparser
-except ImportError:
-    # python3
-    import configparser
-
+from ansible.compat.six.moves import configparser
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 from ansible.module_utils._text import to_bytes, to_text


### PR DESCRIPTION
the ConfigParser module was renamed to configparser in Python3.  Use
six.moves to import it so that the modules will function on Python3.

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
various


##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel, 2.2
```
