### PR TITLE
New module: elasticache_parameter_group for modifying Elasticache cluster settings

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -112,6 +112,12 @@ changed:
     changed: true
 """
 
+# import module snippets
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec, camel_dict_to_snake_dict
+from ansible.module_utils.six import text_type
+import traceback
+
 try:
     import boto3
     import botocore
@@ -321,12 +327,6 @@ def main():
     facts_result = dict(changed=changed, elasticache=camel_dict_to_snake_dict(response))
 
     module.exit_json(**facts_result)
-
-# import module snippets
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec, camel_dict_to_snake_dict
-from ansible.module_utils.six import text_type
-import traceback
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -173,13 +173,13 @@ def check_valid_modification(module, values, modifiable_params):
         # check allowed datatype for modified parameters
         str_to_type = {"integer": int, "string": str}
         if type(new_value) != str_to_type[modifiable_params[parameter][1]]:
-            module.fail_json(msg="%s (type %s) is not an allowed value for the parameter %s. Expected a type %s." % 
+            module.fail_json(msg="%s (type %s) is not an allowed value for the parameter %s. Expected a type %s." %
                              (new_value, type(new_value), parameter, modifiable_params[parameter][1]))
 
         # check allowed values for modifiable parameters
         if str(new_value) not in modifiable_params[parameter][0]:
             if "-" not in modifiable_params[parameter][0]:
-                module.fail_json(msg="%s is not an allowed value for the parameter %s. Valid parameters are: %s." % 
+                module.fail_json(msg="%s is not an allowed value for the parameter %s. Valid parameters are: %s." %
                                  (value, modified, modifiable_params[parameter][0]))
 
         # check if a new value is different from current value
@@ -199,7 +199,7 @@ def check_changed_parameter_values(values, old_parameters, new_parameters):
             if old_parameters[parameter] != new_parameters[parameter]:
                 changed_with_update = True
                 break
-    # otherwise check all to find a change 
+    # otherwise check all to find a change
     else:
         for parameter in old_parameters.keys():
             if old_parameters[parameter] != new_parameters[parameter]:

--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -95,14 +95,14 @@ elasticache:
             "cache_parameter_group_family": "redis3.2",
             "cache_parameter_group_name": "test-please-delete",
             "description": "initial description"
-        },
+        }
         "response_metadata": {
             "http_headers": {
                 "content-length": "562",
                 "content-type": "text/xml",
                 "date": "Mon, 06 Feb 2017 22:14:08 GMT",
                 "x-amzn-requestid": "947291f9-ecb9-11e6-85bd-3baa4eca2cc1"
-            },
+            }
             "http_status_code": 200,
             "request_id": "947291f9-ecb9-11e6-85bd-3baa4eca2cc1",
             "retry_attempts": 0
@@ -177,10 +177,9 @@ def check_valid_modification(module, values, modifiable_params):
                              (new_value, type(new_value), parameter, modifiable_params[parameter][1]))
 
         # check allowed values for modifiable parameters
-        if text_type(new_value) not in modifiable_params[parameter][0]:
-            if "-" not in modifiable_params[parameter][0]:
-                module.fail_json(msg="%s is not an allowed value for the parameter %s. Valid parameters are: %s." %
-                                 (value, modified, modifiable_params[parameter][0]))
+        if text_type(new_value) not in modifiable_params[parameter][0] and not isinstance(new_value, int):
+            module.fail_json(msg="%s is not an allowed value for the parameter %s. Valid parameters are: %s." %
+                                 (new_value, parameter, modifiable_params[parameter][0]))
 
         # check if a new value is different from current value
         if text_type(new_value) != modifiable_params[parameter][2]:

--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -51,7 +51,7 @@ options:
     description:
       - A user-specified list of parameters to reset or modify for the cache parameter group.
     required: no
-    type: list
+    type: dict
     default: None
 """
 

--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -20,7 +20,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 
 DOCUMENTATION = """
 ---
-module: elasticache
+module: elasticache_group_parameter
 short_description: Manage cache security groups in Amazon Elasticache.
 description:
   - Manage cache security groups in Amazon Elasticache.

--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -130,7 +130,7 @@ def create(module, conn, name, group_family, description):
     try:
         response = conn.create_cache_parameter_group(CacheParameterGroupName=name, CacheParameterGroupFamily=group_family, Description=description)
         changed = True
-    except boto.exception.BotoServerError as e:
+    except boto.exception.ClientError as e:
         module.fail_json(msg=e.message)
     return response, changed
 
@@ -140,7 +140,7 @@ def delete(module, conn, name):
         conn.delete_cache_parameter_group(CacheParameterGroupName=name)
         response = {}
         changed = True
-    except boto.exception.BotoServerError as e:
+    except boto.exception.ClientError as e:
         module.fail_json(msg=e.message)
     return response, changed
 
@@ -218,7 +218,7 @@ def modify(module, conn, name, values):
         format_parameters.append({'ParameterName': key, 'ParameterValue': value})
     try:
         response = conn.modify_cache_parameter_group(CacheParameterGroupName=name, ParameterNameValues=format_parameters)
-    except boto.exception.BotoServerError as e:
+    except boto.exception.ClientError as e:
         module.fail_json(msg=e.message)
     return response
 
@@ -242,7 +242,7 @@ def reset(module, conn, name, values):
 
     try:
         response = conn.reset_cache_parameter_group(CacheParameterGroupName=name, ParameterNameValues=format_parameters, ResetAllParameters=all_parameters)
-    except boto.exception.BotoServerError as e:
+    except boto.exception.ClientError as e:
         module.fail_json(msg=e.message)
 
     # determine changed

--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -256,11 +256,9 @@ def main():
     if not region:
         module.fail_json(msg = str("Either region or AWS_REGION or EC2_REGION environment variable or boto config aws_region     or ec2_region must be set."))
 
-    connection = boto3_conn(module, conn_type='client', resource='elasticache', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-    #client = boto3_conn(module, conn_type='client',
-    #                         resource='elasticache', region=region,
-    #                         endpoint="elasticache.%s.amazonaws.com" % region, 
-    #                         **aws_connect_kwargs)  # endpoint was ec2_url
+    connection = boto3_conn(module, conn_type='client', 
+                            resource='elasticache', region=region, 
+                            endpoint=ec2_url, **aws_connect_kwargs)
 
     exists = get_info(connection, parameter_group_name)
      
@@ -289,10 +287,7 @@ def main():
         else:
             changed = False
     elif state == 'reset':
-        #initial_parameters = make_current_modifiable_param_dict(connection, parameter_group_name)
         result, changed = reset(connection, parameter_group_name, update_values)
-        #new_parameters = make_current_modifiable_param_dict(connection, parameter_group_name)
-        # check if initial parameters differ from current parameters
 
     facts_result = dict(changed=changed, elasticache=get_info(connection, parameter_group_name))
 

--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -323,7 +323,7 @@ def main():
     module.exit_json(**facts_result)
 
 # import module snippets
-from ansible.module_utils.basic import *
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec, camel_dict_to_snake_dict
 from ansible.module_utils.six import text_type
 import traceback

--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -86,17 +86,17 @@ EXAMPLES = """
 """
 
 RETURN = """
-elasticache: 
+elasticache:
   description: cache parameter group information and response metadata
   returned: always
   type: dict
-  sample: 
-    cache_parameter_group: 
+  sample:
+    cache_parameter_group:
       cache_parameter_group_family: redis3.2
       cache_parameter_group_name: test-please-delete
       description: "initial description"
-    response_metadata: 
-      http_headers: 
+    response_metadata:
+      http_headers:
         content-length: "562"
         content-type: text/xml
         date: "Mon, 06 Feb 2017 22:14:08 GMT"
@@ -104,11 +104,11 @@ elasticache:
       http_status_code: 200
       request_id: 947291f9-ecb9-11e6-85bd-3baa4eca2cc1
       retry_attempts: 0
-changed: 
+changed:
   description: if the cache parameter group has changed
   returned: always
   type: bool
-  sample: 
+  sample:
     changed: true
 """
 

--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -112,10 +112,6 @@ changed:
     changed: true
 """
 
-from ansible.module_utils.ec2 import boto3_conn
-from ansible.module_utils.six import text_type
-import traceback
-
 try:
     import boto3
     import botocore
@@ -255,24 +251,25 @@ def get_info(conn, name):
 
 def main():
     argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
-        group_family    = dict(required=False, type='str', choices=['memcached1.4', 'redis2.6', 'redis2.8', 'redis3.2']),
-        name            = dict(required=True, type='str'),
-        description     = dict(required=False),
-        state           = dict(required=True),
-        values          = dict(required=False, type='dict'),
-    )
+    argument_spec.update(
+        dict(
+            group_family=dict(type='str', choices=['memcached1.4', 'redis2.6', 'redis2.8', 'redis3.2']),
+            name=dict(required=True, type='str'),
+            description=dict(type='str'),
+            state=dict(required=True),
+            values=dict(type='dict'),
+        )
     )
     module = AnsibleModule(argument_spec=argument_spec)
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto required for this module')
 
-    parameter_group_family  = module.params.get('group_family')
-    parameter_group_name    = module.params.get('name')
-    group_description       = module.params.get('description')
-    state                   = module.params.get('state')
-    values                  = module.params.get('values')
+    parameter_group_family = module.params.get('group_family')
+    parameter_group_name = module.params.get('name')
+    group_description = module.params.get('description')
+    state = module.params.get('state')
+    values = module.params.get('values')
 
     # Retrieve any AWS settings from the environment.
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
@@ -327,7 +324,9 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
+from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec, camel_dict_to_snake_dict
+from ansible.module_utils.six import text_type
+import traceback
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -1,0 +1,342 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = """
+---
+module: elasticache
+short_description: Manage cache security groups in Amazon Elasticache.
+description:
+  - Manage cache security groups in Amazon Elasticache.
+  - Returns information about the specified cache cluster.
+version_added: "2.3"
+author: "Sloane Hertel (@s-hertel)"
+options:
+  group_family:
+    description:
+      - The name of the cache parameter group family that the cache parameter group can be used with. 
+    choices: ['memcached1.4', 'redis2.6', 'redis2.8', 'redis3.2']
+    required: yes
+    type: string
+  name:
+    description:
+     - A user-specified name for the cache parameter group.
+     required: yes
+     type: string
+  description:
+    description:
+      - A user-specified description for the cache parameter group.
+  state:
+    description:
+      - Idempotent actions that will create/modify, destroy, or reset a cache parameter group as needed.
+    choices: ['present', 'absent', 'reset']
+    required: true
+  update_values:
+    description:
+      - A user-specified list of parameters to reset or modify for the cache parameter group.
+    required: no
+    type: list
+    default: None
+"""
+
+EXAMPLES = """
+# Note: None of these examples set aws_access_key, aws_secret_key, or region.
+# It is assumed that their matching environment variables are set.
+---
+- hosts: localhost
+  connection: local
+  tasks:
+    - name: 'Create a test parameter group'
+      elasticache_parameter_group:
+        name: 'test-param-group'
+        group_family: 'redis3.2'
+        description: 'This is a cache parameter group'
+        state: 'present'
+    - name: 'Modify a test parameter group'
+      elasticache_parameter_group:
+        name: 'test-param-group'
+        update_values:
+          - ['activerehashing', 'yes']
+          - ['client-output-buffer-limit-normal-hard-limit', 4]
+        state: 'present'
+    - name: 'Reset all modifiable parameters for the test parameter group'
+      elasticache_parameter_group:
+        name: 'test-param-group'
+        state: reset
+    - name: 'Delete a test parameter group'
+      elasticache_parameter_group:
+        name: 'test-param-group'
+        state: 'absent'
+
+"""
+
+import traceback
+
+try:
+    import boto
+    from boto.elasticache.layer1 import ElastiCacheConnection
+    from boto.regioninfo import RegionInfo
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+
+class ElastiCacheManager(object):
+    def __init__(self, module, aws_connect_kwargs, state, group_name, group_family, description, update_values, region):
+        self.module = module
+        self.aws_connect_kwargs = aws_connect_kwargs
+        self.state = state
+        self.name = group_name
+        self.group_family = group_family
+        self.description = description
+        self.update_values = update_values
+
+        self.changed = False
+        self.response = None
+        self.region = region
+        self._get_elasticache_connection()
+        self.exists = self.get_info()
+
+    def _get_elasticache_connection(self):
+        """Get an elasticache connection"""
+        try:
+            endpoint = "elasticache.%s.amazonaws.com" % self.region
+            connect_region = RegionInfo(name=self.region, endpoint=endpoint)
+            self.conn = ElastiCacheConnection(region=connect_region, **self.aws_connect_kwargs)
+        except boto.exception.NoAuthHandlerFound as e:
+            self.module.fail_json(msg=e.message)
+
+    def create(self):
+        """ Create ElastiCache parameter group if it doesn't exist. If it does exist, update it if needed. """
+        try:
+            self.response = self.conn.create_cache_parameter_group(cache_parameter_group_name=self.name, cache_parameter_group_family=self.group_family, description=self.description)
+            self.changed = True
+        except boto.exception.BotoServerError as e:
+            self.module.fail_json(msg=e.message)
+ 
+    def delete(self):
+        """ Delete ElastiCache parameter group if it exists. """
+        if self.exists:
+            try:
+                self.response = self.conn.delete_cache_parameter_group(cache_parameter_group_name=self.name)
+                self.changed = True
+            except boto.exception.BotoServerError as e:
+                self.module.fail_json(msg=e.message)
+
+    def make_current_modifiable_param_dict(self):
+        """ Gets the current state of the cache parameter group and creates a dictionary with the format: {ParameterName: [Allowed_Values, DataType, ParameterValue]}"""
+        current_info = self.get_info()
+        if current_info is False:
+            self.module.fail_json(msg="The the parameter group cannot be found. Ensure it exists and you have access to it.")
+        
+        parameters = current_info["DescribeCacheParametersResponse"]["DescribeCacheParametersResult"]["Parameters"]
+        modifiable_params = {}
+
+        for i in range(0, len(parameters)):
+            param = parameters[i]
+            if param["IsModifiable"] == True:
+                modifiable_params[param["ParameterName"]] = [param["AllowedValues"], param["DataType"], param["ParameterValue"]]
+
+        return modifiable_params
+
+    def check_valid_parameter_names(self):
+        """ Check if the parameters and values in update_values are valid.  """
+        modifiable_params = self.make_current_modifiable_param_dict()
+        
+        if self.state == "reset":
+            # returning the current parameter dict so we can compare it for changes after everything has been reset
+            return modifiable_params
+
+        changed_with_update = False
+
+        for i in range(0, len(self.update_values)):
+            # check valid modifiable parameters
+            modified = self.update_values[i][0]
+            if modified not in modifiable_params.keys():
+                self.module.fail_json(msg="%s is not a modifiable parameter." % modified)
+
+        changed_with_update = self.check_valid_parameter_name_values(modifiable_params, allowed_index=0, type_index=1, value_index=2)
+
+        return changed_with_update
+
+    def check_changed_parameter_values(self, old_parameters, new_parameters):
+        """ Checking if the new values are different than the old values.  """
+        changed_with_update = False
+
+        # if the user specified parameters to reset, only check those for change
+        if self.update_values:
+            for i in range(0, len(self.update_values)):
+                parameter = self.update_values[i][0]
+                if old_parameters[parameter] != new_parameters[parameter]:
+                    changed_with_update = True
+                    break
+        # otherwise check all to find a change            
+        else:
+            for parameter in old_parameters.keys():
+                if old_parameters[parameter] != new_parameters[parameter]:
+                    changed_with_update = True
+                    break
+        return changed_with_update
+
+    def check_valid_parameter_name_values(self, modifiable_params, allowed_index, type_index, value_index):
+        """ Check if the parameters and values in update_values are valid.  """
+        changed_with_update = False
+
+        new_param = 0
+        new_value = 1
+        
+        # iterating through the length of self.update_values; each index is a parameter,value pair the user wants to modify
+        for i in range(0, len(self.update_values)):
+            
+            # check valid modifiable parameters
+            modified = self.update_values[i][new_param]
+            if modified not in modifiable_params.keys():
+                self.module.fail_json("%s is not a modifiable parameter." % modified)
+            
+            # check allowed values for modifiable parameters
+            value = self.update_values[i][new_value]
+            if str(value) not in modifiable_params[modified][allowed_index]:
+                if "-" not in modifiable_params[modified][allowed_index]:
+                    self.module.fail_json(msg="%s is not an allowed value for the parameter %s. Valid parameters are: %s." % (value, modified, modifiable_params[modified][0]))
+
+            # check allowed datatype for modifiable parameter values
+            modified_type = type(self.update_values[i][new_value])
+            expected_type = modifiable_params[modified][type_index]  # Out of index
+            if (expected_type == "string" and modified_type != str) or (expected_type == "integer" and modified_type != int):
+                self.module.fail_json(msg="%s (type %s) is not an allowed value for the parameter %s. Expected a type %s." % (value, modified_type, modified, expected_type))
+
+            # check if a new value is different from current value; 1 value must be different for changed=True
+            if str(value) != modifiable_params[modified][value_index]:
+                changed_with_update = True
+        
+        return changed_with_update
+
+    def modify(self):
+        """ Modify ElastiCache parameter group to reflect the new information if it differs from the current. """
+        # compares current group parameters with the parameters we've specified to to a value to see if this will change the group
+        changed_with_update = self.check_valid_parameter_names()
+        try:
+            self.response = self.conn.modify_cache_parameter_group(cache_parameter_group_name=self.name, parameter_name_values=self.update_values)
+            self.changed = changed_with_update
+        except boto.exception.BotoServerError as e:
+            self.module.fail_json(msg=e.message)
+
+    def reset(self):
+        """ Reset ElastiCache parameter group if the current information is different from the new information. """
+        # used to compare with the reset parameters' dict to see if there have been changes
+        old_parameters_dict = self.make_current_modifiable_param_dict()
+        
+        # determine whether to reset all or specific parameters
+        if self.update_values:
+            all_parameters = False
+        else:
+            all_parameters = True
+
+        try:
+            self.response = self.conn.reset_cache_parameter_group(cache_parameter_group_name=self.name, parameter_name_values=self.update_values, reset_all_parameters=all_parameters)
+        except boto.exception.BotoServerError as e:
+            self.module.fail_json(msg=e.message) 
+        
+        # determine self.changed
+        new_parameters_dict = self.make_current_modifiable_param_dict()
+        self.changed = self.check_changed_parameter_values(old_parameters_dict, new_parameters_dict)
+
+    def get_info(self):
+        """ Gets info about the ElastiCache parameter group. Returns false if it doesn't exist or we don't have access. """
+        try:
+            data = self.conn.describe_cache_parameters(cache_parameter_group_name=self.name)
+            return data
+        except boto.exception.BotoServerError:
+            return False
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
+        group_family    = dict(required=False, type='str', choices=['memcached1.4', 'redis2.6', 'redis2.8', 'redis3.2']),
+        name            = dict(required=True, type='str'),
+        description     = dict(required=False),
+        state           = dict(required=True),
+        update_values   = dict(required=False, type='list', default=[]),
+    )
+    )
+    module = AnsibleModule(argument_spec=argument_spec)
+
+    req = { 'present'   : {'allow' : ['group_family', 'name', 'description'], 'not_allowed' : [] },
+            'absent'    : {'allow' : [], 'not_allowed' : [] },
+            'reset'     : {'allow' : [], 'not_allowed' : [] },
+    }
+
+    if not HAS_BOTO:
+        module.fail_json(msg='boto required for this module')
+
+    parameter_group_family  = module.params.get('group_family')
+    parameter_group_name    = module.params.get('name')
+    group_description       = module.params.get('description')
+    state                   = module.params.get('state')
+    update_values           = module.params.get('update_values')
+    
+    # check legal parameters
+    for requirement in req[state]['allow']:
+        if not module.params.get(requirement):
+            module.fail_json(msg="Option %s required for state=%s" % (requirement, state))
+    for requirment in req[state]['not_allowed']:
+        if module.params.get(requirement):
+            module.fail_json(msg="Option %s not allowed for state:%s" % (requirement, state))
+
+    # Retrieve any AWS settings from the environment.
+    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module)
+
+    if not region:
+        module.fail_json(msg = str("Either region or AWS_REGION or EC2_REGION environment variable or boto config aws_region or ec2_region must be set."))
+
+    elasticache_manager = ElastiCacheManager(module, aws_connect_kwargs, state, parameter_group_name, parameter_group_family, group_description, update_values, region)
+    exists = elasticache_manager.exists
+    
+    # check if modifications specified or not are valid
+    if state == 'present' and exists and not update_values:
+        module.fail_json(msg="Group already exists. Please specify values to modify using the 'update_values' option or use the state 'reset' if you want to reset all or some group parameters.")
+    elif state == 'present' and update_values and not exists:
+        module.fail_json(msg="No group to modify. Please create the cache parameter group before using the 'update_values' option.")
+    elif state == 'reset' and not exists:
+        module.fail_json(msg="No group %s to reset. Please create the group before using the state 'reset'." % parameter_group_name)
+
+    if state == 'present':
+        # modify existing group
+        if exists:
+            elasticache_manager.modify() 
+        # create group
+        else:
+            elasticache_manager.create()
+    elif state == 'absent':
+        # delete group
+        elasticache_manager.delete()
+    elif state == 'reset':
+        # reset group parameters
+        elasticache_manager.reset()
+
+    facts_result = dict(changed=elasticache_manager.changed, elasticache=elasticache_manager.get_info())
+
+    module.exit_json(**facts_result)
+
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.ec2 import *
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -277,7 +277,7 @@ def main():
     )
     module = AnsibleModule(argument_spec=argument_spec)
 
-    req = { 'present'   : {'allow' : ['group_family', 'name', 'description'], 'not_allowed' : [] },
+    req = { 'present'   : {'allow' : ['group_family', 'name', 'description', 'update_values'], 'not_allowed' : [] },
             'absent'    : {'allow' : [], 'not_allowed' : [] },
             'reset'     : {'allow' : [], 'not_allowed' : [] },
     }
@@ -291,13 +291,14 @@ def main():
     state                   = module.params.get('state')
     update_values           = module.params.get('update_values')
     
+    # FIXME
     # check legal parameters
-    for requirement in req[state]['allow']:
-        if not module.params.get(requirement):
-            module.fail_json(msg="Option %s required for state=%s" % (requirement, state))
-    for requirment in req[state]['not_allowed']:
-        if module.params.get(requirement):
-            module.fail_json(msg="Option %s not allowed for state:%s" % (requirement, state))
+    #for requirement in req[state]['allow']:
+    #    if not module.params.get(requirement):
+    #        module.fail_json(msg="Option %s required for state=%s" % (requirement, state))
+    #for requirment in req[state]['not_allowed']:
+    #    if module.params.get(requirement):
+    #        module.fail_json(msg="Option %s not allowed for state:%s" % (requirement, state))
 
     # Retrieve any AWS settings from the environment.
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module)

--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -86,33 +86,30 @@ EXAMPLES = """
 """
 
 RETURN = """
-elasticache:
-    description: cache parameter group information and response metadata
-    returned: always
-    type: dict
-    sample:
-        "cache_parameter_group": {
-            "cache_parameter_group_family": "redis3.2",
-            "cache_parameter_group_name": "test-please-delete",
-            "description": "initial description"
-        }
-        "response_metadata": {
-            "http_headers": {
-                "content-length": "562",
-                "content-type": "text/xml",
-                "date": "Mon, 06 Feb 2017 22:14:08 GMT",
-                "x-amzn-requestid": "947291f9-ecb9-11e6-85bd-3baa4eca2cc1"
-            }
-            "http_status_code": 200,
-            "request_id": "947291f9-ecb9-11e6-85bd-3baa4eca2cc1",
-            "retry_attempts": 0
-        }
-changed:
-    description: if the cache parameter group has changed
-    returned: always
-    type: bool
-    sample:
-        "changed": true
+elasticache: 
+  description: cache parameter group information and response metadata
+  returned: always
+  type: dict
+  sample: 
+    cache_parameter_group: 
+      cache_parameter_group_family: redis3.2
+      cache_parameter_group_name: test-please-delete
+      description: "initial description"
+    response_metadata: 
+      http_headers: 
+        content-length: "562"
+        content-type: text/xml
+        date: "Mon, 06 Feb 2017 22:14:08 GMT"
+        x-amzn-requestid: 947291f9-ecb9-11e6-85bd-3baa4eca2cc1
+      http_status_code: 200
+      request_id: 947291f9-ecb9-11e6-85bd-3baa4eca2cc1
+      retry_attempts: 0
+changed: 
+  description: if the cache parameter group has changed
+  returned: always
+  type: bool
+  sample: 
+    changed: true
 """
 
 from ansible.module_utils.ec2 import boto3_conn


### PR DESCRIPTION
…ete/reset cache parameter groups.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py

##### ANSIBLE VERSION
```
ansible 2.3.0 (elasticache-parameter-group f06251c042) last updated 2017/02/03 14:33:10 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Create, delete, modify, and reset cache parameter groups. #20842 showed interest in improved functionality of ElastiCache modules.

Sample playbook:
```
---
- hosts: localhost
  connection: local
  tasks:
    - name: "create a parameter group"
      elasticache_parameter_group:
        name: "test-group"
        group_family: "memcached1.4"
        description: "initial description"
        state: "present"
        region: "{{ region }}"
        profile: "{{ profile }}"
```

```
$ ansible-playbook my_playbooks/ec_create.yml -vv

PLAYBOOK: ec_create.yml *********************************************************************
1 plays in my_playbooks/ec_create.yml

PLAY [localhost] ****************************************************************************

TASK [Gathering Facts] **********************************************************************
ok: [localhost]
META: ran handlers

TASK [create test parameter group] **********************************************************
task path: /Users/.../ansible/my_playbooks/ec_create.yml:5
changed: [localhost] => {"changed": true, "elasticache": {"DescribeCacheParametersResponse": {"DescribeCacheParametersResult": {"CacheNodeTypeSpecificParameters": [{"AllowedValues": "1-100000", "CacheNodeTypeSpecificValues": [{"CacheNodeType": "cache.c1.xlarge", "Value": "6600"}, {"CacheNodeType": "cache.m1.large", "Value": "7100"}, {"CacheNodeType": "cache.m1.medium", "Value": "3350"}, {"CacheNodeType": "cache.m1.small", "Value": "1300"}, {"CacheNodeType": "cache.m1.xlarge", "Value": "14600"}, {"CacheNodeType": "cache.m2.2xlarge", "Value": "33800"}, {"CacheNodeType": "cache.m2.4xlarge", "Value": "68000"}, {"CacheNodeType": "cache.m2.xlarge", "Value": "16700"}, {"CacheNodeType": "cache.m3.2xlarge", "Value": "28600"}, {"CacheNodeType": "cache.m3.large", "Value": "6200"}, {"CacheNodeType": "cache.m3.medium", "Value": "2850"}, {"CacheNodeType": "cache.m3.xlarge", "Value": "13600"}, {"CacheNodeType": "cache.m4.10xlarge", "Value": "158355"}, {"CacheNodeType": "cache.m4.2xlarge", "Value": "30412"}, {"CacheNodeType": "cache.m4.4xlarge", "Value": "62234"}, {"CacheNodeType": "cache.m4.large", "Value": "6573"}, {"CacheNodeType": "cache.m4.xlarge", "Value": "14618"}, {"CacheNodeType": "cache.r3.2xlarge", "Value": "59600"}, {"CacheNodeType": "cache.r3.4xlarge", "Value": "120600"}, {"CacheNodeType": "cache.r3.8xlarge", "Value": "242600"}, {"CacheNodeType": "cache.r3.large", "Value": "13800"}, {"CacheNodeType": "cache.r3.xlarge", "Value": "29100"}, {"CacheNodeType": "cache.t1.micro", "Value": "213"}, {"CacheNodeType": "cache.t2.medium", "Value": "3301"}, {"CacheNodeType": "cache.t2.micro", "Value": "555"}, {"CacheNodeType": "cache.t2.small", "Value": "1588"}], "DataType": "integer", "Description": "The maximum configurable amount of memory to use to store items, in megabytes.", "IsModifiable": false, "MinimumEngineVersion": "1.4.5", "ParameterName": "max_cache_memory", "Source": "system"}, {"AllowedValues": "1-8", "CacheNodeTypeSpecificValues": [{"CacheNodeType": "cache.c1.xlarge", "Value": "8"}, {"CacheNodeType": "cache.m1.large", "Value": "2"}, {"CacheNodeType": "cache.m1.medium", "Value": "1"}, {"CacheNodeType": "cache.m1.small", "Value": "1"}, {"CacheNodeType": "cache.m1.xlarge", "Value": "4"}, {"CacheNodeType": "cache.m2.2xlarge", "Value": "4"}, {"CacheNodeType": "cache.m2.4xlarge", "Value": "8"}, {"CacheNodeType": "cache.m2.xlarge", "Value": "2"}, {"CacheNodeType": "cache.m3.2xlarge", "Value": "8"}, {"CacheNodeType": "cache.m3.large", "Value": "2"}, {"CacheNodeType": "cache.m3.medium", "Value": "1"}, {"CacheNodeType": "cache.m3.xlarge", "Value": "4"}, {"CacheNodeType": "cache.m4.10xlarge", "Value": "40"}, {"CacheNodeType": "cache.m4.2xlarge", "Value": "8"}, {"CacheNodeType": "cache.m4.4xlarge", "Value": "16"}, {"CacheNodeType": "cache.m4.large", "Value": "2"}, {"CacheNodeType": "cache.m4.xlarge", "Value": "4"}, {"CacheNodeType": "cache.r3.2xlarge", "Value": "8"}, {"CacheNodeType": "cache.r3.4xlarge", "Value": "16"}, {"CacheNodeType": "cache.r3.8xlarge", "Value": "32"}, {"CacheNodeType": "cache.r3.large", "Value": "2"}, {"CacheNodeType": "cache.r3.xlarge", "Value": "4"}, {"CacheNodeType": "cache.t1.micro", "Value": "1"}, {"CacheNodeType": "cache.t2.medium", "Value": "2"}, {"CacheNodeType": "cache.t2.micro", "Value": "1"}, {"CacheNodeType": "cache.t2.small", "Value": "1"}], "DataType": "integer", "Description": "The number of memcached threads to use.", "IsModifiable": false, "MinimumEngineVersion": "1.4.5", "ParameterName": "num_threads", "Source": "system"}], "Marker": null, "Parameters": [{"AllowedValues": "1-10000", "DataType": "integer", "Description": "The backlog queue limit.", "IsModifiable": false, "MinimumEngineVersion": "1.4.5", "ParameterName": "backlog_queue_limit", "ParameterValue": "1024", "Source": "system"}, {"AllowedValues": "auto,ascii", "DataType": "string", "Description": "Binding protocol.", "IsModifiable": true, "MinimumEngineVersion": "1.4.5", "ParameterName": "binding_protocol", "ParameterValue": "auto", "Source": "system"}, {"AllowedValues": "0,1", "DataType": "boolean", "Description": "If supplied, CAS operations will be disabled, and items stored will consume 8 bytes less than with CAS enabled.", "IsModifiable": true, "MinimumEngineVersion": "1.4.5", "ParameterName": "cas_disabled", "ParameterValue": "0", "Source": "system"}, {"AllowedValues": "1-1024", "DataType": "integer", "Description": "The minimum amount of space to allocate for the smallest item's key + value + flags, in bytes.", "IsModifiable": true, "MinimumEngineVersion": "1.4.5", "ParameterName": "chunk_size", "ParameterValue": "48", "Source": "system"}, {"AllowedValues": "1.01-100.00", "DataType": "float", "Description": "The growth factor controlling the size of each successive memcached chunk - each chunk will be chunk_size_growth_factor times larger than the previous chunk.", "IsModifiable": true, "MinimumEngineVersion": "1.4.5", "ParameterName": "chunk_size_growth_factor", "ParameterValue": "1.25", "Source": "system"}, {"AllowedValues": "0-64", "DataType": "integer", "Description": "Maximum amount of configuration objects that can be stored at once.", "IsModifiable": false, "MinimumEngineVersion": "1.4.14", "ParameterName": "config_max", "ParameterValue": "16", "Source": "system"}, {"AllowedValues": "1024-1048576", "DataType": "integer", "Description": "Maximum size of a configuration object.", "IsModifiable": false, "MinimumEngineVersion": "1.4.14", "ParameterName": "config_size_max", "ParameterValue": "65536", "Source": "system"}, {"AllowedValues": "0,1", "DataType": "boolean", "Description": "If enabled, flush_all command will be disabled. Applicable to 1.4.24 and higher.", "IsModifiable": true, "MinimumEngineVersion": "1.4.24", "ParameterName": "disable_flush_all", "ParameterValue": "0", "Source": "system"}, {"AllowedValues": "0,1", "DataType": "boolean", "Description": "If supplied, when there is no more memory to store items, memcached will return an error rather than evicting items.", "IsModifiable": true, "MinimumEngineVersion": "1.4.5", "ParameterName": "error_on_memory_exhausted", "ParameterValue": "0", "Source": "system"}, {"AllowedValues": "0,1", "DataType": "boolean", "Description": "If enabled and if lru_maintainer is enabled, will make items with an expiration time of 0 unevictable. Take caution as this will crowd out memory available for other evictable items. Will not work if lru_maintainer is not enabled. Applicable to 1.4.24 and higher.", "IsModifiable": true, "MinimumEngineVersion": "1.4.24", "ParameterName": "expirezero_does_not_evict", "ParameterValue": "0", "Source": "system"}, {"AllowedValues": "jenkins,murmur3", "DataType": "string", "Description": "Configure the hash algorithm. Currently jenkins and murmur3 are offered. Default is jenkins. Applicable to 1.4.24 and higher.", "IsModifiable": true, "MinimumEngineVersion": "1.4.24", "ParameterName": "hash_algorithm", "ParameterValue": "jenkins", "Source": "system"}, {"AllowedValues": "12-64", "DataType": "integer", "Description": "Integer multiplier for the initial size of the hash table.", "IsModifiable": false, "MinimumEngineVersion": "1.4.14", "ParameterName": "hashpower_init", "ParameterValue": "16", "Source": "system"}, {"AllowedValues": "0-86400", "DataType": "integer", "Description": "If value is set more than 0, connected clients that have idled for at least this long will be asked to close. Unit is in Seconds. Applicable to 1.4.33 and higher.", "IsModifiable": true, "MinimumEngineVersion": "1.4.33", "ParameterName": "idle_timeout", "ParameterValue": "0", "Source": "system"}, {"AllowedValues": "0,1", "DataType": "boolean", "Description": "Try to use large memory pages.", "IsModifiable": false, "MinimumEngineVersion": "1.4.5", "ParameterName": "large_memory_pages", "ParameterValue": "0", "Source": "system"}, {"AllowedValues": "0,1", "DataType": "boolean", "Description": "Lock down all paged memory.", "IsModifiable": false, "MinimumEngineVersion": "1.4.5", "ParameterName": "lock_down_paged_memory", "ParameterValue": "0", "Source": "system"}, {"AllowedValues": "0,1", "DataType": "boolean", "Description": "If enabled, will enable lru_crawler at launch time. LRU crawler can be enabled at run time too. See ElastiCache documentation. Applicable to 1.4.24 and higher.", "IsModifiable": true, "MinimumEngineVersion": "1.4.24", "ParameterName": "lru_crawler", "ParameterValue": "0", "Source": "system"}, {"AllowedValues": "0,1", "DataType": "boolean", "Description": "If enabled, will enable lru_maintainer. lru_maintainer will run a background thread which shuffles items between/within the LRU's as capacities are reached. Applicable to 1.4.24 and higher.", "IsModifiable": true, "MinimumEngineVersion": "1.4.24", "ParameterName": "lru_maintainer", "ParameterValue": "0", "Source": "system"}, {"AllowedValues": "1024-134217728", "DataType": "integer", "Description": "The size of the largest item storable in the cache, in bytes.", "IsModifiable": true, "MinimumEngineVersion": "1.4.5", "ParameterName": "max_item_size", "ParameterValue": "1048576", "Source": "system"}, {"AllowedValues": "3-65000", "DataType": "integer", "Description": "The maximum number of simultaneous connections.", "IsModifiable": false, "MinimumEngineVersion": "1.4.5", "ParameterName": "max_simultaneous_connections", "ParameterValue": "65000", "Source": "system"}, {"AllowedValues": "0,1", "DataType": "boolean", "Description": "Immediately close new connections if over maximum simultaneous connections limit.", "IsModifiable": true, "MinimumEngineVersion": "1.4.14", "ParameterName": "maxconns_fast", "ParameterValue": "0", "Source": "system"}, {"AllowedValues": "0,1", "DataType": "boolean", "Description": "Maximize core file limit.", "IsModifiable": false, "MinimumEngineVersion": "1.4.5", "ParameterName": "maximize_core_file_limit", "ParameterValue": "0", "Source": "system"}, {"AllowedValues": "0-100000", "DataType": "integer", "Description": "The amount of memory to reserve for memcached connections and other miscellaneous overhead.", "IsModifiable": true, "MinimumEngineVersion": "1.4.5", "ParameterName": "memcached_connections_overhead", "ParameterValue": "100", "Source": "system"}, {"AllowedValues": "0,1", "DataType": "boolean", "Description": "This is an alias for enabling slab_reassign, slab_automove, lru_crawler, lru_maintainer, maxconns_fast and setting hash_algorithm=murmur3. Applicable to 1.4.33 and higher.", "IsModifiable": true, "MinimumEngineVersion": "1.4.33", "ParameterName": "modern", "ParameterValue": "1", "Source": "system"}, {"AllowedValues": "1-1000", "DataType": "integer", "Description": "The maximum number of requests per event, limits the number of requests processed for a given connection to prevent starvation.", "IsModifiable": false, "MinimumEngineVersion": "1.4.5", "ParameterName": "requests_per_event", "ParameterValue": "20", "Source": "system"}, {"AllowedValues": "0-2", "DataType": "integer", "Description": "Controls the aggressiveness of the automatic memory reassignment algorithm.", "IsModifiable": true, "MinimumEngineVersion": "1.4.14", "ParameterName": "slab_automove", "ParameterValue": "0", "Source": "system"}, {"AllowedValues": "524288,1048576", "DataType": "integer", "Description": "Lets users choose 512KB or 1MB for slab_chunk_max. Applicable to 1.4.33 and higher.", "IsModifiable": true, "MinimumEngineVersion": "1.4.33", "ParameterName": "slab_chunk_max", "ParameterValue": "524288", "Source": "system"}, {"AllowedValues": "0,1", "DataType": "boolean", "Description": "Enables the ability to reassign memory.", "IsModifiable": true, "MinimumEngineVersion": "1.4.14", "ParameterName": "slab_reassign", "ParameterValue": "0", "Source": "system"}, {"AllowedValues": "0,1", "DataType": "boolean", "Description": "If enable, users can run \"stats sizes\" command. Not recommended in production environments. Applicable to 1.4.33 and higher.", "IsModifiable": true, "MinimumEngineVersion": "1.4.33", "ParameterName": "track_sizes", "ParameterValue": "0", "Source": "system"}, {"AllowedValues": "256-1024", "DataType": "integer", "Description": "Lets users change \"watch\" command's logging buffer size. Unit is in KB. Applicable to 1.4.33 and higher.", "IsModifiable": true, "MinimumEngineVersion": "1.4.33", "ParameterName": "watcher_logbuf_size", "ParameterValue": "256", "Source": "system"}, {"AllowedValues": "64-1024", "DataType": "integer", "Description": "Lets users change \"watch\" command's worker buffer size. Unit is in KB. Applicable to 1.4.33 and higher.", "IsModifiable": true, "MinimumEngineVersion": "1.4.33", "ParameterName": "worker_logbuf_size", "ParameterValue": "64", "Source": "system"}]}, "ResponseMetadata": {"RequestId": "98fad95f-ea48-11e6-aa93-a1e683c7f8af"}}}}
META: ran handlers
META: ran handlers

PLAY RECAP **********************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0

```
