### PR TITLE
Vault encrypt string cli

### DIFF
--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -197,7 +197,13 @@ class VaultCLI(CLI):
         args = [x for x in self.args if x != '-']
 
         if self.options.encrypt_string_prompt:
-            msg = "string to encrypt:"
+            msg = "String to encrypt: "
+
+            name_prompt_response = display.prompt('Variable name (enter for no name): ')
+            name = None
+            # TODO: enforce var naming rules?
+            if name_prompt_response != "":
+                name = name_prompt_response
 
             # could use private=True for shadowed input if useful
             prompt_response = display.prompt(msg)
@@ -206,7 +212,7 @@ class VaultCLI(CLI):
                 raise AnsibleOptionsError('The plaintext provided from the prompt was empty, not encrypting')
 
             b_plaintext = to_bytes(prompt_response)
-            b_plaintext_list.append((b_plaintext, self.FROM_PROMPT, None))
+            b_plaintext_list.append((b_plaintext, self.FROM_PROMPT, name))
 
         if self.encrypt_string_read_stdin:
             if sys.stdout.isatty():

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -276,11 +276,6 @@ class VaultCLI(CLI):
 
         # TODO: offer block or string ala eyaml
 
-    def _format_delimiter_text(self, name, human_index, src):
-        if name:
-            return '# The encrypted version of variable ("%s", the string #%d from %s).\n' % (name, human_index, src)
-        return '# The encrypted version of the string #%d from %s.)\n' % (human_index, src)
-
     def _format_output_vault_strings(self, b_plaintext_list):
         # If we are only showing one item in the output, we dont need to included commented
         # delimiters in the text
@@ -305,7 +300,10 @@ class VaultCLI(CLI):
             err_msg = None
             if show_delimiter:
                 human_index = index + 1
-                err_msg = self._format_delimiter_text(name, human_index, src)
+                if name:
+                    err_msg = '# The encrypted version of variable ("%s", the string #%d from %s).\n' % (name, human_index, src)
+                else:
+                    err_msg = '# The encrypted version of the string #%d from %s.)\n' % (human_index, src)
             output.append({'out': yaml_text, 'err': err_msg})
 
         return output

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -157,18 +157,26 @@ class VaultCLI(CLI):
             display.display("Reading plaintext input from stdin", stderr=True)
 
         b_plaintext = None
+        b_plaintext_list = []
+
         for plaintext in self.args or ['-']:
             # encrypt_string
             b_plaintext = to_bytes(plaintext)
+            b_plaintext_list.append(b_plaintext)
 
-        if b_plaintext is None:
-            # exception?
-            return
+        show_delimiter = False
+        if len(b_plaintext_list) > 1:
+            show_delimiter = True
 
-        b_ciphertext = self.editor.encrypt_bytes(b_plaintext)
+        # order of args seem important
+        # Or maybe just only support one string...
+        for index, b_plaintext in enumerate(b_plaintext_list):
+            b_ciphertext = self.editor.encrypt_bytes(b_plaintext)
 
-        yaml_text = self.format_ciphertext_yaml(b_ciphertext)
-        print(yaml_text)
+            yaml_text = self.format_ciphertext_yaml(b_ciphertext)
+            if show_delimiter:
+                sys.stderr.write('# The encrypted version of the string #%d from the command line.\n' % (index + 1))
+            print(yaml_text)
         # if '--prompt', prompt for string
 
         if sys.stdout.isatty():

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -414,6 +414,13 @@ class VaultEditor:
         # shuffle tmp file into place
         self.shuffle_files(tmp_path, filename)
 
+    def encrypt_bytes(self, b_plaintext):
+        check_prereqs()
+
+        b_ciphertext = self.vault.encrypt(b_plaintext)
+
+        return b_ciphertext
+
     def encrypt_file(self, filename, output_file=None):
 
         check_prereqs()


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/cli/vault.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (roadmap b038aad173) last updated 2017/02/03 15:10:47 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules', u'/home/adrian/ansible/lib/modules/']

```

##### SUMMARY
Add a 'encrypt_string' option to ansible-vault that can encrypt a string and print out the properly formatted yaml text. Can read stdin, a prompt, or command line args.

Goal is a easy way to encrypt a string for vaulted strings so they can be cut&paste into a playbook, or created and populated from a script that uses 'ansible-vault encrypt_string'.
