### PR TITLE
Adds ANAME support for dnsmadeeasy module

### DIFF
--- a/lib/ansible/modules/net_tools/dnsmadeeasy.py
+++ b/lib/ansible/modules/net_tools/dnsmadeeasy.py
@@ -59,7 +59,7 @@ options:
     description:
       - Record type.
     required: false
-    choices: [ 'A', 'AAAA', 'CNAME', 'HTTPRED', 'MX', 'NS', 'PTR', 'SRV', 'TXT' ]
+    choices: [ 'A', 'AAAA', 'CNAME', 'ANAME', 'HTTPRED', 'MX', 'NS', 'PTR', 'SRV', 'TXT' ]
     default: null
 
   record_value:
@@ -480,7 +480,7 @@ class DME2:
         if not self.all_records:
             self.all_records = self.getRecords()
 
-        if record_type in ["A", "AAAA", "CNAME", "HTTPRED", "PTR"]:
+        if record_type in ["A", "AAAA", "CNAME", "ANAME", "HTTPRED", "PTR"]:
             for result in self.all_records:
                 if result['name'] == record_name and result['type'] == record_type:
                     return result
@@ -570,7 +570,7 @@ def main():
             state=dict(required=True, choices=['present', 'absent']),
             record_name=dict(required=False),
             record_type=dict(required=False, choices=[
-                             'A', 'AAAA', 'CNAME', 'HTTPRED', 'MX', 'NS', 'PTR', 'SRV', 'TXT']),
+                             'A', 'AAAA', 'CNAME', 'ANAME', 'HTTPRED', 'MX', 'NS', 'PTR', 'SRV', 'TXT']),
             record_value=dict(required=False),
             record_ttl=dict(required=False, default=1800, type='int'),
             monitor=dict(default='no', type='bool'),


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
dnsmadeeasy

##### ANSIBLE VERSION
```
ansible 2.3.0 (feature/modules/dnsmadeeasy/aname-support 028ee72c6a) last updated 2017/02/03 17:11:09 (GMT -400)
```

##### SUMMARY
This PR adds support for managing ANAME records in DNS Made Easy.

Currently, only the following records types are supported:

	- A
	- AAAA
	- CNAME
	- HTTPRED
	- MX
	- NS
	- PTR
	- SRV
	- TXT
	
I had the requirement of managing some ANAME records for a few of our domains. Maybe someone else will have this same need at some point, as well.

