### PR TITLE
systemd: propagate potential warning even in case of failure

### DIFF
--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -386,7 +386,7 @@ def main():
             if not module.check_mode:
                 (rc, out, err) = module.run_command("%s %s '%s'" % (systemctl, action, unit))
                 if rc != 0:
-                    module.fail_json(msg="Unable to %s service %s: %s" % (action, unit, out + err))
+                    module.fail_json(msg="Unable to %s service %s: %s" % (action, unit, out + err), **result)
 
             result['enabled'] = not enabled
 
@@ -418,10 +418,10 @@ def main():
                 if not module.check_mode:
                     (rc, out, err) = module.run_command("%s %s '%s'" % (systemctl, action, unit))
                     if rc != 0:
-                        module.fail_json(msg="Unable to %s service %s: %s" % (action, unit, err))
+                        module.fail_json(msg="Unable to %s service %s: %s" % (action, unit, err), **result)
         else:
             # this should not happen?
-            module.fail_json(msg="Service is in unknown state", status=result['status'])
+            module.fail_json(msg="Service is in unknown state", **result)
 
 
     module.exit_json(**result)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
systemd

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel ba39d1158c) last updated 2017/02/01 11:35:04 (GMT +200)
  config file = /home/pilou/src/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Warning is only propagated when the task succeed. This patch allows to propagate the warning in case of failure.