### PR TITLE
systemd: return an error when systemctl command isn't available

### DIFF
--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -327,6 +327,9 @@ def main():
             # Check for loading error
             if is_systemd and 'LoadError' in result['status']:
                 module.fail_json(msg="Error loading unit file '%s': %s" % (unit, result['status']['LoadError']))
+    else:
+        # Check for systemctl command
+        module.run_command(systemctl, check_rc=True)
 
     # Does service exist?
     found = is_systemd or is_initd


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
systemd

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel ba39d1158c) last updated 2017/02/01 11:35:04 (GMT +200)
  config file = /home/lilou/src/admin-dc.git/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
The return code of `systemctl show <unit>` isn't checked: [systemd module assumes](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/system/systemd.py#L299) that the unit isn't found.

In some case, `ansible_service_mgr` is set to `systemd` but `systemctl` command is not available to the user used on the managed host (for example on Debian if `libpam-systemd` isn't installed and the remote used isn't `root`).

This patch check that the `systemctl` without any argument doesn't fail when `systemctl show <unit>` command fails. In the previously mentioned case, it allows to raise a better error than the current `Service is in unknown state`.

Output without patch:
```
TASK HANDLER [dc-base : Restart service] *******************************************************************************************************************
fatal: [Host]: FAILED! => {"changed": false, "failed": true, "msg": "Service is in unknown state", "status": {}}
```
Output with patch:
```
TASK [dc-base : Restart service] *******************************************************************************************************************
fatal: [Host]: FAILED! => {"changed": false, "cmd": "/bin/systemctl", "failed": true, "msg": "Failed to get D-Bus connection: No such file or directory", "rc": 1, "stderr": "Failed to get D-Bus connection: No such file or directory\n", "stdout": "", "stdout_lines": []}
```