### PR TITLE
Azure Inventory: Add caching 

### DIFF
--- a/contrib/inventory/azure_rm.ini
+++ b/contrib/inventory/azure_rm.ini
@@ -1,6 +1,6 @@
 #
 # Configuration file for azure_rm.py
-# 
+#
 [azure]
 # Control which resource groups are included. By default all resources groups are included.
 # Set resource_groups to a comma separated list of resource groups names.
@@ -20,3 +20,14 @@ group_by_resource_group=yes
 group_by_location=yes
 group_by_security_group=yes
 group_by_tag=yes
+
+# API calls to Azure are slow. For this reason, we cache the results of an API
+# call. Set this to the path you want cache files to be written to. The file used
+# to cache the returned JSON is
+#   - ansible-azure.cache
+cache_path = ~/.ansible/tmp
+
+# The number of seconds a cache file is considered valid. After this many
+# seconds, a new API call will be made, and the cache file will be updated.
+# To disable the cache, set this value to 0
+cache_max_age = 1800


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
contrib/inventory/azure_rm.py

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
This adds file caching to the Azure dynamic inventory. When you get a lot of instances in azure it can take minutes for dynamic inventory to work. This adds a level of local caching that brings it down to seconds. 

