### PR TITLE
Add ability to use either sec group name or sec group id or combinati…

### DIFF
--- a/lib/ansible/modules/cloud/amazon/GUIDELINES.md
+++ b/lib/ansible/modules/cloud/amazon/GUIDELINES.md
@@ -285,7 +285,7 @@ Pass this function a list of security group names or combination of security gro
 return a list of IDs.  You should also pass the VPC ID if known because security group names are not necessarily unique
 across VPCs.
 
-### sort_json_policy_dict
+#### sort_json_policy_dict
 
 Pass any JSON policy dict to this function in order to sort any list contained therein. This is useful
 because AWS rarely return lists in the same order that they were submitted so without this function, comparison

--- a/lib/ansible/modules/cloud/amazon/ec2_lc.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_lc.py
@@ -147,7 +147,8 @@ EXAMPLES = '''
 import traceback
 
 from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
+from ansible.module_utils.ec2 import ec2_argument_spec, ec2_connect, connect_to_aws, \
+    get_ec2_security_group_ids_from_names, get_aws_connection_info, AnsibleAWSError
 
 try:
     from boto.ec2.blockdevicemapping import BlockDeviceType, BlockDeviceMapping

--- a/lib/ansible/modules/cloud/amazon/ec2_lc.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_lc.py
@@ -58,8 +58,8 @@ options:
     required: false
   security_groups:
     description:
-      - A list of security groups to apply to the instances. For VPC instances, specify security group IDs. For EC2-Classic, specify either security
-        group names or IDs.
+      - A list of security groups to apply to the instances. Since version 2.4 you can specify either security group names or IDs or a mix.  Previous to 2.4,
+        for VPC instances, specify security group IDs and for EC2-Classic, specify either security group names or IDs.
     required: false
   volumes:
     description:
@@ -184,7 +184,10 @@ def create_launch_config(connection, module):
     name = module.params.get('name')
     image_id = module.params.get('image_id')
     key_name = module.params.get('key_name')
-    security_groups = module.params['security_groups']
+    try:
+        security_groups = get_ec2_security_group_ids_from_names(module.params.get('security_groups'), ec2_connect(module), vpc_id=None, boto3=False)
+    except ValueError as e:
+        module.fail_json(msg=str(e))
     user_data = module.params.get('user_data')
     user_data_path = module.params.get('user_data_path')
     volumes = module.params['volumes']


### PR DESCRIPTION
…on to ec2_lc. Also fix header size in AWS Guidelines

##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
ec2_lc

##### ANSIBLE VERSION
2.3

##### SUMMARY
Allow a user to specify either a sec group name or ID or combination of both when defining a launch config using pre-existing ec2 helper function
