### PR TITLE
[docs/apt] update vague description of only_upgrade

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -116,7 +116,7 @@ options:
     version_added: "2.1"
   only_upgrade:
     description:
-      - Only install/upgrade a package if it is already installed.
+      - Only upgrade a package if it is already installed.
     required: false
     default: false
     version_added: "2.1"


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- `apt`

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* the `only_update` param description was kinda vague:
  * either install if not installed
  * or upgrade if installed
  * or both!?
    * as a result, remove the "install" statement from this sentence