### PR TITLE
vmware_guest: fixes missing customization outside network block - fixes 20904

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1191,7 +1191,7 @@ class PyVmomiHelper(object):
         self.configure_disks(vm_obj=vm_obj)
         self.configure_network(vm_obj=vm_obj)
 
-        if len(self.params['customization']) > 0:
+        if len(self.params['customization']) > 0 or len(self.params['networks']) > 0:
             self.customize_vm(vm_obj=vm_obj)
 
         try:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vmware_guest

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes issue #20904

The network block being evoked outside customization causes the configure_vm 
section to be skipped. Added in logic to resolve that until we can determine if all of the network customizations should be located under customization.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
