### PR TITLE
Add grouping by hostname for the Packet inventory

### DIFF
--- a/contrib/inventory/packet_net.ini
+++ b/contrib/inventory/packet_net.ini
@@ -37,6 +37,7 @@ replace_dash_in_groups = True
 # The packet inventory output can become very large. To manage its size,
 # configure which groups should be created.
 group_by_device_id = True
+group_by_hostname = True
 group_by_facility = True
 group_by_project = True
 group_by_operating_system = True

--- a/contrib/inventory/packet_net.py
+++ b/contrib/inventory/packet_net.py
@@ -334,7 +334,7 @@ class PacketInventory(object):
         if self.group_by_hostname:
             self.push(self.inventory, device.hostname, dest)
             if self.nested_groups:
-                self.push_group(self.inventory, 'hostnames', project.name)                
+                self.push_group(self.inventory, 'hostnames', project.name)
 
         # Inventory: Group by project
         if self.group_by_project:

--- a/contrib/inventory/packet_net.py
+++ b/contrib/inventory/packet_net.py
@@ -175,6 +175,7 @@ class PacketInventory(object):
         # Configure which groups should be created.
         group_by_options = [
             'group_by_device_id',
+            'group_by_hostname',
             'group_by_facility',
             'group_by_project',
             'group_by_operating_system',
@@ -328,6 +329,12 @@ class PacketInventory(object):
             self.inventory[device.id] = [dest]
             if self.nested_groups:
                 self.push_group(self.inventory, 'devices', device.id)
+
+        # Inventory: Group by device name (hopefully a group of 1)
+        if self.group_by_hostname:
+            self.push(self.inventory, device.hostname, dest)
+            if self.nested_groups:
+                self.push_group(self.inventory, 'hostnames', project.name)                
 
         # Inventory: Group by project
         if self.group_by_project:


### PR DESCRIPTION
##### ISSUE TYPE

 - Feature Pull Request


##### COMPONENT NAME

contrib/inventory/packet_net.py

##### ANSIBLE VERSION

```
ansible 2.3.0 (packet-inventory-hostname-grouping 596e001ae5) last updated 2017/02/06 18:40:42 (GMT +300)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

When using the Packet.net inventory, the devices can be grouped by many factors, for example location, device ID, OS. They can not be grouped by the hostname of device though.

This simple PR makes it possible to group the devices by the hostname. It's useful for playbooks which assume the role of a device based on its name.

In following snippet of the output of the inventory scirpt, coreos-{one,two,three} are hostnames of devices, "coreos_stable" is OS typem and "ewr1" is a location.
```
  "coreos-one": [
    "147.75.104.121"
  ], 
  "coreos-three": [
    "147.75.97.17"
  ], 
  "coreos-two": [
    "147.75.104.157"
  ], 
  "coreos_stable": [
    "147.75.97.17", 
    "147.75.104.157", 
    "147.75.104.121"
  ], 
  "ewr1": [
    "147.75.97.17", 
    "147.75.104.157", 
    "147.75.104.121"
  ], 

```
