### PR TITLE
Usage of proper Solaris 11 Package Manager

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -153,7 +153,7 @@ class Facts(object):
                  { 'path' : '/usr/sbin/swlist',     'name' : 'SD-UX' },
                  { 'path' : '/usr/bin/emerge',      'name' : 'portage' },
                  { 'path' : '/usr/sbin/pkgadd',     'name' : 'svr4pkg' },
-                 { 'path' : '/usr/bin/pkg',         'name' : 'pkg' },
+                 { 'path' : '/usr/bin/pkg',         'name' : 'pkg5' },
                  { 'path' : '/usr/bin/xbps-install','name' : 'xbps' },
                  { 'path' : '/usr/local/sbin/pkg',  'name' : 'pkgng' },
                  { 'path' : '/usr/bin/swupd',       'name' : 'swupd' },


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
fact collection
   lib/ansible/module_utils/facts.py

##### ANSIBLE VERSION
ansible 2.2.1.0

##### SUMMARY
The default Package Manager for Solaris 11 has been set to the module pkg, but there is no such module. Instead pkg5 exists and will be used from now on.