### PR TITLE
dnf: add support for validate_certs

### DIFF
--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -94,6 +94,14 @@ options:
     version_added: "2.3"
     default: "/"
 
+  validate_certs:
+    description:
+      - If set to C(no), the SSL certificates will not be validated.
+      - This should only set to C(no) used on personally controlled sites using self-signed certificates as it avoids verifying the source site.
+    required: false
+    default: "yes"
+    choices: ["yes", "no"]
+
 notes: []
 # informational: requirements for nodes
 requirements:

--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -316,6 +316,8 @@ def ensure(module, base, state, names):
     # and fail with a message about what they can't.
     failures = []
     allow_erasing = False
+    base.conf.sslverify = module.params['validate_certs']
+
     if names == ['*'] and state == 'latest':
         base.upgrade_all()
     else:
@@ -462,6 +464,7 @@ def main():
             list=dict(),
             conf_file=dict(default=None, type='path'),
             disable_gpg_check=dict(default=False, type='bool'),
+            validate_certs=dict(required=False, default="yes", type='bool'),
             installroot=dict(default='/', type='path'),
         ),
         required_one_of=[['name', 'list']],


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
dnf module

##### SUMMARY
add support for missing 'validate_certs' option