### PR TITLE
Added option validate_certs to the jenkins_job module

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_job.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job.py
@@ -222,10 +222,10 @@ class JenkinsJob:
             try:
                 _create_unverified_https_context = ssl._create_unverified_context
             except AttributeError:
-            # Legacy Python that doesn't verify HTTPS certificates by default
+                # Legacy Python that doesn't verify HTTPS certificates by default
                 pass
             else:
-            # Handle target environment that doesn't support HTTPS verification
+                # Handle target environment that doesn't support HTTPS verification
                 ssl._create_default_https_context = _create_unverified_https_context
         try:
             if (self.user and self.password):

--- a/lib/ansible/modules/web_infrastructure/jenkins_job.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job.py
@@ -69,6 +69,13 @@ options:
     description:
        - User to authenticate with the Jenkins server.
     required: false
+  validate_certs:
+    description:
+      - If set to C(False), the SSL certificates will not be validated.
+        This should only set to C(False) used on personally controlled sites
+        using self-signed certificates as it avoids verifying the source site.
+    required: False
+    default: True
 '''
 
 EXAMPLES = '''
@@ -119,6 +126,15 @@ EXAMPLES = '''
     enabled: False
     url: http://localhost:8080
     user: admin
+
+# Interacting with an untrusted HTTPS connection
+- jenkins_job:
+    config: "{{ lookup('file', 'templates/test.xml') }}"
+    name: test
+    password: admin
+    url: https://localhost:8080
+    user: admin
+    validate_certs: False
 '''
 
 RETURN = '''
@@ -148,6 +164,11 @@ url:
   returned: success
   type: string
   sample: https://jenkins.mydomain.com
+validate_certs:
+  description: Whether SSL certificates will be validated or not.
+  returned: success
+  type: bool
+  sample: true
 '''
 
 try:
@@ -161,6 +182,7 @@ try:
     python_lxml_installed = True
 except ImportError:
     python_lxml_installed = False
+import ssl
 
 class JenkinsJob:
     def __init__(self, module):
@@ -171,6 +193,7 @@ class JenkinsJob:
         self.password = module.params.get('password')
         self.state = module.params.get('state')
         self.enabled = module.params.get('enabled')
+        self.validate_certs = module.params.get('validate_certs')
         self.token = module.params.get('token')
         self.user = module.params.get('user')
         self.jenkins_url = module.params.get('url')
@@ -194,6 +217,16 @@ class JenkinsJob:
         self.EXCL_STATE = "excluded state"
 
     def get_jenkins_connection(self):
+
+        if self.validate_certs == False:
+            try:
+                _create_unverified_https_context = ssl._create_unverified_context
+            except AttributeError:
+            # Legacy Python that doesn't verify HTTPS certificates by default
+                pass
+            else:
+            # Handle target environment that doesn't support HTTPS verification
+                ssl._create_default_https_context = _create_unverified_https_context
         try:
             if (self.user and self.password):
                 return jenkins.Jenkins(self.jenkins_url, self.user, self.password)
@@ -342,14 +375,15 @@ def job_config_to_string(xml_str):
 def main():
     module = AnsibleModule(
         argument_spec = dict(
-            config      = dict(required=False),
-            name        = dict(required=True),
-            password    = dict(required=False, no_log=True),
-            state       = dict(required=False, choices=['present', 'absent'], default="present"),
-            enabled     = dict(required=False, type='bool'),
-            token       = dict(required=False, no_log=True),
-            url         = dict(required=False, default="http://localhost:8080"),
-            user        = dict(required=False)
+            config          = dict(required=False),
+            name            = dict(required=True),
+            password        = dict(required=False, no_log=True),
+            state           = dict(required=False, choices=['present', 'absent'], default="present"),
+            enabled         = dict(required=False, type='bool'),
+            validate_certs  = dict(required=False, type='bool'),
+            token           = dict(required=False, no_log=True),
+            url             = dict(required=False, default="http://localhost:8080"),
+            user            = dict(required=False)
         ),
         mutually_exclusive = [
             ['password', 'token'],

--- a/lib/ansible/modules/web_infrastructure/jenkins_job.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job.py
@@ -205,6 +205,7 @@ class JenkinsJob:
             'name': self.name,
             'user': self.user,
             'state': self.state,
+            'validate_certs': self.validate_certs,
             'diff': {
                 'before': "",
                 'after': ""
@@ -380,7 +381,7 @@ def main():
             password        = dict(required=False, no_log=True),
             state           = dict(required=False, choices=['present', 'absent'], default="present"),
             enabled         = dict(required=False, type='bool'),
-            validate_certs  = dict(required=False, type='bool'),
+            validate_certs  = dict(required=False, type='bool', default=True),
             token           = dict(required=False, no_log=True),
             url             = dict(required=False, default="http://localhost:8080"),
             user            = dict(required=False)

--- a/lib/ansible/modules/web_infrastructure/jenkins_job.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job.py
@@ -182,7 +182,12 @@ try:
     python_lxml_installed = True
 except ImportError:
     python_lxml_installed = False
-import ssl
+
+try:
+    import ssl
+    python_ssl_installed = True
+except ImportError:
+    python_ssl_installed = False
 
 class JenkinsJob:
     def __init__(self, module):
@@ -369,6 +374,10 @@ def test_dependencies(module):
     if not python_lxml_installed:
         module.fail_json(msg="lxml required for this module. "\
               "see http://lxml.de/installation.html")
+
+    if not python_ssl_installed:
+        module.fail_json(msg="ssl required for this module. "\
+              "see https://pypi.python.org/pypi/ssl")
 
 def job_config_to_string(xml_str):
     return ET.tostring(ET.fromstring(xml_str))

--- a/lib/ansible/modules/web_infrastructure/jenkins_job.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job.py
@@ -224,15 +224,7 @@ class JenkinsJob:
 
     def get_jenkins_connection(self):
 
-        if self.validate_certs == False:
-            try:
-                _create_unverified_https_context = ssl._create_unverified_context
-            except AttributeError:
-                # Legacy Python that doesn't verify HTTPS certificates by default
-                pass
-            else:
-                # Handle target environment that doesn't support HTTPS verification
-                ssl._create_default_https_context = _create_unverified_https_context
+        self.set_ssl_context()
         try:
             if (self.user and self.password):
                 return jenkins.Jenkins(self.jenkins_url, self.user, self.password)
@@ -245,6 +237,18 @@ class JenkinsJob:
         except Exception:
             e = get_exception()
             self.module.fail_json(msg='Unable to connect to Jenkins server, %s' % str(e))
+
+    def set_ssl_context(self):
+        if self.validate_certs == False:
+            try:
+                _create_unverified_https_context = ssl._create_unverified_context
+            except AttributeError:
+                # Legacy Python that doesn't verify HTTPS certificates by default
+                pass
+            else:
+                # Handle target environment that doesn't support HTTPS verification
+                ssl._create_default_https_context = _create_unverified_https_context
+
 
     def job_class_excluded(self, response):
         return response['_class'] in self.job_classes_exceptions


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
Option to disable SSL verification for jenkins_job module

##### ANSIBLE VERSION
```
ansible 2.2.1.0 (detached HEAD 5362910000) last updated 2017/01/21 16:09:44 (GMT +100)
  lib/ansible/modules/core: (detached HEAD 7e8bb413b7) last updated 2017/01/21 16:10:55 (GMT +100)
  lib/ansible/modules/extras: (detached HEAD c501e006ea) last updated 2017/01/21 16:11:38 (GMT +100)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Many companies using self-sign SSL certificates in their estate for Jenkins masters and as a result, if you're trying to use "jenkins_job" module it fails with following error:

```
ansible-playbook -i localhost site.yml -e jenkins_url="https://jenkins-internal.test.com" -e jenkins_token="XXXXXXXXX"
 [WARNING]: Host file not found: localhost

 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [Load variables] **********************************************************
ok: [localhost]

TASK [Add jenkins job] *********************************************************
failed: [localhost] (item=({u'name': u'Test job'], "msg": "Unable to validate if job exists, Error in request: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590) for https://jenkins-internal.test.com"}
```

I've added additional option to this module:

```
  validate_certs:
    description:
      - If set to C(False), the SSL certificates will not be validated.
        This should only set to C(False) used on personally controlled sites
        using self-signed certificates as it avoids verifying the source site.
    required: False
    default: True
```

And now with this option it ignores SSL errors:

```
ansible-playbook -i localhost site.yml -e jenkins_url="https://jenkins-internal.test.com" -e jenkins_token="XXXXXXXXX"
 [WARNING]: Host file not found: localhost

 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [Load variables] **********************************************************
ok: [localhost]

TASK [Add jenkins job] *********************************************************
ok: [localhost] => (item=({u'name': u'Test job'}))

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=0    unreachable=0    failed=0
```