### PR TITLE
Marks metadata files as outdated

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -96,13 +96,13 @@ options:
 
   update_cache:
     description:
-      - Force updating the cache. Has an effect only if state is I(present)
+      - Force updating (expiring) the cache. Has an effect only if state is I(present)
         or I(latest).
     required: false
     version_added: "1.9"
     default: "no"
     choices: ["yes", "no"]
-    aliases: []
+    aliases: [ "expire-cache" ]
 
   validate_certs:
     description:
@@ -1046,7 +1046,7 @@ def ensure(module, state, pkgs, conf_file, enablerepo, disablerepo,
     if state in ['installed', 'present', 'latest']:
 
         if module.params.get('update_cache'):
-            module.run_command(yum_basecmd + ['makecache'])
+            module.run_command(yum_basecmd + ['clean expire-cache'])
 
         my = yum_base(conf_file, installroot)
         try:
@@ -1110,7 +1110,7 @@ def main():
             list=dict(),
             conf_file=dict(default=None),
             disable_gpg_check=dict(required=False, default="no", type='bool'),
-            update_cache=dict(required=False, default="no", type='bool'),
+            update_cache=dict(required=False, default="no", aliases=['expire-cache'], type='bool'),
             validate_certs=dict(required=False, default="yes", type='bool'),
             installroot=dict(required=False, default="/", type='str'),
             # this should not be needed, but exists as a failsafe

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -96,8 +96,8 @@ options:
 
   update_cache:
     description:
-      - Force updating (expiring) the cache. Has an effect only if state is I(present)
-        or I(latest).
+      - Force yum to check if cache is out of date and redownload if needed.
+        Has an effect only if state is I(present) or I(latest).
     required: false
     version_added: "1.9"
     default: "no"
@@ -1046,7 +1046,7 @@ def ensure(module, state, pkgs, conf_file, enablerepo, disablerepo,
     if state in ['installed', 'present', 'latest']:
 
         if module.params.get('update_cache'):
-            module.run_command(yum_basecmd + ['clean expire-cache'])
+            module.run_command(yum_basecmd + ['clean', 'expire-cache'])
 
         my = yum_base(conf_file, installroot)
         try:


### PR DESCRIPTION

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/packaging/os/yum.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.2.1.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This option was added in https://github.com/ansible/ansible/commit/ceeeea84cd1a9bbdb64b8e5b21da7a59205956e4 with the message:
```
Yum does not always update to latest package version unless metadata cache has expired
```

The command used, ``yum makecache``, make sure that the repo is sync, but also [downloads all the metadata](http://yum.baseurl.org/wiki/YumCommands), filling the ``/var/cache/yum`` dir (with rhel and epel it was taking ~3.5GB, instead of ~500MB).

I think the command users are expecting is:
```
yum clean expire-cache
```
[This command](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Deployment_Guide/sec-Working_with_Yum_Cache.html) mark metadata as outdated (not delete it) so the next yum execution should check if there is some new metadata available.

