### PR TITLE
Fixed issue with legacy jenkins instances, following #18995

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_job.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job.py
@@ -189,7 +189,7 @@ class JenkinsJob:
         }
 
         # This kind of jobs do not have a property that makes them enabled/disabled
-        self.job_classes_exceptions = ["jenkins.branch.OrganizationFolder"]
+        self.job_classes_exceptions = ["jenkins.branch.OrganizationFolder","com.cloudbees.hudson.plugins.folder.Folder"]
 
         self.EXCL_STATE = "excluded state"
 
@@ -207,13 +207,14 @@ class JenkinsJob:
             e = get_exception()
             self.module.fail_json(msg='Unable to connect to Jenkins server, %s' % str(e))
 
-    def job_class_excluded(self, response):
-        return response['_class'] in self.job_classes_exceptions
+    def job_class_excluded(self, check_class):
+        return check_class in self.job_classes_exceptions
 
     def get_job_status(self):
         try:
+            check_class = ET.fromstring(self.get_current_config()).tag
             response = self.server.get_job_info(self.name)
-            if self.job_class_excluded(response):
+            if self.job_class_excluded(check_class):
                 return self.EXCL_STATE
             else:
                 return response['color'].encode('utf-8')

--- a/lib/ansible/modules/web_infrastructure/jenkins_job.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job.py
@@ -188,9 +188,6 @@ class JenkinsJob:
             }
         }
 
-        # This kind of jobs do not have a property that makes them enabled/disabled
-        self.job_classes_exceptions = ["jenkins.branch.OrganizationFolder","com.cloudbees.hudson.plugins.folder.Folder"]
-
         self.EXCL_STATE = "excluded state"
 
     def get_jenkins_connection(self):
@@ -207,14 +204,10 @@ class JenkinsJob:
             e = get_exception()
             self.module.fail_json(msg='Unable to connect to Jenkins server, %s' % str(e))
 
-    def job_class_excluded(self, check_class):
-        return check_class in self.job_classes_exceptions
-
     def get_job_status(self):
         try:
-            check_class = ET.fromstring(self.get_current_config()).tag
             response = self.server.get_job_info(self.name)
-            if self.job_class_excluded(check_class):
+            if "color" not in response:
                 return self.EXCL_STATE
             else:
                 return response['color'].encode('utf-8')


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
jenkins_job module

##### ANSIBLE VERSION
```
ansible 2.3.0 (Fix_class_issue_with_jenkins_job 8dc98fee68) last updated 2017/02/07 16:31:22 (GMT +100)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
As a fix for the bug #18995, in #3696 it was added an option to check if "_class" for the internal jenkins plugin is in the excluded list, and it was done by using "get_job_info" API call from python-jenkins module.
Unfortunately this call give different result for the Jenkins ver. 1.* compare to the Jenkins ver. 2.*.

Output for Jenkins 2.*:
```
(u'scm', {u'_class': u'hudson.scm.NullSCM'})
(u'color', u'notbuilt')
(u'lastSuccessfulBuild', None)
(u'actions', [{}, {}, {}, {u'_class': u'com.cloudbees.plugins.credentials.ViewCredentialsAction'}])
(u'lastCompletedBuild', None)
(u'lastUnsuccessfulBuild', None)
(u'upstreamProjects', [])
(u'lastFailedBuild', None)
(u'healthReport', [])
(u'queueItem', None)
(u'lastBuild', None)
**(u'_class', u'hudson.model.FreeStyleProject')**
(u'lastStableBuild', None)
(u'description', u'')
(u'downstreamProjects', [])
(u'concurrentBuild', False)
(u'lastUnstableBuild', None)
(u'buildable', True)
(u'displayNameOrNull', None)
(u'inQueue', False)
(u'keepDependencies', False)
(u'name', u'Test')
(u'displayName', u'Test')
(u'builds', [])
(u'url', u'http://jenkins-internal-v2.master.com/job/Test/')
(u'firstBuild', None)
(u'nextBuildNumber', 1)
(u'property', [{u'_class': u'com.sonyericsson.rebuild.RebuildSettings'}])
```

Output for Jenkins 1.* ("_class" is missing):
```
(u'scm', {})
(u'color', u'notbuilt')
(u'lastSuccessfulBuild', None)
(u'actions', [{}, {}, {}, {}, {}])
(u'lastCompletedBuild', None)
(u'lastUnsuccessfulBuild', None)
(u'upstreamProjects', [])
(u'lastFailedBuild', None)
(u'healthReport', [])
(u'queueItem', None)
(u'lastBuild', None)
(u'lastStableBuild', None)
(u'description', u'')
(u'downstreamProjects', [])
(u'concurrentBuild', False)
(u'lastUnstableBuild', None)
(u'buildable', True)
(u'displayNameOrNull', None)
(u'inQueue', False)
(u'keepDependencies', False)
(u'name', u'Test_job')
(u'displayName', u'Test_job')
(u'builds', [])
(u'url', u'https://jenkins-internal-v1.master.com/job/Test_job/')
(u'firstBuild', None)
(u'nextBuildNumber', 1)
(u'property', [{}, {}])
```

So for Jenkins ver. 1.* this api call doesn't return value **"_class"**, which crashes the module with following error:

 ```
ansible-playbook -i localhost site.yml -e jenkins_url="https://jenkins-internal-v1.master.com" -e jenkins_token="XXXXXXXXX"
 [WARNING]: Host file not found: localhost

 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [Load variables] **********************************************************
ok: [localhost]

TASK [Add jenkins job] *********************************************************
failed: [localhost] (item=({u'name': u'Test job'}), "msg": "Unable to fetch job information, '_class'"}
	to retry, use: --limit @/Users/loginova/work/git_projects/ott-persistence/persistence-jenkins-jobs/site.retry

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=1
```

In order to fix this issue, I suggest to use "get_job_config" API call, which properly works with all Jenkins versions:

```
ansible-playbook -i localhost site.yml -e jenkins_url="https://jenkins-internal-v1.master.com" -e jenkins_token="XXXXXXXXX"
 [WARNING]: Host file not found: localhost

 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [Load variables] **********************************************************
ok: [localhost]

TASK [Add jenkins job] *********************************************************
changed: [localhost] => (item=({u'name': u'Test job'}))

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=2    unreachable=0    failed=0
```

Also I've added "com.cloudbees.hudson.plugins.folder.Folder" class to the list of excluded plugins, since it has same issue with "colour" option.