### PR TITLE
Set block indentation to 1 on iosxr templates

### DIFF
--- a/test/integration/targets/iosxr_template/templates/basic/config.j2
+++ b/test/integration/targets/iosxr_template/templates/basic/config.j2
@@ -1,5 +1,5 @@
 hostname {{ inventory_hostname_short }}
 !
 interface Loopback999
-   description this is a test
-   shutdown
+ description this is a test
+ shutdown


### PR DESCRIPTION
Network devices in the lab have by default an indentation of 1 for
sub-sections, and so does the netcfg.NetworkConfig constructor
indent param.
This will fix reported issue 21055, and make the integration tests
to pass.

Fixes #21055 

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

iosxr integration tests

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (ioxr_template_idempotency_fix cbb1777b37) last updated 2017/02/07 20:57:00 (GMT +200)
```

##### SUMMARY

Network devices in the lab have by default an indentation of 1 for
sub-sections, and so does the netcfg.NetworkConfig constructor
indent param.
This will fix reported issue 21055, and make the integration tests
to pass.
