### PR TITLE
splits _execute_module() into _execute_remote() & _execute_local()

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -762,8 +762,7 @@ class TaskExecutor:
         if self._task.action in self._shared_loader_obj.action_loader:
             handler_name = self._task.action
         else:
-            pc_conn = self._shared_loader_obj.connection_loader.get(self._play_context.connection, class_only=True)
-            handler_name = getattr(pc_conn, 'action_handler', 'normal')
+            handler_name = 'normal'
 
         handler = self._shared_loader_obj.action_loader.get(
             handler_name,

--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -67,7 +67,7 @@ class ConnectionBase(with_metaclass(ABCMeta, object)):
     # language means any language.
     module_implementation_preferences = ('',)
     allow_executable = True
-    action_handler = 'normal'
+    is_local = False
 
     def __init__(self, play_context, new_stdin, *args, **kwargs):
         # All these hasattrs allow subclasses to override these parameters

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -42,7 +42,7 @@ class Connection(_Connection):
 
     transport = 'network_cli'
     has_pipelining = False
-    action_handler = 'network'
+    is_local = True
 
     def __init__(self, play_context, new_stdin, *args, **kwargs):
         super(Connection, self).__init__(play_context, new_stdin, *args, **kwargs)


### PR DESCRIPTION
This splits the method to handle cases where module execution is remote
process based or local process based.  This removes the need to
have separate action plugins for each.  It also puts both local and
remote module execution in the same code path.

This also removes the need for the action_handler var in the connection
plugin and defaults all actions back to using `normal` which is the
current behavior

