### PR TITLE
adds module utils complexargs

### DIFF
--- a/lib/ansible/module_utils/complexargs.py
+++ b/lib/ansible/module_utils/complexargs.py
@@ -1,0 +1,144 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# (c) 2016 Red Hat Inc.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+from ansible.module_utils.basic import AnsibleFallbackNotFound
+from ansible.module_utils.six import iteritems
+
+class ComplexDict(object):
+    """Transforms a dict to with an argument spec
+
+    This class will take a dict and apply an Ansible argument spec to the
+    values.  The resulting dict will contain all of the keys in the param
+    with appropriate values set.
+
+    Example::
+
+        argument_spec = dict(
+            command=dict(key=True),
+            display=dict(default='text', choices=['text', 'json']),
+            validate=dict(type='bool')
+        )
+        transform = ComplexDict(argument_spec, module)
+        value = dict(command='foo')
+        result = transform(value)
+        print result
+        {'command': 'foo', 'display': 'text', 'validate': None}
+
+    Supported argument spec:
+        * key - specifies how to map a single value to a dict
+        * read_from - read and apply the argument_spec from the module
+        * required - a value is required
+        * type - type of value (uses AnsibleModule type checker)
+        * fallback - implements fallback function
+        * choices - set of valid options
+        * default - default value
+
+    """
+
+    def __init__(self, attrs, module):
+        self._attributes = attrs
+        self._module = module
+        self.attr_names = frozenset(self._attributes.keys())
+
+        self._has_key = False
+        for name, attr in iteritems(self._attributes):
+            if attr.get('read_from'):
+                spec = self._module.argument_spec.get(attr['read_from'])
+                if not spec:
+                    raise ValueError('argument_spec %s does not exist' %  attr['read_from'])
+                for key, value in iteritems(spec):
+                    if key not in attr:
+                        attr[key] = value
+
+            if attr.get('key'):
+                if self._has_key:
+                    raise ValueError('only one key value can be specified')
+                self_has_key = True
+                attr['required'] = True
+
+
+    def _dict(self, value):
+        obj = {}
+        for name, attr in iteritems(self._attributes):
+            if attr.get('key'):
+                obj[name] = value
+            else:
+                obj[name] = attr.get('default')
+        return obj
+
+    def __call__(self, value):
+        if not isinstance(value, dict):
+            value = self._dict(value)
+
+        unknown = set(value).difference(self.attr_names)
+        if unknown:
+            raise ValueError('invalid keys: %s' % ','.join(unknown))
+
+        for name, attr in iteritems(self._attributes):
+            if not value.get(name):
+                value[name] = attr.get('default')
+
+            if attr.get('fallback') and not value.get(name):
+                fallback = attr.get('fallback', (None,))
+                fallback_strategy = fallback[0]
+                fallback_args = []
+                fallback_kwargs = {}
+                if fallback_strategy is not None:
+                    for item in fallback[1:]:
+                        if isinstance(item, dict):
+                            fallback_kwargs = item
+                        else:
+                            fallback_args = item
+                    try:
+                        value[name] = fallback_strategy(*fallback_args, **fallback_kwargs)
+                    except AnsibleFallbackNotFound:
+                        continue
+
+            if attr.get('required') and value.get(name) is None:
+                raise ValueError('missing required attribute %s' % name)
+
+            if 'choices' in attr:
+                if value[name] not in attr['choices']:
+                    raise ValueError('%s must be one of %s, got %s' % \
+                            (name, ', '.join(attr['choices']), value[name]))
+
+            if value[name] is not None:
+                value_type = attr.get('type', 'str')
+                type_checker = self._module._CHECK_ARGUMENT_TYPES_DISPATCHER[value_type]
+                type_checker(value[name])
+
+        return value
+
+class ComplexList(ComplexDict):
+    """Extends ```ComplexDict``` to handle a  list of dicts """
+
+    def __call__(self, values):
+        if not isinstance(values, (list, tuple)):
+            raise TypeError('value must be an ordered iterable')
+        return [(super(ComplexList, self).__call__(v)) for v in values]
+
+

--- a/test/units/module_utils/test_complexargs.py
+++ b/test/units/module_utils/test_complexargs.py
@@ -1,0 +1,167 @@
+# (c) 2016 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import json
+
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import Mock
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+from ansible.module_utils.complexargs import ComplexDict
+
+
+def set_module_args(args):
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)
+
+class TestComplexArgsModuleUtils(unittest.TestCase):
+
+
+    def test_basic(self):
+        set_module_args(dict(name='foo'))
+
+        argument_spec = dict(name=dict())
+        module = basic.AnsibleModule(argument_spec)
+
+        spec = dict(
+            name=dict(key=True),
+            param1=dict(),
+            param2=dict()
+        )
+
+        transform = ComplexDict(spec, module)
+        result = transform(module.params['name'])
+
+        self.assertEqual(result['name'], 'foo')
+        self.assertIsNone(result['param1'])
+        self.assertIsNone(result['param2'])
+
+    def test_basic_required(self):
+        set_module_args(dict(name='foo'))
+
+        argument_spec = dict(name=dict())
+        module = basic.AnsibleModule(argument_spec)
+
+        spec = dict(
+            name=dict(key=True),
+            param1=dict(required=True),
+            param2=dict()
+        )
+
+        transform = ComplexDict(spec, module)
+
+        with self.assertRaises(ValueError):
+            transform(module.params['name'])
+
+    def test_basic_default(self):
+        set_module_args(dict(name='foo'))
+
+        argument_spec = dict(name=dict())
+        module = basic.AnsibleModule(argument_spec)
+
+        spec = dict(
+            name=dict(key=True),
+            param1=dict(default='test'),
+            param2=dict()
+        )
+
+        transform = ComplexDict(spec, module)
+        result = transform(module.params['name'])
+
+        self.assertEqual(result['name'], 'foo')
+        self.assertEqual(result['param1'], 'test')
+        self.assertIsNone(result['param2'])
+
+    def test_basic_type_check(self):
+        set_module_args(dict(name={'name': 'foo', 'param1': 'bar'}))
+
+        argument_spec = dict(name=dict(type='dict'))
+        module = basic.AnsibleModule(argument_spec)
+
+        spec = dict(
+            name=dict(key=True),
+            param1=dict(type='bool'),
+            param2=dict()
+        )
+
+        transform = ComplexDict(spec, module)
+
+        with self.assertRaises(SystemExit):
+            transform(module.params['name'])
+
+    def test_basic_read_from(self):
+        set_module_args(dict(name='foo'))
+
+        argument_spec = dict(name=dict(), param1=dict(default='test'))
+        module = basic.AnsibleModule(argument_spec)
+
+        spec = dict(
+            name=dict(key=True),
+            param1=dict(read_from='param1'),
+            param2=dict()
+        )
+
+        transform = ComplexDict(spec, module)
+        result = transform(module.params['name'])
+
+        self.assertEqual(result['name'], 'foo')
+        self.assertEqual(result['param1'], 'test')
+        self.assertIsNone(result['param2'])
+
+    def test_basic_read_from_override(self):
+        set_module_args(dict(name='foo'))
+
+        argument_spec = dict(name=dict(), param1=dict(default='test'))
+        module = basic.AnsibleModule(argument_spec)
+
+        spec = dict(
+            name=dict(key=True),
+            param1=dict(default='bar', read_from='param1'),
+            param2=dict()
+        )
+
+        transform = ComplexDict(spec, module)
+        result = transform(module.params['name'])
+
+        self.assertEqual(result['name'], 'foo')
+        self.assertEqual(result['param1'], 'bar')
+        self.assertIsNone(result['param2'])
+
+    def test_basic_fallback(self):
+        set_module_args(dict(name='foo'))
+
+        argument_spec = dict(name=dict(), param1=dict(default='test'))
+        module = basic.AnsibleModule(argument_spec)
+
+        spec = dict(
+            name=dict(key=True),
+            param1=dict(fallback=(basic.env_fallback, ['PATH'],)),
+            param2=dict()
+        )
+
+        transform = ComplexDict(spec, module)
+        result = transform(module.params['name'])
+
+        self.assertEqual(result['name'], 'foo')
+        self.assertEqual(result['param1'], os.getenv('PATH'))
+        self.assertIsNone(result['param2'])
+


### PR DESCRIPTION
This module eases the burden of working with arguments in modules that
are complex arguments (ie dict based).  It allows module developers to
transform the input into a well known dict.  It also supports the same
constructs as the argument_spec in modules.  See the description in the
module for implementation details.

