### PR TITLE
Fix vyos unit tests.

### DIFF
--- a/test/units/modules/network/vyos/test_vyos_system.py
+++ b/test/units/modules/network/vyos/test_vyos_system.py
@@ -30,6 +30,7 @@ from ansible.compat.tests.mock import patch, MagicMock
 from ansible.errors import AnsibleModuleExit
 from ansible.modules.network.vyos import vyos_system
 from ansible.module_utils._text import to_bytes
+from ansible.module_utils import basic
 
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
@@ -38,7 +39,7 @@ fixture_data = {}
 
 def set_module_args(args):
     json_args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
-    ansible.module_utils.basic._ANSIBLE_ARGS = to_bytes(json_args)
+    basic._ANSIBLE_ARGS = to_bytes(json_args)
 
 
 def load_fixture(name):


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

vyos unit tests

##### ANSIBLE VERSION

```
ansible 2.3.0 (test-fix 0ef8fad21d) last updated 2017/02/07 14:19:24 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Running the `test_vyos_system` test by itself passes, but running it along with all other unit tests will fail due to `_ANSIBLE_ARGS` having retained the value from the `test_vyos_facts` test.