### PR TITLE
refactor postgres modules, sslmode=prefer

### DIFF
--- a/lib/ansible/module_utils/postgres.py
+++ b/lib/ansible/module_utils/postgres.py
@@ -109,7 +109,7 @@ def postgres_common_argument_spec(password_alias=True):
     return dict(
         login_user        = dict(default='postgres', aliases=['login']),
         login_password    = dict(default='', no_log=True, aliases=password_aliases),
-        login_host        = dict(default='localhost', aliases=['host']),
+        login_host        = dict(default='', aliases=['host']),
         login_unix_socket = dict(default='', aliases=['unix_socket']),
         port              = dict(type='int', default=5432),
         ssl_mode          = dict(default='prefer', choices=['disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full']),

--- a/lib/ansible/module_utils/postgres.py
+++ b/lib/ansible/module_utils/postgres.py
@@ -70,9 +70,9 @@ def params_to_kwmap(module):
 
     return kw
 
-def postgres_conn(module, database=None, kw=kw, enable_autocommit=False):
+def postgres_conn(module, database=None, kw=None, enable_autocommit=False):
     # make sure kw is mutable and isn't None
-    kw = kw or None
+    kw = kw or {}
 
     try:
         if psycopg2.__version__ < '2.4.3' and module.params.get('ssl_rootcert') is not None:

--- a/lib/ansible/module_utils/postgres.py
+++ b/lib/ansible/module_utils/postgres.py
@@ -70,7 +70,7 @@ def params_to_kwmap(module):
 
     return kw
 
-def postgres_conn(module, database=None, kw=None, enable_autocommit=False, **params): # conn_type=None, resource=None, region=None, endpoint=None, **params):
+def postgres_conn(module, database=None, kw=None, enable_autocommit=False, **params):
 
     try:
         if psycopg2.__version__ < '2.4.3' and module.params['sslrootcert'] is not None:

--- a/lib/ansible/module_utils/postgres.py
+++ b/lib/ansible/module_utils/postgres.py
@@ -65,7 +65,7 @@ def params_to_kwmap(module):
     if is_localhost and module.params["login_unix_socket"] != "":
         kw["host"] = module.params["login_unix_socket"]
 
-    if psycopg2.__version__ < '2.4.3' and sslrootcert is not None:
+    if psycopg2.__version__ < '2.4.3' and module.params.get('sslrootcert') is not None:
         module.fail_json(msg='psycopg2 must be at least 2.4.3 in order to user the ssl_rootcert parameter')
 
     return kw

--- a/lib/ansible/module_utils/postgres.py
+++ b/lib/ansible/module_utils/postgres.py
@@ -62,8 +62,8 @@ def params_to_kwmap(module):
 
     # If a login_unix_socket is specified, incorporate it here.
     is_localhost = "host" not in kw or kw["host"] == "" or kw["host"] == "localhost"
-    if is_localhost and module.params["login_unix_socket"] != "":
-        kw["host"] = module.params["login_unix_socket"]
+    if is_localhost and module.params.get("login_unix_socket") != "":
+        kw["host"] = module.params.get("login_unix_socket")
 
     if psycopg2.__version__ < '2.4.3' and module.params.get('ssl_rootcert') is not None:
         raise Exception('psycopg2 must be at least 2.4.3 in order to user the ssl_rootcert parameter')

--- a/lib/ansible/module_utils/postgres.py
+++ b/lib/ansible/module_utils/postgres.py
@@ -1,0 +1,119 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Copyright (c), Ted Timmons <ted@timmons.me>, 2017.
+# Most of this was originally added by other creators in the postgresql_user module.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# standard ansible imports
+from ansible.module_utils.basic import get_exception
+
+# standard PG imports
+try:
+    import psycopg2
+    import psycopg2.extras
+except ImportError:
+    postgresqldb_found = False
+else:
+    postgresqldb_found = True
+from ansible.module_utils.six import iteritems
+
+class NotSupportedError(Exception):
+    pass
+
+# common methods
+
+def params_to_kwmap(module):
+    # To use defaults values, keyword arguments must be absent, so
+    # check which values are empty and don't include in the **kw
+    # dictionary
+    params_map = {
+        "login_host":"host",
+        "login_user":"user",
+        "login_password":"password",
+        "port":"port",
+        "ssl_mode":"sslmode",
+        "ssl_rootcert":"sslrootcert"
+    }
+    kw = dict( (params_map[k], v) for (k, v) in iteritems(module.params)
+              if k in params_map and v != '' and v is not None)
+
+    # If a login_unix_socket is specified, incorporate it here.
+    is_localhost = "host" not in kw or kw["host"] == "" or kw["host"] == "localhost"
+    if is_localhost and module.params["login_unix_socket"] != "":
+        kw["host"] = module.params["login_unix_socket"]
+
+    if psycopg2.__version__ < '2.4.3' and sslrootcert is not None:
+        module.fail_json(msg='psycopg2 must be at least 2.4.3 in order to user the ssl_rootcert parameter')
+
+    return kw
+
+def postgres_conn(module, database=None, kw=None, enable_autocommit=False, **params): # conn_type=None, resource=None, region=None, endpoint=None, **params):
+
+    try:
+        if psycopg2.__version__ < '2.4.3' and module.params['sslrootcert'] is not None:
+            module.fail_json(msg='psycopg2 must be at least 2.4.3 in order to use the ssl_rootcert parameter')
+
+        db_connection = psycopg2.connect(database=database, **kw)
+
+        if enable_autocommit:
+            # Enable autocommit so we can create databases
+            if psycopg2.__version__ >= '2.4.2':
+                db_connection.autocommit = True
+            else:
+                db_connection.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+
+        # TODO: part of autocommit?
+        cursor = db_connection.cursor(cursor_factory=psycopg2.extras.DictCursor)
+
+    except TypeError:
+        e = get_exception()
+        if 'sslrootcert' in e.args[0]:
+            module.fail_json(msg='Postgresql server must be at least version 8.4 to support sslrootcert')
+        module.fail_json(msg="unable to connect to database: %s" % e)
+
+    except Exception:
+        e = get_exception()
+        module.fail_json(msg="unable to connect to database: %s" % e)
+
+    return db_connection
+
+
+def postgres_common_argument_spec(password_alias=True):
+    password_aliases = []
+    if password_alias: # sometimes 'password' means something totally different.
+        password_aliases = ['password']
+
+    return dict(
+        login_user        = dict(default='postgres', aliases=['login']),
+        login_password    = dict(default='', no_log=True, aliases=password_aliases),
+        login_host        = dict(default='localhost', aliases=['host']),
+        login_unix_socket = dict(default='', aliases=['unix_socket']),
+        port              = dict(type='int', default=5432),
+        ssl_mode          = dict(default='prefer', choices=['disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full']),
+        ssl_rootcert      = dict(default=None),
+    )
+
+

--- a/lib/ansible/module_utils/postgres.py
+++ b/lib/ansible/module_utils/postgres.py
@@ -70,7 +70,7 @@ def params_to_kwmap(module):
 
     return kw
 
-def postgres_conn(module, database=None, kw=None, enable_autocommit=False, **params):
+def postgres_conn(module, database=None, kw={}, enable_autocommit=False):
 
     try:
         if psycopg2.__version__ < '2.4.3' and module.params['sslrootcert'] is not None:

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -253,7 +253,7 @@ def main():
             except SQLParseError:
                 e = get_exception()
                 module.fail_json(msg=str(e))
-    except NotSupportedError:
+    except pgutils.NotSupportedError:
         e = get_exception()
         module.fail_json(msg=str(e))
     except SystemExit:

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -206,7 +206,6 @@ def main():
         lc_collate=dict(default=""),
         lc_ctype=dict(default=""),
         state=dict(default="present", choices=["absent", "present"]),
-        ssl_rootcert=dict(default=None),
     ))
 
     module = AnsibleModule(

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -33,36 +33,11 @@ options:
       - name of the database to add or remove
     required: true
     default: null
-  login_user:
-    description:
-      - The username used to authenticate with
-    required: false
-    default: null
-  login_password:
-    description:
-      - The password used to authenticate with
-    required: false
-    default: null
-  login_host:
-    description:
-      - Host running the database
-    required: false
-    default: localhost
-  login_unix_socket:
-    description:
-      - Path to a Unix domain socket for local connections
-    required: false
-    default: null
   owner:
     description:
       - Name of the role to set as owner of the database
     required: false
     default: null
-  port:
-    description:
-      - Database port to connect to.
-    required: false
-    default: 5432
   template:
     description:
       - Template used to create the database
@@ -89,27 +64,10 @@ options:
     required: false
     default: present
     choices: [ "present", "absent" ]
-  ssl_mode:
-    description:
-      - Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server.
-      - See https://www.postgresql.org/docs/current/static/libpq-ssl.html for more information on the modes.
-    required: false
-    default: disable
-    choices: [disable, allow, prefer, require, verify-ca, verify-full]
-    version_added: '2.3'
-  ssl_rootcert:
-    description:
-      - Specifies the name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
-    required: false
-    default: null
-    version_added: '2.3'
-notes:
-   - The default authentication assumes that you are either logging in as or sudo'ing to the C(postgres) account on the host.
-   - This module uses I(psycopg2), a Python PostgreSQL database adapter. You must ensure that psycopg2 is installed on
-     the host before using this module. If the remote host is the PostgreSQL server (which is the default case), then PostgreSQL must also be installed on the remote host. For Ubuntu-based systems, install the C(postgresql), C(libpq-dev), and C(python-psycopg2) packages on the remote host before using this module.
-   - The ssl_rootcert parameter requires at least Postgres version 8.4 and I(psycopg2) version 2.4.3.
 requirements: [ psycopg2 ]
 author: "Ansible Core Team"
+extends_documentation_fragment:
+- postgres
 '''
 
 EXAMPLES = '''
@@ -128,6 +86,7 @@ EXAMPLES = '''
     template: template0
 '''
 
+# pg imports
 try:
     import psycopg2
     import psycopg2.extras
@@ -135,10 +94,6 @@ except ImportError:
     postgresqldb_found = False
 else:
     postgresqldb_found = True
-from ansible.module_utils.six import iteritems
-
-class NotSupportedError(Exception):
-    pass
 
 
 # ===========================================
@@ -243,23 +198,20 @@ def db_matches(cursor, db, owner, template, encoding, lc_collate, lc_ctype):
 #
 
 def main():
+    argument_spec = pgutils.postgres_common_argument_spec()
+    argument_spec.update(dict(
+        db=dict(required=True, aliases=['name']),
+        owner=dict(default=""),
+        template=dict(default=""),
+        encoding=dict(default=""),
+        lc_collate=dict(default=""),
+        lc_ctype=dict(default=""),
+        state=dict(default="present", choices=["absent", "present"]),
+        ssl_rootcert=dict(default=None),
+    ))
+
     module = AnsibleModule(
-        argument_spec=dict(
-            login_user=dict(default="postgres"),
-            login_password=dict(default=""),
-            login_host=dict(default=""),
-            login_unix_socket=dict(default=""),
-            port=dict(default="5432"),
-            db=dict(required=True, aliases=['name']),
-            owner=dict(default=""),
-            template=dict(default=""),
-            encoding=dict(default=""),
-            lc_collate=dict(default=""),
-            lc_ctype=dict(default=""),
-            state=dict(default="present", choices=["absent", "present"]),
-            ssl_mode=dict(default="disable", choices=['disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full']),
-            ssl_rootcert=dict(default=None),
-        ),
+        argument_spec = argument_spec,
         supports_check_mode = True
     )
 
@@ -274,60 +226,19 @@ def main():
     lc_collate = module.params["lc_collate"]
     lc_ctype = module.params["lc_ctype"]
     state = module.params["state"]
-    sslrootcert = module.params["ssl_rootcert"]
     changed = False
 
-    # To use defaults values, keyword arguments must be absent, so
-    # check which values are empty and don't include in the **kw
-    # dictionary
-    params_map = {
-        "login_host":"host",
-        "login_user":"user",
-        "login_password":"password",
-        "port":"port",
-        "ssl_mode":"sslmode",
-        "ssl_rootcert":"sslrootcert"
-    }
-    kw = dict( (params_map[k], v) for (k, v) in iteritems(module.params)
-              if k in params_map and v != '' and v is not None)
+    kw = pgutils.params_to_kwmap(module)
 
-    # If a login_unix_socket is specified, incorporate it here.
-    is_localhost = "host" not in kw or kw["host"] == "" or kw["host"] == "localhost"
-    if is_localhost and module.params["login_unix_socket"] != "":
-        kw["host"] = module.params["login_unix_socket"]
-
-    if psycopg2.__version__ < '2.4.3' and sslrootcert is not None:
-        module.fail_json(msg='psycopg2 must be at least 2.4.3 in order to user the ssl_rootcert parameter')
-
-    try:
-        db_connection = psycopg2.connect(database="postgres", **kw)
-        # Enable autocommit so we can create databases
-        if psycopg2.__version__ >= '2.4.2':
-            db_connection.autocommit = True
-        else:
-            db_connection.set_isolation_level(psycopg2
-                                              .extensions
-                                              .ISOLATION_LEVEL_AUTOCOMMIT)
-        cursor = db_connection.cursor(
-            cursor_factory=psycopg2.extras.DictCursor)
-
-    except TypeError:
-        e = get_exception()
-        if 'sslrootcert' in e.args[0]:
-            module.fail_json(msg='Postgresql server must be at least version 8.4 to support sslrootcert')
-        module.fail_json(msg="unable to connect to database: %s" % e)
-
-    except Exception:
-        e = get_exception()
-        module.fail_json(msg="unable to connect to database: %s" % e)
+    db_connection = pgutils.postgres_conn(module, database="postgres", kw=kw, enable_autocommit=True)
+    cursor = db_connection.cursor(cursor_factory=psycopg2.extras.DictCursor)
 
     try:
         if module.check_mode:
             if state == "absent":
                 changed = db_exists(cursor, db)
             elif state == "present":
-                changed = not db_matches(cursor, db, owner, template, encoding,
-                                         lc_collate, lc_ctype)
+                changed = not db_matches(cursor, db, owner, template, encoding, lc_collate, lc_ctype)
             module.exit_json(changed=changed, db=db)
 
         if state == "absent":
@@ -339,8 +250,7 @@ def main():
 
         elif state == "present":
             try:
-                changed = db_create(cursor, db, owner, template, encoding,
-                                lc_collate, lc_ctype)
+                changed = db_create(cursor, db, owner, template, encoding, lc_collate, lc_ctype)
             except SQLParseError:
                 e = get_exception()
                 module.fail_json(msg=str(e))
@@ -357,7 +267,8 @@ def main():
     module.exit_json(changed=changed, db=db)
 
 # import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.database import *
+from ansible.module_utils.basic import AnsibleModule,get_exception
+from ansible.module_utils.database import pg_quote_identifier,SQLParseError
+import ansible.module_utils.postgres as pgutils
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -55,7 +55,8 @@ options:
     default: null
   lc_ctype:
     description:
-      - Character classification (LC_CTYPE) to use in the database (e.g. lower, upper, ...) Must match LC_CTYPE of template database unless C(template0) is used as template.
+      - Character classification (LC_CTYPE) to use in the database (e.g. lower, upper, ...)
+      - Must match LC_CTYPE of template database unless C(template0) is used as template.
     required: false
     default: null
   state:
@@ -155,8 +156,7 @@ def db_create(cursor, db, owner, template, encoding, lc_collate, lc_ctype):
         return True
     else:
         db_info = get_db_info(cursor, db)
-        if (encoding and
-            get_encoding_id(cursor, encoding) != db_info['encoding_id']):
+        if (encoding and get_encoding_id(cursor, encoding) != db_info['encoding_id']):
             raise NotSupportedError(
                 'Changing database encoding is not supported. '
                 'Current encoding: %s' % db_info['encoding']
@@ -181,8 +181,7 @@ def db_matches(cursor, db, owner, template, encoding, lc_collate, lc_ctype):
         return False
     else:
         db_info = get_db_info(cursor, db)
-        if (encoding and
-            get_encoding_id(cursor, encoding) != db_info['encoding_id']):
+        if (encoding and get_encoding_id(cursor, encoding) != db_info['encoding_id']):
             return False
         elif lc_collate and lc_collate != db_info['lc_collate']:
             return False

--- a/lib/ansible/modules/database/postgresql/postgresql_ext.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ext.py
@@ -65,9 +65,6 @@ except ImportError:
 else:
     postgresqldb_found = True
 
-class NotSupportedError(Exception):
-    pass
-
 
 # ===========================================
 # PostgreSQL module specific support methods.
@@ -137,7 +134,7 @@ def main():
 
             elif state == "present":
                 changed = ext_create(cursor, ext)
-    except NotSupportedError:
+    except pgutils.NotSupportedError:
         e = get_exception()
         module.fail_json(msg=str(e))
     except Exception:

--- a/lib/ansible/modules/database/postgresql/postgresql_privs.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_privs.py
@@ -458,7 +458,7 @@ class Connection(object):
             self.cursor.execute(query % (set_what, for_whom))
 
             # Only revoke GRANT/ADMIN OPTION if grant_option actually is False.
-            if grant_option == False:
+            if not grant_option:
                 if obj_type == 'group':
                     query = 'REVOKE ADMIN OPTION FOR %s FROM %s'
                 else:

--- a/lib/ansible/modules/database/postgresql/postgresql_schema.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_schema.py
@@ -38,47 +38,21 @@ options:
       - Name of the database to connect to.
     required: false
     default: postgres
-  login_user:
-    description:
-      - The username used to authenticate with.
-    required: false
-    default: null
-  login_password:
-    description:
-      - The password used to authenticate with.
-    required: false
-    default: null
-  login_host:
-    description:
-      - Host running the database.
-    required: false
-    default: localhost
-  login_unix_socket:
-    description:
-      - Path to a Unix domain socket for local connections.
-    required: false
-    default: null
   owner:
     description:
       - Name of the role to set as owner of the schema.
     required: false
     default: null
-  port:
-    description:
-      - Database port to connect to.
-    required: false
-    default: 5432
   state:
     description:
       - The schema state.
     required: false
     default: present
     choices: [ "present", "absent" ]
-notes:
-   - This module uses I(psycopg2), a Python PostgreSQL database adapter. You must ensure that psycopg2 is installed on
-     the host before using this module. If the remote host is the PostgreSQL server (which is the default case), then PostgreSQL must also be installed on the remote host. For Ubuntu-based systems, install the C(postgresql), C(libpq-dev), and C(python-psycopg2) packages on the remote host before using this module.
 requirements: [ psycopg2 ]
 author: "Flavien Chantelot <contact@flavien.io>"
+extends_documentation_fragment:
+- postgres
 '''
 
 EXAMPLES = '''
@@ -177,18 +151,16 @@ def schema_matches(cursor, schema, owner):
 #
 
 def main():
+    argument_spec = pgutils.postgres_common_argument_spec()
+    argument_spec.update(dict(
+        schema=dict(required=True, aliases=['name']),
+        owner=dict(default=""),
+        database=dict(default="postgres"),
+        state=dict(default="present", choices=["absent", "present"]),
+    ))
+
     module = AnsibleModule(
-        argument_spec=dict(
-            login_user=dict(default="postgres"),
-            login_password=dict(default=""),
-            login_host=dict(default=""),
-            login_unix_socket=dict(default=""),
-            port=dict(default="5432"),
-            schema=dict(required=True, aliases=['name']),
-            owner=dict(default=""),
-            database=dict(default="postgres"),
-            state=dict(default="present", choices=["absent", "present"]),
-        ),
+        argument_spec=argument_spec,
         supports_check_mode = True
     )
 
@@ -201,37 +173,10 @@ def main():
     database = module.params["database"]
     changed = False
 
-    # To use defaults values, keyword arguments must be absent, so
-    # check which values are empty and don't include in the **kw
-    # dictionary
-    params_map = {
-        "login_host":"host",
-        "login_user":"user",
-        "login_password":"password",
-        "port":"port"
-    }
-    kw = dict( (params_map[k], v) for (k, v) in module.params.items()
-              if k in params_map and v != '' )
+    kw = pgutils.params_to_kwmap(module)
 
-    # If a login_unix_socket is specified, incorporate it here.
-    is_localhost = "host" not in kw or kw["host"] == "" or kw["host"] == "localhost"
-    if is_localhost and module.params["login_unix_socket"] != "":
-        kw["host"] = module.params["login_unix_socket"]
-
-    try:
-        db_connection = psycopg2.connect(database=database, **kw)
-        # Enable autocommit so we can create databases
-        if psycopg2.__version__ >= '2.4.2':
-            db_connection.autocommit = True
-        else:
-            db_connection.set_isolation_level(psycopg2
-                                              .extensions
-                                              .ISOLATION_LEVEL_AUTOCOMMIT)
-        cursor = db_connection.cursor(
-            cursor_factory=psycopg2.extras.DictCursor)
-    except Exception:
-        e = get_exception()
-        module.fail_json(msg="unable to connect to database: %s" %(text, str(e)))
+    db_connection = pgutils.postgres_conn(module, database=database, kw=kw, enable_autocommit=True)
+    cursor = db_connection.cursor(cursor_factory=psycopg2.extras.DictCursor)
 
     try:
         if module.check_mode:
@@ -267,8 +212,9 @@ def main():
     module.exit_json(changed=changed, schema=schema)
 
 # import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.database import *
+from ansible.module_utils.basic import AnsibleModule,get_exception
+import ansible.module_utils.postgres as pgutils
+from ansible.module_utils.database import pg_quote_identifier
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/database/postgresql/postgresql_schema.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_schema.py
@@ -84,10 +84,6 @@ except ImportError:
 else:
     postgresqldb_found = True
 
-class NotSupportedError(Exception):
-    pass
-
-
 # ===========================================
 # PostgreSQL module specific support methods.
 #
@@ -199,7 +195,7 @@ def main():
             except SQLParseError:
                 e = get_exception()
                 module.fail_json(msg=str(e))
-    except NotSupportedError:
+    except pgutils.NotSupportedError:
         e = get_exception()
         module.fail_json(msg=str(e))
     except SystemExit:

--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -86,7 +86,8 @@ options:
     choices: [ "present", "absent" ]
   encrypted:
     description:
-      - whether the password is stored hashed in the database. boolean. Passwords can be passed already hashed or unhashed, and postgresql ensures the stored password is hashed when encrypted is set.
+      - whether the password is stored hashed in the database. boolean. Passwords can be passed already
+        hashed or unhashed, and postgresql ensures the stored password is hashed when encrypted is set.
     required: false
     default: false
     version_added: '1.4'
@@ -98,7 +99,8 @@ options:
     version_added: '1.4'
   no_password_changes:
     description:
-      - if C(yes), don't inspect database for password changes. Effective when C(pg_authid) is not accessible (such as AWS RDS). Otherwise, make password changes as necessary.
+      - if C(yes), don't inspect database for password changes. Effective when C(pg_authid) is
+        not accessible (such as AWS RDS). Otherwise, make password changes as necessary.
     required: false
     default: 'no'
     choices: [ "yes", "no" ]
@@ -636,9 +638,9 @@ def main():
     module.exit_json(**kw)
 
 # import module snippets
-from ansible.module_utils.basic import AnsibleModule,get_exception
+from ansible.module_utils.basic import AnsibleModule, get_exception
 import ansible.module_utils.postgres as pgutils
-from ansible.module_utils.database import pg_quote_identifier,SQLParseError
+from ansible.module_utils.database import pg_quote_identifier, SQLParseError
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -48,7 +48,11 @@ options:
   password:
     description:
       - set the user's password, before 1.4 this was required.
-      - "When passing an encrypted password, the encrypted parameter must also be true, and it must be generated with the format C('str[\\"md5\\"] + md5[ password + username ]'), resulting in a total of 35 characters.  An easy way to do this is: C(echo \\"md5`echo -n \\"verysecretpasswordJOE\\" | md5`\\"). Note that if encrypted is set, the stored password will be hashed whether or not it is pre-encrypted."
+      - "When passing an encrypted password, the encrypted parameter must also be true, and
+        it must be generated with the format C('str[\\"md5\\"] + md5[ password + username ]'),
+        resulting in a total of 35 characters.  An easy way to do this is:
+        C(echo \\"md5`echo -n \\"verysecretpasswordJOE\\" | md5`\\"). Note that if encrypted is
+        set, the stored password will be hashed whether or not it is pre-encrypted."
     required: false
     default: null
   db:

--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -584,8 +584,7 @@ def main():
 
     kw = pgutils.params_to_kwmap(module)
 
-    #db_connection = pgutils.postgres_conn(module, database=database, kw=kw, enable_autocommit=True)
-    db_connection = pgutils.postgres_conn(module, kw=kw, enable_autocommit=False)
+    db_connection = pgutils.postgres_conn(module, database=db, enable_autocommit=False)
     cursor = db_connection.cursor(cursor_factory=psycopg2.extras.DictCursor)
 
     kw = dict(user=user)

--- a/lib/ansible/utils/module_docs_fragments/postgres.py
+++ b/lib/ansible/utils/module_docs_fragments/postgres.py
@@ -1,0 +1,70 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+
+class ModuleDocFragment(object):
+
+    # Postgres documentation fragment
+    DOCUMENTATION = """
+options:
+  login_user:
+    description:
+      - The username used to authenticate with
+    required: false
+    default: postgres
+  login_password:
+    description:
+      - The password used to authenticate with
+    required: false
+    default: null
+  login_host:
+    description:
+      - Host running the database
+    required: false
+    default: localhost
+  login_unix_socket:
+    description:
+      - Path to a Unix domain socket for local connections
+    required: false
+    default: null
+  port:
+    description:
+      - Database port to connect to.
+    required: false
+    default: 5432
+  ssl_mode:
+    description:
+      - Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server.
+      - See https://www.postgresql.org/docs/current/static/libpq-ssl.html for more information on the modes.
+      - Default of C(prefer) matches libpq default.
+    required: false
+    default: prefer
+    choices: [disable, allow, prefer, require, verify-ca, verify-full]
+    version_added: '2.3'
+  ssl_rootcert:
+    description:
+      - Specifies the name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+    required: false
+    default: null
+    version_added: '2.3'
+notes:
+- The default authentication assumes that you are either logging in as or sudo'ing to the C(postgres) account on the host.
+- This module uses I(psycopg2), a Python PostgreSQL database adapter. You must ensure that psycopg2 is installed on
+  the host before using this module. If the remote host is the PostgreSQL server (which is the default case), then
+  PostgreSQL must also be installed on the remote host. For Ubuntu-based systems, install the C(postgresql), C(libpq-dev),
+  and C(python-psycopg2) packages on the remote host before using this module.
+- The ssl_rootcert parameter requires at least Postgres version 8.4 and I(psycopg2) version 2.4.3.
+"""

--- a/lib/ansible/utils/module_docs_fragments/postgres.py
+++ b/lib/ansible/utils/module_docs_fragments/postgres.py
@@ -14,9 +14,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 
-
 class ModuleDocFragment(object):
-
     # Postgres documentation fragment
     DOCUMENTATION = """
 options:

--- a/lib/ansible/utils/module_docs_fragments/postgres.py
+++ b/lib/ansible/utils/module_docs_fragments/postgres.py
@@ -56,7 +56,8 @@ options:
     version_added: '2.3'
   ssl_rootcert:
     description:
-      - Specifies the name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+      - Specifies the name of a file containing SSL certificate authority (CA) certificate(s).
+      - If the file exists, the server's certificate will be verified to be signed by one of these authorities.
     required: false
     default: null
     version_added: '2.3'

--- a/lib/ansible/utils/module_docs_fragments/postgres.py
+++ b/lib/ansible/utils/module_docs_fragments/postgres.py
@@ -32,7 +32,7 @@ options:
     description:
       - Host running the database
     required: false
-    default: localhost
+    default: null
   login_unix_socket:
     description:
       - Path to a Unix domain socket for local connections

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -122,11 +122,6 @@ lib/ansible/modules/database/mysql/mysql_db.py
 lib/ansible/modules/database/mysql/mysql_replication.py
 lib/ansible/modules/database/mysql/mysql_user.py
 lib/ansible/modules/database/mysql/mysql_variables.py
-lib/ansible/modules/database/postgresql/postgresql_db.py
-lib/ansible/modules/database/postgresql/postgresql_ext.py
-lib/ansible/modules/database/postgresql/postgresql_privs.py
-lib/ansible/modules/database/postgresql/postgresql_schema.py
-lib/ansible/modules/database/postgresql/postgresql_user.py
 lib/ansible/modules/database/vertica/vertica_schema.py
 lib/ansible/modules/database/vertica/vertica_user.py
 lib/ansible/modules/files/acl.py

--- a/test/units/module_utils/test_postgresql.py
+++ b/test/units/module_utils/test_postgresql.py
@@ -1,0 +1,26 @@
+import json
+
+from ansible.compat.tests import unittest
+
+from ansible.module_utils import postgres
+from ansible.module_utils.basic import AnsibleModule
+from units.mock.procenv import swap_stdin_and_argv
+
+
+import pprint
+
+
+class TestPostgres(unittest.TestCase):
+    def test(self):
+        params = {'foo': 'blippy'}
+        # module weirdness and testing shenagigans
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS=params))
+        self.stdin_swap = swap_stdin_and_argv(stdin_data=args)
+        self.stdin_swap.__enter__()
+
+        a_module = AnsibleModule(argument_spec={'foo': {'required': True, 'aliases': ['name']}})
+        res = postgres.params_to_kwmap(a_module)
+        pprint.pprint(res)
+
+        # unittest doesn't have a clean place to use a context manager, so we have to enter/exit manually
+        self.stdin_swap.__exit__(None, None, None)

--- a/test/units/module_utils/test_postgresql.py
+++ b/test/units/module_utils/test_postgresql.py
@@ -13,14 +13,11 @@ import pprint
 class TestPostgres(unittest.TestCase):
     def test(self):
         params = {'foo': 'blippy'}
-        # module weirdness and testing shenagigans
         args = json.dumps(dict(ANSIBLE_MODULE_ARGS=params))
-        self.stdin_swap = swap_stdin_and_argv(stdin_data=args)
-        self.stdin_swap.__enter__()
 
-        a_module = AnsibleModule(argument_spec={'foo': {'required': True, 'aliases': ['name']}})
-        res = postgres.params_to_kwmap(a_module)
-        pprint.pprint(res)
+        with swap_stdin_and_argv(stdin_data=args):
+            basic._ANSIBLE_ARGS = None
+            a_module = AnsibleModule(argument_spec={'foo': {'required': True, 'aliases': ['name']}})
+            res = postgres.params_to_kwmap(a_module)
+            pprint.pprint(res)
 
-        # unittest doesn't have a clean place to use a context manager, so we have to enter/exit manually
-        self.stdin_swap.__exit__(None, None, None)

--- a/test/units/module_utils/test_postgresql.py
+++ b/test/units/module_utils/test_postgresql.py
@@ -2,7 +2,7 @@ import json
 
 from ansible.compat.tests import unittest
 
-from ansible.module_utils import postgres
+from ansible.module_utils import postgres, basic
 from ansible.module_utils.basic import AnsibleModule
 from units.mock.procenv import swap_stdin_and_argv
 


### PR DESCRIPTION
- ssl_mode is new, the default in Ansible modules was 'disable'. This doesn't match the Postgres default of 'prefer'. Change per irc discussion with abadger.
- refactor to use a common postgresql base util. Tried to keep any aliases.
- refactor to use a common docs fragment.
- fix some mismatched documentation (e.g., login_user didn't have a default in docs, but it is 'postgres' in code). more docfixes needed.
- add no_log to password.

Tested with three databases, so I could test the ssl modes in a bunch of various configurations. I'll show my test play in the PR.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
