### PR TITLE
add nice approximation of the shippable/testrunner pep8 spec

### DIFF
--- a/test/sanity/pep8/README.md
+++ b/test/sanity/pep8/README.md
@@ -25,9 +25,9 @@ Files listed in the [skip list](skip.txt) are not tested by `pep8`.
 
 Files which have been removed from the repository must be removed from the legacy file list and the skip list.
 
-## Running locally
+## Running Locally
 
-You can do a quick pep8 spotcheck by approximating `command_sanity_pep8` in `test/runner/lib/executor.py` like this:
+The pep8 check can be run locally with:
 
-    ./test/runner/ansible-test sanity -v --test pep8 <files to sanity-check>
+    ./test/runner/ansible-test sanity --test pep8 <files to sanity-check>
 

--- a/test/sanity/pep8/README.md
+++ b/test/sanity/pep8/README.md
@@ -29,5 +29,5 @@ Files which have been removed from the repository must be removed from the legac
 
 You can do a quick pep8 spotcheck by approximating `command_sanity_pep8` in `test/runner/lib/executor.py` like this:
 
-    pep8 --ignore `paste -sd "," test/sanity/pep8/current-ignore.txt` --max-line-length=160 --config=/dev/null lib/ansible/modules/mymodule.py
+    ./test/runner/ansible-test sanity -v --test pep8 <files to sanity-check>
 

--- a/test/sanity/pep8/README.md
+++ b/test/sanity/pep8/README.md
@@ -24,3 +24,10 @@ Files listed in the [skip list](skip.txt) are not tested by `pep8`.
 ## Removed Files
 
 Files which have been removed from the repository must be removed from the legacy file list and the skip list.
+
+## Running locally
+
+You can do a quick pep8 spotcheck by approximating `command_sanity_pep8` in `test/runner/lib/executor.py` like this:
+
+    pep8 --ignore `paste -sd "," test/sanity/pep8/current-ignore.txt` --max-line-length=160 --config=/dev/null lib/ansible/modules/mymodule.py
+

--- a/test/sanity/pep8/README.md
+++ b/test/sanity/pep8/README.md
@@ -29,5 +29,5 @@ Files which have been removed from the repository must be removed from the legac
 
 The pep8 check can be run locally with:
 
-    ./test/runner/ansible-test sanity --test pep8 [file-or-directory-path-to-check]
+    ./test/runner/ansible-test sanity --test pep8 [file-or-directory-path-to-check] ...
 

--- a/test/sanity/pep8/README.md
+++ b/test/sanity/pep8/README.md
@@ -29,5 +29,5 @@ Files which have been removed from the repository must be removed from the legac
 
 The pep8 check can be run locally with:
 
-    ./test/runner/ansible-test sanity --test pep8 <files to sanity-check>
+    ./test/runner/ansible-test sanity --test pep8 [file-or-directory-path-to-check]
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
testing/shippable/pep8

##### ANSIBLE VERSION
2.3.0 devel

##### SUMMARY
I needed to short-circuit the pep8 testing so I could fix things and iterate. Passing on, because The More You Know.