### PR TITLE
added qemu_img module to interact with qemu-img

### DIFF
--- a/lib/ansible/modules/cloud/misc/qemu_img.py
+++ b/lib/ansible/modules/cloud/misc/qemu_img.py
@@ -1,0 +1,121 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2013, Jeroen Hoekx <jeroen.hoekx@dsquare.be>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+author: Jeroen Hoekx
+module: qemu_img
+short_description: Create qemu images
+description:
+  - "This module creates images for qemu."
+version_added: "1.2"
+options:
+  dest:
+    description:
+    - The image file to create or remove
+    required: true
+  format:
+    description:
+    - The image format - default qcow2
+    required: false
+  size:
+    description:
+    - The size of the image in megabytes.
+    required: false
+  opt:
+    description:
+    - Comma separated list of format specific options in a name=value format.
+    required: false
+  state:
+    choices: [ "absent", "present" ]
+    description:
+    - If the image should be present or absent - default present
+    required: false
+examples:
+  - description: Create a raw image of 5M.
+    code: qemu_img dest=/tmp/testimg size=5 format=raw
+  - description: Enlarge the image to 6M.
+    code: qemu_img dest=/tmp/testimg size=6 format=raw
+  - description: Remove the image
+    code: qemu_img dest=/tmp/testimg state=absent
+notes:
+  - This module does not change the type of the image.
+'''
+
+import os
+
+from ansible.module_utils.basic import AnsibleModule
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec = dict(
+            dest = dict(type='str', required=True),
+            opt = dict(type='str'),
+            format = dict(type='str', default='qcow2'),
+            size = dict(type='int'),
+            state = dict(type='str', choices=['absent', 'present'], default='present'),
+        ),
+        supports_check_mode = True,
+    )
+
+    changed = False
+    qemu_img = module.get_bin_path('qemu-img', True)
+
+    dest = module.params['dest']
+    img_format = module.params['format']
+    opt = module.params['opt']
+
+    if module.params['state'] == 'present':
+        if not module.params['size']:
+            module.fail_json(msg="Parameter 'size' required")
+        size = module.params['size'] * 1024 * 1024
+
+        if not os.path.exists(dest):
+            if not module.check_mode:
+                if not opt:
+                    module.run_command('%s create -f %s "%s" %s'%(qemu_img, img_format, dest, size), check_rc=True)
+                else:
+                    module.run_command('%s create -f %s -o %s "%s" %s'%(qemu_img, img_format, opt, dest, size), check_rc=True)
+            changed = True
+        else:
+            rc, stdout, _ = module.run_command('%s info "%s"'%(qemu_img, dest), check_rc=True)
+            current_size = None
+            for line in stdout.splitlines():
+                if 'virtual size' in line:
+                    ### virtual size: 5.0M (5242880 bytes)
+                    current_size = int(line.split('(')[1].split()[0])
+            if not current_size:
+                module.fail_json(msg='Unable to read virtual disk size of %s'%(dest))
+            if current_size != size:
+                if not module.check_mode:
+                    module.run_command('%s resize "%s" %s'%(qemu_img, dest, size), check_rc=True)
+                changed = True
+
+    if module.params['state'] == 'absent':
+        if os.path.exists(dest):
+            if not module.check_mode:
+                os.remove(dest)
+            changed = True
+
+    module.exit_json(changed=changed)
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/misc/qemu_img.py
+++ b/lib/ansible/modules/cloud/misc/qemu_img.py
@@ -36,6 +36,8 @@ options:
   options:
     description:
     - List of format specific options in a name=value format.
+    default:
+    - preallocation=metadata
     type: list
   size:
     description:
@@ -123,7 +125,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             dest=dict(type='str', required=True),
-            options=dict(type='list', default='preallocation=metadata'),
+            options=dict(type='list', default=['preallocation=metadata']),
             format=dict(type='str', default='qcow2'),
             size=dict(type='str'),
             grow=dict(type="bool", default=True),

--- a/lib/ansible/modules/cloud/misc/qemu_img.py
+++ b/lib/ansible/modules/cloud/misc/qemu_img.py
@@ -14,9 +14,6 @@ ANSIBLE_METADATA = {'status': ['preview'],
 
 DOCUMENTATION = r'''
 ---
-author:
-- Jeroen Hoekx (@jhoekx)
-- Toshaan Bharvani (@toshywoshy)
 module: qemu_img
 short_description: Manage qemu images
 description:
@@ -35,7 +32,7 @@ options:
     default: qcow2
   options:
     description:
-    - List of format specific options in a name=value format.
+    - List of format specific options in a C(name=value) format.
     default:
     - preallocation=metadata
     type: list
@@ -45,12 +42,12 @@ options:
     type: str
   grow:
     description:
-    - Whether the image is allowed grow.
+    - Whether the image is allowed to grow.
     type: bool
     default: yes
   shrink:
     description:
-    - Whether the image is allowed shrink.
+    - Whether the image is allowed to shrink.
     type: bool
     default: no
   state:
@@ -62,6 +59,9 @@ options:
 notes:
   - This module does not change the type/format of the image.
   - This module does not take snapshots, and should be implemented seperate.
+author:
+- Jeroen Hoekx (@jhoekx)
+- Toshaan Bharvani (@toshywoshy)
 '''
 
 EXAMPLES = r'''
@@ -91,24 +91,24 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-# create qemu image
+# Create qemu image
 present:
   description:
-  - Returns the status of the qemu image that was created
+  - Returns the status of the qemu image that was created.
   type: str
   sample: success
   returned: success
-# remove qemu image
+# Remove qemu image
 absent:
   description:
-  - Returns the status of the qemu image that was removed
+  - Returns the status of the qemu image that was removed.
   type: str
   sample: success
   returned: success
-# resize qemu image
+# Resize qemu image
 resize:
   description:
-  - Returns the status of the qemu image that was resized
+  - Returns the status of the qemu image that was resized.
   type: str
   sample: success
   returned: success
@@ -128,8 +128,8 @@ def main():
             options=dict(type='list', default=['preallocation=metadata']),
             format=dict(type='str', default='qcow2'),
             size=dict(type='str'),
-            grow=dict(type="bool", default=True),
-            shrink=dict(type="bool", default=False),
+            grow=dict(type='bool', default=True),
+            shrink=dict(type='bool', default=False),
             state=dict(type='str', default='present', choices=['absent', 'present']),
         ),
         supports_check_mode=True,
@@ -162,7 +162,7 @@ def main():
             result['changed'] = True
         else:
             try:
-                size_unit = str(size[-1:])
+                size_unit = size[-1:]
                 size = size[:-1]
             except Exception as e:
                 size_unit = 'b'

--- a/lib/ansible/modules/cloud/misc/qemu_img.py
+++ b/lib/ansible/modules/cloud/misc/qemu_img.py
@@ -5,9 +5,12 @@
 # Copyright: (c) 2013, Toshaan Bharvani <toshaan@vantosh.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+__metaclass__ = type
+from __future__ import absolute_import, division, print_function
+
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
-                    'metadata_version': '1.0'}
+                    'metadata_version': '1.1'}
 
 DOCUMENTATION = r'''
 ---
@@ -120,7 +123,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             dest=dict(type='str', required=True),
-            options=dict(type='list', default=['preallocation=metadata']),
+            options=dict(type='list', default='preallocation=metadata'),
             format=dict(type='str', default='qcow2'),
             size=dict(type='str'),
             grow=dict(type="bool", default=True),
@@ -175,7 +178,7 @@ def main():
                 size_descrease = True
                 size = size[1:]
             size = int(float(size) * float(unitmultiplier))
-            rc, stdout, _ = module.run_command('%s info "%s"' % (qemu_img, dest), check_rc=True)
+            rc, stdout, stderr = module.run_command('%s info "%s"' % (qemu_img, dest), check_rc=True)
             current_size = None
             for line in stdout.splitlines():
                 if 'virtual size' in line:
@@ -211,6 +214,7 @@ def main():
             result['changed'] = True
 
     module.exit_json(**result)
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/misc/qemu_img.py
+++ b/lib/ansible/modules/cloud/misc/qemu_img.py
@@ -120,7 +120,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             dest=dict(type='str', required=True),
-            options=dict(type='str', default='preallocation=metadata'),
+            options=dict(type='list', default=['preallocation=metadata']),
             format=dict(type='str', default='qcow2'),
             size=dict(type='str'),
             grow=dict(type="bool", default=True),

--- a/lib/ansible/modules/cloud/misc/qemu_img.py
+++ b/lib/ansible/modules/cloud/misc/qemu_img.py
@@ -5,8 +5,8 @@
 # Copyright: (c) 2013, Toshaan Bharvani <toshaan@vantosh.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-__metaclass__ = type
 from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',

--- a/lib/ansible/modules/cloud/misc/qemu_img.py
+++ b/lib/ansible/modules/cloud/misc/qemu_img.py
@@ -64,9 +64,9 @@ options:
     choices: [ "absent", "present"]
     description:
     - If the image should be present or absent - default present
-  notes:
-    - This module does not change the type/format of the image
-    - This module does not take snapshots, and should be implemented seperate
+notes:
+  - This module does not change the type/format of the image
+  - This module does not take snapshots, and should be implemented seperate
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/misc/qemu_img.py
+++ b/lib/ansible/modules/cloud/misc/qemu_img.py
@@ -41,9 +41,6 @@ options:
     description:
     - The image format - default qcow2
     default: qcow2
-  size:
-    description:
-    - The size of the image in megabytes.
   options:
     description:
     - Comma separated list of format specific options in a name=value format.

--- a/lib/ansible/modules/cloud/misc/qemu_img.py
+++ b/lib/ansible/modules/cloud/misc/qemu_img.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2013, Jeroen Hoekx <jeroen.hoekx@dsquare.be>
+# (c) 2013, Jeroen Hoekx <jeroen.hoekx@dsquare.be>, Toshaan Bharvani <toshaan@vantosh.com>
 #
 # This file is part of Ansible
 #
@@ -18,14 +18,20 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+ANSIBLE_METADATA = { 'status': ['preview'],
+                     'supported_by': 'community',
+                     'version': '1.0'}
+
 DOCUMENTATION = '''
 ---
-author: Jeroen Hoekx
+author:
+  - Jeroen Hoekx (@jhoekx)
+  - Toshaan Bharvani (@toshywoshy)
 module: qemu_img
 short_description: Create qemu images
 description:
   - "This module creates images for qemu."
-version_added: "1.2"
+version_added: "2.3"
 options:
   dest:
     description:
@@ -34,88 +40,174 @@ options:
   format:
     description:
     - The image format - default qcow2
-    required: false
+    default: qcow2
   size:
     description:
     - The size of the image in megabytes.
-    required: false
-  opt:
+  options:
     description:
     - Comma separated list of format specific options in a name=value format.
-    required: false
+  size:
+    description:
+    - The size of the image
+  grow:
+    choices: [ "yes", "no" ]
+    defaults: "yes"
+    description:
+    - Whether the image should grow
+  shrink:
+    choices: [ "yes", "no" ]
+    defaults: "no"
+    description
+    - Whether the image should shrink
   state:
-    choices: [ "absent", "present" ]
+    choices: [ "absent", "present"]
     description:
     - If the image should be present or absent - default present
-    required: false
+  notes:
+    - This module does not change the type/format of the image
+    - This module does not take snapshots, and should be implemented seperate
+'''
+
+EXAMPLES = '''
 examples:
   - description: Create a raw image of 5M.
-    code: qemu_img dest=/tmp/testimg size=5 format=raw
-  - description: Enlarge the image to 6M.
-    code: qemu_img dest=/tmp/testimg size=6 format=raw
+    code: qemu_img dest=/tmp/testimg size=5M format=raw
+
+  - description: Enlarge the image to 6G.
+    code: qemu_img dest=/tmp/testimg size=6G format=qcow2
+
+  - description: Shrink the image by 3G
+    code: qemu_img dest=/tmp/testing size=-3G format=qcow2
+
   - description: Remove the image
     code: qemu_img dest=/tmp/testimg state=absent
-notes:
-  - This module does not change the type of the image.
+'''
+
+RETURN = '''
+# create qemu image
+present:
+  type: string
+  sample: "success"
+  returned: success
+# remove qemu image
+absent:
+  type: string
+  sample: "success"
+  returned: success
+# resize qemu image
+resize:
+  type: string
+  sample: "success"
+  returned: success
 '''
 
 import os
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.pycompat24 import get_exception
 
 def main():
 
     module = AnsibleModule(
         argument_spec = dict(
             dest = dict(type='str', required=True),
-            opt = dict(type='str'),
+            options = dict(type='str', default='preallocation=metadata'),
             format = dict(type='str', default='qcow2'),
-            size = dict(type='int'),
+            size = dict(type='str'),
+            grow= dict(type="bool", default=True),
+            shrink = dict(type="bool", default=False),
             state = dict(type='str', choices=['absent', 'present'], default='present'),
         ),
         supports_check_mode = True,
     )
 
-    changed = False
-    qemu_img = module.get_bin_path('qemu-img', True)
+    result = dict(
+        changed = False,
+    )
 
+    state = module.params['state']
     dest = module.params['dest']
     img_format = module.params['format']
-    opt = module.params['opt']
+    img_options = module.params['options']
+    size = module.params['size']
+    grow = module.boolean(module.params['grow'])
+    shrink = module.boolean(module.params['shrink'])
 
-    if module.params['state'] == 'present':
-        if not module.params['size']:
-            module.fail_json(msg="Parameter 'size' required")
-        size = module.params['size'] * 1024 * 1024
+    qemu_img = module.get_bin_path('qemu-img', True)
 
+    if state == 'present':
+        if not size:
+            module.fail_json(msg="No size defined, creating a disk image requires a size")
         if not os.path.exists(dest):
             if not module.check_mode:
-                if not opt:
-                    module.run_command('%s create -f %s "%s" %s'%(qemu_img, img_format, dest, size), check_rc=True)
+                if not img_options:
+                    module.run_command('%s create -f %s "%s" %s' % (qemu_img, img_format, dest, size), check_rc=True)
                 else:
-                    module.run_command('%s create -f %s -o %s "%s" %s'%(qemu_img, img_format, opt, dest, size), check_rc=True)
-            changed = True
+                    module.run_command('%s create -f %s -o "%s" "%s" %s' % (qemu_img, img_format, img_options, dest, size), check_rc=True)
+            result['changed'] = True
         else:
-            rc, stdout, _ = module.run_command('%s info "%s"'%(qemu_img, dest), check_rc=True)
+            size_unit = size[-1:]
+            if size_unit not in ['T','G','M','k','b','']:
+                module.fail_json(msg="No valid size unit specified")
+            else:
+                if(size_unit == 'T'):
+                    unitmultiplier = 1024*1024*1024*1024
+                elif(size_unit == 'G'):
+                    unitmultiplier = 1024*1024*1024
+                elif(size_unit == 'M'):
+                    unitmultiplier = 1024*1024
+                elif(size_unit == 'k'):
+                    unitmultiplier = 1024
+                else:
+                    unitmultiplier = 1
+            size = size[:-1]
+            size_increase = False
+            size_decrease = False
+            if(size[:1] == '+'):
+                size_increase = True
+                size = size[1:]
+            elif(size[:1] == '-'):
+                size_descrease = True
+                size = size[1:]
+            size = int(float(size)*float(unitmultiplier))
+            rc, stdout, _ = module.run_command('%s info "%s"' % (qemu_img, dest), check_rc=True)
             current_size = None
             for line in stdout.splitlines():
                 if 'virtual size' in line:
                     ### virtual size: 5.0M (5242880 bytes)
                     current_size = int(line.split('(')[1].split()[0])
             if not current_size:
-                module.fail_json(msg='Unable to read virtual disk size of %s'%(dest))
-            if current_size != size:
-                if not module.check_mode:
-                    module.run_command('%s resize "%s" %s'%(qemu_img, dest, size), check_rc=True)
-                changed = True
+                module.fail_json(msg='Unable to read virtual disk size of %s' % (dest))
+            if(grow):
+                newsize = size - current_size
+                if(newsize > 0):
+                    if not module.check_mode:
+                        module.run_command('%s resize "%s" %s' % (qemu_img, dest, size), check_rc=True)
+                    result['changed'] = True
+            if(shrink):
+                if(img_format == 'qcow2'):
+                    module.fail_json(msg="qemu-img does not support shrinking qcow2 images")
+                if (size[:1] == '-'):
+                    newsize = current_size - size
+                else:
+                    newsize = current_size - size
+                if(newsize > 0):
+                    if not module.check_mode:
+                        module.run_command('%s resize "%s" %s' % (qemu_img, dest, size), check_rc=True)
+                    result['changed'] = True
 
-    if module.params['state'] == 'absent':
+    if state == 'absent':
         if os.path.exists(dest):
             if not module.check_mode:
-                os.remove(dest)
-            changed = True
+                try:
+                    os.remove(dest)
+                except:
+                    e = get_exception()
+                    module.fail_json(msg=str(e))
+            result['changed'] = True
 
-    module.exit_json(changed=changed)
+    module.exit_json(**result)
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/misc/qemu_img.py
+++ b/lib/ansible/modules/cloud/misc/qemu_img.py
@@ -58,7 +58,7 @@ options:
   shrink:
     choices: [ "yes", "no" ]
     defaults: "no"
-    description
+    description:
     - Whether the image should shrink
   state:
     choices: [ "absent", "present"]

--- a/lib/ansible/modules/cloud/misc/qemu_img.py
+++ b/lib/ansible/modules/cloud/misc/qemu_img.py
@@ -70,18 +70,29 @@ notes:
 '''
 
 EXAMPLES = '''
-examples:
-  - description: Create a raw image of 5M.
-    code: qemu_img dest=/tmp/testimg size=5M format=raw
+# Create a raw image of 5M.
+- qemu_img:
+    dest: /tmp/testimg
+    size: 5M
+    format: raw
 
-  - description: Enlarge the image to 6G.
-    code: qemu_img dest=/tmp/testimg size=6G format=qcow2
+# Enlarge the image to 6G.
+- qemu_img:
+    dest: /tmp/testimg
+    size: 6G
+    format: qcow2
 
-  - description: Shrink the image by 3G
-    code: qemu_img dest=/tmp/testing size=-3G format=qcow2
+# Shrink the image by 3G
+    code: qemu_img
+    dest: /tmp/testing
+    size: -3G
+    shrink: yes
+    format: qcow2
 
-  - description: Remove the image
-    code: qemu_img dest=/tmp/testimg state=absent
+# Remove the image
+- qemu_img:
+    dest: /tmp/testimg
+    state: absent
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/cloud/misc/qemu_img.py
+++ b/lib/ansible/modules/cloud/misc/qemu_img.py
@@ -31,7 +31,7 @@ module: qemu_img
 short_description: Create qemu images
 description:
   - "This module creates images for qemu."
-version_added: "2.3"
+version_added: "2.4"
 options:
   dest:
     description:
@@ -60,7 +60,8 @@ options:
   state:
     choices: [ "absent", "present"]
     description:
-    - If the image should be present or absent - default present
+    - If the image should be present or absent
+    default: present
 notes:
   - This module does not change the type/format of the image
   - This module does not take snapshots, and should be implemented seperate

--- a/lib/ansible/modules/cloud/misc/qemu_img.py
+++ b/lib/ansible/modules/cloud/misc/qemu_img.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2013, Jeroen Hoekx <jeroen.hoekx@dsquare.be>, Toshaan Bharvani <toshaan@vantosh.com>
+# (c) 2013, Jeroen Hoekx <jeroen.hoekx@dsquare.be>
+#           Toshaan Bharvani <toshaan@vantosh.com>
 #
 # This file is part of Ansible
 #
@@ -18,9 +19,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-ANSIBLE_METADATA = { 'status': ['preview'],
-                     'supported_by': 'community',
-                     'version': '1.0'}
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
 
 DOCUMENTATION = '''
 ---
@@ -116,26 +117,26 @@ import os
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
 
+
 def main():
 
-    module = AnsibleModule(
-        argument_spec = dict(
-            dest = dict(type='str', required=True),
-            options = dict(type='str', default='preallocation=metadata'),
-            format = dict(type='str', default='qcow2'),
-            size = dict(type='str'),
-            grow= dict(type="bool", default=True),
-            shrink = dict(type="bool", default=False),
-            state = dict(type='str', choices=['absent', 'present'], default='present'),
+    module = AnsibleModule(argument_spec=dict(
+            dest=dict(type='str', required=True),
+            options=dict(type='str', default='preallocation=metadata'),
+            format=dict(type='str', default='qcow2'),
+            size=dict(type='str'),
+            grow=dict(type="bool", default=True),
+            shrink=dict(type="bool", default=False),
+            state=dict(type='str', choices=['absent', 'present'], default='present'),
         ),
-        supports_check_mode = True,
+        supports_check_mode=True,
         required_if=[
-            ( "state", "present", [ "size" ] ),
+            ("state", "present", ["size"]),
         ],
     )
 
     result = dict(
-        changed = False,
+        changed=False,
     )
 
     state = module.params['state']
@@ -175,12 +176,12 @@ def main():
             elif(size[:1] == '-'):
                 size_descrease = True
                 size = size[1:]
-            size = int(float(size)*float(unitmultiplier))
+            size = int(float(size) * float(unitmultiplier))
             rc, stdout, _ = module.run_command('%s info "%s"' % (qemu_img, dest), check_rc=True)
             current_size = None
             for line in stdout.splitlines():
                 if 'virtual size' in line:
-                    ### virtual size: 5.0M (5242880 bytes)
+                    # virtual size: 5.0M (5242880 bytes)
                     current_size = int(line.split('(')[1].split()[0])
             if not current_size:
                 module.fail_json(msg='Unable to read virtual disk size of %s' % (dest))

--- a/lib/ansible/modules/cloud/misc/qemu_img.py
+++ b/lib/ansible/modules/cloud/misc/qemu_img.py
@@ -111,7 +111,7 @@ absent:
   returned: success
 # resize qemu image
 resize:
-  description: 
+  description:
     Returns the status of the qemu image that was resized
   type: string
   sample: "success"
@@ -126,14 +126,17 @@ from ansible.module_utils.pycompat24 import get_exception
 
 def main():
 
-    module = AnsibleModule(argument_spec=dict(
+    module = AnsibleModule(
+        argument_spec=dict(
             dest=dict(type='str', required=True),
             options=dict(type='str', default='preallocation=metadata'),
             format=dict(type='str', default='qcow2'),
             size=dict(type='str'),
             grow=dict(type="bool", default=True),
             shrink=dict(type="bool", default=False),
-            state=dict(type='str', choices=['absent', 'present'], default='present'),
+            state=dict(
+                type='str', choices=['absent', 'present'], default='present'
+            ),
         ),
         supports_check_mode=True,
         required_if=[

--- a/lib/ansible/modules/cloud/misc/qemu_img.py
+++ b/lib/ansible/modules/cloud/misc/qemu_img.py
@@ -21,7 +21,7 @@
 
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
-                    'version': '1.0'}
+                    'metadata_version': '1.0'}
 
 DOCUMENTATION = '''
 ---
@@ -50,12 +50,12 @@ options:
     - The size of the image
   grow:
     choices: [ "yes", "no" ]
-    defaults: "yes"
+    default: "yes"
     description:
     - Whether the image is allowed grow
   shrink:
     choices: [ "yes", "no" ]
-    defaults: "no"
+    default: "no"
     description:
     - Whether the image is allowed shrink
   state:
@@ -97,16 +97,22 @@ EXAMPLES = '''
 RETURN = '''
 # create qemu image
 present:
+  description:
+    Returns the status of the qemu image that was created
   type: string
   sample: "success"
   returned: success
 # remove qemu image
 absent:
+  description:
+    Returns the status of the qemu image that was removed
   type: string
   sample: "success"
   returned: success
 # resize qemu image
 resize:
+  description: 
+    Returns the status of the qemu image that was resized
   type: string
   sample: "success"
   returned: success

--- a/lib/ansible/modules/cloud/misc/qemu_img.py
+++ b/lib/ansible/modules/cloud/misc/qemu_img.py
@@ -128,6 +128,9 @@ def main():
             state = dict(type='str', choices=['absent', 'present'], default='present'),
         ),
         supports_check_mode = True,
+        required_if=[
+            ( "state", "present", [ "size" ] ),
+        ],
     )
 
     result = dict(
@@ -145,8 +148,6 @@ def main():
     qemu_img = module.get_bin_path('qemu-img', True)
 
     if state == 'present':
-        if not size:
-            module.fail_json(msg="No size defined, creating a disk image requires a size")
         if not os.path.exists(dest):
             if not module.check_mode:
                 if not img_options:

--- a/lib/ansible/modules/cloud/misc/qemu_img.py
+++ b/lib/ansible/modules/cloud/misc/qemu_img.py
@@ -139,8 +139,8 @@ def main():
     img_format = module.params['format']
     img_options = module.params['options']
     size = module.params['size']
-    grow = module.boolean(module.params['grow'])
-    shrink = module.boolean(module.params['shrink'])
+    grow = module.params['grow']
+    shrink = module.params['shrink']
 
     qemu_img = module.get_bin_path('qemu-img', True)
 

--- a/lib/ansible/modules/cloud/misc/qemu_img.py
+++ b/lib/ansible/modules/cloud/misc/qemu_img.py
@@ -150,9 +150,9 @@ def main():
         if not os.path.exists(dest):
             if not module.check_mode:
                 if not img_options:
-                    module.run_command('%s create -f %s "%s" %s' % (qemu_img, img_format, dest, size), check_rc=True)
+                    rc, stdout, stderr = module.run_command('%s create -f %s "%s" %s' % (qemu_img, img_format, dest, size), check_rc=True)
                 else:
-                    module.run_command('%s create -f %s -o "%s" "%s" %s' % (qemu_img, img_format, img_options, dest, size), check_rc=True)
+                    rc, stdout, stderr = module.run_command('%s create -f %s -o "%s" "%s" %s' % (qemu_img, img_format, img_options, dest, size), check_rc=True)
             result['changed'] = True
         else:
             try:
@@ -182,7 +182,7 @@ def main():
                 newsize = size - current_size
                 if(newsize > 0):
                     if not module.check_mode:
-                        module.run_command('%s resize "%s" %s' % (qemu_img, dest, size), check_rc=True)
+                        rc, stdout, stderr = module.run_command('%s resize "%s" %s' % (qemu_img, dest, size), check_rc=True)
                     result['changed'] = True
             if(shrink):
                 if(img_format == 'qcow2'):
@@ -193,7 +193,7 @@ def main():
                     newsize = current_size - size
                 if(newsize > 0):
                     if not module.check_mode:
-                        module.run_command('%s resize "%s" %s' % (qemu_img, dest, size), check_rc=True)
+                        rc, stdout, stderr = module.run_command('%s resize "%s" %s' % (qemu_img, dest, size), check_rc=True)
                     result['changed'] = True
 
     if state == 'absent':

--- a/lib/ansible/modules/cloud/misc/qemu_img.py
+++ b/lib/ansible/modules/cloud/misc/qemu_img.py
@@ -158,10 +158,14 @@ def main():
         else:
             try:
                 size_unit = str(size[-1:])
+                size = size[:-1]
+            except:
+                size_unit = 'b'
+            try:
                 units = list('b', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y')
                 unitmultiplier = 1024**units.index(size_unit)
             except:
-                unitmultiplier = 1
+                module.fail_json(msg='Unknown size unit : %s' % (size_unit))
             size_increase = False
             size_decrease = False
             if(size[:1] == '+'):

--- a/lib/ansible/modules/cloud/misc/qemu_img.py
+++ b/lib/ansible/modules/cloud/misc/qemu_img.py
@@ -155,21 +155,12 @@ def main():
                     module.run_command('%s create -f %s -o "%s" "%s" %s' % (qemu_img, img_format, img_options, dest, size), check_rc=True)
             result['changed'] = True
         else:
-            size_unit = size[-1:]
-            if size_unit not in ['T','G','M','k','b','']:
-                module.fail_json(msg="No valid size unit specified")
-            else:
-                if(size_unit == 'T'):
-                    unitmultiplier = 1024*1024*1024*1024
-                elif(size_unit == 'G'):
-                    unitmultiplier = 1024*1024*1024
-                elif(size_unit == 'M'):
-                    unitmultiplier = 1024*1024
-                elif(size_unit == 'k'):
-                    unitmultiplier = 1024
-                else:
-                    unitmultiplier = 1
-            size = size[:-1]
+            try:
+                size_unit = str(size[-1:])
+                units = list('b', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y')
+                unitmultiplier = 1024**units.index(size_unit)
+            except:
+                unitmultiplier = 1
             size_increase = False
             size_decrease = False
             if(size[:1] == '+'):

--- a/lib/ansible/modules/cloud/misc/qemu_img.py
+++ b/lib/ansible/modules/cloud/misc/qemu_img.py
@@ -51,12 +51,12 @@ options:
     choices: [ "yes", "no" ]
     defaults: "yes"
     description:
-    - Whether the image should grow
+    - Whether the image is allowed grow
   shrink:
     choices: [ "yes", "no" ]
     defaults: "no"
     description:
-    - Whether the image should shrink
+    - Whether the image is allowed shrink
   state:
     choices: [ "absent", "present"]
     description:

--- a/lib/ansible/modules/cloud/misc/qemu_img.py
+++ b/lib/ansible/modules/cloud/misc/qemu_img.py
@@ -162,7 +162,7 @@ def main():
             except:
                 size_unit = 'b'
             try:
-                units = list('b', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y')
+                units = list(['b', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y'])
                 unitmultiplier = 1024**units.index(size_unit)
             except:
                 module.fail_json(msg='Unknown size unit : %s' % (size_unit))


### PR DESCRIPTION
##### ISSUE TYPE
- New Module Pull Request
##### COMPONENT NAME

qemu_img
##### ANSIBLE VERSION

ansible 2.2.0 (devel 221520cbad) last updated 2016/07/13 10:20:35 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 67dadf3aa4) last updated 2016/07/13 10:20:40 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD f2b255ffa3) last updated 2016/07/13 10:20:41 (GMT +200)

```

```
##### SUMMARY

This module is used to create qemu image files using the qemu-img command.
The module can create, resize (grow, shrink), and delete qemu image files

```
```
