### PR TITLE
Fix docs re inventory_ignore_extensions config

### DIFF
--- a/docs/docsite/rst/intro_configuration.rst
+++ b/docs/docsite/rst/intro_configuration.rst
@@ -502,6 +502,19 @@ to talk to::
 
 It used to be called hostfile in Ansible before 1.9
 
+.. _inventory_ignore_extensions:
+
+inventory_ignore_extensions
+===========================
+
+Coma-separated list of file extension patterns to ignore when Ansible inventory
+is a directory with multiple sources (static and dynamic)::
+
+    inventory_ignore_extensions = ~, .orig, .bak, .ini, .cfg, .retry, .pyc, .pyo
+
+This option can be overridden by setting ``ANSIBLE_INVENTORY_IGNORE``
+environment variable.
+
 .. _jinja2_extensions:
 
 jinja2_extensions

--- a/docs/docsite/rst/intro_dynamic_inventory.rst
+++ b/docs/docsite/rst/intro_dynamic_inventory.rst
@@ -346,7 +346,7 @@ hybrid cloud!
 
 In an inventory directory, executable files will be treated as dynamic inventory sources and most other files as static sources. Files which end with any of the following will be ignored::
 
-    ~, .orig, .bak, .ini, .retry, .pyc, .pyo
+    ~, .orig, .bak, .ini, .cfg, .retry, .pyc, .pyo
 
 You can replace this list with your own selection by configuring an ``inventory_ignore_extensions`` list in ansible.cfg, or setting the ANSIBLE_INVENTORY_IGNORE environment variable. The value in either case should be a comma-separated list of patterns, as shown above.
 

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -280,6 +280,10 @@
 # Controls showing custom stats at the end, off by default
 #show_custom_stats = True
 
+# Controlls which files to ignore when using a directory as inventory with
+# possibly multiple sources (both static and dynamic)
+#inventory_ignore_extensions = ~, .orig, .bak, .ini, .cfg, .retry, .pyc, .pyo
+
 [privilege_escalation]
 #become=True
 #become_method=sudo


### PR DESCRIPTION
The list of ignored by default extensions is outdated in doc for dynamic
inventories, and this option is completely missing from configuration
file overview.

##### ISSUE TYPE
 - Docs Pull Request