### PR TITLE
Adding an elasticache snapshot module.

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
@@ -127,6 +127,11 @@ changed:
     changed: true
 """
 
+# import module snippets
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec, camel_dict_to_snake_dict
+import traceback
+
 try:
     import boto3
     import botocore
@@ -228,11 +233,6 @@ def main():
     facts_result = dict(changed=changed, **camel_dict_to_snake_dict(response))
 
     module.exit_json(**facts_result)
-
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec, camel_dict_to_snake_dict
-import traceback
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
@@ -1,0 +1,267 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = """
+---
+module: elasticache
+short_description: Manage cache snapshots in Amazon Elasticache.
+description:
+  - Manage cache snapshots in Amazon Elasticache.
+  - Returns information about the specified snapshot.
+version_added: "2.3"
+author: "Sloane Hertel (@s-hertel)"
+options:
+  name:
+    description:
+      - The name of the snapshot we want to create, copy, delete, or get information regarding
+    type: string
+    required: yes
+  state:
+    description:
+      - Actions that will create, destroy, or copy a snapshot.
+    choices: ['present', 'absent', 'copy']
+  replication_id:
+    description:
+      - The name of the existing replication group to make the snapshot.
+    type: string
+    required: no
+    default: null
+  cluster_id:
+    description:
+      - The name of an existing cache cluster in the replication group to make the snapshot.
+    type: string
+    required: no
+    default: null
+  target:
+    description:
+      - The name of a snapshot copy
+    type: string
+    required: no
+    default: null
+  bucket:
+    description:
+      - The s3 bucket to which the snapshot is exported
+    type: string
+    required: no
+    default: null
+  source:
+    description:
+      - If set to system , the output shows snapshots that were automatically created by ElastiCache. If set to user the output shows snapshots that were manually created. If omitted, the output shows both automatically and manually created snapshots.
+    type: string
+    choices: ['system', 'user']
+    required: no
+    default: null
+  show_config:
+    description:
+      - Includes node group (shard) configuration in the snapshot description.
+    type: string
+    choices: ['yes', 'no']
+    required: no
+    default: 'no'
+"""
+
+EXAMPLES = """
+# Note: None of these examples set aws_access_key, aws_secret_key, or region.
+# It is assumed that their matching environment variables are set.
+---
+- hosts: localhost
+  connection: local
+  tasks:
+    - name: 'Create a snapshot'
+      elasticache_snapshot:
+        name: 'test-snapshot'
+        state: 'present'
+        cluster_id: '{{ cluster }}'
+        replication_id: '{{ replica }}'
+"""
+
+RETURN = """
+elasticache:
+  description: response metadata and information about the snapshot
+  returned: always
+  type: dict
+  sample:
+    response_metadata:
+      http_headers:
+        content-length: 1490
+        content-type: text/xml
+        date: Tue, 07 Feb 2017 16:43:04 GMT
+        x-amzn-requestid: 7f436dea-ed54-11e6-a04c-ab2372a1f14d
+      http_status_code: 200
+      request_id: 7f436dea-ed54-11e6-a04c-ab2372a1f14d
+      retry_attempts: 0
+    snapshot:
+      auto_minor_version_upgrade: true
+      cache_cluster_create_time: 2017-02-01T17:43:58.261000+00:00
+      cache_cluster_id: test-please-delete
+      cache_node_type: cache.m1.small
+      cache_parameter_group_name: default.redis3.2
+      cache_subnet_group_name: default
+      engine: redis
+      engine_version: 3.2.4
+      node_snapshots:
+        cache_node_create_time: 2017-02-01T17:43:58.261000+00:00
+        cache_node_id: 0001
+        cache_size:
+      num_cache_nodes: 1
+      port: 11211
+      preferred_availability_zone: us-east-1d
+      preferred_maintenance_window: wed:03:00-wed:04:00
+      snapshot_name: deletesnapshot
+      snapshot_retention_limit: 0
+      snapshot_source: manual
+      snapshot_status: creating
+      snapshot_window: 10:00-11:00
+      vpc_id: vpc-c248fda4
+changed:
+    description: if a snapshot has been created, deleted, or copied
+    returned: always
+    type: bool
+    sample:
+      changed: true
+"""
+
+
+from ansible.module_utils.ec2 import boto3_conn
+import traceback
+
+try:
+    import boto3
+    import botocore
+    HAS_BOTO3 = True
+except ImportError:
+    HAS_BOTO3 = False
+
+def create(module, connection, replication_id, cluster_id, name):
+    """ Create an Elasticache backup. """
+    try:
+        response = connection.create_snapshot(ReplicationGroupId=replication_id,
+                                              CacheClusterId=cluster_id,
+                                              SnapshotName=name)
+        changed = True
+    except botocore.exceptions.ClientError as e:
+        if e.response['Error']['Code'] == "SnapshotAlreadyExistsFault":
+            response = {}
+            changed = False
+        else:
+            module.fail_json(msg="Unable to create the snapshot.", exception=traceback.format_exc(e))
+    return response, changed
+
+def copy(module, connection, name, target, bucket):
+    """ Copy an Elasticache backup. """
+    try:
+        response = connection.copy_snapshot(SourceSnapshotName=name,
+                                            TargetSnapshotName=target,
+                                            TargetBucket=bucket)
+        changed = True
+    except botocore.exceptions.ClientError as e:
+        module.fail_json(msg="Unable to copy the snapshot.", exception=traceback.format_exc(e))
+    return response, changed
+
+def delete(module, connection, name):
+    """ Delete an Elasticache backup. """
+    try:
+        response = connection.delete_snapshot(SnapshotName=name)
+        changed = True
+    except botocore.exceptions.ClientError as e:
+        if e.response['Error']['Code'] == "SnapshotNotFoundFault":
+            response = {}
+            changed = False        
+        else:
+            module.fail_json(msg="Unable to delete the snapshot.", exception=traceback.format_exc(e))
+    return response, changed
+
+def get_info(module, connection, replication_id, cluster_id, name, source, show_config):
+    """ Describe an Elasticache backup. Return false if it doesn't exist or isn't accessible. """
+    try:
+        info = connection.describe_snapshots(ReplicationGroupId=replication_id,
+                                             CacheClusterId=cluster_id,
+                                             SnapshotName=name,
+                                             SnapshotSource=source,
+                                             ShowNodeGroupConfig=show_config)
+        return info
+    except botocore.exceptions.ClientError as e:
+        return False
+    return info
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
+        name            = dict(required=True, type='str'),
+        state           = dict(required=True, type='str', choices=['present', 'absent', 'copy']),
+        replication_id  = dict(required=False, type='str'),
+        cluster_id      = dict(required=False, type='str'),
+        target          = dict(required=False, type='str'),
+        bucket          = dict(required=False, type='str'),
+        source          = dict(required=False, type='str', choices=['system', 'user']),
+        show_config     = dict(required=False, type='str', default='no', choices=['yes', 'no']),
+    )
+    )
+        
+    module = AnsibleModule(argument_spec=argument_spec)
+
+    if not HAS_BOTO3:
+        module.fail_json(msg='boto required for this module')
+
+    name                    = module.params.get('name')
+    state                   = module.params.get('state')
+    replication_id          = module.params.get('replication_id')
+    cluster_id              = module.params.get('cluster_id')
+    target                  = module.params.get('target')
+    bucket                  = module.params.get('bucket')
+    source                  = module.params.get('source')
+    show_config             = module.params.get('show_config')
+
+    # Retrieve any AWS settings from the environment.
+    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+    if not region:
+        module.fail_json(msg = str("Either region or AWS_REGION or EC2_REGION environment variable or boto config aws_region or ec2_region must be set."))
+
+    connection = boto3_conn(module, conn_type='client',
+                            resource='elasticache', region=region,
+                            endpoint=ec2_url, **aws_connect_kwargs)
+
+    changed     = False
+    response    = {}
+
+    if state == 'present':
+        for req in [replication_id, cluster_id]:
+            if not req:
+                module.fail_json(msg="The state 'present' requires options: 'replication_id' and 'cluster_id'")
+        response, changed = create(module, connection, replication_id, cluster_id, name)
+    elif state == 'absent':
+        response, changed = delete(module, connection, name)
+    elif state == 'copy':
+        for req in [target, bucket]:
+            if not req:
+                module.fail_json(msg="The state 'copy' requires options: 'target' and 'bucket'.")
+        response, changed = copy(module, connection, name, target, bucket)
+    
+    facts_result = dict(changed=changed, elasticache=camel_dict_to_snake_dict(response))
+
+    module.exit_json(**facts_result)
+
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.ec2 import *
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
@@ -117,11 +117,11 @@ elasticache:
       snapshot_window: 10:00-11:00
       vpc_id: vpc-c248fda4
 changed:
-    description: if a snapshot has been created, deleted, or copied
-    returned: always
-    type: bool
-    sample:
-      changed: true
+  description: if a snapshot has been created, deleted, or copied
+  returned: always
+  type: bool
+  sample:
+    changed: true
 """
 
 

--- a/lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
@@ -127,10 +127,6 @@ changed:
     changed: true
 """
 
-
-from ansible.module_utils.ec2 import boto3_conn
-import traceback
-
 try:
     import boto3
     import botocore
@@ -183,14 +179,15 @@ def delete(module, connection, name):
 
 def main():
     argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
-        name            = dict(required=True, type='str'),
-        state           = dict(required=True, type='str', choices=['present', 'absent', 'copy']),
-        replication_id  = dict(required=False, type='str'),
-        cluster_id      = dict(required=False, type='str'),
-        target          = dict(required=False, type='str'),
-        bucket          = dict(required=False, type='str'),
-    )
+    argument_spec.update(
+        dict(
+            name=dict(required=True, type='str'),
+            state=dict(required=True, type='str', choices=['present', 'absent', 'copy']),
+            replication_id=dict(type='str'),
+            cluster_id=dict(type='str'),
+            target=dict(type='str'),
+            bucket=dict(type='str'),
+        )
     )
 
     module = AnsibleModule(argument_spec=argument_spec)
@@ -198,12 +195,12 @@ def main():
     if not HAS_BOTO3:
         module.fail_json(msg='boto required for this module')
 
-    name                    = module.params.get('name')
-    state                   = module.params.get('state')
-    replication_id          = module.params.get('replication_id')
-    cluster_id              = module.params.get('cluster_id')
-    target                  = module.params.get('target')
-    bucket                  = module.params.get('bucket')
+    name = module.params.get('name')
+    state = module.params.get('state')
+    replication_id  = module.params.get('replication_id')
+    cluster_id = module.params.get('cluster_id')
+    target = module.params.get('target')
+    bucket = module.params.get('bucket')
 
     # Retrieve any AWS settings from the environment.
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
@@ -214,8 +211,8 @@ def main():
                             resource='elasticache', region=region,
                             endpoint=ec2_url, **aws_connect_kwargs)
 
-    changed     = False
-    response    = {}
+    changed = False
+    response = {}
 
     if state == 'present':
         if not all((replication_id, cluster_id)):
@@ -234,7 +231,8 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
+from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, ec2_argument_spec, camel_dict_to_snake_dict
+import traceback
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
@@ -20,7 +20,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 
 DOCUMENTATION = """
 ---
-module: elasticache
+module: elasticache_snapshot
 short_description: Manage cache snapshots in Amazon Elasticache.
 description:
   - Manage cache snapshots in Amazon Elasticache.
@@ -79,43 +79,46 @@ EXAMPLES = """
 """
 
 RETURN = """
-elasticache:
-  description: response metadata and information about the snapshot
+response_metadata:
+  description: response metadata about the snapshot
   returned: always
   type: dict
   sample:
-    response_metadata:
-      http_headers:
-        content-length: 1490
-        content-type: text/xml
-        date: Tue, 07 Feb 2017 16:43:04 GMT
-        x-amzn-requestid: 7f436dea-ed54-11e6-a04c-ab2372a1f14d
-      http_status_code: 200
-      request_id: 7f436dea-ed54-11e6-a04c-ab2372a1f14d
-      retry_attempts: 0
-    snapshot:
-      auto_minor_version_upgrade: true
-      cache_cluster_create_time: 2017-02-01T17:43:58.261000+00:00
-      cache_cluster_id: test-please-delete
-      cache_node_type: cache.m1.small
-      cache_parameter_group_name: default.redis3.2
-      cache_subnet_group_name: default
-      engine: redis
-      engine_version: 3.2.4
-      node_snapshots:
-        cache_node_create_time: 2017-02-01T17:43:58.261000+00:00
-        cache_node_id: 0001
-        cache_size:
-      num_cache_nodes: 1
-      port: 11211
-      preferred_availability_zone: us-east-1d
-      preferred_maintenance_window: wed:03:00-wed:04:00
-      snapshot_name: deletesnapshot
-      snapshot_retention_limit: 0
-      snapshot_source: manual
-      snapshot_status: creating
-      snapshot_window: 10:00-11:00
-      vpc_id: vpc-c248fda4
+    http_headers:
+      content-length: 1490
+      content-type: text/xml
+      date: Tue, 07 Feb 2017 16:43:04 GMT
+      x-amzn-requestid: 7f436dea-ed54-11e6-a04c-ab2372a1f14d
+    http_status_code: 200
+    request_id: 7f436dea-ed54-11e6-a04c-ab2372a1f14d
+    retry_attempts: 0
+snapshot:
+  description: snapshot data
+  returned: always
+  type: dict
+  sample:
+    auto_minor_version_upgrade: true
+    cache_cluster_create_time: 2017-02-01T17:43:58.261000+00:00
+    cache_cluster_id: test-please-delete
+    cache_node_type: cache.m1.small
+    cache_parameter_group_name: default.redis3.2
+    cache_subnet_group_name: default
+    engine: redis
+    engine_version: 3.2.4
+    node_snapshots:
+      cache_node_create_time: 2017-02-01T17:43:58.261000+00:00
+      cache_node_id: 0001
+      cache_size:
+    num_cache_nodes: 1
+    port: 11211
+    preferred_availability_zone: us-east-1d
+    preferred_maintenance_window: wed:03:00-wed:04:00
+    snapshot_name: deletesnapshot
+    snapshot_retention_limit: 0
+    snapshot_source: manual
+    snapshot_status: creating
+    snapshot_window: 10:00-11:00
+    vpc_id: vpc-c248fda4
 changed:
   description: if a snapshot has been created, deleted, or copied
   returned: always
@@ -170,6 +173,8 @@ def delete(module, connection, name):
         if e.response['Error']['Code'] == "SnapshotNotFoundFault":
             response = {}
             changed = False
+        elif e.response['Error']['Code'] == "InvalidSnapshotState":
+            module.fail_json(msg="Error: InvalidSnapshotState. The snapshot is not in an available state or failed state to allow deletion. You may need to wait a few minutes.")
         else:
             module.fail_json(msg="Unable to delete the snapshot.", exception=traceback.format_exc(e))
     return response, changed
@@ -186,7 +191,7 @@ def main():
         bucket          = dict(required=False, type='str'),
     )
     )
-        
+
     module = AnsibleModule(argument_spec=argument_spec)
 
     if not HAS_BOTO3:
@@ -212,19 +217,17 @@ def main():
     response    = {}
 
     if state == 'present':
-        for req in [replication_id, cluster_id]:
-            if not req:
-                module.fail_json(msg="The state 'present' requires options: 'replication_id' and 'cluster_id'")
+        if not all((replication_id, cluster_id)):
+            module.fail_json(msg="The state 'present' requires options: 'replication_id' and 'cluster_id'")
         response, changed = create(module, connection, replication_id, cluster_id, name)
     elif state == 'absent':
         response, changed = delete(module, connection, name)
     elif state == 'copy':
-        for req in [target, bucket]:
-            if not req:
-                module.fail_json(msg="The state 'copy' requires options: 'target' and 'bucket'.")
+        if not all((target, bucket)):
+            module.fail_json(msg="The state 'copy' requires options: 'target' and 'bucket'.")
         response, changed = copy(module, connection, name, target, bucket)
-    
-    facts_result = dict(changed=changed, elasticache=camel_dict_to_snake_dict(response))
+
+    facts_result = dict(changed=changed, **camel_dict_to_snake_dict(response))
 
     module.exit_json(**facts_result)
 

--- a/lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
@@ -30,7 +30,7 @@ author: "Sloane Hertel (@s-hertel)"
 options:
   name:
     description:
-      - The name of the snapshot we want to create, copy, delete, or get information regarding
+      - The name of the snapshot we want to create, copy, delete
     type: string
     required: yes
   state:
@@ -174,7 +174,8 @@ def delete(module, connection, name):
             response = {}
             changed = False
         elif e.response['Error']['Code'] == "InvalidSnapshotState":
-            module.fail_json(msg="Error: InvalidSnapshotState. The snapshot is not in an available state or failed state to allow deletion. You may need to wait a few minutes.")
+            module.fail_json(msg="Error: InvalidSnapshotState. The snapshot is not in an available state or failed state to allow deletion."
+                             "You may need to wait a few minutes.")
         else:
             module.fail_json(msg="Unable to delete the snapshot.", exception=traceback.format_exc(e))
     return response, changed


### PR DESCRIPTION
Allows user to create, copy, or delete a snapshot.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/elasticache_snapshot.py

##### ANSIBLE VERSION
```
ansible 2.3.0 (elasticache-snapshot 1dba88717d) last updated 2017/02/07 17:31:11 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Create, delete, and copy snapshots with elasticache. #20842 showed interest in improved functionality of ElastiCache modules.

Test playbook:
```
---
- hosts: localhost
  connection: local
  tasks:
    - name: "create snapshot"
      elasticache_snapshot:
        name: "test-snapshot"
        replication_id: "{{ replication }}"
        cluster_id: "{{ cluster }}"
        state: "present"
        region: "{{ region }}"
        profile: "{{ user }}"
```
Output:
```
Loading callback plugin default of type stdout, v2.0 from /Users/shertel/Workspace/ansible/lib/ansible/plugins/callback/__init__.py

PLAYBOOK: ec_create_snapshot.yml *********************************************************
1 plays in my_playbooks/ec_create_snapshot.yml

PLAY [localhost] ******************************************************************

TASK [Gathering Facts] ************************************************************
Using module file /Users/shertel/Workspace/ansible/lib/ansible/modules/system/setup.py
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: shertel
<127.0.0.1> EXEC /bin/sh -c 'echo ~ && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/shertel/.ansible/tmp/ansible-tmp-1486572362.830099-86518620017685 `" && echo ansible-tmp-1486572362.830099-86518620017685="` echo /Users/shertel/.ansible/tmp/ansible-tmp-1486572362.830099-86518620017685 `" ) && sleep 0'
<127.0.0.1> PUT /var/folders/by/k8_fbl593dlctgqmwq5wzl2c0000gn/T/tmp7ickqs3y TO /Users/shertel/.ansible/tmp/ansible-tmp-1486572362.830099-86518620017685/setup.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /Users/shertel/.ansible/tmp/ansible-tmp-1486572362.830099-86518620017685/ /Users/shertel/.ansible/tmp/ansible-tmp-1486572362.830099-86518620017685/setup.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/Users/shertel/Workspace/ansible/venv/python3env/bin/python /Users/shertel/.ansible/tmp/ansible-tmp-1486572362.830099-86518620017685/setup.py; rm -rf "/Users/shertel/.ansible/tmp/ansible-tmp-1486572362.830099-86518620017685/" > /dev/null 2>&1 && sleep 0'
ok: [localhost]
META: ran handlers

TASK [create snapshot] ************************************************************
task path: /Users/shertel/Workspace/ansible/my_playbooks/ec_create_snapshot.yml:5
Using module file /Users/shertel/Workspace/ansible/lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: shertel
<127.0.0.1> EXEC /bin/sh -c 'echo ~ && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/shertel/.ansible/tmp/ansible-tmp-1486572368.488385-166467240966919 `" && echo ansible-tmp-1486572368.488385-166467240966919="` echo /Users/shertel/.ansible/tmp/ansible-tmp-1486572368.488385-166467240966919 `" ) && sleep 0'
<127.0.0.1> PUT /var/folders/by/k8_fbl593dlctgqmwq5wzl2c0000gn/T/tmp21s1_0z3 TO /Users/shertel/.ansible/tmp/ansible-tmp-1486572368.488385-166467240966919/elasticache_snapshot.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /Users/shertel/.ansible/tmp/ansible-tmp-1486572368.488385-166467240966919/ /Users/shertel/.ansible/tmp/ansible-tmp-1486572368.488385-166467240966919/elasticache_snapshot.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/Users/shertel/Workspace/ansible/venv/python3env/bin/python /Users/shertel/.ansible/tmp/ansible-tmp-1486572368.488385-166467240966919/elasticache_snapshot.py; rm -rf "/Users/shertel/.ansible/tmp/ansible-tmp-1486572368.488385-166467240966919/" > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "aws_access_key": null,
            "aws_secret_key": null,
            "bucket": null,
            "cluster_id": "new",
            "ec2_url": null,
            "name": "test-snapshot",
            "profile": "shertel",
            "region": "us-east-1",
            "replication_id": "test-please-delete",
            "security_token": null,
            "state": "present",
            "target": null,
            "validate_certs": true
        }
    },
    "response_metadata": {
        "http_headers": {
            "content-length": "1478",
            "content-type": "text/xml",
            "date": "Wed, 08 Feb 2017 16:45:43 GMT",
            "x-amzn-requestid": "08c55b18-ee1e-11e6-879f-437db62c7900"
        },
        "http_status_code": 200,
        "request_id": "08c55b18-ee1e-11e6-879f-437db62c7900",
        "retry_attempts": 0
    },
    "snapshot": {
        "auto_minor_version_upgrade": true,
        "cache_cluster_create_time": "2017-02-08T16:03:14.589000+00:00",
        "cache_cluster_id": "new",
        "cache_node_type": "cache.m1.small",
        "cache_parameter_group_name": "default.redis3.2",
        "cache_subnet_group_name": "default",
        "engine": "redis",
        "engine_version": "3.2.4",
        "node_snapshots": [
            {
                "cache_node_create_time": "2017-02-08T16:03:14.589000+00:00",
                "cache_node_id": "0001",
                "cache_size": ""
            }
        ],
        "num_cache_nodes": 1,
        "port": 11211,
        "preferred_availability_zone": "us-east-1d",
        "preferred_maintenance_window": "wed:03:00-wed:04:00",
        "snapshot_name": "test-snapshot",
        "snapshot_retention_limit": 0,
        "snapshot_source": "manual",
        "snapshot_status": "creating",
        "snapshot_window": "10:00-11:00",
        "vpc_id": "vpc-c248fda4"
    }
}
META: ran handlers
META: ran handlers

PLAY RECAP ************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0
```