### PR TITLE
Fix default value for remote_src

### DIFF
--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -84,7 +84,7 @@ options:
       - Currently remote_src does not support recursive copying.
     choices: [ "True", "False" ]
     required: false
-    default: "no"
+    default: "False"
     version_added: "2.0"
   follow:
     required: false


### PR DESCRIPTION
Default value is clearly False, fixed it to correct value.

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME
copy module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.2.0.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixed default value to False, which is stated in description.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
