### PR TITLE
proxmox: Add public key support: fix #19487

### DIFF
--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -176,6 +176,7 @@ options:
     choices: ['present', 'started', 'absent', 'stopped', 'restarted']
     default: present
   pubkey:
+    version_added: "2.3"
     description:
       - Public key to add to /root/.ssh/authorized_keys
     default: null

--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -176,9 +176,9 @@ options:
     choices: ['present', 'started', 'absent', 'stopped', 'restarted']
     default: present
   pubkey:
-    version_added: "2.3"
     description:
-      - Public key to add to /root/.ssh/authorized_keys
+      - Public key to add to /root/.ssh/authorized_keys.
+    version_added: "2.3"
     default: null
     required: false
     type: string
@@ -348,7 +348,8 @@ def create_instance(module, proxmox, vmid, node, disk, storage, cpus, memory, sw
         kwargs.update(kwargs['mounts'])
         del kwargs['mounts']
       if 'pubkey' in kwargs:
-        kwargs['ssh-public-keys'] = kwargs['pubkey']
+        if float(proxmox.version.get()['version']) >= 4.2:
+          kwargs['ssh-public-keys'] = kwargs['pubkey']
         del kwargs['pubkey']
   else:
       kwargs['cpus']=cpus

--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -415,7 +415,6 @@ def umount_instance(module, proxmox, vm, vmid, timeout):
 
 def main():
   module = AnsibleModule(
-<<<<<<< HEAD
       argument_spec = dict(
           api_host = dict(required=True),
           api_user = dict(required=True),

--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -175,6 +175,13 @@ options:
      - Indicate desired state of the instance
     choices: ['present', 'started', 'absent', 'stopped', 'restarted']
     default: present
+  pubkey:
+    description:
+      - Public key to add to /root/.ssh/authorized_keys
+    default: null
+    required: false
+    type: string
+
 notes:
   - Requires proxmoxer and requests modules on host. This modules can be installed with pip.
 requirements: [ "proxmoxer", "python >= 2.7", "requests" ]
@@ -329,6 +336,7 @@ def node_check(proxmox, node):
 def create_instance(module, proxmox, vmid, node, disk, storage, cpus, memory, swap, timeout, **kwargs):
   proxmox_node = proxmox.nodes(node)
   kwargs = dict((k,v) for k, v in kwargs.items() if v is not None)
+
   if VZ_TYPE =='lxc':
       kwargs['cpulimit']=cpus
       kwargs['rootfs']=disk
@@ -338,9 +346,13 @@ def create_instance(module, proxmox, vmid, node, disk, storage, cpus, memory, sw
       if 'mounts' in kwargs:
         kwargs.update(kwargs['mounts'])
         del kwargs['mounts']
+      if 'pubkey' in kwargs:
+        kwargs['ssh-public-keys'] = kwargs['pubkey']
+        del kwargs['pubkey']
   else:
       kwargs['cpus']=cpus
       kwargs['disk']=disk
+
   taskid = getattr(proxmox_node, VZ_TYPE).create(vmid=vmid, storage=storage, memory=memory, swap=swap, **kwargs)
 
   while timeout:
@@ -402,6 +414,7 @@ def umount_instance(module, proxmox, vm, vmid, timeout):
 
 def main():
   module = AnsibleModule(
+<<<<<<< HEAD
       argument_spec = dict(
           api_host = dict(required=True),
           api_user = dict(required=True),
@@ -428,6 +441,7 @@ def main():
           timeout = dict(type='int', default=30),
           force = dict(type='bool', default='no'),
           state = dict(default='present', choices=['present', 'absent', 'stopped', 'started', 'restarted']),
+          pubkey = dict(type='str', default=None)
           )
   )
 
@@ -502,7 +516,9 @@ def main():
                       cpuunits = module.params['cpuunits'],
                       nameserver = module.params['nameserver'],
                       searchdomain = module.params['searchdomain'],
-                      force = int(module.params['force']))
+                      force = int(module.params['force']),
+                      pubkey = module.params['pubkey']
+                 )
 
       module.exit_json(changed=True, msg="deployed VM %s from template %s"  % (vmid, module.params['ostemplate']))
     except Exception as e:

--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -177,7 +177,7 @@ options:
     default: present
   pubkey:
     description:
-      - Public key to add to /root/.ssh/authorized_keys.
+      - Public key to add to /root/.ssh/authorized_keys. This was added on Proxmox 4.2, it is ignored for earlier versions
     version_added: "2.3"
     default: null
     required: false

--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -181,7 +181,6 @@ options:
     version_added: "2.3"
     default: null
     required: false
-    type: string
 
 notes:
   - Requires proxmoxer and requests modules on host. This modules can be installed with pip.


### PR DESCRIPTION
**ISSUE TYPE**

Bugfix Pull Request

**COMPONENT NAME**

proxmox

**ANSIBLE VERSION**

2.3

**SUMMARY**

this PR fixes #19487 (adding pubkey support to proxmox module)

This is a new PR because I broke #19515 beyond repair, tagging @gundalow as he was commenting on my changes