### PR TITLE
default and minimal callback: display warnings in a consistent manner

### DIFF
--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -56,6 +56,8 @@ class CallbackModule(CallbackBase):
 
             self._display.display(msg, color=C.COLOR_ERROR)
 
+        self._handle_warnings(result._result)
+
         if result._task.loop and 'results' in result._result:
             self._process_items(result)
 
@@ -92,6 +94,8 @@ class CallbackModule(CallbackBase):
                 msg = "ok: [%s]" % result._host.get_name()
             color = C.COLOR_OK
 
+        self._handle_warnings(result._result)
+
         if result._task.loop and 'results' in result._result:
             self._process_items(result)
         else:
@@ -99,8 +103,6 @@ class CallbackModule(CallbackBase):
             if (self._display.verbosity > 0 or '_ansible_verbose_always' in result._result) and not '_ansible_verbose_override' in result._result:
                 msg += " => %s" % (self._dump_results(result._result),)
             self._display.display(msg, color=color)
-
-        self._handle_warnings(result._result)
 
     def v2_runner_on_skipped(self, result):
         if C.DISPLAY_SKIPPED_HOSTS:
@@ -227,8 +229,8 @@ class CallbackModule(CallbackBase):
         else:
             msg += "[%s]" % (result._host.get_name())
 
-        self._display.display(msg + " (item=%s) => %s" % (self._get_item(result._result), self._dump_results(result._result)), color=C.COLOR_ERROR)
         self._handle_warnings(result._result)
+        self._display.display(msg + " (item=%s) => %s" % (self._get_item(result._result), self._dump_results(result._result)), color=C.COLOR_ERROR)
 
     def v2_runner_item_on_skipped(self, result):
         if C.DISPLAY_SKIPPED_HOSTS:

--- a/lib/ansible/plugins/callback/minimal.py
+++ b/lib/ansible/plugins/callback/minimal.py
@@ -55,18 +55,21 @@ class CallbackModule(CallbackBase):
 
             self._display.display(msg, color=C.COLOR_ERROR)
 
+        self._handle_warnings(result._result)
+
         if result._task.action in C.MODULE_NO_JSON and 'module_stderr' not in result._result:
             self._display.display(self._command_generic_msg(result._host.get_name(), result._result, "FAILED"), color=C.COLOR_ERROR)
         else:
-            self._handle_warnings(result._result)
             self._display.display("%s | FAILED! => %s" % (result._host.get_name(), self._dump_results(result._result, indent=4)), color=C.COLOR_ERROR)
 
     def v2_runner_on_ok(self, result):
         self._clean_results(result._result, result._task.action)
+
+        self._handle_warnings(result._result)
+
         if result._task.action in C.MODULE_NO_JSON:
             self._display.display(self._command_generic_msg(result._host.get_name(), result._result, "SUCCESS"), color=C.COLOR_OK)
         else:
-            self._handle_warnings(result._result)
             if 'changed' in result._result and result._result['changed']:
                 self._display.display("%s | SUCCESS => %s" % (result._host.get_name(), self._dump_results(result._result, indent=4)), color=C.COLOR_CHANGED)
             else:

--- a/lib/ansible/plugins/callback/minimal.py
+++ b/lib/ansible/plugins/callback/minimal.py
@@ -58,6 +58,7 @@ class CallbackModule(CallbackBase):
         if result._task.action in C.MODULE_NO_JSON and 'module_stderr' not in result._result:
             self._display.display(self._command_generic_msg(result._host.get_name(), result._result, "FAILED"), color=C.COLOR_ERROR)
         else:
+            self._handle_warnings(result._result)
             self._display.display("%s | FAILED! => %s" % (result._host.get_name(), self._dump_results(result._result, indent=4)), color=C.COLOR_ERROR)
 
     def v2_runner_on_ok(self, result):
@@ -65,11 +66,11 @@ class CallbackModule(CallbackBase):
         if result._task.action in C.MODULE_NO_JSON:
             self._display.display(self._command_generic_msg(result._host.get_name(), result._result, "SUCCESS"), color=C.COLOR_OK)
         else:
+            self._handle_warnings(result._result)
             if 'changed' in result._result and result._result['changed']:
                 self._display.display("%s | SUCCESS => %s" % (result._host.get_name(), self._dump_results(result._result, indent=4)), color=C.COLOR_CHANGED)
             else:
                 self._display.display("%s | SUCCESS => %s" % (result._host.get_name(), self._dump_results(result._result, indent=4)), color=C.COLOR_OK)
-            self._handle_warnings(result._result)
 
     def v2_runner_on_skipped(self, result):
         self._display.display("%s | SKIPPED" % (result._host.get_name()), color=C.COLOR_SKIP)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
default and minimal stdout callback

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel c86a17b7a0) last updated 2017/02/07 10:58:10 (GMT +200)
  config file = /home/pilou/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Fixes #21137

In case of failed run or in case of successful run, warnings are displayed using the same format/color.