### PR TITLE
Add support for AES encrypted keys

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_win_password.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_win_password.py
@@ -37,7 +37,7 @@ options:
   key_passphrase:
     version_added: "2.0"
     description:
-      - The passphrase for the instance key pair. The key must use DES or 3DES encryption for this module to decrypt it. You can use openssl to convert your password protected keys if they do not use DES or 3DES. ex) openssl rsa -in current_key -out new_key -des3.
+      - The passphrase for the instance key pair. The key must use AES, DES or 3DES encryption for this module to decrypt it. You can use openssl to convert your password protected keys if they do not use AES, DES or 3DES. ex) openssl rsa -in current_key -out new_key -des3.
     required: false
     default: null
   wait:
@@ -92,9 +92,10 @@ tasks:
 '''
 
 from base64 import b64decode
-from Crypto.Cipher import PKCS1_v1_5
-from Crypto.PublicKey import RSA
 import datetime
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import padding
 
 try:
     import boto.ec2
@@ -150,15 +151,19 @@ def main():
     else:
         try:
             with f:
-                key = RSA.importKey(f.read(), key_passphrase)
+                key = serialization.load_pem_private_key(
+                    f.read(),
+                    password=key_passphrase,
+                    backend=default_backend()
+                )
         except (ValueError, IndexError, TypeError) as e:
             module.fail_json(msg = "unable to parse key file")
 
-    cipher = PKCS1_v1_5.new(key)
-    sentinel = 'password decryption failed!!!'
-
     try:
-        decrypted = cipher.decrypt(decoded, sentinel)
+        decrypted = key.decrypt(
+            decoded,
+            padding.PKCS1v15()
+        )
     except ValueError as e:
         decrypted = None
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ec2_win_password

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The current version of this module doesn't support pem files encrypted with AES. This is due to the fact that the development of the pycrypto module has stopped.
I'm proposing the actively developed cryptography python module.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [localhost] ***************************************************************

TASK [Get EC2 Windows Password] ************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "unable to parse key file"}
        to retry, use: --limit @/home/vagrant/test.retry

PLAY RECAP *********************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1

```
After:
```
 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [localhost] ***************************************************************

TASK [Get EC2 Windows Password] ************************************************
ok: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0
```
