### PR TITLE
ipa_sudorule: Fixes #21152

### DIFF
--- a/lib/ansible/modules/identity/ipa/ipa_sudorule.py
+++ b/lib/ansible/modules/identity/ipa/ipa_sudorule.py
@@ -246,21 +246,6 @@ def get_sudorule_dict(cmdcategory=None, description=None, hostcategory=None, ipa
     return data
 
 
-def get_sudorule_diff(ipa_sudorule, module_sudorule):
-    data = []
-    for key in module_sudorule.keys():
-        module_value = module_sudorule.get(key, None)
-        ipa_value = ipa_sudorule.get(key, None)
-        if isinstance(ipa_value, list) and not isinstance(module_value, list):
-            module_value = [module_value]
-        if isinstance(ipa_value, list) and isinstance(module_value, list):
-            ipa_value = sorted(ipa_value)
-            module_value = sorted(module_value)
-        if ipa_value != module_value:
-            data.append(key)
-    return data
-
-
 def category_changed(module, client, category_name, ipa_sudorule):
     if ipa_sudorule.get(category_name, None) == ['all']:
         if not module.check_mode:
@@ -303,7 +288,7 @@ def ensure(module, client):
             if not module.check_mode:
                 ipa_sudorule = client.sudorule_add(name=name, item=module_sudorule)
         else:
-            diff = get_sudorule_diff(client, ipa_sudorule, module_sudorule)
+            diff = client.get_diff(ipa_sudorule, module_sudorule)
             if len(diff) > 0:
                 changed = True
                 if not module.check_mode:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bug fix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ipa_sudorule

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (ipa-role-privileges d73a64d6c7) last updated 2017/02/08 16:14:12 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
A bug within the ipa_sudorule module prevents updating exiting sudo rules. This PR fixes bug #21152 .

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
The change removes a function and makes use of a generic one that is already included in module_utils/ipa.py.
Without the fix the following error is raised:
```shell
get_sudorule_diff() takes exactly 2 arguments (3 given)
```

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
