### PR TITLE
Fix type() usage check in validate-modules.

### DIFF
--- a/test/sanity/validate-modules/validate-modules
+++ b/test/sanity/validate-modules/validate-modules
@@ -44,7 +44,7 @@ from voluptuous.humanize import humanize_error
 
 BLACKLIST_DIRS = frozenset(('.git', 'test', '.github', '.idea'))
 INDENT_REGEX = re.compile(r'([\t]*)')
-TYPE_REGEX = re.compile(r'.*(if|or)(\s+.*|\s+)(?<!_)(?<!str\()type\(.*')
+TYPE_REGEX = re.compile(r'.*(if|or)(\s+[^"\']*|\s+)(?<!_)(?<!str\()type\(.*')
 BLACKLIST_IMPORTS = {
     'requests': {
         'new_only': True,


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

validate-modules

##### ANSIBLE VERSION

```
ansible 2.3.0 (validate-fix 2c215f61ff) last updated 2017/02/08 11:59:34 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Fix type() usage check in validate-modules. This avoids false positives when `if` or `or` are in a string preceding the use of type() on the same line. This resolves PR #21127.

The updated regex was tested with the following script, modified from the original version from PR #18439 which added the type() checking feature:

```python
#!/usr/bin/env python

import re

TYPE_REGEX = re.compile(r'.*(if|or)(\s+[^"\']*|\s+)(?<!_)(?<!str\()type\(.*')

# each of these examples needs to be matched or not matched
checks = [
    ['if type(foo) is Bar', True],
    ['if Bar is type(foo)', True],
    ['if type(foo) is not Bar', True],
    ['if Bar is not type(foo)', True],
    ['if type(foo) == Bar', True],
    ['if Bar == type(foo)', True],
    ['if type(foo)==Bar', True],
    ['if Bar==type(foo)', True],
    ['if type(foo) != Bar', True],
    ['if Bar != type(foo)', True],
    ['if type(foo)!=Bar', True],
    ['if Bar!=type(foo)', True],
    ['if foo or type(bar) != Bar', True],
    ['x = type(foo)', False],
    ["error = err.message + ' ' + str(err) + ' - ' + str(type(err))", False],
    # cloud/amazon/ec2_group.py
    ["module.fail_json(msg='Invalid rule parameter type [%s].' % type(rule))", False],
    # files/patch.py
    ["p = type('Params', (), module.params)", False],
    # system/osx_defaults.py
    ["if self.current_value is not None and not isinstance(self.current_value, type(self.value)):", True],
    # system/osx_defaults.py
    ['raise OSXDefaultsException("Type mismatch. Type in defaults: " + type(self.current_value).__name__)', False],
    # network/nxos/nxos_interface.py
    ["if get_interface_type(interface) == 'svi':", False],
    # https://github.com/ansible/ansible/issues/21127
    ["self.module.fail_json(msg='TSIG update error (%s): %s' % (type(e).__name__, str(e)))", False]
]

for idc, check in enumerate(checks):
    cstring = check[0]
    cexpected = check[1]

    match = TYPE_REGEX.match(cstring)
    if cexpected and not match:
        assert False, "%s should have matched" % cstring
    elif not cexpected and match:
        assert False, "%s should not have matched" % cstring
```