### PR TITLE
Fix test which fails on some python 2.6 installs.

### DIFF
--- a/test/units/module_utils/basic/test_set_mode_if_different.py
+++ b/test/units/module_utils/basic/test_set_mode_if_different.py
@@ -21,6 +21,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
+import pytest
 
 try:
     import builtins
@@ -100,7 +101,8 @@ class TestSetModeIfDifferent(TestSetModeIfDifferentBase):
             with patch('os.lchmod', return_value=None, create=True) as m_os:
                 m.side_effect = [self.mock_stat1, self.mock_stat2, self.mock_stat2]
                 self.am._symbolic_mode_to_octal = MagicMock(side_effect=Exception)
-                self.assertRaises(SystemExit, self.am.set_mode_if_different, '/path/to/file', 'o+w,g+w,a-r', False)
+                with pytest.raises(SystemExit):
+                    self.am.set_mode_if_different('/path/to/file', 'o+w,g+w,a-r', False)
 
         original_hasattr = hasattr
         def _hasattr(obj, name):


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

unit tests

##### ANSIBLE VERSION

```
nsible 2.3.0 (units-warnings c67a3e5c80) last updated 2017/02/08 12:42:06 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Fix test which fails on some python 2.6 installs.