### PR TITLE
Update copy module documentation for remote_src

### DIFF
--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -80,9 +80,9 @@ options:
     version_added: "1.5"
   remote_src:
     description:
-      - If False, it will search for src at originating/master machine, if True it will go to the remote/target machine for the src. Default is False.
+      - If C(no), it will search for src at originating/master machine, if C(yes) it will go to the remote/target machine for the src. Default is False.
       - Currently remote_src does not support recursive copying.
-    choices: [ "True", "False" ]
+    choices: [ "yes", "no" ]
     required: false
     default: "no"
     version_added: "2.0"


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
copy module

##### ANSIBLE VERSION

```
ansible 2.1.0.0
```

##### SUMMARY
The documentation mentions True/False, but the default is apparently "no", and looking at https://github.com/ansible/ansible/issues/2930 it seems like using yes/no everywhere is the desired pattern. This confused me so I wanted to update the docs accordingly. Thanks!