### PR TITLE
Restore FreeBSD 11.0 tests for CI.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -14,6 +14,7 @@ matrix:
     - env: TEST=osx/10.11
 
     - env: TEST=freebsd/10.3-STABLE
+    - env: TEST=freebsd/11.0-STABLE
 
     - env: TEST=windows/1
     - env: TEST=windows/2


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

shippable.yml

##### ANSIBLE VERSION

```
ansible 2.3.0 (freebsd-11-ci d05a53ab3c) last updated 2017/02/08 16:33:49 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Restore FreeBSD 11.0 tests for CI.