### PR TITLE
Mask login_password in log

### DIFF
--- a/lib/ansible/modules/cloud/openstack/_keystone_user.py
+++ b/lib/ansible/modules/cloud/openstack/_keystone_user.py
@@ -343,7 +343,7 @@ def main():
                           default="http://127.0.0.1:35357/v2.0"),
         token=dict(required=False),
         login_user=dict(required=False),
-        login_password=dict(required=False),
+        login_password=dict(required=False, no_log=True),
         login_tenant_name=dict(required=False)
     ))
     # keystone operations themselves take an endpoint, not a keystone auth_url

--- a/lib/ansible/modules/cloud/webfaction/webfaction_app.py
+++ b/lib/ansible/modules/cloud/webfaction/webfaction_app.py
@@ -122,7 +122,7 @@ def main():
             extra_info = dict(required=False, default=""),
             port_open = dict(required=False, type='bool', default=False),
             login_name = dict(required=True),
-            login_password = dict(required=True),
+            login_password = dict(required=True, no_log=True),
             machine = dict(required=False, default=False),
         ),
         supports_check_mode=True

--- a/lib/ansible/modules/cloud/webfaction/webfaction_db.py
+++ b/lib/ansible/modules/cloud/webfaction/webfaction_db.py
@@ -114,7 +114,7 @@ def main():
             type = dict(required=True),
             password = dict(required=False, default=None),
             login_name = dict(required=True),
-            login_password = dict(required=True),
+            login_password = dict(required=True, no_log=True),
             machine = dict(required=False, default=False),
         ),
         supports_check_mode=True

--- a/lib/ansible/modules/cloud/webfaction/webfaction_domain.py
+++ b/lib/ansible/modules/cloud/webfaction/webfaction_domain.py
@@ -103,7 +103,7 @@ def main():
             state = dict(required=False, choices=['present', 'absent'], default='present'),
             subdomains = dict(required=False, default=[]),
             login_name = dict(required=True),
-            login_password = dict(required=True),
+            login_password = dict(required=True, no_log=True),
         ),
         supports_check_mode=True
     )

--- a/lib/ansible/modules/cloud/webfaction/webfaction_mailbox.py
+++ b/lib/ansible/modules/cloud/webfaction/webfaction_mailbox.py
@@ -90,7 +90,7 @@ def main():
             mailbox_password=dict(required=True),
             state=dict(required=False, choices=['present', 'absent'], default='present'),
             login_name=dict(required=True),
-            login_password=dict(required=True),
+            login_password=dict(required=True, no_log=True),
         ),
         supports_check_mode=True
     )

--- a/lib/ansible/modules/cloud/webfaction/webfaction_site.py
+++ b/lib/ansible/modules/cloud/webfaction/webfaction_site.py
@@ -122,7 +122,7 @@ def main():
             subdomains = dict(required=False, type='list', default=[]),
             site_apps = dict(required=False, type='list', default=[]),
             login_name = dict(required=True),
-            login_password = dict(required=True),
+            login_password = dict(required=True, no_log=True),
         ),
         supports_check_mode=True
     )

--- a/lib/ansible/modules/database/misc/mongodb_user.py
+++ b/lib/ansible/modules/database/misc/mongodb_user.py
@@ -345,7 +345,7 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
             login_user=dict(default=None),
-            login_password=dict(default=None),
+            login_password=dict(default=None, no_log=True),
             login_host=dict(default='localhost'),
             login_port=dict(default='27017'),
             login_database=dict(default=None),

--- a/lib/ansible/modules/database/mssql/mssql_db.py
+++ b/lib/ansible/modules/database/mssql/mssql_db.py
@@ -159,7 +159,7 @@ def main():
         argument_spec=dict(
             name=dict(required=True, aliases=['db']),
             login_user=dict(default=''),
-            login_password=dict(default=''),
+            login_password=dict(default='', no_log=True),
             login_host=dict(required=True),
             login_port=dict(default='1433'),
             target=dict(default=None),

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -246,7 +246,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             login_user=dict(default="postgres"),
-            login_password=dict(default=""),
+            login_password=dict(default="", no_log=True),
             login_host=dict(default=""),
             login_unix_socket=dict(default=""),
             port=dict(default="5432"),

--- a/lib/ansible/modules/database/postgresql/postgresql_schema.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_schema.py
@@ -180,7 +180,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             login_user=dict(default="postgres"),
-            login_password=dict(default=""),
+            login_password=dict(default="", no_log=True),
             login_host=dict(default=""),
             login_unix_socket=dict(default=""),
             port=dict(default="5432"),

--- a/lib/ansible/modules/database/vertica/vertica_configuration.py
+++ b/lib/ansible/modules/database/vertica/vertica_configuration.py
@@ -145,7 +145,7 @@ def main():
             cluster=dict(default='localhost'),
             port=dict(default='5433'),
             login_user=dict(default='dbadmin'),
-            login_password=dict(default=None),
+            login_password=dict(default=None, no_log=True),
         ), supports_check_mode = True)
 
     if not pyodbc_found:

--- a/lib/ansible/modules/database/vertica/vertica_facts.py
+++ b/lib/ansible/modules/database/vertica/vertica_facts.py
@@ -230,7 +230,7 @@ def main():
             port=dict(default='5433'),
             db=dict(default=None),
             login_user=dict(default='dbadmin'),
-            login_password=dict(default=None),
+            login_password=dict(default=None, no_log=True),
         ), supports_check_mode = True)
 
     if not pyodbc_found:

--- a/lib/ansible/modules/database/vertica/vertica_role.py
+++ b/lib/ansible/modules/database/vertica/vertica_role.py
@@ -185,7 +185,7 @@ def main():
             cluster=dict(default='localhost'),
             port=dict(default='5433'),
             login_user=dict(default='dbadmin'),
-            login_password=dict(default=None),
+            login_password=dict(default=None, no_log=True),
         ), supports_check_mode = True)
 
     if not pyodbc_found:

--- a/lib/ansible/modules/database/vertica/vertica_schema.py
+++ b/lib/ansible/modules/database/vertica/vertica_schema.py
@@ -254,7 +254,7 @@ def main():
             cluster=dict(default='localhost'),
             port=dict(default='5433'),
             login_user=dict(default='dbadmin'),
-            login_password=dict(default=None),
+            login_password=dict(default=None, no_log=True),
         ), supports_check_mode = True)
 
     if not pyodbc_found:

--- a/lib/ansible/modules/database/vertica/vertica_user.py
+++ b/lib/ansible/modules/database/vertica/vertica_user.py
@@ -315,7 +315,7 @@ def main():
             cluster=dict(default='localhost'),
             port=dict(default='5433'),
             login_user=dict(default='dbadmin'),
-            login_password=dict(default=None),
+            login_password=dict(default=None, no_log=True),
         ), supports_check_mode = True)
 
     if not pyodbc_found:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- openstack
- webfaction
- mongodb_user
- mssql
- postgresql
- vertica

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Hi!
Some modules displays `login_password` in log as follows.

```
changed: [sandbox] => {
    "changed": true,
    "db": "dummy",
    "invocation": {
        "module_args": {
            "db": "dummy",
            "encoding": "UTF-8",
            "lc_collate": "C",
            "lc_ctype": "C",
            "login_host": "",
            "login_password": "verysecret",
            "login_unix_socket": "",
            "login_user": "postgres",
```

This PR makes those modules hide `login_password` in log.