### PR TITLE
Removing cmp from ec2_vpc_net.py to be compatible with Python3

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
@@ -149,7 +149,7 @@ def update_vpc_tags(vpc, module, vpc_obj, tags, name):
     tags.update({'Name': name})
     try:
         current_tags = dict((t.name, t.value) for t in vpc.get_all_tags(filters={'resource-id': vpc_obj.id}))
-        if lambda tags, current_tags: (tags > current_tags) - (tags < current_tags):
+        if tags != current_tags:
             if not module.check_mode:
                 vpc.create_tags(vpc_obj.id, tags)
             return True

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
@@ -157,8 +157,7 @@ def update_vpc_tags(vpc, module, vpc_obj, tags, name):
         else:
             if not module.check_mode:
                 vpc.create_tags(vpc_obj.id, tags)
-            return True
-        else:
+                return True
             return False
     except Exception as e:
         e_msg=boto_exception(e)

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
@@ -149,16 +149,11 @@ def update_vpc_tags(vpc, module, vpc_obj, tags, name):
     tags.update({'Name': name})
     try:
         current_tags = dict((t.name, t.value) for t in vpc.get_all_tags(filters={'resource-id': vpc_obj.id}))
-        if sorted(tags) == sorted(current_tags):
-            for tag_key in sorted(tags):
-                if tags[tag_key] != current_tags[tag_key] and not module.check_mode:
-                    vpc.create_tags(vpc_obj.id, tags)
-                    return True
-            return False
-        else:
+        if lambda tags, current_tags: (tags > current_tags) - (tags < current_tags):
             if not module.check_mode:
                 vpc.create_tags(vpc_obj.id, tags)
-                return True
+            return True
+        else:
             return False
     except Exception as e:
         e_msg=boto_exception(e)

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
@@ -149,7 +149,12 @@ def update_vpc_tags(vpc, module, vpc_obj, tags, name):
     tags.update({'Name': name})
     try:
         current_tags = dict((t.name, t.value) for t in vpc.get_all_tags(filters={'resource-id': vpc_obj.id}))
-        if cmp(tags, current_tags):
+        if sorted(tags) == sorted(current_tags):
+            for tag_key in sorted(tags):
+                if tags[tag_key] != current_tags[tag_key] and not module.check_mode:
+                    vpc.create_tags(vpc_obj.id, tags)
+                return True
+        else:
             if not module.check_mode:
                 vpc.create_tags(vpc_obj.id, tags)
             return True

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
@@ -153,7 +153,8 @@ def update_vpc_tags(vpc, module, vpc_obj, tags, name):
             for tag_key in sorted(tags):
                 if tags[tag_key] != current_tags[tag_key] and not module.check_mode:
                     vpc.create_tags(vpc_obj.id, tags)
-                return True
+                    return True
+            return False
         else:
             if not module.check_mode:
                 vpc.create_tags(vpc_obj.id, tags)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_vpc_net.py

##### ANSIBLE VERSION
```
ansible 2.3.0 (remove_cmp_ec2_vpc_net 81f8d11be4) last updated 2017/02/09 08:58:02 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Removed the cmp keyword which has been removed in Python3.

To reproduce bug:
Use Python3
Create a vpc called "testvpc" with a cidr_block of 177.5.0.0/16 with a tag 'this'. Then run the task below updating the 'this' tag.
Task to test:
```
- name: update a vpc
  ec2_vpc_net:
    name: "testvpc"
    cidr_block: "177.5.0.0/16"
    tags:
      this: updated_tag
```

Before my change:
```
fatal: [localhost]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_args": {
            "aws_access_key": null,
            "aws_secret_key": null,
            "cidr_block": "177.5.0.0/16",
            "dhcp_opts_id": null,
            "dns_hostnames": true,
            "dns_support": true,
            "ec2_url": null,
            "multi_ok": false,
            "name": “testvpc”,
            "profile": "shertel",
            "region": "us-east-1",
            "security_token": null,
            "state": "present",
            "tags": {
                "Name": "testvpc",
                "this": "updated_tag"
            },
            "tenancy": "dedicated",
            "validate_certs": true
        }
    },
    "msg": "<class 'Exception'>: name 'cmp' is not defined"
}
	to retry, use: --limit @/Users/shertel/Workspace/ansible/my_playbooks/test_vpc_net.retry

PLAY RECAP *********************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1
```

With change:
```
changed: [localhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "aws_access_key": null,
            "aws_secret_key": null,
            "cidr_block": "177.5.0.0/16",
            "dhcp_opts_id": null,
            "dns_hostnames": true,
            "dns_support": true,
            "ec2_url": null,
            "multi_ok": false,
            "name": “testvpc”,
            "profile": "shertel",
            "region": "us-east-1",
            "security_token": null,
            "state": "present",
            "tags": {
                "Name": “testvpc”,
                "this": "updated_tag"
            },
            "tenancy": "dedicated",
            "validate_certs": true
        }
    },
    "vpc": {
        "cidr_block": "177.5.0.0/16",
        "classic_link_enabled": null,
        "dhcp_options_id": "dopt-3349e054",
        "id": "vpc-13452375",
        "instance_tenancy": "dedicated",
        "is_default": false,
        "state": "available",
        "tags": {
            "Name": “testvpc”,
            "this": "updated_tag"
        }
    }
}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0
```