### PR TITLE
Update Makefile to use ansible-test for pep8.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,11 +140,7 @@ loc:
 	sloccount lib library bin
 
 pep8:
-	@echo "#############################################"
-	@echo "# Running PEP8 Compliance Tests"
-	@echo "#############################################"
-	-pep8 -r --ignore=E501,E221,W291,W391,E302,E251,E203,W293,E231,E303,E201,E225,E261,E241 lib/ bin/
-	# -pep8 -r --ignore=E501,E221,W291,W391,E302,E251,E203,W293,E231,E303,E201,E225,E261,E241 --filename "*" library/
+	$(ANSIBLE_TEST) sanity --test pep8 --python $(PYTHON_VERSION) $(TEST_FLAGS)
 
 pyflakes:
 	pyflakes lib/ansible/*.py lib/ansible/*/*.py bin/*


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Makefile

##### ANSIBLE VERSION

```
ansible 2.3.0 (make-pep8 d09c4f4640) last updated 2017/02/09 09:56:44 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Update Makefile to use ansible-test for pep8. This avoid a mismatch between PEP 8 rules used for CI and those used when run via make.