### PR TITLE
Revert "Enable process isolation for unit tests."

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -624,7 +624,6 @@ def command_units(args):
 
         cmd = [
             'pytest',
-            '--boxed',
             '-r', 'a',
             '--color',
             'yes' if args.color else 'no',

--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -6,7 +6,6 @@ passlib
 pycrypto
 pytest
 pytest-mock
-pytest-xdist
 python-memcached
 pyyaml
 redis


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (no-boxed-units 3a425f2630) last updated 2017/02/09 10:38:58 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

This reverts commit 91526cd9f249f31787309e59235193288282d378.

Removing this feature primarily because it interferes with
collecting proper code coverage results. I may restore the
feature later if that can be resolved.