### PR TITLE
Fix 'task name is not templated in retry callback' (add task_name property to TaskResult)

### DIFF
--- a/lib/ansible/executor/task_result.py
+++ b/lib/ansible/executor/task_result.py
@@ -21,6 +21,7 @@ __metaclass__ = type
 
 from ansible.parsing.dataloader import DataLoader
 
+
 class TaskResult:
     '''
     This class is responsible for interpreting the resulting data
@@ -41,6 +42,10 @@ class TaskResult:
             self._task_fields = dict()
         else:
             self._task_fields = task_fields
+
+    @property
+    def task_name(self):
+        return self._task_fields.get('name', None) or self._task.get_name()
 
     def is_changed(self):
         return self._check_key('changed')

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -301,7 +301,8 @@ class CallbackModule(CallbackBase):
                         self._display.vvvv('%s: %s' % (option,val))
 
     def v2_runner_retry(self, result):
-        msg = "FAILED - RETRYING: %s (%d retries left)." % (result._task, result._result['retries'] - result._result['attempts'])
+        task_name = result.task_name or result._task
+        msg = "FAILED - RETRYING: %s (%d retries left)." % (task_name, result._result['retries'] - result._result['attempts'])
         if (self._display.verbosity > 2 or '_ansible_verbose_always' in result._result) and not '_ansible_verbose_override' in result._result:
             msg += "Result was: %s" % self._dump_results(result._result)
         self._display.display(msg, color=C.COLOR_DEBUG)

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -326,3 +326,6 @@ test_lookup_properties:
 
 args:
 	(cd targets/args && ./runme.sh $(TEST_FLAGS))
+
+test_callback_retry_task_name:
+	(cd targets/callback_retry_task_name && ./runme.sh $(TEST_FLAGS))

--- a/test/integration/Makefile
+++ b/test/integration/Makefile
@@ -27,7 +27,10 @@ UNAME := $(shell uname | tr '[:upper:]' '[:lower:]')
 
 all: other non_destructive destructive
 
-other: ansible test_test_infra parsing test_var_blending test_var_precedence unicode test_templating_settings environment test_as includes blocks pull_run pull_no_127 pull_limit_inventory check_mode test_hash test_handlers test_group_by test_vault test_tags test_lookup_paths no_log test_gathering_facts test_binary_modules_posix test_hosts_field test_lookup_properties args test_jinja2_groupby
+other: ansible test_test_infra parsing test_var_blending test_var_precedence unicode test_templating_settings \
+	environment test_as includes blocks pull_run pull_no_127 pull_limit_inventory check_mode test_hash test_handlers \
+	test_group_by test_vault test_tags test_lookup_paths no_log test_gathering_facts test_binary_modules_posix \
+	test_hosts_field test_lookup_properties args test_jinja2_groupby test_callback_retry_task_name
 
 ansible:
 	(cd targets/ansible && ./runme.sh $(TEST_FLAGS))

--- a/test/integration/targets/callback_retry_task_name/aliases
+++ b/test/integration/targets/callback_retry_task_name/aliases
@@ -1,0 +1,1 @@
+posix/ci/group3

--- a/test/integration/targets/callback_retry_task_name/runme.sh
+++ b/test/integration/targets/callback_retry_task_name/runme.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# we are looking to verify the callback for v2_retry_runner gets a correct task name, include
+# if the value needs templating based on results of previous tasks
+OUTFILE="callback_retry_task_name.out"
+trap 'rm -rf "${OUTFILE}"' EXIT
+
+EXPECTED_REGEX="^.*TASK.*18236 callback task template fix OUTPUT 2"
+ansible-playbook "$@" -i ../../inventory test.yml | tee "${OUTFILE}"
+echo "Grepping for ${EXPECTED_REGEX} in stdout."
+grep -e "${EXPECTED_REGEX}" "${OUTFILE}"

--- a/test/integration/targets/callback_retry_task_name/test.yml
+++ b/test/integration/targets/callback_retry_task_name/test.yml
@@ -1,0 +1,28 @@
+---
+- hosts: testhost
+  gather_facts: False
+  vars:
+      foo: blippy
+  tasks:
+  - name: First run {{ foo }}
+    command: echo "18236 callback task template fix OUTPUT 1"
+    register: the_result_var
+
+  - block:
+      - name: "{{ the_result_var.stdout }}"
+        command: echo "18236 callback task template fix OUTPUT 2"
+        register: the_result_var
+        retries: 1
+        delay: 1
+        until: False
+        ignore_errors: true
+
+      #  - name: assert task_name was
+
+  - name: "{{ the_result_var.stdout }}"
+    command: echo "18236 callback taskadfadf template fix OUTPUT 3"
+    register: the_result_var
+
+  - name: "{{ the_result_var.stdout }}"
+    debug:
+        msg: "nothing to see here."


### PR DESCRIPTION
Fixes #18236

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/executor/task_executor.py
lib/ansible/plugins/callback/default.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (retry_fail_18236 b968b2964e) last updated 2017/02/09 15:46:04 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules', u'/home/adrian/ansible/lib/modules/']

```
