### PR TITLE
resolve #21056 - Add support for full cloning a Qemu VM. Fix some issues. Update doc

### DIFF
--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -709,375 +709,380 @@ import time
 
 
 try:
-  from proxmoxer import ProxmoxAPI
-  HAS_PROXMOXER = True
+    from proxmoxer import ProxmoxAPI
+    HAS_PROXMOXER = True
 except ImportError:
-  HAS_PROXMOXER = False
+    HAS_PROXMOXER = False
 
-VZ_TYPE='qemu'
+VZ_TYPE = 'qemu'
+
 
 def get_nextvmid(proxmox):
-  try:
-    vmid = proxmox.cluster.nextid.get()
-    return vmid
-  except Exception as e:
-    module.fail_json(msg="Unable to get next vmid. Failed with exception: %s")
+    try:
+        vmid = proxmox.cluster.nextid.get()
+        return vmid
+    except Exception as e:
+        module.fail_json(msg="Unable to get next vmid. Failed with exception: %s")
+
 
 def get_vmid(proxmox, name):
-  return [ vm['vmid'] for vm in proxmox.cluster.resources.get(type='vm') if vm['name'] == name ]
+    return [vm['vmid'] for vm in proxmox.cluster.resources.get(type='vm') if vm['name'] == name]
+
 
 def get_vm(proxmox, vmid):
-  return [ vm for vm in proxmox.cluster.resources.get(type='vm') if vm['vmid'] == int(vmid) ]
+    return [vm for vm in proxmox.cluster.resources.get(type='vm') if vm['vmid'] == int(vmid)]
+
 
 def node_check(proxmox, node):
-  return [ True for nd in proxmox.nodes.get() if nd['node'] == node ]
+    return [True for nd in proxmox.nodes.get() if nd['node'] == node]
+
 
 def get_vminfo(module, proxmox, node, vmid, **kwargs):
-        global results
-        results = {}
-        mac = {}
-        devices = {}
-        try:
-          vm = proxmox.nodes(node).qemu(vmid).config.get()
-        except Exception as e:
-          module.fail_json(msg='Getting information for VM with vmid = %s failed with exception: %s' % (vmid, e))
+    global results
+    results = {}
+    mac = {}
+    devices = {}
+    try:
+        vm = proxmox.nodes(node).qemu(vmid).config.get()
+    except Exception as e:
+        module.fail_json(msg='Getting information for VM with vmid = %s failed with exception: %s' % (vmid, e))
 
-        # Sanitize kwargs. Remove not defined args and ensure True and False converted to int.
-        kwargs = dict((k,v) for k, v in kwargs.items() if v is not None)
+    # Sanitize kwargs. Remove not defined args and ensure True and False converted to int.
+    kwargs = dict((k, v) for k, v in kwargs.items() if v is not None)
 
-        # Convert all dict in kwargs to elements. For hostpci[n], ide[n], net[n], numa[n], parallel[n], sata[n], scsi[n], serial[n], virtio[n]
-        for k in kwargs.keys():
-          if isinstance(kwargs[k], dict):
-             kwargs.update(kwargs[k])
-             del kwargs[k]
+    # Convert all dict in kwargs to elements. For hostpci[n], ide[n], net[n], numa[n], parallel[n], sata[n], scsi[n], serial[n], virtio[n]
+    for k in kwargs.keys():
+        if isinstance(kwargs[k], dict):
+            kwargs.update(kwargs[k])
+            del kwargs[k]
 
-        # Split information by type
-        for k, v in kwargs.items():
-          if re.match(r'net[0-9]', k) is not None:
+    # Split information by type
+    for k, v in kwargs.items():
+        if re.match(r'net[0-9]', k) is not None:
             interface = k
             k = vm[k]
             k = re.search('=(.*?),', k).group(1)
             mac[interface] = k
-          if re.match(r'virtio[0-9]', k) is not None or re.match(r'ide[0-9]', k) is not None or re.match(r'scsi[0-9]', k) is not None or re.match(r'sata[0-9]', k) is not None:
+        if re.match(r'virtio[0-9]', k) is not None or re.match(r'ide[0-9]', k) is not None or re.match(r'scsi[0-9]', k) is not None or re.match(r'sata[0-9]', k) is not None:
             device = k
             k = vm[k]
             k = re.search('(.*?),', k).group(1)
             devices[device] = k
 
-        results['mac'] = mac
-        results['devices'] = devices
-        results['vmid'] = int(vmid)
+    results['mac'] = mac
+    results['devices'] = devices
+    results['vmid'] = int(vmid)
+
 
 def settings(module, proxmox, vmid, node, name, timeout, **kwargs):
-  proxmox_node = proxmox.nodes(node)
+    proxmox_node = proxmox.nodes(node)
 
-  # Sanitize kwargs. Remove not defined args and ensure True and False converted to int.
-  kwargs = dict((k,v) for k, v in kwargs.items() if v is not None)
+    # Sanitize kwargs. Remove not defined args and ensure True and False converted to int.
+    kwargs = dict((k, v) for k, v in kwargs.items() if v is not None)
 
-  #module.fail_json(msg='%s' % kwargs)
-  if getattr(proxmox_node, VZ_TYPE)(vmid).config.set(**kwargs) is None:
-    return True
-  else:
-      return False
+    if getattr(proxmox_node, VZ_TYPE)(vmid).config.set(**kwargs) is None:
+        return True
+    else:
+        return False
+
 
 def create_vm(module, proxmox, vmid, newid, node, name, memory, cpu, cores, sockets, timeout, update, **kwargs):
-  # Available only in PVE 4
-  only_v4 = ['force','protection','skiplock']
+    # Available only in PVE 4
+    only_v4 = ['force', 'protection', 'skiplock']
 
-  # valide clone parameters
-  valid_clone_params = ['format', 'full', 'pool', 'snapname', 'storage', 'target']
-  clone_params = {}
-  # Default args for vm. Note: -args option is for experts only. It allows you to pass arbitrary arguments to kvm.
-  vm_args = "-serial unix:/var/run/qemu-server/{}.serial,server,nowait".format(vmid)
+    # valide clone parameters
+    valid_clone_params = ['format', 'full', 'pool', 'snapname', 'storage', 'target']
+    clone_params = {}
+    # Default args for vm. Note: -args option is for experts only. It allows you to pass arbitrary arguments to kvm.
+    vm_args = "-serial unix:/var/run/qemu-server/{}.serial,server,nowait".format(vmid)
 
-  proxmox_node = proxmox.nodes(node)
+    proxmox_node = proxmox.nodes(node)
 
-  # Sanitize kwargs. Remove not defined args and ensure True and False converted to int.
-  kwargs = dict((k,v) for k, v in kwargs.items() if v is not None)
-  kwargs.update(dict([k, int(v)] for k, v in kwargs.items() if isinstance(v, bool)))
+    # Sanitize kwargs. Remove not defined args and ensure True and False converted to int.
+    kwargs = dict((k,v) for k, v in kwargs.items() if v is not None)
+    kwargs.update(dict([k, int(v)] for k, v in kwargs.items() if isinstance(v, bool)))
 
-  # The features work only on PVE 4
-  if PVE_MAJOR_VERSION < 4:
-    for p in only_v4:
-      if p in kwargs:
-         del kwargs[p]
+    # The features work only on PVE 4
+    if PVE_MAJOR_VERSION < 4:
+        for p in only_v4:
+            if p in kwargs:
+                del kwargs[p]
 
-  # If update, don't update disk (virtio, ide, sata, scsi) and network interface
-  if update:
-    if 'virtio' in kwargs:
-      del kwargs['virtio']
-    if 'sata' in kwargs:
-      del kwargs['sata']
-    if 'scsi' in kwargs:
-      del kwargs['scsi']
-    if 'ide' in kwargs:
-      del kwargs['ide']
-    if 'net' in kwargs:
-      del kwargs['net']
+    # If update, don't update disk (virtio, ide, sata, scsi) and network interface
+    if update:
+        if 'virtio' in kwargs:
+            del kwargs['virtio']
+        if 'sata' in kwargs:
+            del kwargs['sata']
+        if 'scsi' in kwargs:
+            del kwargs['scsi']
+        if 'ide' in kwargs:
+            del kwargs['ide']
+        if 'net' in kwargs:
+            del kwargs['net']
 
-  # Convert all dict in kwargs to elements. For hostpci[n], ide[n], net[n], numa[n], parallel[n], sata[n], scsi[n], serial[n], virtio[n]
-  for k in kwargs.keys():
-    if isinstance(kwargs[k], dict):
-      kwargs.update(kwargs[k])
-      del kwargs[k]
+    # Convert all dict in kwargs to elements. For hostpci[n], ide[n], net[n], numa[n], parallel[n], sata[n], scsi[n], serial[n], virtio[n]
+    for k in kwargs.keys():
+        if isinstance(kwargs[k], dict):
+            kwargs.update(kwargs[k])
+            del kwargs[k]
 
-  # Rename numa_enabled  to numa. According the API documentation
-  if 'numa_enabled' in kwargs:
-    kwargs['numa'] = kwargs['numa_enabled']
-    del kwargs['numa_enabled']
+    # Rename numa_enabled  to numa. According the API documentation
+    if 'numa_enabled' in kwargs:
+        kwargs['numa'] = kwargs['numa_enabled']
+        del kwargs['numa_enabled']
 
-  # -args and skiplock require root@pam user
-  if module.params['api_user'] == "root@pam" and module.params['args'] is None:
-    if not update:
-      kwargs['args'] = vm_args
-  elif module.params['api_user'] == "root@pam" and module.params['args'] is not None:
-    kwargs['args'] = module.params['args']
-  elif module.params['api_user'] != "root@pam" and module.params['args'] is not None:
-    module.fail_json(msg='args parameter require root@pam user. ')
+    # -args and skiplock require root@pam user
+    if module.params['api_user'] == "root@pam" and module.params['args'] is None:
+        if not update:
+            kwargs['args'] = vm_args
+    elif module.params['api_user'] == "root@pam" and module.params['args'] is not None:
+        kwargs['args'] = module.params['args']
+    elif module.params['api_user'] != "root@pam" and module.params['args'] is not None:
+        module.fail_json(msg='args parameter require root@pam user. ')
 
-  if module.params['api_user'] != "root@pam" and module.params['skiplock'] is not None:
-    module.fail_json(msg='skiplock parameter require root@pam user. ')
+    if module.params['api_user'] != "root@pam" and module.params['skiplock'] is not None:
+        module.fail_json(msg='skiplock parameter require root@pam user. ')
 
-  if update:
-    #module.fail_json(msg='%s %s %s %s %s %s' % (name, memory, cpu, cores, sockets, kwargs))
-    if getattr(proxmox_node, VZ_TYPE)(vmid).config.set(name=name, memory=memory, cpu=cpu, cores=cores, sockets=sockets, **kwargs) is None:
-      return True
+    if update:
+        if getattr(proxmox_node, VZ_TYPE)(vmid).config.set(name=name, memory=memory, cpu=cpu, cores=cores, sockets=sockets, **kwargs) is None:
+            return True
+        else:
+            return False
+    elif module.params['clone'] is not None:
+        for param in valid_clone_params:
+            if module.params[param] is not None:
+                clone_params[param] = module.params[param]
+        clone_params.update(dict([k, int(v)] for k, v in clone_params.items() if isinstance(v, bool)))
+        taskid = proxmox_node.qemu(vmid).clone.post(newid=newid, name=name, **clone_params)
     else:
-      return False
-  elif module.params['clone'] is not None:
-    for param in valid_clone_params:
-      if module.params[param] is not None:
-         clone_params[param] = module.params[param]
-    clone_params.update(dict([k, int(v)] for k, v in clone_params.items() if isinstance(v, bool)))
-    taskid = proxmox_node.qemu(vmid).clone.post(newid=newid, name=name, **clone_params)
-  else:
-      taskid = getattr(proxmox_node, VZ_TYPE).create(vmid=vmid, name=name, memory=memory, cpu=cpu, cores=cores, sockets=sockets, **kwargs)
+        taskid = getattr(proxmox_node, VZ_TYPE).create(vmid=vmid, name=name, memory=memory, cpu=cpu, cores=cores, sockets=sockets, **kwargs)
 
-  while timeout:
-    if ( proxmox_node.tasks(taskid).status.get()['status'] == 'stopped'
-        and proxmox_node.tasks(taskid).status.get()['exitstatus'] == 'OK' ):
-      return True
-    timeout = timeout - 1
-    if timeout == 0:
-      module.fail_json(msg='Reached timeout while waiting for creating VM. Last line in task before timeout: %s'
-                       % proxmox_node.tasks(taskid).log.get()[:1])
-    time.sleep(1)
-  return False
+    while timeout:
+        if (proxmox_node.tasks(taskid).status.get()['status'] == 'stopped'
+            and proxmox_node.tasks(taskid).status.get()['exitstatus'] == 'OK'):
+            return True
+        timeout = timeout - 1
+        if timeout == 0:
+            module.fail_json(msg='Reached timeout while waiting for creating VM. Last line in task before timeout: %s'
+                             % proxmox_node.tasks(taskid).log.get()[:1])
+        time.sleep(1)
+    return False
+
 
 def start_vm(module, proxmox, vm, vmid, timeout):
-  taskid = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.start.post()
-  while timeout:
-    if ( proxmox.nodes(vm[0]['node']).tasks(taskid).status.get()['status'] == 'stopped'
-        and proxmox.nodes(vm[0]['node']).tasks(taskid).status.get()['exitstatus'] == 'OK' ):
-      return True
-    timeout = timeout - 1
-    if timeout == 0:
-      module.fail_json(msg='Reached timeout while waiting for starting VM. Last line in task before timeout: %s'
-                       % proxmox.nodes(vm[0]['node']).tasks(taskid).log.get()[:1])
+    taskid = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.start.post()
+    while timeout:
+        if (proxmox.nodes(vm[0]['node']).tasks(taskid).status.get()['status'] == 'stopped'
+            and proxmox.nodes(vm[0]['node']).tasks(taskid).status.get()['exitstatus'] == 'OK' ):
+            return True
+        timeout = timeout - 1
+        if timeout == 0:
+            module.fail_json(msg='Reached timeout while waiting for starting VM. Last line in task before timeout: %s'
+                             % proxmox.nodes(vm[0]['node']).tasks(taskid).log.get()[:1])
 
-    time.sleep(1)
-  return False
+        time.sleep(1)
+    return False
+
 
 def stop_vm(module, proxmox, vm, vmid, timeout, force):
-  if force:
-    taskid = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.shutdown.post(forceStop=1)
-  else:
-    taskid = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.shutdown.post()
-  while timeout:
-    if ( proxmox.nodes(vm[0]['node']).tasks(taskid).status.get()['status'] == 'stopped'
-        and proxmox.nodes(vm[0]['node']).tasks(taskid).status.get()['exitstatus'] == 'OK' ):
-      return True
-    timeout = timeout - 1
-    if timeout == 0:
-      module.fail_json(msg='Reached timeout while waiting for stopping VM. Last line in task before timeout: %s'
-                       % proxmox.nodes(vm[0]['node']).tasks(taskid).log.get()[:1])
+    if force:
+        taskid = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.shutdown.post(forceStop=1)
+    else:
+        taskid = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.shutdown.post()
+    while timeout:
+        if (proxmox.nodes(vm[0]['node']).tasks(taskid).status.get()['status'] == 'stopped'
+            and proxmox.nodes(vm[0]['node']).tasks(taskid).status.get()['exitstatus'] == 'OK'):
+            return True
+        timeout = timeout - 1
+        if timeout == 0:
+            module.fail_json(msg='Reached timeout while waiting for stopping VM. Last line in task before timeout: %s'
+                             % proxmox.nodes(vm[0]['node']).tasks(taskid).log.get()[:1])
+        time.sleep(1)
+    return False
 
-    time.sleep(1)
-  return False
 
 def main():
-  module = AnsibleModule(
-    argument_spec = dict(
-      acpi = dict(type='bool', default='yes'),
-      agent = dict(type='bool'),
-      args = dict(type='str', default=None),
-      api_host = dict(required=True),
-      api_user = dict(required=True),
-      api_password = dict(no_log=True),
-      autostart = dict(type='bool', default='no'),
-      balloon = dict(type='int',default=0),
-      bios = dict(choices=['seabios', 'ovmf']),
-      boot = dict(type='str', default='cnd'),
-      bootdisk = dict(type='str'),
-      clone = dict(type='str', default=None),
-      cores = dict(type='int', default=1),
-      cpu = dict(type='str', default='kvm64'),
-      cpulimit = dict(type='int'),
-      cpuunits = dict(type='int', default=1000),
-      delete = dict(type='str', default=None),
-      description = dict(type='str'),
-      digest = dict(type='str'),
-      force = dict(type='bool', default=None),
-      format = dict(type='str', default='qcow2', choices=['cloop', 'cow', 'qcow', 'qcow2', 'qed', 'raw', 'vmdk' ]),
-      freeze = dict(type='bool'),
-      full = dict(type='bool', default='yes'),
-      hostpci = dict(type='dict'),
-      hotplug = dict(type='str'),
-      hugepages = dict(choices=['any', '2', '1024']),
-      ide = dict(type='dict', default=None),
-      keyboard = dict(type='str'),
-      kvm = dict(type='bool', default='yes'),
-      localtime = dict(type='bool'),
-      lock = dict(choices=['migrate', 'backup', 'snapshot', 'rollback']),
-      machine = dict(type='str'),
-      memory = dict(type='int', default=512),
-      migrate_downtime = dict(type='int'),
-      migrate_speed = dict(type='int'),
-      name = dict(type='str'),
-      net = dict(type='dict'),
-      newid = dict(type='int', default=None),
-      node = dict(),
-      numa = dict(type='dict'),
-      numa_enabled = dict(type='bool'),
-      onboot = dict(type='bool', default='yes'),
-      ostype = dict(default='l26', choices=['other', 'wxp', 'w2k', 'w2k3', 'w2k8', 'wvista', 'win7', 'win8', 'l24', 'l26', 'solaris']),
-      parallel = dict(type='dict'),
-      pool = dict(type='str'),
-      protection = dict(type='bool'),
-      reboot = dict(type='bool'),
-      revert = dict(type='str', default=None),
-      sata = dict(type='dict'),
-      scsi = dict(type='dict'),
-      scsihw = dict(choices=['lsi', 'lsi53c810', 'virtio-scsi-pci', 'virtio-scsi-single', 'megasas', 'pvscsi']),
-      serial = dict(type='dict'),
-      shares = dict(type='int'),
-      skiplock = dict(type='bool'),
-      smbios = dict(type='str'),
-      snapname = dict(type='str'),
-      sockets = dict(type='int', default=1),
-      startdate = dict(type='str'),
-      startup = dict(),
-      state = dict(default='present', choices=['present', 'absent', 'stopped', 'started', 'restarted', 'current']),
-      storage = dict(type='str'),
-      tablet = dict(type='bool', default='no'),
-      target = dict(type='str'),
-      tdf = dict(type='bool'),
-      template = dict(type='bool', default='no'),
-      timeout = dict(type='int', default=30),
-      update = dict(type='bool', default='no'),
-      validate_certs = dict(type='bool', default='no'),
-      vcpus = dict(type='int', default=None),
-      vga = dict(default='std', choices=['std', 'cirrus', 'vmware', 'qxl', 'serial0', 'serial1', 'serial2', 'serial3', 'qxl2', 'qxl3', 'qxl4']),
-      virtio = dict(type='dict', default=None),
-      vmid = dict(type='int', default=None),
-      watchdog = dict(),
-    ),
-    mutually_exclusive = [('delete', 'revert'), ('delete','update'), ('revert','update'), ('clone', 'update'), ('clone', 'delete'), ('clone','revert')],
-    required_one_of=[('name','vmid',)],
-    required_if=[('state', 'present', ['node'])]
-  )
+    module = AnsibleModule(
+        argument_spec = dict(
+            acpi = dict(type='bool', default='yes'),
+            agent = dict(type='bool'),
+            args = dict(type='str', default=None),
+            api_host = dict(required=True),
+            api_user = dict(required=True),
+            api_password = dict(no_log=True),
+            autostart = dict(type='bool', default='no'),
+            balloon = dict(type='int',default=0),
+            bios = dict(choices=['seabios', 'ovmf']),
+            boot = dict(type='str', default='cnd'),
+            bootdisk = dict(type='str'),
+            clone = dict(type='str', default=None),
+            cores = dict(type='int', default=1),
+            cpu = dict(type='str', default='kvm64'),
+            cpulimit = dict(type='int'),
+            cpuunits = dict(type='int', default=1000),
+            delete = dict(type='str', default=None),
+            description = dict(type='str'),
+            digest = dict(type='str'),
+            force = dict(type='bool', default=None),
+            format = dict(type='str', default='qcow2', choices=['cloop', 'cow', 'qcow', 'qcow2', 'qed', 'raw', 'vmdk' ]),
+            freeze = dict(type='bool'),
+            full = dict(type='bool', default='yes'),
+            hostpci = dict(type='dict'),
+            hotplug = dict(type='str'),
+            hugepages = dict(choices=['any', '2', '1024']),
+            ide = dict(type='dict', default=None),
+            keyboard = dict(type='str'),
+            kvm = dict(type='bool', default='yes'),
+            localtime = dict(type='bool'),
+            lock = dict(choices=['migrate', 'backup', 'snapshot', 'rollback']),
+            machine = dict(type='str'),
+            memory = dict(type='int', default=512),
+            migrate_downtime = dict(type='int'),
+            migrate_speed = dict(type='int'),
+            name = dict(type='str'),
+            net = dict(type='dict'),
+            newid = dict(type='int', default=None),
+            node = dict(),
+            numa = dict(type='dict'),
+            numa_enabled = dict(type='bool'),
+            onboot = dict(type='bool', default='yes'),
+            ostype = dict(default='l26', choices=['other', 'wxp', 'w2k', 'w2k3', 'w2k8', 'wvista', 'win7', 'win8', 'l24', 'l26', 'solaris']),
+            parallel = dict(type='dict'),
+            pool = dict(type='str'),
+            protection = dict(type='bool'),
+            reboot = dict(type='bool'),
+            revert = dict(type='str', default=None),
+            sata = dict(type='dict'),
+            scsi = dict(type='dict'),
+            scsihw = dict(choices=['lsi', 'lsi53c810', 'virtio-scsi-pci', 'virtio-scsi-single', 'megasas', 'pvscsi']),
+            serial = dict(type='dict'),
+            shares = dict(type='int'),
+            skiplock = dict(type='bool'),
+            smbios = dict(type='str'),
+            snapname = dict(type='str'),
+            sockets = dict(type='int', default=1),
+            startdate = dict(type='str'),
+            startup = dict(),
+            state = dict(default='present', choices=['present', 'absent', 'stopped', 'started', 'restarted', 'current']),
+            storage = dict(type='str'),
+            tablet = dict(type='bool', default='no'),
+            target = dict(type='str'),
+            tdf = dict(type='bool'),
+            template = dict(type='bool', default='no'),
+            timeout = dict(type='int', default=30),
+            update = dict(type='bool', default='no'),
+            validate_certs = dict(type='bool', default='no'),
+            vcpus = dict(type='int', default=None),
+            vga = dict(default='std', choices=['std', 'cirrus', 'vmware', 'qxl', 'serial0', 'serial1', 'serial2', 'serial3', 'qxl2', 'qxl3', 'qxl4']),
+            virtio = dict(type='dict', default=None),
+            vmid = dict(type='int', default=None),
+            watchdog = dict(),
+        ),
+        mutually_exclusive = [('delete', 'revert'), ('delete','update'), ('revert','update'), ('clone', 'update'), ('clone', 'delete'), ('clone','revert')],
+        required_one_of=[('name','vmid',)],
+        required_if=[('state', 'present', ['node'])]
+    )
 
-  if not HAS_PROXMOXER:
-    module.fail_json(msg='proxmoxer required for this module')
+    if not HAS_PROXMOXER:
+        module.fail_json(msg='proxmoxer required for this module')
 
-  api_user = module.params['api_user']
-  api_host = module.params['api_host']
-  api_password = module.params['api_password']
-  clone = module.params['clone']
-  cpu = module.params['cpu']
-  cores = module.params['cores']
-  delete = module.params['delete']
-  memory = module.params['memory']
-  name = module.params['name']
-  newid = module.params['newid']
-  node = module.params['node']
-  revert = module.params['revert']
-  sockets = module.params['sockets']
-  state = module.params['state']
-  timeout = module.params['timeout']
-  update = bool(module.params['update'])
-  vmid = module.params['vmid']
-  validate_certs = module.params['validate_certs']
+    api_user = module.params['api_user']
+    api_host = module.params['api_host']
+    api_password = module.params['api_password']
+    clone = module.params['clone']
+    cpu = module.params['cpu']
+    cores = module.params['cores']
+    delete = module.params['delete']
+    memory = module.params['memory']
+    name = module.params['name']
+    newid = module.params['newid']
+    node = module.params['node']
+    revert = module.params['revert']
+    sockets = module.params['sockets']
+    state = module.params['state']
+    timeout = module.params['timeout']
+    update = bool(module.params['update'])
+    vmid = module.params['vmid']
+    validate_certs = module.params['validate_certs']
 
-  # If password not set get it from PROXMOX_PASSWORD env
-  if not api_password:
+    # If password not set get it from PROXMOX_PASSWORD env
+    if not api_password:
+        try:
+            api_password = os.environ['PROXMOX_PASSWORD']
+        except KeyError as e:
+            module.fail_json(msg='You should set api_password param or use PROXMOX_PASSWORD environment variable')
+
     try:
-      api_password = os.environ['PROXMOX_PASSWORD']
-    except KeyError as e:
-      module.fail_json(msg='You should set api_password param or use PROXMOX_PASSWORD environment variable')
-
-  try:
-    proxmox = ProxmoxAPI(api_host, user=api_user, password=api_password, verify_ssl=validate_certs)
-    global VZ_TYPE
-    global PVE_MAJOR_VERSION
-    PVE_MAJOR_VERSION = 3 if float(proxmox.version.get()['version']) < 4.0 else 4
-  except Exception as e:
-    module.fail_json(msg='authorization on proxmox cluster failed with exception: %s' % e)
-
-  # If vmid not set get the Next VM id from ProxmoxAPI
-  # If vm name is set get the VM id from ProxmoxAPI
-  if not vmid:
-    if state == 'present' and ( not update and not clone) and (not delete and not revert):
-      try:
-        vmid = get_nextvmid(proxmox)
-      except Exception as e:
-        module.fail_json(msg="Can't get the next vimd for VM {} automatically. Ensure your cluster state is good".format(name))
-    else:
-      try:
-        if not clone:
-          vmid = get_vmid(proxmox, name)[0]
-        else:
-          vmid = get_vmid(proxmox, clone)[0]
-      except Exception as e:
-        if not clone:
-          module.fail_json(msg="VM {} does not exist in cluster.".format(name))
-        else:
-          module.fail_json(msg="VM {} does not exist in cluster.".format(clone))
-
-  if clone is not None:
-    if get_vmid(proxmox, name):
-      module.exit_json(changed=False, msg="VM with name <%s> already exists" % name)
-    if vmid is not None:
-      vm = get_vm(proxmox, vmid)
-      if not vm:
-        module.fail_json(msg='VM with vmid = %s does not exist in cluster' % vmid)
-    if not newid:
-      try:
-        newid = get_nextvmid(proxmox)
-      except Exception as e:
-        module.fail_json(msg="Can't get the next vimd for VM {} automatically. Ensure your cluster state is good".format(name))
-    else:
-      vm = get_vm(proxmox, newid)
-      if vm:
-        module.exit_json(changed=False, msg="vmid %s with VM name %s already exists" % (newid, name))
-
-  if delete is not None:
-    try:
-      settings(module, proxmox, vmid, node, name, timeout,
-                        delete = delete,)
-      module.exit_json(changed=True, msg="Settings has deleted on VM {} with vmid {}".format(name, vmid))
+        proxmox = ProxmoxAPI(api_host, user=api_user, password=api_password, verify_ssl=validate_certs)
+        global VZ_TYPE
+        global PVE_MAJOR_VERSION
+        PVE_MAJOR_VERSION = 3 if float(proxmox.version.get()['version']) < 4.0 else 4
     except Exception as e:
-      module.fail_json(msg='Unable to delete settings on VM {} with vimd {}: '.format(name, vmid) + str(e))
-  elif revert is not None:
-    try:
-      settings(module, proxmox, vmid, node, name, timeout,
-                    revert = revert,)
-      module.exit_json(changed=True, msg="Settings has reverted on VM {} with vmid {}".format(name, vmid))
-    except Exception as e:
-      module.fail_json(msg='Unable to revert settings on VM {} with vimd {}: Maybe is not a pending task...   '.format(name, vmid) + str(e))
+        module.fail_json(msg='authorization on proxmox cluster failed with exception: %s' % e)
 
-  if state == 'present':
-    try:
-      if get_vm(proxmox, vmid) and not (update or clone):
-        module.exit_json(changed=False, msg="VM with vmid <%s> already exists" % vmid)
-      elif get_vmid(proxmox, name) and not (update or clone):
-        module.exit_json(changed=False, msg="VM with name <%s> already exists" % name)
-      elif not (node, name):
-        module.fail_json(msg='node, name is mandatory for creating/updating vm')
-      elif not node_check(proxmox, node):
-        module.fail_json(msg="node '%s' does not exist in cluster" % node)
+    # If vmid not set get the Next VM id from ProxmoxAPI
+    # If vm name is set get the VM id from ProxmoxAPI
+    if not vmid:
+        if state == 'present' and ( not update and not clone) and (not delete and not revert):
+            try:
+                vmid = get_nextvmid(proxmox)
+            except Exception as e:
+                module.fail_json(msg="Can't get the next vimd for VM {} automatically. Ensure your cluster state is good".format(name))
+        else:
+            try:
+                if not clone:
+                    vmid = get_vmid(proxmox, name)[0]
+                else:
+                    vmid = get_vmid(proxmox, clone)[0]
+            except Exception as e:
+                if not clone:
+                    module.fail_json(msg="VM {} does not exist in cluster.".format(name))
+                else:
+                    module.fail_json(msg="VM {} does not exist in cluster.".format(clone))
 
-      create_vm(module, proxmox, vmid, newid, node, name, memory, cpu, cores, sockets, timeout, update,
+    if clone is not None:
+        if get_vmid(proxmox, name):
+            module.exit_json(changed=False, msg="VM with name <%s> already exists" % name)
+        if vmid is not None:
+            vm = get_vm(proxmox, vmid)
+            if not vm:
+                module.fail_json(msg='VM with vmid = %s does not exist in cluster' % vmid)
+        if not newid:
+            try:
+                newid = get_nextvmid(proxmox)
+            except Exception as e:
+                module.fail_json(msg="Can't get the next vimd for VM {} automatically. Ensure your cluster state is good".format(name))
+        else:
+            vm = get_vm(proxmox, newid)
+            if vm:
+                module.exit_json(changed=False, msg="vmid %s with VM name %s already exists" % (newid, name))
+
+    if delete is not None:
+        try:
+            settings(module, proxmox, vmid, node, name, timeout, delete=delete)
+            module.exit_json(changed=True, msg="Settings has deleted on VM {} with vmid {}".format(name, vmid))
+        except Exception as e:
+            module.fail_json(msg='Unable to delete settings on VM {} with vimd {}: '.format(name, vmid) + str(e))
+    elif revert is not None:
+        try:
+            settings(module, proxmox, vmid, node, name, timeout, revert=revert)
+            module.exit_json(changed=True, msg="Settings has reverted on VM {} with vmid {}".format(name, vmid))
+        except Exception as e:
+            module.fail_json(msg='Unable to revert settings on VM {} with vimd {}: Maybe is not a pending task...   '.format(name, vmid) + str(e))
+
+    if state == 'present':
+        try:
+            if get_vm(proxmox, vmid) and not (update or clone):
+                module.exit_json(changed=False, msg="VM with vmid <%s> already exists" % vmid)
+            elif get_vmid(proxmox, name) and not (update or clone):
+                module.exit_json(changed=False, msg="VM with name <%s> already exists" % name)
+            elif not (node, name):
+                module.fail_json(msg='node, name is mandatory for creating/updating vm')
+            elif not node_check(proxmox, node):
+                module.fail_json(msg="node '%s' does not exist in cluster" % node)
+
+            create_vm(module, proxmox, vmid, newid, node, name, memory, cpu, cores, sockets, timeout, update,
                       acpi = module.params['acpi'],
                       agent = module.params['agent'],
                       autostart = module.params['autostart'],
@@ -1130,103 +1135,104 @@ def main():
                       virtio = module.params['virtio'],
                       watchdog = module.params['watchdog'])
 
-      if not clone:
-          get_vminfo(module, proxmox, node, vmid,
-              ide = module.params['ide'],
-              net = module.params['net'],
-              sata = module.params['sata'],
-              scsi = module.params['scsi'],
-              virtio = module.params['virtio'])
-      if update:
-        module.exit_json(changed=True, msg="VM %s with vmid %s updated" % (name, vmid))
-      elif clone is not None:
-        module.exit_json(changed=True, msg="VM %s with newid %s cloned from vm with vmid %s" % (name, newid, vmid))
-      else:
-        module.exit_json(changed=True, msg="VM %s with vmid %s deployed" % (name, vmid), **results)
-    except Exception as e:
-      if update:
-        module.fail_json(msg="Unable to update vm {} with vimd {}=".format(name, vmid) + str(e))
-      elif clone is not None:
-        module.fail_json(msg="Unable to clone vm {} from vimd {}=".format(name, vmid) + str(e))
-      else:
-        module.fail_json(msg="creation of %s VM %s with vmid %s failed with exception=%s" % ( VZ_TYPE, name, vmid, e ))
+            if not clone:
+                get_vminfo(module, proxmox, node, vmid,
+                    ide = module.params['ide'],
+                    net = module.params['net'],
+                    sata = module.params['sata'],
+                    scsi = module.params['scsi'],
+                    virtio = module.params['virtio'])
+            if update:
+                module.exit_json(changed=True, msg="VM %s with vmid %s updated" % (name, vmid))
+            elif clone is not None:
+                module.exit_json(changed=True, msg="VM %s with newid %s cloned from vm with vmid %s" % (name, newid, vmid))
+            else:
+                module.exit_json(changed=True, msg="VM %s with vmid %s deployed" % (name, vmid), **results)
+        except Exception as e:
+            if update:
+                module.fail_json(msg="Unable to update vm {} with vimd {}=".format(name, vmid) + str(e))
+            elif clone is not None:
+                module.fail_json(msg="Unable to clone vm {} from vimd {}=".format(name, vmid) + str(e))
+            else:
+                module.fail_json(msg="creation of %s VM %s with vmid %s failed with exception=%s" % (VZ_TYPE, name, vmid, e))
 
-  elif state == 'started':
-    try:
-      vm = get_vm(proxmox, vmid)
-      if not vm:
-        module.fail_json(msg='VM with vmid <%s> does not exist in cluster' % vmid)
-      if getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.current.get()['status'] == 'running':
-        module.exit_json(changed=False, msg="VM %s is already running" % vmid)
+    elif state == 'started':
+        try:
+            vm = get_vm(proxmox, vmid)
+            if not vm:
+                module.fail_json(msg='VM with vmid <%s> does not exist in cluster' % vmid)
+            if getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.current.get()['status'] == 'running':
+                module.exit_json(changed=False, msg="VM %s is already running" % vmid)
 
-      if start_vm(module, proxmox, vm, vmid, timeout):
-        module.exit_json(changed=True, msg="VM %s started" % vmid)
-    except Exception as e:
-      module.fail_json(msg="starting of VM %s failed with exception: %s" % ( vmid, e ))
+            if start_vm(module, proxmox, vm, vmid, timeout):
+                module.exit_json(changed=True, msg="VM %s started" % vmid)
+        except Exception as e:
+            module.fail_json(msg="starting of VM %s failed with exception: %s" % (vmid, e))
 
-  elif state == 'stopped':
-    try:
-      vm = get_vm(proxmox, vmid)
-      if not vm:
-        module.fail_json(msg='VM with vmid = %s does not exist in cluster' % vmid)
+    elif state == 'stopped':
+        try:
+            vm = get_vm(proxmox, vmid)
+            if not vm:
+                module.fail_json(msg='VM with vmid = %s does not exist in cluster' % vmid)
 
-      if getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.current.get()['status'] == 'stopped':
-        module.exit_json(changed=False, msg="VM %s is already stopped" % vmid)
+            if getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.current.get()['status'] == 'stopped':
+                module.exit_json(changed=False, msg="VM %s is already stopped" % vmid)
 
-      if stop_vm(module, proxmox, vm, vmid, timeout, force = module.params['force']):
-        module.exit_json(changed=True, msg="VM %s is shutting down" % vmid)
-    except Exception as e:
-      module.fail_json(msg="stopping of VM %s failed with exception: %s" % ( vmid, e ))
+            if stop_vm(module, proxmox, vm, vmid, timeout, force = module.params['force']):
+                module.exit_json(changed=True, msg="VM %s is shutting down" % vmid)
+        except Exception as e:
+            module.fail_json(msg="stopping of VM %s failed with exception: %s" % (vmid, e))
 
-  elif state == 'restarted':
-    try:
-      vm = get_vm(proxmox, vmid)
-      if not vm:
-        module.fail_json(msg='VM with vmid = %s does not exist in cluster' % vmid)
-      if getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.current.get()['status'] == 'stopped':
-        module.exit_json(changed=False, msg="VM %s is not running" % vmid)
+    elif state == 'restarted':
+        try:
+            vm = get_vm(proxmox, vmid)
+            if not vm:
+                module.fail_json(msg='VM with vmid = %s does not exist in cluster' % vmid)
+            if getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.current.get()['status'] == 'stopped':
+                module.exit_json(changed=False, msg="VM %s is not running" % vmid)
 
-      if ( stop_vm(module, proxmox, vm, vmid, timeout, force = module.params['force']) and
-          start_vm(module, proxmox, vm, vmid, timeout) ):
-        module.exit_json(changed=True, msg="VM %s is restarted" % vmid)
-    except Exception as e:
-      module.fail_json(msg="restarting of VM %s failed with exception: %s" % ( vmid, e ))
+            if (stop_vm(module, proxmox, vm, vmid, timeout, force = module.params['force'])
+                    and start_vm(module, proxmox, vm, vmid, timeout)):
+                module.exit_json(changed=True, msg="VM %s is restarted" % vmid)
+        except Exception as e:
+            module.fail_json(msg="restarting of VM %s failed with exception: %s" % ( vmid, e ))
 
-  elif state == 'absent':
-    try:
-      vm = get_vm(proxmox, vmid)
-      if not vm:
-        module.exit_json(changed=False, msg="VM %s does not exist" % vmid)
+    elif state == 'absent':
+        try:
+            vm = get_vm(proxmox, vmid)
+            if not vm:
+                module.exit_json(changed=False, msg="VM %s does not exist" % vmid)
 
-      if getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.current.get()['status'] == 'running':
-        module.exit_json(changed=False, msg="VM %s is running. Stop it before deletion." % vmid)
+            if getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.current.get()['status'] == 'running':
+                module.exit_json(changed=False, msg="VM %s is running. Stop it before deletion." % vmid)
 
-      taskid = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE).delete(vmid)
-      while timeout:
-        if ( proxmox.nodes(vm[0]['node']).tasks(taskid).status.get()['status'] == 'stopped'
-            and proxmox.nodes(vm[0]['node']).tasks(taskid).status.get()['exitstatus'] == 'OK' ):
-          module.exit_json(changed=True, msg="VM %s removed" % vmid)
-        timeout = timeout - 1
-        if timeout == 0:
-          module.fail_json(msg='Reached timeout while waiting for removing VM. Last line in task before timeout: %s'
-                           % proxmox_node.tasks(taskid).log.get()[:1])
+            taskid = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE).delete(vmid)
+            while timeout:
+                if (proxmox.nodes(vm[0]['node']).tasks(taskid).status.get()['status'] == 'stopped'
+                    and proxmox.nodes(vm[0]['node']).tasks(taskid).status.get()['exitstatus'] == 'OK' ):
+                    module.exit_json(changed=True, msg="VM %s removed" % vmid)
+                timeout = timeout - 1
+                if timeout == 0:
+                    module.fail_json(msg='Reached timeout while waiting for removing VM. Last line in task before timeout: %s'
+                                     % proxmox_node.tasks(taskid).log.get()[:1])
 
-        time.sleep(1)
-    except Exception as e:
-      module.fail_json(msg="deletion of VM %s failed with exception: %s" % ( vmid, e ))
+                time.sleep(1)
+        except Exception as e:
+            module.fail_json(msg="deletion of VM %s failed with exception: %s" % (vmid, e))
 
-  elif state == 'current':
-    status = {}
-    try:
-      vm = get_vm(proxmox, vmid)
-      if not vm:
-        module.fail_json(msg='VM with vmid = %s does not exist in cluster' % vmid)
-      current = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.current.get()['status']
-      status['status'] = current
-      if status:
-         module.exit_json(changed=False, msg="VM %s with vmid = %s is %s" % (name, vmid, current), **status)
-    except Exception as e:
-      module.fail_json(msg="Unable to get vm {} with vmid = {} status: ".format(name, vmid) + str(e))
+    elif state == 'current':
+        status = {}
+        try:
+            vm = get_vm(proxmox, vmid)
+            if not vm:
+                module.fail_json(msg='VM with vmid = %s does not exist in cluster' % vmid)
+            current = getattr(proxmox.nodes(vm[0]['node']), VZ_TYPE)(vmid).status.current.get()['status']
+            status['status'] = current
+            if status:
+                module.exit_json(changed=False, msg="VM %s with vmid = %s is %s" % (name, vmid, current), **status)
+        except Exception as e:
+            module.fail_json(msg="Unable to get vm {} with vmid = {} status: ".format(name, vmid) + str(e))
+
 
 # import module snippets
 from ansible.module_utils.basic import *

--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -19,7 +19,7 @@ along with this software.  If not, see <http://www.gnu.org/licenses/>.
 
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
-                    'version': '1.1'}
+                    'version': '1.0'}
 
 DOCUMENTATION = '''
 ---
@@ -36,21 +36,18 @@ options:
     required: false
     default: "yes"
     choices: [ "yes", "no" ]
-    type: boolean
   agent:
     description:
       - Specify if the QEMU GuestAgent should be enabled/disabled.
     required: false
     default: null
     choices: [ "yes", "no" ]
-    type: boolean
   args:
     description:
       - Pass arbitrary arguments to kvm.
       - This option is for experts only!
     default: "-serial unix:/var/run/qemu-server/VMID.serial,server,nowait"
     required: false
-    type: string
   api_host:
     description:
       - Specify the target host of the Proxmox VE cluster.
@@ -71,86 +68,73 @@ options:
     required: false
     default: "no"
     choices: [ "yes", "no" ]
-    type: boolean
   balloon:
     description:
       - Specify the amount of RAM for the VM in MB.
       - Using zero disables the balloon driver.
     required: false
     default: 0
-    type: integer
   bios:
     description:
       - Specify the BIOS implementation.
     choices: ['seabios', 'ovmf']
     required: false
     default: null
-    type: string
   boot:
     description:
       - Specify the boot order -> boot on floppy C(a), hard disk C(c), CD-ROM C(d), or network C(n).
       - You can combine to set order.
     required: false
     default: cnd
-    type: string
   bootdisk:
     description:
       - Enable booting from specified disk. C((ide|sata|scsi|virtio)\d+)
     required: false
     default: null
-    type: string
   clone:
     description:
       - Name of VM to be cloned. If C(vmid) is setted, C(clone) can take arbitrary value but required for intiating the clone.
     required: false
     default: null
-    type: string
   cores:
     description:
       - Specify number of cores per socket.
     required: false
     default: 1
-    type: integer
   cpu:
     description:
       - Specify emulated CPU type.
     required: false
     default: kvm64
-    type: string
   cpulimit:
     description:
       - Specify if CPU usage will be limited. Value 0 indicates no CPU limit.
       - If the computer has 2 CPUs, it has total of '2' CPU time
     required: false
     default: null
-    type: integer
   cpuunits:
     description:
       - Specify CPU weight for a VM.
       - You can disable fair-scheduler configuration by setting this to 0
     default: 1000
     required: false
-    type: integer
   delete:
     description:
       - Specify a list of settings you want to delete.
     required: false
     default: null
-    type: string
   description:
     description:
       - Specify the description for the VM. Only used on the configuration web interface.
       - This is saved as comment inside the configuration file.
     required: false
     default: null
-    type: string
   digest:
     description:
       - Specify if to prevent changes if current configuration file has different SHA1 digest.
       - This can be used to prevent concurrent modifications.
     required: false
     default: null
-    type: string
   force:
     description:
       - Allow to force stop VM.
@@ -158,7 +142,6 @@ options:
     default: null
     choices: [ "yes", "no" ]
     required: false
-    type: boolean
   format:
     description:
       - Target drive’s backing file’s data format.
@@ -166,14 +149,12 @@ options:
     default: qcow2
     choices: [ "cloop", "cow", "qcow", "qcow2", "qed", "raw", "vmdk" ]
     required: false
-    type: string
   freeze:
     description:
       - Specify if PVE should freeze CPU at startup (use 'c' monitor command to start execution).
     required: false
     default: null
     choices: [ "yes", "no" ]
-    type: boolean
   full:
     description:
       - Create a full copy of all disk. This is always done when you clone a normal VM.
@@ -182,7 +163,6 @@ options:
     default: yes
     choices: [ "yes", "no"]
     required: false
-    type: boolean
   hostpci:
     description:
       - Specify a hash/dictionary of map host pci devices into guest. C(hostpci='{"key":"value", "key":"value"}').
@@ -195,7 +175,6 @@ options:
       - /!\ This option allows direct access to host hardware. So it is no longer possible to migrate such machines - use with special care.
     required: false
     default: null
-    type: A hash/dictionary defining host pci devices
   hotplug:
     description:
       - Selectively enable hotplug features.
@@ -203,14 +182,12 @@ options:
       - Value 0 disables hotplug completely and value 1 is an alias for the default C('network,disk,usb').
     required: false
     default: null
-    type: string
   hugepages:
     description:
       - Enable/disable hugepages memory.
     choices: ['any', '2', '1024']
     required: false
     default: null
-    type: string
   ide:
     description:
       - A hash/dictionary of volume used as IDE hard disk or CD-ROM. C(ide='{"key":"value", "key":"value"}').
@@ -221,20 +198,17 @@ options:
       - C(format) is the drive’s backing file’s data format. C(qcow2|raw|subvol).
     required: false
     default: null
-    type: A hash/dictionary defining ide
   keyboard:
     description:
       - Sets the keyboard layout for VNC server.
     required: false
     default: null
-    type: string
   kvm:
     description:
       - Enable/disable KVM hardware virtualization.
     required: false
     default: "yes"
     choices: [ "yes", "no" ]
-    type: boolean
   localtime:
     description:
       - Sets the real time clock to local time.
@@ -242,40 +216,34 @@ options:
     required: false
     default: null
     choices: [ "yes", "no" ]
-    type: boolean
   lock:
     description:
       - Lock/unlock the VM.
     choices: ['migrate', 'backup', 'snapshot', 'rollback']
     required: false
     default: null
-    type: string
   machine:
     description:
       - Specifies the Qemu machine type.
       - type => C((pc|pc(-i440fx)?-\d+\.\d+(\.pxe)?|q35|pc-q35-\d+\.\d+(\.pxe)?))
     required: false
     default: null
-    type: string
   memory:
     description:
       - Memory size in MB for instance.
     required: false
     default: 512
-    type: integer
   migrate_downtime:
     description:
       - Sets maximum tolerated downtime (in seconds) for migrations.
     required: false
     default: null
-    type: integer
   migrate_speed:
     description:
       - Sets maximum speed (in MB/s) for migrations.
       - A value of 0 is no limit.
     required: false
     default: null
-    type: integer
   name:
     description:
       - Specifies the VM name. Only used on the configuration web interface.
@@ -294,14 +262,12 @@ options:
       - If you specify no bridge, we create a kvm 'user' (NATed) network device, which provides DHCP and DNS services.
     default: null
     required: false
-    type: A hash/dictionary defining interfaces
   newid:
     description:
       - VMID for the clone. Used only with clone.
       - If newid is not set, the next available VM ID will be fetched from ProxmoxAPI.
     default: null
     required: false
-    type: integer
   node:
     description:
       - Proxmox VE node, where the new VM will be created.
@@ -320,14 +286,12 @@ options:
       - C(policy) NUMA allocation policy.
     default: null
     required: false
-    type: A hash/dictionary defining NUMA topology
   onboot:
     description:
       - Specifies whether a VM will be started during system bootup.
     default: "yes"
     choices: [ "yes", "no" ]
     required: false
-    type: boolean
   ostype:
     description:
       - Specifies guest operating system. This is used to enable special optimization/features for specific operating systems.
@@ -335,7 +299,6 @@ options:
     choices: ['other', 'wxp', 'w2k', 'w2k3', 'w2k8', 'wvista', 'win7', 'win8', 'l24', 'l26', 'solaris']
     default: l26
     required: false
-    type: string
   parallel:
     description:
       - A hash/dictionary of map host parallel devices. C(parallel='{"key":"value", "key":"value"}').
@@ -343,33 +306,28 @@ options:
       - Values allowed are - C("/dev/parport\d+|/dev/usb/lp\d+").
     default: null
     required: false
-    type: A hash/dictionary defining host parallel devices
   pool:
     description:
       - Add the new VM to the specified pool.
     default: null
     required: false
-    type: string
   protection:
     description:
       - Enable/disable the protection flag of the VM. This will enable/disable the remove VM and remove disk operations.
     default: null
     choices: [ "yes", "no" ]
     required: false
-    type: boolean
   reboot:
     description:
       - Allow reboot. If set to yes, the VM exit on reboot.
     default: null
     choices: [ "yes", "no" ]
     required: false
-    type: boolean
   revert:
     description:
       - Revert a pending change.
     default: null
     required: false
-    type: string
   sata:
     description:
       - A hash/dictionary of volume used as sata hard disk or CD-ROM. C(sata='{"key":"value", "key":"value"}').
@@ -380,7 +338,6 @@ options:
       - C(format) is the drive’s backing file’s data format. C(qcow2|raw|subvol).
     default: null
     required: false
-    type: A hash/dictionary defining sata
   scsi:
     description:
       - A hash/dictionary of volume used as SCSI hard disk or CD-ROM. C(scsi='{"key":"value", "key":"value"}').
@@ -391,14 +348,12 @@ options:
       - C(format) is the drive’s backing file’s data format. C(qcow2|raw|subvol).
     default: null
     required: false
-    type: A hash/dictionary defining scsi
   scsihw:
     description:
       - Specifies the SCSI controller model.
     choices: ['lsi', 'lsi53c810', 'virtio-scsi-pci', 'virtio-scsi-single', 'megasas', 'pvscsi']
     required: false
     default: null
-    type: string
   serial:
     description:
       - A hash/dictionary of serial device to create inside the VM. C('{"key":"value", "key":"value"}').
@@ -407,7 +362,6 @@ options:
       - /!\ If you pass through a host serial device, it is no longer possible to migrate such machines - use with special care.
     default: null
     required: false
-    type: A hash/dictionary defining serial
   shares:
     description:
       - Rets amount of memory shares for auto-ballooning. (0 - 50000).
@@ -416,40 +370,33 @@ options:
       - Using 0 disables auto-ballooning, this means no limit.
     required: false
     default: null
-    type: integer
   skiplock:
     description:
       - Ignore locks
       - Only root is allowed to use this option.
     required: false
     default: null
-    choices: [ "yes", "no" ]
-    type: boolean
   smbios:
     description:
       - Specifies SMBIOS type 1 fields.
     required: false
     default: null
-    type: string
   snapname:
     description:
       - The name of the snapshot. Used only with clone.
     default: null
     required: false
-    type: string
   sockets:
     description:
       - Sets the number of CPU sockets. (1 - N).
     required: false
     default: 1
-    type: integer
   startdate:
     description:
       - Sets the initial date of the real time clock.
       - Valid format for date are C('now') or C('2016-09-25T16:01:21') or C('2016-09-25').
     required: false
     default: null
-    type: string
   startup:
     description:
       - Startup and shutdown behavior. C([[order=]\d+] [,up=\d+] [,down=\d+]).
@@ -457,7 +404,6 @@ options:
       - Shutdown in done with reverse ordering.
     required: false
     default: null
-    type: string
   state:
     description:
       - Indicates desired state of the instance.
@@ -470,41 +416,35 @@ options:
       - Target storage for full clone.
     default: null
     required: false
-    type: string
   tablet:
     description:
       - Enables/disables the USB tablet device.
     required: false
     choices: [ "yes", "no" ]
     default: "no"
-    type: boolean
   target:
     description:
       - Target node. Only allowed if the original VM is on shared storage.
       - Used only with clone
     default: null
     required: false
-    type: string
   tdf:
     description:
       - Enables/disables time drift fix.
     required: false
     default: null
     choices: [ "yes", "no" ]
-    type: boolean
   template:
     description:
       - Enables/disables the template.
     required: false
     default: "no"
     choices: [ "yes", "no" ]
-    type: boolean
   timeout:
     description:
       - Timeout for operations.
     default: 30
     required: false
-    type: integer
   update:
     description:
       - If C(yes), the VM will be update with new value.
@@ -513,20 +453,17 @@ options:
     default: "no"
     choices: [ "yes", "no" ]
     required: false
-    type: boolean
   validate_certs:
     description:
       - If C(no), SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
     default: "no"
     choices: [ "yes", "no" ]
     required: false
-    type: boolean
   vcpus:
     description:
       - Sets number of hotplugged vcpus.
     required: false
     default: null
-    type: integer
   vga:
     description:
       - Select VGA type. If you want to use high resolution modes (>= 1280x1024x16) then you should use option 'std' or 'vmware'.
@@ -543,20 +480,17 @@ options:
       - C(format) is the drive’s backing file’s data format. C(qcow2|raw|subvol).
     required: false
     default: null
-    type: A hash/dictionary defining virtio
   vmid:
     description:
       - Specifies the VM ID. Instead use I(name) parameter.
       - If vmid is not set, the next available VM ID will be fetched from ProxmoxAPI.
     default: null
     required: false
-    type: integer
   watchdog:
     description:
       - Creates a virtual hardware watchdog device.
     required: false
     default: null
-    type: string
 Notes:
   - Requires proxmoxer and requests modules on host. This modules can be installed with pip.
 requirements: [ "proxmoxer", "requests" ]
@@ -1037,7 +971,10 @@ def main():
       virtio = dict(type='dict', default=None),
       vmid = dict(type='int', default=None),
       watchdog = dict(),
-    )
+    ),
+    mutually_exclusive = [('delete', 'revert'), ('delete','update'), ('revert','update'), ('clone', 'update'), ('clone', 'delete'), ('clone','revert')],
+    required_one_of=[('name','vmid',)],
+    required_if=[('state', 'present', ['node'])]
   )
 
   if not HAS_PROXMOXER:
@@ -1046,16 +983,20 @@ def main():
   api_user = module.params['api_user']
   api_host = module.params['api_host']
   api_password = module.params['api_password']
+  clone = module.params['clone']
   cpu = module.params['cpu']
   cores = module.params['cores']
+  delete = module.params['delete']
   memory = module.params['memory']
   name = module.params['name']
   newid = module.params['newid']
   node = module.params['node']
+  revert = module.params['revert']
   sockets = module.params['sockets']
   state = module.params['state']
   timeout = module.params['timeout']
   update = bool(module.params['update'])
+  vmid = module.params['vmid']
   validate_certs = module.params['validate_certs']
 
   # If password not set get it from PROXMOX_PASSWORD env
@@ -1075,62 +1016,63 @@ def main():
 
   # If vmid not set get the Next VM id from ProxmoxAPI
   # If vm name is set get the VM id from ProxmoxAPI
-  if module.params['delete'] is not None and module.params['revert'] is not None:
-     module.fail_json(msg='delete and revert parameters is mutually exclusive')
-
-  if module.params['delete'] is not None or module.params['revert'] is not None:
-    if module.params['vmid'] is not None:
-      vmid = module.params['vmid']
-    elif module.params['name'] is not None:
+  if not vmid:
+    if state == 'present' and ( not update and not clone) and (not delete and not revert):
       try:
-        vmid = get_vmid(proxmox, name)[0]
+        vmid = get_nextvmid(proxmox)
       except Exception as e:
-        module.fail_json(msg="VM {} is not present on the cluster. Note: <Update: Yes> is mutually exclusive with a vm not created".format(name))
-    if module.params['delete'] is not None:
-       try:
-         settings(module, proxmox, vmid, node, name, timeout,
-                              delete = module.params['delete'],)
-         module.exit_json(changed=True, msg="Settings has deleted on VM {} with vmid {}".format(name, vmid))
-       except Exception as e:
-         module.fail_json(msg='Unable to delete settings on vm {} with vimd {}: '.format(name, vmid) + str(e))
-    elif module.params['revert'] is not None:
-       try:
-         settings(module, proxmox, vmid, node, name, timeout,
-                              revert = module.params['revert'],)
-         module.exit_json(changed=True, msg="Settings has reverted on VM {} with vmid {}".format(name, vmid))
-       except Exception as e:
-         module.fail_json(msg='Unable to revert settings on vm {} with vimd {}: Maybe is not a pending task...   '.format(name, vmid) + str(e))
-
-  if not module.params['clone']:
-    if module.params['vmid'] is not None:
-      vmid = module.params['vmid']
-    elif state == 'present' and not update:
-      vmid = get_nextvmid(proxmox)
-    elif module.params['name'] is not None:
-      try:
-        vmid = get_vmid(proxmox, name)[0]
-      except Exception as e:
-        module.fail_json(msg="VM {} is not present on the cluster. Note: <Update: Yes> is mutually exclusive with a vm not created".format(name))
-  elif module.params['clone'] is not None:
-    if module.params['vmid'] is not None:
-      vmid = module.params['vmid']
+        module.fail_json(msg="Can't get the next vimd for VM {} automatically. Ensure your cluster state is good".format(name))
     else:
       try:
-        vmid = get_vmid(proxmox, module.params['clone'])[0]
+        if not clone:
+          vmid = get_vmid(proxmox, name)[0]
+        else:
+          vmid = get_vmid(proxmox, clone)[0]
       except Exception as e:
-        module.fail_json(msg="VM {} is not present on the cluster.".format(name))
-    if module.params['newid'] is not None:
-      newid = module.params['newid']
+        if not clone:
+          module.fail_json(msg="VM {} does not exist in cluster.".format(name))
+        else:
+          module.fail_json(msg="VM {} does not exist in cluster.".format(clone))
+
+  if clone is not None:
+    if get_vmid(proxmox, name):
+      module.exit_json(changed=False, msg="VM with name <%s> already exists" % name)
+    if vmid is not None:
+      vm = get_vm(proxmox, vmid)
+      if not vm:
+        module.fail_json(msg='VM with vmid = %s does not exist in cluster' % vmid)
+    if not newid:
+      try:
+        newid = get_nextvmid(proxmox)
+      except Exception as e:
+        module.fail_json(msg="Can't get the next vimd for VM {} automatically. Ensure your cluster state is good".format(name))
     else:
-      newid = get_nextvmid(proxmox)
+      vm = get_vm(proxmox, newid)
+      if vm:
+        module.exit_json(changed=False, msg="vmid %s with VM name %s already exists" % (newid, name))
+
+  if delete is not None:
+    try:
+      settings(module, proxmox, vmid, node, name, timeout,
+                        delete = delete,)
+      module.exit_json(changed=True, msg="Settings has deleted on VM {} with vmid {}".format(name, vmid))
+    except Exception as e:
+      module.fail_json(msg='Unable to delete settings on VM {} with vimd {}: '.format(name, vmid) + str(e))
+  elif revert is not None:
+    try:
+      settings(module, proxmox, vmid, node, name, timeout,
+                    revert = revert,)
+      module.exit_json(changed=True, msg="Settings has reverted on VM {} with vmid {}".format(name, vmid))
+    except Exception as e:
+      module.fail_json(msg='Unable to revert settings on VM {} with vimd {}: Maybe is not a pending task...   '.format(name, vmid) + str(e))
 
   if state == 'present':
     try:
-      if get_vm(proxmox, vmid) and not (update or module.params['clone']):
+      if get_vm(proxmox, vmid) and not (update or clone):
         module.exit_json(changed=False, msg="VM with vmid <%s> already exists" % vmid)
-      elif get_vmid(proxmox, name) and not (update or module.params['clone']):
+      elif get_vmid(proxmox, name) and not (update or clone):
         module.exit_json(changed=False, msg="VM with name <%s> already exists" % name)
-      elif not (node, module.params['name']):
+      elif not (node, name):
         module.fail_json(msg='node, name is mandatory for creating/updating vm')
       elif not node_check(proxmox, node):
         module.fail_json(msg="node '%s' does not exist in cluster" % node)
@@ -1188,7 +1130,7 @@ def main():
                       virtio = module.params['virtio'],
                       watchdog = module.params['watchdog'])
 
-      if not module.params['clone']:
+      if not clone:
           get_vminfo(module, proxmox, node, vmid,
               ide = module.params['ide'],
               net = module.params['net'],
@@ -1197,14 +1139,14 @@ def main():
               virtio = module.params['virtio'])
       if update:
         module.exit_json(changed=True, msg="VM %s with vmid %s updated" % (name, vmid))
-      elif module.params['clone'] is not None:
+      elif clone is not None:
         module.exit_json(changed=True, msg="VM %s with newid %s cloned from vm with vmid %s" % (name, newid, vmid))
       else:
         module.exit_json(changed=True, msg="VM %s with vmid %s deployed" % (name, vmid), **results)
     except Exception as e:
       if update:
         module.fail_json(msg="Unable to update vm {} with vimd {}=".format(name, vmid) + str(e))
-      elif module.params['clone'] is not None:
+      elif clone is not None:
         module.fail_json(msg="Unable to clone vm {} from vimd {}=".format(name, vmid) + str(e))
       else:
         module.fail_json(msg="creation of %s VM %s with vmid %s failed with exception=%s" % ( VZ_TYPE, name, vmid, e ))


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/cloud/misc/proxmox_kvm.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```yaml
ansible --version
ansible 2.2.0.0
  config file = /usr/local/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #21056
Add new feature
  - Clone

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```yaml
---
- hosts: orchestrator
  remote_user: root
  gather_facts: False
  vars:
    instance:
      - name: spynal
        proxmox:
          api_host  : labhyp.helldorado.info
          node      : labhyp1
          cores     : 2
          vcpus     : 1
          net       : '{"net0":"virtio,bridge=vmbr0"}'
          virtio    : '{"virtio0":"VMs:50,format=qcow2"}'
```

```yaml
- name: CLONE
  local_action:
    module: proxmox_kvm
    api_user     : "{{ item.proxmox.api_user|default('root@pam') }}"
    api_password : "{{ item.proxmox.api_password|default(omit) }}"
    api_host     : "{{ item.proxmox.api_host }}"
    node         : "{{ item.proxmox.node }}"
    name         :  "{{ item.name }}"
    clone        : zavala
    storage      : 'VMs'
    timeout      : 300
  with_items: "{{ instance }}"
```

> ℹ️  Some output has truncated

```yaml
ansible@spynal-orchestrator:/usr/local/ansible/orchestrator (master)$ ansible-playbook playbooks/servers.yml -vvvv
PLAYBOOK: servers.yml **********************************************************
1 plays in playbooks/servers.yml

PLAY [orchestrator] ************************************************************

TASK [deploy : Include virtual] ************************************************
task path: /usr/local/ansible/orchestrator/roles/deploy/tasks/main.yml:4
included: /usr/local/ansible/orchestrator/roles/deploy/tasks/virtual.yml for spynal-orchestrator

TASK [deploy : CLONE] **********************************************************
task path: /usr/local/ansible/orchestrator/roles/deploy/tasks/virtual.yml:32
Using module file /usr/local/ansible/orchestrator/roles/deploy/library/proxmox_kvm.py
changed: [spynal-orchestrator -> localhost] => (item={{
        },
        "module_name": "proxmox_kvm"
    },
    "item": {
        "cores" : 2,
        "delete": "cpuunits",
        "name": "spynal",
        "net": "{\"net0\":\"virtio,bridge=vmbr0\"}",
        "proxmox": {
            "api_host": "labhyp.helldorado.info",
            "node": "labhyp1"
        },
        "vcpus": 1,
        "virtio": "{\"virtio0\":\"VMs:50,format=qcow2\"}"
    },
    "msg": "VM spynal with newid 136 cloned from vm with vmid 108"
}

PLAY RECAP *********************************************************************
spynal-orchestrator        : ok=2    changed=1    unreachable=0    failed=0
```

Issue #21056

##### Update/Delete/Revert VM parameters

###### Update
```yaml
---
- hosts: orchestrator
  remote_user: root
  gather_facts: False
  vars:
    instance:
      - name: spynal
        proxmox:
          api_host : labhyp.helldorado.info
          node     : labhyp1
          cores    : 4
          vcpus    : 1
          net      : '{"net0":"virtio,bridge=vmbr0"}'
          virtio   : '{"virtio0":"VMs:50,format=qcow2"}'
          update   : yes
```

```yaml
- name: CREATE/UPDATE VM
  local_action:
    module: proxmox_kvm
    api_user      : "{{ item.proxmox.api_user|default('root@pam') }}"
    api_password  : "{{ item.proxmox.api_password|default(omit) }}"
    api_host      : "{{ item.proxmox.api_host }}"
    node          : "{{ item.proxmox.node }}"
    name          : "{{ item.name }}"
    kvm           : "{{ item.kvm|default('yes') }}"
    net           : '{"net0":"virtio,bridge={{ vlan|default(pxe.vlan) }}"}'
    virtio        : "{{ item.virtio }}"
    cores         : "{{ item.cores|default('4') }}"
    sockets       : "{{ item.sockets|default('1') }}"
    vcpus         : "{{ item.vcpus|default(omit) }}"
    memory        : "{{ item.memory|default('2048') }}"
    balloon       : "{{ item.ballon|default(omit) }}"
    hotplug       : "{{ item.hotplug|default('memory,cpu,disk,network') }}"
    numa_enabled  : "{{ item.numa_enabled|default('yes') }}"
    keyboard      : "{{ item.keyboard|default('fr') }}"
    state         : "{{ item.state|default('present') }}"
    update        : "{{ item.update|default('yes') }}"
    delete        : "{{ item.delete|default(omit) }}"
    cpuunits      : "{{ item.cpuunits|default(omit) }}"
    revert        : "{{ item.revert|default(omit) }}"
  register: qemu
  with_items: "{{ instance }}"
```

###### Delete

> Param `delete: 'template'` added in instance dict per example

```yaml
ansible@spynal-orchestrator:/usr/local/ansible/orchestrator (master)$ ansible-playbook playbooks/servers.yml -vvvvvvvvv
PLAYBOOK: servers.yml **********************************************************
1 plays in playbooks/servers.yml

PLAY [orchestrator] ************************************************************

TASK [deploy : Include virtual] ************************************************
task path: /usr/local/ansible/orchestrator/roles/deploy/tasks/main.yml:4
included: /usr/local/ansible/orchestrator/roles/deploy/tasks/virtual.yml for spynal-orchestrator

TASK [deploy : CREATE/UPDATE VM] ******************************************************
task path: /usr/local/ansible/orchestrator/roles/deploy/tasks/virtual.yml:4
Using module file /usr/local/ansible/orchestrator/roles/deploy/library/proxmox_kvm.py
changed: [spynal-orchestrator -> localhost] => (item={}) => {
    "changed": true,
    "invocation": {
        "module_args": {
        },
        "module_name": "proxmox_kvm"
    },
    "item": {
        "cores": 2,
        "cpuunits": 50000,
        "delete": "template",
        "name": "combo",
        "net": "{\"net0\":\"virtio,bridge=vmbr0\"}",
        "proxmox": {
            "api_host": "labhyp.helldorado.info",
            "node": "labhyp1"
        },
        "tag": 1488514,
        "update": true,
        "vcpus": 1,
        "virtio": "{\"virtio0\":\"VMs:50,format=qcow2\"}"
    },
    "msg": "Settings has deleted on VM combo with vmid 108"
}

PLAY RECAP *********************************************************************
spynal-orchestrator        : ok=2    changed=1    unreachable=0    failed=0
```

###### Revert

> Param `revert: 'cpuunits'` added in instance dict per example

```yaml
ansible@spynal-abah-orchestrator:/usr/local/ansible/orchestrator (master)$ ansible-playbook playbooks/servers.yml -vvvvvvvvv

PLAYBOOK: servers.yml **********************************************************
1 plays in playbooks/servers.yml

PLAY [orchestrator] ************************************************************

TASK [deploy : Include virtual] ************************************************
task path: /usr/local/ansible/orchestrator/roles/deploy/tasks/main.yml:4
included: /usr/local/ansible/orchestrator/roles/deploy/tasks/virtual.yml for spynal-orchestrator

TASK [deploy : CREATE/UPDATE VM] ******************************************************
task path: /usr/local/ansible/orchestrator/roles/deploy/tasks/virtual.yml:4
Using module file /usr/local/ansible/orchestrator/roles/deploy/library/proxmox_kvm.py
changed: [spynal-orchestrator -> localhost] => (item={}) => {
    "changed": true,
    "invocation": {
        "module_args": {
            },
        },
        "module_name": "proxmox_kvm"
    },
    "item": {
        "cores": 2,
        "cpuunits": 50000,
        "name": "combo",
        "net": "{\"net0\":\"virtio,bridge=vmbr0\"}",
        "proxmox": {
            "api_host": "labhyp.helldorado.info",
            "node": "labhyp1"
        },
        "revert": "cpuunits",
        "tag": 1488514,
        "update": true,
        "vcpus": 1,
        "virtio": "{\"virtio0\":\"VMs:50,format=qcow2\"}"
    },
    "msg": "Settings has reverted on VM combo with vmid 108"
}

PLAY RECAP *********************************************************************
spynal-orchestrator        : ok=2    changed=1    unreachable=0    failed=0
```
