### PR TITLE
uri: Removed the restriction on "approved" methods.

### DIFF
--- a/lib/ansible/modules/network/basics/uri.py
+++ b/lib/ansible/modules/network/basics/uri.py
@@ -196,14 +196,16 @@ EXAMPLES = '''
     method: POST
     body: "name=your_username&password=your_password&enter=Sign%20in"
     status_code: 302
-    HEADER_Content-Type: "application/x-www-form-urlencoded"
+    headers:
+      Content-Type: "application/x-www-form-urlencoded"
   register: login
 
 - uri:
     url: https://your.form.based.auth.example.com/dashboard.php
     method: GET
     return_content: yes
-    HEADER_Cookie: "{{login.set_cookie}}"
+    headers:
+      Cookie: "{{login.set_cookie}}"
 
 - name: Queue build of a project in Jenkins
   uri:

--- a/lib/ansible/modules/network/basics/uri.py
+++ b/lib/ansible/modules/network/basics/uri.py
@@ -75,7 +75,7 @@ options:
     description:
       - The HTTP method of the request or response. It MUST be uppercase.
     required: false
-    choices: [ "GET", "POST", "PUT", "HEAD", "DELETE", "OPTIONS", "PATCH", "TRACE", "CONNECT", "REFRESH" ]
+    choices: [ "GET", "POST", "PUT", "HEAD", "DELETE", "OPTIONS", "PATCH", "TRACE", "CONNECT", "REFRESH", "..." ]
     default: "GET"
   return_content:
     description:
@@ -370,7 +370,7 @@ def main():
         url_password = dict(required=False, default=None, aliases=['password'], no_log=True),
         body = dict(required=False, default=None, type='raw'),
         body_format = dict(required=False, default='raw', choices=['raw', 'json']),
-        method = dict(required=False, default='GET', choices=['GET', 'POST', 'PUT', 'HEAD', 'DELETE', 'OPTIONS', 'PATCH', 'TRACE', 'CONNECT', 'REFRESH']),
+        method = dict(required=False, default='GET'),
         return_content = dict(required=False, default='no', type='bool'),
         follow_redirects = dict(required=False, default='safe', choices=['all', 'safe', 'none', 'yes', 'no']),
         creates = dict(required=False, default=None, type='path'),


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module / network / basic / uri

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file = /Users/jris/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I removed the restriction on "approved" methods for the uri module.
There are many cases where sending non-standard methods may be desireable, including, but not limited to, sending the PURGE method to varnish. The PURGE method is not standard, but it IS convention.
The limitation, as it is now, seems like a good, pretty idea, but in reality it does nothing but block users from doing some things they might want to do.

Further:
The examples in the documentation, showed the old, deprecated way of specifying headers.
I changed them to the new way.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```