### PR TITLE
IAM module returns created keys

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam.py
+++ b/lib/ansible/modules/cloud/amazon/iam.py
@@ -346,7 +346,7 @@ def update_user(module, iam, name, new_name, new_path, key_state, key_count, key
         status = [ck['status'] for ck in
                   iam.get_all_access_keys(name).list_access_keys_result.access_key_metadata]
         key_qty = len(current_keys)
-    except boto.exception.BotoServerError, err:
+    except boto.exception.BotoServerError as err:
         error_msg = boto_exception(err)
         if 'cannot be found' in error_msg and updated:
             current_keys = [ck['access_key_id'] for ck in

--- a/lib/ansible/modules/cloud/amazon/iam.py
+++ b/lib/ansible/modules/cloud/amazon/iam.py
@@ -719,6 +719,15 @@ def main():
                 been_updated = True
             name_change, key_list, user_changed, new_key = update_user(
                 module, iam, name, new_name, new_path, key_state, key_count, key_ids, password, been_updated)
+            if new_key:
+                user_meta = {'access_keys': list(new_key)}
+                user_meta['access_keys'].extend(
+                    [{'access_key_id': key, 'status': value} for key, value in key_list.items() if
+                     key not in [it['access_key_id'] for it in new_key]])
+            else:
+                user_meta = {
+                    'access_keys': [{'access_key_id': key, 'status': value} for key, value in key_list.items()]}
+
             if name_change and new_name:
                 orig_name = name
                 name = new_name
@@ -734,22 +743,23 @@ def main():
             if new_name and new_path:
                 module.exit_json(changed=changed, groups=user_groups, old_user_name=orig_name,
                                  new_user_name=new_name, old_path=path, new_path=new_path, keys=key_list,
-                                 created_keys=new_key)
+                                 created_keys=new_key, user_meta=user_meta)
             elif new_name and not new_path and not been_updated:
                 module.exit_json(
                     changed=changed, groups=user_groups, old_user_name=orig_name, new_user_name=new_name, keys=key_list,
-                    created_keys=new_key)
+                    created_keys=new_key, user_meta=user_meta)
             elif new_name and not new_path and been_updated:
                 module.exit_json(
                     changed=changed, groups=user_groups, user_name=new_name, keys=key_list, key_state=key_state,
-                    created_keys=new_key)
+                    created_keys=new_key, user_meta=user_meta)
             elif not new_name and new_path:
                 module.exit_json(
                     changed=changed, groups=user_groups, user_name=name, old_path=path, new_path=new_path,
-                    keys=key_list, created_keys=new_key)
+                    keys=key_list, created_keys=new_key, user_meta=user_meta)
             else:
                 module.exit_json(
-                    changed=changed, groups=user_groups, user_name=name, keys=key_list, created_keys=new_key)
+                    changed=changed, groups=user_groups, user_name=name, keys=key_list, created_keys=new_key,
+                    user_meta=user_meta)
 
         elif state == 'update' and not user_exists:
             module.fail_json(

--- a/lib/ansible/modules/cloud/amazon/iam.py
+++ b/lib/ansible/modules/cloud/amazon/iam.py
@@ -387,14 +387,14 @@ def update_user(module, iam, name, new_name, new_path, key_state, key_count, key
                                          (name, current_keys, keys)
                                      )
 
-                if key_state == 'remove':
-                    if access_key in current_keys:
-                        try:
-                            iam.delete_access_key(access_key, user_name=name)
-                        except boto.exception.BotoServerError as err:
-                            module.fail_json(changed=False, msg=str(err))
-                        else:
-                            changed = True
+            if key_state == 'remove':
+                if access_key in current_keys:
+                    try:
+                        iam.delete_access_key(access_key, user_name=name)
+                    except boto.exception.BotoServerError as err:
+                        module.fail_json(changed=False, msg=str(err))
+                    else:
+                        changed = True
 
     try:
         final_keys, final_key_status = \


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
cloud/amazon/iam

##### ANSIBLE VERSION
```
ansible 2.3.0 (iam-keys 3aee11e48b) last updated 2017/02/10 08:26:38 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

Migrating  https://github.com/ansible/ansible-modules-core/pull/3385 by @defionscode

Fixes issues in https://github.com/ansible/ansible-modules-core/issues/3346

Fixes issue https://github.com/ansible/ansible-modules-core/issues/2821 where newly created keys were not appearing in the returned output by the module. 

Adds list with created keys to output:
```
{"changed": true, "created_keys": [{"access_key_id": "FAKE3FZHKFAKE2QA", "access_key_selector": "HMAC", "create_date": "2016-04-07T20:09:11.799Z", "secret_access_key": "fake_key_alsjdflkasdfksf;lksjdfkls", "status": "Active", "user_name": "pullrequest_testing"}], "groups": null, "keys": {"FAKE3FZHKFAKE2QA": "Active"}, "user_name": "pullrequest_testing"}```
```
