### PR TITLE
Adds doc fragments for the available env vars

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/f5.py
+++ b/lib/ansible/utils/module_docs_fragments/f5.py
@@ -23,26 +23,33 @@ options:
   password:
     description:
       - The password for the user account used to connect to the BIG-IP.
+        This option can be omitted if the environment variable C(F5_PASSWORD)
+        is set.
     required: true
   server:
     description:
-      - The BIG-IP host.
+      - The BIG-IP host. This option can be omitted if the environment
+        variable C(F5_SERVER) is set.
     required: true
   server_port:
     description:
-      - The BIG-IP server port.
+      - The BIG-IP server port. This option can be omitted if the environment
+        variable C(F5_SERVER_PORT) is set.
     required: false
     default: 443
     version_added: 2.2
   user:
     description:
       - The username to connect to the BIG-IP with. This user must have
-        administrative privileges on the device.
+        administrative privileges on the device. This option can be omitted
+        if the environment variable C(F5_USER) is set.
     required: true
   validate_certs:
     description:
       - If C(no), SSL certificates will not be validated. This should only be
         used on personally controlled sites using self-signed certificates.
+        This option can be omitted if the environment variable
+        C(F5_VALIDATE_CERTS) is set.
     required: false
     default: yes
     choices:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/utils/module_docs_fragments/f5.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides

```

##### SUMMARY
For F5 modules, the options that are commonly specified can
also be specified in the environment variables. This patch
adds the doc fragments that describe which env var goes
with which module option.