### PR TITLE
Make ec2_vol pep8 and add tags parameter

### DIFF
--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -41,7 +41,6 @@ lib/ansible/modules/cloud/amazon/ec2_remote_facts.py
 lib/ansible/modules/cloud/amazon/ec2_scaling_policy.py
 lib/ansible/modules/cloud/amazon/ec2_snapshot_facts.py
 lib/ansible/modules/cloud/amazon/ec2_tag.py
-lib/ansible/modules/cloud/amazon/ec2_vol.py
 lib/ansible/modules/cloud/amazon/ec2_vol_facts.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_options_facts.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_vol.py

##### ANSIBLE VERSION
```
ansible 2.3.0 (add-ec2-vol-tags-param 9f5aa92b74) last updated 2017/02/10 11:28:07 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Fixes #10631

Fixing PEP8 Issues and added a tags option (as suggested in #10631) but not sure if there is any demand. Would be happy to remove that addition from the PR so it just fixes the pep8 errors. 
