### PR TITLE
updated the ec2.py to include ansible_host to be compatible with ansible 2.0+

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -929,6 +929,7 @@ class Ec2Inventory(object):
 
         self.inventory["_meta"]["hostvars"][hostname] = self.get_host_info_dict_from_instance(instance)
         self.inventory["_meta"]["hostvars"][hostname]['ansible_ssh_host'] = dest
+        self.inventory["_meta"]["hostvars"][hostname]['ansible_host'] = dest
 
 
     def add_rds_instance(self, instance, region):
@@ -1028,6 +1029,7 @@ class Ec2Inventory(object):
 
         self.inventory["_meta"]["hostvars"][hostname] = self.get_host_info_dict_from_instance(instance)
         self.inventory["_meta"]["hostvars"][hostname]['ansible_ssh_host'] = dest
+        self.inventory["_meta"]["hostvars"][hostname]['ansible_host'] = dest
 
     def add_elasticache_cluster(self, cluster, region):
         ''' Adds an ElastiCache cluster to the inventory and index, as long as


### PR DESCRIPTION
According to the Ansible Docs, ansible_ssh_host is being deprecated.  See page here.

http://docs.ansible.com/ansible/intro_inventory.html

The ansible ec2.py dynamic inventory doesn't include this new variable, just the old one.  This PR adds the ansible_host to the inventory.  IT does NOT delete the ansible_ssh_host.