### PR TITLE
aos_ip_pool - Clean up doc

### DIFF
--- a/lib/ansible/modules/network/aos/aos_ip_pool.py
+++ b/lib/ansible/modules/network/aos/aos_ip_pool.py
@@ -31,40 +31,35 @@ short_description: Manage AOS IP Pool
 description:
   - Apstra AOS Ip Pool module let you manage your IP Pool easily. You can create
     create and delete IP Pool by Name, ID or by using a JSON File. This module
-    is idempotent and support the I(check) mode. It's using the AOS REST API
+    is idempotent and support the I(check) mode. It's using the AOS REST API.
 requirements:
   - "aos-pyez >= 0.6.0"
 options:
   session:
     description:
-      - An existing AOS session as obtained by aos_login module
+      - An existing AOS session as obtained by aos_login module.
     required: true
   name:
     description:
       - Name of the IP Pool to manage.
         Only one of I(name), I(id) or I(content) can be set.
-    required: false
   id:
     description:
       - AOS Id of the IP Pool to manage (can't be used to create a new IP Pool),
         Only one of I(name), I(id) or I(content) can be set.
-    required: false
   content:
     description:
-      - Datastructure of the IP Pool to create. The data can be in YAML / JSON or
+      - Datastructure of the IP Pool to manage. The data can be in YAML / JSON or
         directly a variable. It's the same datastructure that is returned
         on success in I(value).
-    required: false
   state:
     description:
-      - Indicate what is the expected state of the IP Pool (present or not)
+      - Indicate what is the expected state of the IP Pool (present or not).
     default: present
     choices: ['present', 'absent']
-    required: false
   subnets:
     description:
-      - List of subnet that needs to be part of the IP Pool
-    required: false
+      - List of subnet that needs to be part of the IP Pool.
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
network/aos/aos_ip_pool

##### ANSIBLE VERSION
```
ansible 2.3.0 (fix_ip_pool_doc bcf9c00ecb) last updated 2017/02/10 11:35:25 (GMT -700)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Small cleanup of the documentation to incorporate feedback from the other modules from @gundalow 
- Removed `required: false`
- Add hard stop

