### PR TITLE
[WIP] add standard options handler

### DIFF
--- a/lib/ansible/plugins/lookup/__init__.py
+++ b/lib/ansible/plugins/lookup/__init__.py
@@ -70,6 +70,7 @@ class LookupBase(with_metaclass(ABCMeta, object)):
             ret.append({'key': key, 'value': terms[key]})
         return ret
 
+    @staticmethod
     def _update_options(options, item):
         """
         examines item and determines if it is an option

--- a/lib/ansible/plugins/lookup/__init__.py
+++ b/lib/ansible/plugins/lookup/__init__.py
@@ -70,6 +70,18 @@ class LookupBase(with_metaclass(ABCMeta, object)):
             ret.append({'key': key, 'value': terms[key]})
         return ret
 
+    def _update_options(options, item):
+        """
+        examines item and determines if it is an option
+        it also updates option dictionary with the value
+        """
+        if '=' in item:
+            k,v = item.split('=')
+            if k in options:
+                options[k] = v
+                return True
+        return False
+
     @abstractmethod
     def run(self, terms, variables=None, **kwargs):
         """

--- a/lib/ansible/plugins/lookup/env.py
+++ b/lib/ansible/plugins/lookup/env.py
@@ -26,11 +26,12 @@ class LookupModule(LookupBase):
     def run(self, terms, variables, **kwargs):
 
         options = {'allow_undefined': True, 'default': ''}
+
+        # override options passed in
+        options.update(kwargs)
+
         ret = []
         for term in terms:
-
-            if self.update_options(options, term):
-                continue
 
             var = term.split()[0]
             envvar = os.getenv(var)

--- a/lib/ansible/plugins/lookup/env.py
+++ b/lib/ansible/plugins/lookup/env.py
@@ -25,9 +25,22 @@ class LookupModule(LookupBase):
 
     def run(self, terms, variables, **kwargs):
 
+        options = {'allow_undefined': True, 'default': ''}
         ret = []
         for term in terms:
+
+            if self.update_options(options, term):
+                continue
+
             var = term.split()[0]
-            ret.append(os.getenv(var, ''))
+            envvar = os.getenv(var)
+
+            if envvar is None:
+                if options['allow_undefined']:
+                    ret.append(options['default'])
+                else:
+                    raise AnsibleError('Undefined environment variable: %s' % var)
+            else:
+                ret.append(envvar)
 
         return ret


### PR DESCRIPTION
allow customization of 'env' lookup behaviour

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lookup plugins
env loookup
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

create 'option parsing' in general for lookups, add new options to env lookup

fixes #17329