### PR TITLE
Disable Network integration tests

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -20,8 +20,6 @@ matrix:
     - env: TEST=windows/2
     - env: TEST=windows/3
 
-    - env: TEST=network
-
     - env: TEST=linux/centos6/1
     - env: TEST=linux/centos7/1
     - env: TEST=linux/fedora24/1


### PR DESCRIPTION
This will disable the integration tests for all network platforms & modules, though the unit tests will still run.

This is needed while a large refactor of the networking code is done.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/21270)
<!-- Reviewable:end -->
