### PR TITLE
Fix incorrect wording in the 'find' module 'paths' parameter

### DIFF
--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -58,7 +58,7 @@ options:
         required: true
         aliases: [ "name", "path" ]
         description:
-            - List of paths to the file or directory to search. All paths must be fully qualified.
+            - List of paths of directories to search. All paths must be fully qualified.
     file_type:
         required: false
         description:


### PR DESCRIPTION
##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

**Module:** [`find`](http://docs.ansible.com/ansible/find_module.html)

##### ANSIBLE VERSION

```
N/A
```

##### SUMMARY

The [`find` module](http://docs.ansible.com/ansible/find_module.html) currently documents the `paths` parameter as such:

> List of paths to the file or directory to search. All paths must be fully qualified.

This is incorrect and will cause errors. The `find` module **only** accepts directory paths for the `paths` parameter.

* https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/files/find.py#L330-L378

*Snippet*

```python
        if os.path.isdir(npath):
            # do the stuff
        else:
            msg+="%s was skipped as it does not seem to be a valid directory or it cannot be accessed\n" % npath
```

##### CHANGES

This PR changes the `paths` docstring to accurately reflect the behavior of the `find` module when used.

```diff
-            - List of paths to the file or directory to search. All paths must be fully qualified.
+            - List of paths of directories to search. All paths must be fully qualified.
```

