### PR TITLE
Extend os image container and disk formats

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_image.py
+++ b/lib/ansible/modules/cloud/openstack/os_image.py
@@ -127,7 +127,7 @@ def main():
     argument_spec = openstack_full_argument_spec(
         name              = dict(required=True),
         disk_format       = dict(default='qcow2', choices=['ami', 'ari', 'aki', 'vhd', 'vmdk', 'raw', 'qcow2', 'vdi', 'iso']),
-        container_format  = dict(default='bare', choices=['ami', 'aki', 'ari', 'bare', 'ovf', 'ova']),
+        container_format  = dict(default='bare', choices=['ami', 'aki', 'ari', 'bare', 'ovf', 'ova', 'docker']),
         owner             = dict(default=None),
         min_disk          = dict(type='int', default=0),
         min_ram           = dict(type='int', default=0),

--- a/lib/ansible/modules/cloud/openstack/os_image.py
+++ b/lib/ansible/modules/cloud/openstack/os_image.py
@@ -126,7 +126,7 @@ def main():
 
     argument_spec = openstack_full_argument_spec(
         name              = dict(required=True),
-        disk_format       = dict(default='qcow2', choices=['ami', 'ari', 'aki', 'vhd', 'vmdk', 'raw', 'qcow2', 'vdi', 'iso']),
+        disk_format       = dict(default='qcow2', choices=['ami', 'ari', 'aki', 'vhd', 'vmdk', 'raw', 'qcow2', 'vdi', 'iso', 'vhdx', 'ploop']),
         container_format  = dict(default='bare', choices=['ami', 'aki', 'ari', 'bare', 'ovf', 'ova', 'docker']),
         owner             = dict(default=None),
         min_disk          = dict(type='int', default=0),


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
cloud/openstack/os_image

##### SUMMARY
Extend os image container and disk formats to match supported formats described in openstack  glance documentation http://docs.openstack.org/developer/glance/formats.html
