### PR TITLE
Fix service_mgr fact for Solaris; svcs is used to list services

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -385,8 +385,7 @@ class Facts(object):
         elif self.facts['system'] == 'AIX':
             self.facts['service_mgr'] = 'src'
         elif self.facts['system'] == 'SunOS':
-            #FIXME: smf?
-            self.facts['service_mgr'] = 'svcs'
+            self.facts['service_mgr'] = 'smf'
         elif self.facts['distribution'] == 'OpenWrt':
             self.facts['service_mgr'] = 'openwrt_init'
         elif self.facts['system'] == 'Linux':


### PR DESCRIPTION


##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

`facts.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
v2.3
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The `ansible_service_mgr` fact on Solaris (and derivatives) is incorrectly set to `svcs`. That command does exist, however it's not used to actually manage services with.
