### PR TITLE
win_nssm improvements

### DIFF
--- a/lib/ansible/modules/windows/win_nssm.py
+++ b/lib/ansible/modules/windows/win_nssm.py
@@ -76,6 +76,7 @@ options:
     required: false
     default: null
   app_parameters_free_form:
+    version_added: "2.3.0"
     description:
       - Single string of parameters to be passed to the service. Use either this or 'app_parameters', not both
   dependencies:

--- a/lib/ansible/modules/windows/win_nssm.py
+++ b/lib/ansible/modules/windows/win_nssm.py
@@ -75,6 +75,9 @@ options:
       - Parameters to be passed to the application when it starts
     required: false
     default: null
+  app_parameters_free_form:
+    description:
+      - Single string of parameters to be passed to the service. Use either this or 'app_parameters', not both
   dependencies:
     description:
       - Service dependencies that has to be started to trigger startup, separated by comma.
@@ -143,6 +146,16 @@ EXAMPLES = r'''
     app_parameters:
         _: bar
         "-file": "output.bat"
+
+# Use the single line parameters option to specify an arbitrary string of parameters
+# for the service executable
+- name: Make sure the Consul service runs
+  win_nssm:
+      name: consul
+      application: "C:\\consul\\consul.exe"
+      app_parameters_free_form: "agent -config-dir=C:\\consul\\config"
+      stdout_file: "C:\\consul\\log.txt"
+      stderr_file: "C:\\consul\\error.txt"
 
 # Install and start the foo service, redirecting stdout and stderr to the same file
 - win_nssm:


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
win_nssm

##### ANSIBLE VERSION
```
2.3.0
```

##### SUMMARY
I've explained my rationale in this issue: #21289

In short, this adds an extra option to win_nssm which allows simply to specify the service parameters as a single string. This allows for (in some cases) easier configuration, and better idempodency detection.