### PR TITLE
Remove expanduser usage because of path type

### DIFF
--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -781,8 +781,8 @@ def main():
         supports_check_mode = True,
     )
 
-    src        = os.path.expanduser(module.params['src'])
-    dest       = os.path.expanduser(module.params['dest'])
+    src        = module.params['src']
+    dest       = module.params['dest']
     copy       = module.params['copy']
     remote_src = module.params['remote_src']
     file_args = module.load_file_common_arguments(module.params)


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
lib/modules/files/unarchive.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
With the addition of the 'path' type, the usage of expanduser
is redundant. This patch removes that extra usage because the
module already uses path type.

related to #12263