### PR TITLE
ec2.py: Better error messages for OptInRequired

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -598,6 +598,10 @@ class Ec2Inventory(object):
 
             if e.error_code == 'AuthFailure':
                 error = self.get_auth_error_message()
+            if e.error_code == "OptInRequired":
+                error = "RDS hasn't been enabled for this account yet. " \
+                    "You must either log in to the RDS service through the AWS console to enable it, " \
+                    "or set 'rds = False' in ec2.ini"
             if not e.reason == "Forbidden":
                 error = "Looks like AWS RDS is down:\n%s" % e.message
             self.fail_with_error(error, 'getting RDS instances')
@@ -680,6 +684,10 @@ class Ec2Inventory(object):
 
             if e.error_code == 'AuthFailure':
                 error = self.get_auth_error_message()
+            if e.error_code == "OptInRequired":
+                error = "ElastiCache hasn't been enabled for this account yet. " \
+                    "You must either log in to the ElastiCache service through the AWS console to enable it, " \
+                    "or set 'elasticache = False' in ec2.ini"
             if not e.reason == "Forbidden":
                 error = "Looks like AWS ElastiCache is down:\n%s" % e.message
             self.fail_with_error(error, 'getting ElastiCache clusters')


### PR DESCRIPTION
For ec2 dynamic inventory plugin, improve error messages for RDS and ElastiCache failures for code OptInRequired.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2.py inventory plugin

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY

This change improves the error messages shown for ec2.py inventory plugin when it fails connecting to either rds or elasticache with the OptInRequired error code.

Fixes #10840


Before change:

```
$ ./ec2.py --list
ERROR: "Forbidden", while: getting RDS instances

$ ./ec2.py --list
ERROR: "Forbidden", while: getting ElastiCache clusters
```

After change:

```
$  ./ec2.py --list
ERROR: "RDS hasn't been enabled for this account yet. You must either log in to the RDS service through the AWS console to enable it, or set 'rds = False' in ec2.ini", while: getting RDS instances

$ ./ec2.py --list
ERROR: "ElastiCache hasn't been enabled for this account yet. You must either log in to the ElastiCache service through the AWS console to enable it, or set 'elasticache = False' in ec2.ini", while: getting ElastiCache cluster

```