### PR TITLE
Removes usage of expanduser because of type path

### DIFF
--- a/lib/ansible/modules/packaging/language/bower.py
+++ b/lib/ansible/modules/packaging/language/bower.py
@@ -209,7 +209,7 @@ def main():
     name = module.params['name']
     offline = module.params['offline']
     production = module.params['production']
-    path = os.path.expanduser(module.params['path'])
+    path = module.params['path']
     relative_execpath = module.params['relative_execpath']
     state = module.params['state']
     version = module.params['version']


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/modules/packaging/language/bower.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
The usage of type 'path' for the path option makes the use
of expanduser redundant. This patch removes the expanduser
call because the path type is already used for the path
option