### PR TITLE
Replace expanduser with type path

### DIFF
--- a/lib/ansible/modules/network/basics/get_url.py
+++ b/lib/ansible/modules/network/basics/get_url.py
@@ -289,13 +289,13 @@ def main():
     argument_spec = url_argument_spec()
     argument_spec.update(
         url = dict(required=True),
-        dest = dict(required=True),
+        dest = dict(required=True, type='path'),
         backup = dict(default=False, type='bool'),
         sha256sum = dict(default=''),
         checksum = dict(default=''),
         timeout = dict(required=False, type='int', default=10),
         headers = dict(required=False, default=None),
-        tmp_dest = dict(required=False, default=''),
+        tmp_dest = dict(required=False, default='', type='path'),
     )
 
     module = AnsibleModule(
@@ -305,14 +305,14 @@ def main():
     )
 
     url  = module.params['url']
-    dest = os.path.expanduser(module.params['dest'])
+    dest = module.params['dest']
     backup = module.params['backup']
     force = module.params['force']
     sha256sum = module.params['sha256sum']
     checksum = module.params['checksum']
     use_proxy = module.params['use_proxy']
     timeout = module.params['timeout']
-    tmp_dest = os.path.expanduser(module.params['tmp_dest'])
+    tmp_dest = module.params['tmp_dest']
 
     # Parse headers to dict
     if module.params['headers']:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/basics/get_url.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
This patch removes the use of expanduser and replaces it with
type 'path' for the option. This is related to #12263.