### PR TITLE
Fix Proxmox module crashing if the hostname doesn't exist and there's no vmid

### DIFF
--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -504,7 +504,10 @@ def main():
     if not vmid and state == 'present':
         vmid = get_nextvmid(module, proxmox)
     elif not vmid and hostname:
-        vmid = get_vmid(proxmox, hostname)[0]
+        hosts = get_vmid(proxmox, hostname)
+        if len(hosts) == 0:
+            module.fail_json(msg="Vmid could not be fetched => Hostname doesn't exist (action: %s)" % state)
+        vmid = hosts[0]
     elif not vmid:
         module.exit_json(changed=False, msg="Vmid could not be fetched for the following action: %s" % state)
 

--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -332,7 +332,7 @@ def get_nextvmid(module, proxmox):
 
 
 def get_vmid(proxmox, hostname):
-    return [vm['vmid'] for vm in proxmox.cluster.resources.get(type='vm') if vm['name'] == hostname]
+    return [vm['vmid'] for vm in proxmox.cluster.resources.get(type='vm') if 'name' in vm and vm['name'] == hostname]
 
 
 def get_instance(proxmox, vmid):


### PR DESCRIPTION

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
proxmox

##### ANSIBLE VERSION
2.3.0
```

```

##### SUMMARY


```
- name: check if hostname exists
 proxmox: node={{ node }} api_user={{ api_user }} api_password={{ api_password }} api_host='homeserver' password='12345' hostname={{ hostname }} state='started'
```
This crashes the module instead of failing the execution


Previous output
```

TASK [checking if machine exists] ****************************************************************************************************************************************************************************************************************************************
 [WARNING]: Removed unexpected internal key in module return: _ansible_parsed = False

fatal: [homeserver]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Shared connection to homeserver closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_FADjev/ansible_module_proxmox.py\", line 613, in <module>\r\n    main()\r\n  File \"/tmp/ansible_FADjev/ansible_module_proxmox.py\", line 494, in main\r\n    vmid = get_vmid(proxmox, hostname)[0]\r\nIndexError: list index out of range\r\n", "msg": "MODULE FAILURE", "rc": 0}                                                 
        to retry, use: --limit @/home/david/ansible/base/mysql.retry

```

New output:

```
TASK [checking if machine exists] ****************************************************************************************************************************************************************************************************************************************
fatal: [homeserver]: FAILED! => {"changed": false, "failed": true, "msg": "Vmid could not be fetched => Hostname doesn't exist (action: started)"}
        to retry, use: --limit @/home/david/ansible/base/mysql.retry
```