### PR TITLE
Add dist-upgrade and extra_args to zypper module

### DIFF
--- a/lib/ansible/modules/packaging/os/zypper.py
+++ b/lib/ansible/modules/packaging/os/zypper.py
@@ -110,6 +110,12 @@ options:
         required: false
         default: "no"
         choices: [ "yes", "no" ]
+    extra_args:
+        version_added: "2.4"
+        required: false
+        description:
+          - Add additional options to C(zypper) command.
+          - Options should be supplied in a single line as if given in the command line.
 
 # informational: requirements for nodes
 requirements:
@@ -316,6 +322,10 @@ def get_cmd(m, subcommand):
             cmd.append('--force')
         if m.params['oldpackage']:
             cmd.append('--oldpackage')
+    if m.params['extra_args']:
+        args_list = m.params['extra_args'].split(' ')
+        cmd.extend(args_list)
+
     return cmd
 
 
@@ -459,6 +469,7 @@ def main():
             force = dict(required=False, default='no', type='bool'),
             update_cache = dict(required=False, aliases=['refresh'], default='no', type='bool'),
             oldpackage = dict(required=False, default='no', type='bool'),
+            extra_args = dict(required=False, default=None),
         ),
         supports_check_mode = True
     )


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
zypper

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (zypper-dup-function 04ad35b007) last updated 2017/02/12 23:34:35 (GMT +800)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Adds support for `zypper dist-upgrade` and `--no-allow-vendor-change`. This combination is a recommended method of keeping an openSUSE Tumbleweed system with additional repositories updated. 

Syntax follows semantics as set by `name='*' state=latest type=patch`, ideally invoked as `name='*' state=latest type=dist-upgrade no_allow_vendor_change=yes`.
