### PR TITLE
Fix nxos_* depends on ansible.module_utils.nxos.Cli

### DIFF
--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -263,9 +263,13 @@ class Cli(NxapiConfigMixin, CliBase):
 
     NET_PASSWD_RE = re.compile(r"[\r\n]?password: $", re.I)
 
+    def __init__(self):
+        self.default_output = "text"
+        super(Cli, self).__init__()
+
     def connect(self, params, **kwargs):
         super(Cli, self).connect(params, kickstart=False, **kwargs)
-        self.shell.send('terminal length 0')
+        self.shell.send({'command': 'terminal length 0'})
 
     ### Command methods ###
 


### PR DESCRIPTION
Object of the ansible.module_utils.nxos.Cli class must have the `default_output` attribute to be compatible with ansible/module_utils/netcli.py.

Method ansible.module_utils.shell.Shell#send waits for Command() object, not just regular command str.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/network/nxos

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 87aa59af79) last updated 2017/02/12 12:38:01 (GMT +300)
  config file = /Users/idrey/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Fix of NXOS network modules when CLI transport used.