### PR TITLE
set no_log for update_password in user module

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -2149,7 +2149,7 @@ def main():
             ssh_key_file=dict(default=None, type='path'),
             ssh_key_comment=dict(default=ssh_defaults['comment'], type='str'),
             ssh_key_passphrase=dict(default=None, type='str', no_log=True),
-            update_password=dict(default='always',choices=['always','on_create'],type='str'),
+            update_password=dict(default='always',choices=['always','on_create'],type='str', no_log=True),
             expires=dict(default=None, type='float'),
         ),
         supports_check_mode=True


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/system/user

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fix: [WARNING]: Module did not set no_log for update_password

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [common : set /usr/bin/zsh as default shell] ***...
 [WARNING]: Module did not set no_log for update_password
```
