### PR TITLE
Updated quoting - Fixes #20954

### DIFF
--- a/lib/ansible/modules/source_control/git_config.py
+++ b/lib/ansible/modules/source_control/git_config.py
@@ -235,7 +235,7 @@ def main():
             module.exit_json(changed=False, msg="")
 
     if not module.check_mode:
-        new_value_quoted = "'" + new_value + "'"
+        new_value_quoted = "'" + new_value.replace("'", "'\"'\"'") + "'"
         (rc, out, err) = module.run_command(' '.join(args + [new_value_quoted]), cwd=dir)
         if err:
             module.fail_json(rc=rc, msg=err, cmd=' '.join(args + [new_value_quoted]))


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/source_control/git_config.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Updated to use s.replace to quote any singlequotes inside the value for git_config.
Fixes #20954 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
ansible-playbook git-test.yml 
 [WARNING]: Host file not found: /etc/ansible/hosts

 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [localhost] ****************************************************************************************

TASK [Gathering Facts] **********************************************************************************
ok: [localhost]

TASK [Add pretty git log] *******************************************************************************
ok: [localhost]

PLAY RECAP **********************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0   
```
