### PR TITLE
Ensure that s3_bucket versioning is correctly enabled

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -168,22 +168,21 @@ def _create_or_update_bucket(connection, module, location):
 
     # Versioning
     versioning_status = bucket.get_versioning_status()
-    if versioning_status:
-        if versioning is not None:
-            if versioning and versioning_status['Versioning'] != "Enabled":
-                try:
-                    bucket.configure_versioning(versioning)
-                    changed = True
-                    versioning_status = bucket.get_versioning_status()
-                except S3ResponseError as e:
-                    module.fail_json(msg=e.message)
-            elif not versioning and versioning_status['Versioning'] != "Enabled":
-                try:
-                    bucket.configure_versioning(versioning)
-                    changed = True
-                    versioning_status = bucket.get_versioning_status()
-                except S3ResponseError as e:
-                    module.fail_json(msg=e.message)
+    if versioning is not None:
+        if versioning and versioning_status.get('Versioning') != "Enabled":
+            try:
+                bucket.configure_versioning(versioning)
+                changed = True
+                versioning_status = bucket.get_versioning_status()
+            except S3ResponseError as e:
+                module.fail_json(msg=e.message)
+        elif not versioning and versioning_status.get('Versioning') == "Enabled":
+            try:
+                bucket.configure_versioning(versioning)
+                changed = True
+                versioning_status = bucket.get_versioning_status()
+            except S3ResponseError as e:
+                module.fail_json(msg=e.message)
 
     # Requester pays
     requester_pays_status = get_request_payment_status(bucket)

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -49,11 +49,13 @@ options:
     aliases: [ S3_URL ]
   ceph:
     description:
-      - Enable API compatibility with Ceph. It takes into account the S3 API subset working with Ceph in order to provide the same module behaviour where possible.
+      - Enable API compatibility with Ceph. It takes into account the S3 API subset working
+        with Ceph in order to provide the same module behaviour where possible.
     version_added: "2.2"
   requester_pays:
     description:
-      - With Requester Pays buckets, the requester instead of the bucket owner pays the cost of the request and the data download from the bucket.
+      - With Requester Pays buckets, the requester instead of the bucket owner pays the cost
+        of the request and the data download from the bucket.
     required: false
     default: no
     choices: [ 'yes', 'no' ]
@@ -110,16 +112,19 @@ EXAMPLES = '''
 
 '''
 
+import json
 import os
+import traceback
 import xml.etree.ElementTree as ET
-import ansible.module_utils.six.moves.urllib.parse as urlparse
 
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
+import ansible.module_utils.six.moves.urllib.parse as urlparse
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import get_aws_connection_info, ec2_argument_spec
+from ansible.module_utils.ec2 import sort_json_policy_dict
 
 try:
     import boto.ec2
-    from boto.s3.connection import OrdinaryCallingFormat, Location
+    from boto.s3.connection import OrdinaryCallingFormat, Location, S3Connection
     from boto.s3.tagging import Tags, TagSet
     from boto.exception import BotoServerError, S3CreateError, S3ResponseError
     HAS_BOTO = True
@@ -175,14 +180,14 @@ def _create_or_update_bucket(connection, module, location):
                 changed = True
                 versioning_status = bucket.get_versioning_status()
             except S3ResponseError as e:
-                module.fail_json(msg=e.message)
+                module.fail_json(msg=e.message, exception=traceback.format_exc())
         elif not versioning and versioning_status.get('Versioning') == "Enabled":
             try:
                 bucket.configure_versioning(versioning)
                 changed = True
                 versioning_status = bucket.get_versioning_status()
             except S3ResponseError as e:
-                module.fail_json(msg=e.message)
+                module.fail_json(msg=e.message, exception=traceback.format_exc())
 
     # Requester pays
     requester_pays_status = get_request_payment_status(bucket)
@@ -246,7 +251,8 @@ def _create_or_update_bucket(connection, module, location):
             except S3ResponseError as e:
                 module.fail_json(msg=e.message)
 
-    module.exit_json(changed=changed, name=bucket.name, versioning=versioning_status, requester_pays=requester_pays_status, policy=current_policy, tags=current_tags_dict)
+    module.exit_json(changed=changed, name=bucket.name, versioning=versioning_status,
+                     requester_pays=requester_pays_status, policy=current_policy, tags=current_tags_dict)
 
 
 def _destroy_bucket(connection, module):

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -66,7 +66,6 @@ lib/ansible/modules/cloud/amazon/redshift.py
 lib/ansible/modules/cloud/amazon/route53.py
 lib/ansible/modules/cloud/amazon/route53_health_check.py
 lib/ansible/modules/cloud/amazon/s3.py
-lib/ansible/modules/cloud/amazon/s3_bucket.py
 lib/ansible/modules/cloud/amazon/s3_lifecycle.py
 lib/ansible/modules/cloud/amazon/s3_sync.py
 lib/ansible/modules/cloud/amazon/s3_website.py


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
s3_bucket

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel a6cb377420) last updated 2017/02/13 10:23:20 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
If versioning is not enabled, then `get_bucket_versioning`
can return an empty dict.

If that happens, the code to enable versioning should still
run!

The logic for suspending versioning was also incorrect, so
have updated that too.

Fixes #20491

Tested with:
```
hacking/test-module -m lib/ansible/modules/cloud/amazon/s3_bucket.py -a "profile=sandbox name=test-2017-02-13-1039 versioning=no"
 hacking/test-module -m lib/ansible/modules/cloud/amazon/s3_bucket.py -a "profile=sandbox name=test-2017-02-13-1039 versioning=yes"
 hacking/test-module -m lib/ansible/modules/cloud/amazon/s3_bucket.py -a "profile=sandbox name=test-2017-02-13-1039 versioning=no"
```

and results now as expected