### PR TITLE
ini_file should only append trailing newline on existing files

### DIFF
--- a/lib/ansible/modules/files/ini_file.py
+++ b/lib/ansible/modules/files/ini_file.py
@@ -177,7 +177,7 @@ def do_ini(module, filename, section=None, option=None, value=None,
     changed = False
 
     # last line of file may not contain a trailing newline
-    if ini_lines[-1] == "" or ini_lines[-1][-1] != '\n':
+    if ini_lines and (ini_lines[-1] == "" or ini_lines[-1][-1] != '\n'):
         ini_lines[-1] += '\n'
         changed = True
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ini_file

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file =
  configured module search path = [u'library/']
```

##### SUMMARY
ini_file should only attempt to append trailing newline to file on existing files.

Module errors on [ini_file.py#L180](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/files/ini_file.py#L180) on new files. Introduced in 222e1c97b.

See also: ansible/ansible#19883


Before:
```
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_HeRI62/ansible_module_ini_file.py", line 314, in <module>
    main()
  File "/tmp/ansible_HeRI62/ansible_module_ini_file.py", line 300, in main
    (changed,backup_file,diff,msg) = do_ini(module, path, section, option, value, state, backup, no_extra_spaces, create)
  File "/tmp/ansible_HeRI62/ansible_module_ini_file.py", line 180, in do_ini
    if ini_lines[-1] == "" or ini_lines[-1][-1] != '\n':
IndexError: list index out of range
```

After:

Successful creation & modification of file.