### PR TITLE
Improving nxos_ip_interface module

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_ip_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_ip_interface.py
@@ -466,7 +466,7 @@ def main():
         state=dict(required=False, default='present',
                    choices=['present', 'absent']),
         allow_secondary=dict(required=False, default=False,
-                             choices=[True, False], type='bool'),
+                             type='bool'),
         include_defaults=dict(default=True),
         config=dict(),
         save=dict(type='bool', default=False)

--- a/lib/ansible/modules/network/nxos/nxos_ip_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_ip_interface.py
@@ -54,7 +54,7 @@ options:
         default: null
     tag:
         description:
-            - Route tag for IPv4 ot IPv6 Address in integer format.
+            - Route tag for IPv4 or IPv6 Address in integer format.
         required: false
         default: 0
         version_added: "2.4"

--- a/lib/ansible/modules/network/nxos/nxos_ip_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_ip_interface.py
@@ -23,7 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_ip_interface
-version_added: "2.2"
+version_added: "2.1"
 short_description: Manages L3 attributes for IPv4 and IPv6 interfaces.
 description:
     - Manages Layer 3 attributes for IPv4 and IPv6 interfaces.

--- a/lib/ansible/modules/network/nxos/nxos_ip_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_ip_interface.py
@@ -146,7 +146,11 @@ changed:
 # COMMON CODE FOR MIGRATION
 import re
 
-import ipaddress
+try:
+    import ipaddress
+    HAS_IPADDRESS = True
+except ImportError:
+    HAS_IPADDRESS = False
 
 from ansible.module_utils.basic import get_exception
 from ansible.module_utils.netcfg import NetworkConfig, ConfigLine
@@ -620,6 +624,9 @@ def main():
     )
     module = get_network_module(argument_spec=argument_spec,
                                 supports_check_mode=True)
+
+    if not HAS_IPADDRESS:
+        module.fail_json(msg="ipaddress is required for this module. Run 'pip install ipaddress' for install.")
 
     addr = module.params['addr']
     version = module.params['version']

--- a/lib/ansible/modules/network/nxos/nxos_ip_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_ip_interface.py
@@ -150,6 +150,8 @@ import ipaddress
 # COMMON CODE FOR MIGRATION
 import re
 
+import ipaddress
+
 from ansible.module_utils.basic import get_exception
 from ansible.module_utils.netcfg import NetworkConfig, ConfigLine
 from ansible.module_utils.shell import ShellError
@@ -161,16 +163,15 @@ except ImportError:
 
 
 def to_list(val):
-     if isinstance(val, (list, tuple)):
-         return list(val)
-     elif val is not None:
-         return [val]
-     else:
-         return list()
+    if isinstance(val, (list, tuple)):
+        return list(val)
+    elif val is not None:
+        return [val]
+    else:
+        return list()
 
 
 class CustomNetworkConfig(NetworkConfig):
-
     def expand_section(self, configobj, S=None):
         if S is None:
             S = list()
@@ -205,7 +206,6 @@ class CustomNetworkConfig(NetworkConfig):
         if not obj:
             raise ValueError('path does not exist in config')
         return self.expand_section(obj)
-
 
     def add(self, lines, parents=None):
         """Adds one or lines of configuration
@@ -262,6 +262,7 @@ def get_network_module(**kwargs):
     except NameError:
         return NetworkModule(**kwargs)
 
+
 def get_config(module, include_defaults=False):
     config = module.params['config']
     if not config:
@@ -271,6 +272,7 @@ def get_config(module, include_defaults=False):
             defaults = module.params['include_defaults']
             config = module.config.get_config(include_defaults=defaults)
     return CustomNetworkConfig(indent=2, contents=config)
+
 
 def load_config(module, candidate):
     config = get_config(module)
@@ -299,6 +301,8 @@ def load_config(module, candidate):
         result['updates'] = commands
 
     return result
+
+
 # END OF COMMON CODE
 
 def execute_config_command(commands, module):
@@ -331,6 +335,7 @@ def find_same_addr(existing, addr, mask, full=False, **kwargs):
             else:
                 return address
     return False
+
 
 # TODO: remove
 # This method doesn't used any more, because we don't use JSON output.
@@ -376,6 +381,7 @@ def execute_show(cmds, module, command_type='cli_show'):
 def execute_show_command(command, module, command_type='cli_show'):
     body = execute_show([command], module, command_type=command_type)
     return body
+
 
 # TODO: remove
 # This method isn't used
@@ -538,7 +544,7 @@ def parse_unstructured_data(body, interface_name, version, module):
                     # interface['prefix'] = prefix
 
             interface_list_table = splitted_body[
-                                first_reference_point:last_reference_point]
+                                   first_reference_point:last_reference_point]
 
             for each_line in interface_list_table:
                 address = each_line.strip().split(' ')[0]
@@ -688,7 +694,7 @@ def validate_params(addr, interface, mask, tag, allow_secondary, version, state,
             module.fail_json(msg="Warning! 'mask' must be an integer between"
                                  " 1 and 32 when version v4 and up to 128 "
                                  "when version v6.", version=version,
-                                 mask=mask)
+                             mask=mask)
     if addr is not None and mask is not None:
         try:
             ipaddress.ip_interface('{}/{}'.format(addr, mask).decode('utf-8'))
@@ -700,9 +706,9 @@ def validate_params(addr, interface, mask, tag, allow_secondary, version, state,
             if tag < 0 and tag > 4294967295:
                 raise ValueError
         except ValueError:
-                module.fail_json(msg="Warning! 'tag' must be an integer between"
-                                     " 0 (default) and 4294967295."
-                                     "To use tag you must set 'addr' and 'mask' params.", tag=tag)
+            module.fail_json(msg="Warning! 'tag' must be an integer between"
+                                 " 0 (default) and 4294967295."
+                                 "To use tag you must set 'addr' and 'mask' params.", tag=tag)
     if allow_secondary is not None:
         try:
             if addr is None or mask is None:
@@ -714,19 +720,19 @@ def validate_params(addr, interface, mask, tag, allow_secondary, version, state,
 
 def main():
     argument_spec = dict(
-            interface=dict(required=True),
-            addr=dict(required=False),
-            version=dict(required=False, choices=['v4', 'v6'],
-                         default='v4'),
-            mask=dict(type='str', required=False),
-            tag=dict(required=False, default=0, type='int'),
-            state=dict(required=False, default='present',
-                       choices=['present', 'absent']),
-            allow_secondary=dict(required=False, default=False,
-                                 choices=[True, False], type='bool'),
-            include_defaults=dict(default=True),
-            config=dict(),
-            save=dict(type='bool', default=False)
+        interface=dict(required=True),
+        addr=dict(required=False),
+        version=dict(required=False, choices=['v4', 'v6'],
+                     default='v4'),
+        mask=dict(type='str', required=False),
+        tag=dict(required=False, default=0, type='int'),
+        state=dict(required=False, default='present',
+                   choices=['present', 'absent']),
+        allow_secondary=dict(required=False, default=False,
+                             choices=[True, False], type='bool'),
+        include_defaults=dict(default=True),
+        config=dict(),
+        save=dict(type='bool', default=False)
     )
     module = get_network_module(argument_spec=argument_spec,
                                 supports_check_mode=True)

--- a/lib/ansible/modules/network/nxos/nxos_ip_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_ip_interface.py
@@ -57,17 +57,21 @@ options:
             - Route tag for IPv4 ot IPv6 Address in integer format.
         required: false
         default: 0
+        version_added: "2.3"
     allow_secondary:
         description:
             - Allow to configure IPv4 secondary addresses on interface.
         required: false
         default: false
+        version_added: "2.3"
     state:
         description:
             - Specify desired state of the resource.
         required: false
         default: present
         choices: ['present','absent']
+requirements:
+    - "ipaddress"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/network/nxos/nxos_ip_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_ip_interface.py
@@ -645,8 +645,6 @@ def main():
     changed = False
     end_state = existing
 
-    prefix = str(ipaddress.ip_interface('{}/{}'.format(addr, mask).decode('utf-8')).network)
-
     if state == 'absent' and existing['addresses']:
         if find_same_addr(existing, addr, mask):
             command = get_remove_ip_config_commands(interface, addr,

--- a/lib/ansible/modules/network/nxos/nxos_ip_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_ip_interface.py
@@ -120,15 +120,15 @@ proposed:
 existing:
     description: k/v pairs of existing IP attributes on the interface
     type: dict
-    sample: {"addresses": [{"addr": "11.11.11.11", "mask": 17, "tag": 101}],
+    sample: {"addresses": [{"addr": "11.11.11.11", "mask": 17, "tag": 101, "secondary": false}],
             "interface": "ethernet1/32", "prefixes": ["11.11.0.0/17"],
             "type": "ethernet", "vrf": "default"}
 end_state:
     description: k/v pairs of IP attributes after module execution
     returned: always
     type: dict
-    sample: {"addresses": [{"addr": "11.11.11.11", "mask": 17, "tag": 101},
-                           {"addr": "20.20.20.20", "mask": 24, "tag": 100}],
+    sample: {"addresses": [{"addr": "11.11.11.11", "mask": 17, "tag": 101, "secondary": false},
+                           {"addr": "20.20.20.20", "mask": 24, "tag": 100, "secondary": true}],
             "interface": "ethernet1/32", "prefixes": ["11.11.0.0/17", "20.20.20.0/24"],
             "type": "ethernet", "vrf": "default"}
 updates:

--- a/lib/ansible/modules/network/nxos/nxos_ip_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_ip_interface.py
@@ -115,8 +115,8 @@ proposed:
     description: k/v pairs of parameters passed into module
     returned: always
     type: dict
-    sample: "proposed": {"addr": "20.20.20.20", "allow_secondary": true,
-                        "interface": "Ethernet1/32", "mask": "24", "tag": "100"}
+    sample: {"addr": "20.20.20.20", "allow_secondary": true,
+            "interface": "Ethernet1/32", "mask": "24", "tag": 100}
 existing:
     description: k/v pairs of existing IP attributes on the interface
     type: dict

--- a/lib/ansible/modules/network/nxos/nxos_ip_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_ip_interface.py
@@ -120,7 +120,7 @@ proposed:
 existing:
     description: k/v pairs of existing IP attributes on the interface
     type: dict
-    sample: {"addresses": [{"addr": "11.11.11.11", "mask": 17, "tag": 101},
+    sample: {"addresses": [{"addr": "11.11.11.11", "mask": 17, "tag": 101}],
             "interface": "ethernet1/32", "prefixes": ["11.11.0.0/17"],
             "type": "ethernet", "vrf": "default"}
 end_state:

--- a/lib/ansible/modules/network/nxos/nxos_ip_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_ip_interface.py
@@ -16,19 +16,18 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-ANSIBLE_METADATA = {'metadata_version': '1.0',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
 
 DOCUMENTATION = '''
 ---
 module: nxos_ip_interface
-extends_documentation_fragment: nxos
-version_added: "2.1"
+version_added: "2.2"
 short_description: Manages L3 attributes for IPv4 and IPv6 interfaces.
 description:
     - Manages Layer 3 attributes for IPv4 and IPv6 interfaces.
+extends_documentation_fragment: nxos
 author:
     - Jason Edelman (@jedelman8)
     - Gabriele Gerbino (@GGabriele)
@@ -53,6 +52,16 @@ options:
             - Subnet mask for IPv4 or IPv6 Address in decimal format.
         required: false
         default: null
+    tag:
+        description:
+            - Route tag for IPv4 ot IPv6 Address in integer format.
+        required: false
+        default: 0
+    allow_secondary:
+        description:
+            - Allow to configure IPv4 secondary addresses on interface.
+        required: false
+        default: false
     state:
         description:
             - Specify desired state of the resource.
@@ -79,6 +88,26 @@ EXAMPLES = '''
     state: present
     addr: '2001::db8:800:200c:cccb'
     mask: 64
+
+- name: Ensure ipv4 address is configured with tag
+  nxos_ip_interface:
+    interface: Ethernet1/32
+    transport: nxapi
+    version: v4
+    state: present
+    tag: 100
+    addr: 20.20.20.20
+    mask: 24
+
+- name: Configure ipv4 address as secondary if needed
+  nxos_ip_interface:
+    interface: Ethernet1/32
+    transport: nxapi
+    version: v4
+    state: present
+    allow_secondary: true
+    addr: 21.21.21.21
+    mask: 24
 '''
 
 RETURN = '''
@@ -86,25 +115,27 @@ proposed:
     description: k/v pairs of parameters passed into module
     returned: always
     type: dict
-    sample: {"addr": "20.20.20.20", "interface": "ethernet1/32", "mask": "24"}
+    sample: "proposed": {"addr": "20.20.20.20", "allow_secondary": true,
+                        "interface": "Ethernet1/32", "mask": "24", "tag": "100"}
 existing:
     description: k/v pairs of existing IP attributes on the interface
     type: dict
-    sample: {"addresses": [{"addr": "11.11.11.11", "mask": 17}],
-            "interface": "ethernet1/32", "prefix": "11.11.0.0",
+    sample: {"addresses": [{"addr": "11.11.11.11", "mask": 17, "tag": 101},
+            "interface": "ethernet1/32", "prefixes": ["11.11.0.0/17"],
             "type": "ethernet", "vrf": "default"}
 end_state:
     description: k/v pairs of IP attributes after module execution
     returned: always
     type: dict
-    sample: {"addresses": [{"addr": "20.20.20.20", "mask": 24}],
-            "interface": "ethernet1/32", "prefix": "20.20.20.0",
+    sample: {"addresses": [{"addr": "11.11.11.11", "mask": 17, "tag": 101},
+                           {"addr": "20.20.20.20", "mask": 24, "tag": 100}],
+            "interface": "ethernet1/32", "prefixes": ["11.11.0.0/17", "20.20.20.0/24"],
             "type": "ethernet", "vrf": "default"}
 updates:
     description: commands sent to the device
     returned: always
     type: list
-    sample: ["interface ethernet1/32", "ip address 20.20.20.20/24"]
+    sample: ["interface ethernet1/32", "ip address 20.20.20.20/24 secondary tag 100"]
 changed:
     description: check to see if a change was made on the device
     returned: always
@@ -112,36 +143,254 @@ changed:
     sample: true
 '''
 
-from ansible.module_utils.nxos import get_config, load_config, run_commands
-from ansible.module_utils.nxos import nxos_argument_spec, check_args
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.netcfg import CustomNetworkConfig
+import json
+import collections
+import ipaddress
 
+# COMMON CODE FOR MIGRATION
 import re
 
-def execute_show_command(command, module, command_type='cli_show'):
-    if module.params['transport'] == 'cli':
-        command += ' | json'
-        cmds = [command]
-        body = run_commands(module, cmds)
-    elif module.params['transport'] == 'nxapi':
-        cmds = [command]
-        body = run_commands(module, cmds)
+from ansible.module_utils.basic import get_exception
+from ansible.module_utils.netcfg import NetworkConfig, ConfigLine
+from ansible.module_utils.shell import ShellError
 
+try:
+    from ansible.module_utils.nxos import get_module
+except ImportError:
+    from ansible.module_utils.nxos import NetworkModule
+
+
+def to_list(val):
+     if isinstance(val, (list, tuple)):
+         return list(val)
+     elif val is not None:
+         return [val]
+     else:
+         return list()
+
+
+class CustomNetworkConfig(NetworkConfig):
+
+    def expand_section(self, configobj, S=None):
+        if S is None:
+            S = list()
+        S.append(configobj)
+        for child in configobj.children:
+            if child in S:
+                continue
+            self.expand_section(child, S)
+        return S
+
+    def get_object(self, path):
+        for item in self.items:
+            if item.text == path[-1]:
+                parents = [p.text for p in item.parents]
+                if parents == path[:-1]:
+                    return item
+
+    def to_block(self, section):
+        return '\n'.join([item.raw for item in section])
+
+    def get_section(self, path):
+        try:
+            section = self.get_section_objects(path)
+            return self.to_block(section)
+        except ValueError:
+            return list()
+
+    def get_section_objects(self, path):
+        if not isinstance(path, list):
+            path = [path]
+        obj = self.get_object(path)
+        if not obj:
+            raise ValueError('path does not exist in config')
+        return self.expand_section(obj)
+
+
+    def add(self, lines, parents=None):
+        """Adds one or lines of configuration
+        """
+
+        ancestors = list()
+        offset = 0
+        obj = None
+
+        ## global config command
+        if not parents:
+            for line in to_list(lines):
+                item = ConfigLine(line)
+                item.raw = line
+                if item not in self.items:
+                    self.items.append(item)
+
+        else:
+            for index, p in enumerate(parents):
+                try:
+                    i = index + 1
+                    obj = self.get_section_objects(parents[:i])[0]
+                    ancestors.append(obj)
+
+                except ValueError:
+                    # add parent to config
+                    offset = index * self.indent
+                    obj = ConfigLine(p)
+                    obj.raw = p.rjust(len(p) + offset)
+                    if ancestors:
+                        obj.parents = list(ancestors)
+                        ancestors[-1].children.append(obj)
+                    self.items.append(obj)
+                    ancestors.append(obj)
+
+            # add child objects
+            for line in to_list(lines):
+                # check if child already exists
+                for child in ancestors[-1].children:
+                    if child.text == line:
+                        break
+                else:
+                    offset = len(parents) * self.indent
+                    item = ConfigLine(line)
+                    item.raw = line.rjust(len(line) + offset)
+                    item.parents = ancestors
+                    ancestors[-1].children.append(item)
+                    self.items.append(item)
+
+
+def get_network_module(**kwargs):
+    try:
+        return get_module(**kwargs)
+    except NameError:
+        return NetworkModule(**kwargs)
+
+def get_config(module, include_defaults=False):
+    config = module.params['config']
+    if not config:
+        try:
+            config = module.get_config()
+        except AttributeError:
+            defaults = module.params['include_defaults']
+            config = module.config.get_config(include_defaults=defaults)
+    return CustomNetworkConfig(indent=2, contents=config)
+
+def load_config(module, candidate):
+    config = get_config(module)
+
+    commands = candidate.difference(config)
+    commands = [str(c).strip() for c in commands]
+
+    save_config = module.params['save']
+
+    result = dict(changed=False)
+
+    if commands:
+        if not module.check_mode:
+            try:
+                module.configure(commands)
+            except AttributeError:
+                module.config(commands)
+
+            if save_config:
+                try:
+                    module.config.save_config()
+                except AttributeError:
+                    module.execute(['copy running-config startup-config'])
+
+        result['changed'] = True
+        result['updates'] = commands
+
+    return result
+# END OF COMMON CODE
+
+def execute_config_command(commands, module):
+    try:
+        module.configure(commands)
+    except ShellError:
+        clie = get_exception()
+        module.fail_json(msg='Error sending CLI commands',
+                         error=str(clie), commands=commands)
+    except AttributeError:
+        try:
+            commands.insert(0, 'configure')
+            module.cli.add_commands(commands, output='config')
+            module.cli.run_commands()
+        except ShellError:
+            clie = get_exception()
+            module.fail_json(msg='Error sending CLI commands',
+                             error=str(clie), commands=commands)
+
+
+def find_same_addr(existing, addr, mask, full=False, **kwargs):
+    for address in existing['addresses']:
+        if address['addr'] == addr and address['mask'] == mask:
+            if full:
+                if kwargs['version'] == 'v4' and int(address['tag']) == kwargs['tag']:
+                    return address
+                elif kwargs['version'] == 'v6':
+                    # Currently we don't get info about IPv6 address tag
+                    return False
+            else:
+                return address
+    return False
+
+# TODO: remove
+# This method doesn't used any more, because we don't use JSON output.
+#
+# def get_cli_body_ssh(command, response, module):
+#     """Get response for when transport=cli.  This is kind of a hack and mainly
+#     needed because these modules were originally written for NX-API.  And
+#     not every command supports "| json" when using cli/ssh.  As such, we assume
+#     if | json returns an XML string, it is a valid command, but that the
+#     resource doesn't exist yet. Instead, we assume if '^' is found in response,
+#     it is an invalid command.
+#     """
+#     if 'xml' in response[0]:
+#         body = []
+#     elif '^' in response[0] or 'show run' in response[0] or response[0] == '\n':
+#         body = response
+#     else:
+#         try:
+#             body = [json.loads(response[0])]
+#         except ValueError:
+#             module.fail_json(msg='Command does not support JSON output',
+#                              command=command)
+#     return body
+
+
+def execute_show(cmds, module, command_type='cli_show'):
+    command_type_map = {
+        'cli_show': 'json',
+        'cli_show_ascii': 'text'
+    }
+
+    try:
+        command_type = command_type_map.get(command_type)
+        module.cli.add_commands(cmds, output=command_type, raw=True)
+        response = module.cli.run_commands()
+    except ShellError:
+        clie = get_exception()
+        module.fail_json(msg='Error sending {0}'.format(cmds),
+                         error=str(clie))
+    return response
+
+
+def execute_show_command(command, module, command_type='cli_show'):
+    body = execute_show([command], module, command_type=command_type)
     return body
 
-
-def apply_key_map(key_map, table):
-    new_dict = {}
-    for key, value in table.items():
-        new_key = key_map.get(key)
-        if new_key:
-            value = table.get(key)
-            if value:
-                new_dict[new_key] = str(value)
-            else:
-                new_dict[new_key] = value
-    return new_dict
+# TODO: remove
+# This method isn't used
+#
+# def apply_key_map(key_map, table):
+#     new_dict = {}
+#     for key, value in table.items():
+#         new_key = key_map.get(key)
+#         if new_key:
+#             value = table.get(key)
+#             if value:
+#                 new_dict[new_key] = str(value)
+#             else:
+#                 new_dict[new_key] = value
+#     return new_dict
 
 
 def get_interface_type(interface):
@@ -165,7 +414,7 @@ def is_default(interface, module):
     command = 'show run interface {0}'.format(interface)
 
     try:
-        body = execute_show_command(command, module)[0]
+        body = execute_show_command(command, module, command_type='cli_show_ascii')[0]
         if 'invalid' in body.lower():
             return 'DNE'
         else:
@@ -179,21 +428,16 @@ def is_default(interface, module):
 
 
 def get_interface_mode(interface, intf_type, module):
-    command = 'show interface {0}'.format(interface)
+    command = 'show interface {0} switchport'.format(interface)
     mode = 'unknown'
 
     if intf_type in ['ethernet', 'portchannel']:
-        body = execute_show_command(command, module)[0]
-
-        if isinstance(body, str):
-            if 'invalid interface format' in body.lower():
-                module.fail_json(msg='Invalid interface name. Please check '
-                                     'its format.', interface=interface)
-
-        interface_table = body['TABLE_interface']['ROW_interface']
-        mode = str(interface_table.get('eth_mode', 'layer3'))
-        if mode == 'access' or mode == 'trunk':
-            mode = 'layer2'
+        body = execute_show_command(command, module, command_type='cli_show_ascii')[0]
+        if len(body) > 0:
+            if 'Switchport: Disabled' in body:
+                mode = 'layer3'
+            elif 'Switchport: Enabled' in body:
+                mode = "layer2"
     elif intf_type == 'svi':
         mode = 'layer3'
     return mode
@@ -204,146 +448,170 @@ def send_show_command(interface_name, version, module):
         command = 'show ip interface {0}'.format(interface_name)
     elif version == 'v6':
         command = 'show ipv6 interface {0}'.format(interface_name)
-
-    if module.params['transport'] == 'nxapi' and version == 'v6':
-        body = execute_show_command(command, module,
-                                    command_type='cli_show_ascii')
-    else:
-        body = execute_show_command(command, module)
+    body = execute_show_command(command, module, command_type='cli_show_ascii')
     return body
 
 
-def parse_structured_data(body, interface_name, version, module):
-    address_list = []
+# TODO: remove
+# This method doesn't used any more, because there aren't
+# information about tags from JSON output for IPv4 secondary addresses and IPv6 addresses
+#
+# def parse_structured_data(body, interface_name, version, module):
+#     address_list = []
+#
+#     interface_key = {
+#         'subnet': 'prefix',
+#         'prefix': 'prefix'
+#     }
+#
+#     try:
+#         interface_table = body[0]['TABLE_intf']['ROW_intf']
+#         try:
+#             vrf_table = body[0]['TABLE_vrf']['ROW_vrf']
+#             vrf = vrf_table['vrf-name-out']
+#         except KeyError:
+#             vrf = None
+#     except (KeyError, AttributeError):
+#         return {}
+#
+#     interface = apply_key_map(interface_key, interface_table)
+#     interface['interface'] = interface_name
+#     interface['type'] = get_interface_type(interface_name)
+#     interface['vrf'] = vrf
+#
+#     if version == 'v4':
+#         address = {}
+#         address['addr'] = interface_table.get('prefix', None)
+#         if address['addr'] is not None:
+#             address['mask'] = str(interface_table.get('masklen', None))
+#             interface['addresses'] = [address]
+#             prefix = "{0}/{1}".format(address['addr'], address['mask'])
+#             address_list.append(prefix)
+#         else:
+#             interface['addresses'] = []
+#
+#     elif version == 'v6':
+#         address_list = interface_table.get('addr', [])
+#         interface['addresses'] = []
+#
+#         if address_list:
+#             if not isinstance(address_list, list):
+#                 address_list = [address_list]
+#
+#             for ipv6 in address_list:
+#                 address = {}
+#                 splitted_address = ipv6.split('/')
+#                 address['addr'] = splitted_address[0]
+#                 address['mask'] = splitted_address[1]
+#                 interface['addresses'].append(address)
+#         else:
+#             interface['addresses'] = []
+#
+#     return interface, address_list
 
-    interface_key = {
-        'subnet': 'prefix',
-        'prefix': 'prefix'
-    }
 
-    try:
-        interface_table = body[0]['TABLE_intf']['ROW_intf']
-        try:
-            vrf_table = body[0]['TABLE_vrf']['ROW_vrf']
-            vrf = vrf_table['vrf-name-out']
-        except KeyError:
-            vrf = None
-    except (KeyError, AttributeError):
-        return {}
-
-    interface = apply_key_map(interface_key, interface_table)
-    interface['interface'] = interface_name
-    interface['type'] = get_interface_type(interface_name)
-    interface['vrf'] = vrf
-
-    if version == 'v4':
-        address = {}
-        address['addr'] = interface_table.get('prefix', None)
-        if address['addr'] is not None:
-            address['mask'] = str(interface_table.get('masklen', None))
-            interface['addresses'] = [address]
-            prefix = "{0}/{1}".format(address['addr'], address['mask'])
-            address_list.append(prefix)
-        else:
-            interface['addresses'] = []
-
-    elif version == 'v6':
-        address_list = interface_table.get('addr', [])
-        interface['addresses'] = []
-
-        if address_list:
-            if not isinstance(address_list, list):
-                address_list = [address_list]
-
-            for ipv6 in address_list:
-                address = {}
-                splitted_address = ipv6.split('/')
-                address['addr'] = splitted_address[0]
-                address['mask'] = splitted_address[1]
-                interface['addresses'].append(address)
-        else:
-            interface['addresses'] = []
-
-    return interface, address_list
-
-
-def parse_unstructured_data(body, interface_name, module):
+def parse_unstructured_data(body, interface_name, version, module):
     interface = {}
-    address_list = []
+    interface['addresses'] = []
+    interface['prefixes'] = []
     vrf = None
 
     body = body[0]
-    if "ipv6 is disabled" not in body.lower():
-        splitted_body = body.split('\n')
+    splitted_body = body.split('\n')
 
-        # We can have multiple IPv6 on the same interface.
-        # We need to parse them manually from raw output.
-        for index in range(0, len(splitted_body) - 1):
-            if "IPv6 address:" in splitted_body[index]:
-                first_reference_point = index + 1
-            elif "IPv6 subnet:" in splitted_body[index]:
-                last_reference_point = index
-                prefix_line = splitted_body[last_reference_point]
-                prefix = prefix_line.split('IPv6 subnet:')[1].strip()
-                interface['prefix'] = prefix
+    if version == "v6":
+        if "ipv6 is disabled" not in body.lower():
+            address_list = []
+            # We can have multiple IPv6 on the same interface.
+            # We need to parse them manually from raw output.
+            for index in range(0, len(splitted_body) - 1):
+                if "IPv6 address:" in splitted_body[index]:
+                    first_reference_point = index + 1
+                elif "IPv6 subnet:" in splitted_body[index]:
+                    last_reference_point = index
+                    break
+                    # TODO: remove
+                    # 'prefix' appends when addresses adding to 'address_list'
+                    #
+                    # prefix_line = splitted_body[last_reference_point]
+                    # prefix = prefix_line.split('IPv6 subnet:')[1].strip()
+                    # interface['prefix'] = prefix
 
-        interface_list_table = splitted_body[
-            first_reference_point:last_reference_point]
+            interface_list_table = splitted_body[
+                                first_reference_point:last_reference_point]
 
-        for each_line in interface_list_table:
-            address = each_line.strip().split(' ')[0]
-            if address not in address_list:
-                address_list.append(address)
+            for each_line in interface_list_table:
+                address = each_line.strip().split(' ')[0]
+                if address not in address_list:
+                    address_list.append(address)
+                    interface['prefixes'].append(str(ipaddress.ip_interface(address.decode('utf-8')).network))
 
-        interface['addresses'] = []
-        if address_list:
-            for ipv6 in address_list:
-                address = {}
-                splitted_address = ipv6.split('/')
-                address['addr'] = splitted_address[0]
-                address['mask'] = splitted_address[1]
-                interface['addresses'].append(address)
-
-        try:
-            vrf_regex = '.*VRF\s+(?P<vrf>\S+).*'
-            match_vrf = re.match(vrf_regex, body, re.DOTALL)
-            group_vrf = match_vrf.groupdict()
-            vrf = group_vrf["vrf"]
-        except AttributeError:
-            vrf = None
+            if address_list:
+                for ipv6 in address_list:
+                    address = {}
+                    splitted_address = ipv6.split('/')
+                    address['addr'] = splitted_address[0]
+                    address['mask'] = splitted_address[1]
+                    interface['addresses'].append(address)
 
     else:
-        # IPv6's not been configured on this interface yet.
-        interface['addresses'] = []
+        for index in range(0, len(splitted_body) - 1):
+            if "IP address" in splitted_body[index]:
+                regex = '.*IP\saddress:\s(?P<addr>\d{1,3}(?:\.\d{1,3}){3}),\sIP\ssubnet:\s\d{1,3}(?:\.\d{1,3}){3}\/(?P<mask>\d+)(?:\s(?P<secondary>secondary)\s)?.+?tag:\s(?P<tag>\d+).*'
+                match = re.match(regex, splitted_body[index])
+                if match:
+                    match_dict = match.groupdict()
+                    if match_dict['secondary'] is None:
+                        match_dict['secondary'] = False
+                    else:
+                        match_dict['secondary'] = True
+                    match_dict['tag'] = int(match_dict['tag'])
+                    interface['addresses'].append(match_dict)
+                    prefix = str(ipaddress.ip_interface("{addr}/{mask}".format(**match_dict).decode('utf-8')).network)
+                    interface['prefixes'].append(prefix)
+
+    try:
+        vrf_regex = '.*VRF\s+"(?P<vrf>\S+?)".*'
+        match_vrf = re.match(vrf_regex, body, re.DOTALL)
+        group_vrf = match_vrf.groupdict()
+        vrf = group_vrf["vrf"]
+    except AttributeError:
+        vrf = None
 
     interface['interface'] = interface_name
     interface['type'] = get_interface_type(interface_name)
     interface['vrf'] = vrf
 
-    return interface, address_list
+    return interface
 
 
 def get_ip_interface(interface_name, version, module):
     body = send_show_command(interface_name, version, module)
+    interface = parse_unstructured_data(body, interface_name, version, module)
 
-    # nxapi default response doesn't reflect the actual interface state
-    # when dealing with IPv6. That's why we need to get raw output instead
-    # and manually parse it.
-    if module.params['transport'] == 'nxapi' and version == 'v6':
-        interface, address_list = parse_unstructured_data(
-            body, interface_name, module)
-    else:
-        interface, address_list = parse_structured_data(
-            body, interface_name, version, module)
-
-    return interface, address_list
+    return interface
 
 
-def get_remove_ip_config_commands(interface, addr, mask, version):
+def get_remove_ip_config_commands(interface, addr, mask, existing, version):
     commands = []
     commands.append('interface {0}'.format(interface))
     if version == 'v4':
-        commands.append('no ip address')
+        # We can't just remove primary address if secondary address exists
+        for address in existing['addresses']:
+            if address['addr'] == addr:
+                if address['secondary']:
+                    commands.append('no ip address {0}/{1} secondary'.format(addr, mask))
+                elif len(existing['addresses']) > 1:
+                    for address in existing['addresses']:
+                        if address['addr'] != addr:
+                            commands.append('no ip address {0}/{1} secondary'.format(address['addr'], address['mask']))
+                            command = 'ip address {0}/{1}'.format(address['addr'], address['mask'])
+                            if 'tag' in address and address['tag'] != 0:
+                                command += " tag " + str(address['tag'])
+                            commands.append(command)
+                else:
+                    commands.append('no ip address {0}/{1}'.format(addr, mask))
+                break
     else:
         commands.append('no ipv6 address {0}/{1}'.format(addr, mask))
 
@@ -354,16 +622,32 @@ def get_config_ip_commands(delta, interface, existing, version):
     commands = []
     delta = dict(delta)
 
+    # TODO: remove
+    # ['addr', 'mask'] aren't correct keys for existing variable
+    # 
     # loop used in the situation that just an IP address or just a
     # mask is changing, not both.
-    for each in ['addr', 'mask']:
-        if each not in delta:
-            delta[each] = existing[each]
+    # for each in ['addr', 'mask']:
+    #     if each not in delta:
+    #         delta[each] = existing[each]
 
     if version == 'v4':
         command = 'ip address {addr}/{mask}'.format(**delta)
+        if len(existing['addresses']) > 0 and delta['allow_secondary']:
+            for address in existing['addresses']:
+                if delta['addr'] == address['addr'] and address['secondary'] is False:
+                    break
+            else:
+                command += ' secondary'
     else:
         command = 'ipv6 address {addr}/{mask}'.format(**delta)
+
+    if int(delta['tag']) > 0:
+        command += ' tag {tag}'.format(**delta)
+    elif int(delta['tag']) == 0:
+        # Case when we need to remove tag. Just enter command like 'ip address ...' not enough
+        commands += get_remove_ip_config_commands(interface, delta['addr'], delta['mask'], existing, version)
+
     commands.append(command)
     commands.insert(0, 'interface {0}'.format(interface))
 
@@ -380,7 +664,7 @@ def flatten_list(command_lists):
     return flat_command_list
 
 
-def validate_params(addr, interface, mask, version, state, intf_type, module):
+def validate_params(addr, interface, mask, tag, allow_secondary, version, state, intf_type, module):
     if state == "present":
         if addr is None or mask is None:
             module.fail_json(msg="An IP address AND a mask must be provided "
@@ -390,7 +674,7 @@ def validate_params(addr, interface, mask, version, state, intf_type, module):
             module.fail_json(msg="IPv6 address and mask must be provided when "
                                  "state=absent.")
 
-    if (intf_type != "ethernet" and module.params["transport"] == "cli"):
+    if intf_type != "ethernet" and module.params["transport"] == "cli":
         if is_default(interface, module) == "DNE":
             module.fail_json(msg="That interface does not exist yet. Create "
                                  "it first.", interface=interface)
@@ -405,94 +689,91 @@ def validate_params(addr, interface, mask, version, state, intf_type, module):
                                  " 1 and 32 when version v4 and up to 128 "
                                  "when version v6.", version=version,
                                  mask=mask)
+    if addr is not None and mask is not None:
+        try:
+            ipaddress.ip_interface('{}/{}'.format(addr, mask).decode('utf-8'))
+        except ValueError:
+            module.fail_json(msg="Warning! Invalid ip address or mask set.", addr=addr, mask=mask)
+
+    if tag is not None:
+        try:
+            if tag < 0 and tag > 4294967295:
+                raise ValueError
+        except ValueError:
+                module.fail_json(msg="Warning! 'tag' must be an integer between"
+                                     " 0 (default) and 4294967295."
+                                     "To use tag you must set 'addr' and 'mask' params.", tag=tag)
+    if allow_secondary is not None:
+        try:
+            if addr is None or mask is None:
+                raise ValueError
+        except ValueError:
+            module.fail_json(msg="Warning! 'secondary' can be used only when 'addr' and 'mask' set.",
+                             allow_secondary=allow_secondary)
 
 
 def main():
     argument_spec = dict(
-        interface=dict(required=True),
-        addr=dict(required=False),
-        version=dict(required=False, choices=['v4', 'v6'],
+            interface=dict(required=True),
+            addr=dict(required=False),
+            version=dict(required=False, choices=['v4', 'v6'],
                          default='v4'),
-        mask=dict(type='str', required=False),
-        state=dict(required=False, default='present',
+            mask=dict(type='str', required=False),
+            tag=dict(required=False, default=0, type='int'),
+            state=dict(required=False, default='present',
                        choices=['present', 'absent']),
-        include_defaults=dict(default=True),
-        config=dict(),
-        save=dict(type='bool', default=False)
+            allow_secondary=dict(required=False, default=False,
+                                 choices=[True, False], type='bool'),
+            include_defaults=dict(default=True),
+            config=dict(),
+            save=dict(type='bool', default=False)
     )
-
-    argument_spec.update(nxos_argument_spec)
-
-    module = AnsibleModule(argument_spec=argument_spec,
+    module = get_network_module(argument_spec=argument_spec,
                                 supports_check_mode=True)
-
-    warnings = list()
-    check_args(module, warnings)
-
 
     addr = module.params['addr']
     version = module.params['version']
     mask = module.params['mask']
+    tag = module.params['tag']
+    allow_secondary = module.params['allow_secondary']
     interface = module.params['interface'].lower()
     state = module.params['state']
 
     intf_type = get_interface_type(interface)
-    validate_params(addr, interface, mask, version, state, intf_type, module)
+    validate_params(addr, interface, mask, tag, allow_secondary, version, state, intf_type, module)
 
     mode = get_interface_mode(interface, intf_type, module)
     if mode == 'layer2':
         module.fail_json(msg='That interface is a layer2 port.\nMake it '
                              'a layer 3 port first.', interface=interface)
 
-    existing, address_list = get_ip_interface(interface, version, module)
+    existing = get_ip_interface(interface, version, module)
 
-    args = dict(addr=addr, mask=mask, interface=interface)
+    args = dict(addr=addr, mask=mask, tag=tag, interface=interface, allow_secondary=allow_secondary)
     proposed = dict((k, v) for k, v in args.items() if v is not None)
     commands = []
     changed = False
     end_state = existing
 
+    prefix = str(ipaddress.ip_interface('{}/{}'.format(addr, mask).decode('utf-8')).network)
+
     if state == 'absent' and existing['addresses']:
-        if version == 'v6':
-            for address in existing['addresses']:
-                if address['addr'] == addr and address['mask'] == mask:
-                    command = get_remove_ip_config_commands(interface, addr,
-                                                            mask, version)
-                    commands.append(command)
-
-        else:
+        if find_same_addr(existing, addr, mask):
             command = get_remove_ip_config_commands(interface, addr,
-                                                    mask, version)
+                                                    mask, existing, version)
             commands.append(command)
-
     elif state == 'present':
-        if not existing['addresses']:
-            command = get_config_ip_commands(proposed, interface,
-                                             existing, version)
+        if not find_same_addr(existing, addr, mask, full=True, tag=tag, version=version):
+            command = get_config_ip_commands(proposed, interface, existing, version)
             commands.append(command)
-        else:
-            prefix = "{0}/{1}".format(addr, mask)
-            if prefix not in address_list:
-                command = get_config_ip_commands(proposed, interface,
-                                                 existing, version)
-                commands.append(command)
-            else:
-                for address in existing['addresses']:
-                    if (address['addr'] == addr and
-                            int(address['mask']) != int(mask)):
-                        command = get_config_ip_commands(proposed, interface,
-                                                         existing, version)
-                        commands.append(command)
-
     cmds = flatten_list(commands)
     if cmds:
         if module.check_mode:
             module.exit_json(changed=True, commands=cmds)
         else:
-            load_config(module, cmds)
+            execute_config_command(cmds, module)
             changed = True
-            end_state, address_list = get_ip_interface(interface, version,
-                                                       module)
+            end_state = get_ip_interface(interface, version, module)
             if 'configure' in cmds:
                 cmds.pop(0)
 
@@ -502,11 +783,9 @@ def main():
     results['end_state'] = end_state
     results['updates'] = cmds
     results['changed'] = changed
-    results['warnings'] = warnings
 
     module.exit_json(**results)
 
 
 if __name__ == '__main__':
     main()
-

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -596,7 +596,6 @@ lib/ansible/modules/network/nxos/nxos_igmp_snooping.py
 lib/ansible/modules/network/nxos/nxos_install_os.py
 lib/ansible/modules/network/nxos/nxos_interface.py
 lib/ansible/modules/network/nxos/nxos_interface_ospf.py
-lib/ansible/modules/network/nxos/nxos_ip_interface.py
 lib/ansible/modules/network/nxos/nxos_ntp.py
 lib/ansible/modules/network/nxos/nxos_ntp_auth.py
 lib/ansible/modules/network/nxos/nxos_ntp_options.py


### PR DESCRIPTION
Added features:

  * Route tags for an IP address at interface level with 'tag' option
  * Support of IPv4 secondary addresses if option `allow_secondary` is
true (false by default). If option `allow_secondary` is false primary
IPv4 address will be replaced

All features support NXAPI and CLI transport, but only with text/raw
output. Currently not possible to get route tags for secondary IPv4/IPv6
addresses from JSON output.

Other changes:
  * Module return state `changed` only when configuration commands were
executed
  * Module result includes multiple prefixes if secondary IPv4 addresses were
found

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ansible/modules/network/nxos/nxos_ip_interface

##### ANSIBLE VERSION
```
ansible --version
ansible 2.2.1.0 (stable-2.2 6176c95838) last updated 2017/02/13 16:48:05 (GMT +300)
  lib/ansible/modules/core: (feature-nxos-ip-interface 2c1f374da0) last updated 2017/02/13 21:58:33 (GMT +300)
  lib/ansible/modules/extras: (detached HEAD 994349b647) last updated 2017/02/13 16:58:44 (GMT +300)
  config file = /Users/idrey/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
I have tested this commit with playbook that can be downloaded by [link](https://gist.github.com/Drey/fa7360f9746c6269f17598b96cb95d82) and Ansible version from branch stable-2.2.

Thanks!
