### PR TITLE
Removes usage of expanduser due to type 'path'

### DIFF
--- a/lib/ansible/modules/files/ini_file.py
+++ b/lib/ansible/modules/files/ini_file.py
@@ -288,7 +288,7 @@ def main():
         supports_check_mode = True
     )
 
-    path = os.path.expanduser(module.params['path'])
+    path = module.params['path']
     section = module.params['section']
     option = module.params['option']
     value = module.params['value']


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/files/ini_file.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Removes the usage of the expanduser function because it is
being performed automatically by the type 'path' of the
path option. Related to #12263