### PR TITLE
Removes expanduser in favor of type path

### DIFF
--- a/lib/ansible/modules/commands/expect.py
+++ b/lib/ansible/modules/commands/expect.py
@@ -129,9 +129,9 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             command=dict(required=True),
-            chdir=dict(),
-            creates=dict(),
-            removes=dict(),
+            chdir=dict(type='path'),
+            creates=dict(type='path'),
+            removes=dict(type='path'),
             responses=dict(type='dict', required=True),
             timeout=dict(type='int', default=30),
             echo=dict(type='bool', default=False),
@@ -162,18 +162,17 @@ def main():
         module.fail_json(rc=256, msg="no command given")
 
     if chdir:
-        chdir = os.path.abspath(os.path.expanduser(chdir))
+        chdir = os.path.abspath(chdir)
         os.chdir(chdir)
 
     if creates:
         # do not run the command if the line contains creates=filename
         # and the filename already exists.  This allows idempotence
         # of command executions.
-        v = os.path.expanduser(creates)
-        if os.path.exists(v):
+        if os.path.exists(creates):
             module.exit_json(
                 cmd=args,
-                stdout="skipped, since %s exists" % v,
+                stdout="skipped, since %s exists" % creates,
                 changed=False,
                 rc=0
             )
@@ -182,11 +181,10 @@ def main():
         # do not run the command if the line contains removes=filename
         # and the filename does not exist.  This allows idempotence
         # of command executions.
-        v = os.path.expanduser(removes)
-        if not os.path.exists(v):
+        if not os.path.exists(removes):
             module.exit_json(
                 cmd=args,
-                stdout="skipped, since %s does not exist" % v,
+                stdout="skipped, since %s does not exist" % removes,
                 changed=False,
                 rc=0
             )


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/commands/expect.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Removes the usage of expanduser in favor of the type 'path' for
module options. Related to #12263