### PR TITLE
Removes expanduser calls

### DIFF
--- a/lib/ansible/modules/files/replace.py
+++ b/lib/ansible/modules/files/replace.py
@@ -155,7 +155,7 @@ def main():
     )
 
     params = module.params
-    path = os.path.expanduser(params['path'])
+    path = params['path']
     res_args = dict()
 
     if os.path.isdir(path):


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/files/replace.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
The usage of type='path' includes the expanduser call itself. This
patch removes its duplicate usage. Related to #12263