### PR TITLE
win_user: Clean up parameter handling and $result hash

### DIFF
--- a/lib/ansible/modules/windows/win_user.ps1
+++ b/lib/ansible/modules/windows/win_user.ps1
@@ -66,8 +66,8 @@ $password_never_expires = Get-AnsibleParam -obj $params -name "password_never_ex
 $user_cannot_change_password = Get-AnsibleParam -obj $params -name "user_cannot_change_password" -type "bool"
 $account_disabled = Get-AnsibleParam -obj $params -name "account_disabled" -type "bool"
 $account_locked = Get-AnsibleParam -obj $params -name "account_locked" -type "bool"
-$groups = Get-AnsibleParam -obj $params -name "groups" -type "str"
-$groups_action = Get-AnsibleParam -obj $params -name "groups_action" -type "str" -default "replace" -validateset "add","replace","remove"
+$groups = Get-AnsibleParam -obj $params -name "groups"
+$groups_action = Get-AnsibleParam -obj $params -name "groups_action" -type "str" -default "replace" -validateset "add","remove","replace"
 
 If ($account_locked -ne $null -and $account_locked) {
     Fail-Json $result "account_locked must be set to 'no' if provided"

--- a/lib/ansible/modules/windows/win_user.ps1
+++ b/lib/ansible/modules/windows/win_user.ps1
@@ -33,7 +33,8 @@ function Get-User($user) {
 function Get-UserFlag($user, $flag) {
     If ($user.UserFlags[0] -band $flag) {
         $true
-    } Else {
+    }
+    Else {
         $false
     }
 }
@@ -48,11 +49,11 @@ function Clear-UserFlag($user, $flag) {
 
 ########
 
+$params = Parse-Args $args;
+
 $result = @{
     changed = $false
-}
-
-$params = Parse-Args $args
+};
 
 $username = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true
 $fullname = Get-AnsibleParam -obj $params -name "fullname" -type "str"
@@ -75,7 +76,8 @@ If ($account_locked -ne $null -and $account_locked) {
 If ($groups -ne $null) {
     If ($groups -is [System.String]) {
         [string[]]$groups = $groups.Split(",")
-    } ElseIf ($groups -isnot [System.Collections.IList]) {
+    }
+    ElseIf ($groups -isnot [System.Collections.IList]) {
         Fail-Json $result "groups must be a string or array"
     }
     $groups = $groups | ForEach { ([string]$_).Trim() } | Where { $_ }
@@ -96,7 +98,8 @@ If ($state -eq 'present') {
             }
             $user_obj.SetInfo()
             $result.changed = $true
-        } ElseIf (($password -ne $null) -and ($update_password -eq 'always')) {
+        }
+        ElseIf (($password -ne $null) -and ($update_password -eq 'always')) {
             [void][system.reflection.assembly]::LoadWithPartialName('System.DirectoryServices.AccountManagement')
             $host_name = [System.Net.Dns]::GetHostName()
             $pc = New-Object -TypeName System.DirectoryServices.AccountManagement.PrincipalContext 'Machine', $host_name
@@ -104,7 +107,8 @@ If ($state -eq 'present') {
             # ValidateCredentials will fail if either of these are true- just force update...
             If($user_obj.AccountDisabled -or $user_obj.PasswordExpired) {
                 $password_match = $false
-            } Else {
+            }
+            Else {
                 $password_match = $pc.ValidateCredentials($username, $password)
             }
 
@@ -128,7 +132,8 @@ If ($state -eq 'present') {
         If (($password_never_expires -ne $null) -and ($password_never_expires -ne (Get-UserFlag $user_obj $ADS_UF_DONT_EXPIRE_PASSWD))) {
             If ($password_never_expires) {
                 Set-UserFlag $user_obj $ADS_UF_DONT_EXPIRE_PASSWD
-            } Else {
+            }
+            Else {
                 Clear-UserFlag $user_obj $ADS_UF_DONT_EXPIRE_PASSWD
             }
             $result.changed = $true
@@ -136,7 +141,8 @@ If ($state -eq 'present') {
         If (($user_cannot_change_password -ne $null) -and ($user_cannot_change_password -ne (Get-UserFlag $user_obj $ADS_UF_PASSWD_CANT_CHANGE))) {
             If ($user_cannot_change_password) {
                 Set-UserFlag $user_obj $ADS_UF_PASSWD_CANT_CHANGE
-            } Else {
+            }
+            Else {
                 Clear-UserFlag $user_obj $ADS_UF_PASSWD_CANT_CHANGE
             }
             $result.changed = $true
@@ -161,7 +167,8 @@ If ($state -eq 'present') {
                         If ($group_obj) {
                             $group_obj.Remove($user_obj.Path)
                             $result.changed = $true
-                        } Else {
+                        }
+                        Else {
                             Fail-Json $result "group '$grp' not found"
                         }
                     }
@@ -174,14 +181,16 @@ If ($state -eq 'present') {
                         If ($group_obj) {
                             $group_obj.Add($user_obj.Path)
                             $result.changed = $true
-                        } Else {
+                        }
+                        Else {
                             Fail-Json $result "group '$grp' not found"
                         }
                     }
                 }
             }
         }
-    } catch {
+    }
+    catch {
         Fail-Json $result $_.Exception.Message
     }
 }
@@ -194,7 +203,8 @@ ElseIf ($state -eq 'absent') {
             $result.changed = $true
             $user_obj = $null
         }
-    } catch {
+    }
+    catch {
         Fail-Json $result $_.Exception.Message
     }
 }
@@ -222,12 +232,14 @@ try {
         }
         $result.groups = $user_groups
         $result.state = "present"
-    } Else {
+    }
+    Else {
         $result.name = $username
         $result.msg = "User '$username' was not found"
         $result.state = "absent"
     }
-} catch {
+}
+catch {
     Fail-Json $result $_.Exception.Message
 }
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Changes include:
- Use of Get-AnsibleParam and parameter types/validateset
- Removed parameter validation
- Replace $result PSObject with normal hash