### PR TITLE
powershell.ps1: Add str, int, float types and ignore $null values

### DIFF
--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -206,6 +206,7 @@ Function Get-AnsibleParam($obj, $name, $default = $null, $resultobj = @{}, $fail
 
     }
 
+    # If $value -eq $null, the parameter was unspecified
     if ($value -ne $null -and $type -eq "path") {
         # Expand environment variables on path-type
         $value = Expand-Environment($value)
@@ -215,6 +216,12 @@ Function Get-AnsibleParam($obj, $name, $default = $null, $resultobj = @{}, $fail
     } elseif ($value -ne $null -and $type -eq "bool") {
         # Convert boolean types to real Powershell booleans
         $value = $value | ConvertTo-Bool
+    } elseif ($value -ne $null -and $type -eq "int") {
+        # Convert int types to real Powershell integers
+        $value = $value -as [int]
+    } elseif ($value -ne $null -and $type -eq "float") {
+        # Convert float types to real Powershell floats
+        $value = $value -as [float]
     }
 
     return $value


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
powershell.ps1

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Changes include:
- New "str" type support using -type "str"
- New "int" type support using -type "int"
- New "float" type support using -type "float"
- Ensure that $null values are retained
  (Note: $null means unspecified value for parameters)
- Some minor cosmetic changes