### PR TITLE
win_file_version: Clean up and check-mode support

### DIFF
--- a/lib/ansible/modules/windows/win_file_version.ps1
+++ b/lib/ansible/modules/windows/win_file_version.ps1
@@ -19,18 +19,19 @@
 # WANT_JSON
 # POWERSHELL_COMMON
 
-$params = Parse-Args $args;
+$params = Parse-Args $args -supports_check_mode $true
 
-$result = New-Object psobject @{
-    win_file_version = New-Object psobject
+$result = @{
+    win_file_version = @{}
     changed = $false
 }
 
-$path = Get-AnsibleParam $params "path" -type "path" -failifempty $true -resultobj $result
+$path = Get-AnsibleParam -obj $params -name "path" -type "path" -failifempty $true -resultobj $result
 
 If (-Not (Test-Path -Path $path -PathType Leaf)){
     Fail-Json $result "Specfied path $path does exist or is not a file."
 }
+
 $ext = [System.IO.Path]::GetExtension($path)
 If ( $ext -notin '.exe', '.dll'){
     Fail-Json $result "Specfied path $path is not a vaild file type; must be DLL or EXE."
@@ -62,17 +63,16 @@ Try {
     If ($file_private_part -eq $null){
         $file_private_part = ''
     }
-}
-Catch{
+} Catch{
     Fail-Json $result "Error: $_.Exception.Message"
 }
 
-Set-Attr $result.win_file_version "path" $path.toString()
-Set-Attr $result.win_file_version "file_version" $file_version.toString()
-Set-Attr $result.win_file_version "product_version" $product_version.toString()
-Set-Attr $result.win_file_version "file_major_part" $file_major_part.toString()
-Set-Attr $result.win_file_version "file_minor_part" $file_minor_part.toString()
-Set-Attr $result.win_file_version "file_build_part" $file_build_part.toString()
-Set-Attr $result.win_file_version "file_private_part" $file_private_part.toString()
-Exit-Json $result;
+$result.win_file_version.path = $path.toString()
+$result.win_file_version.file_version = $file_version.toString()
+$result.win_file_version.product_version = $product_version.toString()
+$result.win_file_version.file_major_part = $file_major_part.toString()
+$result.win_file_version.file_minor_part = $file_minor_part.toString()
+$result.win_file_version.file_build_part = $file_build_part.toString()
+$result.win_file_version.file_private_part = $file_private_part.toString()
 
+Exit-Json $result

--- a/lib/ansible/modules/windows/win_file_version.ps1
+++ b/lib/ansible/modules/windows/win_file_version.ps1
@@ -31,7 +31,6 @@ $path = Get-AnsibleParam -obj $params -name "path" -type "path" -failifempty $tr
 If (-Not (Test-Path -Path $path -PathType Leaf)){
     Fail-Json $result "Specfied path $path does exist or is not a file."
 }
-
 $ext = [System.IO.Path]::GetExtension($path)
 If ( $ext -notin '.exe', '.dll'){
     Fail-Json $result "Specfied path $path is not a vaild file type; must be DLL or EXE."
@@ -63,7 +62,8 @@ Try {
     If ($file_private_part -eq $null){
         $file_private_part = ''
     }
-} Catch{
+}
+Catch{
     Fail-Json $result "Error: $_.Exception.Message"
 }
 
@@ -74,5 +74,4 @@ $result.win_file_version.file_major_part = $file_major_part.toString()
 $result.win_file_version.file_minor_part = $file_minor_part.toString()
 $result.win_file_version.file_build_part = $file_build_part.toString()
 $result.win_file_version.file_private_part = $file_private_part.toString()
-
-Exit-Json $result
+Exit-Json $result;


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_file_version

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Changes include:
- Replacing $result PSObject with hash
- Use Get-AnsibleParam using -type