### PR TITLE
win_group: Clean up and check-mode support

### DIFF
--- a/lib/ansible/modules/windows/win_group.ps1
+++ b/lib/ansible/modules/windows/win_group.ps1
@@ -19,47 +19,47 @@
 # WANT_JSON
 # POWERSHELL_COMMON
 
-$params = Parse-Args $args;
+$params = Parse-Args $args
+$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
 
-$result = New-Object PSObject;
-Set-Attr $result "changed" $false;
+$name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true
+$state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present","absent"
+$description = Get-AnsibleParam -obj $params -name "description" -type "str"
 
-$name = Get-Attr $params "name" -failifempty $true
-
-$state = Get-Attr $params "state" "present"
-$state = $state.ToString().ToLower()
-If (($state -ne "present") -and ($state -ne "absent")) {
-    Fail-Json $result "state is '$state'; must be 'present' or 'absent'"
+$result = @{
+    changed = $false
 }
-
-$description = Get-Attr $params "description" $null
 
 $adsi = [ADSI]"WinNT://$env:COMPUTERNAME"
-$group = $adsi.Children | Where-Object {$_.SchemaClassName -eq 'group' -and $_.Name -eq $name }
+$group = $adsi.Children | Where-Object { $_.SchemaClassName -eq 'group' -and $_.Name -eq $name }
 
 try {
-    If ($state -eq "present") {
-        If (-not $group) {
-            $group = $adsi.Create("Group", $name)
-            $group.SetInfo()
+    if ($state -eq "present") {
+        if (-not $group) {
+            if (-not $check_mode) {
+                $group = $adsi.Create("Group", $name)
+                $group.SetInfo()
+            }
 
-            Set-Attr $result "changed" $true
+            $result.changed = $true
         }
 
-        If ($null -ne $description) {
-            IF (-not $group.description -or $group.description -ne $description) {
+        if ($null -ne $description) {
+            if (-not $group.description -or $group.description -ne $description) {
                 $group.description = $description
-                $group.SetInfo()
-                Set-Attr $result "changed" $true
+                if (-not $check_mode) {
+                    $group.SetInfo()
+                }
+                $result.changed = $true
             }
         }
+    } elseif ($state -eq "absent" -and $group) {
+        if (-not $check_mode) {
+            $adsi.delete("Group", $group.Name.Value)
+        }
+        $result.changed = $true
     }
-    ElseIf ($state -eq "absent" -and $group) {
-        $adsi.delete("Group", $group.Name.Value)
-        Set-Attr $result "changed" $true
-    }
-}
-catch {
+} catch {
     Fail-Json $result $_.Exception.Message
 }
 

--- a/lib/ansible/modules/windows/win_group.ps1
+++ b/lib/ansible/modules/windows/win_group.ps1
@@ -19,7 +19,7 @@
 # WANT_JSON
 # POWERSHELL_COMMON
 
-$params = Parse-Args $args
+$params = Parse-Args $args;
 $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
 
 $name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true
@@ -31,12 +31,12 @@ $result = @{
 }
 
 $adsi = [ADSI]"WinNT://$env:COMPUTERNAME"
-$group = $adsi.Children | Where-Object { $_.SchemaClassName -eq 'group' -and $_.Name -eq $name }
+$group = $adsi.Children | Where-Object {$_.SchemaClassName -eq 'group' -and $_.Name -eq $name }
 
 try {
-    if ($state -eq "present") {
-        if (-not $group) {
-            if (-not $check_mode) {
+    If ($state -eq "present") {
+        If (-not $group) {
+            If (-not $check_mode) {
                 $group = $adsi.Create("Group", $name)
                 $group.SetInfo()
             }
@@ -44,22 +44,24 @@ try {
             $result.changed = $true
         }
 
-        if ($null -ne $description) {
-            if (-not $group.description -or $group.description -ne $description) {
+        If ($null -ne $description) {
+            IF (-not $group.description -or $group.description -ne $description) {
                 $group.description = $description
-                if (-not $check_mode) {
+                If (-not $check_mode) {
                     $group.SetInfo()
                 }
                 $result.changed = $true
             }
         }
-    } elseif ($state -eq "absent" -and $group) {
-        if (-not $check_mode) {
+    }
+    ElseIf ($state -eq "absent" -and $group) {
+        If (-not $check_mode) {
             $adsi.delete("Group", $group.Name.Value)
         }
         $result.changed = $true
     }
-} catch {
+}
+catch {
     Fail-Json $result $_.Exception.Message
 }
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_group

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Changes include:
- Use Get-AnsibleParam with -type/-validateset support
- Replace $result PSObject with normal hash
- Add check-mode support