### PR TITLE
win_owner: Clean up and check-mode support

### DIFF
--- a/lib/ansible/modules/windows/win_owner.ps1
+++ b/lib/ansible/modules/windows/win_owner.ps1
@@ -98,10 +98,7 @@ try {
 
     if ($acl.getOwner([System.Security.Principal.SecurityIdentifier]) -ne $objUser) {
         $acl.setOwner($objUser)
-        if (-not $check_mode) {
-            Set-Acl $file.FullName $acl
-        }
-
+        Set-Acl -Path $file.FullName -AclObject $acl -WhatIf:$check_mode
         $result.changed = $true
     }
 
@@ -112,10 +109,7 @@ try {
 
             if ($acl.getOwner([System.Security.Principal.SecurityIdentifier]) -ne $objUser) {
                 $acl.setOwner($objUser)
-                if (-not $check_mode) {
-                    Set-Acl $file.FullName $acl
-                }
-
+                Set-Acl -Path $file.FullName -AclObject $acl -WhatIf:$check_mode
                 $result.changed = $true
             }
         }

--- a/lib/ansible/modules/windows/win_owner.py
+++ b/lib/ansible/modules/windows/win_owner.py
@@ -44,7 +44,6 @@ options:
   recurse:
     description:
       - Indicates if the owner should be changed recursively
-    required: false
     choices:
       - no
       - yes


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_share

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Changes include:
- Use Get-AnsibleParam with -type/-validateset
- Replace $result PSObject with normal hash
- Add check-mode support