### PR TITLE
Use with statement when doing rw on files

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -1494,26 +1494,23 @@ class Ec2Inventory(object):
         ''' Reads the inventory from the cache file and returns it as a JSON
         object '''
 
-        cache = open(self.cache_path_cache, 'r')
-        json_inventory = cache.read()
-        return json_inventory
-
+        with open(self.cache_path_cache, 'r') as f:
+            json_inventory = f.read()
+            return json_inventory
 
     def load_index_from_cache(self):
         ''' Reads the index from the cache file sets self.index '''
 
-        cache = open(self.cache_path_index, 'r')
-        json_index = cache.read()
-        self.index = json.loads(json_index)
-
+        with open(self.cache_path_index, 'r') as f:
+            json_index = f.read()
+            self.index = json.loads(json_index)
 
     def write_to_cache(self, data, filename):
         ''' Writes data in JSON format to a file '''
 
         json_data = self.json_format_dict(data, True)
-        cache = open(filename, 'w')
-        cache.write(json_data)
-        cache.close()
+        with open(filename, 'w') as f:
+            f.write(json_data)
 
     def uncammelize(self, key):
         temp = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', key)

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -1502,8 +1502,7 @@ class Ec2Inventory(object):
         ''' Reads the index from the cache file sets self.index '''
 
         with open(self.cache_path_index, 'r') as f:
-            json_index = f.read()
-            self.index = json.loads(json_index)
+            self.index = json.load(f)
 
     def write_to_cache(self, data, filename):
         ''' Writes data in JSON format to a file '''


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
contrib/inventory/ec2.py

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Small bug fix to make sure files are closed when they're opened. Uses python's `with` statement. Compatible with python 2.5 and above.
```
./ec2.py --list
# printed huge list, took a while to display

./ec2.py --list
# second time around was much faster, since results were cached
# (confirms my change works as expected)
```
