### PR TITLE
Contributing new dldp module to manage HUAWEI data center CloudEngine switch

### DIFF
--- a/lib/ansible/module_utils/cloudengine.py
+++ b/lib/ansible/module_utils/cloudengine.py
@@ -27,11 +27,11 @@
 import re
 import time
 
-from ansible.module_utils.basic import json
+from ansible.module_utils.basic import json, get_exception
 from ansible.module_utils.network import NetworkError
 from ansible.module_utils.network import add_argument,\
     register_transport, to_list
-from ansible.module_utils.shell import CliBase
+from ansible.module_utils.shell import CliBase, ShellError
 
 try:
     from ncclient import manager
@@ -64,8 +64,22 @@ class CeConfigMixin(object):
             cmd += ' include-default'
         if regular:
             cmd += ' ' + regular
+        cfg = self.execute([cmd])[0]
+        if not include_defaults:
+            return cfg
 
-        return self.execute([cmd])[0]
+        # remove default configuration prefix
+        if cfg:
+            cmds = cfg.split("\n")
+            for i in range(len(cmds)):
+                if not cmds[i]:
+                    continue
+                if cmds[i].count('~') > 0:
+                    index = cmds[i].index('~')
+                    if cmds[i][:index] == ' '*index:
+                        cmds[i] = cmds[i].replace("~", "", 1)
+            cfg = '\n'.join(cmds)
+        return cfg
 
     def load_config(self, config):
         """ load_config """
@@ -77,29 +91,18 @@ class CeConfigMixin(object):
         except TypeError:
             self.execute(['system-view immediately',
                           'commit label %s' % checkpoint])
+        except Exception:
+            raise
 
         try:
             try:
                 self.configure(config)
-            except NetworkError:
+            except (NetworkError, Exception):
                 self.load_checkpoint(checkpoint)
+                self.clear_checkpoint(checkpoint)
                 raise
         finally:
-            # get commit id and clear it
-            responses = self.execute(
-                'display configuration commit list '
-                'label | include %s' % checkpoint)
-            match = re.match(
-                r'[\r\n]?\d+\s+(\d{10})\s+ansible.*', responses[0])
-            if match is not None:
-                try:
-                    self.execute(['return',
-                                  'clear configuration commit %s '
-                                  'label' % match.group(1)], output='text')
-                except TypeError:
-                    self.execute(['return',
-                                  'clear configuration commit %s '
-                                  'label' % match.group(1)])
+            self.clear_checkpoint(checkpoint)
 
     def save_config(self, **kwargs):
         """ save_config """
@@ -122,6 +125,24 @@ class CeConfigMixin(object):
                            ' label %s' % checkpoint])
         pass
 
+    def clear_checkpoint(self, checkpoint):
+        """ clear checkpoint """
+
+        # get commit id and clear it
+        responses = self.execute(
+            'display configuration commit list '
+            'label | include %s' % checkpoint)
+        match = re.match(
+            r'[\r\n]?\d+\s+(\d{10})\s+ansible.*', responses[0])
+        if match is not None:
+            try:
+                self.execute(['return',
+                              'clear configuration commit %s '
+                              'label' % match.group(1)], output='text')
+            except TypeError:
+                self.execute(['return',
+                              'clear configuration commit %s '
+                              'label' % match.group(1)])
 
 class Netconf(object):
     """ Netconf """
@@ -195,7 +216,8 @@ class Cli(CeConfigMixin, CliBase):
     """ Cli """
 
     CLI_PROMPTS_RE = [
-        re.compile(r'[\r\n]?[<|\[]{1}.+[>|\]]{1}(?:\s*)$'),
+        re.compile(r'[\r\n]?<.+>(?:\s*)$'),
+        re.compile(r'[\r\n]?\[.+\](?:\s*)$'),
     ]
 
     CLI_ERRORS_RE = [
@@ -209,7 +231,8 @@ class Cli(CeConfigMixin, CliBase):
         re.compile(r"'[^']' +returned error code: ?\d+"),
         re.compile(r"syntax error"),
         re.compile(r"unknown command"),
-        re.compile(r"Error\[\d+\]: ")
+        re.compile(r"Error\[\d+\]: ", re.I),
+        re.compile(r"Error:", re.I)
     ]
 
     NET_PASSWD_RE = re.compile(r"[\r\n]?password: $", re.I)
@@ -220,6 +243,21 @@ class Cli(CeConfigMixin, CliBase):
         super(Cli, self).connect(params, kickstart=False, **kwargs)
         self.shell.send('screen-length 0 temporary')
         self.shell.send('mmi-mode enable')
+
+    def execute(self, commands):
+        try:
+            return self.shell.send(commands)
+        except ShellError:
+            exc = get_exception()
+            cmd = ""
+            if exc.command:
+                cmd = "Command: %s\r\n" % str(exc.command)
+            msg = str(exc.message)
+            if str(exc.command) in msg:
+                msg = msg.replace(str(exc.command), "")
+            if "matched error in response: " in msg:
+                msg = msg.replace("matched error in response: ", "")
+            raise NetworkError(cmd+msg, commands=commands)
 
     def run_commands(self, commands):
         """ run_commands """
@@ -268,3 +306,39 @@ def prepare_commands(commands):
         if cmd.command.endswith('| json'):
             cmd.output = 'json'
         yield cmd
+
+def get_cli_exception(exc=None):
+    """ get cli exception message"""
+
+    msg = list()
+    if not exc:
+        exc = get_exception()
+    if exc:
+        errs = str(exc).split("\r\n")
+        for err in errs:
+            if not err:
+                continue
+            if "matched error in response:" in err:
+                continue
+            if " at '^' position" in err:
+                err = err.replace(" at '^' position", "")
+            if err.replace(" ", "") == "^":
+                continue
+            if len(err) > 2 and err[0] in ["<", "["] and err[-1] in [">", "]"]:
+                continue
+            if err[-1] == ".":
+                err = err[:-1]
+            if err.replace(" ", "") == "":
+                continue
+            msg.append(err)
+    else:
+        msg = ["Error: Fail to get cli exception message."]
+
+    while msg[-1][-1] == ' ':
+        msg[-1] = msg[-1][:-1]
+
+    if msg[-1][-1] != ".":
+        msg[-1] += "."
+
+    return ", ".join(msg).capitalize()
+

--- a/lib/ansible/modules/network/cloudengine/ce_command.py
+++ b/lib/ansible/modules/network/cloudengine/ce_command.py
@@ -37,7 +37,7 @@ extends_documentation_fragment: cloudengine
 options:
   commands:
     description:
-      - The commands to send to the remote HUAWEI CloudEngine device 
+      - The commands to send to the remote HUAWEI CloudEngine device
         over the configured provider.  The resulting output from the
         command is returned. If the I(wait_for) argument is provided,
         the module is not returned until the condition is satisfied

--- a/lib/ansible/modules/network/cloudengine/ce_config.py
+++ b/lib/ansible/modules/network/cloudengine/ce_config.py
@@ -1,0 +1,351 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = """
+---
+module: ce_config
+version_added: "2.3"
+author: "QijunPan (@CloudEngine-Ansible)"
+short_description: Manage Huawei CloudEngine configuration sections
+description:
+  - Huawei CloudEngine configurations use a simple block indent file syntax
+    for segmenting configuration into sections.  This module provides
+    an implementation for working with CloudEngine configuration sections in
+    a deterministic way.  This module works with CLI
+    transports.
+extends_documentation_fragment: cloudengine
+options:
+  lines:
+    description:
+      - The ordered set of commands that should be configured in the
+        section.  The commands must be the exact same commands as found
+        in the device running-config.  Be sure to note the configuration
+        command syntax as some commands are automatically modified by the
+        device config parser.
+    required: false
+    default: null
+  parents:
+    description:
+      - The ordered set of parents that uniquely identify the section
+        the commands should be checked against.  If the parents argument
+        is omitted, the commands are checked against the set of top
+        level or global commands.
+    required: false
+    default: null
+  src:
+    description:
+      - The I(src) argument provides a path to the configuration file
+        to load into the remote system.  The path can either be a full
+        system path to the configuration file if the value starts with /
+        or relative to the root of the implemented role or playbook.
+        This argument is mutually exclusive with the I(lines) and
+        I(parents) arguments.
+    required: false
+    default: null
+  before:
+    description:
+      - The ordered set of commands to push on to the command stack if
+        a change needs to be made.  This allows the playbook designer
+        the opportunity to perform configuration commands prior to pushing
+        any changes without affecting how the set of commands are matched
+        against the system.
+    required: false
+    default: null
+  after:
+    description:
+      - The ordered set of commands to append to the end of the command
+        stack if a change needs to be made.  Just like with I(before) this
+        allows the playbook designer to append a set of commands to be
+        executed after the command set.
+    required: false
+    default: null
+  match:
+    description:
+      - Instructs the module on the way to perform the matching of
+        the set of commands against the current device config.  If
+        match is set to I(line), commands are matched line by line.  If
+        match is set to I(strict), command lines are matched with respect
+        to position.  If match is set to I(exact), command lines
+        must be an equal match.  Finally, if match is set to I(none), the
+        module will not attempt to compare the source configuration with
+        the running configuration on the remote device.
+    required: false
+    default: line
+    choices: ['line', 'strict', 'exact', 'none']
+  replace:
+    description:
+      - Instructs the module on the way to perform the configuration
+        on the device.  If the replace argument is set to I(line) then
+        the modified lines are pushed to the device in configuration
+        mode.  If the replace argument is set to I(block) then the entire
+        command block is pushed to the device in configuration mode if any
+        line is not correct.
+    required: false
+    default: line
+    choices: ['line', 'block']
+  backup:
+    description:
+      - This argument will cause the module to create a full backup of
+        the current C(current-configuration) from the remote device before any
+        changes are made.  The backup file is written to the C(backup)
+        folder in the playbook root directory.  If the directory does not
+        exist, it is created.
+    required: false
+    default: no
+    choices: ['yes', 'no']
+  config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source.  There are times when it is not
+        desirable to have the task get the current running-config for
+        every task in a playbook.  The I(config) argument allows the
+        implementer to pass in the configuration to use as the base
+        config for comparison.
+    required: false
+    default: null
+  defaults:
+    description:
+      - The I(defaults) argument will influence how the running-config
+        is collected from the device.  When the value is set to true,
+        the command used to collect the running-config is append with
+        the all keyword.  When the value is set to false, the command
+        is issued without the all keyword
+    required: false
+    default: false
+  save:
+    description:
+      - The C(save) argument instructs the module to save the
+        running-config to startup-config.  This operation is performed
+        after any changes are made to the current running config.  If
+        no changes are made, the configuration is still saved to the
+        startup config.  This option will always cause the module to
+        return changed.
+    required: false
+    default: false
+"""
+
+EXAMPLES = """
+# Note: examples below use the following provider dict to handle
+#       transport and authentication to the node.
+vars:
+  cli:
+    host: "{{ inventory_hostname }}"
+    username: admin
+    password: admin
+    transport: cli
+
+- name: configure top level configuration and save it
+  ce_config:
+    lines: sysname {{ inventory_hostname }}
+    save: yes
+    provider: "{{ cli }}"
+
+- ce_config:
+    lines:
+      - rule 10 permit source 1.1.1.1 32
+      - rule 20 permit source 2.2.2.2 32
+      - rule 30 permit source 3.3.3.3 32
+      - rule 40 permit source 4.4.4.4 32
+      - rule 50 permit source 5.5.5.5 32
+    parents: acl 2000
+    before: undo acl 2000
+    match: exact
+    provider: "{{ cli }}"
+
+- ce_config:
+    lines:
+      - rule 10 permit source 1.1.1.1 32
+      - rule 20 permit source 2.2.2.2 32
+      - rule 30 permit source 3.3.3.3 32
+      - rule 40 permit source 4.4.4.4 32
+    parents: acl 2000
+    before: undo acl 2000
+    replace: block
+    provider: "{{ cli }}"
+"""
+
+RETURN = """
+updates:
+  description: The set of commands that will be pushed to the remote device
+  returned: Only when lines is specified.
+  type: list
+  sample: ['...', '...']
+backup_path:
+  description: The full path to the backup file
+  returned: when backup is yes
+  type: path
+  sample: /playbooks/ansible/backup/ce_config.2016-07-16@22:28:34
+"""
+
+from ansible.module_utils.cloudengine import get_cli_exception
+from ansible.module_utils.basic import get_exception
+from ansible.module_utils.network import NetworkModule, NetworkError
+from ansible.module_utils.netcfg import NetworkConfig, dumps
+from ansible.module_utils.basic import remove_values
+
+try:
+    from ansible.errors import AnsibleModuleExit
+    HAS_ANSIBLE_MODULE_EXIT = True
+except ImportError:
+    HAS_ANSIBLE_MODULE_EXIT = False
+
+
+def config_exit(module, **result):
+    """ return from the module, without error """
+
+    if HAS_ANSIBLE_MODULE_EXIT:
+        if 'changed' not in result:
+            result['changed'] = False
+        if 'invocation' not in result:
+            result['invocation'] = {'module_args': module.params}
+        result = remove_values(result, module.no_log_values)
+        raise AnsibleModuleExit(result)
+    else:
+        module.exit_json(**result)
+
+def config_fail(module, **result):
+    """ return from the module, with an error message """
+
+    if HAS_ANSIBLE_MODULE_EXIT:
+        assert 'msg' in result, "implementation error -- msg to explain the error is required"
+        result['failed'] = True
+        if 'invocation' not in result:
+            result['invocation'] = {'module_args': module.params}
+        result = remove_values(result, module.no_log_values)
+        raise AnsibleModuleExit(result)
+    else:
+        module.fail_json(**result)
+
+
+def get_candidate(module):
+    """ get candidat info. """
+    candidate = NetworkConfig(indent=1)
+    if module.params['src']:
+        candidate.load(module.params['src'])
+    elif module.params['lines']:
+        parents = module.params['parents'] or list()
+        candidate.add(module.params['lines'], parents=parents)
+    return candidate
+
+
+def get_config(module):
+    """ get current configuration. """
+
+    contents = module.params['config']
+    if not contents:
+        defaults = module.params['defaults']
+        contents = module.config.get_config(include_defaults=defaults)
+    return NetworkConfig(indent=1, contents=contents)
+
+
+def run(module, result):
+    """ module run. """
+
+    match = module.params['match']
+    replace = module.params['replace']
+
+    candidate = get_candidate(module)
+
+    if match != 'none':
+        config = get_config(module)
+        path = module.params['parents']
+        configobjs = candidate.difference(config, path=path, match=match,
+                                          replace=replace)
+    else:
+        configobjs = candidate.items
+
+    if configobjs:
+        commands = dumps(configobjs, 'commands').split('\n')
+        if module.params['lines']:
+            if module.params['before']:
+                commands[:0] = module.params['before']
+
+            if module.params['after']:
+                commands.extend(module.params['after'])
+
+            result['updates'] = commands
+
+        if not module.check_mode:
+            module.config.load_config(commands)
+
+        result['changed'] = True
+
+    if module.params['save']:
+        if not module.check_mode:
+            module.config.save_config()
+        result['changed'] = True
+
+
+def main():
+    """ main entry point for module execution
+    """
+
+    argument_spec = dict(
+        src=dict(type='path'),
+
+        lines=dict(aliases=['commands'], type='list'),
+        parents=dict(type='list'),
+
+        before=dict(type='list'),
+        after=dict(type='list'),
+
+        match=dict(default='line',
+                   choices=['line', 'strict', 'exact', 'none']),
+        replace=dict(default='line', choices=['line', 'block']),
+        config=dict(),
+        defaults=dict(type='bool', default=False),
+
+        backup=dict(type='bool', default=False),
+        save=dict(type='bool', default=False),
+    )
+
+    mutually_exclusive = [('lines', 'src')]
+
+    required_if = [('match', 'strict', ['lines']),
+                   ('match', 'exact', ['lines']),
+                   ('replace', 'block', ['lines'])]
+
+    module = NetworkModule(argument_spec=argument_spec,
+                           connect_on_load=False,
+                           mutually_exclusive=mutually_exclusive,
+                           required_if=required_if,
+                           supports_check_mode=True)
+
+    warnings = list()
+
+    result = dict(changed=False, warnings=warnings)
+
+    if module.params['backup']:
+        result['__backup__'] = module.config.get_config()
+
+    try:
+        run(module, result)
+    except NetworkError:
+        exc = get_exception()
+        config_fail(module, msg=get_cli_exception(exc), **exc.kwargs)
+
+    config_exit(module, **result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/cloudengine/ce_dldp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_dldp.py
@@ -1,0 +1,604 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = '''
+---
+
+module: ce_dldp
+version_added: "2.3"
+short_description: Manages global DLDP configuration.
+description:
+    - Manages global DLDP configuration.
+extends_documentation_fragment: cloudengine
+author:
+    - Zhijin Zhou (@CloudEngine-Ansible)
+notes:
+    - The relevant configurations will be deleted if DLDP is disabled using enable=false.
+    - When using auth_mode=none, it will restore the default DLDP authentication mode(By default,
+      DLDP packets are not authenticated.).
+    - By default, the working mode of DLDP is enhance, so you are advised to use work_mode=enhance to restore defualt
+      DLDP working mode.
+    - The default interval for sending Advertisement packets is 5 seconds, so you are advised to use time_interval=5 to
+      restore defualt DLDP interval.
+options:
+    enable:
+        description:
+            - Set global DLDP enable state.
+        required: false
+        default: null
+        choices: ['true', 'false']
+    work_mode:
+        description:
+            - Set global DLDP work-mode
+        required: false
+        default: null
+        choices: ['enhance', 'normal']
+    time_internal:
+        description:
+            - Specifies the interval for sending Advertisement packets.
+              The value is an integer ranging from 1 to 100, in seconds.
+              The default interval for sending Advertisement packets is 5 seconds.
+        required: false
+        default: null
+    auth_mode:
+        description:
+            - Specifies authentication algorithm of DLDP.
+        required: false
+        default: null
+        choices: ['md5', 'simple', 'sha', 'hmac-sha256', 'none']
+    auth_pwd:
+        description:
+            - Specifies authentication password.
+              The value is a string of 1 to 16 case-sensitive plaintexts or 24/32/48/108/128 case-sensitive encrypted
+              characters. The string excludes a question mark (?).
+        required: false
+        default: null
+    reset:
+        description:
+            - Specify whether reset DLDP state of disabled interfaces.
+        required: false
+        default: null
+        choices: ['true', 'false']
+'''
+
+EXAMPLES = '''
+# Configure global DLDP enable state
+- ce_dldp:
+    enable: true
+    username: "{{ un }}"
+    password: "{{ pwd }}"
+    host: "{{ inventory_hostname }}"
+
+# Configure DLDP work-mode and ensure global DLDP state is already enabled
+- ce_dldp:
+    enable: true
+    work_mode: normal
+    username: "{{ un }}"
+    password: "{{ pwd }}"
+    host: "{{ inventory_hostname }}"
+
+# Configure advertisement message time interval in seconds and ensure global DLDP state is already enabled
+- ce_dldp:
+    enable: true
+    time_interval: 6
+    username: "{{ un }}"
+    password: "{{ pwd }}"
+    host: "{{ inventory_hostname }}"
+
+# Configure a DLDP authentication mode and ensure global DLDP state is already enabled
+- ce_dldp:
+    enable: true
+    auth_mode: md5
+    auth_pwd: abc
+    username: "{{ un }}"
+    password: "{{ pwd }}"
+    host: "{{ inventory_hostname }}"
+
+# Reset DLDP state of disabled interfaces and ensure global DLDP state is already enabled
+- ce_dldp:
+    enable: true
+    reset: true
+    username: "{{ un }}"
+    password: "{{ pwd }}"
+    host: "{{ inventory_hostname }}"
+'''
+
+RETURN = '''
+proposed:
+    description: k/v pairs of parameters passed into module
+    returned: always
+    type: dict
+    sample: {
+                "enable": "true",
+                "reset": "true",
+                "time_internal": "12",
+                "work_mode": "normal"
+            }
+existing:
+    description:
+        - k/v pairs of existing global DLDP configration
+    type: dict
+    sample: {
+                "enable": "false",
+                "reset": "false",
+                "time_internal": "5",
+                "work_mode": "enhance"
+            }
+end_state:
+    description: k/v pairs of global DLDP configration after module execution
+    returned: always
+    type: dict
+    sample: {
+                "enable": "true",
+                "reset": "true",
+                "time_internal": "12",
+                "work_mode": "normal"
+            }
+updates:
+    description: command sent to the device
+    returned: always
+    type: list
+    sample: [
+                "dldp enable",
+                "dldp work-mode normal",
+                "dldp interval 12",
+                "dldp reset"
+            ]
+changed:
+    description: check to see if a change was made on the device
+    returned: always
+    type: boolean
+    sample: true
+'''
+
+import sys
+import copy
+from xml.etree import ElementTree
+from ansible.module_utils.network import NetworkModule
+from ansible.module_utils.cloudengine import get_netconf
+
+try:
+    from ncclient.operations.rpc import RPCError
+    HAS_NCCLIENT = True
+except ImportError:
+    HAS_NCCLIENT = False
+
+CE_NC_ACTION_RESET_DLDP = """
+<action>
+  <dldp xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+    <resetDldp></resetDldp>
+  </dldp>
+</action>
+"""
+
+CE_NC_GET_GLOBAL_DLDP_CONFIG = """
+<filter type="subtree">
+  <dldp xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+    <dldpSys>
+      <dldpEnable></dldpEnable>
+      <dldpInterval></dldpInterval>
+      <dldpWorkMode></dldpWorkMode>
+      <dldpAuthMode></dldpAuthMode>
+    </dldpSys>
+  </dldp>
+</filter>
+"""
+
+CE_NC_MERGE_DLDP_GLOBAL_CONFIG_HEAD = """
+<config>
+  <dldp xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+    <dldpSys operation="merge">
+      <dldpEnable>%s</dldpEnable>
+      <dldpInterval>%s</dldpInterval>
+      <dldpWorkMode>%s</dldpWorkMode>
+"""
+
+CE_NC_MERGE_DLDP_GLOBAL_CONFIG_TAIL = """
+    </dldpSys>
+  </dldp>
+</config>
+"""
+
+
+class Dldp(object):
+    """Manage global dldp configration"""
+
+    def __init__(self, argument_spec):
+        self.spec = argument_spec
+        self.module = None
+        self.netconf = None
+        self.init_module()
+
+        # dldp global configration info
+        self.enable = self.module.params['enable'] or None
+        self.work_mode = self.module.params['work_mode'] or None
+        self.internal = self.module.params['time_interval'] or None
+        self.reset = self.module.params['reset'] or None
+        self.auth_mode = self.module.params['auth_mode']
+        self.auth_pwd = self.module.params['auth_pwd']
+
+        self.dldp_conf = dict()
+        self.same_conf = False
+
+        # host info
+        self.host = self.module.params['host']
+        self.username = self.module.params['username']
+        self.port = self.module.params['port']
+
+        # state
+        self.changed = False
+        self.updates_cmd = list()
+        self.results = dict()
+        self.proposed = dict()
+        self.existing = list()
+        self.end_state = list()
+
+        # init netconf connect
+        self.init_netconf()
+
+    def check_config_if_same(self):
+        """judge whether current config is the same as what we excepted"""
+
+        if self.enable and self.enable != self.dldp_conf['dldpEnable']:
+            return False
+
+        if self.internal and self.internal != self.dldp_conf['dldpInterval']:
+            return False
+
+        work_mode = 'normal'
+        if self.dldp_conf['dldpWorkMode'] == 'dldpEnhance':
+            work_mode = 'enhance'
+        if self.work_mode and self.work_mode != work_mode:
+            return False
+
+        if self.auth_mode:
+            if self.auth_mode != 'none':
+                return False
+
+            if self.auth_mode == 'none' and self.dldp_conf['dldpAuthMode'] != 'dldpAuthNone':
+                return False
+
+        if self.reset and self.reset == 'true':
+            return False
+
+        return True
+
+    def check_params(self):
+        """Check all input params"""
+
+        if (self.auth_mode and self.auth_mode != 'none' and not self.auth_pwd) \
+                or (self.auth_pwd and not self.auth_mode):
+            self.module.fail_json(msg="Error: auth_mode and auth_pwd must both exist or not exist.")
+
+        if self.dldp_conf['dldpEnable'] == 'false' and not self.enable:
+            if self.work_mode or self.reset or self.internal or self.auth_mode:
+                self.module.fail_json(msg="Error: when DLDP is already disabled globally, "
+                                      "work_mode, time_internal auth_mode and reset parameters are not "
+                                      "expected to configure.")
+
+        if self.enable == 'false' and (self.work_mode or self.internal or self.reset or self.auth_mode):
+            self.module.fail_json(msg="Error: when using enable=false, work_mode, "
+                                  "time_internal auth_mode and reset parameters are not expected "
+                                  "to configure.")
+
+        if self.internal:
+            if not self.internal.isdigit():
+                self.module.fail_json(
+                    msg='Error: time_interval must be digit.')
+
+            if int(self.internal) < 1 or int(self.internal) > 100:
+                self.module.fail_json(
+                    msg='Error: The value of time_internal should be between 1 and 100.')
+
+        if self.auth_pwd:
+            if '?' in self.auth_pwd:
+                self.module.fail_json(
+                    msg='Error: The auth_pwd string excludes a question mark (?).')
+            if (len(self.auth_pwd) != 24) and (len(self.auth_pwd) != 32) and (len(self.auth_pwd) != 48) and \
+                    (len(self.auth_pwd) != 108) and (len(self.auth_pwd) != 128):
+                if (len(self.auth_pwd) < 1) or (len(self.auth_pwd) > 16):
+                    self.module.fail_json(
+                        msg='Error: The value is a string of 1 to 16 case-sensitive plaintexts or 24/32/48/108/128 '
+                            'case-sensitive encrypted characters.')
+
+    def init_module(self):
+        """init module object"""
+        self.module = NetworkModule(
+            argument_spec=self.spec, supports_check_mode=True)
+
+    def init_netconf(self):
+        """init netconf interface"""
+
+        if HAS_NCCLIENT:
+            self.netconf = get_netconf(host=self.host, port=self.port,
+                                       username=self.username,
+                                       password=self.module.params['password'])
+            if not self.netconf:
+                self.module.fail_json(msg='Error: netconf init failed')
+        else:
+            self.module.fail_json(
+                msg='Error: No ncclient package, please install it.')
+
+    def check_response(self, con_obj, xml_name):
+        """Check if response message is already succeed"""
+
+        xml_str = con_obj.xml
+        if "<ok/>" not in xml_str:
+            self.module.fail_json(msg='Error: %s failed.' % xml_name)
+
+    def netconf_get_config(self, xml_str):
+        """netconf get config"""
+
+        try:
+            con_obj = self.netconf.get_config(filter=xml_str)
+        except RPCError:
+            err = sys.exc_info()[1]
+            self.module.fail_json(msg='Error: %s' %
+                                  err.message.replace("\r\n", ""))
+
+        return con_obj
+
+    def netconf_set_config(self, xml_str, xml_name):
+        """netconf set config"""
+
+        try:
+            con_obj = self.netconf.set_config(config=xml_str)
+            self.check_response(con_obj, xml_name)
+        except RPCError:
+            err = sys.exc_info()[1]
+            self.module.fail_json(msg='Error: %s' %
+                                  err.message.replace("\r\n", ""))
+
+        return con_obj
+
+    def netconf_set_action(self, xml_str, xml_name):
+        """netconf set action"""
+
+        try:
+            con_obj = self.netconf.execute_action(action=xml_str)
+            self.check_response(con_obj, xml_name)
+        except RPCError:
+            err = sys.exc_info()[1]
+            self.module.fail_json(msg='Error: %s' %
+                                  err.message.replace("\r\n", ""))
+
+        return con_obj
+
+    def get_dldp_exist_config(self):
+        """get current dldp existed configuration"""
+        dldp_conf = dict()
+        xml_str = CE_NC_GET_GLOBAL_DLDP_CONFIG
+        con_obj = self.netconf_get_config(xml_str)
+        if "<data/>" in con_obj.xml:
+            return dldp_conf
+
+        xml_str = con_obj.xml.replace('\r', '').replace('\n', '').\
+            replace('xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"', "").\
+            replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
+
+        # get global dldp info
+        root = ElementTree.fromstring(xml_str)
+        topo = root.find("data/dldp/dldpSys")
+        if not topo:
+            self.module.fail_json(
+                msg="Error: Get current DLDP configration failed.")
+
+        for eles in topo:
+            if eles.tag in ["dldpEnable", "dldpInterval", "dldpWorkMode", "dldpAuthMode"]:
+                dldp_conf[eles.tag] = eles.text
+
+        return dldp_conf
+
+    def config_global_dldp(self):
+        """config global dldp"""
+        if self.same_conf:
+            return
+
+        enable = self.enable
+        if not self.enable:
+            enable = self.dldp_conf['dldpEnable']
+
+        internal = self.internal
+        if not self.internal:
+            internal = self.dldp_conf['dldpInterval']
+
+        work_mode = self.work_mode
+        if not self.work_mode:
+            work_mode = self.dldp_conf['dldpWorkMode']
+
+        if work_mode == 'enhance' or work_mode == 'dldpEnhance':
+            work_mode = 'dldpEnhance'
+        else:
+            work_mode = 'dldpNormal'
+
+        auth_mode = self.auth_mode
+        if not self.auth_mode:
+            auth_mode = self.dldp_conf['dldpAuthMode']
+        if auth_mode == 'md5':
+            auth_mode = 'dldpAuthMD5'
+        elif auth_mode == 'simple':
+            auth_mode = 'dldpAuthSimple'
+        elif auth_mode == 'sha':
+            auth_mode = 'dldpAuthSHA'
+        elif auth_mode == 'hmac-sha256':
+            auth_mode = 'dldpAuthHMAC-SHA256'
+        elif auth_mode == 'none':
+            auth_mode = 'dldpAuthNone'
+
+        xml_str = CE_NC_MERGE_DLDP_GLOBAL_CONFIG_HEAD % (
+            enable, internal, work_mode)
+        if self.auth_mode:
+            if self.auth_mode == 'none':
+                xml_str += "<dldpAuthMode>dldpAuthNone</dldpAuthMode>"
+            else:
+                xml_str += "<dldpAuthMode>%s</dldpAuthMode>" % auth_mode
+                xml_str += "<dldpPasswords>%s</dldpPasswords>" % self.auth_pwd
+
+        xml_str += CE_NC_MERGE_DLDP_GLOBAL_CONFIG_TAIL
+        self.netconf_set_config(xml_str, "MERGE_DLDP_GLOBAL_CONFIG")
+
+        if self.reset == 'true':
+            xml_str = CE_NC_ACTION_RESET_DLDP
+            self.netconf_set_action(xml_str, "ACTION_RESET_DLDP")
+
+        self.changed = True
+
+    def get_existing(self):
+        """get existing info"""
+        dldp_conf = dict()
+
+        dldp_conf['enable'] = self.dldp_conf.get('dldpEnable', None)
+        dldp_conf['time_interval'] = self.dldp_conf.get('dldpInterval', None)
+        work_mode = self.dldp_conf.get('dldpWorkMode', None)
+        if work_mode == 'dldpEnhance':
+            dldp_conf['work_mode'] = 'enhance'
+        else:
+            dldp_conf['work_mode'] = 'normal'
+
+        auth_mode = self.dldp_conf.get('dldpAuthMode', None)
+        if auth_mode == 'dldpAuthNone':
+            dldp_conf['auth_mode'] = 'none'
+        elif auth_mode == 'dldpAuthSimple':
+            dldp_conf['auth_mode'] = 'simple'
+        elif auth_mode == '?dldpAuthMD5':
+            dldp_conf['auth_mode'] = 'md5'
+        elif auth_mode == 'dldpAuthSHA':
+            dldp_conf['auth_mode'] = 'sha'
+        else:
+            dldp_conf['auth_mode'] = 'hmac-sha256'
+
+        dldp_conf['reset'] = 'false'
+
+        self.existing = copy.deepcopy(dldp_conf)
+
+    def get_proposed(self):
+        """get proposed result"""
+
+        self.proposed = dict(enable=self.enable, work_mode=self.work_mode,
+                             time_interval=self.internal, reset=self.reset,
+                             auth_mode=self.auth_mode, auth_pwd=self.auth_pwd)
+
+    def get_update_cmd(self):
+        """get update commands"""
+        if self.same_conf:
+            return
+
+        if self.enable and self.enable != self.dldp_conf['dldpEnable']:
+            if self.enable == 'true':
+                self.updates_cmd.append("dldp enable")
+            elif self.enable == 'false':
+                self.updates_cmd.append("undo dldp enable")
+                return
+
+        work_mode = 'normal'
+        if self.dldp_conf['dldpWorkMode'] == 'dldpEnhance':
+            work_mode = 'enhance'
+        if self.work_mode and self.work_mode != work_mode:
+            if self.work_mode == 'enhance':
+                self.updates_cmd.append("dldp work-mode enhance")
+            else:
+                self.updates_cmd.append("dldp work-mode normal")
+
+        if self.internal and self.internal != self.dldp_conf['dldpInterval']:
+            self.updates_cmd.append("dldp interval %s" % self.internal)
+
+        if self.auth_mode:
+            if self.auth_mode == 'none':
+                self.updates_cmd.append("undo dldp authentication-mode")
+            else:
+                self.updates_cmd.append("dldp authentication-mode %s %s" % (self.auth_mode, self.auth_pwd))
+
+        if self.reset and self.reset == 'true':
+            self.updates_cmd.append('dldp reset')
+
+    def get_end_state(self):
+        """get end state info"""
+        dldp_conf = dict()
+        self.dldp_conf = self.get_dldp_exist_config()
+
+        dldp_conf['enable'] = self.dldp_conf.get('dldpEnable', None)
+        dldp_conf['time_interval'] = self.dldp_conf.get('dldpInterval', None)
+        work_mode = self.dldp_conf.get('dldpWorkMode', None)
+        if work_mode == 'dldpEnhance':
+            dldp_conf['work_mode'] = 'enhance'
+        else:
+            dldp_conf['work_mode'] = 'normal'
+
+        auth_mode = self.dldp_conf.get('dldpAuthMode', None)
+        if auth_mode == 'dldpAuthNone':
+            dldp_conf['auth_mode'] = 'none'
+        elif auth_mode == 'dldpAuthSimple':
+            dldp_conf['auth_mode'] = 'simple'
+        elif auth_mode == '?dldpAuthMD5':
+            dldp_conf['auth_mode'] = 'md5'
+        elif auth_mode == 'dldpAuthSHA':
+            dldp_conf['auth_mode'] = 'sha'
+        else:
+            dldp_conf['auth_mode'] = 'hmac-sha256'
+
+        dldp_conf['reset'] = 'false'
+        if self.reset == 'true':
+            dldp_conf['reset'] = 'true'
+        self.end_state = copy.deepcopy(dldp_conf)
+
+    def show_result(self):
+        """show result"""
+        self.results['changed'] = self.changed
+        self.results['proposed'] = self.proposed
+        self.results['existing'] = self.existing
+        self.results['end_state'] = self.end_state
+        if self.changed:
+            self.results['updates'] = self.updates_cmd
+        else:
+            self.results['updates'] = list()
+
+        self.module.exit_json(**self.results)
+
+    def work(self):
+        """worker"""
+        self.dldp_conf = self.get_dldp_exist_config()
+        self.check_params()
+        self.same_conf = self.check_config_if_same()
+        self.get_existing()
+        self.get_proposed()
+        self.config_global_dldp()
+        self.get_update_cmd()
+        self.get_end_state()
+        self.show_result()
+
+
+def main():
+    """main function entry"""
+    argument_spec = dict(
+        enable=dict(choices=['true', 'false'], type='str'),
+        work_mode=dict(choices=['enhance', 'normal'], type='str'),
+        time_interval=dict(type='str'),
+        reset=dict(choices=['true', 'false'], type='str'),
+        auth_mode=dict(choices=['md5', 'simple', 'sha', 'hmac-sha256', 'none'], type='str'),
+        auth_pwd=dict(type='str', no_log=True),
+    )
+
+    dldp_obj = Dldp(argument_spec)
+    dldp_obj.work()
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/cloudengine/ce_dldp_interface.py
+++ b/lib/ansible/modules/network/cloudengine/ce_dldp_interface.py
@@ -1,0 +1,672 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = '''
+---
+
+module: ce_dldp_interface
+version_added: "2.3"
+short_description: Manages interface DLDP configuration.
+description:
+    - Manages interface DLDP configuration.
+extends_documentation_fragment: cloudengine
+author:
+    - Zhou Zhijin (@CloudEngine-Ansible)
+notes:
+    - If C(state=present, enable=false), interface DLDP enable will be turned off and
+      related interface DLDP confuration will be cleared.
+    - If C(state=absent), only local_mac is supported to configure.
+options:
+    interface:
+        description:
+            - Must be fully qualified interface name, i.e. GE1/0/1, 10GE1/0/1, 40GE1/0/22, 100GE1/0/1.
+        required: true
+    enable:
+        description:
+            - Set interface DLDP enable state.
+        required: false
+        default: null
+        choices: ['true', 'false']
+    mode_enable:
+        description:
+            - Set DLDP compatible-mode enable state.
+        required: false
+        default: null
+        choices: ['true', 'false']
+    local_mac:
+        description:
+            - Set the source MAC address for DLDP packets sent in the DLDP-compatible mode.
+              The value of MAC address is in H-H-H format. H contains 1 to 4 hexadecimal digits.
+        required: false
+        default: null
+    reset:
+        description:
+            - Specify whether reseting interface DLDP state.
+        required: false
+        default: null
+        choices: ['true', 'false']
+    state:
+        description:
+            - Manage the state of the resource.
+        required: false
+        default: present
+        choices: ['present','absent']
+'''
+
+EXAMPLES = '''
+# Configure interface DLDP enable state and ensure global dldp enable is turned on
+- ce_dldp_interface: enable=true host=68.170.147.165 username=huawei password=huawei
+
+# Configuire interface DLDP compatible-mode enable state  and ensure interface DLDP state is already enabled
+- ce_dldp_interface: enable=true mode_enable=true host=68.170.147.165 username=huawei password=huawei
+
+# Configuire the source MAC address for DLDP packets sent in the DLDP-compatible mode  and
+  ensure interface DLDP state and compatible-mode enable state  is already enabled
+- ce_dldp_interface: enable=true mode_enable=true local_mac=aa-aa-aa host=68.170.147.165 username=huawei password=huawei
+
+# Reset DLDP state of specified interface and ensure interface DLDP state is already enabled
+- ce_dldp_interface: enable=true reset=true host=68.170.147.165 username=huawei password=huawei
+
+# Unconfigure interface DLDP local mac addreess when C(state=absent)
+- ce_dldp_interface: state=absent local_mac=aa-aa-aa host=68.170.147.165 username=huawei password=huawei
+'''
+
+RETURN = '''
+proposed:
+    description: k/v pairs of parameters passed into module
+    returned: always
+    type: dict
+    sample: {
+                "enable": "true",
+                "interface": "40GE2/0/22",
+                "local_mac": "aa-aa-aa",
+                "mode_enable": "true",
+                "reset": "true"
+            }
+existing:
+    description:
+        - k/v pairs of existing interface DLDP configration
+    type: dict
+    sample: {
+                "enable": "false",
+                "interface": "40GE2/0/22",
+                "local_mac": null,
+                "mode_enable": null,
+                "reset": "false"
+            }
+end_state:
+    description: k/v pairs of interface DLDP configration after module execution
+    returned: always
+    type: dict
+    sample: {
+                "enable": "true",
+                "interface": "40GE2/0/22",
+                "local_mac": "00aa-00aa-00aa",
+                "mode_enable": "true",
+                "reset": "true"
+            }
+updates:
+    description: command sent to the device
+    returned: always
+    type: list
+    sample: [
+                "dldp enable",
+                "dldp compatible-mode enable",
+                "dldp compatible-mode local-mac aa-aa-aa",
+                "dldp reset"
+            ]
+changed:
+    description: check to see if a change was made on the device
+    returned: always
+    type: boolean
+    sample: true
+'''
+
+import sys
+import copy
+import re
+from xml.etree import ElementTree
+from ansible.module_utils.network import NetworkModule
+from ansible.module_utils.cloudengine import get_netconf
+
+try:
+    from ncclient.operations.rpc import RPCError
+    HAS_NCCLIENT = True
+except ImportError:
+    HAS_NCCLIENT = False
+
+
+CE_NC_ACTION_RESET_INTF_DLDP = """
+<action>
+  <dldp xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+    <resetIfDldp>
+      <ifName>%s</ifName>
+    </resetIfDldp>
+  </dldp>
+</action>
+"""
+
+CE_NC_GET_INTF_DLDP_CONFIG = """
+<filter type="subtree">
+  <dldp xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+    <dldpInterfaces>
+      <dldpInterface>
+        <ifName>%s</ifName>
+        <dldpEnable></dldpEnable>
+        <dldpCompatibleEnable></dldpCompatibleEnable>
+        <dldpLocalMac></dldpLocalMac>
+      </dldpInterface>
+    </dldpInterfaces>
+  </dldp>
+</filter>
+"""
+
+CE_NC_MERGE_DLDP_INTF_CONFIG = """
+<config>
+  <dldp xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+    <dldpInterfaces>
+      <dldpInterface operation="merge">
+        <ifName>%s</ifName>
+        <dldpEnable>%s</dldpEnable>
+        <dldpCompatibleEnable>%s</dldpCompatibleEnable>
+        <dldpLocalMac>%s</dldpLocalMac>
+      </dldpInterface>
+    </dldpInterfaces>
+  </dldp>
+</config>
+"""
+
+CE_NC_CREATE_DLDP_INTF_CONFIG = """
+<config>
+  <dldp xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+    <dldpInterfaces>
+      <dldpInterface operation="create">
+        <ifName>%s</ifName>
+        <dldpEnable>%s</dldpEnable>
+        <dldpCompatibleEnable>%s</dldpCompatibleEnable>
+        <dldpLocalMac>%s</dldpLocalMac>
+      </dldpInterface>
+    </dldpInterfaces>
+  </dldp>
+</config>
+"""
+
+CE_NC_DELETE_DLDP_INTF_CONFIG = """
+<config>
+  <dldp xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+    <dldpInterfaces>
+      <dldpInterface operation="delete">
+        <ifName>%s</ifName>
+      </dldpInterface>
+    </dldpInterfaces>
+  </dldp>
+</config>
+"""
+
+
+def judge_is_mac_same(mac1, mac2):
+    """judge whether two macs are the same"""
+
+    if mac1 == mac2:
+        return True
+
+    list1 = re.findall(r'([0-9A-Fa-f]+)', mac1)
+    list2 = re.findall(r'([0-9A-Fa-f]+)', mac2)
+    if len(list1) != len(list2):
+        return False
+
+    for index, value in enumerate(list1, start=0):
+        if value.lstrip('0').lower() != list2[index].lstrip('0').lower():
+            return False
+
+    return True
+
+
+def get_interface_type(interface):
+    """Gets the type of interface, such as 10GE, ETH-TRUNK, VLANIF..."""
+
+    if interface is None:
+        return None
+
+    iftype = None
+
+    if interface.upper().startswith('GE'):
+        iftype = 'ge'
+    elif interface.upper().startswith('10GE'):
+        iftype = '10ge'
+    elif interface.upper().startswith('25GE'):
+        iftype = '25ge'
+    elif interface.upper().startswith('4X10GE'):
+        iftype = '4x10ge'
+    elif interface.upper().startswith('40GE'):
+        iftype = '40ge'
+    elif interface.upper().startswith('100GE'):
+        iftype = '100ge'
+    elif interface.upper().startswith('VLANIF'):
+        iftype = 'vlanif'
+    elif interface.upper().startswith('LOOPBACK'):
+        iftype = 'loopback'
+    elif interface.upper().startswith('METH'):
+        iftype = 'meth'
+    elif interface.upper().startswith('ETH-TRUNK'):
+        iftype = 'eth-trunk'
+    elif interface.upper().startswith('VBDIF'):
+        iftype = 'vbdif'
+    elif interface.upper().startswith('NVE'):
+        iftype = 'nve'
+    elif interface.upper().startswith('TUNNEL'):
+        iftype = 'tunnel'
+    elif interface.upper().startswith('ETHERNET'):
+        iftype = 'ethernet'
+    elif interface.upper().startswith('FCOE-PORT'):
+        iftype = 'fcoe-port'
+    elif interface.upper().startswith('FABRIC-PORT'):
+        iftype = 'fabric-port'
+    elif interface.upper().startswith('STACK-PORT'):
+        iftype = 'stack-Port'
+    elif interface.upper().startswith('NULL'):
+        iftype = 'null'
+    else:
+        return None
+
+    return iftype.lower()
+
+
+class DldpInterface(object):
+    """Manage interface dldp configration"""
+
+    def __init__(self, argument_spec):
+        self.spec = argument_spec
+        self.module = None
+        self.netconf = None
+        self.init_module()
+
+        # dldp interface configration info
+        self.interface = self.module.params['interface']
+        self.enable = self.module.params['enable'] or None
+        self.reset = self.module.params['reset'] or None
+        self.mode_enable = self.module.params['mode_enable'] or None
+        self.local_mac = self.module.params['local_mac'] or None
+        self.state = self.module.params['state']
+
+        self.dldp_intf_conf = dict()
+        self.same_conf = False
+
+        # host info
+        self.host = self.module.params['host']
+        self.username = self.module.params['username']
+        self.port = self.module.params['port']
+
+        # state
+        self.changed = False
+        self.updates_cmd = list()
+        self.results = dict()
+        self.proposed = dict()
+        self.existing = list()
+        self.end_state = list()
+
+        # init netconf connect
+        self.init_netconf()
+
+    def check_config_if_same(self):
+        """judge whether current config is the same as what we excepted"""
+
+        if self.state == 'absent':
+            return False
+        else:
+            if self.enable and self.enable != self.dldp_intf_conf['dldpEnable']:
+                return False
+
+            if self.mode_enable and self.mode_enable != self.dldp_intf_conf['dldpCompatibleEnable']:
+                return False
+
+            if self.local_mac:
+                flag = judge_is_mac_same(
+                    self.local_mac, self.dldp_intf_conf['dldpLocalMac'])
+                if not flag:
+                    return False
+
+            if self.reset and self.reset == 'true':
+                return False
+        return True
+
+    def check_macaddr(self):
+        """check mac-address whether valid"""
+
+        valid_char = '0123456789abcdef-'
+        mac = self.local_mac
+
+        if len(mac) > 16:
+            return False
+
+        mac_list = re.findall(r'([0-9a-fA-F]+)', mac)
+        if len(mac_list) != 3:
+            return False
+
+        if mac.count('-') != 2:
+            return False
+
+        for _, value in enumerate(mac, start=0):
+            if value.lower() not in valid_char:
+                return False
+
+        return True
+
+    def check_params(self):
+        """Check all input params"""
+
+        if not self.interface:
+            self.module.fail_json(msg='Error: Interface name cannot be empty.')
+
+        if self.interface:
+            intf_type = get_interface_type(self.interface)
+            if not intf_type:
+                self.module.fail_json(
+                    msg='Error: Interface name of %s '
+                        'is error.' % self.interface)
+
+        if (self.state == 'absent') and (self.reset or self.mode_enable or self.enable):
+            self.module.fail_json(msg="Error: It's better to use state=present when "
+                                  "configuring or unconfiguring enable, mode_enable "
+                                  "or using reset flag. state=absent is just for "
+                                  "when using local_mac param.")
+
+        if self.state == 'absent' and not self.local_mac:
+            self.module.fail_json(
+                msg="Error: Please specify local_mac parameter.")
+
+        if self.state == 'present':
+            if (self.dldp_intf_conf['dldpEnable'] == 'false' and not self.enable and
+                    (self.mode_enable or self.local_mac or self.reset)):
+                self.module.fail_json(msg="Error: when DLDP is already disabled on this port, "
+                                      "mode_enable, local_mac and reset parameters are not "
+                                      "expected to configure.")
+
+            if self.enable == 'false' and (self.mode_enable or self.local_mac or self.reset):
+                self.module.fail_json(msg="Error: when using enable=false, "
+                                      "mode_enable, local_mac and reset parameters "
+                                      "are not expected to configure.")
+
+        if self.local_mac and (self.mode_enable == 'false' or
+                               (self.dldp_intf_conf['dldpCompatibleEnable'] == 'false'
+                                and self.mode_enable != 'true')):
+            self.module.fail_json(msg="Error: when DLDP compatible-mode is disabled on this port, "
+                                      "Configuring local_mac is not allowed.")
+
+        if self.local_mac:
+            if not self.check_macaddr():
+                self.module.fail_json(
+                    msg="Error: local_mac has invalid value %s." % self.local_mac)
+
+    def init_module(self):
+        """init module object"""
+
+        self.module = NetworkModule(
+            argument_spec=self.spec, supports_check_mode=True)
+
+    def init_netconf(self):
+        """init netconf interface"""
+
+        if HAS_NCCLIENT:
+            self.netconf = get_netconf(host=self.host, port=self.port,
+                                       username=self.username,
+                                       password=self.module.params['password'])
+            if not self.netconf:
+                self.module.fail_json(msg='Error: netconf init failed')
+        else:
+            self.module.fail_json(
+                msg='Error: No ncclient package, please install it.')
+
+    def check_response(self, con_obj, xml_name):
+        """Check if response message is already succeed"""
+
+        xml_str = con_obj.xml
+        if "<ok/>" not in xml_str:
+            self.module.fail_json(msg='Error: %s failed.' % xml_name)
+
+    def netconf_get_config(self, xml_str):
+        """netconf get config"""
+
+        try:
+            con_obj = self.netconf.get_config(filter=xml_str)
+        except RPCError:
+            err = sys.exc_info()[1]
+            self.module.fail_json(msg='Error: %s' % err.message.replace("\r\n", ""))
+
+        return con_obj
+
+    def netconf_set_config(self, xml_str, xml_name):
+        """netconf set config"""
+
+        try:
+            con_obj = self.netconf.set_config(config=xml_str)
+            self.check_response(con_obj, xml_name)
+        except RPCError:
+            err = sys.exc_info()[1]
+            self.module.fail_json(msg='Error: %s' % err.message.replace("\r\n", ""))
+
+        return con_obj
+
+    def netconf_set_action(self, xml_str, xml_name):
+        """netconf set action"""
+
+        try:
+            con_obj = self.netconf.execute_action(action=xml_str)
+            self.check_response(con_obj, xml_name)
+        except RPCError:
+            err = sys.exc_info()[1]
+            self.module.fail_json(msg='Error: %s' % err.message.replace("\r\n", ""))
+
+        return con_obj
+
+    def get_dldp_intf_exist_config(self):
+        """get current dldp existed config"""
+
+        dldp_conf = dict()
+        xml_str = CE_NC_GET_INTF_DLDP_CONFIG % self.interface
+        con_obj = self.netconf_get_config(xml_str)
+        if "<data/>" in con_obj.xml:
+            dldp_conf['dldpEnable'] = 'false'
+            dldp_conf['dldpCompatibleEnable'] = ""
+            dldp_conf['dldpLocalMac'] = ""
+            return dldp_conf
+
+        xml_str = con_obj.xml.replace('\r', '').replace('\n', '').\
+            replace('xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"', "").\
+            replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
+
+        # get global dldp info
+        root = ElementTree.fromstring(xml_str)
+        topo = root.find("data/dldp/dldpInterfaces/dldpInterface")
+        if topo is None:
+            self.module.fail_json(
+                msg="Error: Get current DLDP configration failed.")
+        for eles in topo:
+            if eles.tag in ["dldpEnable", "dldpCompatibleEnable", "dldpLocalMac"]:
+                if not eles.text:
+                    dldp_conf[eles.tag] = ""
+                else:
+                    dldp_conf[eles.tag] = eles.text
+
+        return dldp_conf
+
+    def config_intf_dldp(self):
+        """config global dldp"""
+
+        if self.same_conf:
+            return
+
+        if self.state == "present":
+            enable = self.enable
+            if not self.enable:
+                enable = self.dldp_intf_conf['dldpEnable']
+
+            mode_enable = self.mode_enable
+            if not self.mode_enable:
+                mode_enable = self.dldp_intf_conf['dldpCompatibleEnable']
+
+            local_mac = self.local_mac
+            if not self.local_mac:
+                local_mac = self.dldp_intf_conf['dldpLocalMac']
+
+            if self.enable == 'false' and self.enable != self.dldp_intf_conf['dldpEnable']:
+                xml_str = CE_NC_DELETE_DLDP_INTF_CONFIG % self.interface
+                self.netconf_set_config(xml_str, "DELETE_DLDP_INTF_CONFIG")
+            elif self.dldp_intf_conf['dldpEnable'] == 'false' and self.enable == 'true':
+                xml_str = CE_NC_CREATE_DLDP_INTF_CONFIG % (
+                    self.interface, self.enable, mode_enable, local_mac)
+                self.netconf_set_config(xml_str, "CREATE_DLDP_INTF_CONFIG")
+            elif self.dldp_intf_conf['dldpEnable'] == 'true':
+                if mode_enable == 'false':
+                    local_mac = ''
+                xml_str = CE_NC_MERGE_DLDP_INTF_CONFIG % (
+                    self.interface, enable, mode_enable, local_mac)
+                self.netconf_set_config(xml_str, "MERGE_DLDP_INTF_CONFIG")
+
+            if self.reset == 'true':
+                xml_str = CE_NC_ACTION_RESET_INTF_DLDP % self.interface
+                self.netconf_set_action(xml_str, "ACTION_RESET_INTF_DLDP")
+
+            self.changed = True
+        else:
+            if self.local_mac and judge_is_mac_same(self.local_mac, self.dldp_intf_conf['dldpLocalMac']):
+                xml_str = CE_NC_MERGE_DLDP_INTF_CONFIG % (self.interface, self.dldp_intf_conf[
+                    'dldpEnable'], self.dldp_intf_conf['dldpCompatibleEnable'], '')
+                self.netconf_set_config(
+                    xml_str, "UNDO_DLDP_INTF_LOCAL_MAC_CONFIG")
+                self.changed = True
+
+    def get_existing(self):
+        """get existing info"""
+
+        dldp_conf = dict()
+
+        dldp_conf['interface'] = self.interface
+        dldp_conf['enable'] = self.dldp_intf_conf.get('dldpEnable', None)
+        dldp_conf['mode_enable'] = self.dldp_intf_conf.get(
+            'dldpCompatibleEnable', None)
+        dldp_conf['local_mac'] = self.dldp_intf_conf.get('dldpLocalMac', None)
+        dldp_conf['reset'] = 'false'
+
+        self.existing = copy.deepcopy(dldp_conf)
+
+    def get_proposed(self):
+        """get proposed result """
+
+        self.proposed = dict(interface=self.interface, enable=self.enable,
+                             mode_enable=self.mode_enable, local_mac=self.local_mac,
+                             reset=self.reset, state=self.state)
+
+    def get_update_cmd(self):
+        """get updatede commands"""
+
+        if self.same_conf:
+            return
+
+        if self.state == "present":
+            if self.enable and self.enable != self.dldp_intf_conf['dldpEnable']:
+                if self.enable == 'true':
+                    self.updates_cmd.append("dldp enable")
+                elif self.enable == 'false':
+                    self.updates_cmd.append("undo dldp enable")
+
+            if self.mode_enable and self.mode_enable != self.dldp_intf_conf['dldpCompatibleEnable']:
+                if self.mode_enable == 'true':
+                    self.updates_cmd.append("dldp compatible-mode enable")
+                else:
+                    self.updates_cmd.append("undo dldp compatible-mode enable")
+
+            if self.local_mac:
+                flag = judge_is_mac_same(
+                    self.local_mac, self.dldp_intf_conf['dldpLocalMac'])
+                if not flag:
+                    self.updates_cmd.append(
+                        "dldp compatible-mode local-mac %s" % self.local_mac)
+
+            if self.reset and self.reset == 'true':
+                self.updates_cmd.append('dldp reset')
+        else:
+            if self.changed:
+                self.updates_cmd.append("undo dldp compatible-mode local-mac")
+
+    def get_end_state(self):
+        """get end state info"""
+
+        dldp_conf = dict()
+        self.dldp_intf_conf = self.get_dldp_intf_exist_config()
+
+        dldp_conf['interface'] = self.interface
+        dldp_conf['enable'] = self.dldp_intf_conf.get('dldpEnable', None)
+        dldp_conf['mode_enable'] = self.dldp_intf_conf.get(
+            'dldpCompatibleEnable', None)
+        dldp_conf['local_mac'] = self.dldp_intf_conf.get('dldpLocalMac', None)
+        dldp_conf['reset'] = 'false'
+        if self.reset == 'true':
+            dldp_conf['reset'] = 'true'
+
+        self.end_state = copy.deepcopy(dldp_conf)
+
+    def show_result(self):
+        """show result"""
+
+        self.results['changed'] = self.changed
+        self.results['proposed'] = self.proposed
+        self.results['existing'] = self.existing
+        self.results['end_state'] = self.end_state
+        if self.changed:
+            self.results['updates'] = self.updates_cmd
+        else:
+            self.results['updates'] = list()
+
+        self.module.exit_json(**self.results)
+
+    def work(self):
+        """excute task"""
+
+        self.dldp_intf_conf = self.get_dldp_intf_exist_config()
+        self.check_params()
+        self.same_conf = self.check_config_if_same()
+        self.get_existing()
+        self.get_proposed()
+        self.config_intf_dldp()
+        self.get_update_cmd()
+        self.get_end_state()
+        self.show_result()
+
+
+def main():
+    """main function entry"""
+
+    argument_spec = dict(
+        interface=dict(required=True, type='str'),
+        enable=dict(choices=['true', 'false'], type='str'),
+        reset=dict(choices=['true', 'false'], type='str'),
+        mode_enable=dict(choices=['true', 'false'], type='str'),
+        local_mac=dict(type='str'),
+        state=dict(choices=['absent', 'present'], default='present'),
+    )
+
+    dldp_intf_obj = DldpInterface(argument_spec)
+    dldp_intf_obj.work()
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/plugins/action/ce_config.py
+++ b/lib/ansible/plugins/action/ce_config.py
@@ -1,0 +1,28 @@
+#
+# Copyright 2015 Peter Sprygada <psprygada@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+from ansible.plugins.action.net_config import ActionModule as NetActionModule
+
+class ActionModule(NetActionModule, ActionBase):
+    pass
+
+


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
cloudengine/ce (network module)

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
config file = /etc/ansible/ansible.cfg
configured module search path = ['/home/ansible-2.1.1.0/lib/ansible/modules/core/network/cloudengine', '/home/ansible-2.1.1.0/lib/ansible/module_utils', '/home/ansible-2.1.1.0/lib/ansible/modules', '/home/ansible-2.1.1.0', '/home/ansible-2.1.1.0/lib/ansible/utils/']
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [Config dldp enable=true on interface] ************************************
task path: /usr1/code/OpenNESS/code/current/KVM/intg/test/testcases/test-ce_dldp_interface.yml:44
Using module file /usr/local/lib/python2.7/site-packages/ansible-2.3.0-py2.7.egg/ansible/modules/core/network/cloudengine/ce_dldp_interface.py
<ce_6850> ESTABLISH LOCAL CONNECTION FOR USER: root
<ce_6850> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1487042834.84-102346426919016 `" && echo ansible-tmp-1487042834.84-102346426919016="` echo $HOME/.ansible/tmp/ansible-tmp-1487042834.84-102346426919016 `" ) && sleep 0'
<ce_6850> PUT /tmp/tmpOhGPUo TO /root/.ansible/tmp/ansible-tmp-1487042834.84-102346426919016/ce_dldp_interface.py
<ce_6850> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1487042834.84-102346426919016/ /root/.ansible/tmp/ansible-tmp-1487042834.84-102346426919016/ce_dldp_interface.py && sleep 0'
<ce_6850> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1487042834.84-102346426919016/ce_dldp_interface.py; rm -rf "/root/.ansible/tmp/ansible-tmp-1487042834.84-102346426919016/" > /dev/null 2>&1 && sleep 0'
changed: [ce_6850] => {
    "changed": true, 
    "end_state": {
        "enable": "true", 
        "interface": "40GE1/0/6", 
        "local_mac": "", 
        "mode_enable": "false", 
        "reset": "false"
    }, 
    "existing": {
        "enable": "false", 
        "interface": "40GE1/0/6", 
        "local_mac": "", 
        "mode_enable": "", 
        "reset": "false"
    }, 
    "invocation": {
        "module_args": {
            "auth_pass": null, 
            "authorize": false, 
            "enable": "true", 
            "host": "ce_6850", 
            "interface": "40GE1/0/6", 
            "local_mac": null, 
            "mode_enable": null, 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 12345, 
            "provider": null, 
            "reset": null, 
            "ssh_keyfile": null, 
            "state": "present", 
            "timeout": 10, 
            "transport": null, 
            "use_ssl": false, 
            "username": "rootDC", 
            "validate_certs": true
        }, 
        "module_name": "ce_dldp_interface"
    }, 
    "proposed": {
        "enable": "true", 
        "interface": "40GE1/0/6", 
        "local_mac": null, 
        "mode_enable": null, 
        "reset": null, 
        "state": "present"
    }, 
    "updates": [
        "dldp enable"
    ]
}


TASK [ensure DLDP enable state is false] ***************************************
task path: /usr1/code/OpenNESS/code/current/KVM/intg/test/testcases/test-ce_dldp.yml:17
Using module file /usr/local/lib/python2.7/site-packages/ansible-2.3.0-py2.7.egg/ansible/modules/core/network/cloudengine/ce_dldp.py
<ce_6850> ESTABLISH LOCAL CONNECTION FOR USER: root
<ce_6850> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1487042907.41-261215281704035 `" && echo ansible-tmp-1487042907.41-261215281704035="` echo $HOME/.ansible/tmp/ansible-tmp-1487042907.41-261215281704035 `" ) && sleep 0'
<ce_6850> PUT /tmp/tmphxqEh8 TO /root/.ansible/tmp/ansible-tmp-1487042907.41-261215281704035/ce_dldp.py
<ce_6850> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1487042907.41-261215281704035/ /root/.ansible/tmp/ansible-tmp-1487042907.41-261215281704035/ce_dldp.py && sleep 0'
<ce_6850> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1487042907.41-261215281704035/ce_dldp.py; rm -rf "/root/.ansible/tmp/ansible-tmp-1487042907.41-261215281704035/" > /dev/null 2>&1 && sleep 0'
changed: [ce_6850] => {
    "changed": true, 
    "end_state": {
        "auth_mode": "none", 
        "enable": "false", 
        "reset": "false", 
        "time_interval": "5", 
        "work_mode": "enhance"
    }, 
    "existing": {
        "auth_mode": "none", 
        "enable": "true", 
        "reset": "false", 
        "time_interval": "5", 
        "work_mode": "normal"
    }, 
    "invocation": {
        "module_args": {
            "auth_mode": null, 
            "auth_pass": null, 
            "auth_pwd": null, 
            "authorize": false, 
            "enable": "false", 
            "host": "ce_6850", 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 12345, 
            "provider": null, 
            "reset": null, 
            "ssh_keyfile": null, 
            "time_interval": null, 
            "timeout": 10, 
            "transport": null, 
            "use_ssl": false, 
            "username": "rootDC", 
            "validate_certs": true, 
            "work_mode": null
        }, 
        "module_name": "ce_dldp"
    }, 
    "proposed": {
        "auth_mode": null, 
        "auth_pwd": null, 
        "enable": "false", 
        "reset": null, 
        "time_interval": null, 
        "work_mode": null
    }, 
    "updates": [
        "undo dldp enable"
    ]
}
```
