### PR TITLE
dig: Include the error for unhandled exception

### DIFF
--- a/lib/ansible/plugins/lookup/dig.py
+++ b/lib/ansible/plugins/lookup/dig.py
@@ -178,7 +178,7 @@ class LookupModule(LookupBase):
             except dns.exception.SyntaxError:
                 pass
             except Exception as e:
-                raise AnsibleError("dns.reversename unhandled exception", str(e))
+                raise AnsibleError("dns.reversename unhandled exception. Error was: {0}".format(e))
 
         try:
             answers = myres.query(domain, qtype)
@@ -207,6 +207,6 @@ class LookupModule(LookupBase):
         except dns.resolver.Timeout:
             ret.append('')
         except dns.exception.DNSException as e:
-            raise AnsibleError("dns.resolver unhandled exception", e)
+            raise AnsibleError("dns.resolver unhandled exception. Error was: {0}".format(e))
 
         return ret


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
dig.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
$ ansible --version
ansible 2.2.0.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When running into a unhandled exception it was really hard to know what the error was.
Now it will include the error message which should help clarify why the error occoured
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
fatal: [xxxx]: FAILED! => {"failed": true, "msg": "dns.resolver unhandled exception"}
```
After:
```
fatal: [xxxx]: FAILED! => {"failed": true, "msg": "dns.resolver unhandled exception. Error was: All nameservers failed to answer the query xx.xx.xx.xx.in-addr.arpa. IN PTR: Server xx.xx.xx.xx UDP port 53 anwered SERVFAIL"}
```
