### PR TITLE
ios local action creates circular reference

### DIFF
--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -365,6 +365,7 @@ def main():
                     commands.extend(module.params['after'])
 
             result['commands'] = commands
+            result['updates'] = commands
             result['banners'] = banners
 
             # send the configuration commands to the device and merge

--- a/lib/ansible/plugins/action/ios.py
+++ b/lib/ansible/plugins/action/ios.py
@@ -35,9 +35,7 @@ class ActionModule(_ActionModule):
 
     def run(self, tmp=None, task_vars=None):
 
-        self.load_provider()
-
-        provider = self._task.args['provider']
+        provider = self.load_provider()
 
         pc = copy.deepcopy(self._play_context)
         pc.connection = 'network_cli'
@@ -60,6 +58,7 @@ class ActionModule(_ActionModule):
             self._play_context.become = False
             self._play_context.become_method = None
 
+
         return super(ActionModule, self).run(tmp, task_vars)
 
     def _get_socket_path(self, play_context):
@@ -71,13 +70,14 @@ class ActionModule(_ActionModule):
     def load_provider(self):
         provider = self._task.args.get('provider', {})
         for key, value in iteritems(ios_argument_spec):
-            if key in self._task.args:
-                provider[key] = self._task.args[key]
-            elif 'fallback' in value:
-                provider[key] = self._fallback(value['fallback'])
-            elif key not in provider:
-                provider[key] = None
-        self._task.args['provider'] = provider
+            if key != 'provider' and key not in provider:
+                if key in self._task.args:
+                    provider[key] = self._task.args[key]
+                elif 'fallback' in value:
+                    provider[key] = self._fallback(value['fallback'])
+                elif key not in provider:
+                    provider[key] = None
+        return provider
 
     def _fallback(self, fallback):
         strategy = fallback[0]


### PR DESCRIPTION
When loading the params in the local action, the provider key was
inadvertently being loaded as well.  This created the circular
reference.  The load_provider() method will now check for the provider
key and skip it when encountered.

fixes #21399

