### PR TITLE
Fix Cloudflare module not updating CNAME records

### DIFF
--- a/lib/ansible/modules/network/cloudflare_dns.py
+++ b/lib/ansible/modules/network/cloudflare_dns.py
@@ -592,7 +592,7 @@ class CloudflareAPI(object):
             if ('data' in new_record) and ('data' in cur_record):
                 if (cur_record['data'] > new_record['data']) - (cur_record['data'] < new_record['data']):
                     do_update = True
-            if (type == 'CNAME') and (cur_record['content'] != new_record['content']):
+            if (params['type'] == 'CNAME') and (cur_record['content'] != new_record['content']):
                 do_update = True
             if do_update:
                 if not self.module.check_mode:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Module: cloudflare_dns

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (fix_cloudflare_cname e472ef7462) last updated 2017/02/14 11:36:55 (GMT -200)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
CNAME changes were never updated when changing its value because the module was using `type` instead of `params['type']`

<!-- Paste verbatim command output below, e.g. before and after your change -->
**I've removed the account_email from outputs below**

###### Before

Record creation worked fine
```
***********************************
PARSED OUTPUT
{
    "changed": true,
    "invocation": {
        "module_args": {
            "account_api_token": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "account_email": "---",
            "port": null,
            "priority": 1,
            "proto": null,
            "proxied": false,
            "record": "ansible-test",
            "service": null,
            "solo": null,
            "state": "present",
            "timeout": 30,
            "ttl": 1,
            "type": "CNAME",
            "value": "www.ensible.com",
            "weight": 1,
            "zone": "batatas.org"
        }
    },
    "result": {
        "record": {
            "content": "www.ensible.com",
            "created_on": "2017-02-14T13:47:50.742045Z",
            "id": "0b492744932011b8934907ab29b8a207",
            "locked": false,
            "meta": {
                "auto_added": false
            },
            "modified_on": "2017-02-14T13:47:50.742045Z",
            "name": "ansible-test.batatas.org",
            "proxiable": true,
            "proxied": false,
            "ttl": 1,
            "type": "CNAME",
            "zone_id": "13bd44c31debea36914643f3798722d6",
            "zone_name": "batatas.org"
        }
    }
}
```

But it would not update. Notice the difference between **invocation.module_args.value** and **result.record.content**
```
***********************************
PARSED OUTPUT
{
    "changed": false,
    "invocation": {
        "module_args": {
            "account_api_token": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "account_email": "---",
            "port": null,
            "priority": 1,
            "proto": null,
            "proxied": false,
            "record": "ansible-test",
            "service": null,
            "solo": null,
            "state": "present",
            "timeout": 30,
            "ttl": 1,
            "type": "CNAME",
            "value": "www.ansible.com",
            "weight": 1,
            "zone": "batatas.org"
        }
    },
    "result": {
        "record": {
            "content": "www.ensible.com",
            "created_on": "2017-02-14T13:47:50.742045Z",
            "id": "0b492744932011b8934907ab29b8a207",
            "locked": false,
            "meta": {
                "auto_added": false
            },
            "modified_on": "2017-02-14T13:47:50.742045Z",
            "name": "ansible-test.batatas.org",
            "proxiable": true,
            "proxied": false,
            "ttl": 1,
            "type": "CNAME",
            "zone_id": "13bd44c31debea36914643f3798722d6",
            "zone_name": "batatas.org"
        }
    }
}
```

###### After

Record creation still working
```
***********************************
PARSED OUTPUT
{
    "changed": true,
    "invocation": {
        "module_args": {
            "account_api_token": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "account_email": "---",
            "port": null,
            "priority": 1,
            "proto": null,
            "proxied": false,
            "record": "ansible-test",
            "service": null,
            "solo": null,
            "state": "present",
            "timeout": 30,
            "ttl": 1,
            "type": "CNAME",
            "value": "www.ensible.com",
            "weight": 1,
            "zone": "batatas.org"
        }
    },
    "result": {
        "record": {
            "content": "www.ensible.com",
            "created_on": "2017-02-14T13:49:32.416783Z",
            "id": "e6f6756e50cc4c0e30f3ec02e01c94fe",
            "locked": false,
            "meta": {
                "auto_added": false
            },
            "modified_on": "2017-02-14T13:49:32.416783Z",
            "name": "ansible-test.batatas.org",
            "proxiable": true,
            "proxied": false,
            "ttl": 1,
            "type": "CNAME",
            "zone_id": "13bd44c31debea36914643f3798722d6",
            "zone_name": "batatas.org"
        }
    }
}
```

But now it updates correctly
```
***********************************
PARSED OUTPUT
{
    "changed": true,
    "invocation": {
        "module_args": {
            "account_api_token": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "account_email": "---",
            "port": null,
            "priority": 1,
            "proto": null,
            "proxied": false,
            "record": "ansible-test",
            "service": null,
            "solo": null,
            "state": "present",
            "timeout": 30,
            "ttl": 1,
            "type": "CNAME",
            "value": "www.ansible.com",
            "weight": 1,
            "zone": "batatas.org"
        }
    },
    "result": {
        "record": {
            "content": "www.ansible.com",
            "created_on": "2017-02-14T13:49:49.373369Z",
            "id": "e6f6756e50cc4c0e30f3ec02e01c94fe",
            "locked": false,
            "meta": {
                "auto_added": false
            },
            "modified_on": "2017-02-14T13:49:49.373369Z",
            "name": "ansible-test.batatas.org",
            "proxiable": true,
            "proxied": false,
            "ttl": 1,
            "type": "CNAME",
            "zone_id": "13bd44c31debea36914643f3798722d6",
            "zone_name": "batatas.org"
        }
    }
}
```