### PR TITLE
extend module zypper_repository

### DIFF
--- a/lib/ansible/modules/packaging/os/zypper_repository.py
+++ b/lib/ansible/modules/packaging/os/zypper_repository.py
@@ -3,6 +3,7 @@
 
 # (c) 2013, Matthias Vogelgesang <matthias.vogelgesang@gmail.com>
 # (c) 2014, Justin Lecher <jlec@gentoo.org>
+# (c) 2017, Christian Wittmer <chris@computersalat.de>
 #
 # This file is part of Ansible
 #
@@ -31,7 +32,7 @@ author: "Matthias Vogelgesang (@matze)"
 version_added: "1.5"
 short_description: Add, modify and remove zypper repositories
 description:
-    - Add or remove Zypper repositories on SUSE and openSUSE
+    - Add, modify or remove zypper repositories on SLE and openSUSE
 options:
     name:
         required: false

--- a/lib/ansible/modules/packaging/os/zypper_repository.py
+++ b/lib/ansible/modules/packaging/os/zypper_repository.py
@@ -457,7 +457,8 @@ def main():
     if rc == 0:
         module.exit_json(changed=True, repodata=repodata, action=action, state=state, warnings=warnings)
     else:
-        module.fail_json(msg="zypper failed with rc %s" % rc, rc=rc, stdout=stdout, stderr=stderr, repodata=repodata, action=action, state=state, warnings=warnings)
+        module.fail_json(msg="zypper failed with rc %s" % rc, rc=rc, stdout=stdout, stderr=stderr, repodata=repodata, action=action, state=state,
+                         warnings=warnings)
 
 # import module snippets
 from ansible.module_utils.basic import *


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### SUMMARY
add option **action** to make module more flexible, instead of _adding_ or _removing_.
Sometimes you want to be able to modify an existing repo (enable/disable, refesh/no-refresh), especially before upgrading to a new release ...

Please review carefully, cause this is my first walk on 'python' ... tested with my plays in different situations and it is doing what is expected.