### PR TITLE
Adds a factory function for getting REST api tools

### DIFF
--- a/lib/ansible/module_utils/f5.py
+++ b/lib/ansible/module_utils/f5.py
@@ -144,5 +144,31 @@ def fq_list_names(partition,list_names):
     return map(lambda x: fq_name(partition,x),list_names)
 
 
+def get_mgmt_root(type, **kwargs):
+    if type == 'bigip':
+        return BigIpMgmt(
+            kwargs['server'],
+            kwargs['user'],
+            kwargs['password'],
+            port=kwargs['server_port'],
+            token='tmos'
+        )
+    elif type == 'iworkflow':
+        return iWorkflowMgmt(
+            kwargs['server'],
+            kwargs['user'],
+            kwargs['password'],
+            port=kwargs['server_port'],
+            token='local'
+        )
+    elif type == 'bigiq':
+        return BigIqMgmt(
+            kwargs['server'],
+            kwargs['user'],
+            kwargs['password'],
+            port=kwargs['server_port'],
+            token='local'
+        )
+
 class F5ModuleError(Exception):
     pass


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/module_utils/f5.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
I plan on converting most all f5 modules to use the rest api, so
this is part of that conversion. it adds a factory method to get
the various rest management root apis provided in the f5 sdk