### PR TITLE
cloud/vmware/vmware_vmotion: added storage vmotion capabilities.

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -22,9 +22,8 @@ except ImportError:
     HAS_PYVMOMI = False
 
 from ansible.module_utils._text import to_text
-from ansible.module_utils.six import integer_types, iteritems, string_types
+from ansible.module_utils.six import integer_types, iteritems, string_types, raise_from
 from ansible.module_utils.basic import env_fallback
-from ansible.module_utils import six
 
 
 class TaskError(Exception):
@@ -57,7 +56,7 @@ def wait_for_task(task, max_backoff=64, timeout=3600):
             except AttributeError:
                 pass
             finally:
-                six.raise_from(TaskError(error_msg), task.info.error)
+                raise_from(TaskError(error_msg), task.info.error)
         if task.info.state in [vim.TaskInfo.State.running, vim.TaskInfo.State.queued]:
             sleep_time = min(2 ** failure_counter + randint(1, 1000), max_backoff)
             time.sleep(sleep_time)

--- a/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
@@ -2,16 +2,23 @@
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2015, Bede Carroll <bc+github () bedecarroll.com>
+
+# Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
+# Copyright: (c) 2018, Ansible Project
+#
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
 
-DOCUMENTATION = '''
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = r'''
 ---
 module: vmware_vmotion
 short_description: Move a virtual machine using vMotion, and/or its vmdks using storage vMotion.
@@ -20,8 +27,8 @@ description:
       host, and/or its vmdks to another datastore using storage vMotion.
 version_added: 2.2
 author:
-    - Bede Carroll (@bedecarroll)
-    - Olivier Boukili (@oboukili)
+- Bede Carroll (@bedecarroll)
+- Olivier Boukili (@oboukili)
 notes:
     - Tested on vSphere 6.0
 requirements:
@@ -29,58 +36,58 @@ requirements:
     - pyVmomi
 options:
     vm_name:
-        description:
-            - Name of the VM to perform a vMotion on
-        required: True
-        aliases: ['vm']
+      description:
+      - Name of the VM to perform a vMotion on.
+      - This is required parameter, if C(vm_uuid) is not set.
+      - Version 2.6 onwards, this parameter is not a required parameter, unlike the previous versions.
+      aliases: ['vm']
+    vm_uuid:
+      description:
+      - UUID of the virtual machine to perform a vMotion operation on.
+      - This is a required parameter, if C(vm_name) is not set.
+      aliases: ['uuid']
+      version_added: 2.7
     destination_host:
-        description:
-            - Name of the end host the VM should be running on (at least one of destination_host or destination_datastore is required)
-        aliases: ['destination']
+      description:
+      - Name of the destination host the virtual machine should be running on.
+      - Version 2.6 onwards, this parameter is not a required parameter, unlike the previous versions.
+      aliases: ['destination']
     destination_datastore:
-        description:
-            - Name of the end datastore the VM's vmdk should be moved on (at least one of destination_host or destination_datastore is required)
-        required: False
-        aliases: ['datastore']
-        version_added: 2.5
-
+      description:
+      - "Name of the destination datastore the virtual machine's vmdk should be moved on."
+      aliases: ['datastore']
+      version_added: 2.7
 extends_documentation_fragment: vmware.documentation
 '''
 
 EXAMPLES = '''
-# Example from Ansible playbook
+- name: Perform vMotion of virtual machine
+  vmware_vmotion:
+    hostname: 'vcenter_hostname'
+    username: 'vcenter_username'
+    password: 'vcenter_password'
+    validate_certs: False
+    vm_name: 'vm_name_as_per_vcenter'
+    destination_host: 'destination_host_as_per_vcenter'
 
-    - name: Perform vMotion of VM
-      local_action:
-        module: vmware_vmotion
-        hostname: 'vcenter_hostname'
-        username: 'vcenter_username'
-        password: 'vcenter_password'
-        validate_certs: False
-        vm_name: 'vm_name_as_per_vcenter'
-        destination_host: 'destination_host_as_per_vcenter'
+- name: Perform storage vMotion of of virtual machine
+  vmware_vmotion:
+    hostname: 'vcenter_hostname'
+    username: 'vcenter_username'
+    password: 'vcenter_password'
+    validate_certs: False
+    vm_name: 'vm_name_as_per_vcenter'
+    destination_datastore: 'destination_datastore_as_per_vcenter'
 
-    - name: Perform storage vMotion of of VM
-      local_action:
-        module: vmware_vmotion
-        hostname: 'vcenter_hostname'
-        username: 'vcenter_username'
-        password: 'vcenter_password'
-        validate_certs: False
-        vm_name: 'vm_name_as_per_vcenter'
-        destination_datastore: 'destination_datastore_as_per_vcenter'
-
-    - name: Perform storage vMotion and host vMotion of VM
-      local_action:
-        module: vmware_vmotion
-        hostname: 'vcenter_hostname'
-        username: 'vcenter_username'
-        password: 'vcenter_password'
-        validate_certs: False
-        vm_name: 'vm_name_as_per_vcenter'
-        destination_host: 'destination_host_as_per_vcenter'
-        destination_datastore: 'destination_datastore_as_per_vcenter'
-
+- name: Perform storage vMotion and host vMotion of virtual machine
+  vmware_vmotion:
+    hostname: 'vcenter_hostname'
+    username: 'vcenter_username'
+    password: 'vcenter_password'
+    validate_certs: False
+    vm_name: 'vm_name_as_per_vcenter'
+    destination_host: 'destination_host_as_per_vcenter'
+    destination_datastore: 'destination_datastore_as_per_vcenter'
 '''
 
 RETURN = '''
@@ -89,135 +96,205 @@ running_host:
     returned: changed or success
     type: string
     sample: 'host1.example.com'
-datastores:
-    description: List the datastores the virtual machine uses
-    returned: changed or success
-    type: list
-    sample: '[datastore1]'
-
 '''
 
 try:
     from pyVmomi import vim
-    HAS_PYVMOMI = True
 except ImportError:
-    HAS_PYVMOMI = False
+    pass
 
+from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.vmware import (connect_to_api, find_hostsystem_by_name, find_vm_by_name,
-                                         find_datastore_by_name, vmware_argument_spec, wait_for_task)
+from ansible.module_utils.vmware import (PyVmomi, find_hostsystem_by_name,
+                                         find_vm_by_id, find_datastore_by_name,
+                                         vmware_argument_spec, wait_for_task, TaskError)
 
 
-def migrate_vm(vm_object, host_object=None, datastore_object=None):
-    """
-    Migrate virtual machine and return the task.
-    """
-    relocate_spec = vim.vm.RelocateSpec(host=host_object, datastore=datastore_object)
-    task_object = vm_object.Relocate(relocate_spec)
-    return task_object
+class VmotionManager(PyVmomi):
+    def __init__(self, module):
+        super(VmotionManager, self).__init__(module)
+        self.vm = None
+        self.vm_uuid = self.params.get('vm_uuid', None)
+        self.vm_name = self.params.get('vm_name', None)
+        result = dict()
+
+        self.get_vm()
+        if self.vm is None:
+            self.module.fail_json(msg="Failed to find the virtual"
+                                      " machine with %s" % (self.vm_uuid or self.vm_name))
+
+        # Get Destination Host System if specified by user
+        dest_host_name = self.params.get('destination_host', None)
+        self.host_object = None
+        if dest_host_name is not None:
+            self.host_object = find_hostsystem_by_name(content=self.content,
+                                                       hostname=dest_host_name)
+
+        # Get Destination Datastore if specified by user
+        dest_datastore = self.params.get('destination_datastore', None)
+        self.datastore_object = None
+        if dest_datastore is not None:
+            self.datastore_object = find_datastore_by_name(content=self.content,
+                                                           datastore_name=dest_datastore)
+
+        # Atleast one of datastore, host system is required to migrate
+        if self.datastore_object is None and self.host_object is None:
+            self.module.fail_json(msg="Unable to find destination datastore"
+                                      " and destination host system.")
+
+        # Check if datastore is required, this check is required if destination
+        # and source host system does not share same datastore.
+        host_datastore_required = []
+        for vm_datastore in self.vm.datastore:
+            if self.host_object and vm_datastore not in self.host_object.datastore:
+                host_datastore_required.append(True)
+            else:
+                host_datastore_required.append(False)
+
+        if any(host_datastore_required) and dest_datastore is None:
+            msg = "Destination host system does not share" \
+                  " datastore ['%s'] with source host system ['%s'] on which" \
+                  " virtual machine is located.  Please specify destination_datastore" \
+                  " to rectify this problem." % ("', '".join([ds.name for ds in self.host_object.datastore]),
+                                                 "', '".join([ds.name for ds in self.vm.datastore]))
+
+            self.module.fail_json(msg=msg)
+
+        storage_vmotion_needed = True
+        change_required = True
+
+        if self.host_object and self.datastore_object:
+            # We have both host system and datastore object
+            if not self.datastore_object.summary.accessible:
+                # Datastore is not accessible
+                self.module.fail_json(msg='Destination datastore %s is'
+                                          ' not accessible.' % dest_datastore)
+
+            if self.datastore_object not in self.host_object.datastore:
+                # Datastore is not associated with host system
+                self.module.fail_json(msg="Destination datastore %s provided"
+                                          " is not associated with destination"
+                                          " host system %s. Please specify"
+                                          " datastore value ['%s'] associated with"
+                                          " the given host system." % (dest_datastore,
+                                                                       dest_host_name,
+                                                                       "', '".join([ds.name for ds in self.host_object.datastore])))
+
+            if self.vm.runtime.host.name == dest_host_name and dest_datastore in [ds.name for ds in self.vm.datastore]:
+                change_required = False
+
+        if self.host_object and self.datastore_object is None:
+            if self.vm.runtime.host.name == dest_host_name:
+                # VM is already located on same host
+                change_required = False
+
+            storage_vmotion_needed = False
+
+        elif self.datastore_object and self.host_object is None:
+            if self.datastore_object in self.vm.datastore:
+                # VM is already located on same datastore
+                change_required = False
+
+            if not self.datastore_object.summary.accessible:
+                # Datastore is not accessible
+                self.module.fail_json(msg='Destination datastore %s is'
+                                          ' not accessible.' % dest_datastore)
+
+        if module.check_mode:
+            result['running_host'] = module.params['destination_host']
+            result['changed'] = True
+            module.exit_json(**result)
+
+        if change_required:
+            # Migrate VM and get Task object back
+            task_object = self.migrate_vm()
+            # Wait for task to complete
+            try:
+                wait_for_task(task_object)
+            except TaskError as task_error:
+                self.module.fail_json(msg=to_native(task_error))
+            # If task was a success the VM has moved, update running_host and complete module
+            if task_object.info.state == vim.TaskInfo.State.success:
+                # The storage layout is not automatically refreshed, so we trigger it to get coherent module return values
+                if storage_vmotion_needed:
+                    self.vm.RefreshStorageInfo()
+                result['running_host'] = module.params['destination_host']
+                result['changed'] = True
+                module.exit_json(**result)
+            else:
+                msg = 'Unable to migrate virtual machine due to an error, please check vCenter'
+                if task_object.info.error is not None:
+                    msg += " : %s" % task_object.info.error
+                module.fail_json(msg=msg)
+        else:
+            try:
+                host = self.vm.summary.runtime.host
+                result['running_host'] = host.summary.config.name
+            except vim.fault.NoPermission:
+                result['running_host'] = 'NA'
+            result['changed'] = False
+            module.exit_json(**result)
+
+    def migrate_vm(self):
+        """
+        Migrate virtual machine and return the task.
+        """
+        relocate_spec = vim.vm.RelocateSpec(host=self.host_object,
+                                            datastore=self.datastore_object)
+        task_object = self.vm.Relocate(relocate_spec)
+        return task_object
+
+    def get_vm(self):
+        """
+        Find unique virtual machine either by UUID or Name.
+        Returns: virtual machine object if found, else None.
+
+        """
+        vms = []
+        if self.vm_uuid:
+            vm_obj = find_vm_by_id(self.content, vm_id=self.params['vm_uuid'], vm_id_type="uuid")
+            vms = [vm_obj]
+
+        elif self.vm_name:
+            objects = self.get_managed_objects_properties(vim_type=vim.VirtualMachine, properties=['name'])
+            for temp_vm_object in objects:
+                if len(temp_vm_object.propSet) != 1:
+                    continue
+                if temp_vm_object.obj.name == self.vm_name:
+                    vms.append(temp_vm_object.obj)
+                    break
+
+        if len(vms) > 1:
+            self.module.fail_json(msg="Multiple virtual machines with same name %s found."
+                                      " Please specify vm_uuid instead of vm_name." % self.vm_name)
+
+        self.vm = vms[0]
 
 
 def main():
-
     argument_spec = vmware_argument_spec()
     argument_spec.update(
         dict(
-            vm_name=dict(required=True, aliases=['vm'], type='str'),
-            destination_host=dict(required=False, aliases=['destination'], type='str'),
-            destination_datastore=dict(required=False, aliases=['datastore'], type='str')
+            vm_name=dict(aliases=['vm']),
+            vm_uuid=dict(aliases=['uuid']),
+            destination_host=dict(aliases=['destination']),
+            destination_datastore=dict(aliases=['datastore'])
         )
     )
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_one_of=[['destination_host', 'destination_datastore']])
 
-    if not HAS_PYVMOMI:
-        module.fail_json(msg='pyVmomi is required for this module')
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_one_of=[
+            ['destination_host', 'destination_datastore'],
+            ['vm_uuid', 'vm_name'],
+        ],
+        mutually_exclusive=[
+            ['vm_uuid', 'vm_name'],
+        ],
+    )
 
-    content = connect_to_api(module=module)
-
-    vm_object = find_vm_by_name(content=content, vm_name=module.params['vm_name'])
-    if module.params['destination_host'] is not None:
-        host_object = find_hostsystem_by_name(content=content, hostname=module.params['destination_host'])
-    else:
-        host_object = None
-    if module.params['destination_datastore'] is not None:
-        datastore_object = find_datastore_by_name(content=content, datastore_name=module.params['destination_datastore'])
-    else:
-        datastore_object = None
-
-    # Setup result
-    result = {
-        'changed': False
-    }
-
-    # Check if we could find the VM or Host
-    if not vm_object:
-        module.fail_json(msg='Cannot find virtual machine')
-    if not host_object and module.params['destination_host'] is not None:
-        module.fail_json(msg='Cannot find host')
-    if not datastore_object and module.params['destination_datastore'] is not None:
-        module.fail_json(msg='Cannot find datastore')
-    elif not datastore_object.summary.accessible:
-        module.fail_json(msg='Datastore is not accessible')
-
-    # Make sure VM isn't already at the destination host
-    if module.params['destination_host'] is None:
-        hostVMotionNeeded = False
-    elif module.params['destination_host'] is not None and vm_object.runtime.host.name == module.params['destination_host']:
-        hostVMotionNeeded = False
-    else:
-        hostVMotionNeeded = True
-
-    # Make sure VMDKs destination datastore is available on destination esx host (or on the current esx host if not specified)
-    if module.params['destination_datastore'] is None:
-        storageVMotionNeeded = False
-    else:
-        if module.params['destination_host'] is not None:
-            if not datastore_object in host_object.datastore:
-                module.fail_json(msg="Datastore is not accessible on host")
-        # Check whether VMDKs are already on the destination datastore
-        if datastore_object in list(element.datastore for element in vm_object.storage.perDatastoreUsage):
-            storageVMotionNeeded = False
-        else:
-            storageVMotionNeeded = True
-
-    if not module.check_mode:
-        if hostVMotionNeeded or storageVMotionNeeded:
-            # Migrate VM and get Task object back
-            task_object = migrate_vm(vm_object=vm_object, host_object=host_object, datastore_object=datastore_object)
-            # Wait for task to complete
-            wait_for_task(task_object)
-            # If task was a success the VM has moved, update running_host and complete module
-            if task_object.info.state == vim.TaskInfo.State.success:
-                vm_object = find_vm_by_name(content=content, vm_name=module.params['vm_name'])
-                # The storage layout is not automatically refreshed, so we trigger it to get coherent module return values
-                if storageVMotionNeeded:
-                    vm_object.RefreshStorageInfo()
-                result['changed'] = True
-            else:
-                if task_object.info.error is None:
-                    module.fail_json(msg='Unable to migrate VM due to an error, please check vCenter')
-                else:
-                    module.fail_json(msg='Unable to migrate VM due to an error: %s' % task_object.info.error)
-
-        result['running_host'] = vm_object.runtime.host.name
-        result['datastores'] = list(outerelement.summary.name for outerelement in
-                                list(innerelement.datastore for innerelement in vm_object.storage.perDatastoreUsage))
-
-    else:
-        # If we are in check mode return a result as if move was performed
-        if hostVMotionNeeded:
-            result['running_host'] = module.params['destination_host']
-            result['changed'] = True
-        else:
-            result['running_host'] = vm_object.runtime.host.name
-        if storageVMotionNeeded:
-            result['datastores'] = module.params['destination_datastore']
-            result['changed'] = True
-        else:
-            result['datastores'] = list(outerelement.summary.name for outerelement in
-                                   list(innerelement.datastore for innerelement in vm_object.storage.perDatastoreUsage))
-
-    module.exit_json(**result)
+    vmotion_manager = VmotionManager(module)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
@@ -20,7 +20,8 @@ description:
       host, and/or its vmdks to another datastore using storage vMotion.
 version_added: 2.2
 author:
-- Bede Carroll (@bedecarroll)
+    - Bede Carroll (@bedecarroll)
+    - Olivier Boukili (@oboukili)
 notes:
     - Tested on vSphere 6.0
 requirements:
@@ -35,7 +36,6 @@ options:
     destination_host:
         description:
             - Name of the end host the VM should be running on (at least one of destination_host or destination_datastore is required)
-        required: False
         aliases: ['destination']
     destination_datastore:
         description:

--- a/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
@@ -136,11 +136,11 @@ def main():
     content = connect_to_api(module=module)
 
     vm_object = find_vm_by_name(content=content, vm_name=module.params['vm_name'])
-    if module.params['destination_host'] != None:
+    if module.params['destination_host'] is not None:
         host_object = find_hostsystem_by_name(content=content, hostname=module.params['destination_host'])
     else:
         host_object = None
-    if module.params['destination_datastore'] != None:
+    if module.params['destination_datastore'] is not None:
         datastore_object = find_datastore_by_name(content=content, datastore_name=module.params['destination_datastore'])
     else:
         datastore_object = None
@@ -153,26 +153,26 @@ def main():
     # Check if we could find the VM or Host
     if not vm_object:
         module.fail_json(msg='Cannot find virtual machine')
-    if not host_object and module.params['destination_host'] != None:
+    if not host_object and module.params['destination_host'] is not None:
         module.fail_json(msg='Cannot find host')
-    if not datastore_object and module.params['destination_datastore'] != None:
+    if not datastore_object and module.params['destination_datastore'] is not None:
         module.fail_json(msg='Cannot find datastore')
     elif not datastore_object.summary.accessible:
         module.fail_json(msg='Datastore is not accessible')
 
     # Make sure VM isn't already at the destination host
-    if module.params['destination_host'] == None:
+    if module.params['destination_host'] is None:
         hostVMotionNeeded = False
-    elif module.params['destination_host'] != None and vm_object.runtime.host.name == module.params['destination_host']:
+    elif module.params['destination_host'] is not None and vm_object.runtime.host.name == module.params['destination_host']:
         hostVMotionNeeded = False
     else:
         hostVMotionNeeded = True
 
     # Make sure VMDKs destination datastore is available on destination esx host (or on the current esx host if not specified)
-    if module.params['destination_datastore'] == None:
+    if module.params['destination_datastore'] is None:
         storageVMotionNeeded = False
     else:
-        if module.params['destination_host'] != None:
+        if module.params['destination_host'] is not None:
             if not datastore_object in host_object.datastore:
                 module.fail_json(msg="Datastore is not accessible on host")
         # Check whether VMDKs are already on the destination datastore

--- a/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
@@ -42,7 +42,7 @@ options:
             - Name of the end datastore the VM's vmdk should be moved on (at least one of destination_host or destination_datastore is required)
         required: False
         aliases: ['datastore']
-        version_added: 2.4
+        version_added: 2.5
 
 extends_documentation_fragment: vmware.documentation
 '''
@@ -91,7 +91,7 @@ running_host:
     sample: 'host1.example.com'
 datastores:
     description: List the datastores the virtual machine uses
-    returned: ['changed', 'success']
+    returned: changed or success
     type: list
     sample: '[datastore1]'
 
@@ -104,8 +104,8 @@ except ImportError:
     HAS_PYVMOMI = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.vmware import (connect_to_api, find_hostsystem_by_name, find_vm_by_name, find_datastore_by_name,
-                                         vmware_argument_spec, wait_for_task)
+from ansible.module_utils.vmware import (connect_to_api, find_hostsystem_by_name, find_vm_by_name,
+                                         find_datastore_by_name, vmware_argument_spec, wait_for_task)
 
 
 def migrate_vm(vm_object, host_object=None, datastore_object=None):

--- a/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
@@ -14,10 +14,10 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: vmware_vmotion
-short_description: Move a virtual machine using vMotion
+short_description: Move a virtual machine using vMotion, and/or its vmdks using storage vMotion.
 description:
     - Using VMware vCenter, move a virtual machine using vMotion to a different
-      host.
+      host, and/or its vmdks to another datastore using storage vMotion.
 version_added: 2.2
 author:
 - Bede Carroll (@bedecarroll)
@@ -34,9 +34,15 @@ options:
         aliases: ['vm']
     destination_host:
         description:
-            - Name of the end host the VM should be running on
-        required: True
+            - Name of the end host the VM should be running on (at least one of destination_host or destination_datastore is required)
+        required: False
         aliases: ['destination']
+    destination_datastore:
+        description:
+            - Name of the end datastore the VM's vmdk should be moved on (at least one of destination_host or destination_datastore is required)
+        required: False
+        aliases: ['datastore']
+
 extends_documentation_fragment: vmware.documentation
 '''
 
@@ -52,6 +58,28 @@ EXAMPLES = '''
         validate_certs: False
         vm_name: 'vm_name_as_per_vcenter'
         destination_host: 'destination_host_as_per_vcenter'
+
+    - name: Perform storage vMotion of of VM
+      local_action:
+        module: vmware_vmotion
+        hostname: 'vcenter_hostname'
+        username: 'vcenter_username'
+        password: 'vcenter_password'
+        validate_certs: False
+        vm_name: 'vm_name_as_per_vcenter'
+        destination_datastore: 'destination_datastore_as_per_vcenter'
+
+    - name: Perform storage vMotion and host vMotion of VM
+      local_action:
+        module: vmware_vmotion
+        hostname: 'vcenter_hostname'
+        username: 'vcenter_username'
+        password: 'vcenter_password'
+        validate_certs: False
+        vm_name: 'vm_name_as_per_vcenter'
+        destination_host: 'destination_host_as_per_vcenter'
+        destination_datastore: 'destination_datastore_as_per_vcenter'
+
 '''
 
 RETURN = '''
@@ -60,6 +88,14 @@ running_host:
     returned: changed or success
     type: string
     sample: 'host1.example.com'
+datastores:
+    description: List the datastores the virtual machine uses
+    returned:
+        - changed
+        - success
+    type: list
+    sample: '[datastore1]'
+
 '''
 
 try:
@@ -69,15 +105,15 @@ except ImportError:
     HAS_PYVMOMI = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.vmware import (connect_to_api, find_hostsystem_by_name, find_vm_by_name,
+from ansible.module_utils.vmware import (connect_to_api, find_hostsystem_by_name, find_vm_by_name, find_datastore_by_name,
                                          vmware_argument_spec, wait_for_task)
 
 
-def migrate_vm(vm_object, host_object):
+def migrate_vm(vm_object, host_object=None, datastore_object=None):
     """
     Migrate virtual machine and return the task.
     """
-    relocate_spec = vim.vm.RelocateSpec(host=host_object)
+    relocate_spec = vim.vm.RelocateSpec(host=host_object, datastore=datastore_object)
     task_object = vm_object.Relocate(relocate_spec)
     return task_object
 
@@ -88,10 +124,11 @@ def main():
     argument_spec.update(
         dict(
             vm_name=dict(required=True, aliases=['vm'], type='str'),
-            destination_host=dict(required=True, aliases=['destination'], type='str'),
+            destination_host=dict(required=False, aliases=['destination'], type='str'),
+            destination_datastore=dict(required=False, aliases=['datastore'], type='str')
         )
     )
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_one_of=[['destination_host', 'destination_datastore']])
 
     if not HAS_PYVMOMI:
         module.fail_json(msg='pyVmomi is required for this module')
@@ -99,7 +136,14 @@ def main():
     content = connect_to_api(module=module)
 
     vm_object = find_vm_by_name(content=content, vm_name=module.params['vm_name'])
-    host_object = find_hostsystem_by_name(content=content, hostname=module.params['destination_host'])
+    if module.params['destination_host'] != None:
+        host_object = find_hostsystem_by_name(content=content, hostname=module.params['destination_host'])
+    else:
+        host_object = None
+    if module.params['destination_datastore'] != None:
+        datastore_object = find_datastore_by_name(content=content, datastore_name=module.params['destination_datastore'])
+    else:
+        datastore_object = None
 
     # Setup result
     result = {
@@ -109,36 +153,72 @@ def main():
     # Check if we could find the VM or Host
     if not vm_object:
         module.fail_json(msg='Cannot find virtual machine')
-    if not host_object:
+    if not host_object and module.params['destination_host'] != None:
         module.fail_json(msg='Cannot find host')
+    if not datastore_object and module.params['destination_datastore'] != None:
+        module.fail_json(msg='Cannot find datastore')
+    elif not datastore_object.summary.accessible:
+        module.fail_json(msg='Datastore is not accessible')
 
-    # Make sure VM isn't already at the destination
-    if vm_object.runtime.host.name == module.params['destination_host']:
-        module.exit_json(**result)
+    # Make sure VM isn't already at the destination host
+    if module.params['destination_host'] == None:
+        hostVMotionNeeded = False
+    elif module.params['destination_host'] != None and vm_object.runtime.host.name == module.params['destination_host']:
+        hostVMotionNeeded = False
+    else:
+        hostVMotionNeeded = True
+
+    # Make sure VMDKs destination datastore is available on destination esx host (or on the current esx host if not specified)
+    if module.params['destination_datastore'] == None:
+        storageVMotionNeeded = False
+    else:
+        if module.params['destination_host'] != None:
+            if not datastore_object in host_object.datastore:
+                module.fail_json(msg="Datastore is not accessible on host")
+        # Check whether VMDKs are already on the destination datastore
+        if datastore_object in list(element.datastore for element in vm_object.storage.perDatastoreUsage):
+            storageVMotionNeeded = False
+        else:
+            storageVMotionNeeded = True
 
     if not module.check_mode:
-        # Migrate VM and get Task object back
-        task_object = migrate_vm(vm_object=vm_object, host_object=host_object)
-
-        # Wait for task to complete
-        wait_for_task(task_object)
-
-        # If task was a success the VM has moved, update running_host and complete module
-        if task_object.info.state == vim.TaskInfo.State.success:
-            vm_object = find_vm_by_name(content=content, vm_name=module.params['vm_name'])
-            result['running_host'] = vm_object.runtime.host.name
-            result['changed'] = True
-            module.exit_json(**result)
-        else:
-            if task_object.info.error is None:
-                module.fail_json(msg='Unable to migrate VM due to an error, please check vCenter')
+        if hostVMotionNeeded or storageVMotionNeeded:
+            # Migrate VM and get Task object back
+            task_object = migrate_vm(vm_object=vm_object, host_object=host_object, datastore_object=datastore_object)
+            # Wait for task to complete
+            wait_for_task(task_object)
+            # If task was a success the VM has moved, update running_host and complete module
+            if task_object.info.state == vim.TaskInfo.State.success:
+                vm_object = find_vm_by_name(content=content, vm_name=module.params['vm_name'])
+                # The storage layout is not automatically refreshed, so we trigger it to get coherent module return values
+                if storageVMotionNeeded:
+                    vm_object.RefreshStorageInfo()
+                result['changed'] = True
             else:
-                module.fail_json(msg='Unable to migrate VM due to an error: %s' % task_object.info.error)
+                if task_object.info.error is None:
+                    module.fail_json(msg='Unable to migrate VM due to an error, please check vCenter')
+                else:
+                    module.fail_json(msg='Unable to migrate VM due to an error: %s' % task_object.info.error)
+
+        result['running_host'] = vm_object.runtime.host.name
+        result['datastores'] = list(outerelement.summary.name for outerelement in
+                                list(innerelement.datastore for innerelement in vm_object.storage.perDatastoreUsage))
+
     else:
         # If we are in check mode return a result as if move was performed
-        result['running_host'] = module.params['destination_host']
-        result['changed'] = True
-        module.exit_json(**result)
+        if hostVMotionNeeded:
+            result['running_host'] = module.params['destination_host']
+            result['changed'] = True
+        else:
+            result['running_host'] = vm_object.runtime.host.name
+        if storageVMotionNeeded:
+            result['datastores'] = module.params['destination_datastore']
+            result['changed'] = True
+        else:
+            result['datastores'] = list(outerelement.summary.name for outerelement in
+                                   list(innerelement.datastore for innerelement in vm_object.storage.perDatastoreUsage))
+
+    module.exit_json(**result)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vmotion.py
@@ -42,6 +42,7 @@ options:
             - Name of the end datastore the VM's vmdk should be moved on (at least one of destination_host or destination_datastore is required)
         required: False
         aliases: ['datastore']
+        version_added: 2.4
 
 extends_documentation_fragment: vmware.documentation
 '''
@@ -90,9 +91,7 @@ running_host:
     sample: 'host1.example.com'
 datastores:
     description: List the datastores the virtual machine uses
-    returned:
-        - changed
-        - success
+    returned: ['changed', 'success']
     type: list
     sample: '[datastore1]'
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

vmware_vmotion.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Added "Storage vMotion" capabilities to vmware_vmotion module.
Now enables the virtual machine storage migration to another datastore, simultaneously (or not, up the the module invocation) with the virtual machine host migration.
Doesn't break compatibility with the previous version of the module.

**Needs ansible/ansible#17538 to be merged for this change to work**

output before:

```
{
    "changed": true, 
    "invocation": {
        "module_args": {
            "destination_host": "esx2", 
            "hostname": "myvcenter", 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "username": "administrator@myvspheredomain.com", 
            "vm_name": "myVM"
        }
    }, 
    "running_host": "esx2"
}

```

output after:

```
{
    "changed": true, 
    "datastores": [
        "datastore2"
    ], 
    "invocation": {
        "module_args": {
            "destination_datastore": "datastore2", 
            "destination_host": "esx2", 
            "hostname": "myvcenter", 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "username": "administrator@myvspheredomain.com", 
            "vm_name": "myVM"
        }
    }, 
    "running_host": "esx2"
}

```
