### PR TITLE
Adds a factory function for getting REST api tools

### DIFF
--- a/test/compile/python2.4-skip.txt
+++ b/test/compile/python2.4-skip.txt
@@ -46,6 +46,7 @@
 /lib/ansible/module_utils/vmware.py
 /lib/ansible/module_utils/netconf.py
 /lib/ansible/module_utils/junos.py
+/lib/ansible/module_utils/f5.py
 /lib/ansible/parsing/
 /lib/ansible/playbook/
 /lib/ansible/plugins/


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/module_utils/f5.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
I plan on converting most all f5 modules to use the rest api, so
this is part of that conversion. it adds a factory method to get
the various rest management root apis provided in the f5 sdk