### PR TITLE
Enable MySQL tests on FreeBSD.

### DIFF
--- a/test/integration/targets/mysql_db/aliases
+++ b/test/integration/targets/mysql_db/aliases
@@ -1,4 +1,3 @@
 destructive
 posix/ci/group1
-skip/freebsd
 skip/osx

--- a/test/integration/targets/mysql_user/aliases
+++ b/test/integration/targets/mysql_user/aliases
@@ -1,4 +1,3 @@
 destructive
 posix/ci/group1
-skip/freebsd
 skip/osx

--- a/test/integration/targets/mysql_variables/aliases
+++ b/test/integration/targets/mysql_variables/aliases
@@ -1,4 +1,3 @@
 destructive
 posix/ci/group1
-skip/freebsd
 skip/osx

--- a/test/integration/targets/setup_mysql_db/tasks/main.yml
+++ b/test/integration/targets/setup_mysql_db/tasks/main.yml
@@ -41,5 +41,24 @@
   with_items: "{{mysql_packages}}"
   when: ansible_pkg_mgr  ==  'apt'
 
+- name: install mysqldb_test FreeBSD dependencies
+  pkgng:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{mysql_packages}}"
+  when: ansible_os_family == "FreeBSD"
+
+- name: install mysql-python package via pip (FreeBSD)
+  pip:
+    name: mysql-python
+    state: present
+  when: ansible_os_family == "FreeBSD"
+
+- name: enable mysql-server service (FreeBSD)
+  lineinfile:
+    path: /etc/rc.conf
+    line: 'mysql_server_enable="YES"'
+  when: ansible_os_family == "FreeBSD"
+
 - name: start mysql_db service if not running
   service: name={{ mysql_service }} state=started

--- a/test/integration/targets/setup_mysql_db/vars/FreeBSD.yml
+++ b/test/integration/targets/setup_mysql_db/vars/FreeBSD.yml
@@ -1,0 +1,5 @@
+mysql_service: 'mysql-server'
+
+mysql_packages:
+    - mariadb101-server
+    - py27-mysql-connector-python2


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

Integration Tests

##### ANSIBLE VERSION

```
ansible 2.3.0 (mysql-freebsd-test 0c70bc4089) last updated 2017/02/14 11:53:22 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Enable MySQL tests on FreeBSD.