### PR TITLE
Move to using a requirements.txt to install the python packages.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 prune ticket_stubs
 prune hacking
 include README.md COPYING
+include requrements.txt
 include examples/hosts
 include examples/ansible.cfg
 include lib/ansible/module_utils/powershell.ps1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 prune ticket_stubs
 prune hacking
 include README.md COPYING
-include requrements.txt
+include requirements.txt
 include examples/hosts
 include examples/ansible.cfg
 include lib/ansible/module_utils/powershell.ps1

--- a/docs/docsite/rst/intro_installation.rst
+++ b/docs/docsite/rst/intro_installation.rst
@@ -330,9 +330,11 @@ If you don't have pip installed in your version of Python, install pip::
 
     $ sudo easy_install pip
 
-Ansible also uses the following Python modules that need to be installed [1]_::
+Ansible also uses the following Python modules that need to be installed [1]_:
 
-    $ sudo pip install paramiko PyYAML Jinja2 httplib2 six
+.. code-block:: bash
+
+    $ sudo pip install -r ./requirements.txt
 
 To update ansible checkouts, use pull-with-rebase so any local changes are replayed.
 
@@ -383,4 +385,4 @@ You can also use "sudo make install".
    `irc.freenode.net <http://irc.freenode.net>`_
        #ansible IRC chat channel
 
-.. [1] If you have issues with the "pycrypto" package install on Mac OSX, which is included as a dependency for paramiko, then you may need to try "CC=clang sudo -E pip install pycrypto".
+.. [1] If you have issues with the "pycrypto" package install on Mac OSX, then you may need to try ``CC=clang sudo -E pip install pycrypto``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+# Note: this requirements.txt file is used to specify what dependencies are
+# needed to make the package run rather than for deployment of a tested set of
+# packages.  Thus, this should be the loosest set possible (only required
+# packages, not optional ones, and with the widest range of versions that could
+# be suitable)
+jinja2
+PyYAML
+paramiko
+pycrypto >= 2.6
+setuptools

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,13 @@ except ImportError:
             " install setuptools).")
     sys.exit(1)
 
+with open('requirements.txt') as requirements_file:
+    install_requirements = requirements_file.read().splitlines()
+    if not install_requirements:
+        print("Unable to read requirements from the requirements.txt file"
+                "That indicates this copy of the source code is incomplete.")
+        sys.exit(2)
+
 setup(
     name='ansible',
     version=__version__,
@@ -21,7 +28,7 @@ setup(
     license='GPLv3',
     # Ansible will also make use of a system copy of python-six and
     # python-selectors2 if installed but use a Bundled copy if it's not.
-    install_requires=['paramiko', 'jinja2', "PyYAML", 'setuptools', 'pycrypto >= 2.6'],
+    install_requires=install_requirements,
     package_dir={ '': 'lib' },
     packages=find_packages('lib'),
     package_data={

--- a/test/compile/python2.4-skip.txt
+++ b/test/compile/python2.4-skip.txt
@@ -53,4 +53,5 @@
 /lib/ansible/template/
 /lib/ansible/utils/
 /lib/ansible/vars/
+/setup.py
 /test/


### PR DESCRIPTION
This makes it easy to keep the documentation and actual package
dependencies in sync.

Fixes #18453

##### ISSUE TYPE

 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
Installing ansible

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```
