### PR TITLE
refactor postgres, step 1

### DIFF
--- a/lib/ansible/module_utils/postgres.py
+++ b/lib/ansible/module_utils/postgres.py
@@ -1,0 +1,68 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Copyright (c), Ted Timmons <ted@timmons.me>, 2017.
+# Most of this was originally added by other creators in the postgresql_user module.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# standard ansible imports
+from ansible.module_utils.basic import get_exception
+
+# standard PG imports
+HAS_PSYCOPG2 = False
+try:
+    import psycopg2
+    import psycopg2.extras
+except ImportError:
+    pass
+else:
+    HAS_PSYCOPG2 = True
+
+from ansible.module_utils.six import iteritems
+
+def ensure_libs(sslrootcert=None):
+    if not HAS_PSYCOPG2:
+        return 'psycopg2 is not installed. we need psycopg2.'
+    if sslrootcert and psycopg2.__version__ < '2.4.3':
+        return 'psycopg2 must be at least 2.4.3 in order to use the ssl_rootcert parameter'
+
+    # no problems
+    return None
+
+def postgres_common_argument_spec(password_alias=True):
+    password_aliases = []
+    if password_alias: # sometimes 'password' means something totally different.
+        password_aliases = ['password']
+
+    return dict(
+        login_user        = dict(default='postgres', aliases=['login']),
+        login_password    = dict(default='', no_log=True, aliases=password_aliases),
+        login_host        = dict(default='', aliases=['host']),
+        login_unix_socket = dict(default='', aliases=['unix_socket']),
+        port              = dict(type='int', default=5432),
+        ssl_mode          = dict(default='disable', choices=['disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full']),
+        ssl_rootcert      = dict(default=None),
+    )
+

--- a/lib/ansible/module_utils/postgres.py
+++ b/lib/ansible/module_utils/postgres.py
@@ -51,16 +51,12 @@ def ensure_libs(sslrootcert=None):
     # no problems
     return None
 
-def postgres_common_argument_spec(password_alias=True):
-    password_aliases = []
-    if password_alias: # sometimes 'password' means something totally different.
-        password_aliases = ['password']
-
+def postgres_common_argument_spec():
     return dict(
-        login_user        = dict(default='postgres', aliases=['login']),
-        login_password    = dict(default='', no_log=True, aliases=password_aliases),
-        login_host        = dict(default='', aliases=['host']),
-        login_unix_socket = dict(default='', aliases=['unix_socket']),
+        login_user        = dict(default='postgres'),
+        login_password    = dict(default='', no_log=True),
+        login_host        = dict(default=''),
+        login_unix_socket = dict(default=''),
         port              = dict(type='int', default=5432),
         ssl_mode          = dict(default='disable', choices=['disable', 'allow', 'prefer', 'require', 'verify-ca', 'verify-full']),
         ssl_rootcert      = dict(default=None),

--- a/lib/ansible/module_utils/postgres.py
+++ b/lib/ansible/module_utils/postgres.py
@@ -28,7 +28,7 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # standard ansible imports
-from ansible.module_utils.basic import get_exception
+from ansible.module_utils.basic import get_exception, AnsibleModule
 
 # standard PG imports
 HAS_PSYCOPG2 = False

--- a/lib/ansible/module_utils/postgres.py
+++ b/lib/ansible/module_utils/postgres.py
@@ -28,7 +28,7 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 # standard ansible imports
-from ansible.module_utils.basic import get_exception, AnsibleModule
+from ansible.module_utils.basic import get_exception
 
 # standard PG imports
 HAS_PSYCOPG2 = False

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -64,20 +64,6 @@ options:
     required: false
     default: present
     choices: [ "present", "absent" ]
-  ssl_mode:
-    description:
-      - Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server.
-      - See https://www.postgresql.org/docs/current/static/libpq-ssl.html for more information on the modes.
-    required: false
-    default: disable
-    choices: [disable, allow, prefer, require, verify-ca, verify-full]
-    version_added: '2.3'
-  ssl_rootcert:
-    description:
-      - Specifies the name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
-    required: false
-    default: null
-    version_added: '2.3'
 author: "Ansible Core Team"
 extends_documentation_fragment:
 - postgres

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -219,7 +219,7 @@ def db_matches(cursor, db, owner, template, encoding, lc_collate, lc_ctype):
 
 def main():
     argument_spec = pgutils.postgres_common_argument_spec()
-    argument_spec.append(dict(
+    argument_spec.update(dict(
         db=dict(required=True, aliases=['name']),
         owner=dict(default=""),
         template=dict(default=""),

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -109,7 +109,7 @@ else:
 from ansible.module_utils.six import iteritems
 
 import ansible.module_utils.postgres as pgutils
-from ansible.module_utils.basic import get_exception
+from ansible.module_utils.basic import get_exception, AnsibleModule
 
 
 class NotSupportedError(Exception):

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -109,6 +109,7 @@ else:
 from ansible.module_utils.six import iteritems
 
 import ansible.module_utils.postgres as pgutils
+from ansible.module_utils.database import SQLParseError, pg_quote_identifier
 from ansible.module_utils.basic import get_exception, AnsibleModule
 
 

--- a/lib/ansible/utils/module_docs_fragments/postgres.py
+++ b/lib/ansible/utils/module_docs_fragments/postgres.py
@@ -1,0 +1,70 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class ModuleDocFragment(object):
+    # Postgres documentation fragment
+    DOCUMENTATION = """
+options:
+  login_user:
+    description:
+      - The username used to authenticate with
+    required: false
+    default: postgres
+  login_password:
+    description:
+      - The password used to authenticate with
+    required: false
+    default: null
+  login_host:
+    description:
+      - Host running the database
+    required: false
+    default: null
+  login_unix_socket:
+    description:
+      - Path to a Unix domain socket for local connections
+    required: false
+    default: null
+  port:
+    description:
+      - Database port to connect to.
+    required: false
+    default: 5432
+  ssl_mode:
+    description:
+      - Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server.
+      - See https://www.postgresql.org/docs/current/static/libpq-ssl.html for more information on the modes.
+      - Default of C(prefer) matches libpq default.
+    required: false
+    default: prefer
+    choices: [disable, allow, prefer, require, verify-ca, verify-full]
+    version_added: '2.3'
+  ssl_rootcert:
+    description:
+      - Specifies the name of a file containing SSL certificate authority (CA) certificate(s).
+      - If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+    required: false
+    default: null
+    version_added: '2.3'
+notes:
+- The default authentication assumes that you are either logging in as or sudo'ing to the C(postgres) account on the host.
+- This module uses I(psycopg2), a Python PostgreSQL database adapter. You must ensure that psycopg2 is installed on
+  the host before using this module. If the remote host is the PostgreSQL server (which is the default case), then
+  PostgreSQL must also be installed on the remote host. For Ubuntu-based systems, install the C(postgresql), C(libpq-dev),
+  and C(python-psycopg2) packages on the remote host before using this module.
+- The ssl_rootcert parameter requires at least Postgres version 8.4 and I(psycopg2) version 2.4.3.
+requirements: [ psycopg2 ]
+"""

--- a/test/units/module_utils/test_postgresql.py
+++ b/test/units/module_utils/test_postgresql.py
@@ -1,0 +1,45 @@
+import json
+
+from ansible.compat.tests import unittest
+
+from ansible.module_utils import postgres, basic
+from ansible.module_utils.basic import AnsibleModule
+from units.mock.procenv import swap_stdin_and_argv
+
+
+import pprint
+
+
+class TestPostgres(unittest.TestCase):
+    def test_ensure_libs_no_rootcert(self):
+        params = {'foo': 'blippy'}
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS=params))
+
+        with swap_stdin_and_argv(stdin_data=args):
+            basic._ANSIBLE_ARGS = None
+            error_txt = postgres.ensure_libs(sslrootcert=None)
+            self.assertFalse(error_txt)
+            pprint.pprint(error_txt)
+
+    def test_ensure_libs_with_rootcert(self):
+        params = {'foo': 'blippy'}
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS=params))
+
+        with swap_stdin_and_argv(stdin_data=args):
+            basic._ANSIBLE_ARGS = None
+
+            error_txt = postgres.ensure_libs(sslrootcert=True)
+            self.assertFalse(error_txt)
+            pprint.pprint(error_txt)
+
+#    def test_sslmode_prefer(self):
+#        params = {'foo': 'blippy'}
+#        args = json.dumps(dict(ANSIBLE_MODULE_ARGS=params))
+#
+#        with swap_stdin_and_argv(stdin_data=args):
+#            basic._ANSIBLE_ARGS = None
+#            error_txt = postgres.ensure_libs(sslrootcert=None)
+#            self.assertFalse(error_txt)
+#            #a_module = AnsibleModule(argument_spec={'foo': {'required': True, 'aliases': ['name']}})
+#            #res = postgres.params_to_kwmap(a_module)
+#            pprint.pprint(error_txt)

--- a/test/units/module_utils/test_postgresql.py
+++ b/test/units/module_utils/test_postgresql.py
@@ -1,6 +1,9 @@
 import json
+import sys
 
 from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import patch, MagicMock
+from ansible.compat.six.moves import builtins
 
 from ansible.module_utils import postgres, basic
 from ansible.module_utils.basic import AnsibleModule
@@ -9,37 +12,64 @@ from units.mock.procenv import swap_stdin_and_argv
 
 import pprint
 
+realimport = builtins.__import__
 
 class TestPostgres(unittest.TestCase):
-    def test_ensure_libs_no_rootcert(self):
-        params = {'foo': 'blippy'}
-        args = json.dumps(dict(ANSIBLE_MODULE_ARGS=params))
+    def clear_modules(self, mods):
+        for mod in mods:
+            if mod in sys.modules:
+                del sys.modules[mod]
 
-        with swap_stdin_and_argv(stdin_data=args):
-            basic._ANSIBLE_ARGS = None
-            error_txt = postgres.ensure_libs(sslrootcert=None)
-            self.assertFalse(error_txt)
-            pprint.pprint(error_txt)
+    @patch.object(builtins, '__import__')
+    def test_postgres_pg2_missing_ensure_libs(self, mock_import):
+        def _mock_import(name, *args, **kwargs):
+            if name == 'psycopg2':
+                raise ImportError
+            return realimport(name, *args, **kwargs)
 
-    def test_ensure_libs_with_rootcert(self):
-        params = {'foo': 'blippy'}
-        args = json.dumps(dict(ANSIBLE_MODULE_ARGS=params))
+        self.clear_modules(['psycopg2', 'ansible.module_utils.postgres'])
+        mock_import.side_effect = _mock_import
+        mod = builtins.__import__('ansible.module_utils.postgres')
 
-        with swap_stdin_and_argv(stdin_data=args):
-            basic._ANSIBLE_ARGS = None
+        self.assertFalse(mod.module_utils.postgres.HAS_PSYCOPG2)
 
-            error_txt = postgres.ensure_libs(sslrootcert=True)
-            self.assertFalse(error_txt)
-            pprint.pprint(error_txt)
+        ensure_ret = mod.module_utils.postgres.ensure_libs(sslrootcert=None)
+        self.assertIn('psycopg2 is not installed', ensure_ret)
+        pprint.pprint(ensure_ret)
 
-#    def test_sslmode_prefer(self):
-#        params = {'foo': 'blippy'}
-#        args = json.dumps(dict(ANSIBLE_MODULE_ARGS=params))
-#
-#        with swap_stdin_and_argv(stdin_data=args):
-#            basic._ANSIBLE_ARGS = None
-#            error_txt = postgres.ensure_libs(sslrootcert=None)
-#            self.assertFalse(error_txt)
-#            #a_module = AnsibleModule(argument_spec={'foo': {'required': True, 'aliases': ['name']}})
-#            #res = postgres.params_to_kwmap(a_module)
-#            pprint.pprint(error_txt)
+    @patch.object(builtins, '__import__')
+    def test_postgres_pg2_found_ensure_libs(self, mock_import):
+        def _mock_import(name, *args, **kwargs):
+            if 'psycopg2' in name:
+                return MagicMock()
+            return realimport(name, *args, **kwargs)
+
+        self.clear_modules(['psycopg2', 'ansible.module_utils.postgres'])
+        mock_import.side_effect = _mock_import
+        mod = builtins.__import__('ansible.module_utils.postgres')
+
+        self.assertTrue(mod.module_utils.postgres.HAS_PSYCOPG2)
+
+        ensure_ret = mod.module_utils.postgres.ensure_libs(sslrootcert=None)
+        self.assertFalse(ensure_ret)
+        pprint.pprint(ensure_ret)
+
+    @patch.object(builtins, '__import__')
+    def test_postgres_pg2_found_ensure_libs_old_version(self, mock_import):
+        def _mock_import(name, *args, **kwargs):
+            if 'psycopg2' in name:
+                m = MagicMock()
+                m.__version__ = '2.4.1'
+                return m
+            return realimport(name, *args, **kwargs)
+
+        self.clear_modules(['psycopg2', 'ansible.module_utils.postgres'])
+        mock_import.side_effect = _mock_import
+        mod = builtins.__import__('ansible.module_utils.postgres')
+
+        self.assertTrue(mod.module_utils.postgres.HAS_PSYCOPG2)
+
+        ensure_ret = mod.module_utils.postgres.ensure_libs(sslrootcert="yes")
+        self.assertTrue(ensure_ret)
+        self.assertIn('psycopg2 must be at least 2.4.3 in order to use', ensure_ret)
+        pprint.pprint(ensure_ret)


### PR DESCRIPTION
* adds a basic unit test module
* first step towards a common utils module
* set postgresql_db doc argument defaults to what the code actually uses

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
postgres

##### ANSIBLE VERSION
2.3.0

##### SUMMARY
The initial goal was to change the default for ssl_mode to `prefer` to make the pg modules match other pg libraries. I got carried away with a refactor (#21118). I will ping mattclay/alikins/ryansb on IRC when I'm ready, but for now I'm doing some iterative commits to ensure everything stays correct.