### PR TITLE
Bugfix: nxos_interface when switchport mode is fex-fabric

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface.py
@@ -292,7 +292,8 @@ def get_interface(intf, module):
             "access": "layer2",
             "trunk": "layer2",
             "routed": "layer3",
-            "layer3": "layer3"
+            "layer3": "layer3",
+            "fex-fabric": "layer2"
         }
     }
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/network/nxos/nxos_interface

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file = /Users/idrey/.ansible.cfg
  configured module search path = ['/Users/idrey/code/ansible/lib/ansible/modules']
```

##### SUMMARY
This bugfix resolve case when we want to change settings of an interface that configured with 'switchport mode fex-fabric' NXOS CLI command. This command used on parent switch when we connect Cisco Nexus FEX uplink interfaces to it. 

**Output before bugfix**

```
fatal: [local-n9000v-01]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_name": "nxos_interface"
    },
    "module_stderr": "Traceback (most recent call last):\n  File \"/var/folders/x_/hgn62t715kl9w1bxh_0_89ch0000gn/T/ansible_p55opS/ansible_module_nxos_interface.py\", line 971, in <module>\n    main()\n  File \"/var/folders/x_/hgn62t715kl9w1bxh_0_89ch0000gn/T/ansible_p55opS/ansible_module_nxos_interface.py\", line 884, in main\n    existing, is_default = smart_existing(module, intf_type, normalized_interface)\n  File \"/var/folders/x_/hgn62t715kl9w1bxh_0_89ch0000gn/T/ansible_p55opS/ansible_module_nxos_interface.py\", line 702, in smart_existing\n    existing = get_interface(normalized_interface, module)\n  File \"/var/folders/x_/hgn62t715kl9w1bxh_0_89ch0000gn/T/ansible_p55opS/ansible_module_nxos_interface.py\", line 462, in get_interface\n    temp_dict = apply_value_map(mode_value_map, temp_dict)\n  File \"/var/folders/x_/hgn62t715kl9w1bxh_0_89ch0000gn/T/ansible_p55opS/ansible_module_nxos_interface.py\", line 619, in apply_value_map\n    resource[key] = value[resource.get(key)]\nKeyError: 'fex-fabric'\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE"
```

**Output after bugfix**

```
changed: [local-n9000v-01] => {
    "changed": true,
    "end_state": {
        "admin_state": "down",
        "description": "Test",
        "interface": "Ethernet1/3",
        "mode": "layer2",
        "type": "ethernet"
    },
    "existing": {
        "admin_state": "up",
        "interface": "Ethernet1/3",
        "mode": "layer2",
        "type": "ethernet"
    },
    "invocation": {
        "module_args": {
            "admin_state": "down",
            "auth_pass": null,
            "authorize": false,
            "config": null,
            "description": "Test",
            "fabric_forwarding_anycast_gateway": null,
            "host": "10.133.133.2",
            "include_defaults": "True",
            "interface": "Eth1/3",
            "interface_type": null,
            "ip_forward": null,
            "mode": "layer2",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": null,
            "provider": {
                "host": "10.133.133.2",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "timeout": 60,
                "transport": "nxapi",
                "use_ssl": true,
                "username": "step",
                "validate_certs": false
            },
            "save": false,
            "ssh_keyfile": null,
            "state": "present",
            "timeout": 60,
            "transport": "nxapi",
            "use_ssl": true,
            "username": "step",
            "validate_certs": false
        },
        "module_name": "nxos_interface"
    },
    "proposed": {
        "admin_state": "down",
        "description": "Test",
        "mode": "layer2"
    },
    "updates": [
        "interface Ethernet1/3",
        "description Test",
        "shutdown"
    ]
}
```