### PR TITLE
Contributing new file_copy module to manage HUAWEI data center CloudEngine switch

### DIFF
--- a/lib/ansible/module_utils/cloudengine.py
+++ b/lib/ansible/module_utils/cloudengine.py
@@ -27,11 +27,11 @@
 import re
 import time
 
-from ansible.module_utils.basic import json
+from ansible.module_utils.basic import json, get_exception
 from ansible.module_utils.network import NetworkError
 from ansible.module_utils.network import add_argument,\
     register_transport, to_list
-from ansible.module_utils.shell import CliBase
+from ansible.module_utils.shell import CliBase, ShellError
 
 try:
     from ncclient import manager
@@ -64,8 +64,22 @@ class CeConfigMixin(object):
             cmd += ' include-default'
         if regular:
             cmd += ' ' + regular
+        cfg = self.execute([cmd])[0]
+        if not include_defaults:
+            return cfg
 
-        return self.execute([cmd])[0]
+        # remove default configuration prefix
+        if cfg:
+            cmds = cfg.split("\n")
+            for i in range(len(cmds)):
+                if not cmds[i]:
+                    continue
+                if cmds[i].count('~') > 0:
+                    index = cmds[i].index('~')
+                    if cmds[i][:index] == ' '*index:
+                        cmds[i] = cmds[i].replace("~", "", 1)
+            cfg = '\n'.join(cmds)
+        return cfg
 
     def load_config(self, config):
         """ load_config """
@@ -77,29 +91,18 @@ class CeConfigMixin(object):
         except TypeError:
             self.execute(['system-view immediately',
                           'commit label %s' % checkpoint])
+        except Exception:
+            raise
 
         try:
             try:
                 self.configure(config)
-            except NetworkError:
+            except (NetworkError, Exception):
                 self.load_checkpoint(checkpoint)
+                self.clear_checkpoint(checkpoint)
                 raise
         finally:
-            # get commit id and clear it
-            responses = self.execute(
-                'display configuration commit list '
-                'label | include %s' % checkpoint)
-            match = re.match(
-                r'[\r\n]?\d+\s+(\d{10})\s+ansible.*', responses[0])
-            if match is not None:
-                try:
-                    self.execute(['return',
-                                  'clear configuration commit %s '
-                                  'label' % match.group(1)], output='text')
-                except TypeError:
-                    self.execute(['return',
-                                  'clear configuration commit %s '
-                                  'label' % match.group(1)])
+            self.clear_checkpoint(checkpoint)
 
     def save_config(self, **kwargs):
         """ save_config """
@@ -122,6 +125,24 @@ class CeConfigMixin(object):
                            ' label %s' % checkpoint])
         pass
 
+    def clear_checkpoint(self, checkpoint):
+        """ clear checkpoint """
+
+        # get commit id and clear it
+        responses = self.execute(
+            'display configuration commit list '
+            'label | include %s' % checkpoint)
+        match = re.match(
+            r'[\r\n]?\d+\s+(\d{10})\s+ansible.*', responses[0])
+        if match is not None:
+            try:
+                self.execute(['return',
+                              'clear configuration commit %s '
+                              'label' % match.group(1)], output='text')
+            except TypeError:
+                self.execute(['return',
+                              'clear configuration commit %s '
+                              'label' % match.group(1)])
 
 class Netconf(object):
     """ Netconf """
@@ -195,7 +216,8 @@ class Cli(CeConfigMixin, CliBase):
     """ Cli """
 
     CLI_PROMPTS_RE = [
-        re.compile(r'[\r\n]?[<|\[]{1}.+[>|\]]{1}(?:\s*)$'),
+        re.compile(r'[\r\n]?<.+>(?:\s*)$'),
+        re.compile(r'[\r\n]?\[.+\](?:\s*)$'),
     ]
 
     CLI_ERRORS_RE = [
@@ -209,7 +231,8 @@ class Cli(CeConfigMixin, CliBase):
         re.compile(r"'[^']' +returned error code: ?\d+"),
         re.compile(r"syntax error"),
         re.compile(r"unknown command"),
-        re.compile(r"Error\[\d+\]: ")
+        re.compile(r"Error\[\d+\]: ", re.I),
+        re.compile(r"Error:", re.I)
     ]
 
     NET_PASSWD_RE = re.compile(r"[\r\n]?password: $", re.I)
@@ -220,6 +243,21 @@ class Cli(CeConfigMixin, CliBase):
         super(Cli, self).connect(params, kickstart=False, **kwargs)
         self.shell.send('screen-length 0 temporary')
         self.shell.send('mmi-mode enable')
+
+    def execute(self, commands):
+        try:
+            return self.shell.send(commands)
+        except ShellError:
+            exc = get_exception()
+            cmd = ""
+            if exc.command:
+                cmd = "Command: %s\r\n" % str(exc.command)
+            msg = str(exc.message)
+            if str(exc.command) in msg:
+                msg = msg.replace(str(exc.command), "")
+            if "matched error in response: " in msg:
+                msg = msg.replace("matched error in response: ", "")
+            raise NetworkError(cmd+msg, commands=commands)
 
     def run_commands(self, commands):
         """ run_commands """
@@ -268,3 +306,39 @@ def prepare_commands(commands):
         if cmd.command.endswith('| json'):
             cmd.output = 'json'
         yield cmd
+
+def get_cli_exception(exc=None):
+    """ get cli exception message"""
+
+    msg = list()
+    if not exc:
+        exc = get_exception()
+    if exc:
+        errs = str(exc).split("\r\n")
+        for err in errs:
+            if not err:
+                continue
+            if "matched error in response:" in err:
+                continue
+            if " at '^' position" in err:
+                err = err.replace(" at '^' position", "")
+            if err.replace(" ", "") == "^":
+                continue
+            if len(err) > 2 and err[0] in ["<", "["] and err[-1] in [">", "]"]:
+                continue
+            if err[-1] == ".":
+                err = err[:-1]
+            if err.replace(" ", "") == "":
+                continue
+            msg.append(err)
+    else:
+        msg = ["Error: Fail to get cli exception message."]
+
+    while msg[-1][-1] == ' ':
+        msg[-1] = msg[-1][:-1]
+
+    if msg[-1][-1] != ".":
+        msg[-1] += "."
+
+    return ", ".join(msg).capitalize()
+

--- a/lib/ansible/modules/network/cloudengine/ce_command.py
+++ b/lib/ansible/modules/network/cloudengine/ce_command.py
@@ -37,7 +37,7 @@ extends_documentation_fragment: cloudengine
 options:
   commands:
     description:
-      - The commands to send to the remote HUAWEI CloudEngine device 
+      - The commands to send to the remote HUAWEI CloudEngine device
         over the configured provider.  The resulting output from the
         command is returned. If the I(wait_for) argument is provided,
         the module is not returned until the condition is satisfied

--- a/lib/ansible/modules/network/cloudengine/ce_config.py
+++ b/lib/ansible/modules/network/cloudengine/ce_config.py
@@ -1,0 +1,351 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = """
+---
+module: ce_config
+version_added: "2.3"
+author: "QijunPan (@CloudEngine-Ansible)"
+short_description: Manage Huawei CloudEngine configuration sections
+description:
+  - Huawei CloudEngine configurations use a simple block indent file syntax
+    for segmenting configuration into sections.  This module provides
+    an implementation for working with CloudEngine configuration sections in
+    a deterministic way.  This module works with CLI
+    transports.
+extends_documentation_fragment: cloudengine
+options:
+  lines:
+    description:
+      - The ordered set of commands that should be configured in the
+        section.  The commands must be the exact same commands as found
+        in the device running-config.  Be sure to note the configuration
+        command syntax as some commands are automatically modified by the
+        device config parser.
+    required: false
+    default: null
+  parents:
+    description:
+      - The ordered set of parents that uniquely identify the section
+        the commands should be checked against.  If the parents argument
+        is omitted, the commands are checked against the set of top
+        level or global commands.
+    required: false
+    default: null
+  src:
+    description:
+      - The I(src) argument provides a path to the configuration file
+        to load into the remote system.  The path can either be a full
+        system path to the configuration file if the value starts with /
+        or relative to the root of the implemented role or playbook.
+        This argument is mutually exclusive with the I(lines) and
+        I(parents) arguments.
+    required: false
+    default: null
+  before:
+    description:
+      - The ordered set of commands to push on to the command stack if
+        a change needs to be made.  This allows the playbook designer
+        the opportunity to perform configuration commands prior to pushing
+        any changes without affecting how the set of commands are matched
+        against the system.
+    required: false
+    default: null
+  after:
+    description:
+      - The ordered set of commands to append to the end of the command
+        stack if a change needs to be made.  Just like with I(before) this
+        allows the playbook designer to append a set of commands to be
+        executed after the command set.
+    required: false
+    default: null
+  match:
+    description:
+      - Instructs the module on the way to perform the matching of
+        the set of commands against the current device config.  If
+        match is set to I(line), commands are matched line by line.  If
+        match is set to I(strict), command lines are matched with respect
+        to position.  If match is set to I(exact), command lines
+        must be an equal match.  Finally, if match is set to I(none), the
+        module will not attempt to compare the source configuration with
+        the running configuration on the remote device.
+    required: false
+    default: line
+    choices: ['line', 'strict', 'exact', 'none']
+  replace:
+    description:
+      - Instructs the module on the way to perform the configuration
+        on the device.  If the replace argument is set to I(line) then
+        the modified lines are pushed to the device in configuration
+        mode.  If the replace argument is set to I(block) then the entire
+        command block is pushed to the device in configuration mode if any
+        line is not correct.
+    required: false
+    default: line
+    choices: ['line', 'block']
+  backup:
+    description:
+      - This argument will cause the module to create a full backup of
+        the current C(current-configuration) from the remote device before any
+        changes are made.  The backup file is written to the C(backup)
+        folder in the playbook root directory.  If the directory does not
+        exist, it is created.
+    required: false
+    default: no
+    choices: ['yes', 'no']
+  config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source.  There are times when it is not
+        desirable to have the task get the current running-config for
+        every task in a playbook.  The I(config) argument allows the
+        implementer to pass in the configuration to use as the base
+        config for comparison.
+    required: false
+    default: null
+  defaults:
+    description:
+      - The I(defaults) argument will influence how the running-config
+        is collected from the device.  When the value is set to true,
+        the command used to collect the running-config is append with
+        the all keyword.  When the value is set to false, the command
+        is issued without the all keyword
+    required: false
+    default: false
+  save:
+    description:
+      - The C(save) argument instructs the module to save the
+        running-config to startup-config.  This operation is performed
+        after any changes are made to the current running config.  If
+        no changes are made, the configuration is still saved to the
+        startup config.  This option will always cause the module to
+        return changed.
+    required: false
+    default: false
+"""
+
+EXAMPLES = """
+# Note: examples below use the following provider dict to handle
+#       transport and authentication to the node.
+vars:
+  cli:
+    host: "{{ inventory_hostname }}"
+    username: admin
+    password: admin
+    transport: cli
+
+- name: configure top level configuration and save it
+  ce_config:
+    lines: sysname {{ inventory_hostname }}
+    save: yes
+    provider: "{{ cli }}"
+
+- ce_config:
+    lines:
+      - rule 10 permit source 1.1.1.1 32
+      - rule 20 permit source 2.2.2.2 32
+      - rule 30 permit source 3.3.3.3 32
+      - rule 40 permit source 4.4.4.4 32
+      - rule 50 permit source 5.5.5.5 32
+    parents: acl 2000
+    before: undo acl 2000
+    match: exact
+    provider: "{{ cli }}"
+
+- ce_config:
+    lines:
+      - rule 10 permit source 1.1.1.1 32
+      - rule 20 permit source 2.2.2.2 32
+      - rule 30 permit source 3.3.3.3 32
+      - rule 40 permit source 4.4.4.4 32
+    parents: acl 2000
+    before: undo acl 2000
+    replace: block
+    provider: "{{ cli }}"
+"""
+
+RETURN = """
+updates:
+  description: The set of commands that will be pushed to the remote device
+  returned: Only when lines is specified.
+  type: list
+  sample: ['...', '...']
+backup_path:
+  description: The full path to the backup file
+  returned: when backup is yes
+  type: path
+  sample: /playbooks/ansible/backup/ce_config.2016-07-16@22:28:34
+"""
+
+from ansible.module_utils.cloudengine import get_cli_exception
+from ansible.module_utils.basic import get_exception
+from ansible.module_utils.network import NetworkModule, NetworkError
+from ansible.module_utils.netcfg import NetworkConfig, dumps
+from ansible.module_utils.basic import remove_values
+
+try:
+    from ansible.errors import AnsibleModuleExit
+    HAS_ANSIBLE_MODULE_EXIT = True
+except ImportError:
+    HAS_ANSIBLE_MODULE_EXIT = False
+
+
+def config_exit(module, **result):
+    """ return from the module, without error """
+
+    if HAS_ANSIBLE_MODULE_EXIT:
+        if 'changed' not in result:
+            result['changed'] = False
+        if 'invocation' not in result:
+            result['invocation'] = {'module_args': module.params}
+        result = remove_values(result, module.no_log_values)
+        raise AnsibleModuleExit(result)
+    else:
+        module.exit_json(**result)
+
+def config_fail(module, **result):
+    """ return from the module, with an error message """
+
+    if HAS_ANSIBLE_MODULE_EXIT:
+        assert 'msg' in result, "implementation error -- msg to explain the error is required"
+        result['failed'] = True
+        if 'invocation' not in result:
+            result['invocation'] = {'module_args': module.params}
+        result = remove_values(result, module.no_log_values)
+        raise AnsibleModuleExit(result)
+    else:
+        module.fail_json(**result)
+
+
+def get_candidate(module):
+    """ get candidat info. """
+    candidate = NetworkConfig(indent=1)
+    if module.params['src']:
+        candidate.load(module.params['src'])
+    elif module.params['lines']:
+        parents = module.params['parents'] or list()
+        candidate.add(module.params['lines'], parents=parents)
+    return candidate
+
+
+def get_config(module):
+    """ get current configuration. """
+
+    contents = module.params['config']
+    if not contents:
+        defaults = module.params['defaults']
+        contents = module.config.get_config(include_defaults=defaults)
+    return NetworkConfig(indent=1, contents=contents)
+
+
+def run(module, result):
+    """ module run. """
+
+    match = module.params['match']
+    replace = module.params['replace']
+
+    candidate = get_candidate(module)
+
+    if match != 'none':
+        config = get_config(module)
+        path = module.params['parents']
+        configobjs = candidate.difference(config, path=path, match=match,
+                                          replace=replace)
+    else:
+        configobjs = candidate.items
+
+    if configobjs:
+        commands = dumps(configobjs, 'commands').split('\n')
+        if module.params['lines']:
+            if module.params['before']:
+                commands[:0] = module.params['before']
+
+            if module.params['after']:
+                commands.extend(module.params['after'])
+
+            result['updates'] = commands
+
+        if not module.check_mode:
+            module.config.load_config(commands)
+
+        result['changed'] = True
+
+    if module.params['save']:
+        if not module.check_mode:
+            module.config.save_config()
+        result['changed'] = True
+
+
+def main():
+    """ main entry point for module execution
+    """
+
+    argument_spec = dict(
+        src=dict(type='path'),
+
+        lines=dict(aliases=['commands'], type='list'),
+        parents=dict(type='list'),
+
+        before=dict(type='list'),
+        after=dict(type='list'),
+
+        match=dict(default='line',
+                   choices=['line', 'strict', 'exact', 'none']),
+        replace=dict(default='line', choices=['line', 'block']),
+        config=dict(),
+        defaults=dict(type='bool', default=False),
+
+        backup=dict(type='bool', default=False),
+        save=dict(type='bool', default=False),
+    )
+
+    mutually_exclusive = [('lines', 'src')]
+
+    required_if = [('match', 'strict', ['lines']),
+                   ('match', 'exact', ['lines']),
+                   ('replace', 'block', ['lines'])]
+
+    module = NetworkModule(argument_spec=argument_spec,
+                           connect_on_load=False,
+                           mutually_exclusive=mutually_exclusive,
+                           required_if=required_if,
+                           supports_check_mode=True)
+
+    warnings = list()
+
+    result = dict(changed=False, warnings=warnings)
+
+    if module.params['backup']:
+        result['__backup__'] = module.config.get_config()
+
+    try:
+        run(module, result)
+    except NetworkError:
+        exc = get_exception()
+        config_fail(module, msg=get_cli_exception(exc), **exc.kwargs)
+
+    config_exit(module, **result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/cloudengine/ce_file_copy.py
+++ b/lib/ansible/modules/network/cloudengine/ce_file_copy.py
@@ -1,0 +1,441 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = '''
+---
+module: ce_file_copy
+version_added: "2.3"
+short_description: Copy a file to a remote cloudengine device over SCP.
+description:
+    - Copy a file to a remote cloudengine device over SCP.
+extends_documentation_fragment: cloudengine
+author:
+    - Zhou Zhijin (@CloudEngine-Ansible)
+notes:
+    - The feature must be enabled with feature scp-server.
+    - If the file is already present, no transfer will take place.
+options:
+    local_file:
+        description:
+            - Path to local file. Local directory must exist.
+              The maximum length of local_file is 4096.
+        required: true
+    remote_file:
+        description:
+            - Remote file path of the copy. Remote directories must exist.
+              If omitted, the name of the local file will be used.
+              The maximum length of remote_file is 4096.
+        required: false
+        default: null
+    file_system:
+        description:
+            - The remote file system of the device. If omitted,
+              devices that support a file_system parameter will use
+              their default values.
+              File system indicates the storage medium and can be set to as follows,
+              1) 'flash:' is root directory of the flash memory on the master MPU.
+              2) 'slave#flash:' is root directory of the flash memory on the slave MPU.
+                 If no slave MPU exists, this drive is unavailable.
+              3) 'chassis ID/slot number#flash:' is root directory of the flash memory on
+                 a device in a stack. For example, 1/5#flash indicates the flash memory
+                 whose chassis ID is 1 and slot number is 5.
+        required: false
+        default: 'flash:'
+'''
+
+EXAMPLES = '''
+#Copy a local file to remote device
+- ce_file_copy: local_file=/usr/vrpcfg.cfg remote_file=/vrpcfg.cfg file_system=flash:
+'''
+
+RETURN = '''
+changed:
+    description: check to see if a change was made on the device
+    returned: always
+    type: boolean
+    sample: true
+transfer_result:
+    description: information about transfer result.
+    returned: always
+    type: string
+    sample: 'The local file has been successfully transferred to the device.'
+local_file:
+    description: The path of the local file.
+    returned: always
+    type: string
+    sample: '/usr/work/vrpcfg.zip'
+remote_file:
+    description: The path of the remote file.
+    returned: always
+    type: string
+    sample: '/vrpcfg.zip'
+'''
+
+import sys
+import re
+import os
+import time
+from xml.etree import ElementTree
+import paramiko
+from ansible.module_utils.shell import ShellError
+from ansible.module_utils.basic import get_exception
+from ansible.module_utils.network import NetworkModule, NetworkError
+from ansible.module_utils.netcli import FailedConditionsError, FailedConditionalError
+from ansible.module_utils.netcli import AddCommandError
+from ansible.module_utils.cloudengine import get_netconf
+from ansible.module_utils.netcli import CommandRunner
+from ansible.module_utils.cloudengine import get_cli_exception
+
+try:
+    from ncclient.operations.rpc import RPCError
+    HAS_NCCLIENT = True
+except ImportError:
+    HAS_NCCLIENT = False
+
+try:
+    from scp import SCPClient
+    HAS_SCP = True
+except ImportError:
+    HAS_SCP = False
+
+CE_NC_GET_FILE_INFO = """
+<filter type="subtree">
+  <vfm xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+    <dirs>
+      <dir>
+        <fileName>%s</fileName>
+        <dirName>%s</dirName>
+        <DirSize></DirSize>
+      </dir>
+    </dirs>
+  </vfm>
+</filter>
+"""
+
+CE_NC_GET_SCP_ENABLE = """
+<filter type="subtree">
+  <sshs xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+    <sshServer>
+      <scpEnable></scpEnable>
+    </sshServer>
+  </sshs>
+</filter>
+"""
+
+
+class FileCopy(object):
+    """file copy function class"""
+
+    def __init__(self, argument_spec):
+        self.spec = argument_spec
+        self.module = None
+        self.netconf = None
+        self.init_module()
+
+        # file copy parameters
+        self.local_file = self.module.params['local_file']
+        self.remote_file = self.module.params['remote_file']
+        self.file_system = self.module.params['file_system']
+
+        # host info
+        self.host = self.module.params['host']
+        self.username = self.module.params['username']
+        self.port = self.module.params['port']
+
+        # state
+        self.transfer_result = None
+        self.changed = False
+
+        # init netconf connect
+        self.init_netconf()
+
+    def init_module(self):
+        """ init_module"""
+
+        self.module = NetworkModule(
+            argument_spec=self.spec, supports_check_mode=True)
+
+    def init_netconf(self):
+        """ init_netconf"""
+
+        if HAS_NCCLIENT:
+            self.netconf = get_netconf(host=self.host, port=self.port,
+                                       username=self.username,
+                                       password=self.module.params['password'])
+        else:
+            self.module.fail_json(
+                msg='Error: No ncclient package, please install it.')
+
+    def check_response(self, con_obj, xml_name):
+        """Check if response message is already succeed."""
+
+        xml_str = con_obj.xml
+        if "<ok/>" not in xml_str:
+            self.module.fail_json(msg='Error: %s failed.' % xml_name)
+
+    def netconf_set_config(self, xml_str, xml_name):
+        """ netconf set config """
+
+        try:
+            con_obj = self.netconf.set_config(config=xml_str)
+            self.check_response(con_obj, xml_name)
+        except RPCError:
+            err = sys.exc_info()[1]
+            self.module.fail_json(msg='Error: %s' %
+                                  err.message.replace('\r\n', ''))
+
+        return con_obj
+
+    def netconf_get_config(self, xml_str):
+        """ netconf get config """
+
+        try:
+            con_obj = self.netconf.get_config(filter=xml_str)
+        except RPCError:
+            err = sys.exc_info()[1]
+            self.module.fail_json(msg='Error: %s' %
+                                  err.message.replace('\r\n', ''))
+
+        return con_obj
+
+    def remote_file_exists(self, dst, file_system='flash:'):
+        """ remote file whether exists """
+
+        full_path = file_system + dst
+        file_name = os.path.basename(full_path)
+        file_path = os.path.dirname(full_path)
+        file_path = file_path + '/'
+        xml_str = CE_NC_GET_FILE_INFO % (file_name, file_path)
+        con_obj = self.netconf_get_config(xml_str)
+        if "<data/>" in con_obj.xml:
+            return False, 0
+
+        xml_str = con_obj.xml.replace('\r', '').replace('\n', '').\
+            replace('xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"', "").\
+            replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
+
+        # get file info
+        root = ElementTree.fromstring(xml_str)
+        topo = root.find("data/vfm/dirs/dir")
+        if topo is None:
+            return False, 0
+
+        for eles in topo:
+            if eles.tag in ["DirSize"]:
+                return True, int(eles.text.replace(',', ''))
+
+        return False, 0
+
+    def local_file_exists(self):
+        """ local file whether exists """
+
+        return os.path.isfile(self.local_file)
+
+    def excute_command(self, commands):
+        """ excute_command"""
+
+        output = ''
+        runner = CommandRunner(self.module)
+        for cmd in commands:
+            try:
+                runner.add_command(**cmd)
+            except AddCommandError:
+                self.module.fail_json(
+                    msg='duplicate command detected: %s' % cmd)
+
+        try:
+            runner.run()
+        except FailedConditionsError:
+            exc = get_exception()
+            self.module.fail_json(
+                msg=get_cli_exception(exc), failed_conditions=exc.failed_conditions)
+        except FailedConditionalError:
+            exc = get_exception()
+            self.module.fail_json(
+                msg=get_cli_exception(exc), failed_conditional=exc.failed_conditional)
+        except NetworkError:
+            exc = get_exception()
+            self.module.fail_json(msg=get_cli_exception(exc))
+
+        for cmd in commands:
+            try:
+                output = runner.get_command(cmd['command'], cmd.get('output'))
+            except ValueError:
+                self.module.fail_json(
+                    msg='command not executed due to check_mode, see warnings')
+        return output
+
+    def enough_space(self):
+        """ whether device has enough space"""
+
+        commands = list()
+        cmd = {'output': None, 'command': 'dir %s' % self.file_system}
+        commands.append(cmd)
+        output = self.excute_command(commands)
+        if not output:
+            return True
+
+        match = re.search(r'\((.*) KB free\)', output)
+        kbytes_free = match.group(1)
+        kbytes_free = kbytes_free.replace(',', '')
+
+        file_size = os.path.getsize(self.local_file)
+        if int(kbytes_free) * 1024 > file_size:
+            return True
+
+        return False
+
+    def transfer_file(self, dest):
+        """ begin to transfer file by scp"""
+
+        if not self.local_file_exists():
+            self.module.fail_json(
+                msg='Could not transfer file. Local file doesn\'t exist.')
+
+        if not self.enough_space():
+            self.module.fail_json(
+                msg='Could not transfer file. Not enough space on device.')
+
+        hostname = self.module.params['host']
+        username = self.module.params['username']
+        password = self.module.params['password']
+        port = self.module.params['port']
+
+        ssh = paramiko.SSHClient()
+        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        ssh.connect(hostname=hostname, username=username,
+                    password=password, port=port)
+
+        full_remote_path = '{}{}'.format(self.file_system, dest)
+        scp = SCPClient(ssh.get_transport())
+        try:
+            scp.put(self.local_file, full_remote_path)
+        except:
+            time.sleep(10)
+            file_exists, temp_size = self.remote_file_exists(
+                dest, self.file_system)
+            file_size = os.path.getsize(self.local_file)
+            if file_exists and int(temp_size) == int(file_size):
+                pass
+            else:
+                scp.close()
+                self.module.fail_json(msg='Could not transfer file. There was an error '
+                                      'during transfer. Please make sure the format of '
+                                      'input parameters is right.')
+
+        scp.close()
+        return True
+
+    def get_scp_enable(self):
+        """ get scp enable state"""
+
+        xml_str = CE_NC_GET_SCP_ENABLE
+        con_obj = self.netconf_get_config(xml_str)
+        if "<data/>" in con_obj.xml:
+            return False
+
+        xml_str = con_obj.xml.replace('\r', '').replace('\n', '').\
+            replace('xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"', "").\
+            replace('xmlns="http://www.huawei.com/netconf/vrp"', "")
+
+        # get file info
+        root = ElementTree.fromstring(xml_str)
+        topo = root.find("data/sshs/sshServer")
+        if topo is None:
+            return False
+
+        for eles in topo:
+            if eles.tag in ["scpEnable"]:
+                return True, eles.text
+
+        return False
+
+    def work(self):
+        """ excute task """
+
+        if not HAS_SCP:
+            self.module.fail_json(
+                msg="'Error: No scp package, please install it.'")
+
+        if self.local_file and len(self.local_file) > 4096:
+            self.module.fail_json(
+                msg="'Error: The maximum length of local_file is 4096.'")
+
+        if self.remote_file and len(self.remote_file) > 4096:
+            self.module.fail_json(
+                msg="'Error: The maximum length of remote_file is 4096.'")
+
+        retcode, cur_state = self.get_scp_enable()
+        if retcode and cur_state == 'Disable':
+            self.module.fail_json(
+                msg="'Error: Please ensure SCP server is enabled.'")
+
+        if not os.path.isfile(self.local_file):
+            self.module.fail_json(
+                msg="Local file {} not found".format(self.local_file))
+
+        dest = self.remote_file or ('/' + os.path.basename(self.local_file))
+        remote_exists, file_size = self.remote_file_exists(
+            dest, file_system=self.file_system)
+        if remote_exists and (os.path.getsize(self.local_file) != file_size):
+            remote_exists = False
+
+        if not remote_exists:
+            self.changed = True
+            file_exists = False
+        else:
+            file_exists = True
+            self.transfer_result = 'The local file already exists on the device.'
+
+        if not file_exists:
+            try:
+                self.transfer_file(dest)
+                self.transfer_result = 'The local file has been successfully ' \
+                                       'transferred to the device.'
+            except ShellError:
+                clie = get_exception()
+                self.module.fail_json(msg=get_cli_exception(clie))
+
+        if self.remote_file is None:
+            self.remote_file = '/' + os.path.basename(self.local_file)
+
+        self.module.exit_json(
+            changed=self.changed,
+            transfer_result=self.transfer_result,
+            local_file=self.local_file,
+            remote_file=self.remote_file,
+            file_system=self.file_system)
+
+
+def main():
+    """ main function entry"""
+    argument_spec = dict(
+        local_file=dict(required=True),
+        remote_file=dict(required=False),
+        file_system=dict(required=False, default='flash:')
+    )
+
+    filecopy_obj = FileCopy(argument_spec)
+    filecopy_obj.work()
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/plugins/action/ce_config.py
+++ b/lib/ansible/plugins/action/ce_config.py
@@ -1,0 +1,28 @@
+#
+# Copyright 2015 Peter Sprygada <psprygada@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+from ansible.plugins.action.net_config import ActionModule as NetActionModule
+
+class ActionModule(NetActionModule, ActionBase):
+    pass
+
+


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
cloudengine/ce (network module)

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
config file = /etc/ansible/ansible.cfg
configured module search path = ['/home/ansible-2.1.1.0/lib/ansible/modules/core/network/cloudengine', '/home/ansible-2.1.1.0/lib/ansible/module_utils', '/home/ansible-2.1.1.0/lib/ansible/modules', '/home/ansible-2.1.1.0', '/home/ansible-2.1.1.0/lib/ansible/utils/']
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [copy small file] *********************************************************
task path: /usr1/code/OpenNESS/code/current/KVM/intg/test/testcases/test-ce_file_copy.yml:39
Using module file /usr/local/lib/python2.7/site-packages/ansible-2.3.0-py2.7.egg/ansible/modules/core/network/cloudengine/ce_file_copy.py
<ce_6850> ESTABLISH LOCAL CONNECTION FOR USER: root
<ce_6850> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1487043298.92-108129377995121 `" && echo ansible-tmp-1487043298.92-108129377995121="` echo $HOME/.ansible/tmp/ansible-tmp-1487043298.92-108129377995121 `" ) && sleep 0'
<ce_6850> PUT /tmp/tmpwkmmes TO /root/.ansible/tmp/ansible-tmp-1487043298.92-108129377995121/ce_file_copy.py
<ce_6850> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1487043298.92-108129377995121/ /root/.ansible/tmp/ansible-tmp-1487043298.92-108129377995121/ce_file_copy.py && sleep 0'
<ce_6850> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1487043298.92-108129377995121/ce_file_copy.py; rm -rf "/root/.ansible/tmp/ansible-tmp-1487043298.92-108129377995121/" > /dev/null 2>&1 && sleep 0'
changed: [ce_6850] => {
    "changed": true, 
    "file_system": "flash:", 
    "invocation": {
        "module_args": {
            "auth_pass": null, 
            "authorize": false, 
            "file_system": "flash:", 
            "host": "ce_6850", 
            "local_file": "/usr/zzj.cfg", 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 12345, 
            "provider": null, 
            "remote_file": null, 
            "ssh_keyfile": null, 
            "timeout": 10, 
            "transport": null, 
            "use_ssl": false, 
            "username": "rootDC", 
            "validate_certs": true
        }, 
        "module_name": "ce_file_copy"
    }, 
    "local_file": "/usr/zzj.cfg", 
    "remote_file": "/zzj.cfg", 
    "transfer_result": "The local file has been successfully transferred to the device."
}
```
