### PR TITLE
Contributing new eth_trunk module to manage HUAWEI data center CloudEngine switch

### DIFF
--- a/lib/ansible/module_utils/cloudengine.py
+++ b/lib/ansible/module_utils/cloudengine.py
@@ -27,11 +27,11 @@
 import re
 import time
 
-from ansible.module_utils.basic import json
+from ansible.module_utils.basic import json, get_exception
 from ansible.module_utils.network import NetworkError
 from ansible.module_utils.network import add_argument,\
     register_transport, to_list
-from ansible.module_utils.shell import CliBase
+from ansible.module_utils.shell import CliBase, ShellError
 
 try:
     from ncclient import manager
@@ -64,8 +64,22 @@ class CeConfigMixin(object):
             cmd += ' include-default'
         if regular:
             cmd += ' ' + regular
+        cfg = self.execute([cmd])[0]
+        if not include_defaults:
+            return cfg
 
-        return self.execute([cmd])[0]
+        # remove default configuration prefix
+        if cfg:
+            cmds = cfg.split("\n")
+            for i in range(len(cmds)):
+                if not cmds[i]:
+                    continue
+                if cmds[i].count('~') > 0:
+                    index = cmds[i].index('~')
+                    if cmds[i][:index] == ' '*index:
+                        cmds[i] = cmds[i].replace("~", "", 1)
+            cfg = '\n'.join(cmds)
+        return cfg
 
     def load_config(self, config):
         """ load_config """
@@ -77,29 +91,18 @@ class CeConfigMixin(object):
         except TypeError:
             self.execute(['system-view immediately',
                           'commit label %s' % checkpoint])
+        except Exception:
+            raise
 
         try:
             try:
                 self.configure(config)
-            except NetworkError:
+            except (NetworkError, Exception):
                 self.load_checkpoint(checkpoint)
+                self.clear_checkpoint(checkpoint)
                 raise
         finally:
-            # get commit id and clear it
-            responses = self.execute(
-                'display configuration commit list '
-                'label | include %s' % checkpoint)
-            match = re.match(
-                r'[\r\n]?\d+\s+(\d{10})\s+ansible.*', responses[0])
-            if match is not None:
-                try:
-                    self.execute(['return',
-                                  'clear configuration commit %s '
-                                  'label' % match.group(1)], output='text')
-                except TypeError:
-                    self.execute(['return',
-                                  'clear configuration commit %s '
-                                  'label' % match.group(1)])
+            self.clear_checkpoint(checkpoint)
 
     def save_config(self, **kwargs):
         """ save_config """
@@ -122,6 +125,24 @@ class CeConfigMixin(object):
                            ' label %s' % checkpoint])
         pass
 
+    def clear_checkpoint(self, checkpoint):
+        """ clear checkpoint """
+
+        # get commit id and clear it
+        responses = self.execute(
+            'display configuration commit list '
+            'label | include %s' % checkpoint)
+        match = re.match(
+            r'[\r\n]?\d+\s+(\d{10})\s+ansible.*', responses[0])
+        if match is not None:
+            try:
+                self.execute(['return',
+                              'clear configuration commit %s '
+                              'label' % match.group(1)], output='text')
+            except TypeError:
+                self.execute(['return',
+                              'clear configuration commit %s '
+                              'label' % match.group(1)])
 
 class Netconf(object):
     """ Netconf """
@@ -195,7 +216,8 @@ class Cli(CeConfigMixin, CliBase):
     """ Cli """
 
     CLI_PROMPTS_RE = [
-        re.compile(r'[\r\n]?[<|\[]{1}.+[>|\]]{1}(?:\s*)$'),
+        re.compile(r'[\r\n]?<.+>(?:\s*)$'),
+        re.compile(r'[\r\n]?\[.+\](?:\s*)$'),
     ]
 
     CLI_ERRORS_RE = [
@@ -209,7 +231,8 @@ class Cli(CeConfigMixin, CliBase):
         re.compile(r"'[^']' +returned error code: ?\d+"),
         re.compile(r"syntax error"),
         re.compile(r"unknown command"),
-        re.compile(r"Error\[\d+\]: ")
+        re.compile(r"Error\[\d+\]: ", re.I),
+        re.compile(r"Error:", re.I)
     ]
 
     NET_PASSWD_RE = re.compile(r"[\r\n]?password: $", re.I)
@@ -220,6 +243,21 @@ class Cli(CeConfigMixin, CliBase):
         super(Cli, self).connect(params, kickstart=False, **kwargs)
         self.shell.send('screen-length 0 temporary')
         self.shell.send('mmi-mode enable')
+
+    def execute(self, commands):
+        try:
+            return self.shell.send(commands)
+        except ShellError:
+            exc = get_exception()
+            cmd = ""
+            if exc.command:
+                cmd = "Command: %s\r\n" % str(exc.command)
+            msg = str(exc.message)
+            if str(exc.command) in msg:
+                msg = msg.replace(str(exc.command), "")
+            if "matched error in response: " in msg:
+                msg = msg.replace("matched error in response: ", "")
+            raise NetworkError(cmd+msg, commands=commands)
 
     def run_commands(self, commands):
         """ run_commands """
@@ -268,3 +306,39 @@ def prepare_commands(commands):
         if cmd.command.endswith('| json'):
             cmd.output = 'json'
         yield cmd
+
+def get_cli_exception(exc=None):
+    """ get cli exception message"""
+
+    msg = list()
+    if not exc:
+        exc = get_exception()
+    if exc:
+        errs = str(exc).split("\r\n")
+        for err in errs:
+            if not err:
+                continue
+            if "matched error in response:" in err:
+                continue
+            if " at '^' position" in err:
+                err = err.replace(" at '^' position", "")
+            if err.replace(" ", "") == "^":
+                continue
+            if len(err) > 2 and err[0] in ["<", "["] and err[-1] in [">", "]"]:
+                continue
+            if err[-1] == ".":
+                err = err[:-1]
+            if err.replace(" ", "") == "":
+                continue
+            msg.append(err)
+    else:
+        msg = ["Error: Fail to get cli exception message."]
+
+    while msg[-1][-1] == ' ':
+        msg[-1] = msg[-1][:-1]
+
+    if msg[-1][-1] != ".":
+        msg[-1] += "."
+
+    return ", ".join(msg).capitalize()
+

--- a/lib/ansible/modules/network/cloudengine/ce_command.py
+++ b/lib/ansible/modules/network/cloudengine/ce_command.py
@@ -37,7 +37,7 @@ extends_documentation_fragment: cloudengine
 options:
   commands:
     description:
-      - The commands to send to the remote HUAWEI CloudEngine device 
+      - The commands to send to the remote HUAWEI CloudEngine device
         over the configured provider.  The resulting output from the
         command is returned. If the I(wait_for) argument is provided,
         the module is not returned until the condition is satisfied

--- a/lib/ansible/modules/network/cloudengine/ce_config.py
+++ b/lib/ansible/modules/network/cloudengine/ce_config.py
@@ -1,0 +1,351 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = """
+---
+module: ce_config
+version_added: "2.3"
+author: "QijunPan (@CloudEngine-Ansible)"
+short_description: Manage Huawei CloudEngine configuration sections
+description:
+  - Huawei CloudEngine configurations use a simple block indent file syntax
+    for segmenting configuration into sections.  This module provides
+    an implementation for working with CloudEngine configuration sections in
+    a deterministic way.  This module works with CLI
+    transports.
+extends_documentation_fragment: cloudengine
+options:
+  lines:
+    description:
+      - The ordered set of commands that should be configured in the
+        section.  The commands must be the exact same commands as found
+        in the device running-config.  Be sure to note the configuration
+        command syntax as some commands are automatically modified by the
+        device config parser.
+    required: false
+    default: null
+  parents:
+    description:
+      - The ordered set of parents that uniquely identify the section
+        the commands should be checked against.  If the parents argument
+        is omitted, the commands are checked against the set of top
+        level or global commands.
+    required: false
+    default: null
+  src:
+    description:
+      - The I(src) argument provides a path to the configuration file
+        to load into the remote system.  The path can either be a full
+        system path to the configuration file if the value starts with /
+        or relative to the root of the implemented role or playbook.
+        This argument is mutually exclusive with the I(lines) and
+        I(parents) arguments.
+    required: false
+    default: null
+  before:
+    description:
+      - The ordered set of commands to push on to the command stack if
+        a change needs to be made.  This allows the playbook designer
+        the opportunity to perform configuration commands prior to pushing
+        any changes without affecting how the set of commands are matched
+        against the system.
+    required: false
+    default: null
+  after:
+    description:
+      - The ordered set of commands to append to the end of the command
+        stack if a change needs to be made.  Just like with I(before) this
+        allows the playbook designer to append a set of commands to be
+        executed after the command set.
+    required: false
+    default: null
+  match:
+    description:
+      - Instructs the module on the way to perform the matching of
+        the set of commands against the current device config.  If
+        match is set to I(line), commands are matched line by line.  If
+        match is set to I(strict), command lines are matched with respect
+        to position.  If match is set to I(exact), command lines
+        must be an equal match.  Finally, if match is set to I(none), the
+        module will not attempt to compare the source configuration with
+        the running configuration on the remote device.
+    required: false
+    default: line
+    choices: ['line', 'strict', 'exact', 'none']
+  replace:
+    description:
+      - Instructs the module on the way to perform the configuration
+        on the device.  If the replace argument is set to I(line) then
+        the modified lines are pushed to the device in configuration
+        mode.  If the replace argument is set to I(block) then the entire
+        command block is pushed to the device in configuration mode if any
+        line is not correct.
+    required: false
+    default: line
+    choices: ['line', 'block']
+  backup:
+    description:
+      - This argument will cause the module to create a full backup of
+        the current C(current-configuration) from the remote device before any
+        changes are made.  The backup file is written to the C(backup)
+        folder in the playbook root directory.  If the directory does not
+        exist, it is created.
+    required: false
+    default: no
+    choices: ['yes', 'no']
+  config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source.  There are times when it is not
+        desirable to have the task get the current running-config for
+        every task in a playbook.  The I(config) argument allows the
+        implementer to pass in the configuration to use as the base
+        config for comparison.
+    required: false
+    default: null
+  defaults:
+    description:
+      - The I(defaults) argument will influence how the running-config
+        is collected from the device.  When the value is set to true,
+        the command used to collect the running-config is append with
+        the all keyword.  When the value is set to false, the command
+        is issued without the all keyword
+    required: false
+    default: false
+  save:
+    description:
+      - The C(save) argument instructs the module to save the
+        running-config to startup-config.  This operation is performed
+        after any changes are made to the current running config.  If
+        no changes are made, the configuration is still saved to the
+        startup config.  This option will always cause the module to
+        return changed.
+    required: false
+    default: false
+"""
+
+EXAMPLES = """
+# Note: examples below use the following provider dict to handle
+#       transport and authentication to the node.
+vars:
+  cli:
+    host: "{{ inventory_hostname }}"
+    username: admin
+    password: admin
+    transport: cli
+
+- name: configure top level configuration and save it
+  ce_config:
+    lines: sysname {{ inventory_hostname }}
+    save: yes
+    provider: "{{ cli }}"
+
+- ce_config:
+    lines:
+      - rule 10 permit source 1.1.1.1 32
+      - rule 20 permit source 2.2.2.2 32
+      - rule 30 permit source 3.3.3.3 32
+      - rule 40 permit source 4.4.4.4 32
+      - rule 50 permit source 5.5.5.5 32
+    parents: acl 2000
+    before: undo acl 2000
+    match: exact
+    provider: "{{ cli }}"
+
+- ce_config:
+    lines:
+      - rule 10 permit source 1.1.1.1 32
+      - rule 20 permit source 2.2.2.2 32
+      - rule 30 permit source 3.3.3.3 32
+      - rule 40 permit source 4.4.4.4 32
+    parents: acl 2000
+    before: undo acl 2000
+    replace: block
+    provider: "{{ cli }}"
+"""
+
+RETURN = """
+updates:
+  description: The set of commands that will be pushed to the remote device
+  returned: Only when lines is specified.
+  type: list
+  sample: ['...', '...']
+backup_path:
+  description: The full path to the backup file
+  returned: when backup is yes
+  type: path
+  sample: /playbooks/ansible/backup/ce_config.2016-07-16@22:28:34
+"""
+
+from ansible.module_utils.cloudengine import get_cli_exception
+from ansible.module_utils.basic import get_exception
+from ansible.module_utils.network import NetworkModule, NetworkError
+from ansible.module_utils.netcfg import NetworkConfig, dumps
+from ansible.module_utils.basic import remove_values
+
+try:
+    from ansible.errors import AnsibleModuleExit
+    HAS_ANSIBLE_MODULE_EXIT = True
+except ImportError:
+    HAS_ANSIBLE_MODULE_EXIT = False
+
+
+def config_exit(module, **result):
+    """ return from the module, without error """
+
+    if HAS_ANSIBLE_MODULE_EXIT:
+        if 'changed' not in result:
+            result['changed'] = False
+        if 'invocation' not in result:
+            result['invocation'] = {'module_args': module.params}
+        result = remove_values(result, module.no_log_values)
+        raise AnsibleModuleExit(result)
+    else:
+        module.exit_json(**result)
+
+def config_fail(module, **result):
+    """ return from the module, with an error message """
+
+    if HAS_ANSIBLE_MODULE_EXIT:
+        assert 'msg' in result, "implementation error -- msg to explain the error is required"
+        result['failed'] = True
+        if 'invocation' not in result:
+            result['invocation'] = {'module_args': module.params}
+        result = remove_values(result, module.no_log_values)
+        raise AnsibleModuleExit(result)
+    else:
+        module.fail_json(**result)
+
+
+def get_candidate(module):
+    """ get candidat info. """
+    candidate = NetworkConfig(indent=1)
+    if module.params['src']:
+        candidate.load(module.params['src'])
+    elif module.params['lines']:
+        parents = module.params['parents'] or list()
+        candidate.add(module.params['lines'], parents=parents)
+    return candidate
+
+
+def get_config(module):
+    """ get current configuration. """
+
+    contents = module.params['config']
+    if not contents:
+        defaults = module.params['defaults']
+        contents = module.config.get_config(include_defaults=defaults)
+    return NetworkConfig(indent=1, contents=contents)
+
+
+def run(module, result):
+    """ module run. """
+
+    match = module.params['match']
+    replace = module.params['replace']
+
+    candidate = get_candidate(module)
+
+    if match != 'none':
+        config = get_config(module)
+        path = module.params['parents']
+        configobjs = candidate.difference(config, path=path, match=match,
+                                          replace=replace)
+    else:
+        configobjs = candidate.items
+
+    if configobjs:
+        commands = dumps(configobjs, 'commands').split('\n')
+        if module.params['lines']:
+            if module.params['before']:
+                commands[:0] = module.params['before']
+
+            if module.params['after']:
+                commands.extend(module.params['after'])
+
+            result['updates'] = commands
+
+        if not module.check_mode:
+            module.config.load_config(commands)
+
+        result['changed'] = True
+
+    if module.params['save']:
+        if not module.check_mode:
+            module.config.save_config()
+        result['changed'] = True
+
+
+def main():
+    """ main entry point for module execution
+    """
+
+    argument_spec = dict(
+        src=dict(type='path'),
+
+        lines=dict(aliases=['commands'], type='list'),
+        parents=dict(type='list'),
+
+        before=dict(type='list'),
+        after=dict(type='list'),
+
+        match=dict(default='line',
+                   choices=['line', 'strict', 'exact', 'none']),
+        replace=dict(default='line', choices=['line', 'block']),
+        config=dict(),
+        defaults=dict(type='bool', default=False),
+
+        backup=dict(type='bool', default=False),
+        save=dict(type='bool', default=False),
+    )
+
+    mutually_exclusive = [('lines', 'src')]
+
+    required_if = [('match', 'strict', ['lines']),
+                   ('match', 'exact', ['lines']),
+                   ('replace', 'block', ['lines'])]
+
+    module = NetworkModule(argument_spec=argument_spec,
+                           connect_on_load=False,
+                           mutually_exclusive=mutually_exclusive,
+                           required_if=required_if,
+                           supports_check_mode=True)
+
+    warnings = list()
+
+    result = dict(changed=False, warnings=warnings)
+
+    if module.params['backup']:
+        result['__backup__'] = module.config.get_config()
+
+    try:
+        run(module, result)
+    except NetworkError:
+        exc = get_exception()
+        config_fail(module, msg=get_cli_exception(exc), **exc.kwargs)
+
+    config_exit(module, **result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/cloudengine/ce_eth_trunk.py
+++ b/lib/ansible/modules/network/cloudengine/ce_eth_trunk.py
@@ -1,0 +1,731 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = '''
+---
+module: ce_eth_trunk
+version_added: "2.3"
+short_description: Manages Eth-Trunk interfaces.
+description:
+    - Manages Eth-Trunk specific configuration parameters.
+extends_documentation_fragment: cloudengine
+author: QijunPan (@CloudEngine-Ansible)
+notes:
+    - C(state=absent) removes the Eth-Trunk config and interface if it
+      already exists. If members to be removed are not explicitly
+      passed, all existing members (if any), are removed,
+      and Eth-Trunk removed.
+    - Members must be a list.
+options:
+    trunk_id:
+        description:
+            - Eth-Trunk interface number.
+              The value is an integer.
+              The value range depends on the assign forward eth-trunk mode { 256 | 512 | 1024 } command.
+              When 256 is specified, the value ranges from 0 to 255.
+              When 512 is specified, the value ranges from 0 to 511.
+              When 1024 is specified, the value ranges from 0 to 1023.
+        required: true
+    mode:
+        description:
+            - Specifies the working mode of an Eth-Trunk interface.
+        required: false
+        default: null
+        choices: ['manual','lacp-dynamic','lacp-static']
+    min_links:
+        description:
+            - Specifies the minimum number of Eth-Trunk member links in the Up state.
+              The value is an integer ranging from 1 to the maximum number of interfaces
+              that can be added to a Eth-Trunk interface.
+        required: false
+        default: null
+    hash_type:
+        description:
+            - Hash algorithm used for load balancing among Eth-Trunk member interfaces.
+        required: false
+        default: null
+        choices: ['src-dst-ip', 'src-dst-mac', 'enhanced', 'dst-ip', 'dst-mac', 'src-ip', 'src-mac']
+    members:
+        description:
+            - List of interfaces that will be managed in a given Eth-Trunk.
+              The interface name must be full name.
+        required: false
+        default: null
+    force:
+        description:
+            - When true it forces Eth-Trunk members to match what is
+              declared in the members param. This can be used to remove
+              members.
+        required: false
+        choices: ['true', 'false']
+        default: false
+    state:
+        description:
+            - Manage the state of the resource.
+        required: false
+        default: present
+        choices: ['present','absent']
+'''
+EXAMPLES = '''
+# Ensure Eth-Trunk100 is created, add two members, and set to mode lacp-static
+- ce_eth_trunk:
+    trunk_id: 100
+    members: ['40GE1/0/24','40GE1/0/25']
+    mode: 'lacp-static'
+    state: present
+    username: "{{ un }}"
+    password: "{{ pwd }}"
+    host: "{{ inventory_hostname }}"
+'''
+
+RETURN = '''
+proposed:
+    description: k/v pairs of parameters passed into module
+    returned: always
+    type: dict
+    sample: {"trunk_id": "100", "members": ['40GE1/0/24','40GE1/0/25'], "mode": "lacp-static"}
+existing:
+    description:
+        - k/v pairs of existing Eth-Trunk
+    type: dict
+    sample: {"trunk_id": "100", "hash_type": "mac", "members_detail": [
+            {"memberIfName": "40GE1/0/25", "memberIfState": "Down"}],
+            "min_links": "1", "mode": "manual"}
+end_state:
+    description: k/v pairs of Eth-Trunk info after module execution
+    returned: always
+    type: dict
+    sample: {"trunk_id": "100", "hash_type": "mac", "members_detail": [
+            {"memberIfName": "40GE1/0/24", "memberIfState": "Down"},
+            {"memberIfName": "40GE1/0/25", "memberIfState": "Down"}],
+            "min_links": "1", "mode": "lacp-static"}
+updates:
+    description: command sent to the device
+    returned: always
+    type: list
+    sample: ["interface Eth-Trunk 100",
+             "mode lacp-static",
+             "interface 40GE1/0/25",
+             "eth-trunk 100"]
+changed:
+    description: check to see if a change was made on the device
+    returned: always
+    type: boolean
+    sample: true
+'''
+
+import re
+import sys
+from ansible.module_utils.network import NetworkModule
+from ansible.module_utils.cloudengine import get_netconf
+
+try:
+    from ncclient.operations.rpc import RPCError
+    HAS_NCCLIENT = True
+except ImportError:
+    HAS_NCCLIENT = False
+
+
+CE_NC_GET_TRUNK = """
+<filter type="subtree">
+  <ifmtrunk xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+    <TrunkIfs>
+      <TrunkIf>
+        <ifName>Eth-Trunk%s</ifName>
+        <minUpNum></minUpNum>
+        <maxUpNum></maxUpNum>
+        <trunkType></trunkType>
+        <hashType></hashType>
+        <workMode></workMode>
+        <upMemberIfNum></upMemberIfNum>
+        <memberIfNum></memberIfNum>
+        <TrunkMemberIfs>
+          <TrunkMemberIf>
+            <memberIfName></memberIfName>
+            <memberIfState></memberIfState>
+          </TrunkMemberIf>
+        </TrunkMemberIfs>
+      </TrunkIf>
+    </TrunkIfs>
+  </ifmtrunk>
+</filter>
+"""
+
+CE_NC_XML_BUILD_TRUNK_CFG = """
+<config>
+  <ifmtrunk xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+    <TrunkIfs>%s</TrunkIfs>
+  </ifmtrunk>
+</config>
+"""
+
+CE_NC_XML_DELETE_TRUNK = """
+<TrunkIf operation="delete">
+  <ifName>Eth-Trunk%s</ifName>
+</TrunkIf>
+"""
+
+CE_NC_XML_CREATE_TRUNK = """
+<TrunkIf operation="merge">
+  <ifName>Eth-Trunk%s</ifName>
+</TrunkIf>
+"""
+
+CE_NC_XML_MERGE_MINUPNUM = """
+<TrunkIf operation="merge">
+  <ifName>Eth-Trunk%s</ifName>
+  <minUpNum>%s</minUpNum>
+</TrunkIf>
+"""
+
+CE_NC_XML_MERGE_HASHTYPE = """
+<TrunkIf operation="merge">
+  <ifName>Eth-Trunk%s</ifName>
+  <hashType>%s</hashType>
+</TrunkIf>
+"""
+
+CE_NC_XML_MERGE_WORKMODE = """
+<TrunkIf operation="merge">
+  <ifName>Eth-Trunk%s</ifName>
+  <workMode>%s</workMode>
+</TrunkIf>
+"""
+
+CE_NC_XML_BUILD_MEMBER_CFG = """
+<TrunkIf>
+  <ifName>Eth-Trunk%s</ifName>
+  <TrunkMemberIfs>%s</TrunkMemberIfs>
+</TrunkIf>
+"""
+
+CE_NC_XML_MERGE_MEMBER = """
+<TrunkMemberIf operation="merge">
+  <memberIfName>%s</memberIfName>
+</TrunkMemberIf>
+"""
+
+CE_NC_XML_DELETE_MEMBER = """
+<TrunkMemberIf operation="delete">
+  <memberIfName>%s</memberIfName>
+</TrunkMemberIf>
+"""
+
+MODE_XML2CLI = {"Manual": "manual", "Dynamic": "lacp-dynamic", "Static": "lacp-static"}
+MODE_CLI2XML = {"manual": "Manual", "lacp-dynamic": "Dynamic", "lacp-static": "Static"}
+HASH_XML2CLI = {"IP": "src-dst-ip", "MAC": "src-dst-mac", "Enhanced": "enhanced",
+                "Desip": "dst-ip", "Desmac": "dst-mac", "Sourceip": "src-ip", "Sourcemac": "src-mac"}
+HASH_CLI2XML = {"src-dst-ip": "IP", "src-dst-mac": "MAC", "enhanced": "Enhanced",
+                "dst-ip": "Desip", "dst-mac": "Desmac", "src-ip": "Sourceip", "src-mac": "Sourcemac"}
+
+def get_interface_type(interface):
+    """Gets the type of interface, such as 10GE, ETH-TRUNK, VLANIF..."""
+
+    if interface is None:
+        return None
+
+    iftype = None
+
+    if interface.upper().startswith('GE'):
+        iftype = 'ge'
+    elif interface.upper().startswith('10GE'):
+        iftype = '10ge'
+    elif interface.upper().startswith('25GE'):
+        iftype = '25ge'
+    elif interface.upper().startswith('4X10GE'):
+        iftype = '4x10ge'
+    elif interface.upper().startswith('40GE'):
+        iftype = '40ge'
+    elif interface.upper().startswith('100GE'):
+        iftype = '100ge'
+    elif interface.upper().startswith('VLANIF'):
+        iftype = 'vlanif'
+    elif interface.upper().startswith('LOOPBACK'):
+        iftype = 'loopback'
+    elif interface.upper().startswith('METH'):
+        iftype = 'meth'
+    elif interface.upper().startswith('ETH-TRUNK'):
+        iftype = 'eth-trunk'
+    elif interface.upper().startswith('VBDIF'):
+        iftype = 'vbdif'
+    elif interface.upper().startswith('NVE'):
+        iftype = 'nve'
+    elif interface.upper().startswith('TUNNEL'):
+        iftype = 'tunnel'
+    elif interface.upper().startswith('ETHERNET'):
+        iftype = 'ethernet'
+    elif interface.upper().startswith('FCOE-PORT'):
+        iftype = 'fcoe-port'
+    elif interface.upper().startswith('FABRIC-PORT'):
+        iftype = 'fabric-port'
+    elif interface.upper().startswith('STACK-PORT'):
+        iftype = 'stack-port'
+    elif interface.upper().startswith('NULL'):
+        iftype = 'null'
+    else:
+        return None
+
+    return iftype.lower()
+
+def mode_xml_to_cli_str(mode):
+    """convert mode to cli format string"""
+
+    if not mode:
+        return ""
+
+    return MODE_XML2CLI.get(mode)
+
+def hash_type_xml_to_cli_str(hash_type):
+    """convert trunk hash type netconf xml to cli format string"""
+
+    if not hash_type:
+        return ""
+
+    return HASH_XML2CLI.get(hash_type)
+
+class EthTrunk(object):
+    """
+    Manages Eth-Trunk interfaces.
+    """
+
+    def __init__(self, argument_spec):
+        self.spec = argument_spec
+        self.module = None
+        self.netconf = None
+        self.__init_module__()
+
+        # module input info
+        self.trunk_id = self.module.params['trunk_id']
+        self.mode = self.module.params['mode']
+        self.min_links = self.module.params['min_links']
+        self.hash_type = self.module.params['hash_type']
+        self.members = self.module.params['members']
+        self.state = self.module.params['state']
+        self.force = self.module.params['force']
+
+        # host info
+        self.host = self.module.params['host']
+        self.username = self.module.params['username']
+        self.port = self.module.params['port']
+
+        # state
+        self.changed = False
+        self.updates_cmd = list()
+        self.results = dict()
+        self.proposed = dict()
+        self.existing = dict()
+        self.end_state = dict()
+
+        # interface info
+        self.trunk_info = dict()
+
+        # init netconf connect
+        self.__init_netconf__()
+
+    def __init_module__(self):
+        """ init module """
+
+        self.module = NetworkModule(
+            argument_spec=self.spec, supports_check_mode=True)
+
+    def __init_netconf__(self):
+        """ init netconf """
+
+        if not HAS_NCCLIENT:
+            raise Exception("the ncclient library is required")
+
+        self.netconf = get_netconf(host=self.host,
+                                   port=self.port,
+                                   username=self.username,
+                                   password=self.module.params['password'])
+        if not self.netconf:
+            self.module.fail_json(msg='Error: netconf init failed')
+
+    def check_response(self, con_obj, xml_name):
+        """Check if response message is already succeed."""
+
+        xml_str = con_obj.xml
+        if "<ok/>" not in xml_str:
+            self.module.fail_json(msg='Error: %s failed.' % xml_name)
+
+    def netconf_get_config(self, xml_str):
+        """ netconf get config """
+
+        try:
+            con_obj = self.netconf.get_config(filter=xml_str)
+        except RPCError:
+            err = sys.exc_info()[1]
+            self.module.fail_json(msg='Error: %s' % err.message.replace("\r\n", ""))
+
+        return con_obj
+
+    def netconf_set_config(self, xml_str, xml_name):
+        """ netconf set config """
+
+        try:
+            con_obj = self.netconf.set_config(config=xml_str)
+            self.check_response(con_obj, xml_name)
+        except RPCError:
+            err = sys.exc_info()[1]
+            self.module.fail_json(msg='Error: %s' % err.message.replace("\r\n", ""))
+
+        return con_obj
+
+    def netconf_set_action(self, xml_str, xml_name):
+        """ netconf set config """
+
+        try:
+            con_obj = self.netconf.execute_action(action=xml_str)
+            self.check_response(con_obj, xml_name)
+        except RPCError:
+            err = sys.exc_info()[1]
+            self.module.fail_json(msg='Error: %s' % err.message.replace("\r\n", ""))
+
+        return con_obj
+
+    def get_trunk_dict(self, trunk_id):
+        """ get one interface attributes dict."""
+
+        trunk_info = dict()
+        conf_str = CE_NC_GET_TRUNK % trunk_id
+        con_obj = self.netconf_get_config(conf_str)
+
+        if "<data/>" in con_obj.xml:
+            return trunk_info
+
+        # get trunk base info
+        base = re.findall(
+            r'.*<ifName>(.*)</ifName>.*\s*'
+            r'<minUpNum>(.*)</minUpNum>.*\s*'
+            r'<maxUpNum>(.*)</maxUpNum>.*\s*'
+            r'<trunkType>(.*)</trunkType>.*\s*'
+            r'<hashType>(.*)</hashType>.*\s*'
+            r'<workMode>(.*)</workMode>.*\s*'
+            r'<upMemberIfNum>(.*)</upMemberIfNum>.*\s*'
+            r'<memberIfNum>(.*)</memberIfNum>.*', con_obj.xml)
+
+        if base:
+            trunk_info = dict(ifName=base[0][0],
+                              trunkId=base[0][0].lower().replace("eth-trunk", "").replace(" ", ""),
+                              minUpNum=base[0][1],
+                              maxUpNum=base[0][2],
+                              trunkType=base[0][3],
+                              hashType=base[0][4],
+                              workMode=base[0][5],
+                              upMemberIfNum=base[0][6],
+                              memberIfNum=base[0][7])
+
+        # get trunk member interface info
+        member = re.findall(
+            r'.*<memberIfName>(.*)</memberIfName>.*\s*'
+            r'<memberIfState>(.*)</memberIfState>.*', con_obj.xml)
+        trunk_info["TrunkMemberIfs"] = list()
+
+        for mem in member:
+            trunk_info["TrunkMemberIfs"].append(
+                dict(memberIfName=mem[0], memberIfState=mem[1]))
+
+        return trunk_info
+
+    def is_member_exist(self, ifname):
+        """is trunk member exist"""
+
+        if not self.trunk_info["TrunkMemberIfs"]:
+            return False
+
+        for mem in self.trunk_info["TrunkMemberIfs"]:
+            if ifname.replace(" ", "").upper() == mem["memberIfName"].replace(" ", "").upper():
+                return True
+
+        return False
+
+    def get_mode_xml_str(self):
+        """trunk mode netconf xml fromat string"""
+
+        return MODE_CLI2XML.get(self.mode)
+
+    def get_hash_type_xml_str(self):
+        """trunk hash type netconf xml format string"""
+
+        return HASH_CLI2XML.get(self.hash_type)
+
+    def create_eth_trunk(self):
+        """Create Eth-Trunk interface"""
+
+        xml_str = CE_NC_XML_CREATE_TRUNK % self.trunk_id
+        self.updates_cmd.append("interface Eth-Trunk %s" % self.trunk_id)
+
+        if self.hash_type:
+            self.updates_cmd.append("load-balance %s" % self.hash_type)
+            xml_str += CE_NC_XML_MERGE_HASHTYPE % (self.trunk_id, self.get_hash_type_xml_str())
+
+        if self.mode:
+            self.updates_cmd.append("mode %s" % self.mode)
+            xml_str += CE_NC_XML_MERGE_WORKMODE % (self.trunk_id, self.get_mode_xml_str())
+
+        if self.min_links:
+            self.updates_cmd.append("least active-linknumber %s" % self.min_links)
+            xml_str += CE_NC_XML_MERGE_MINUPNUM % (self.trunk_id, self.min_links)
+
+        if self.members:
+            mem_xml = ""
+            for mem in self.members:
+                mem_xml += CE_NC_XML_MERGE_MEMBER % mem.upper()
+                self.updates_cmd.append("interface %s" % mem)
+                self.updates_cmd.append("eth-trunk %s" % self.trunk_id)
+            xml_str += CE_NC_XML_BUILD_MEMBER_CFG % (self.trunk_id, mem_xml)
+        cfg_xml = CE_NC_XML_BUILD_TRUNK_CFG % xml_str
+        self.netconf_set_config(cfg_xml, "CREATE_TRUNK")
+        self.changed = True
+
+    def delete_eth_trunk(self):
+        """Delete Eth-Trunk interface and remove all member"""
+
+        if not self.trunk_info:
+            return
+
+        xml_str = ""
+        mem_str = ""
+        if self.trunk_info["TrunkMemberIfs"]:
+            for mem in self.trunk_info["TrunkMemberIfs"]:
+                mem_str += CE_NC_XML_DELETE_MEMBER % mem["memberIfName"]
+                self.updates_cmd.append("interface %s" % mem["memberIfName"])
+                self.updates_cmd.append("undo eth-trunk")
+            if mem_str:
+                xml_str += CE_NC_XML_BUILD_MEMBER_CFG % (self.trunk_id, mem_str)
+
+        xml_str += CE_NC_XML_DELETE_TRUNK % self.trunk_id
+        self.updates_cmd.append("undo interface Eth-Trunk %s" % self.trunk_id)
+        cfg_xml = CE_NC_XML_BUILD_TRUNK_CFG % xml_str
+        self.netconf_set_config(cfg_xml, "DELETE_TRUNK")
+        self.changed = True
+
+    def remove_member(self):
+        """delete trunk member"""
+
+        if not self.members:
+            return
+
+        change = False
+        mem_xml = ""
+        xml_str = ""
+        for mem in self.members:
+            if self.is_member_exist(mem):
+                mem_xml += CE_NC_XML_DELETE_MEMBER % mem.upper()
+                self.updates_cmd.append("interface %s" % mem)
+                self.updates_cmd.append("undo eth-trunk")
+        if mem_xml:
+            xml_str += CE_NC_XML_BUILD_MEMBER_CFG % (self.trunk_id, mem_xml)
+            change = True
+
+        if not change:
+            return
+
+        cfg_xml = CE_NC_XML_BUILD_TRUNK_CFG % xml_str
+        self.netconf_set_config(cfg_xml, "REMOVE_TRUNK_MEMBER")
+        self.changed = True
+
+    def merge_eth_trunk(self):
+        """Create or merge Eth-Trunk"""
+
+        change = False
+        xml_str = ""
+        self.updates_cmd.append("interface Eth-Trunk %s" % self.trunk_id)
+        if self.hash_type and self.get_hash_type_xml_str() != self.trunk_info["hashType"]:
+            self.updates_cmd.append("load-balance %s" %
+                                    self.hash_type)
+            xml_str += CE_NC_XML_MERGE_HASHTYPE % (
+                self.trunk_id, self.get_hash_type_xml_str())
+            change = True
+        if self.min_links and self.min_links != self.trunk_info["minUpNum"]:
+            self.updates_cmd.append(
+                "least active-linknumber %s" % self.min_links)
+            xml_str += CE_NC_XML_MERGE_MINUPNUM % (
+                self.trunk_id, self.min_links)
+            change = True
+        if self.mode and self.get_mode_xml_str() != self.trunk_info["workMode"]:
+            self.updates_cmd.append("mode %s" % self.mode)
+            xml_str += CE_NC_XML_MERGE_WORKMODE % (
+                self.trunk_id, self.get_mode_xml_str())
+            change = True
+
+        if not change:
+            self.updates_cmd.pop()   # remove 'interface Eth-Trunk' command
+
+        # deal force:
+        # When true it forces Eth-Trunk members to match
+        # what is declared in the members param.
+        if self.force == "true" and self.trunk_info["TrunkMemberIfs"]:
+            mem_xml = ""
+            for mem in self.trunk_info["TrunkMemberIfs"]:
+                if not self.members or mem["memberIfName"].replace(" ", "").upper() not in self.members:
+                    mem_xml += CE_NC_XML_DELETE_MEMBER % mem["memberIfName"]
+                    self.updates_cmd.append("interface %s" % mem["memberIfName"])
+                    self.updates_cmd.append("undo eth-trunk")
+            if mem_xml:
+                xml_str += CE_NC_XML_BUILD_MEMBER_CFG % (self.trunk_id, mem_xml)
+                change = True
+
+        if self.members:
+            mem_xml = ""
+            for mem in self.members:
+                if not self.is_member_exist(mem):
+                    mem_xml += CE_NC_XML_MERGE_MEMBER % mem.upper()
+                    self.updates_cmd.append("interface %s" % mem)
+                    self.updates_cmd.append("eth-trunk %s" % self.trunk_id)
+            if mem_xml:
+                xml_str += CE_NC_XML_BUILD_MEMBER_CFG % (
+                    self.trunk_id, mem_xml)
+                change = True
+
+        if not change:
+            return
+
+        cfg_xml = CE_NC_XML_BUILD_TRUNK_CFG % xml_str
+        self.netconf_set_config(cfg_xml, "MERGE_TRUNK")
+        self.changed = True
+
+    def check_params(self):
+        """Check all input params"""
+
+        # trunk_id check
+        if not self.trunk_id.isdigit():
+            self.module.fail_json(msg='The parameter of trunk_id is invalid.')
+
+        # min_links check
+        if self.min_links and not self.min_links.isdigit():
+            self.module.fail_json(msg='The parameter of min_links is invalid.')
+
+        # members check and convert members to upper
+        if self.members:
+            for mem in self.members:
+                if not get_interface_type(mem.replace(" ", "")):
+                    self.module.fail_json(
+                        msg='The parameter of members is invalid.')
+
+            for mem_id in range(len(self.members)):
+                self.members[mem_id] = self.members[mem_id].replace(" ", "").upper()
+
+    def get_proposed(self):
+        """get proposed info"""
+
+        self.proposed["trunk_id"] = self.trunk_id
+        self.proposed["mode"] = self.mode
+        if self.min_links:
+            self.proposed["min_links"] = self.min_links
+        self.proposed["hash_type"] = self.hash_type
+        if self.members:
+            self.proposed["members"] = self.members
+        self.proposed["state"] = self.state
+        self.proposed["force"] = self.force
+
+    def get_existing(self):
+        """get existing info"""
+
+        if not self.trunk_info:
+            return
+
+        self.existing["trunk_id"] = self.trunk_info["trunkId"]
+        self.existing["min_links"] = self.trunk_info["minUpNum"]
+        self.existing["hash_type"] = hash_type_xml_to_cli_str(self.trunk_info["hashType"])
+        self.existing["mode"] = mode_xml_to_cli_str(self.trunk_info["workMode"])
+        self.existing["members_detail"] = self.trunk_info["TrunkMemberIfs"]
+
+    def get_end_state(self):
+        """get end state info"""
+
+        trunk_info = self.get_trunk_dict(self.trunk_id)
+        if not trunk_info:
+            return
+
+        self.end_state["trunk_id"] = trunk_info["trunkId"]
+        self.end_state["min_links"] = trunk_info["minUpNum"]
+        self.end_state["hash_type"] = hash_type_xml_to_cli_str(trunk_info["hashType"])
+        self.end_state["mode"] = mode_xml_to_cli_str(trunk_info["workMode"])
+        self.end_state["members_detail"] = trunk_info["TrunkMemberIfs"]
+
+    def work(self):
+        """worker"""
+
+        self.check_params()
+        self.trunk_info = self.get_trunk_dict(self.trunk_id)
+        self.get_existing()
+        self.get_proposed()
+
+        # deal present or absent
+        if self.state == "present":
+            if not self.trunk_info:
+                # create
+                self.create_eth_trunk()
+            else:
+                # merge trunk
+                self.merge_eth_trunk()
+        else:
+            if self.trunk_info:
+                if not self.members:
+                    # remove all members and delete trunk
+                    self.delete_eth_trunk()
+                else:
+                    # remove some trunk members
+                    self.remove_member()
+            else:
+                self.module.fail_json(msg='Error: Eth-Trunk does not exist.')
+
+        self.get_end_state()
+        self.results['changed'] = self.changed
+        self.results['proposed'] = self.proposed
+        self.results['existing'] = self.existing
+        self.results['end_state'] = self.end_state
+        if self.changed:
+            self.results['updates'] = self.updates_cmd
+        else:
+            self.results['updates'] = list()
+
+        self.module.exit_json(**self.results)
+
+
+def main():
+    """Module main"""
+
+    argument_spec = dict(
+        trunk_id=dict(required=True),
+        mode=dict(required=False,
+                  choices=['manual', 'lacp-dynamic', 'lacp-static'],
+                  type='str'),
+        min_links=dict(required=False, type='str'),
+        hash_type=dict(required=False,
+                       choices=['src-dst-ip', 'src-dst-mac', 'enhanced',
+                                'dst-ip', 'dst-mac', 'src-ip', 'src-mac'],
+                       type='str'),
+        members=dict(required=False, default=None, type='list'),
+        force=dict(required=False, default='false', type='str',
+                   choices=['true', 'false']),
+        state=dict(required=False, default='present',
+                   choices=['present', 'absent'])
+    )
+
+    module = EthTrunk(argument_spec)
+    module.work()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/plugins/action/ce_config.py
+++ b/lib/ansible/plugins/action/ce_config.py
@@ -1,0 +1,28 @@
+#
+# Copyright 2015 Peter Sprygada <psprygada@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+from ansible.plugins.action.net_config import ActionModule as NetActionModule
+
+class ActionModule(NetActionModule, ActionBase):
+    pass
+
+


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
cloudengine/ce (network module)

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
config file = /etc/ansible/ansible.cfg
configured module search path = ['/home/ansible-2.1.1.0/lib/ansible/modules/core/network/cloudengine', '/home/ansible-2.1.1.0/lib/ansible/module_utils', '/home/ansible-2.1.1.0/lib/ansible/modules', '/home/ansible-2.1.1.0', '/home/ansible-2.1.1.0/lib/ansible/utils/']
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [Ensure trunk 100 is exist] ***********************************************
task path: /usr1/code/OpenNESS/code/current/KVM/intg/test/testcases/test-ce_eth_trunk.yml:27
Using module file /usr/local/lib/python2.7/site-packages/ansible-2.3.0-py2.7.egg/ansible/modules/core/network/cloudengine/ce_eth_trunk.py
<ce_6850> ESTABLISH LOCAL CONNECTION FOR USER: root
<ce_6850> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1487042983.5-210744467252991 `" && echo ansible-tmp-1487042983.5-210744467252991="` echo $HOME/.ansible/tmp/ansible-tmp-1487042983.5-210744467252991 `" ) && sleep 0'
<ce_6850> PUT /tmp/tmpBy5aW3 TO /root/.ansible/tmp/ansible-tmp-1487042983.5-210744467252991/ce_eth_trunk.py
<ce_6850> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1487042983.5-210744467252991/ /root/.ansible/tmp/ansible-tmp-1487042983.5-210744467252991/ce_eth_trunk.py && sleep 0'
<ce_6850> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1487042983.5-210744467252991/ce_eth_trunk.py; rm -rf "/root/.ansible/tmp/ansible-tmp-1487042983.5-210744467252991/" > /dev/null 2>&1 && sleep 0'
changed: [ce_6850] => {
    "changed": true, 
    "end_state": {
        "hash_type": "enhanced", 
        "members_detail": [], 
        "min_links": "1", 
        "mode": "manual", 
        "trunk_id": "100"
    }, 
    "existing": {}, 
    "invocation": {
        "module_args": {
            "auth_pass": null, 
            "authorize": false, 
            "force": "false", 
            "hash_type": null, 
            "host": "ce_6850", 
            "members": null, 
            "min_links": null, 
            "mode": null, 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 12345, 
            "provider": null, 
            "ssh_keyfile": null, 
            "state": "present", 
            "timeout": 10, 
            "transport": null, 
            "trunk_id": "100", 
            "use_ssl": false, 
            "username": "rootDC", 
            "validate_certs": true
        }, 
        "module_name": "ce_eth_trunk"
    }, 
    "proposed": {
        "force": "false", 
        "hash_type": null, 
        "mode": null, 
        "state": "present", 
        "trunk_id": "100"
    }, 
    "updates": [
        "interface Eth-Trunk 100"
    ]
}
```
