### PR TITLE
Contributing new ce_evpn_bgp_rr ce_evpn_global module to manage HUAWEI data center CloudEngine switch

### DIFF
--- a/lib/ansible/module_utils/cloudengine.py
+++ b/lib/ansible/module_utils/cloudengine.py
@@ -27,11 +27,11 @@
 import re
 import time
 
-from ansible.module_utils.basic import json
+from ansible.module_utils.basic import json, get_exception
 from ansible.module_utils.network import NetworkError
 from ansible.module_utils.network import add_argument,\
     register_transport, to_list
-from ansible.module_utils.shell import CliBase
+from ansible.module_utils.shell import CliBase, ShellError
 
 try:
     from ncclient import manager
@@ -64,8 +64,22 @@ class CeConfigMixin(object):
             cmd += ' include-default'
         if regular:
             cmd += ' ' + regular
+        cfg = self.execute([cmd])[0]
+        if not include_defaults:
+            return cfg
 
-        return self.execute([cmd])[0]
+        # remove default configuration prefix
+        if cfg:
+            cmds = cfg.split("\n")
+            for i in range(len(cmds)):
+                if not cmds[i]:
+                    continue
+                if cmds[i].count('~') > 0:
+                    index = cmds[i].index('~')
+                    if cmds[i][:index] == ' '*index:
+                        cmds[i] = cmds[i].replace("~", "", 1)
+            cfg = '\n'.join(cmds)
+        return cfg
 
     def load_config(self, config):
         """ load_config """
@@ -77,29 +91,18 @@ class CeConfigMixin(object):
         except TypeError:
             self.execute(['system-view immediately',
                           'commit label %s' % checkpoint])
+        except Exception:
+            raise
 
         try:
             try:
                 self.configure(config)
-            except NetworkError:
+            except (NetworkError, Exception):
                 self.load_checkpoint(checkpoint)
+                self.clear_checkpoint(checkpoint)
                 raise
         finally:
-            # get commit id and clear it
-            responses = self.execute(
-                'display configuration commit list '
-                'label | include %s' % checkpoint)
-            match = re.match(
-                r'[\r\n]?\d+\s+(\d{10})\s+ansible.*', responses[0])
-            if match is not None:
-                try:
-                    self.execute(['return',
-                                  'clear configuration commit %s '
-                                  'label' % match.group(1)], output='text')
-                except TypeError:
-                    self.execute(['return',
-                                  'clear configuration commit %s '
-                                  'label' % match.group(1)])
+            self.clear_checkpoint(checkpoint)
 
     def save_config(self, **kwargs):
         """ save_config """
@@ -122,6 +125,24 @@ class CeConfigMixin(object):
                            ' label %s' % checkpoint])
         pass
 
+    def clear_checkpoint(self, checkpoint):
+        """ clear checkpoint """
+
+        # get commit id and clear it
+        responses = self.execute(
+            'display configuration commit list '
+            'label | include %s' % checkpoint)
+        match = re.match(
+            r'[\r\n]?\d+\s+(\d{10})\s+ansible.*', responses[0])
+        if match is not None:
+            try:
+                self.execute(['return',
+                              'clear configuration commit %s '
+                              'label' % match.group(1)], output='text')
+            except TypeError:
+                self.execute(['return',
+                              'clear configuration commit %s '
+                              'label' % match.group(1)])
 
 class Netconf(object):
     """ Netconf """
@@ -195,7 +216,8 @@ class Cli(CeConfigMixin, CliBase):
     """ Cli """
 
     CLI_PROMPTS_RE = [
-        re.compile(r'[\r\n]?[<|\[]{1}.+[>|\]]{1}(?:\s*)$'),
+        re.compile(r'[\r\n]?<.+>(?:\s*)$'),
+        re.compile(r'[\r\n]?\[.+\](?:\s*)$'),
     ]
 
     CLI_ERRORS_RE = [
@@ -209,7 +231,8 @@ class Cli(CeConfigMixin, CliBase):
         re.compile(r"'[^']' +returned error code: ?\d+"),
         re.compile(r"syntax error"),
         re.compile(r"unknown command"),
-        re.compile(r"Error\[\d+\]: ")
+        re.compile(r"Error\[\d+\]: ", re.I),
+        re.compile(r"Error:", re.I)
     ]
 
     NET_PASSWD_RE = re.compile(r"[\r\n]?password: $", re.I)
@@ -220,6 +243,21 @@ class Cli(CeConfigMixin, CliBase):
         super(Cli, self).connect(params, kickstart=False, **kwargs)
         self.shell.send('screen-length 0 temporary')
         self.shell.send('mmi-mode enable')
+
+    def execute(self, commands):
+        try:
+            return self.shell.send(commands)
+        except ShellError:
+            exc = get_exception()
+            cmd = ""
+            if exc.command:
+                cmd = "Command: %s\r\n" % str(exc.command)
+            msg = str(exc.message)
+            if str(exc.command) in msg:
+                msg = msg.replace(str(exc.command), "")
+            if "matched error in response: " in msg:
+                msg = msg.replace("matched error in response: ", "")
+            raise NetworkError(cmd+msg, commands=commands)
 
     def run_commands(self, commands):
         """ run_commands """
@@ -268,3 +306,39 @@ def prepare_commands(commands):
         if cmd.command.endswith('| json'):
             cmd.output = 'json'
         yield cmd
+
+def get_cli_exception(exc=None):
+    """ get cli exception message"""
+
+    msg = list()
+    if not exc:
+        exc = get_exception()
+    if exc:
+        errs = str(exc).split("\r\n")
+        for err in errs:
+            if not err:
+                continue
+            if "matched error in response:" in err:
+                continue
+            if " at '^' position" in err:
+                err = err.replace(" at '^' position", "")
+            if err.replace(" ", "") == "^":
+                continue
+            if len(err) > 2 and err[0] in ["<", "["] and err[-1] in [">", "]"]:
+                continue
+            if err[-1] == ".":
+                err = err[:-1]
+            if err.replace(" ", "") == "":
+                continue
+            msg.append(err)
+    else:
+        msg = ["Error: Fail to get cli exception message."]
+
+    while msg[-1][-1] == ' ':
+        msg[-1] = msg[-1][:-1]
+
+    if msg[-1][-1] != ".":
+        msg[-1] += "."
+
+    return ", ".join(msg).capitalize()
+

--- a/lib/ansible/modules/network/cloudengine/ce_command.py
+++ b/lib/ansible/modules/network/cloudengine/ce_command.py
@@ -37,7 +37,7 @@ extends_documentation_fragment: cloudengine
 options:
   commands:
     description:
-      - The commands to send to the remote HUAWEI CloudEngine device 
+      - The commands to send to the remote HUAWEI CloudEngine device
         over the configured provider.  The resulting output from the
         command is returned. If the I(wait_for) argument is provided,
         the module is not returned until the condition is satisfied

--- a/lib/ansible/modules/network/cloudengine/ce_config.py
+++ b/lib/ansible/modules/network/cloudengine/ce_config.py
@@ -1,0 +1,351 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = """
+---
+module: ce_config
+version_added: "2.3"
+author: "QijunPan (@CloudEngine-Ansible)"
+short_description: Manage Huawei CloudEngine configuration sections
+description:
+  - Huawei CloudEngine configurations use a simple block indent file syntax
+    for segmenting configuration into sections.  This module provides
+    an implementation for working with CloudEngine configuration sections in
+    a deterministic way.  This module works with CLI
+    transports.
+extends_documentation_fragment: cloudengine
+options:
+  lines:
+    description:
+      - The ordered set of commands that should be configured in the
+        section.  The commands must be the exact same commands as found
+        in the device running-config.  Be sure to note the configuration
+        command syntax as some commands are automatically modified by the
+        device config parser.
+    required: false
+    default: null
+  parents:
+    description:
+      - The ordered set of parents that uniquely identify the section
+        the commands should be checked against.  If the parents argument
+        is omitted, the commands are checked against the set of top
+        level or global commands.
+    required: false
+    default: null
+  src:
+    description:
+      - The I(src) argument provides a path to the configuration file
+        to load into the remote system.  The path can either be a full
+        system path to the configuration file if the value starts with /
+        or relative to the root of the implemented role or playbook.
+        This argument is mutually exclusive with the I(lines) and
+        I(parents) arguments.
+    required: false
+    default: null
+  before:
+    description:
+      - The ordered set of commands to push on to the command stack if
+        a change needs to be made.  This allows the playbook designer
+        the opportunity to perform configuration commands prior to pushing
+        any changes without affecting how the set of commands are matched
+        against the system.
+    required: false
+    default: null
+  after:
+    description:
+      - The ordered set of commands to append to the end of the command
+        stack if a change needs to be made.  Just like with I(before) this
+        allows the playbook designer to append a set of commands to be
+        executed after the command set.
+    required: false
+    default: null
+  match:
+    description:
+      - Instructs the module on the way to perform the matching of
+        the set of commands against the current device config.  If
+        match is set to I(line), commands are matched line by line.  If
+        match is set to I(strict), command lines are matched with respect
+        to position.  If match is set to I(exact), command lines
+        must be an equal match.  Finally, if match is set to I(none), the
+        module will not attempt to compare the source configuration with
+        the running configuration on the remote device.
+    required: false
+    default: line
+    choices: ['line', 'strict', 'exact', 'none']
+  replace:
+    description:
+      - Instructs the module on the way to perform the configuration
+        on the device.  If the replace argument is set to I(line) then
+        the modified lines are pushed to the device in configuration
+        mode.  If the replace argument is set to I(block) then the entire
+        command block is pushed to the device in configuration mode if any
+        line is not correct.
+    required: false
+    default: line
+    choices: ['line', 'block']
+  backup:
+    description:
+      - This argument will cause the module to create a full backup of
+        the current C(current-configuration) from the remote device before any
+        changes are made.  The backup file is written to the C(backup)
+        folder in the playbook root directory.  If the directory does not
+        exist, it is created.
+    required: false
+    default: no
+    choices: ['yes', 'no']
+  config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source.  There are times when it is not
+        desirable to have the task get the current running-config for
+        every task in a playbook.  The I(config) argument allows the
+        implementer to pass in the configuration to use as the base
+        config for comparison.
+    required: false
+    default: null
+  defaults:
+    description:
+      - The I(defaults) argument will influence how the running-config
+        is collected from the device.  When the value is set to true,
+        the command used to collect the running-config is append with
+        the all keyword.  When the value is set to false, the command
+        is issued without the all keyword
+    required: false
+    default: false
+  save:
+    description:
+      - The C(save) argument instructs the module to save the
+        running-config to startup-config.  This operation is performed
+        after any changes are made to the current running config.  If
+        no changes are made, the configuration is still saved to the
+        startup config.  This option will always cause the module to
+        return changed.
+    required: false
+    default: false
+"""
+
+EXAMPLES = """
+# Note: examples below use the following provider dict to handle
+#       transport and authentication to the node.
+vars:
+  cli:
+    host: "{{ inventory_hostname }}"
+    username: admin
+    password: admin
+    transport: cli
+
+- name: configure top level configuration and save it
+  ce_config:
+    lines: sysname {{ inventory_hostname }}
+    save: yes
+    provider: "{{ cli }}"
+
+- ce_config:
+    lines:
+      - rule 10 permit source 1.1.1.1 32
+      - rule 20 permit source 2.2.2.2 32
+      - rule 30 permit source 3.3.3.3 32
+      - rule 40 permit source 4.4.4.4 32
+      - rule 50 permit source 5.5.5.5 32
+    parents: acl 2000
+    before: undo acl 2000
+    match: exact
+    provider: "{{ cli }}"
+
+- ce_config:
+    lines:
+      - rule 10 permit source 1.1.1.1 32
+      - rule 20 permit source 2.2.2.2 32
+      - rule 30 permit source 3.3.3.3 32
+      - rule 40 permit source 4.4.4.4 32
+    parents: acl 2000
+    before: undo acl 2000
+    replace: block
+    provider: "{{ cli }}"
+"""
+
+RETURN = """
+updates:
+  description: The set of commands that will be pushed to the remote device
+  returned: Only when lines is specified.
+  type: list
+  sample: ['...', '...']
+backup_path:
+  description: The full path to the backup file
+  returned: when backup is yes
+  type: path
+  sample: /playbooks/ansible/backup/ce_config.2016-07-16@22:28:34
+"""
+
+from ansible.module_utils.cloudengine import get_cli_exception
+from ansible.module_utils.basic import get_exception
+from ansible.module_utils.network import NetworkModule, NetworkError
+from ansible.module_utils.netcfg import NetworkConfig, dumps
+from ansible.module_utils.basic import remove_values
+
+try:
+    from ansible.errors import AnsibleModuleExit
+    HAS_ANSIBLE_MODULE_EXIT = True
+except ImportError:
+    HAS_ANSIBLE_MODULE_EXIT = False
+
+
+def config_exit(module, **result):
+    """ return from the module, without error """
+
+    if HAS_ANSIBLE_MODULE_EXIT:
+        if 'changed' not in result:
+            result['changed'] = False
+        if 'invocation' not in result:
+            result['invocation'] = {'module_args': module.params}
+        result = remove_values(result, module.no_log_values)
+        raise AnsibleModuleExit(result)
+    else:
+        module.exit_json(**result)
+
+def config_fail(module, **result):
+    """ return from the module, with an error message """
+
+    if HAS_ANSIBLE_MODULE_EXIT:
+        assert 'msg' in result, "implementation error -- msg to explain the error is required"
+        result['failed'] = True
+        if 'invocation' not in result:
+            result['invocation'] = {'module_args': module.params}
+        result = remove_values(result, module.no_log_values)
+        raise AnsibleModuleExit(result)
+    else:
+        module.fail_json(**result)
+
+
+def get_candidate(module):
+    """ get candidat info. """
+    candidate = NetworkConfig(indent=1)
+    if module.params['src']:
+        candidate.load(module.params['src'])
+    elif module.params['lines']:
+        parents = module.params['parents'] or list()
+        candidate.add(module.params['lines'], parents=parents)
+    return candidate
+
+
+def get_config(module):
+    """ get current configuration. """
+
+    contents = module.params['config']
+    if not contents:
+        defaults = module.params['defaults']
+        contents = module.config.get_config(include_defaults=defaults)
+    return NetworkConfig(indent=1, contents=contents)
+
+
+def run(module, result):
+    """ module run. """
+
+    match = module.params['match']
+    replace = module.params['replace']
+
+    candidate = get_candidate(module)
+
+    if match != 'none':
+        config = get_config(module)
+        path = module.params['parents']
+        configobjs = candidate.difference(config, path=path, match=match,
+                                          replace=replace)
+    else:
+        configobjs = candidate.items
+
+    if configobjs:
+        commands = dumps(configobjs, 'commands').split('\n')
+        if module.params['lines']:
+            if module.params['before']:
+                commands[:0] = module.params['before']
+
+            if module.params['after']:
+                commands.extend(module.params['after'])
+
+            result['updates'] = commands
+
+        if not module.check_mode:
+            module.config.load_config(commands)
+
+        result['changed'] = True
+
+    if module.params['save']:
+        if not module.check_mode:
+            module.config.save_config()
+        result['changed'] = True
+
+
+def main():
+    """ main entry point for module execution
+    """
+
+    argument_spec = dict(
+        src=dict(type='path'),
+
+        lines=dict(aliases=['commands'], type='list'),
+        parents=dict(type='list'),
+
+        before=dict(type='list'),
+        after=dict(type='list'),
+
+        match=dict(default='line',
+                   choices=['line', 'strict', 'exact', 'none']),
+        replace=dict(default='line', choices=['line', 'block']),
+        config=dict(),
+        defaults=dict(type='bool', default=False),
+
+        backup=dict(type='bool', default=False),
+        save=dict(type='bool', default=False),
+    )
+
+    mutually_exclusive = [('lines', 'src')]
+
+    required_if = [('match', 'strict', ['lines']),
+                   ('match', 'exact', ['lines']),
+                   ('replace', 'block', ['lines'])]
+
+    module = NetworkModule(argument_spec=argument_spec,
+                           connect_on_load=False,
+                           mutually_exclusive=mutually_exclusive,
+                           required_if=required_if,
+                           supports_check_mode=True)
+
+    warnings = list()
+
+    result = dict(changed=False, warnings=warnings)
+
+    if module.params['backup']:
+        result['__backup__'] = module.config.get_config()
+
+    try:
+        run(module, result)
+    except NetworkError:
+        exc = get_exception()
+        config_fail(module, msg=get_cli_exception(exc), **exc.kwargs)
+
+    config_exit(module, **result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/cloudengine/ce_evpn_bgp_rr.py
+++ b/lib/ansible/modules/network/cloudengine/ce_evpn_bgp_rr.py
@@ -1,0 +1,534 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = '''
+---
+module: ce_evpn_bgp_rr
+version_added: "2.3"
+short_description: Manages RR for the VXLAN Network.
+extends_documentation_fragment: cloudengine
+description:
+    - Configure an RR in BGP-EVPN address family view.
+author: Zhijin Zhou (@CloudEngine-Ansible)
+notes:
+    - Ensure that BGP view is existed.
+    - The peer, peer_type, and reflect_client arguments must all exist or not exist.
+options:
+    as_number:
+        description:
+            - Specifies the number of the AS, in integer format.
+              The value is an integer that ranges from 1 to 4294967295.
+        required: true
+        default: null
+    bgp_instance:
+        description:
+            - Specifies the name of a BGP instance.
+              The value of instance-name can be an integer 1 or a string of 1 to 31.
+        required: false
+        default: null
+    bgp_evpn_enable:
+        description:
+            - Enable or disable the BGP-EVPN address family.
+        required: false
+        choices: ['true','false']
+        default: true
+    peer_type:
+        description:
+            - Specify the peer type.
+        required: false
+        choices: ['group_name','ipv4_address']
+        default: null
+    peer:
+        description:
+            - Specifies the IPv4 address or the group name of a peer.
+        required: false
+        default: null
+    reflect_client:
+        description:
+            - Configure the local device as the route reflector and the peer or peer group as the client of the route reflector
+        required: false
+        choices: ['true','false']
+        default: null
+    policy_vpn_target:
+        description:
+            - Enable or disable the VPN-Target filtering.
+        required: false
+        choices: ['true','false']
+        default: null
+'''
+
+EXAMPLES = '''
+# Configure BGP-EVPN address family view and ensure that BGP view has existed.
+- ce_evpn_bgp_rr:
+    as_number=20
+    bgp_evpn_enable=true
+    username: "{{ un }}"
+    password: "{{ pwd }}"
+    host: "{{ inventory_hostname }}"
+
+# Configure reflect client and ensure peer has existed.
+- ce_evpn_bgp_rr:
+    as_number=20
+    peer_type=ipv4_address
+    peer=192.8.3.3
+    reflect_client=true
+    username: "{{ un }}"
+    password: "{{ pwd }}"
+    host: "{{ inventory_hostname }}"
+
+# Configure the VPN-Target filtering.
+- ce_evpn_bgp_rr:
+    as_number=20
+    policy_vpn_target=true
+    username: "{{ un }}"
+    password: "{{ pwd }}"
+    host: "{{ inventory_hostname }}"
+
+# Configure an RR in BGP-EVPN address family view.
+- ce_evpn_bgp_rr:
+    as_number=20
+    bgp_evpn_enable=true
+    peer_type=ipv4_address
+    peer=192.8.3.3
+    reflect_client=true
+    policy_vpn_target=false
+    username: "{{ un }}"
+    password: "{{ pwd }}"
+    host: "{{ inventory_hostname }}"
+'''
+
+RETURN = '''
+proposed:
+    description: k/v pairs of parameters passed into module
+    returned: always
+    type: dict
+    sample: {
+                "as_number": "20",
+                "bgp_evpn_enable": "true",
+                "bgp_instance": null,
+                "peer": "192.8.3.3",
+                "peer_type": "ipv4_address",
+                "policy_vpn_target": "false",
+                "reflect_client": "true"
+            }
+existing:
+    description: k/v pairs of existing attributes on the device
+    type: dict
+    sample: {
+                "as_number": "20",
+                "bgp_evpn_enable": "false",
+                "bgp_instance": null,
+                "peer": null,
+                "peer_type": null,
+                "policy_vpn_target": "false",
+                "reflect_client": "false"
+            }
+end_state:
+    description: k/v pairs of end attributes on the device
+    returned: always
+    type: dict or null
+    sample: {
+                "as_number": "20",
+                "bgp_evpn_enable": "true",
+                "bgp_instance": null,
+                "peer": "192.8.3.3",
+                "peer_type": "ipv4_address",
+                "policy_vpn_target": "false",
+                "reflect_client": "true"
+            }
+updates:
+    description: command list sent to the device
+    returned: always
+    type: list
+    sample: [
+                "bgp 20",
+                "  l2vpn-family evpn",
+                "    peer 192.8.3.3 enable",
+                "    peer 192.8.3.3 reflect-client",
+                "    undo policy vpn-target"
+            ]
+changed:
+    description: check to see if a change was made on the device
+    returned: always
+    type: boolean
+    sample: true
+'''
+
+import re
+from ansible.module_utils.network import NetworkModule, NetworkError
+from ansible.module_utils.cloudengine import get_cli_exception
+
+
+def is_config_exist(cmp_cfg, test_cfg):
+    """is configuration exist"""
+
+    if not cmp_cfg or not test_cfg:
+        return False
+
+    return bool(test_cfg in cmp_cfg)
+
+
+class EvpnBgpRr(object):
+    """Manange RR in BGP-EVPN address family view"""
+
+    def __init__(self, argument_spec):
+        self.spec = argument_spec
+        self.module = None
+        self.__init_module__()
+
+        # RR configuration parameters
+        self.as_number = self.module.params['as_number']
+        self.bgp_instance = self.module.params['bgp_instance']
+        self.peer_type = self.module.params['peer_type']
+        self.peer = self.module.params['peer']
+        self.bgp_evpn_enable = self.module.params['bgp_evpn_enable']
+        self.reflect_client = self.module.params['reflect_client']
+        self.policy_vpn_target = self.module.params['policy_vpn_target']
+
+        self.commands = list()
+        self.config = None
+        self.bgp_evpn_config = ""
+        self.cur_config = dict()
+        self.conf_exist = False
+
+        # host info
+        self.host = self.module.params['host']
+        self.username = self.module.params['username']
+        self.password = self.module.params['password']
+        self.port = self.module.params['port']
+
+        # state
+        self.changed = False
+        self.updates_cmd = list()
+        self.results = dict()
+        self.proposed = dict()
+        self.existing = dict()
+        self.end_state = dict()
+
+    def __init_module__(self):
+        """init module"""
+
+        self.module = NetworkModule(
+            argument_spec=self.spec, connect_on_load=False, supports_check_mode=True)
+
+    def cli_load_config(self, commands):
+        """load config by cli"""
+
+        if not self.module.check_mode:
+            try:
+                self.module.config.load_config(commands)
+            except NetworkError:
+                err = get_cli_exception()
+                self.module.fail_json(msg=err)
+
+    def is_bgp_view_exist(self):
+        """judge whether BGP view has existed"""
+
+        if self.bgp_instance:
+            view_cmd = "bgp %s instance %s" % (
+                self.as_number, self.bgp_instance)
+        else:
+            view_cmd = "bgp %s" % self.as_number
+
+        return is_config_exist(self.config, view_cmd)
+
+    def is_l2vpn_family_evpn_exist(self):
+        """judge whether BGP-EVPN address family view has existed"""
+
+        view_cmd = "l2vpn-family evpn"
+        return is_config_exist(self.config, view_cmd)
+
+    def is_reflect_client_exist(self):
+        """judge whether reflect client is configured"""
+
+        view_cmd = "peer %s reflect-client" % self.peer
+        return is_config_exist(self.bgp_evpn_config, view_cmd)
+
+    def is_policy_vpn_target_exist(self):
+        """judge whether the VPN-Target filtering is enabled"""
+
+        view_cmd = "undo policy vpn-target"
+        if is_config_exist(self.bgp_evpn_config, view_cmd):
+            return False
+        else:
+            return True
+
+    def get_config_in_bgp_view(self):
+        """get configuration in BGP view"""
+
+        exp = " | section include"
+        if self.as_number:
+            if self.bgp_instance:
+                exp += " bgp %s instance %s" % (self.as_number,
+                                                self.bgp_instance)
+            else:
+                exp += " bgp %s" % self.as_number
+
+        return self.module.config.get_config(include_defaults=False, regular=exp)
+
+    def get_config_in_bgp_evpn_view(self):
+        """get configuration in BGP_EVPN view"""
+
+        self.bgp_evpn_config = ""
+        if not self.config:
+            return ""
+
+        index = self.config.find("l2vpn-family evpn")
+        if index == -1:
+            return ""
+
+        return self.config[index:]
+
+    def get_current_config(self):
+        """get current configuration"""
+
+        if not self.as_number:
+            self.module.fail_json(msg='Error: The value of as-number cannot be empty.')
+
+        self.cur_config['bgp_exist'] = False
+        self.cur_config['bgp_evpn_enable'] = 'false'
+        self.cur_config['reflect_client'] = 'false'
+        self.cur_config['policy_vpn_target'] = 'false'
+        self.cur_config['peer_type'] = None
+        self.cur_config['peer'] = None
+
+        self.config = self.get_config_in_bgp_view()
+
+        if not self.is_bgp_view_exist():
+            return
+        self.cur_config['bgp_exist'] = True
+
+        if not self.is_l2vpn_family_evpn_exist():
+            return
+        self.cur_config['bgp_evpn_enable'] = 'true'
+
+        self.bgp_evpn_config = self.get_config_in_bgp_evpn_view()
+        if self.is_reflect_client_exist():
+            self.cur_config['reflect_client'] = 'true'
+            self.cur_config['peer_type'] = self.peer_type
+            self.cur_config['peer'] = self.peer
+
+        if self.is_policy_vpn_target_exist():
+            self.cur_config['policy_vpn_target'] = 'true'
+
+    def get_existing(self):
+        """get existing config"""
+
+        self.existing = dict(as_number=self.as_number,
+                             bgp_instance=self.bgp_instance,
+                             peer_type=self.cur_config['peer_type'],
+                             peer=self.cur_config['peer'],
+                             bgp_evpn_enable=self.cur_config[
+                                 'bgp_evpn_enable'],
+                             reflect_client=self.cur_config['reflect_client'],
+                             policy_vpn_target=self.cur_config[
+                                 'policy_vpn_target'])
+
+    def get_proposed(self):
+        """get proposed config"""
+
+        self.proposed = dict(as_number=self.as_number,
+                             bgp_instance=self.bgp_instance,
+                             peer_type=self.peer_type,
+                             peer=self.peer,
+                             bgp_evpn_enable=self.bgp_evpn_enable,
+                             reflect_client=self.reflect_client,
+                             policy_vpn_target=self.policy_vpn_target)
+
+    def get_end_state(self):
+        """get end config"""
+
+        self.get_current_config()
+        self.end_state = dict(as_number=self.as_number,
+                              bgp_instance=self.bgp_instance,
+                              peer_type=self.cur_config['peer_type'],
+                              peer=self.cur_config['peer'],
+                              bgp_evpn_enable=self.cur_config[
+                                  'bgp_evpn_enable'],
+                              reflect_client=self.cur_config['reflect_client'],
+                              policy_vpn_target=self.cur_config['policy_vpn_target'])
+
+    def show_result(self):
+        """ show result"""
+
+        self.results['changed'] = self.changed
+        self.results['proposed'] = self.proposed
+        self.results['existing'] = self.existing
+        self.results['end_state'] = self.end_state
+        if self.changed:
+            self.results['updates'] = self.updates_cmd
+        else:
+            self.results['updates'] = list()
+
+        self.module.exit_json(**self.results)
+
+    def judge_if_config_exist(self):
+        """ judge whether configuration has existed"""
+
+        if self.bgp_evpn_enable and self.bgp_evpn_enable != self.cur_config['bgp_evpn_enable']:
+            return False
+
+        if self.bgp_evpn_enable == 'false' and self.cur_config['bgp_evpn_enable'] == 'false':
+            return True
+
+        if self.reflect_client and self.reflect_client == 'true':
+            if self.peer_type and self.peer_type != self.cur_config['peer_type']:
+                return False
+            if self.peer and self.peer != self.cur_config['peer']:
+                return False
+        if self.reflect_client and self.reflect_client != self.cur_config['reflect_client']:
+            return False
+
+        if self.policy_vpn_target and self.policy_vpn_target != self.cur_config['policy_vpn_target']:
+            return False
+
+        return True
+
+    def cli_add_command(self, command, undo=False):
+        """add command to self.update_cmd and self.commands"""
+
+        if undo and command.lower() not in ["quit", "return"]:
+            cmd = "undo " + command
+        else:
+            cmd = command
+
+        self.commands.append(cmd)          # set to device
+        if command.lower() not in ["quit", "return"]:
+            self.updates_cmd.append(cmd)   # show updates result
+
+    def config_rr(self):
+        """configure RR"""
+
+        if self.conf_exist:
+            return
+
+        if self.bgp_instance:
+            view_cmd = "bgp %s instance %s" % (
+                self.as_number, self.bgp_instance)
+        else:
+            view_cmd = "bgp %s" % self.as_number
+        self.cli_add_command(view_cmd)
+
+        if self.bgp_evpn_enable == 'false':
+            self.cli_add_command("  undo l2vpn-family evpn")
+        else:
+            self.cli_add_command("  l2vpn-family evpn")
+            if self.reflect_client and self.reflect_client != self.cur_config['reflect_client']:
+                if self.reflect_client == 'true':
+                    self.cli_add_command("    peer %s enable" % self.peer)
+                    self.cli_add_command(
+                        "    peer %s reflect-client" % self.peer)
+                else:
+                    self.cli_add_command(
+                        "    undo peer %s reflect-client" % self.peer)
+                    self.cli_add_command("    undo peer %s enable" % self.peer)
+            if self.cur_config['bgp_evpn_enable'] == 'true':
+                if self.policy_vpn_target and self.policy_vpn_target != self.cur_config['policy_vpn_target']:
+                    if self.policy_vpn_target == 'true':
+                        self.cli_add_command("    policy vpn-target")
+                    else:
+                        self.cli_add_command("    undo policy vpn-target")
+            else:
+                if self.policy_vpn_target and self.policy_vpn_target == 'false':
+                    self.cli_add_command("    undo policy vpn-target")
+
+        if self.commands:
+            self.cli_load_config(self.commands)
+            self.changed = True
+
+    def check_is_ipv4_addr(self):
+        """check ipaddress validate"""
+
+        rule1 = r'(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.'
+        rule2 = r'(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])'
+        ipv4_regex = '%s%s%s%s%s%s' % ('^', rule1, rule1, rule1, rule2, '$')
+
+        return bool(re.match(ipv4_regex, self.peer))
+
+    def check_params(self):
+        """Check all input params"""
+
+        if self.cur_config['bgp_exist'] == 'false':
+            self.module.fail_json(msg="Error: BGP view doesnot exist.")
+
+        if self.bgp_instance:
+            if len(self.bgp_instance) < 1 or len(self.bgp_instance) > 31:
+                self.module.fail_json(
+                    msg="Error: The length of BGP instance-name must be between 1 or a string of 1 to and 31.")
+
+        if self.as_number:
+            if len(self.as_number) > 11 or len(self.as_number) == 0:
+                self.module.fail_json(
+                    msg='Error: The len of as_number %s is out of [1 - 11].' % self.as_number)
+
+        tmp_dict1 = dict(peer_type=self.peer_type,
+                         peer=self.peer,
+                         reflect_client=self.reflect_client)
+        tmp_dict2 = dict((k, v)
+                         for k, v in tmp_dict1.items() if v is not None)
+        if len(tmp_dict2) != 0 and len(tmp_dict2) != 3:
+            self.module.fail_json(
+                msg='Error: The peer, peer_type, and reflect_client arguments must all exist or not exist.')
+
+        if self.peer_type:
+            if self.peer_type == 'ipv4_address' and not self.check_is_ipv4_addr():
+                self.module.fail_json(msg='Error: Illegal IPv4 address.')
+            elif self.peer_type == 'group_name' and self.check_is_ipv4_addr():
+                self.module.fail_json(
+                    msg='Error: Ip address cannot be configured as group-name.')
+
+    def work(self):
+        """excute task"""
+
+        self.get_current_config()
+        self.check_params()
+        self.get_existing()
+        self.get_proposed()
+        self.conf_exist = self.judge_if_config_exist()
+
+        self.config_rr()
+
+        self.get_end_state()
+        self.show_result()
+
+
+def main():
+    """main function entry"""
+
+    argument_spec = dict(
+        as_number=dict(required=True, type='str'),
+        bgp_instance=dict(required=False, type='str'),
+        bgp_evpn_enable=dict(required=False, type='str',
+                             default='true', choices=['true', 'false']),
+        peer_type=dict(required=False, type='str', choices=[
+            'group_name', 'ipv4_address']),
+        peer=dict(required=False, type='str'),
+        reflect_client=dict(required=False, type='str',
+                            choices=['true', 'false']),
+        policy_vpn_target=dict(required=False, choices=['true', 'false']),
+    )
+
+    evpn_bgp_rr = EvpnBgpRr(argument_spec)
+    evpn_bgp_rr.work()
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/cloudengine/ce_evpn_global.py
+++ b/lib/ansible/modules/network/cloudengine/ce_evpn_global.py
@@ -1,0 +1,225 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = '''
+---
+module: ce_evpn_global
+version_added: "2.3"
+short_description: Manages global configuration of EVPN.
+extends_documentation_fragment: cloudengine
+description:
+    - Manages global configuration of EVPN.
+author: Zhijin Zhou (@CloudEngine-Ansible)
+notes:
+    - Before configuring evpn_overlay_enable=false, delete other EVPN configurations.
+options:
+    evpn_overlay_enable:
+        description:
+            - configure EVPN as the VXLAN control plane.
+        required: true
+        choices: ['true','false']
+'''
+
+EXAMPLES = '''
+# Configure EVPN as the VXLAN control plan
+- ce_evpn_global: evpn_overlay_enable=true
+# Unconfigure EVPN as the VXLAN control plan
+- ce_evpn_global: evpn_overlay_enable=false
+'''
+
+RETURN = '''
+proposed:
+    description: k/v pairs of parameters passed into module
+    returned: always
+    type: dict
+    sample: {
+                "evpn_overlay_enable": "true"
+            }
+existing:
+    description: k/v pairs of existing attributes on the device
+    type: dict
+    sample: {
+                "evpn_overlay_enable": "false"
+            }
+end_state:
+    description: k/v pairs of end attributes on the interface
+    returned: always
+    type: dict or null
+    sample: {
+                "evpn_overlay_enable": "true"
+            }
+updates:
+    description: command list sent to the device
+    returned: always
+    type: list
+    sample: [
+                "evpn-overlay enable",
+            ]
+changed:
+    description: check to see if a change was made on the device
+    returned: always
+    type: boolean
+    sample: true
+'''
+
+
+from ansible.module_utils.network import NetworkModule, NetworkError
+from ansible.module_utils.cloudengine import get_cli_exception
+
+
+class EvpnGlobal(object):
+    """Manange global configuration of EVPN"""
+
+    def __init__(self, argument_spec, ):
+        self.spec = argument_spec
+        self.module = None
+        self.init_module()
+
+        # EVPN global configuration parameters
+        self.overlay_enable = self.module.params['evpn_overlay_enable']
+
+        self.commands = list()
+        self.global_info = dict()
+        self.conf_exist = False
+
+        # host info
+        self.host = self.module.params['host']
+        self.username = self.module.params['username']
+        self.password = self.module.params['password']
+        self.port = self.module.params['port']
+
+        # state
+        self.changed = False
+        self.updates_cmd = list()
+        self.results = dict()
+        self.proposed = dict()
+        self.existing = dict()
+        self.end_state = dict()
+
+    def init_module(self):
+        """init_module"""
+        self.module = NetworkModule(
+            argument_spec=self.spec, connect_on_load=False, supports_check_mode=True)
+
+    def cli_load_config(self, commands):
+        """load config by cli"""
+        if not self.module.check_mode:
+            try:
+                self.module.config.load_config(commands)
+            except NetworkError:
+                err = get_cli_exception()
+                self.module.fail_json(msg=err)
+
+    def cli_add_command(self, command, undo=False):
+        """add command to self.update_cmd and self.commands"""
+        if undo and command.lower() not in ["quit", "return"]:
+            cmd = "undo " + command
+        else:
+            cmd = command
+
+        self.commands.append(cmd)          # set to device
+        if command.lower() not in ["quit", "return"]:
+            self.updates_cmd.append(cmd)   # show updates result
+
+    def get_evpn_global_info(self):
+        """ get current EVPN global configration"""
+        self.global_info['evpnOverLay'] = 'false'
+
+        exp = " | include evpn-overlay enable"
+        config = self.module.config.get_config(
+            include_defaults=False, regular=exp)
+        if config:
+            self.global_info['evpnOverLay'] = 'true'
+
+    def get_existing(self):
+        """get existing config"""
+        self.existing = dict(
+            evpn_overlay_enable=self.global_info['evpnOverLay'])
+
+    def get_proposed(self):
+        """get proposed config"""
+        self.proposed = dict(evpn_overlay_enable=self.overlay_enable)
+
+    def get_end_state(self):
+        """get end config"""
+        self.get_evpn_global_info()
+        self.end_state = dict(
+            evpn_overlay_enable=self.global_info['evpnOverLay'])
+
+    def show_result(self):
+        """ show result"""
+        self.results['changed'] = self.changed
+        self.results['proposed'] = self.proposed
+        self.results['existing'] = self.existing
+        self.results['end_state'] = self.end_state
+        if self.changed:
+            self.results['updates'] = self.updates_cmd
+        else:
+            self.results['updates'] = list()
+
+        self.module.exit_json(**self.results)
+
+    def judge_if_config_exist(self):
+        """ judge whether configuration has existed"""
+        if self.overlay_enable == self.global_info['evpnOverLay']:
+            return True
+
+        return False
+
+    def config_evnp_global(self):
+        """ set global EVPN configration"""
+        if not self.conf_exist:
+            if self.overlay_enable == 'true':
+                self.cli_add_command('evpn-overlay enable')
+            else:
+                self.cli_add_command('evpn-overlay enable', True)
+
+            if self.commands:
+                self.cli_load_config(self.commands)
+                self.changed = True
+
+    def work(self):
+        """excute task"""
+        self.get_evpn_global_info()
+        self.get_existing()
+        self.get_proposed()
+        self.conf_exist = self.judge_if_config_exist()
+
+        self.config_evnp_global()
+
+        self.get_end_state()
+        self.show_result()
+
+
+def main():
+    """main function entry"""
+
+    argument_spec = dict(
+        evpn_overlay_enable=dict(
+            required=True, type='str', choices=['true', 'false']),
+    )
+
+    evpn_global = EvpnGlobal(argument_spec)
+    evpn_global.work()
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/plugins/action/ce_config.py
+++ b/lib/ansible/plugins/action/ce_config.py
@@ -1,0 +1,28 @@
+#
+# Copyright 2015 Peter Sprygada <psprygada@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.action import ActionBase
+from ansible.plugins.action.net_config import ActionModule as NetActionModule
+
+class ActionModule(NetActionModule, ActionBase):
+    pass
+
+


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
cloudengine/ce (network module)

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
config file = /etc/ansible/ansible.cfg
configured module search path = ['/home/ansible-2.1.1.0/lib/ansible/modules/core/network/cloudengine', '/home/ansible-2.1.1.0/lib/ansible/module_utils', '/home/ansible-2.1.1.0/lib/ansible/modules', '/home/ansible-2.1.1.0', '/home/ansible-2.1.1.0/lib/ansible/utils/']
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [Ensure BGP_EVPN view is enabled] *****************************************
task path: /usr1/code/OpenNESS/code/current/KVM/intg/test/testcases/test-ce_evpn_bgp_rr.yml:26
Using module file /usr/local/lib/python2.7/site-packages/ansible-2.3.0-py2.7.egg/ansible/modules/core/network/cloudengine/ce_evpn_bgp_rr.py
<ce_6850> ESTABLISH LOCAL CONNECTION FOR USER: root
<ce_6850> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1487043094.89-41930298354553 `" && echo ansible-tmp-1487043094.89-41930298354553="` echo $HOME/.ansible/tmp/ansible-tmp-1487043094.89-41930298354553 `" ) && sleep 0'
<ce_6850> PUT /tmp/tmpqLpJ6p TO /root/.ansible/tmp/ansible-tmp-1487043094.89-41930298354553/ce_evpn_bgp_rr.py
<ce_6850> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1487043094.89-41930298354553/ /root/.ansible/tmp/ansible-tmp-1487043094.89-41930298354553/ce_evpn_bgp_rr.py && sleep 0'
<ce_6850> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1487043094.89-41930298354553/ce_evpn_bgp_rr.py; rm -rf "/root/.ansible/tmp/ansible-tmp-1487043094.89-41930298354553/" > /dev/null 2>&1 && sleep 0'
changed: [ce_6850] => {
    "changed": true, 
    "end_state": {
        "as_number": "20", 
        "bgp_evpn_enable": "true", 
        "bgp_instance": null, 
        "peer": null, 
        "peer_type": null, 
        "policy_vpn_target": "true", 
        "reflect_client": "false"
    }, 
    "existing": {
        "as_number": "20", 
        "bgp_evpn_enable": "false", 
        "bgp_instance": null, 
        "peer": null, 
        "peer_type": null, 
        "policy_vpn_target": "false", 
        "reflect_client": "false"
    }, 
    "invocation": {
        "module_args": {
            "as_number": "20", 
            "auth_pass": null, 
            "authorize": false, 
            "bgp_evpn_enable": "true", 
            "bgp_instance": null, 
            "host": "ce_6850", 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "peer": null, 
            "peer_type": null, 
            "policy_vpn_target": null, 
            "port": 12345, 
            "provider": null, 
            "reflect_client": null, 
            "ssh_keyfile": null, 
            "timeout": 10, 
            "transport": null, 
            "use_ssl": false, 
            "username": "rootDC", 
            "validate_certs": true
        }, 
        "module_name": "ce_evpn_bgp_rr"
    }, 
    "proposed": {
        "as_number": "20", 
        "bgp_evpn_enable": "true", 
        "bgp_instance": null, 
        "peer": null, 
        "peer_type": null, 
        "policy_vpn_target": null, 
        "reflect_client": null
    }, 
    "updates": [
        "bgp 20", 
        "  l2vpn-family evpn"
    ]
}


TASK [Config EVPN overlay enable is enabled] ***********************************
task path: /usr1/code/OpenNESS/code/current/KVM/intg/test/testcases/test-ce_evpn_global.yml:21
Using module file /usr/local/lib/python2.7/site-packages/ansible-2.3.0-py2.7.egg/ansible/modules/core/network/cloudengine/ce_evpn_global.py
<ce_6850> ESTABLISH LOCAL CONNECTION FOR USER: root
<ce_6850> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1487043198.77-27261539909719 `" && echo ansible-tmp-1487043198.77-27261539909719="` echo $HOME/.ansible/tmp/ansible-tmp-1487043198.77-27261539909719 `" ) && sleep 0'
<ce_6850> PUT /tmp/tmpFqdCx4 TO /root/.ansible/tmp/ansible-tmp-1487043198.77-27261539909719/ce_evpn_global.py
<ce_6850> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1487043198.77-27261539909719/ /root/.ansible/tmp/ansible-tmp-1487043198.77-27261539909719/ce_evpn_global.py && sleep 0'
<ce_6850> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1487043198.77-27261539909719/ce_evpn_global.py; rm -rf "/root/.ansible/tmp/ansible-tmp-1487043198.77-27261539909719/" > /dev/null 2>&1 && sleep 0'
changed: [ce_6850] => {
    "changed": true, 
    "end_state": {
        "evpn_overlay_enable": "true"
    }, 
    "existing": {
        "evpn_overlay_enable": "false"
    }, 
    "invocation": {
        "module_args": {
            "auth_pass": null, 
            "authorize": false, 
            "evpn_overlay_enable": "true", 
            "host": "ce_6850", 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 12345, 
            "provider": null, 
            "ssh_keyfile": null, 
            "timeout": 10, 
            "transport": null, 
            "use_ssl": false, 
            "username": "rootDC", 
            "validate_certs": true
        }, 
        "module_name": "ce_evpn_global"
    }, 
    "proposed": {
        "evpn_overlay_enable": "true"
    }, 
    "updates": [
        "evpn-overlay enable"
    ]
}
```
