### PR TITLE
network_cli shouldn't be specified anymore

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -274,7 +274,6 @@ def network_inventory(remotes):
         options = dict(
             ansible_host=remote.connection.hostname,
             ansible_user=remote.connection.username,
-            ansible_connection='network_cli',
             ansible_ssh_private_key_file=remote.ssh_key.key,
             ansible_network_os=remote.platform,
         )


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
ansible-test


##### SUMMARY
This isn't a user settable option anymore, so use the default

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/21458)
<!-- Reviewable:end -->
