### PR TITLE
Change the f5 modules to use f5_utils file

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_device_dns.py
+++ b/lib/ansible/modules/network/f5/bigip_device_dns.py
@@ -397,7 +397,7 @@ def main():
 
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible.module_utils.f5 import *
+from ansible.module_utils.f5_utils import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/f5/bigip_device_ntp.py
+++ b/lib/ansible/modules/network/f5/bigip_device_ntp.py
@@ -257,7 +257,7 @@ def main():
 
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible.module_utils.f5 import *
+from ansible.module_utils.f5_utils import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/f5/bigip_device_sshd.py
+++ b/lib/ansible/modules/network/f5/bigip_device_sshd.py
@@ -344,7 +344,7 @@ def main():
 
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible.module_utils.f5 import *
+from ansible.module_utils.f5_utils import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/f5/bigip_facts.py
+++ b/lib/ansible/modules/network/f5/bigip_facts.py
@@ -1722,7 +1722,7 @@ def main():
 
 # include magic from lib/ansible/module_common.py
 from ansible.module_utils.basic import *
-from ansible.module_utils.f5 import *
+from ansible.module_utils.f5_utils import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/f5/bigip_gtm_datacenter.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_datacenter.py
@@ -366,7 +366,7 @@ def main():
 
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible.module_utils.f5 import *
+from ansible.module_utils.f5_utils import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/f5/bigip_gtm_facts.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_facts.py
@@ -489,7 +489,7 @@ def main():
 
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible.module_utils.f5 import *
+from ansible.module_utils.f5_utils import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/f5/bigip_gtm_virtual_server.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_virtual_server.py
@@ -92,7 +92,7 @@ else:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
-from ansible.module_utils.f5 import bigip_api, f5_argument_spec
+from ansible.module_utils.f5_utils import bigip_api, f5_argument_spec
 
 
 def server_exists(api, server):

--- a/lib/ansible/modules/network/f5/bigip_gtm_wide_ip.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_wide_ip.py
@@ -77,7 +77,7 @@ else:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
-from ansible.module_utils.f5 import bigip_api, f5_argument_spec
+from ansible.module_utils.f5_utils import bigip_api, f5_argument_spec
 
 
 def get_wide_ip_lb_method(api, wide_ip):

--- a/lib/ansible/modules/network/f5/bigip_hostname.py
+++ b/lib/ansible/modules/network/f5/bigip_hostname.py
@@ -182,7 +182,7 @@ def main():
         module.fail_json(msg=str(e))
 
 from ansible.module_utils.basic import *
-from ansible.module_utils.f5 import *
+from ansible.module_utils.f5_utils import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/f5/bigip_irule.py
+++ b/lib/ansible/modules/network/f5/bigip_irule.py
@@ -382,7 +382,7 @@ def main():
 
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible.module_utils.f5 import *
+from ansible.module_utils.f5_utils import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/f5/bigip_monitor_http.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_http.py
@@ -441,7 +441,7 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-from ansible.module_utils.f5 import *
+from ansible.module_utils.f5_utils import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/f5/bigip_monitor_tcp.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_tcp.py
@@ -483,7 +483,7 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
-from ansible.module_utils.f5 import *
+from ansible.module_utils.f5_utils import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/f5/bigip_node.py
+++ b/lib/ansible/modules/network/f5/bigip_node.py
@@ -461,7 +461,7 @@ def main():
     module.exit_json(**result)
 
 from ansible.module_utils.basic import *
-from ansible.module_utils.f5 import *
+from ansible.module_utils.f5_utils import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/f5/bigip_pool.py
+++ b/lib/ansible/modules/network/f5/bigip_pool.py
@@ -582,7 +582,7 @@ def main():
     module.exit_json(**result)
 
 from ansible.module_utils.basic import *
-from ansible.module_utils.f5 import *
+from ansible.module_utils.f5_utils import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/f5/bigip_pool_member.py
+++ b/lib/ansible/modules/network/f5/bigip_pool_member.py
@@ -503,7 +503,7 @@ def main():
     module.exit_json(**result)
 
 from ansible.module_utils.basic import *
-from ansible.module_utils.f5 import *
+from ansible.module_utils.f5_utils import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/f5/bigip_routedomain.py
+++ b/lib/ansible/modules/network/f5/bigip_routedomain.py
@@ -524,7 +524,7 @@ def main():
 
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible.module_utils.f5 import *
+from ansible.module_utils.f5_utils import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/f5/bigip_selfip.py
+++ b/lib/ansible/modules/network/f5/bigip_selfip.py
@@ -698,7 +698,7 @@ def main():
 
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible.module_utils.f5 import *
+from ansible.module_utils.f5_utils import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/f5/bigip_snat_pool.py
+++ b/lib/ansible/modules/network/f5/bigip_snat_pool.py
@@ -411,7 +411,7 @@ def main():
 
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible.module_utils.f5 import *
+from ansible.module_utils.f5_utils import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/f5/bigip_ssl_certificate.py
+++ b/lib/ansible/modules/network/f5/bigip_ssl_certificate.py
@@ -514,7 +514,7 @@ def main():
         module.fail_json(msg=str(e))
 
 from ansible.module_utils.basic import *
-from ansible.module_utils.f5 import *
+from ansible.module_utils.f5_utils import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/f5/bigip_sys_db.py
+++ b/lib/ansible/modules/network/f5/bigip_sys_db.py
@@ -221,7 +221,7 @@ def main():
         module.fail_json(msg=str(e))
 
 from ansible.module_utils.basic import *
-from ansible.module_utils.f5 import *
+from ansible.module_utils.f5_utils import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/f5/bigip_sys_global.py
+++ b/lib/ansible/modules/network/f5/bigip_sys_global.py
@@ -424,7 +424,7 @@ def main():
 
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible.module_utils.f5 import *
+from ansible.module_utils.f5_utils import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/f5/bigip_virtual_server.py
+++ b/lib/ansible/modules/network/f5/bigip_virtual_server.py
@@ -799,7 +799,7 @@ def main():
     module.exit_json(**result)
 # import module snippets
 from ansible.module_utils.basic import *
-from ansible.module_utils.f5 import *
+from ansible.module_utils.f5_utils import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/f5/bigip_vlan.py
+++ b/lib/ansible/modules/network/f5/bigip_vlan.py
@@ -445,7 +445,7 @@ def main():
 
 from ansible.module_utils.basic import *
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible.module_utils.f5 import *
+from ansible.module_utils.f5_utils import *
 
 if __name__ == '__main__':
     main()

--- a/test/compile/python2.4-skip.txt
+++ b/test/compile/python2.4-skip.txt
@@ -46,7 +46,8 @@
 /lib/ansible/module_utils/vmware.py
 /lib/ansible/module_utils/netconf.py
 /lib/ansible/module_utils/junos.py
-/lib/ansible/module_utils/f5.py
+/lib/ansible/module_utils/f5_utils.py
+/lib/ansible/module_utils/f5_cli.py
 /lib/ansible/parsing/
 /lib/ansible/playbook/
 /lib/ansible/plugins/

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -12,7 +12,6 @@ lib/ansible/inventory/dir.py
 lib/ansible/inventory/script.py
 lib/ansible/module_utils/basic.py
 lib/ansible/module_utils/ec2.py
-lib/ansible/module_utils/f5.py
 lib/ansible/module_utils/facts.py
 lib/ansible/module_utils/known_hosts.py
 lib/ansible/module_utils/mysql.py


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
All f5 components

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
The f5 module utils were using a file name that appeared to
conflict with the f5 python SDK's namespace. This patch just changes
the name of the included class to be f5_utils to avoid the issue
of namespace collisions.

This was not apparent previously because the common code (import from f5.bigip yada yada) was done in the module and not in the module_util. When it moved to the module util, the namespace implied by python became "f5" and that prevented me from importing the real f5 python sdk.

Changing the name of the file to f5_utils and completely removing the f5.py file prevents this collision from occurring.