### PR TITLE
Add quota for the number of floating IP's to allow in Network.

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_quota.py
+++ b/lib/ansible/modules/cloud/openstack/os_quota.py
@@ -59,7 +59,11 @@ options:
     floating_ips:
         required: False
         default: None
-        description: Number of floating IP's to allow.
+        description: Number of floating IP's to allow in Compute.
+    floatingip:
+        required: False
+        default: None
+        description: Number of floating IP's to allow in Network.
     gigabytes:
         required: False
         default: None
@@ -198,6 +202,7 @@ EXAMPLES = '''
     cores: "{{ item.cores }}"
     fixed_ips: "{{ item.fixed_ips }}"
     floating_ips: "{{ item.floating_ips }}"
+    floatingip: "{{ item.floatingip }}"
     gigabytes: "{{ item.gigabytes }}"
     injected_file_size: "{{ item.injected_file_size }}"
     injected_files: "{{ item.injected_files }}"
@@ -369,6 +374,7 @@ def main():
         cores=dict(required=False, type='int', default=None),
         fixed_ips=dict(required=False, type='int', default=None),
         floating_ips=dict(required=False, type='int', default=None),
+        floatingip=dict(required=False, type='int', default=None),
         gigabytes=dict(required=False, type='int', default=None),
         gigabytes_types=dict(required=False, type='dict', default={}),
         injected_file_size=dict(required=False, type='int', default=None),

--- a/lib/ansible/modules/cloud/openstack/os_quota.py
+++ b/lib/ansible/modules/cloud/openstack/os_quota.py
@@ -60,12 +60,12 @@ options:
         required: False
         default: None
         description: Number of floating IP's to allow in Compute.
-        aliases: ['nova_floating_ips']
+        aliases: ['compute_floating_ips']
     floatingip:
         required: False
         default: None
         description: Number of floating IP's to allow in Network.
-        aliases: ['neutron_floating_ips']
+        aliases: ['network_floating_ips']
     gigabytes:
         required: False
         default: None
@@ -375,8 +375,8 @@ def main():
         backups=dict(required=False, type='int', default=None),
         cores=dict(required=False, type='int', default=None),
         fixed_ips=dict(required=False, type='int', default=None),
-        floating_ips=dict(required=False, type='int', default=None, aliases=['nova_floating_ips']),
-        floatingip=dict(required=False, type='int', default=None, aliases=['neutron_floating_ips']),
+        floating_ips=dict(required=False, type='int', default=None, aliases=['compute_floating_ips']),
+        floatingip=dict(required=False, type='int', default=None, aliases=['network_floating_ips']),
         gigabytes=dict(required=False, type='int', default=None),
         gigabytes_types=dict(required=False, type='dict', default={}),
         injected_file_size=dict(required=False, type='int', default=None),

--- a/lib/ansible/modules/cloud/openstack/os_quota.py
+++ b/lib/ansible/modules/cloud/openstack/os_quota.py
@@ -60,10 +60,12 @@ options:
         required: False
         default: None
         description: Number of floating IP's to allow in Compute.
+        aliases: ['nova_floating_ips']
     floatingip:
         required: False
         default: None
         description: Number of floating IP's to allow in Network.
+        aliases: ['neutron_floating_ips']
     gigabytes:
         required: False
         default: None
@@ -373,8 +375,8 @@ def main():
         backups=dict(required=False, type='int', default=None),
         cores=dict(required=False, type='int', default=None),
         fixed_ips=dict(required=False, type='int', default=None),
-        floating_ips=dict(required=False, type='int', default=None),
-        floatingip=dict(required=False, type='int', default=None),
+        floating_ips=dict(required=False, type='int', default=None, aliases=['nova_floating_ips']),
+        floatingip=dict(required=False, type='int', default=None, aliases=['neutron_floating_ips']),
         gigabytes=dict(required=False, type='int', default=None),
         gigabytes_types=dict(required=False, type='dict', default={}),
         injected_file_size=dict(required=False, type='int', default=None),


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
openstack module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

In openstack, you have 2 locations where you could define the (quota) allowed number of floating IP's.
One in Nova(compute), another in Neutron(network).

In the current module, there is only one "floating_ips" quota which is only valid for Nova.
I added "floatingip" quota which is supposed to be valid for Neutron.

I've tested this with our current openstack newton installation.

Of course, once this PR is accepted, the doc must be updated as well.

Best regards,
Chenjun Shen

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
