### PR TITLE
#19587 add yum skip-broken

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -1103,25 +1103,18 @@ def ensure(module, state, pkgs, conf_file, enablerepo, disablerepo,
             module.run_command(yum_basecmd + ['clean', 'expire-cache'])
 
         my = yum_base(conf_file, installroot)
-        try:
-            if disablerepo:
+        if disablerepo:
+            try:
                 my.repos.disableRepo(disablerepo)
-            current_repos = my.repos.repos.keys()
-            if enablerepo:
-                try:
-                    my.repos.enableRepo(enablerepo)
-                    new_repos = my.repos.repos.keys()
-                    for i in new_repos:
-                        if not i in current_repos:
-                            rid = my.repos.getRepo(i)
-                            a = rid.repoXML.repoid  ##  if no one complains remove this on next MR
-                    current_repos = new_repos
-                except yum.Errors.YumBaseError:
-                    e = get_exception()
-                    module.fail_json(msg="Error setting/accessing repos: %s" % (e))
-        except yum.Errors.YumBaseError:
-            e = get_exception()
-            module.fail_json(msg="Error accessing repos: %s" % e)
+            except yum.Errors.YumBaseError:
+                yum_error = get_exception()
+                module.fail_json(msg="Error setting/accessing repos: %s" % (yum_error))
+        if enablerepo:
+            try:
+                my.repos.enableRepo(enablerepo)
+            except yum.Errors.YumBaseError:
+                yum_error = get_exception()
+                module.fail_json(msg="Error setting/accessing repos: %s" % (yum_error))
     if state in ['installed', 'present']:
         if disable_gpg_check:
             yum_basecmd.append('--nogpgcheck')

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -35,7 +35,9 @@ description:
 options:
   name:
     description:
-      - "Package name, or package specifier with version, like C(name-1.0). When using state=latest, this can be '*' which means run: yum -y update. You can also pass a url or a local path to a rpm file (using state=present).  To operate on several packages this can accept a comma separated list of packages or (as of 2.0) a list of packages."
+      - "Package name, or package specifier with version, like C(name-1.0). When using state=latest, this can be '*' which means run: yum -y update.
+         You can also pass a url or a local path to a rpm file (using state=present).  To operate on several packages this can accept a comma separated list
+         of packages or (as of 2.0) a list of packages."
     required: true
     default: null
     aliases: [ 'pkg' ]
@@ -631,7 +633,17 @@ def list_stuff(module, repoquerybin, conf_file, stuff, installroot='/'):
     elif stuff == 'repos':
         return [ dict(repoid=name, state='enabled') for name in sorted(repolist(module, repoq)) if name.strip() ]
     else:
-        return [ pkg_to_dict(p) for p in sorted(is_installed(module, repoq, stuff, conf_file, qf=is_installed_qf, installroot=installroot) + is_available(module, repoq, stuff, conf_file, qf=qf, installroot=installroot)) if p.strip() ]
+        return [ pkg_to_dict(p) for p in sorted(is_installed(module,
+                                                             repoq,
+                                                             stuff,
+                                                             conf_file,
+                                                             qf=is_installed_qf,
+                                                             installroot=installroot) + is_available(module,
+                                                                                                     repoq,
+                                                                                                     stuff,
+                                                                                                     conf_file,
+                                                                                                     qf=qf,
+                                                                                                     installroot=installroot)) if p.strip() ]
 
 def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, installroot='/'):
 
@@ -991,7 +1003,10 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, in
                 msg = '%s will be updated' % w
             elif w not in updates:
                 other_pkg = will_update_from_other_package[w]
-                to_update.append((w, 'because of (at least) %s-%s.%s from %s' % (other_pkg, updates[other_pkg]['version'], updates[other_pkg]['dist'], updates[other_pkg]['repo'])))
+                to_update.append((w, 'because of (at least) %s-%s.%s from %s' % (other_pkg,
+                                                                                 updates[other_pkg]['version'],
+                                                                                 updates[other_pkg]['dist'],
+                                                                                 updates[other_pkg]['repo'])))
             else:
                 to_update.append((w, '%s.%s from %s' % (updates[w]['version'], updates[w]['dist'], updates[w]['repo'])))
 
@@ -1122,17 +1137,6 @@ def ensure(module, state, pkgs, conf_file, enablerepo, disablerepo,
 
 
 def main():
-
-    # state=installed name=pkgspec
-    # state=removed name=pkgspec
-    # state=latest name=pkgspec
-    #
-    # informational commands:
-    #   list=installed
-    #   list=updates
-    #   list=available
-    #   list=repos
-    #   list=pkgspec
 
     module = AnsibleModule(
         argument_spec = dict(

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -648,12 +648,13 @@ def list_stuff(module, repoquerybin, conf_file, stuff, installroot='/'):
                                                              stuff,
                                                              conf_file,
                                                              qf=is_installed_qf,
-                                                             installroot=installroot) + is_available(module,
-                                                                                                     repoq,
-                                                                                                     stuff,
-                                                                                                     conf_file,
-                                                                                                     qf=qf,
-                                                                                                     installroot=installroot)) if p.strip() ]
+                                                             installroot=installroot) +
+                                                is_available(module,
+                                                             repoq,
+                                                             stuff,
+                                                             conf_file,
+                                                             qf=qf,
+                                                             installroot=installroot)) if p.strip() ]
 
 def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, installroot='/'):
 

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -103,7 +103,7 @@ options:
     required: false
     version_added: "2.3"
     default: "no"
-    choices: ["yes, "no"]
+    choices: ["yes", "no"]
     aliases: []
 
   update_cache:

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -643,18 +643,8 @@ def list_stuff(module, repoquerybin, conf_file, stuff, installroot='/'):
     elif stuff == 'repos':
         return [ dict(repoid=name, state='enabled') for name in sorted(repolist(module, repoq)) if name.strip() ]
     else:
-        return [ pkg_to_dict(p) for p in sorted(is_installed(module,
-                                                             repoq,
-                                                             stuff,
-                                                             conf_file,
-                                                             qf=is_installed_qf,
-                                                             installroot=installroot) +
-                                                is_available(module,
-                                                             repoq,
-                                                             stuff,
-                                                             conf_file,
-                                                             qf=qf,
-                                                             installroot=installroot)) if p.strip() ]
+        return [ pkg_to_dict(p) for p in sorted(is_installed(module,repoq, stuff, conf_file, qf=is_installed_qf, installroot=installroot)+
+                                                is_available(module, repoq, stuff, conf_file, qf=qf, installroot=installroot)) if p.strip()]
 
 def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, installroot='/'):
 
@@ -1011,7 +1001,6 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, in
         for w in will_update:
             if w.startswith('@'):
                 to_update.append((w, None))
-                res['msg'] += '%s will be updated' % w
             elif w not in updates:
                 other_pkg = will_update_from_other_package[w]
                 to_update.append((w, 'because of (at least) %s-%s.%s from %s' % (other_pkg,
@@ -1125,7 +1114,7 @@ def ensure(module, state, pkgs, conf_file, enablerepo, disablerepo,
                     for i in new_repos:
                         if not i in current_repos:
                             rid = my.repos.getRepo(i)
-                            a = rid.repoXML.repoid  ##  if no one complains remove this on next MR 
+                            a = rid.repoXML.repoid  ##  if no one complains remove this on next MR
                     current_repos = new_repos
                 except yum.Errors.YumBaseError:
                     e = get_exception()
@@ -1151,6 +1140,18 @@ def ensure(module, state, pkgs, conf_file, enablerepo, disablerepo,
 
 
 def main():
+
+    # state=installed name=pkgspec
+    # state=removed name=pkgspec
+    # state=latest name=pkgspec
+    #
+    # informational commands:
+    #   list=installed
+    #   list=updates
+    #   list=available
+    #   list=repos
+    #   list=pkgspec
+
 
     module = AnsibleModule(
         argument_spec = dict(

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -96,6 +96,16 @@ options:
     choices: ["yes", "no"]
     aliases: []
 
+  skip_broken:
+    description:
+      - Resolve depsolve problems by removing packages that are causing problems from the trans‐
+        action.
+    required: false
+    version_added: "2.3"
+    default: "no"
+    choices: ["yes, "no"]
+    aliases: []
+
   update_cache:
     description:
       - Force yum to check if cache is out of date and redownload if needed.
@@ -1053,7 +1063,7 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, in
     return res
 
 def ensure(module, state, pkgs, conf_file, enablerepo, disablerepo,
-           disable_gpg_check, exclude, repoq, installroot='/'):
+           disable_gpg_check, exclude, repoq, skip_broken, installroot='/'):
 
     # fedora will redirect yum to dnf, which has incompatibilities
     # with how this module expects yum to operate. If yum-deprecated
@@ -1073,6 +1083,10 @@ def ensure(module, state, pkgs, conf_file, enablerepo, disablerepo,
 
     dis_repos =[]
     en_repos = []
+
+    if skip_broken:
+        yum_basecmd.extend('--skip-broken')
+
     if disablerepo:
         dis_repos = disablerepo.split(',')
         r_cmd = ['--disablerepo=%s' % disablerepo]
@@ -1149,6 +1163,7 @@ def main():
             list=dict(),
             conf_file=dict(default=None),
             disable_gpg_check=dict(required=False, default="no", type='bool'),
+            skip_broken=dict(required=False, default="no", aliases=[], type='bool'),
             update_cache=dict(required=False, default="no", aliases=['expire-cache'], type='bool'),
             validate_certs=dict(required=False, default="yes", type='bool'),
             installroot=dict(required=False, default="/", type='str'),
@@ -1205,8 +1220,9 @@ def main():
         enablerepo = params.get('enablerepo', '')
         disablerepo = params.get('disablerepo', '')
         disable_gpg_check = params['disable_gpg_check']
+        skip_broken = params['skip_broken']
         results = ensure(module, state, pkg, params['conf_file'], enablerepo,
-                     disablerepo, disable_gpg_check, exclude, repoquery,
+                     disablerepo, disable_gpg_check, exclude, repoquery, skip_broken,
                      params['installroot'])
         if repoquery:
             results['msg'] = '%s %s' % (results.get('msg',''),

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -1120,7 +1120,7 @@ def ensure(module, state, pkgs, conf_file, enablerepo, disablerepo,
             This docstring will be removed together when issue: #21619
             will be solved.
 
-            This has been triggered by: #19587 and #195870
+            This has been triggered by: #19587
         """
 
         if module.params.get('update_cache'):

--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -1011,7 +1011,7 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, in
         for w in will_update:
             if w.startswith('@'):
                 to_update.append((w, None))
-                msg = '%s will be updated' % w
+                res['msg'] += '%s will be updated' % w
             elif w not in updates:
                 other_pkg = will_update_from_other_package[w]
                 to_update.append((w, 'because of (at least) %s-%s.%s from %s' % (other_pkg,
@@ -1086,7 +1086,7 @@ def ensure(module, state, pkgs, conf_file, enablerepo, disablerepo,
     en_repos = []
 
     if skip_broken:
-        yum_basecmd.extend('--skip-broken')
+        yum_basecmd.extend(['--skip-broken'])
 
     if disablerepo:
         dis_repos = disablerepo.split(',')
@@ -1125,7 +1125,7 @@ def ensure(module, state, pkgs, conf_file, enablerepo, disablerepo,
                     for i in new_repos:
                         if not i in current_repos:
                             rid = my.repos.getRepo(i)
-                            a = rid.repoXML.repoid
+                            a = rid.repoXML.repoid  ##  if no one complains remove this on next MR 
                     current_repos = new_repos
                 except yum.Errors.YumBaseError:
                     e = get_exception()
@@ -1147,7 +1147,6 @@ def ensure(module, state, pkgs, conf_file, enablerepo, disablerepo,
         # should be caught by AnsibleModule argument_spec
         module.fail_json(msg="we should never get here unless this all"
                 " failed", changed=False, results='', errors='unexpected state')
-
     return res
 
 

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -186,7 +186,6 @@ lib/ansible/modules/packaging/os/opkg.py
 lib/ansible/modules/packaging/os/pacman.py
 lib/ansible/modules/packaging/os/rhn_register.py
 lib/ansible/modules/packaging/os/swdepot.py
-lib/ansible/modules/packaging/os/yum.py
 lib/ansible/modules/packaging/os/zypper.py
 lib/ansible/modules/source_control/github_hooks.py
 lib/ansible/modules/storage/netapp/netapp_e_amg.py


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
modules/packaging/os/yum.py 

##### ANSIBLE VERSION
targeting 2.3  i guess


##### SUMMARY
adding skip_broken option, --skip-broken as per yum man is a general option meaning it can be added all other the place, therefore, adding it into the yum_basecmd 

bonus: did some pep8 refactor 

<!---
this fixes https://github.com/ansible/ansible/issues/19587
-->

test-module pastebin http://pastebin.com/mgCmcVdq 
