### PR TITLE
Fixes idempotency issue when upgrading chocolatey packages

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -198,7 +198,7 @@ Function Choco-Upgrade
         $cmd += " --execution-timeout=$executiontimeout"
     }
 
-    $results = invoke-expression $cmd
+    $output = invoke-expression $cmd
 
     $result.rc = $LastExitCode
     if ($LastExitCode -notin $successexitcodes)
@@ -208,7 +208,7 @@ Function Choco-Upgrade
         Throw "Error installing $package"
     }
 
-    if ("$output" -match ' upgraded (\d+)/\d+ package\(s\)\. ')
+    if ("$output" -match ' upgraded (\d+)/\d+ package')
     {
         if ($matches[1] -gt 0)
         {


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_chocolatey

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
It seems chocolatey have changed the output of a package upgrade so the previous regexp wasn't detecting change when a package had in fact been updated.

Chocolatey outputs something like this:
```
Chocolatey upgraded 1/1 packages. 0 packages failed.
```

But the module was looking for this regexp:
``` upgraded (\d+)/\d+ package\(s\)\.```

Removing the `\(s\)\.` section ensures idempotency and should be backward compatible with whatever version of chocolatey was using the previous expression.


<!-- Paste verbatim command output below, e.g. before and after your change -->
```
# Before when upgrading a chocolatey package
{"changed":false}

# After
{"changed":true}
```
