### PR TITLE
Fix hash filter for non-ascii strings and Python3

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -48,7 +48,7 @@ from ansible import errors
 from ansible.compat.six import iteritems, string_types, integer_types
 from ansible.compat.six.moves import reduce
 from ansible.compat.six.moves import shlex_quote
-from ansible.module_utils._text import to_text
+from ansible.module_utils._text import to_bytes, to_text
 from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.utils.hashing import md5s, checksum_s
 from ansible.utils.unicode import unicode_wrap
@@ -236,7 +236,7 @@ def get_hash(data, hashtype='sha1'):
     except:
         return None
 
-    h.update(data)
+    h.update(to_bytes(data, errors='surrogate_then_strict'))
     return h.hexdigest()
 
 def get_encrypted_password(password, hashtype='sha512', salt=None):

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -119,3 +119,9 @@
   assert:
     that:
       - "users | json_query('[*].hosts[].host') == ['host_a', 'host_b', 'host_c', 'host_d']"
+
+- name: Test hash filter
+  assert:
+    that:
+      - '"{{ "hash" | hash("sha1") }}" == "2346ad27d7568ba9896f1b7da6b5991251debdf2"'
+      - '"{{ "café" | hash("sha1") }}" == "f424452a9673918c6f09b0cdd35b20be8e6ae7d7"'


### PR DESCRIPTION
hashlib hashes operate on byte strings.  When given a text string on
Python3, hashlib backtraces.  When given a text string on Python2,
hashlib will backtrace if the string contains non-ascii characters.
Encode the text string to utf-8 prior to hashing to avoid this problem.

Fixes #21452

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/filter/core.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.2
```