### PR TITLE
Add Tower Label module

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_label.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_label.py
@@ -1,0 +1,160 @@
+#!/usr/bin/python
+#coding: utf-8 -*-
+
+# (c) 2017, Wayne Witzel III <wayne@riotousliving.com>
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = '''
+---
+module: tower_label
+version_added: "2.3"
+short_description: create, update, or destroy Ansible Tower label.
+description:
+    - Create, update, or destroy Ansible Tower labels. See
+      U(https://www.ansible.com/tower) for an overview.
+options:
+    name:
+      description:
+        - Name to use for the label.
+      required: True
+      default: null
+    organization:
+      description:
+        - Organization the label should be applied to.
+      required: True
+      default: null
+    state:
+      description:
+        - Desired state of the resource.
+      required: False
+      default: "present"
+      choices: ["present", "absent"]
+    tower_host:
+      description:
+        - URL to your Tower instance.
+      required: False
+      default: null
+    tower_username:
+        description:
+          - Username for your Tower instance.
+        required: False
+        default: null
+    tower_password:
+        description:
+          - Password for your Tower instance.
+        required: False
+        default: null
+    tower_verify_ssl:
+        description:
+          - Dis/allow insecure connections to Tower. If C(no), SSL certificates will not be validated.
+            This should only be used on personally controlled sites using self-signed certificates.
+        required: False
+        default: True
+    tower_config_file:
+      description:
+        - Path to the Tower config file. See notes.
+      required: False
+      default: null
+
+
+requirements:
+  - "python >= 2.6"
+  - "ansible-tower-cli >= 3.0.3"
+
+notes:
+  - If no I(config_file) is provided we will attempt to use the tower-cli library
+    defaults to find your Tower host information.
+  - I(config_file) should contain Tower configuration in the following format
+      host=hostname
+      username=username
+      password=password
+'''
+
+
+EXAMPLES = '''
+- name: Add label to tower organization
+  tower_label
+    name: Custom Label
+    organization: My Organization
+    state: present
+    tower_config_file: "~/tower_cli.cfg"
+'''
+
+try:
+    import tower_cli
+    import tower_cli.utils.exceptions as exc
+
+    from tower_cli.conf import settings
+    from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode
+
+    HAS_TOWER_CLI = True
+except ImportError:
+    HAS_TOWER_CLI = False
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec = dict(
+            name = dict(required=True),
+            organization = dict(required=True),
+            tower_host = dict(),
+            tower_username = dict(),
+            tower_password = dict(no_log=True),
+            tower_verify_ssl = dict(type='bool', default=True),
+            tower_config_file = dict(type='path'),
+            state = dict(choices=['present', 'absent'], default='present'),
+        ),
+        supports_check_mode=True
+    )
+
+    if not HAS_TOWER_CLI:
+        module.fail_json(msg='ansible-tower-cli required for this module')
+
+    name = module.params.get('name')
+    organization = module.params.get('organization')
+    state = module.params.get('state')
+
+    json_output = {'label': name, 'state': state}
+
+    tower_auth = tower_auth_config(module)
+    with settings.runtime_values(**tower_auth):
+        tower_check_mode(module)
+        label = tower_cli.get_resource('label')
+
+        try:
+            org_res = tower_cli.get_resource('organization')
+            org = org_res.get(name=organization)
+
+            if state == 'present':
+                result = label.modify(name=name, organization=org['id'], create_on_missing=True)
+                json_output['id'] = result['id']
+            elif state == 'absent':
+                result = label.delete(name=name, organization=org['id'])
+        except (exc.NotFound) as excinfo:
+            module.fail_json(msg='Failed to update label, organization not found: {0}'.format(excinfo), changed=False)
+        except (exc.ConnectionError, exc.BadRequest, exc.NotFound) as excinfo:
+            module.fail_json(msg='Failed to update label: {0}'.format(excinfo), changed=False)
+
+    json_output['changed'] = result['changed']
+    module.exit_json(**json_output)
+
+
+from ansible.module_utils.basic import AnsibleModule
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
Ansible Tower label module.

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (tower_module_inventory f3c2dc08d6) last updated 2017/02/15 12:39:16 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Allows playbook authors to create Ansible Tower labels.
