### PR TITLE
add a intg test for issue #19835

### DIFF
--- a/test/integration/targets/postgresql/defaults/main.yml
+++ b/test/integration/targets/postgresql/defaults/main.yml
@@ -3,5 +3,6 @@
 db_name: 'ansible_db'
 db_user1: 'ansible_db_user1'
 db_user2: 'ansible_db_user2'
+db_user3: 'ansible_db_user3'
 
 tmp_dir: '/tmp'

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -374,6 +374,112 @@
     that:
       - "result.stdout_lines[-1] == '(0 rows)'"
 
+# Test cases to replicate issue 19835
+- name: Create a user "{{ db_user3 }}"  to test issue 19835
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_user:
+    name: "{{ db_user3 }}"
+    encrypted: 'yes'
+    password: "md55c8ccfd9d6711fc69a7eae647fc54f51"
+    login_user: "{{ pg_user }}"
+    #role_attr_flags: "NOSUPERUSER,NOCREATEROLE,NOCREATEDB,noinherit,NOLOGIN"
+    db: postgres
+  register: result
+
+- name: Check that ansible reports that "{{ db_user3 }}" was created for testing issue 19835
+  assert:
+    that:
+      - "result.changed == True"
+
+- name: debug result
+  debug:
+    var: result
+
+- name: Check that "{{ db_user3 }}" was created for testing issue 19835
+  become_user: "{{ pg_user }}"
+  become: True
+  shell: echo "select * from pg_user where usename='{{ db_user3 }}';" | psql -d postgres
+  register: result
+
+- assert:
+    that:
+      - "result.stdout_lines[-1] == '(1 row)'"
+
+- name: Modify user "{{ db_user3 }}" to have only login role attributes for testing issue 19835
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_user:
+    name: "{{ db_user3 }}"
+    state: "present"
+    role_attr_flags: "NOSUPERUSER,NOCREATEROLE,NOCREATEDB,noinherit"
+    login_user: "{{ pg_user }}"
+    db: postgres
+  register: result
+
+- name: Check that ansible reports it modified the roles for testing issue 19835
+  assert:
+    that:
+      - "result.changed == True"
+
+- name: Check that the user "{{ db_user3 }}" has the requested role attributes for testing issue 19835
+  become_user: "{{ pg_user }}"
+  become: True
+  shell: echo "select 'super:'||rolsuper, 'createrole:'||rolcreaterole, 'create:'||rolcreatedb, 'inherit:'||rolinherit, 'login:'||rolcanlogin from pg_roles where rolname='{{ db_user3 }}';" | psql -d postgres
+  register: result
+
+- name: Modify a single role attribute on the user "{{ db_user3 }}"  with no_password_changes set to yes. issue 19835
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_user:
+    name: "{{ db_user3 }}"
+    state: "present"
+    role_attr_flags: "CREATEDB"
+    no_password_changes: yes
+    login_user: "{{ pg_user }}"
+    db: postgres
+  register: result
+
+- name: Check that ansible reports it modified the role with no_password_changes set to yes. issue 19835
+  assert:
+    that:
+      - "result.changed == True"
+
+- name: Check that the user "{{ db_user3 }}" has the requested role attributes with no_password_changes set to yes. issue 19835
+  become_user: "{{ pg_user }}"
+  become: True
+  shell: echo "select 'super:'||rolsuper, 'createrole:'||rolcreaterole, 'create:'||rolcreatedb, 'inherit:'||rolinherit, 'login:'||rolcanlogin  from pg_roles where rolname='{{ db_user3 }}';" | psql -d postgres
+  register: result
+
+- name: Assert that the request role attributes check for user "{{ db_user3 }}" was correct with no_password_changes set to yes. issue 19835
+  assert:
+    that:
+      - "result.stdout_lines[-1] == '(1 row)'"
+      - "'super:f' in result.stdout_lines[-2]"
+      - "'createrole:f' in result.stdout_lines[-2]"
+      - "'create:t' in result.stdout_lines[-2]"
+      - "'inherit:f' in result.stdout_lines[-2]"
+      - "'login:t' in result.stdout_lines[-2]"
+
+- name: Cleanup the "{{ db_user3 }}" user
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_user:
+    name: "{{ db_user3 }}"
+    state: 'absent'
+    login_user: "{{ pg_user }}"
+    db: postgres
+
+- name: Check that "{{ db_user3 }}"  was removed
+  become_user: "{{ pg_user }}"
+  become: True
+  shell: echo "select * from pg_user where usename='{{ db_user3 }}';" | psql -d postgres
+  register: result
+
+- assert:
+    that:
+      - "result.stdout_lines[-1] == '(0 rows)'"
+
 ### TODO: test expires, fail_on_user
 
 #


### PR DESCRIPTION
(postgresql_user changing role_attr_flags with no_password_checks
fails)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- Test pull request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
test/integration/targets/postgresql

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (postgresql_user_test_19835 abe13f94b6) last updated 2017/02/15 13:43:09 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
Add a regression test to the integration tests for this issue.

https://github.com/ansible/ansible/pull/19834 fixed the issue and was merged as e89259dbd060b407e76c1c47fc0545c7ad9c9da4, this adds a test