### PR TITLE
Changed datacenter Required to False since default is set. Fixes 'req…

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -107,7 +107,7 @@ options:
    datacenter:
         description:
             - Destination datacenter for the deploy operation
-        required: True
+        required: False
         default: ha-datacenter
    cluster:
         description:
@@ -1262,7 +1262,7 @@ def main():
             disk=dict(required=False, type='list', default=[]),
             hardware=dict(required=False, type='dict', default={}),
             force=dict(required=False, type='bool', default=False),
-            datacenter=dict(required=True, type='str', default='ha-datacenter'),
+            datacenter=dict(required=False, type='str', default='ha-datacenter'),
             esxi_hostname=dict(required=False, type='str', default=None),
             cluster=dict(required=False, type='str', default=None),
             wait_for_ip_address=dict(required=False, type='bool', default=False),


### PR DESCRIPTION
…uired and default are mutually exclusive for datacenter' error. Fixes 21076

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vmware_guest module
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Setting Required=True and a Default in the datacenter arg in vmware_guest results in an error. Required and default are mutually exclusive. Set required=false since there is a default set. Fixes #21076 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
"msg": "Module alias error: internal error: required and default are mutually exclusive for datacenter"

---

localhost                  : ok=1    changed=1    unreachable=0    failed=0 
```
