### PR TITLE
fix failing fail_json call in postgresql_schema

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_schema.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_schema.py
@@ -101,6 +101,7 @@ schema:
     sample: "acme"
 '''
 
+import traceback
 
 try:
     import psycopg2
@@ -231,7 +232,7 @@ def main():
             cursor_factory=psycopg2.extras.DictCursor)
     except Exception:
         e = get_exception()
-        module.fail_json(msg="unable to connect to database: %s" %(text, str(e)))
+        module.fail_json(msg="unable to connect to database: {0}".format(str(e)), exception=traceback.format_exc())
 
     try:
         if module.check_mode:
@@ -262,7 +263,7 @@ def main():
         raise
     except Exception:
         e = get_exception()
-        module.fail_json(msg="Database query failed: %s" %(text, str(e)))
+        module.fail_json(msg="Database query failed: {0}".format(str(e)), exception=traceback.format_exc())
 
     module.exit_json(changed=changed, schema=schema)
 

--- a/lib/ansible/modules/database/postgresql/postgresql_schema.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_schema.py
@@ -101,8 +101,6 @@ schema:
     sample: "acme"
 '''
 
-import traceback
-
 try:
     import psycopg2
     import psycopg2.extras
@@ -110,6 +108,10 @@ except ImportError:
     postgresqldb_found = False
 else:
     postgresqldb_found = True
+
+import traceback
+
+from ansible.module_utils._text import to_native
 
 class NotSupportedError(Exception):
     pass
@@ -232,7 +234,7 @@ def main():
             cursor_factory=psycopg2.extras.DictCursor)
     except Exception:
         e = get_exception()
-        module.fail_json(msg="unable to connect to database: {0}".format(str(e)), exception=traceback.format_exc())
+        module.fail_json(msg="unable to connect to database: %s" % to_native(e), exception=traceback.format_exc())
 
     try:
         if module.check_mode:
@@ -263,7 +265,7 @@ def main():
         raise
     except Exception:
         e = get_exception()
-        module.fail_json(msg="Database query failed: {0}".format(str(e)), exception=traceback.format_exc())
+        module.fail_json(msg="Database query failed: %s" % to_native(e), exception=traceback.format_exc())
 
     module.exit_json(changed=changed, schema=schema)
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

modules/database/postgresql/postgresql_schema

##### ANSIBLE VERSION
```
2.3.0
```

##### SUMMARY

Here's an example of the error that was coming out. Massaged some linebreaks and backslashes to make it more readable:

    "module_stderr": "Traceback (most recent call last):
      File "/tmp/ansible_3X05GE/ansible_module_postgresql_schema.py", line 274, in <module>
        main()
      File "/tmp/ansible_3X05GE/ansible_module_postgresql_schema.py", line 265, in main
        module.fail_json(msg="Database query failed: %s" %(text, str(e)))
      NameError: global name 'text' is not defined
    ",

Now it triggers with the correct exception and shows the traceback. This duplication of str(e) and traceback seems to be the best design pattern.

Sample of the new output:

    An exception occurred during task execution. The full traceback is:
    Traceback (most recent call last):
      File "/tmp/ansible_gp4v1Q/ansible_module_postgresql_schema.py", line 254, in main
        changed = schema_create(cursor, schema, owner)
    ...
        return super(DictCursor, self).execute(query, vars)
    ProgrammingError: permission denied for database schemadb

    fatal: [localhost]: FAILED! => {
        "changed": false,
        "failed": true,
    ...
        },
        "msg": "Database query failed: permission denied for database schemadb\n"
