### PR TITLE
service: deprecate state=running

### DIFF
--- a/lib/ansible/plugins/action/service.py
+++ b/lib/ansible/plugins/action/service.py
@@ -68,7 +68,7 @@ class ActionModule(ActionBase):
 
             # for backwards compatibility
             if 'state' in new_module_args and new_module_args['state'] == 'running':
-                self._display.deprecated(msg="state=running is deprecated. Please use state=started", version="2.4")
+                self._display.deprecated(msg="state=running is deprecated. Please use state=started", version="2.7")
                 new_module_args['state'] = 'started'
 
             if module in self.UNUSED_PARAMS:

--- a/lib/ansible/plugins/action/service.py
+++ b/lib/ansible/plugins/action/service.py
@@ -68,6 +68,7 @@ class ActionModule(ActionBase):
 
             # for backwards compatibility
             if 'state' in new_module_args and new_module_args['state'] == 'running':
+                self._display.deprecated(msg="state=running is deprecated. Please use state=started", version="2.4")
                 new_module_args['state'] = 'started'
 
             if module in self.UNUSED_PARAMS:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
service

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

##### SUMMARY

Probably a good time point to deprecate state=running

@bcoca thoughts?