### PR TITLE
adding 'version_added' field for environment_variables option in lambda.py

### DIFF
--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -102,6 +102,7 @@ options:
     required: false
     default: None
     aliases: [ 'environment' ]
+    version_added: 2.3
 author:
     - 'Steyn Huizinga (@steynovich)'
 extends_documentation_fragment:

--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -102,7 +102,7 @@ options:
     required: false
     default: None
     aliases: [ 'environment' ]
-    version_added: 2.3
+    version_added: "2.3"
 author:
     - 'Steyn Huizinga (@steynovich)'
 extends_documentation_fragment:


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/lambda.py

##### ANSIBLE VERSION
```
ansible 2.3.0 (lambda-env-var-version-added 73eb575753) last updated 2017/02/15 17:35:53 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Adding a version_added field that was forgotten in the commit 22701806c34bb7787e5337b1814b367af7eab211. Fixes #21455 
