### PR TITLE
[GCE] gce_net integration test

### DIFF
--- a/test/integration/gce.yml
+++ b/test/integration/gce.yml
@@ -6,4 +6,5 @@
     - { role: test_gce_mig, tags: test_gce_mig }
     - { role: test_gcdns, tags: test_gcdns }
     - { role: test_gce_tag, tags: test_gce_tag }
-    # TODO: tests for gce_lb, gce_net, gc_storage
+    - { role: test_gce_net, tags: test_gce_net }
+    # TODO: tests for gce_lb, gc_storage

--- a/test/integration/roles/test_gce_net/defaults/main.yml
+++ b/test/integration/roles/test_gce_net/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# defaults file for test_gce_net
+firewall_name: "{{ resource_prefix|lower }}-fwrule"
+network_name_auto: "{{ resource_prefix|lower }}-auto"
+network_name_custom: "{{ resource_prefix|lower }}-custom"
+network_name_legacy: "{{ resource_prefix|lower }}-legacy"
+subnetwork_name_custom: "{{ resource_prefix|lower }}-subnetwork-custom"
+subnetwork_region: "us-east1"
+service_account_email: "{{ gce_service_account_email }}"
+pem_file: "{{ gce_pem_file }}"
+project_id: "{{ gce_project_id }}"

--- a/test/integration/roles/test_gce_net/tasks/main.yml
+++ b/test/integration/roles/test_gce_net/tasks/main.yml
@@ -1,0 +1,217 @@
+# gce_net Integration Test
+# Note: 'pause' is used during the Delete phase of the test.
+# This is to ensure that the subnetwork is removed before removing
+# the custom network.
+
+# ============================================================
+- name: test Create Legacy Network (change=true)
+  gce_net:
+    name: "{{ network_name_legacy }}"
+    ipv4_range: '10.240.17.0/24'
+    mode: legacy
+    state: "present"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+  register: result
+
+- name: "assert legacy network created"
+  assert:
+    that:
+      - 'result.changed'
+      - 'result.state == "present"'
+
+# ============================================================
+- name: test Create Auto Network (change=true)
+  gce_net:
+    name: "{{ network_name_auto }}"
+    mode: auto
+    state: "present"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+  register: result
+
+- name: "assert auto network created"
+  assert:
+    that:
+      - 'result.changed'
+      - 'result.state == "present"'
+
+# ============================================================
+- name: test Create Network with custom Subnetwork (change=true)
+  gce_net:
+    name: "{{ network_name_custom }}"
+    mode: custom
+    subnet_name: "{{ subnetwork_name_custom }}"
+    subnet_region: "{{ subnetwork_region }}"
+    ipv4_range: '10.240.16.0/24'
+    state: "present"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+  register: result
+
+- name: "assert subnetwork network created"
+  assert:
+    that:
+      - 'result.changed'
+      - 'result.state == "present"'
+
+# ============================================================
+- name: Create Firewall Rule (change=true)
+  gce_net:
+    name: default
+    fwname: "{{ firewall_name }}"
+    allowed: tcp:80
+    state: "present"
+    src_tags: "foo,bar"
+    src_range: ['10.2.1.1/32']
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+  register: result
+
+- name: "assert fw created"
+  assert:
+    that:
+      - 'result.changed'
+      - 'result.state == "present"'
+
+# ============================================================
+- name: Update Firewall Rule (change=true)
+  gce_net:
+    name: default
+    fwname: "{{ firewall_name }}"
+    allowed: tcp:81
+    state: "present"
+    src_tags: "foo,bar,baz"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+  register: result
+
+- name: "assert fw updated"
+  assert:
+    that:
+      - 'result.changed'
+      - 'result.state == "present"'
+      - 'result.src_tags|length == 3'
+
+# ============================================================
+- name: Update Firewall Rule w/icmp (no port) (change=true)
+  gce_net:
+    name: default
+    fwname: "{{ firewall_name }}"
+    allowed: tcp:81;icmp
+    state: "present"
+    src_tags: "foo,bar,baz"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+  register: result
+
+- name: "assert fw updated"
+  assert:
+    that:
+      - 'result.changed'
+      - 'result.state == "present"'
+      - 'result.src_tags|length == 3'
+
+# ============================================================
+- name: Update Firewall Rule w/source range (change=true)
+  gce_net:
+    name: default
+    fwname: "{{ firewall_name }}"
+    allowed: tcp:81
+    state: "present"
+    src_tags: "foo,bar,baz"
+    src_range: ['10.1.1.1/32']
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+  register: result
+
+- name: "assert fw updated source range"
+  assert:
+    that:
+      - 'result.changed'
+      - 'result.state == "present"'
+      - 'result.src_range|length == 1'
+
+# ============================================================
+- name: Delete Legacy Network (change=true)
+  gce_net:
+    name: "{{ network_name_legacy }}"
+    state: "absent"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+  register: result
+  tags: delete
+
+- name: "assert legacy network deleted"
+  tags: delete
+  assert:
+    that:
+      - 'result.changed'
+      - 'result.state == "absent"'
+# ============================================================
+- name: Delete auto Network (change=true)
+  gce_net:
+    name: "{{ network_name_auto }}"
+    state: "absent"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+  register: result
+  tags: delete
+
+- name: "assert auto network deleted"
+  tags: delete
+  assert:
+    that:
+      - 'result.changed'
+      - 'result.state == "absent"'
+
+# ============================================================
+- name: Delete SubNetwork of Custom Network (change=true)
+  gce_net:
+    name: "{{ network_name_custom }}"
+    subnet_name: "{{ subnetwork_name_custom }}"
+    subnet_region: "{{ subnetwork_region }}"
+    state: "absent"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+  register: result
+  tags: delete
+
+
+- name: "assert custom subnetwork deleted"
+  tags: delete
+  assert:
+    that:
+      - 'result.changed'
+      - 'result.state == "absent"'
+
+# ============================================================
+- pause: seconds=30
+
+# ============================================================
+- name: Delete Custom Network (change=true)
+  gce_net:
+    name: "{{ network_name_custom }}"
+    state: "absent"
+    service_account_email: "{{ service_account_email }}"
+    pem_file: "{{ pem_file }}"
+    project_id: "{{ project_id }}"
+  register: result
+  tags: delete
+
+- name: "assert custom network deleted"
+  tags: delete
+  assert:
+    that:
+      - 'result.changed'
+      - 'result.state == "absent"'


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Integration Test Pull Request


##### COMPONENT NAME
gce_net

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (gce-net-int da4934b0d9) last updated 2017/02/15 23:54:18 (GMT +000)
  config file = /home/supertom/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
New Integration test for the gce_net module (currently one does not exist).  Test creates different networks (auto, legacy and custom) and creates and modifies a firewall rule.  Finally, it tears it all down.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->

Run from test/integration with:
```
TEST_FLAGS='--tags "test_gce_net"' make gce
```
