### PR TITLE
'override' option for include_vars, allowing ignoring already set variables

### DIFF
--- a/lib/ansible/modules/utilities/logic/include_vars.py
+++ b/lib/ansible/modules/utilities/logic/include_vars.py
@@ -65,6 +65,12 @@ options:
     description:
         - This module allows you to specify the 'file' option directly w/o any other options.
           There is no 'free-form' option, this is just an indicator, see example below.
+  override:
+    version_added: "2.4"
+    description:
+      - Load the variables, overriding existing values. If false, will ignore any variables that are already set.
+    default: True
+    required: False
 '''
 
 EXAMPLES = """


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
include_vars action

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (include-vars-override baff913407) last updated 2017/02/15 21:26:56 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add an 'override' option to include_vars. If true (as is default), include_vars works as normal. If false, include_vars will not override existing variables when it runs. This can be useful, for example, if trying to load additional defaults.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
Integration test & doc updates included to show this behavior.
