### PR TITLE
Add flag to Docker pull_image to know when the image is already latest

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -430,9 +430,13 @@ class AnsibleDockerClient(Client):
         Pull an image
         '''
         self.log("Pulling image %s:%s" % (name, tag))
+        alreadyToLatest = False
         try:
             for line in self.pull(name, tag=tag, stream=True, decode=True):
                 self.log(line, pretty_print=True)
+                if line.get('status'):
+                    if line.get('status').startswith('Status: Image is up to date for'):
+                        alreadyToLatest = True
                 if line.get('error'):
                     if line.get('errorDetail'):
                         error_detail = line.get('errorDetail')
@@ -444,6 +448,6 @@ class AnsibleDockerClient(Client):
         except Exception as exc:
             self.fail("Error pulling image %s:%s - %s" % (name, tag, str(exc)))
 
-        return self.find_image(name, tag)
+        return self.find_image(name, tag), alreadyToLatest
 
 

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1748,9 +1748,12 @@ class ContainerManager(DockerBaseClass):
         if not self.check_mode:
             if not image or self.parameters.pull:
                 self.log("Pull the image.")
-                image = self.client.pull_image(repository, tag)
-                self.results['actions'].append(dict(pulled_image="%s:%s" % (repository, tag)))
-                self.results['changed'] = True
+                image, alreadyToLatest = self.client.pull_image(repository, tag)
+                if alreadyToLatest:
+                    self.results['changed'] = False
+                else:
+                    self.results['changed'] = True
+                    self.results['actions'].append(dict(pulled_image="%s:%s" % (repository, tag)))
         self.log("image")
         self.log(image, pretty_print=True)
         return image


### PR DESCRIPTION
Whenever the flag pull is set to 'yes' the resource is always shown
as `changed`. That is not true in case the image is already at the
latest version.

Related to ansible/ansible#19549

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils docker_common

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The docker module, whenever the flag `pull` is set to `yes`, shows the task as `changed` even if nothing has actually happened. This is due to the fact that the module tries to pull the image from the registry and, even if there are no updates available, shows the resource as `changed`.

If the image is not pulled to a newer version the resource should be marked as `ok`

This pull request is part of a change in the module, for now we just need a way to see if the image that the user wants to pull is already up to date. That is done using the flag `alreadyToLatest`.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
