### PR TITLE
cloud: ovirt: logout if token is not used

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_affinity_groups.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_affinity_groups.py
@@ -293,7 +293,8 @@ def main():
     )
     check_sdk(module)
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         # Check if unsupported parameters were passed:
         supported_41 = ('host_enforcing', 'host_rule', 'hosts')
         if not check_support(
@@ -346,7 +347,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/ovirt/ovirt_affinity_labels.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_affinity_labels.py
@@ -181,7 +181,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         affinity_labels_service = connection.system_service().affinity_labels_service()
         affinity_labels_module = AffinityLabelsModule(
             connection=connection,
@@ -199,7 +200,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/ovirt/ovirt_affinity_labels_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_affinity_labels_facts.py
@@ -110,7 +110,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         affinity_labels_service = connection.system_service().affinity_labels_service()
         labels = []
         all_labels = affinity_labels_service.list()
@@ -155,7 +156,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/ovirt/ovirt_clusters.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_clusters.py
@@ -540,7 +540,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         clusters_service = connection.system_service().clusters_service()
         clusters_module = ClustersModule(
             connection=connection,
@@ -558,7 +559,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/ovirt/ovirt_clusters_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_clusters_facts.py
@@ -81,7 +81,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         clusters_service = connection.system_service().clusters_service()
         clusters = clusters_service.list(search=module.params['pattern'])
         module.exit_json(
@@ -100,7 +101,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/ovirt/ovirt_datacenters.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_datacenters.py
@@ -195,7 +195,8 @@ def main():
     check_params(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         data_centers_service = connection.system_service().data_centers_service()
         clusters_module = DatacentersModule(
             connection=connection,
@@ -213,7 +214,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/ovirt/ovirt_datacenters_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_datacenters_facts.py
@@ -80,7 +80,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         datacenters_service = connection.system_service().data_centers_service()
         datacenters = datacenters_service.list(search=module.params['pattern'])
         module.exit_json(
@@ -99,7 +100,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/ovirt/ovirt_disks.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disks.py
@@ -448,7 +448,8 @@ def main():
     try:
         disk = None
         state = module.params['state']
-        connection = create_connection(module.params.get('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         disks_service = connection.system_service().disks_service()
         disks_module = DisksModule(
             connection=connection,
@@ -518,7 +519,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/ovirt/ovirt_external_providers.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_external_providers.py
@@ -247,7 +247,8 @@ def main():
     check_params(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         provider_type, external_providers_service = _external_provider_service(
             provider_type=module.params.get('type'),
             system_service=connection.system_service(),
@@ -269,7 +270,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/ovirt/ovirt_external_providers_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_external_providers_facts.py
@@ -119,7 +119,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         external_providers_service = _external_provider_service(
             provider_type=module.params.pop('type'),
             system_service=connection.system_service(),
@@ -148,7 +149,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/ovirt/ovirt_groups.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_groups.py
@@ -156,7 +156,8 @@ def main():
     check_params(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         groups_service = connection.system_service().groups_service()
         groups_module = GroupsModule(
             connection=connection,
@@ -174,7 +175,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/ovirt/ovirt_groups_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_groups_facts.py
@@ -80,7 +80,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         groups_service = connection.system_service().groups_service()
         groups = groups_service.list(search=module.params['pattern'])
         module.exit_json(
@@ -99,7 +100,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_networks.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_networks.py
@@ -255,7 +255,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         hosts_service = connection.system_service().hosts_service()
         host_networks_module = HostNetworksModule(
             connection=connection,
@@ -373,7 +374,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_pm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_pm.py
@@ -196,7 +196,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         hosts_service = connection.system_service().hosts_service()
         host = search_by_name(hosts_service, module.params['name'])
         fence_agents_service = hosts_service.host_service(host.id).fence_agents_service()
@@ -237,7 +238,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/ovirt/ovirt_hosts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_hosts.py
@@ -334,7 +334,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         hosts_service = connection.system_service().hosts_service()
         hosts_module = HostsModule(
             connection=connection,
@@ -444,7 +445,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/ovirt/ovirt_hosts_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_hosts_facts.py
@@ -82,7 +82,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         hosts_service = connection.system_service().hosts_service()
         hosts = hosts_service.list(search=module.params['pattern'])
         module.exit_json(
@@ -101,7 +102,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/ovirt/ovirt_mac_pools.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_mac_pools.py
@@ -154,7 +154,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         mac_pools_service = connection.system_service().mac_pools_service()
         mac_pools_module = MACPoolModule(
             connection=connection,
@@ -172,7 +173,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/ovirt/ovirt_networks.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_networks.py
@@ -217,7 +217,8 @@ def main():
     check_params(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         clusters_service = connection.system_service().clusters_service()
         networks_service = connection.system_service().networks_service()
         networks_module = NetworksModule(
@@ -261,7 +262,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/ovirt/ovirt_networks_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_networks_facts.py
@@ -82,7 +82,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         networks_service = connection.system_service().networks_service()
         networks = networks_service.list(search=module.params['pattern'])
         module.exit_json(
@@ -101,7 +102,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/ovirt/ovirt_nics.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_nics.py
@@ -185,7 +185,8 @@ def main():
     try:
         # Locate the service that manages the virtual machines and use it to
         # search for the NIC:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         vms_service = connection.system_service().vms_service()
 
         # Locate the VM, where we will manage NICs:
@@ -240,7 +241,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 if __name__ == "__main__":
     main()

--- a/lib/ansible/modules/cloud/ovirt/ovirt_nics_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_nics_facts.py
@@ -87,7 +87,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         vms_service = connection.system_service().vms_service()
         vm_name = module.params['vm']
         vm = search_by_name(vms_service, vm_name)
@@ -119,7 +120,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/ovirt/ovirt_permissions.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_permissions.py
@@ -285,7 +285,8 @@ def main():
         module.fail_json(msg='"user_name" or "group_name" is required')
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         permissions_service = _object_service(connection, module).permissions_service()
         permissions_module = PermissionsModule(
             connection=connection,
@@ -304,7 +305,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/ovirt/ovirt_permissions_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_permissions_facts.py
@@ -115,7 +115,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         permissions_service = _permissions_service(connection, module)
         permissions = []
         for p in permissions_service.list():
@@ -132,7 +133,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/ovirt/ovirt_quotas.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_quotas.py
@@ -238,7 +238,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         datacenters_service = connection.system_service().data_centers_service()
         dc_name = module.params['datacenter']
         dc_id = getattr(search_by_name(datacenters_service, dc_name), 'id', None)
@@ -290,7 +291,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/ovirt/ovirt_quotas_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_quotas_facts.py
@@ -86,7 +86,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         datacenters_service = connection.system_service().data_centers_service()
         dc_name = module.params['datacenter']
         dc = search_by_name(datacenters_service, dc_name)
@@ -118,7 +119,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/ovirt/ovirt_snapshots.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_snapshots.py
@@ -242,7 +242,8 @@ def main():
     check_sdk(module)
 
     vm_name = module.params.get('vm_name')
-    connection = create_connection(module.params.pop('auth'))
+    auth = module.params.pop('auth')
+    connection = create_connection(auth)
     vms_service = connection.system_service().vms_service()
     vm = search_by_name(vms_service, vm_name)
     if not vm:
@@ -264,7 +265,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/ovirt/ovirt_snapshots_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_snapshots_facts.py
@@ -93,7 +93,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         vms_service = connection.system_service().vms_service()
         vm_name = module.params['vm']
         vm = search_by_name(vms_service, vm_name)
@@ -129,7 +130,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
@@ -425,7 +425,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         storage_domains_service = connection.system_service().storage_domains_service()
         storage_domains_module = StorageDomainModule(
             connection=connection,
@@ -470,7 +471,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains_facts.py
@@ -82,7 +82,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         storage_domains_service = connection.system_service().storage_domains_service()
         storage_domains = storage_domains_service.list(search=module.params['pattern'])
         module.exit_json(
@@ -101,7 +102,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/ovirt/ovirt_tags.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_tags.py
@@ -187,7 +187,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         tags_service = connection.system_service().tags_service()
         tags_module = TagsModule(
             connection=connection,
@@ -205,7 +206,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/ovirt/ovirt_tags_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_tags_facts.py
@@ -101,7 +101,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         tags_service = connection.system_service().tags_service()
         tags = []
         all_tags = tags_service.list()
@@ -146,7 +147,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
@@ -223,7 +223,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         templates_service = connection.system_service().templates_service()
         templates_module = TemplatesModule(
             connection=connection,
@@ -306,7 +307,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/ovirt/ovirt_templates_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_templates_facts.py
@@ -82,7 +82,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         templates_service = connection.system_service().templates_service()
         templates = templates_service.list(search=module.params['pattern'])
         module.exit_json(
@@ -101,7 +102,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/ovirt/ovirt_users.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_users.py
@@ -135,7 +135,8 @@ def main():
     check_params(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         users_service = connection.system_service().users_service()
         users_module = UsersModule(
             connection=connection,
@@ -161,7 +162,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/ovirt/ovirt_users_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_users_facts.py
@@ -80,7 +80,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         users_service = connection.system_service().users_service()
         users = users_service.list(search=module.params['pattern'])
         module.exit_json(
@@ -99,7 +100,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vmpools.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vmpools.py
@@ -183,7 +183,8 @@ def main():
     check_params(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         vm_pools_service = connection.system_service().vm_pools_service()
         vm_pools_module = VmPoolsModule(
             connection=connection,
@@ -212,7 +213,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vmpools_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vmpools_facts.py
@@ -80,7 +80,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         vmpools_service = connection.system_service().vm_pools_service()
         vmpools = vmpools_service.list(search=module.params['pattern'])
         module.exit_json(
@@ -99,7 +100,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
@@ -937,7 +937,8 @@ def main():
 
     try:
         state = module.params['state']
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         vms_service = connection.system_service().vms_service()
         vms_module = VmsModule(
             connection=connection,
@@ -1053,7 +1054,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout='token' not in module.params['auth'])
 
 
 if __name__ == "__main__":

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms_facts.py
@@ -95,7 +95,8 @@ def main():
     check_sdk(module)
 
     try:
-        connection = create_connection(module.params.pop('auth'))
+        auth = module.params.pop('auth')
+        connection = create_connection(auth)
         vms_service = connection.system_service().vms_service()
         vms = vms_service.list(
             search=module.params['pattern'],
@@ -119,7 +120,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout=False)
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt_*

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR changes the logic, so we now logout the user only in case the user passed the username/password. In case user passed token we don't revoke it.

We must use it like this, because in case the user will use `ansible-console` and ENV variables with username password for example, we don't logout the user, which may overload oVirt engine.