### PR TITLE
Add support for hidden users on macOS

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -48,6 +48,13 @@ options:
         required: false
         description:
             - Optionally sets the I(UID) of the user.
+    hidden:
+        required: false
+        default: 0
+        choices: [ 0, 1 ]
+        description:
+            - Optionally hide the user from the login window and system
+              preferences on macOS.
     non_unique:
         required: false
         default: "no"
@@ -289,6 +296,7 @@ class User(object):
         self.state      = module.params['state']
         self.name       = module.params['name']
         self.uid        = module.params['uid']
+        self.hidden     = module.params['hidden']
         self.non_unique  = module.params['non_unique']
         self.seuser     = module.params['seuser']
         self.group      = module.params['group']
@@ -1501,6 +1509,7 @@ class DarwinUser(User):
         ('shell', 'UserShell'),
         ('uid', 'UniqueID'),
         ('group', 'PrimaryGroupID'),
+        ('hidden', 'IsHidden'),
     ]
 
     def _get_dscl(self):
@@ -2130,6 +2139,8 @@ def main():
             shell=dict(default=None, type='str'),
             password=dict(default=None, type='str', no_log=True),
             login_class=dict(default=None, type='str'),
+            # following options are specific to macOS
+            hidden=dict(default='0', choices=['0', '1'], type='str'),
             # following options are specific to selinux
             seuser=dict(default=None, type='str'),
             # following options are specific to userdel


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
user module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This patch contains the necessary code for supporting hidden users on macOS as described at https://support.apple.com/en-us/HT203998. It's pretty simple but I wanted to point out the design decision to make the type a str instead of an int, the primary reason for this on line 1786 a check is made that would fail if the value `0` or `False` is passed, resulting in no changes being made to set attribute. 

This is to resolve issue  #19819 

This is my first PR so please let me know if there is anything that needs added/changed.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
##### PRE_CHANGE
```
$ sudo python3 /usr/local/bin/ansible localhost -m user -a "name=hiddenuser hidden=1" -vvvv
localhost | FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_args": {
            "hidden": "1",
            "name": "hiddenuser"
        },
        "module_name": "user"
    },
    "msg": "unsupported parameter for module: hidden"
}
```
##### POST-CHANGE
```
$ sudo python3 /usr/local/bin/ansible localhost -m user -a "name=hiddenuser hidden=1" -vvvv

localhost | SUCCESS => {
    "changed": true,
    "comment": "",
    "createhome": true,
    "group": -1,
    "home": "/Users/hiddenuser",
    "invocation": {
        "module_args": {
            "append": false,
            "comment": null,
            "createhome": true,
            "expires": null,
            "force": false,
            "generate_ssh_key": null,
            "group": null,
            "groups": null,
            "hidden": "1",
            "home": null,
            "login_class": null,
            "move_home": false,
            "name": "hiddenuser",
            "non_unique": false,
            "password": null,
            "remove": false,
            "seuser": null,
            "shell": null,
            "skeleton": null,
            "ssh_key_bits": 0,
            "ssh_key_comment": "ansible-generated on *****",
            "ssh_key_file": null,
            "ssh_key_passphrase": null,
            "ssh_key_type": "rsa",
            "state": "present",
            "system": false,
            "uid": null,
            "update_password": "always"
        }
    },
    "name": "hiddenuser",
    "shell": "/usr/bin/false",
    "state": "present",
    "system": false,
    "uid": 505
}
```
