### PR TITLE
win_chocolatey: Clean up parameter handling

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -31,7 +31,9 @@ module: win_chocolatey
 version_added: "1.9"
 short_description: Installs packages using chocolatey
 description:
-    - Installs packages using Chocolatey (http://chocolatey.org/). If Chocolatey is missing from the system, the module will install it. List of packages can be found at http://chocolatey.org/packages
+    - Installs packages using Chocolatey (U(http://chocolatey.org/)).
+    - If Chocolatey is missing from the system, the module will install it.
+    - List of packages can be found at U(http://chocolatey.org/packages)
 options:
   name:
     description:
@@ -43,25 +45,29 @@ options:
     choices:
       - present
       - absent
+      - latest
     default: present
   force:
     description:
-      - Forces install of the package (even if it already exists). Using Force will cause ansible to always report that a change was made
+      - Forces install of the package (even if it already exists).
+      - Using C(force) will cause ansible to always report that a change was made
     choices:
       - yes
       - no
     default: no
   upgrade:
     description:
-      - If package is already installed it, try to upgrade to the latest version or to the specified version
+      - If package is already installed it, try to upgrade to the latest version or to the specified version.
+      - As of Ansible v2.3 this is deprecated, set parameter C(state) to "latest" for the same result.
+    version_removed: '2.3'
     choices:
       - yes
       - no
     default: no
   version:
     description:
-      - Specific version of the package to be installed
-      - Ignored when state == 'absent'
+      - Specific version of the package to be installed.
+      - Ignored when C(state) is set to "absent".
   source:
     description:
       - Specify source rather than using default chocolatey repository
@@ -76,13 +82,11 @@ options:
   allow_empty_checksums:
     description:
       - Allow empty Checksums to be used
-    require: false
     default: false
     version_added: '2.2'
   ignore_checksums:
     description:
       - Ignore Checksums
-    require: false
     default: false
     version_added: '2.2'
   ignore_dependencies:

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -221,7 +221,6 @@ lib/ansible/modules/web_infrastructure/jira.py
 lib/ansible/modules/web_infrastructure/nginx_status_facts.py
 lib/ansible/modules/windows/win_acl.py
 lib/ansible/modules/windows/win_acl_inheritance.py
-lib/ansible/modules/windows/win_chocolatey.py
 lib/ansible/modules/windows/win_command.py
 lib/ansible/modules/windows/win_feature.py
 lib/ansible/modules/windows/win_lineinfile.py


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_chocolatey

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Changes include:

- Use Get-AnsibleParam with -type/-validateset
- Replace $result PSObject with normal hash
- Deprecate 'upgrade' parameter by using state=latest