### PR TITLE
Move availability_zone docs to each OpenStack module

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_auth.py
+++ b/lib/ansible/modules/cloud/openstack/os_auth.py
@@ -30,6 +30,11 @@ description:
 requirements:
     - "python >= 2.6"
     - "shade"
+options:
+  availability_zone:
+    description:
+      - Ignored. Present for backwards compatability
+    required: false
 extends_documentation_fragment: openstack
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_flavor_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_flavor_facts.py
@@ -80,6 +80,10 @@ options:
      required: false
      default: false
      version_added: "2.3"
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 extends_documentation_fragment: openstack
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_floating_ip.py
+++ b/lib/ansible/modules/cloud/openstack/os_floating_ip.py
@@ -87,6 +87,10 @@ options:
      required: false
      default: false
      version_added: "2.1"
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 requirements: ["shade"]
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_group.py
+++ b/lib/ansible/modules/cloud/openstack/os_group.py
@@ -43,6 +43,10 @@ options:
        - Should the resource be present or absent.
      choices: [present, absent]
      default: present
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 requirements:
     - "python >= 2.6"
     - "shade"

--- a/lib/ansible/modules/cloud/openstack/os_image.py
+++ b/lib/ansible/modules/cloud/openstack/os_image.py
@@ -92,6 +92,10 @@ options:
        - Should the resource be present or absent.
      choices: [present, absent]
      default: present
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 requirements: ["shade"]
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_image_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_image_facts.py
@@ -36,6 +36,10 @@ options:
      description:
         - Name or ID of the image
      required: true
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 extends_documentation_fragment: openstack
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_ironic.py
+++ b/lib/ansible/modules/cloud/openstack/os_ironic.py
@@ -118,10 +118,10 @@ options:
           re-assert the password field.
       required: false
       default: false
-   availability_zone:
-     description:
-       - Ignored. Present for backwards compatability
-     required: false
+    availability_zone:
+      description:
+        - Ignored. Present for backwards compatability
+      required: false
 
 requirements: ["shade", "jsonpatch"]
 '''

--- a/lib/ansible/modules/cloud/openstack/os_ironic.py
+++ b/lib/ansible/modules/cloud/openstack/os_ironic.py
@@ -118,6 +118,10 @@ options:
           re-assert the password field.
       required: false
       default: false
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 
 requirements: ["shade", "jsonpatch"]
 '''

--- a/lib/ansible/modules/cloud/openstack/os_ironic_inspect.py
+++ b/lib/ansible/modules/cloud/openstack/os_ironic_inspect.py
@@ -58,6 +58,10 @@ options:
         - A timeout in seconds to tell the role to wait for the node to complete introspection if wait is set to True.
       required: false
       default: 1200
+    availability_zone:
+      description:
+        - Ignored. Present for backwards compatability
+      required: false
 
 requirements: ["shade"]
 '''

--- a/lib/ansible/modules/cloud/openstack/os_ironic_node.py
+++ b/lib/ansible/modules/cloud/openstack/os_ironic_node.py
@@ -105,7 +105,11 @@ options:
       description:
         - An integer value representing the number of seconds to
           wait for the node activation or deactivation to complete.
-      version_added: "2.1"
+    availability_zone:
+      description:
+        - Ignored. Present for backwards compatability
+      required: false
+        version_added: "2.1"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/openstack/os_ironic_node.py
+++ b/lib/ansible/modules/cloud/openstack/os_ironic_node.py
@@ -105,11 +105,11 @@ options:
       description:
         - An integer value representing the number of seconds to
           wait for the node activation or deactivation to complete.
+      version_added: "2.1"
     availability_zone:
       description:
         - Ignored. Present for backwards compatability
       required: false
-        version_added: "2.1"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/openstack/os_keypair.py
+++ b/lib/ansible/modules/cloud/openstack/os_keypair.py
@@ -52,6 +52,10 @@ options:
       - Should the resource be present or absent.
     choices: [present, absent]
     default: present
+  availability_zone:
+    description:
+      - Ignored. Present for backwards compatability
+    required: false
 requirements: []
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_keystone_domain.py
+++ b/lib/ansible/modules/cloud/openstack/os_keystone_domain.py
@@ -48,6 +48,10 @@ options:
        - Should the resource be present or absent.
      choices: [present, absent]
      default: present
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 requirements:
     - "python >= 2.6"
     - "shade"

--- a/lib/ansible/modules/cloud/openstack/os_keystone_domain_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_keystone_domain_facts.py
@@ -41,6 +41,10 @@ options:
           this dictionary may be additional dictionaries.
      required: false
      default: None
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/openstack/os_keystone_role.py
+++ b/lib/ansible/modules/cloud/openstack/os_keystone_role.py
@@ -37,6 +37,10 @@ options:
        - Should the resource be present or absent.
      choices: [present, absent]
      default: present
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 requirements:
     - "python >= 2.6"
     - "shade"

--- a/lib/ansible/modules/cloud/openstack/os_keystone_service.py
+++ b/lib/ansible/modules/cloud/openstack/os_keystone_service.py
@@ -53,6 +53,10 @@ options:
        - Should the resource be present or absent.
      choices: [present, absent]
      default: present
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 requirements:
     - "python >= 2.6"
     - "shade"

--- a/lib/ansible/modules/cloud/openstack/os_network.py
+++ b/lib/ansible/modules/cloud/openstack/os_network.py
@@ -82,6 +82,10 @@ options:
      required: false
      default: None
      version_added: "2.1"
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 requirements: ["shade"]
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_networks_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_networks_facts.py
@@ -40,6 +40,10 @@ options:
         - A dictionary of meta data to use for further filtering.  Elements of
           this dictionary may be additional dictionaries.
      required: false
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 extends_documentation_fragment: openstack
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_nova_flavor.py
+++ b/lib/ansible/modules/cloud/openstack/os_nova_flavor.py
@@ -82,6 +82,10 @@ options:
           assigned if a value is not specified.
      required: false
      default: "auto"
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 requirements: ["shade"]
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_object.py
+++ b/lib/ansible/modules/cloud/openstack/os_object.py
@@ -54,6 +54,10 @@ options:
        - Should the resource be present or absent.
      choices: [present, absent]
      default: present
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/openstack/os_port.py
+++ b/lib/ansible/modules/cloud/openstack/os_port.py
@@ -101,6 +101,10 @@ options:
        - Should the resource be present or absent.
      choices: [present, absent]
      default: present
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/openstack/os_port_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_port_facts.py
@@ -45,6 +45,10 @@ options:
               the port dictionary, or strings within nested dictionaries.
         required: false
         default: null
+    availability_zone:
+      description:
+        - Ignored. Present for backwards compatability
+      required: false
 extends_documentation_fragment: openstack
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_project.py
+++ b/lib/ansible/modules/cloud/openstack/os_project.py
@@ -58,6 +58,10 @@ options:
        - Should the resource be present or absent.
      choices: [present, absent]
      default: present
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 requirements:
     - "python >= 2.6"
     - "shade"

--- a/lib/ansible/modules/cloud/openstack/os_project_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_project_facts.py
@@ -46,6 +46,10 @@ options:
           this dictionary may be additional dictionaries.
      required: false
      default: None
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/openstack/os_quota.py
+++ b/lib/ansible/modules/cloud/openstack/os_quota.py
@@ -156,6 +156,10 @@ options:
         required: False
         default: None
         description: Number of LVM volumes to allow.
+    availability_zone:
+      description:
+        - Ignored. Present for backwards compatability
+      required: false
 
 
 requirements:

--- a/lib/ansible/modules/cloud/openstack/os_recordset.py
+++ b/lib/ansible/modules/cloud/openstack/os_recordset.py
@@ -61,6 +61,10 @@ options:
        - Should the resource be present or absent.
      choices: [present, absent]
      default: present
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 requirements:
     - "python >= 2.6"
     - "shade"

--- a/lib/ansible/modules/cloud/openstack/os_router.py
+++ b/lib/ansible/modules/cloud/openstack/os_router.py
@@ -75,6 +75,10 @@ options:
         - List of subnets to attach to the router internal interface.
      required: false
      default: None
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 requirements: ["shade"]
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_security_group.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group.py
@@ -45,6 +45,10 @@ options:
        - Should the resource be present or absent.
      choices: [present, absent]
      default: present
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
@@ -74,6 +74,10 @@ options:
        - Should the resource be present or absent.
      choices: [present, absent]
      default: present
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 requirements: ["shade"]
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -192,6 +192,10 @@ options:
      required: false
      default: true
      version_added: "2.2"
+   availability_zone:
+     description:
+       - Availability zone in which to create the server.
+     required: false
 requirements:
     - "python >= 2.6"
     - "shade"

--- a/lib/ansible/modules/cloud/openstack/os_server_actions.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_actions.py
@@ -59,6 +59,10 @@ options:
        - Image the server should be rebuilt with
      default: null
      version_added: "2.3"
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 requirements:
     - "python >= 2.6"
     - "shade"

--- a/lib/ansible/modules/cloud/openstack/os_server_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_facts.py
@@ -45,6 +45,10 @@ options:
           of additional API calls.
      required: false
      default: false
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 extends_documentation_fragment: openstack
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_server_group.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_group.py
@@ -47,6 +47,10 @@ options:
           valid policy names are anti-affinity, affinity, soft-anti-affinity
           and soft-affinity.
      required: false
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 requirements:
     - "python >= 2.6"
     - "shade"

--- a/lib/ansible/modules/cloud/openstack/os_server_volume.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_volume.py
@@ -49,6 +49,10 @@ options:
       - Device you want to attach. Defaults to auto finding a device name.
      required: false
      default: None
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 requirements:
     - "python >= 2.6"
     - "shade"

--- a/lib/ansible/modules/cloud/openstack/os_stack.py
+++ b/lib/ansible/modules/cloud/openstack/os_stack.py
@@ -66,6 +66,10 @@ options:
         - Maximum number of seconds to wait for the stack creation
       required: false
       default: 3600
+    availability_zone:
+      description:
+        - Ignored. Present for backwards compatability
+      required: false
 requirements:
     - "python >= 2.6"
     - "shade"

--- a/lib/ansible/modules/cloud/openstack/os_subnet.py
+++ b/lib/ansible/modules/cloud/openstack/os_subnet.py
@@ -114,6 +114,10 @@ options:
      required: false
      default: None
      version_added: "2.1"
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 requirements:
     - "python >= 2.6"
     - "shade"

--- a/lib/ansible/modules/cloud/openstack/os_subnets_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_subnets_facts.py
@@ -40,6 +40,10 @@ options:
         - A dictionary of meta data to use for further filtering.  Elements of
           this dictionary may be additional dictionaries.
      required: false
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 extends_documentation_fragment: openstack
 '''
 

--- a/lib/ansible/modules/cloud/openstack/os_user.py
+++ b/lib/ansible/modules/cloud/openstack/os_user.py
@@ -73,6 +73,10 @@ options:
        - Should the resource be present or absent.
      choices: [present, absent]
      default: present
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 requirements:
     - "python >= 2.6"
     - "shade"

--- a/lib/ansible/modules/cloud/openstack/os_user_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_user_facts.py
@@ -46,6 +46,10 @@ options:
           this dictionary may be additional dictionaries.
      required: false
      default: None
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/openstack/os_user_group.py
+++ b/lib/ansible/modules/cloud/openstack/os_user_group.py
@@ -41,6 +41,10 @@ options:
        - Should the user be present or absent in the group
      choices: [present, absent]
      default: present
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 requirements:
     - "python >= 2.6"
     - "shade"

--- a/lib/ansible/modules/cloud/openstack/os_user_role.py
+++ b/lib/ansible/modules/cloud/openstack/os_user_role.py
@@ -63,6 +63,10 @@ options:
        - Should the roles be present or absent on the user.
      choices: [present, absent]
      default: present
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 requirements:
     - "python >= 2.6"
     - "shade"

--- a/lib/ansible/modules/cloud/openstack/os_volume.py
+++ b/lib/ansible/modules/cloud/openstack/os_volume.py
@@ -70,6 +70,10 @@ options:
        - Should the resource be present or absent.
      choices: [present, absent]
      default: present
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 requirements:
      - "python >= 2.6"
      - "shade"

--- a/lib/ansible/modules/cloud/openstack/os_zone.py
+++ b/lib/ansible/modules/cloud/openstack/os_zone.py
@@ -63,6 +63,10 @@ options:
        - Should the resource be present or absent.
      choices: [present, absent]
      default: present
+   availability_zone:
+     description:
+       - Ignored. Present for backwards compatability
+     required: false
 requirements:
     - "python >= 2.6"
     - "shade"

--- a/lib/ansible/utils/module_docs_fragments/openstack.py
+++ b/lib/ansible/utils/module_docs_fragments/openstack.py
@@ -48,10 +48,6 @@ options:
     description:
       - Name of the region.
     required: false
-  availability_zone:
-    description:
-      - Name of the availability zone.
-    required: false
   wait:
     description:
       - Should ansible wait until the requested resource is complete.


### PR DESCRIPTION
This argument is in the central list for hysterical raisins (mostly me
being a doofus) but is used in almost none of them. Document it
explicitly in each module to stop the confusion.
