### PR TITLE
Added sudo user to rsync path. Fixes #19746

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -341,7 +341,7 @@ class ActionModule(ActionBase):
                 # If no rsync_path is set, become was originally set, and dest is
                 # remote then add privilege escalation here.
                 if self._play_context.become_method == 'sudo':
-                    rsync_path = 'sudo rsync'
+                    rsync_path = 'sudo -u %s rsync' % self._play_context.become_user
                 # TODO: have to add in the rest of the become methods here
 
             # We cannot use privilege escalation on the machine running the


### PR DESCRIPTION
##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/synchronize.py

##### ANSIBLE VERSION
```
ansible 2.3.0
```

##### SUMMARY
This fixes #19746 by inserting the become user into the rsync path within the synchronize action plugin.
