### PR TITLE
Fix ansible-test selection of inventory file.

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -550,11 +550,11 @@ def command_integration_role(args, target, start_at_task):
 
     vars_file = 'integration_config.yml'
 
-    if 'windows/' in target.aliases:
+    if isinstance(args, WindowsIntegrationConfig):
         inventory = 'inventory.winrm'
         hosts = 'windows'
         gather_facts = False
-    elif 'network/' in target.aliases:
+    elif isinstance(args, NetworkIntegrationConfig):
         inventory = 'inventory.networking'
         hosts = target.name[:target.name.find('_')]
         gather_facts = False


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (at-fix 94f3331b58) last updated 2017/02/16 14:26:45 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Fix ansible-test selection of inventory file. This permits a test target to exist in both windows and posix integration tests at the same time.