### PR TITLE
Added example of referring to AWS-credentials

### DIFF
--- a/docs/docsite/rst/guide_aws.rst
+++ b/docs/docsite/rst/guide_aws.rst
@@ -42,6 +42,13 @@ For storing these in a vars_file, ideally encrypted with ansible-vault::
     ec2_access_key: "--REMOVED--"
     ec2_secret_key: "--REMOVED--"
 
+Note that if you store credentials in vars_file, you need to refer them in each AWS-module::
+
+    - ec2
+      aws_access_key: "{{ec2_access_key}}"
+      aws_secret_key: "{{ec2_secret_key}}"
+      image: "..."
+
 .. _aws_provisioning:
 
 Provisioning

--- a/docs/docsite/rst/guide_aws.rst
+++ b/docs/docsite/rst/guide_aws.rst
@@ -42,7 +42,7 @@ For storing these in a vars_file, ideally encrypted with ansible-vault::
     ec2_access_key: "--REMOVED--"
     ec2_secret_key: "--REMOVED--"
 
-Note that if you store credentials in vars_file, you need to refer them in each AWS-module::
+Note that if you store your credentials in vars_file, you need to refer to them in each AWS-module. For example::
 
     - ec2
       aws_access_key: "{{ec2_access_key}}"


### PR DESCRIPTION
.. when they're stored in variables. Spent few hours trying to figure out why credentials from vault/variables were not used.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Docs » Amazon Web Services Guide 

##### ANSIBLE VERSION
(I think that this is irrelevant but ok...)
```
ansible 2.0.0.2
  config file = /Users/joona/work/lambdascan/api/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
If storing AWS credentials to variables, they need to be referred from each AWS-module (ec2, iam_role, etc.). This was not clear from the documentation.
