### PR TITLE
allow renaming ec2.py and search for an ini file with the same name

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -220,12 +220,22 @@ class Ec2Inventory(object):
 
     def read_settings(self):
         ''' Reads the settings from the ec2.ini file '''
+
+        scriptbasename = __file__
+        scriptbasename = os.path.basename(scriptbasename)
+        scriptbasename = scriptbasename.replace('.py', '')
+
+        defaults = {'ec2': {
+            'ini_path': os.path.join(os.path.dirname(__file__), '%s.ini' % scriptbasename)
+            }
+        }
+
         if six.PY3:
             config = configparser.ConfigParser()
         else:
             config = configparser.SafeConfigParser()
-        ec2_default_ini_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'ec2.ini')
-        ec2_ini_path = os.path.expanduser(os.path.expandvars(os.environ.get('EC2_INI_PATH', ec2_default_ini_path)))
+        ec2_ini_path = os.environ.get('EC2_INI_PATH', defaults['ec2']['ini_path'])
+        ec2_ini_path = os.path.expanduser(os.path.expandvars(ec2_ini_path))
         config.read(ec2_ini_path)
 
         # is eucalyptus?


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
contrib/ec2.py

##### ANSIBLE VERSION
irrelevant

##### SUMMARY
With this proposed PR, we want to make the use of many ec2 dynamic inventory files more flexible.
We are using multiple AWS accounts. We want to use different ini file (one for every account) and only one ec2.py.

p.s. Inspired by `vmware_inventory.py` ;-)