### PR TITLE
synchronize: quote private_key

### DIFF
--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -438,7 +438,7 @@ def main():
     if private_key is None:
         private_key = ''
     else:
-        private_key = '-i '+ private_key
+        private_key = '-i "%s"' % private_key
 
     ssh_opts = '-S none'
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
synchronize

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel a5d34f2ac2) last updated 2017/02/17 12:43:51 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

Assume an inventory that tells Ansible which ssh key to use, and that key has a space:
```
default ansible_ssh_host=192.168.121.10 ansible_ssh_port=22 ansible_ssh_user='vagrant' ansible_ssh_private_key_file='/home/user/Some Folder/.vagrant/machines/default/libvirt/private_key'
``` 

And a simple task to synchronize a file:
```
    - name: synchronize a file
      synchronize:
        src: /etc/issue
        dest: /tmp/issue2
```

This will currently fail when passing the key to `rsync`'s `--rsh` option:

```
fatal: [default]: FAILED! => {"changed": false, "cmd": "/usr/bin/rsync --delay-updates -F --compress --archive --rsh 'ssh -i /home/user/Some Folder/.vagrant/machines/default/libvirt/private_key -S none -o StrictHostKeyChecking=no -o Port=22' --out-format='<<CHANGED>>%i %n%L' \"/etc/issue\" \"vagrant@192.168.121.10:/tmp/issue2\"", "failed": true, "msg": "Warning: Identity file /home/user/Some not accessible: No such file or directory.\nssh: Could not resolve hostname folder/.vagrant/machines/default/libvirt/private_key: No address associated with hostname\r\nrsync: connection unexpectedly closed (0 bytes received so far) [sender]\nrsync error: unexplained error (code 255) at io.c(226) [sender=3.1.2]\n", "rc": 255}
```

Simply adding double-quotes around the string solves the issue. Using double-quotes as single-quotes are already used for `--rsh 'ssh …'`.