### PR TITLE
Introduce module.warn() in all modules

### DIFF
--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -61,12 +61,13 @@ eos_argument_spec = {
     'transport': dict(choices=['cli', 'eapi'])
 }
 
-def check_args(module, warnings):
+# NOTE: Below warnings parameter is a leftover for compatibility
+def check_args(module, warnings=None):
     provider = module.params['provider'] or {}
     for key in eos_argument_spec:
         if key not in ['provider', 'transport'] and module.params[key]:
-            warnings.append('argument %s has been deprecated and will be '
-                    'removed in a future version' % key)
+            module.warn('argument %s has been deprecated and will be '
+                        'removed in a future version' % key)
 
 def load_params(module):
     provider = module.params.get('provider') or dict()

--- a/lib/ansible/module_utils/ios.py
+++ b/lib/ansible/module_utils/ios.py
@@ -43,12 +43,13 @@ ios_argument_spec = {
     'provider': dict(type='dict'),
 }
 
-def check_args(module, warnings):
+# NOTE: Below warnings parameter is a leftover for compatibility
+def check_args(module, warnings=None):
     provider = module.params['provider'] or {}
     for key in ios_argument_spec:
         if key != 'provider' and module.params[key]:
-            warnings.append('argument %s has been deprecated and will be '
-                    'removed in a future version' % key)
+            module.warn('argument %s has been deprecated and will be '
+                        'removed in a future version' % key)
 
 def get_config(module, flags=[]):
     cmd = 'show running-config '

--- a/lib/ansible/module_utils/iosxr.py
+++ b/lib/ansible/module_utils/iosxr.py
@@ -42,12 +42,13 @@ iosxr_argument_spec = {
     'provider': dict(type='dict', no_log=True)
 }
 
-def check_args(module, warnings):
+# NOTE: Below warnings parameter is a leftover for compatibility
+def check_args(module, warnings=None):
     provider = module.params['provider'] or {}
     for key in iosxr_argument_spec:
         if key != 'provider' and module.params[key]:
-            warnings.append('argument %s has been deprecated and will be '
-                    'removed in a future version' % key)
+            module.warn('argument %s has been deprecated and will be '
+                        'removed in a future version' % key)
 
 def get_config(module, flags=[]):
     cmd = 'show running-config '

--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -43,12 +43,13 @@ junos_argument_spec = {
     'provider': dict(type='dict'),
 }
 
-def check_args(module, warnings):
+# NOTE: Below warnings parameter is a leftover for compatibility
+def check_args(module, warnings=None):
     provider = module.params['provider'] or {}
     for key in junos_argument_spec:
         if key in ('provider', 'transport') and module.params[key]:
-            warnings.append('argument %s has been deprecated and will be '
-                    'removed in a future version' % key)
+            module.warn('argument %s has been deprecated and will be '
+                        'removed in a future version' % key)
 
 def validate_rollback_id(value):
     try:

--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -54,12 +54,13 @@ nxos_argument_spec = {
     'transport': dict(choices=['cli', 'nxapi'])
 }
 
-def check_args(module, warnings):
+# NOTE: Below warnings parameter is a leftover for compatibility
+def check_args(module, warnings=None):
     provider = module.params['provider'] or {}
     for key in nxos_argument_spec:
         if key not in ['provider', 'transport'] and module.params[key]:
-            warnings.append('argument %s has been deprecated and will be '
-                    'removed in a future version' % key)
+            module.warn('argument %s has been deprecated and will be '
+                        'removed in a future version' % key)
 
 def load_params(module):
     provider = module.params.get('provider') or dict()

--- a/lib/ansible/module_utils/vyos.py
+++ b/lib/ansible/module_utils/vyos.py
@@ -43,12 +43,13 @@ vyos_argument_spec = {
     'provider': dict(type='dict', no_log=True),
 }
 
-def check_args(module, warnings):
+# NOTE: Below warnings parameter is a leftover for compatibility
+def check_args(module, warnings=None):
     provider = module.params['provider'] or {}
     for key in vyos_argument_spec:
         if key != 'provider' and module.params[key]:
-            warnings.append('argument %s has been deprecated and will be '
-                    'removed in a future version' % key)
+            module.warn('argument %s has been deprecated and will be '
+                        'removed in a future version' % key)
 
 def get_config(module, target='commands'):
     cmd = ' '.join(['show configuration', target])

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -493,9 +493,9 @@ def main():
             module.fail_json(msg=boto_exception(err), exception=traceback.format_exc())
 
     if module.params['template_format'] is not None:
-        result['warnings'] = [('Argument `template_format` is deprecated '
-            'since Ansible 2.3, JSON and YAML templates are now passed '
-            'directly to the CloudFormation API.')]
+        module.warn('Argument `template_format` is deprecated '
+                    'since Ansible 2.3, JSON and YAML templates are now passed '
+                    'directly to the CloudFormation API.')
     module.exit_json(**result)
 
 # import module snippets

--- a/lib/ansible/modules/cloud/amazon/ec2_eip.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eip.py
@@ -388,7 +388,7 @@ def main():
         module.fail_json(msg="parameters are required together: ('device_id', 'private_ip_address')")
 
     if instance_id:
-        warnings = ["instance_id is no longer used, please use device_id going forward"]
+        module.warn("instance_id is no longer used, please use device_id going forward")
         is_instance = True
         device_id = instance_id
     else:
@@ -429,8 +429,6 @@ def main():
     except (boto.exception.EC2ResponseError, EIPException) as e:
         module.fail_json(msg=str(e))
 
-    if instance_id:
-        result['warnings'] = warnings
     module.exit_json(**result)
 
 # import module snippets

--- a/lib/ansible/modules/files/assemble.py
+++ b/lib/ansible/modules/files/assemble.py
@@ -171,7 +171,7 @@ def assemble_from_fragments(src_path, delimiter=None, compiled_regexp=None, igno
     return temp_path
 
 
-def cleanup(path, result=None):
+def cleanup(module, path):
     # cleanup just in case
     if os.path.exists(path):
         try:
@@ -179,8 +179,7 @@ def cleanup(path, result=None):
         except (IOError, OSError):
             e = get_exception()
             # don't error on possible race conditions, but keep warning
-            if result is not None:
-                result['warnings'] = ['Unable to remove temp file (%s): %s' % (path, str(e))]
+            module.warn('Unable to remove temp file (%s): %s' % (path, e))
 
 
 def main():
@@ -248,7 +247,7 @@ def main():
             (rc, out, err) = module.run_command(validate % path)
             result['validation'] = dict(rc=rc, stdout=out, stderr=err)
             if rc != 0:
-                cleanup(path)
+                cleanup(module, path)
                 module.fail_json(msg="failed to validate: rc:%s error:%s" % (rc, err))
         if backup and dest_hash is not None:
             result['backup_file'] = module.backup_local(dest)
@@ -256,7 +255,7 @@ def main():
         module.atomic_move(path, dest, unsafe_writes=module.params['unsafe_writes'])
         changed = True
 
-    cleanup(path, result)
+    cleanup(module, path)
 
     # handle file permissions
     file_args = module.load_file_common_arguments(module.params)

--- a/lib/ansible/modules/network/asa/asa_command.py
+++ b/lib/ansible/modules/network/asa/asa_command.py
@@ -174,14 +174,12 @@ def main():
     commands = list(parse_commands(module))
     conditionals = module.params['wait_for'] or list()
 
-    warnings = list()
-
     runner = CommandRunner(module)
 
     for cmd in commands:
         if module.check_mode and not cmd['command'].startswith('show'):
-            warnings.append('only show commands are supported when using '
-                            'check mode, not executing `%s`' % cmd['command'])
+            module.warn('only show commands are supported when using '
+                        'check mode, not executing `%s`' % cmd['command'])
         else:
             if cmd['command'].startswith('conf'):
                 module.fail_json(msg='asa_command does not support running '
@@ -191,7 +189,7 @@ def main():
                 runner.add_command(**cmd)
             except AddCommandError:
                 exc = get_exception()
-                warnings.append('duplicate command detected: %s' % cmd)
+                module.warn('duplicate command detected: %s' % cmd)
 
     for item in conditionals:
         runner.add_conditional(item)
@@ -218,7 +216,6 @@ def main():
             output = 'command not executed due to check_mode, see warnings'
         result['stdout'].append(output)
 
-    result['warnings'] = warnings
     result['stdout_lines'] = list(to_lines(result['stdout']))
 
     module.exit_json(**result)

--- a/lib/ansible/modules/network/cloudengine/ce_command.py
+++ b/lib/ansible/modules/network/cloudengine/ce_command.py
@@ -205,14 +205,12 @@ def main():
     commands = list(parse_commands(module))
     conditionals = module.params['wait_for'] or list()
 
-    warnings = list()
-
     runner = CommandRunner(module)
 
     for cmd in commands:
         if module.check_mode and not cmd['command'].startswith('dis'):
-            warnings.append('only display commands are supported when using '
-                            'check mode, not executing `%s`' % cmd['command'])
+            module.warn('only display commands are supported when using '
+                        'check mode, not executing `%s`' % cmd['command'])
         else:
             if cmd['command'].startswith('sys'):
                 module.fail_json(msg='ce_command does not support running '
@@ -222,7 +220,7 @@ def main():
                 runner.add_command(**cmd)
             except AddCommandError:
                 exc = get_exception()
-                warnings.append('duplicate command detected: %s' % cmd)
+                module.warn('duplicate command detected: %s' % cmd)
 
     try:
         for item in conditionals:
@@ -258,7 +256,6 @@ def main():
             output = 'command not executed due to check_mode, see warnings'
         result['stdout'].append(output)
 
-    result['warnings'] = warnings
     result['stdout_lines'] = list(to_lines(result['stdout']))
 
     module.exit_json(**result)

--- a/lib/ansible/modules/network/dellos10/dellos10_command.py
+++ b/lib/ansible/modules/network/dellos10/dellos10_command.py
@@ -166,14 +166,12 @@ def main():
     commands = module.params['commands']
     conditionals = module.params['wait_for'] or list()
 
-    warnings = list()
-
     runner = CommandRunner(module)
 
     for cmd in commands:
         if module.check_mode and not cmd.startswith('show'):
-            warnings.append('only show commands are supported when using '
-                            'check mode, not executing `%s`' % cmd)
+            module.warn('only show commands are supported when using '
+                        'check mode, not executing `%s`' % cmd)
         else:
             if cmd.startswith('conf'):
                 module.fail_json(msg='dellos10_command does not support running '
@@ -207,7 +205,6 @@ def main():
         result['stdout'].append(output)
 
 
-    result['warnings'] = warnings
     result['stdout_lines'] = list(to_lines(result['stdout']))
 
     module.exit_json(**result)

--- a/lib/ansible/modules/network/dellos6/dellos6_command.py
+++ b/lib/ansible/modules/network/dellos6/dellos6_command.py
@@ -166,14 +166,12 @@ def main():
     commands = module.params['commands']
     conditionals = module.params['wait_for'] or list()
 
-    warnings = list()
-
     runner = CommandRunner(module)
 
     for cmd in commands:
         if module.check_mode and not cmd.startswith('show'):
-            warnings.append('only show commands are supported when using '
-                            'check mode, not executing `%s`' % cmd)
+            module.warn('only show commands are supported when using '
+                        'check mode, not executing `%s`' % cmd)
         else:
             if cmd.startswith('conf'):
                 module.fail_json(msg='dellos6_command does not support running '
@@ -206,7 +204,6 @@ def main():
             output = 'command not executed due to check_mode, see warnings'
         result['stdout'].append(output)
 
-    result['warnings'] = warnings
     result['stdout_lines'] = list(to_lines(result['stdout']))
 
     module.exit_json(**result)

--- a/lib/ansible/modules/network/dellos9/dellos9_command.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_command.py
@@ -177,14 +177,12 @@ def main():
     commands = module.params['commands']
     conditionals = module.params['wait_for'] or list()
 
-    warnings = list()
-
     runner = CommandRunner(module)
 
     for cmd in commands:
         if module.check_mode and not cmd.startswith('show'):
-            warnings.append('only show commands are supported when using '
-                            'check mode, not executing `%s`' % cmd)
+            module.warn('only show commands are supported when using '
+                        'check mode, not executing `%s`' % cmd)
         else:
             if cmd.startswith('conf'):
                 module.fail_json(msg='dellos9_command does not support running '
@@ -217,7 +215,6 @@ def main():
             output = 'command not executed due to check_mode, see warnings'
         result['stdout'].append(output)
 
-    result['warnings'] = warnings
     result['stdout_lines'] = list(to_lines(result['stdout']))
 
     module.exit_json(**result)

--- a/lib/ansible/modules/network/eos/_eos_template.py
+++ b/lib/ansible/modules/network/eos/_eos_template.py
@@ -181,11 +181,9 @@ def main():
                            mutually_exclusive=mutually_exclusive,
                            supports_check_mode=True)
 
-    warnings = check_args(module)
+    check_args(module)
 
     result = {'changed': False}
-    if warnings:
-        result['warnings'] = warnings
 
     src = module.params['src']
     candidate = NetworkConfig(contents=src, indent=3)

--- a/lib/ansible/modules/network/eos/eos_command.py
+++ b/lib/ansible/modules/network/eos/eos_command.py
@@ -142,7 +142,7 @@ def to_lines(stdout):
         lines.append(item)
     return lines
 
-def parse_commands(module, warnings):
+def parse_commands(module):
     spec = dict(
         command=dict(key=True),
         output=dict(),
@@ -155,7 +155,7 @@ def parse_commands(module, warnings):
 
     for index, item in enumerate(commands):
         if module.check_mode and not item['command'].startswith('show'):
-            warnings.append(
+            module.warn(
                 'Only show commands are supported when using check_mode, not '
                 'executing %s' % item['command']
             )
@@ -188,11 +188,8 @@ def main():
 
     result = {'changed': False}
 
-    warnings = list()
-    check_args(module, warnings)
-    commands = parse_commands(module, warnings)
-    if warnings:
-        result['warnings'] = warnings
+    check_args(module)
+    commands = parse_commands(module)
 
     wait_for = module.params['wait_for'] or list()
 

--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -210,12 +210,12 @@ from ansible.module_utils.eos import run_commands
 from ansible.module_utils.eos import eos_argument_spec
 from ansible.module_utils.eos import check_args as eos_check_args
 
-def check_args(module, warnings):
-    eos_check_args(module, warnings)
+def check_args(module):
+    eos_check_args(module)
     if module.params['force']:
-        warnings.append('The force argument is deprecated, please use '
-                        'match=none instead.  This argument will be '
-                        'removed in the future')
+        module.warn('The force argument is deprecated, please use '
+                    'match=none instead.  This argument will be '
+                    'removed in the future')
 
 def get_candidate(module):
     candidate = NetworkConfig(indent=3)
@@ -307,12 +307,9 @@ def main():
     if module.params['force'] is True:
         module.params['match'] = 'none'
 
-    warnings = list()
-    check_args(module, warnings)
+    check_args(module)
 
     result = {'changed': False}
-    if warnings:
-        result['warnings'] = warnings
 
     if module.params['backup']:
         result['__backup__'] = get_config(module)

--- a/lib/ansible/modules/network/ios/_ios_template.py
+++ b/lib/ansible/modules/network/ios/_ios_template.py
@@ -147,9 +147,7 @@ def main():
     candidate = NetworkConfig(contents=module.params['src'], indent=1)
 
     result = {'changed': False}
-    warnings = list()
-    check_args(module, warnings)
-    result['warnings'] = warnings
+    check_args(module)
 
     if module.params['backup']:
         result['__backup__'] = get_config(module=module)

--- a/lib/ansible/modules/network/ios/ios_command.py
+++ b/lib/ansible/modules/network/ios/ios_command.py
@@ -144,7 +144,7 @@ def to_lines(stdout):
             item = str(item).split('\n')
         yield item
 
-def parse_commands(module, warnings):
+def parse_commands(module):
     command = ComplexList(dict(
         command=dict(key=True),
         prompt=dict(),
@@ -153,7 +153,7 @@ def parse_commands(module, warnings):
     commands = command(module.params['commands'])
     for index, item in enumerate(commands):
         if module.check_mode and not item['command'].startswith('show'):
-            warnings.append(
+            module.warn(
                 'only show commands are supported when using check mode, not '
                 'executing `%s`' % item['command']
             )
@@ -185,10 +185,8 @@ def main():
 
     result = {'changed': False}
 
-    warnings = list()
-    check_args(module, warnings)
-    commands = parse_commands(module, warnings)
-    result['warnings'] = warnings
+    check_args(module)
+    commands = parse_commands(module)
 
     wait_for = module.params['wait_for'] or list()
     conditionals = [Conditional(c) for c in wait_for]

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -216,16 +216,16 @@ from ansible.module_utils.netcfg import NetworkConfig, dumps
 from ansible.module_utils.six import iteritems
 
 
-def check_args(module, warnings):
-    ios_check_args(module, warnings)
+def check_args(module):
+    ios_check_args(module)
     if module.params['multiline_delimiter']:
         if len(module.params['multiline_delimiter']) != 1:
             module.fail_json(msg='multiline_delimiter value can only be a '
                                  'single character')
     if module.params['force']:
-        warnings.append('The force argument is deprecated as of Ansible 2.2, '
-                        'please use match=none instead.  This argument will '
-                        'be removed in the future')
+        module.warn('The force argument is deprecated as of Ansible 2.2, '
+                    'please use match=none instead.  This argument will '
+                    'be removed in the future')
 
 def extract_banners(config):
     banners = {}
@@ -332,9 +332,7 @@ def main():
 
     result = {'changed': False}
 
-    warnings = list()
-    check_args(module, warnings)
-    result['warnings'] = warnings
+    check_args(module)
 
     if any((module.params['lines'], module.params['src'])):
         match = module.params['match']

--- a/lib/ansible/modules/network/ios/ios_system.py
+++ b/lib/ansible/modules/network/ios/ios_system.py
@@ -357,9 +357,7 @@ def main():
 
     result = {'changed': False}
 
-    warnings = list()
-    check_args(module, warnings)
-    result['warnings'] = warnings
+    check_args(module)
 
     want = map_params_to_obj(module)
     have = map_config_to_obj(module)

--- a/lib/ansible/modules/network/ios/ios_vrf.py
+++ b/lib/ansible/modules/network/ios/ios_vrf.py
@@ -338,9 +338,7 @@ def main():
 
     result = {'changed': False}
 
-    warnings = list()
-    check_args(module, warnings)
-    result['warnings'] = warnings
+    check_args(module)
 
     want = map_params_to_obj(module)
     have = map_config_to_obj(module)

--- a/lib/ansible/modules/network/iosxr/iosxr_command.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_command.py
@@ -142,7 +142,7 @@ def to_lines(stdout):
             item = str(item).split('\n')
         yield item
 
-def parse_commands(module, warnings):
+def parse_commands(module):
     command = ComplexList(dict(
         command=dict(key=True),
         prompt=dict(),
@@ -152,7 +152,7 @@ def parse_commands(module, warnings):
 
     for index, item in enumerate(commands):
         if module.check_mode and not item['command'].startswith('show'):
-            warnings.append(
+            module.warn(
                 'only show commands are supported when using check mode, not '
                 'executing `%s`' % item['command']
             )
@@ -180,10 +180,9 @@ def main():
     module = AnsibleModule(argument_spec=spec,
                            supports_check_mode=True)
 
-    warnings = list()
-    check_args(module, warnings)
+    check_args(module)
 
-    commands = parse_commands(module, warnings)
+    commands = parse_commands(module)
 
     wait_for = module.params['wait_for'] or list()
     conditionals = [Conditional(c) for c in wait_for]
@@ -217,7 +216,6 @@ def main():
     result = {
         'changed': False,
         'stdout': responses,
-        'warnings': warnings,
         'stdout_lines': list(to_lines(responses))
     }
 

--- a/lib/ansible/modules/network/iosxr/iosxr_system.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_system.py
@@ -245,10 +245,9 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
 
-    warnings = list()
-    check_args(module, warnings)
+    check_args(module)
 
-    result = {'changed': False, 'warnings': warnings}
+    result = {'changed': False}
 
     want = map_params_to_obj(module)
     have = map_config_to_obj(module)

--- a/lib/ansible/modules/network/junos/junos_command.py
+++ b/lib/ansible/modules/network/junos/junos_command.py
@@ -137,8 +137,8 @@ from ansible.module_utils.six import string_types
 from ansible.module_utils.netcli import Conditional
 from ansible.module_utils.network_common import ComplexList
 
-def check_args(module, warnings):
-    junos_check_args(module, warnings)
+def check_args(module):
+    junos_check_args(module)
 
     if module.params['rpcs']:
         module.fail_json(msg='argument rpcs has been deprecated, please use '
@@ -152,7 +152,7 @@ def to_lines(stdout):
         lines.append(item)
     return lines
 
-def parse_commands(module, warnings):
+def parse_commands(module):
     spec = dict(
         command=dict(key=True),
         output=dict(default=module.params['display'], choices=['text', 'json']),
@@ -165,7 +165,7 @@ def parse_commands(module, warnings):
 
     for index, item in enumerate(commands):
         if module.check_mode and not item['command'].startswith('show'):
-            warnings.append(
+            module.warn(
                 'Only show commands are supported when using check_mode, not '
                 'executing %s' % item['command']
             )
@@ -202,10 +202,9 @@ def main():
                            supports_check_mode=True)
 
 
-    warnings = list()
-    check_args(module, warnings)
+    check_args(module)
 
-    commands = parse_commands(module, warnings)
+    commands = parse_commands(module)
 
     wait_for = module.params['wait_for'] or list()
     conditionals = [Conditional(c) for c in wait_for]
@@ -237,7 +236,6 @@ def main():
 
     result = {
         'changed': False,
-        'warnings': warnings,
         'stdout': responses,
         'stdout_lines': to_lines(responses)
     }

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -187,7 +187,7 @@ from ansible.module_utils.netcfg import NetworkConfig
 
 DEFAULT_COMMENT = 'configured by junos_config'
 
-def check_args(module, warnings):
+def check_args(module):
     if module.params['zeroize']:
         module.fail_json(msg='argument zeroize is deprecated and no longer '
                 'supported, use junos_command instead')
@@ -323,10 +323,9 @@ def main():
                            mutually_exclusive=mutually_exclusive,
                            supports_check_mode=True)
 
-    warnings = list()
-    check_args(module, warnings)
+    check_args(module)
 
-    result = {'changed': False, 'warnings': warnings}
+    result = {'changed': False}
 
     if module.params['backup']:
         result['__backup__'] = get_configuration()

--- a/lib/ansible/modules/network/junos/junos_netconf.py
+++ b/lib/ansible/modules/network/junos/junos_netconf.py
@@ -147,10 +147,9 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
 
-    warnings = list()
-    check_args(module, warnings)
+    check_args(module)
 
-    result = {'changed': False, 'warnings': warnings}
+    result = {'changed': False}
 
     want = map_params_to_obj(module)
     have = map_config_to_obj(module)

--- a/lib/ansible/modules/network/openswitch/ops_command.py
+++ b/lib/ansible/modules/network/openswitch/ops_command.py
@@ -176,14 +176,12 @@ def main():
     commands = list(parse_commands(module))
     conditionals = module.params['wait_for'] or list()
 
-    warnings = list()
-
     runner = CommandRunner(module)
 
     for cmd in commands:
         if module.check_mode and not cmd['command'].startswith('show'):
-            warnings.append('only show commands are supported when using '
-                            'check mode, not executing `%s`' % cmd['command'])
+            module.warn('only show commands are supported when using '
+                        'check mode, not executing `%s`' % cmd['command'])
         else:
             if cmd['command'].startswith('conf'):
                 module.fail_json(msg='ops_command does not support running '
@@ -193,7 +191,7 @@ def main():
                 runner.add_command(**cmd)
             except AddCommandError:
                 exc = get_exception()
-                warnings.append('duplicate command detected: %s' % cmd)
+                module.warn('duplicate command detected: %s' % cmd)
 
     for item in conditionals:
         runner.add_conditional(item)
@@ -220,7 +218,6 @@ def main():
             output = 'command not executed due to check_mode, see warnings'
         result['stdout'].append(output)
 
-    result['warnings'] = warnings
     result['stdout_lines'] = list(to_lines(result['stdout']))
 
     module.exit_json(**result)

--- a/lib/ansible/modules/network/sros/sros_command.py
+++ b/lib/ansible/modules/network/sros/sros_command.py
@@ -186,14 +186,12 @@ def main():
     commands = list(parse_commands(module))
     conditionals = module.params['wait_for'] or list()
 
-    warnings = list()
-
     runner = CommandRunner(module)
 
     for cmd in commands:
         if module.check_mode and not cmd['command'].startswith('show'):
-            warnings.append('only show commands are supported when using '
-                            'check mode, not executing `%s`' % cmd['command'])
+            module.warn('only show commands are supported when using '
+                        'check mode, not executing `%s`' % cmd['command'])
         else:
             if cmd['command'].startswith('conf'):
                 module.fail_json(msg='sros_command does not support running '
@@ -203,7 +201,7 @@ def main():
                 runner.add_command(**cmd)
             except AddCommandError:
                 exc = get_exception()
-                warnings.append('duplicate command detected: %s' % cmd)
+                module.warn('duplicate command detected: %s' % cmd)
 
     for item in conditionals:
         runner.add_conditional(item)
@@ -230,7 +228,6 @@ def main():
             output = 'command not executed due to check_mode, see warnings'
         result['stdout'].append(output)
 
-    result['warnings'] = warnings
     result['stdout_lines'] = list(to_lines(result['stdout']))
 
     module.exit_json(**result)

--- a/lib/ansible/modules/network/sros/sros_config.py
+++ b/lib/ansible/modules/network/sros/sros_config.py
@@ -258,10 +258,9 @@ def run(module, result):
 
         # check if creating checkpoints is possible
         if not module.connection.rollback_enabled:
-            warn = 'Cannot create checkpoint.  Please enable this feature ' \
-                   'using the sros_rollback module.  Automatic rollback ' \
-                   'will be disabled'
-            result['warnings'].append(warn)
+            module.warn('Cannot create checkpoint.  Please enable this feature ' \
+                        'using the sros_rollback module.  Automatic rollback ' \
+                        'will be disabled')
 
         # send the configuration commands to the device and merge
         # them with the current running config
@@ -299,7 +298,7 @@ def main():
                            mutually_exclusive=mutually_exclusive,
                            supports_check_mode=True)
 
-    result = dict(changed=False, warnings=list())
+    result = dict(changed=False)
 
     if module.params['backup']:
         result['__backup__'] = module.config.get_config()

--- a/lib/ansible/modules/network/vyos/vyos_command.py
+++ b/lib/ansible/modules/network/vyos/vyos_command.py
@@ -147,7 +147,7 @@ def to_lines(stdout):
         yield item
 
 
-def parse_commands(module, warnings):
+def parse_commands(module):
     command = ComplexList(dict(
         command=dict(key=True),
         prompt=dict(),
@@ -157,8 +157,8 @@ def parse_commands(module, warnings):
 
     for index, cmd in enumerate(commands):
         if module.check_mode and not cmd['command'].startswith('show'):
-            warnings.append('only show commands are supported when using '
-                            'check mode, not executing `%s`' % cmd['command'])
+            module.warn('only show commands are supported when using '
+                        'check mode, not executing `%s`' % cmd['command'])
         commands[index] = module.jsonify(cmd)
 
     return commands
@@ -179,10 +179,9 @@ def main():
 
     module = AnsibleModule(argument_spec=spec, supports_check_mode=True)
 
-    warnings = list()
-    check_args(module, warnings)
+    check_args(module)
 
-    commands = parse_commands(module, warnings)
+    commands = parse_commands(module)
 
     wait_for = module.params['wait_for'] or list()
     conditionals = [Conditional(c) for c in wait_for]
@@ -214,7 +213,6 @@ def main():
     result = {
         'changed': False,
         'stdout': responses,
-        'warnings': warnings,
         'stdout_lines': list(to_lines(responses)),
     }
 

--- a/lib/ansible/modules/network/vyos/vyos_config.py
+++ b/lib/ansible/modules/network/vyos/vyos_config.py
@@ -227,8 +227,7 @@ def run(module, result):
         load_config(module, commands, commit=commit, comment=comment, save=save)
 
         if result.get('filtered'):
-            result['warnings'].append('Some configuration commands were '
-                                      'removed, please see the filtered key')
+            module.warn('Some configuration commands were removed, please see the filtered key')
 
         result['changed'] = True
 
@@ -258,10 +257,9 @@ def main():
         supports_check_mode=True
     )
 
-    warnings = list()
-    check_args(module, warnings)
+    check_args(module)
 
-    result = dict(changed=False, warnings=warnings)
+    result = dict(changed=False)
 
     if module.params['backup']:
         result['__backup__'] = get_config(module=module)

--- a/lib/ansible/modules/network/vyos/vyos_system.py
+++ b/lib/ansible/modules/network/vyos/vyos_system.py
@@ -194,10 +194,9 @@ def main():
         mutually_exclusive=[('domain_name', 'domain_search')],
     )
 
-    warnings = list()
-    check_args(module, warnings)
+    check_args(module)
 
-    result = {'changed': False, 'warnings': warnings}
+    result = {'changed': False}
 
     want = map_param_to_obj(module)
     have = config_to_dict(module)

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -964,7 +964,7 @@ def main():
     git_version_used = git_version(git_path, module)
 
     if depth is not None and git_version_used < LooseVersion('1.9.1'):
-        result['warnings'].append("Your git version is too old to fully support the depth argument. Falling back to full checkouts.")
+        module.warn("Your git version is too old to fully support the depth argument. Falling back to full checkouts.")
         depth = None
 
     recursive = module.params['recursive']

--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -631,9 +631,7 @@ def main():
         linux_mounts = get_linux_mounts(module)
 
         if linux_mounts is None:
-            args['warnings'] = (
-                'Cannot open file /proc/self/mountinfo. '
-                'Bind mounts might be misinterpreted.')
+            module.warn('Cannot open file /proc/self/mountinfo. Bind mounts might be misinterpreted.')
 
     # Override defaults with user specified params
     for key in ('src', 'fstype', 'passno', 'opts', 'dump', 'fstab'):


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Various modules, incl: cloudformation ec2_eip assemble git mount asa_command ce_command  dellos10_command dellos6_command dellos9_command eos_command ios_command iosxr_command junos_command ops_command sros_command vyos_command

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
This is a small rewrite of all warnings to use module.warn()
We kept compatibility with check_args() in the various common network
libraries in module_utils so that out-of-tree modules keep on working.