### PR TITLE
Improve YAMLSyntax/Gotchas

### DIFF
--- a/docs/docsite/rst/YAMLSyntax.rst
+++ b/docs/docsite/rst/YAMLSyntax.rst
@@ -123,9 +123,17 @@ While YAML is generally friendly, the following is going to result in a YAML syn
 
     foo: somebody said I should put a colon here: so I did
 
-You will want to quote any hash values using colons, like so::
+    windows_drive: c:
+
+But this will work::
+
+    windows_path: c:\windows
+
+You will want to quote hash values using colons followed by a space or the end of the line::
 
     foo: "somebody said I should put a colon here: so I did"
+    
+    windows_drive: "c:"
 
 And then the colon will be preserved.
 

--- a/docs/docsite/rst/YAMLSyntax.rst
+++ b/docs/docsite/rst/YAMLSyntax.rst
@@ -125,7 +125,7 @@ While YAML is generally friendly, the following is going to result in a YAML syn
 
     windows_drive: c:
 
-But this will work::
+...but this will work::
 
     windows_path: c:\windows
 
@@ -135,7 +135,7 @@ You will want to quote hash values using colons followed by a space or the end o
     
     windows_drive: "c:"
 
-And then the colon will be preserved.
+...and then the colon will be preserved.
 
 Further, Ansible uses "{{ var }}" for variables.  If a value after a colon starts
 with a "{", YAML will think it is a dictionary, so you must quote it, like so::


### PR DESCRIPTION
Colons don't need to be quoted unless when followed by a space or the end of the line

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
YAMLSyntax.rst

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel d3d1aa2dca) last updated 2017/02/17 14:45:39 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
The documentation was incomplete regarding the need to quote colons in a hash value. Improved it as per [this comment](https://github.com/ansible/ansible/issues/20595#issuecomment-280647415).