### PR TITLE
[WIP] Replace Foreman and Katello all encompassing modules with specific mo…

### DIFF
--- a/lib/ansible/modules/remote_management/foreman/foreman_organization.py
+++ b/lib/ansible/modules/remote_management/foreman/foreman_organization.py
@@ -1,0 +1,142 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# (c) 2016, Eric D Helms <ericdhelms@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: foreman_organization
+short_description: Manage Foreman Organization
+description:
+    - Manage Foreman Organization
+author: "Eric D Helms (@ehelms)"
+requirements:
+    - "nailgun >= 0.28.0"
+    - "python >= 2.6"
+    - datetime
+options:
+    server_url:
+        description:
+            - URL of Foreman server
+        required: true
+    username:
+        description:
+            - Username on Foreman server
+        required: true
+    password:
+        description:
+            - Password for user accessing Foreman server
+        required: true
+    verify_ssl:
+        description:
+            - Verify SSL of the Foreman server
+        required: false
+    name:
+        description:
+            - Name of the Foreman organization
+        required: true
+'''
+
+EXAMPLES = '''
+- name: "Create CI Organization"
+  local_action:
+      module: foreman_organization
+      username: "admin"
+      password: "admin"
+      server_url: "https://fakeserver.com"
+      name: "My Cool New Organization"
+'''
+
+RETURN = '''# '''
+
+import datetime
+
+try:
+    from nailgun import entities, entity_fields
+    from nailgun.config import ServerConfig
+    HAS_NAILGUN_PACKAGE = True
+except:
+    HAS_NAILGUN_PACKAGE = False
+
+class NailGun(object):
+    def __init__(self, server, entities, module):
+        self._server = server
+        self._entities = entities
+        self._module = module
+
+    def organization(self, name):
+        org = self._entities.Organization(self._server, name=name)
+        org = org.search(set(), {'search': 'name={}'.format(name)})[0]
+        updated = False
+
+        if org and org.name != name:
+            org = self._entities.Organization(self._server, name=name, id=org.id)
+            org.update()
+            updated = True
+        elif not org:
+            org = self._entities.Organization(self._server, name=name)
+            org.create()
+            updated = True
+
+        return updated
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            server_url=dict(required=True),
+            username=dict(required=True, no_log=True),
+            password=dict(required=True, no_log=True),
+            verify_ssl=dict(required=False, type='bool', default=False),
+            name=dict(required=True, no_log=False),
+        ),
+        supports_check_mode=True
+    )
+
+    if not HAS_NAILGUN_PACKAGE:
+        module.fail_json(msg="Missing required nailgun module (check docs or install with: pip install nailgun")
+
+    server_url = module.params['server_url']
+    username = module.params['username']
+    password = module.params['password']
+    verify_ssl = module.params['verify_ssl']
+    name = module.params['name']
+
+    server = ServerConfig(
+        url=server_url,
+        auth=(username, password),
+        verify=verify_ssl
+    )
+    ng = NailGun(server, entities, module)
+
+    # Lets make an connection to the server with username and password
+    try:
+        org = entities.Organization(server)
+        org.search()
+    except Exception as e:
+        module.fail_json(msg="Failed to connect to Foreman server: %s " % e)
+
+    try:
+        changed = ng.organization(name)
+        module.exit_json(changed=changed)
+    except Exception as e:
+        module.fail_json(msg=e)
+
+# import module snippets
+from ansible.module_utils.basic import *
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/remote_management/foreman/katello.py
+++ b/lib/ansible/modules/remote_management/foreman/katello.py
@@ -487,29 +487,15 @@ def main():
 
     result = False
 
-    if entity == 'product':
-        if action == 'sync':
-            result = ng.sync_product(params)
-        else:
-            result = ng.product(params)
-    elif entity == 'repository':
-        if action == 'sync':
-            result = ng.sync_repository(params)
-        else:
-            result = ng.repository(params)
-    elif entity == 'manifest':
+    if entity == 'manifest':
         result = ng.manifest(params)
     elif entity == 'repository_set':
         result = ng.repository_set(params)
     elif entity == 'sync_plan':
         result = ng.sync_plan(params)
     elif entity == 'content_view':
-        if action == 'publish':
-            result = ng.publish(params)
-        elif action == 'promote':
+        if action == 'promote':
             result = ng.promote(params)
-        else:
-            result = ng.content_view(params)
     elif entity == 'lifecycle_environment':
         result = ng.lifecycle_environment(params)
     elif entity == 'activation_key':

--- a/lib/ansible/modules/remote_management/foreman/katello_product.py
+++ b/lib/ansible/modules/remote_management/foreman/katello_product.py
@@ -1,0 +1,159 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# (c) 2016, Eric D Helms <ericdhelms@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: katello_product
+short_description: Create and Manage Katello products
+description:
+    - Create and Manage Katello products
+author: "Eric D Helms (@ehelms)"
+requirements:
+    - "nailgun >= 0.28.0"
+    - "python >= 2.6"
+    - datetime
+options:
+    server_url:
+        description:
+            - URL of Foreman server
+        required: true
+    username:
+        description:
+            - Username on Foreman server
+        required: true
+    password:
+        description:
+            - Password for user accessing Foreman server
+        required: true
+    verify_ssl:
+        description:
+            - Verify SSL of the Foreman server
+        required: false
+    name:
+        description:
+            - Name of the Katello product
+        required: true
+    organization:
+        description:
+            - Organization that the Product is in
+        required: true
+'''
+
+EXAMPLES = '''
+- name: "Create Fedora product"
+  local_action:
+      module: katello_product
+      username: "admin"
+      password: "admin"
+      server_url: "https://fakeserver.com"
+      name: "Fedora"
+      organization: "My Cool new Organization"
+'''
+
+RETURN = '''# '''
+
+import datetime
+
+try:
+    from nailgun import entities, entity_fields
+    from nailgun.config import ServerConfig
+    HAS_NAILGUN_PACKAGE = True
+except:
+    HAS_NAILGUN_PACKAGE = False
+
+class NailGun(object):
+    def __init__(self, server, entities, module):
+        self._server = server
+        self._entities = entities
+        self._module = module
+
+    def find_organization(self, name):
+        org = self._entities.Organization(self._server, name=name)
+        response = org.search(set(), {'search': 'name={}'.format(name)})
+
+        if len(response) == 1:
+            return response[0]
+        else:
+            self._module.fail_json(msg="No organization found for %s" % name)
+
+    def product(self, name, organization):
+        updated = False
+        org = self.find_organization(organization)
+        product = self._entities.Product(self._server, name=name, organization=org)
+        product = product.search()[0]
+
+        if product and product.name != name:
+            product = self._entities.Product(self._server, name=name, id=product.id)
+            product.update()
+            updated = True
+        elif not product:
+            product = self._entities.Product(self._server, name=name, organization=org)
+            product.create()
+            updated = True
+        
+        return updated
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            server_url=dict(required=True),
+            username=dict(required=True, no_log=True),
+            password=dict(required=True, no_log=True),
+            verify_ssl=dict(required=False, type='bool', default=False),
+            name=dict(required=True, no_log=False),
+            organization=dict(required=True, no_log=False),
+        ),
+        supports_check_mode=True
+    )
+
+    if not HAS_NAILGUN_PACKAGE:
+        module.fail_json(msg="Missing required nailgun module (check docs or install with: pip install nailgun")
+
+    server_url = module.params['server_url']
+    username = module.params['username']
+    password = module.params['password']
+    verify_ssl = module.params['verify_ssl']
+    name = module.params['name']
+    organization = module.params['organization']
+
+    server = ServerConfig(
+        url=server_url,
+        auth=(username, password),
+        verify=verify_ssl
+    )
+    ng = NailGun(server, entities, module)
+
+    # Lets make an connection to the server with username and password
+    try:
+        org = entities.Organization(server)
+        org.search()
+    except Exception as e:
+        module.fail_json(msg="Failed to connect to Foreman server: %s " % e)
+
+    try:
+        changed = ng.product(name, organization)
+        module.exit_json(changed=changed)
+    except Exception as e:
+        module.fail_json(msg=e)
+
+# import module snippets
+from ansible.module_utils.basic import *
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/remote_management/foreman/katello_publish.py
+++ b/lib/ansible/modules/remote_management/foreman/katello_publish.py
@@ -1,0 +1,157 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# (c) 2016, Eric D Helms <ericdhelms@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: katello_publish
+short_description: Publish a Katello content view
+description:
+    - Publish a Katello content view
+author: "Eric D Helms (@ehelms)"
+requirements:
+    - "nailgun >= 0.28.0"
+    - "python >= 2.6"
+    - datetime
+options:
+    server_url:
+        description:
+            - URL of Foreman server
+        required: true
+    username:
+        description:
+            - Username on Foreman server
+        required: true
+    password:
+        description:
+            - Password for user accessing Foreman server
+        required: true
+    content_view:
+        description:
+            - Name of the content view to publish
+        required: true
+    organization:
+        description:
+            - Organization that the Product is in
+        required: true
+'''
+
+EXAMPLES = '''
+- name: "Publish a content view"
+  local_action:
+      module: katello_publish
+      username: "admin"
+      password: "admin"
+      server_url: "https://fakeserver.com"
+      content_view: "CV 1"
+      organization: "Default Organization"
+'''
+
+RETURN = '''# '''
+
+import datetime
+
+try:
+    from nailgun import entities, entity_fields, entity_mixins
+    from nailgun.config import ServerConfig
+    HAS_NAILGUN_PACKAGE = True
+except:
+    HAS_NAILGUN_PACKAGE = False
+
+
+class NailGun(object):
+    def __init__(self, server, entities, module):
+        self._server = server
+        self._entities = entities
+        self._module = module
+        entity_mixins.TASK_TIMEOUT = 180000 #Publishes can sometimes take a long, long time
+
+    def find_organization(self, name):
+        org = self._entities.Organization(self._server, name=name)
+        response = org.search(set(), {'search': 'name={}'.format(name)})
+
+        if len(response) == 1:
+            return response[0]
+        else:
+            self._module.fail_json(msg="No organization found for %s" % name)
+
+    def find_content_view(self, name, organization):
+        org = self.find_organization(organization)
+
+        content_view = self._entities.ContentView(self._server, name=name, organization=org)
+        response = content_view.search()
+
+        if len(response) == 1:
+            return response[0]
+        else:
+            self._module.fail_json(msg="No Content View found for %s" % name)
+
+    def publish(self, content_view, organization):
+        content_view = self.find_content_view(content_view, organization)
+
+        return content_view.publish()
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            server_url=dict(required=True),
+            username=dict(required=True, no_log=True),
+            password=dict(required=True, no_log=True),
+            verify_ssl=dict(required=False, type='bool', default=False),
+            content_view=dict(required=True, no_log=False),
+            organization=dict(required=True, no_log=False),
+        ),
+        supports_check_mode=True
+    )
+
+    if not HAS_NAILGUN_PACKAGE:
+        module.fail_json(msg="Missing required nailgun module (check docs or install with: pip install nailgun")
+
+    server_url = module.params['server_url']
+    verify_ssl = module.params['verify_ssl']
+    username = module.params['username']
+    password = module.params['password']
+    content_view = module.params['content_view']
+    organization = module.params['organization']
+
+    server = ServerConfig(
+        url=server_url,
+        auth=(username, password),
+        verify=verify_ssl
+    )
+    ng = NailGun(server, entities, module)
+
+    # Lets make an connection to the server with username and password
+    try:
+        org = entities.Organization(server)
+        org.search()
+    except Exception as e:
+        module.fail_json(msg="Failed to connect to Foreman server: %s " % e)
+
+    try:
+        changed = ng.publish(content_view, organization)
+        module.exit_json(changed=changed)
+    except Exception as e:
+        module.fail_json(msg=e)
+
+# import module snippets
+from ansible.module_utils.basic import *
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/remote_management/foreman/katello_repository.py
+++ b/lib/ansible/modules/remote_management/foreman/katello_repository.py
@@ -1,0 +1,189 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# (c) 2016, Eric D Helms <ericdhelms@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: katello_repository
+short_description: Create and manage Katello repository
+description:
+    - Crate and manage a Katello repository
+author: "Eric D Helms (@ehelms)"
+requirements:
+    - "nailgun >= 0.28.0"
+    - "python >= 2.6"
+    - datetime
+options:
+    server_url:
+        description:
+            - URL of Foreman server
+        required: true
+    username:
+        description:
+            - Username on Foreman server
+        required: true
+    password:
+        description:
+            - Password for user accessing Foreman server
+        required: true
+    name:
+        description:
+            - Name of the repository
+        required: true
+    product:
+        description:
+            - Product to which the repository lives in
+        required: true
+    organization:
+        description:
+            - Organization that the Product is in
+        required: true
+'''
+
+EXAMPLES = '''
+- name: "Create repository"
+  local_action:
+      module: katello
+      username: "admin"
+      password: "admin"
+      server_url: "https://fakeserver.com"
+      name: "My repository"
+      type: "yum"
+      product: "My Product"
+      organization: "Default Organization"
+'''
+
+RETURN = '''# '''
+
+import datetime
+
+try:
+    from nailgun import entities, entity_fields, entity_mixins
+    from nailgun.config import ServerConfig
+    HAS_NAILGUN_PACKAGE = True
+except:
+    HAS_NAILGUN_PACKAGE = False
+
+
+class NailGun(object):
+    def __init__(self, server, entities, module):
+        self._server = server
+        self._entities = entities
+        self._module = module
+        entity_mixins.TASK_TIMEOUT = 1000
+
+    def find_organization(self, name):
+        org = self._entities.Organization(self._server, name=name)
+        response = org.search(set(), {'search': 'name={}'.format(name)})
+
+        if len(response) == 1:
+            return response[0]
+        else:
+            self._module.fail_json(msg="No organization found for %s" % name)
+
+    def find_product(self, name, organization):
+        org = self.find_organization(organization)
+
+        product = self._entities.Product(self._server, name=name, organization=org)
+        response = product.search()
+
+        if len(response) == 1:
+            return response[0]
+        else:
+            self._module.fail_json(msg="No Product found for %s" % name)
+
+    def repository(self, name, type, product, organization):
+        updated = False
+        product = self.find_product(product, organization)
+
+        repository = self._entities.Repository(self._server, name=name, product=product)
+        repository._fields['organization'] = entity_fields.OneToOneField(entities.Organization)
+        repository.organization = product.organization
+        repository = repository.search()
+
+        if len(repository) == 1:
+            repository = repository[0]
+
+        if repository and repository.name != name:
+            repository = self._entities.Repository(self._server, name=name, id=repository.id)
+            repository.update()
+            updated = True
+        elif not repository:
+            repository = self._entities.Repository(
+                    self._server,
+                    name=name,
+                    content_type=type,
+                    product=product,
+            )
+            repository.create()
+            updated = True
+        
+        return updated
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            server_url=dict(required=True),
+            username=dict(required=True, no_log=True),
+            password=dict(required=True, no_log=True),
+            verify_ssl=dict(required=False, type='bool', default=False),
+            product=dict(required=True, no_log=False),
+            organization=dict(required=True, no_log=False),
+            name=dict(required=True, no_log=False),
+            type=dict(required=True, no_log=False),
+        ),
+        supports_check_mode=True
+    )
+
+    if not HAS_NAILGUN_PACKAGE:
+        module.fail_json(msg="Missing required nailgun module (check docs or install with: pip install nailgun")
+
+    server_url = module.params['server_url']
+    verify_ssl = module.params['verify_ssl']
+    username = module.params['username']
+    password = module.params['password']
+    product = module.params['product']
+    organization = module.params['organization']
+    name = module.params['name']
+    type = module.params['type']
+
+    server = ServerConfig(
+        url=server_url,
+        auth=(username, password),
+        verify=verify_ssl
+    )
+    ng = NailGun(server, entities, module)
+
+    # Lets make an connection to the server with username and password
+    try:
+        org = entities.Organization(server)
+        org.search()
+    except Exception as e:
+        module.fail_json(msg="Failed to connect to Foreman server: %s " % e)
+
+    try:
+        changed = ng.repository(name, type, product, organization)
+        module.exit_json(changed=changed)
+    except Exception as e:
+        module.fail_json(msg=e)
+
+# import module snippets
+from ansible.module_utils.basic import *
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/remote_management/foreman/katello_sync.py
+++ b/lib/ansible/modules/remote_management/foreman/katello_sync.py
@@ -1,0 +1,181 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# (c) 2016, Eric D Helms <ericdhelms@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: katello_sync
+short_description: Sync a Katello repository or product
+description:
+    - Sync a Katello repository or product
+author: "Eric D Helms (@ehelms)"
+requirements:
+    - "nailgun >= 0.28.0"
+    - "python >= 2.6"
+    - datetime
+options:
+    server_url:
+        description:
+            - URL of Foreman server
+        required: true
+    username:
+        description:
+            - Username on Foreman server
+        required: true
+    password:
+        description:
+            - Password for user accessing Foreman server
+        required: true
+    repository:
+        description:
+            - Name of the repository to sync
+        required: true
+    product:
+        description:
+            - Product to which the repository lives in
+        required: true
+    organization:
+        description:
+            - Organization that the Product is in
+        required: true
+'''
+
+EXAMPLES = '''
+- name: "Sync repository"
+  local_action:
+      module: katello_sync
+      username: "admin"
+      password: "admin"
+      server_url: "https://fakeserver.com"
+      repository: "My repository"
+      product: "My Product"
+      organization: "Default Organization"
+'''
+
+RETURN = '''# '''
+
+import datetime
+
+try:
+    from nailgun import entities, entity_fields, entity_mixins
+    from nailgun.config import ServerConfig
+    HAS_NAILGUN_PACKAGE = True
+except:
+    HAS_NAILGUN_PACKAGE = False
+
+
+class NailGun(object):
+    def __init__(self, server, entities, module):
+        self._server = server
+        self._entities = entities
+        self._module = module
+        entity_mixins.TASK_TIMEOUT = 180000 #Publishes can sometimes take a long, long time
+
+    def find_organization(self, name):
+        org = self._entities.Organization(self._server, name=name)
+        response = org.search(set(), {'search': 'name={}'.format(name)})
+
+        if len(response) == 1:
+            return response[0]
+        else:
+            self._module.fail_json(msg="No organization found for %s" % name)
+
+    def find_product(self, name, organization):
+        org = self.find_organization(organization)
+
+        product = self._entities.Product(self._server, name=name, organization=org)
+        response = product.search()
+
+        if len(response) == 1:
+            return response[0]
+        else:
+            self._module.fail_json(msg="No Product found for %s" % name)
+
+    def find_repository(self, name, product, organization):
+        product = self.find_product(product, organization)
+
+        repository = self._entities.Repository(self._server, name=name, product=product)
+        repository._fields['organization'] = entity_fields.OneToOneField(entities.Organization)
+        repository.organization = product.organization
+        response = repository.search()
+
+        if len(response) == 1:
+            return response[0]
+        else:
+            self._module.fail_json(msg="No Repository found for %s" % name)
+
+    def sync(self, product, organization, repository = None):
+        org = self.find_organization(organization)
+
+        if repository == None:
+            product = self.find_product(product, organization)
+            return product.sync()
+        else:
+            repository = self.find_repository(repository, product, organization)
+            return repository.sync()
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            server_url=dict(required=True),
+            username=dict(required=True, no_log=True),
+            password=dict(required=True, no_log=True),
+            verify_ssl=dict(required=False, type='bool', default=False),
+            product=dict(required=True, no_log=False),
+            organization=dict(required=True, no_log=False),
+            repository=dict(required=False, no_log=False),
+        ),
+        supports_check_mode=True
+    )
+
+    if not HAS_NAILGUN_PACKAGE:
+        module.fail_json(msg="Missing required nailgun module (check docs or install with: pip install nailgun")
+
+    server_url = module.params['server_url']
+    verify_ssl = module.params['verify_ssl']
+    username = module.params['username']
+    password = module.params['password']
+    repository = module.params['repository']
+    product = module.params['product']
+    organization = module.params['organization']
+
+    server = ServerConfig(
+        url=server_url,
+        auth=(username, password),
+        verify=verify_ssl
+    )
+    ng = NailGun(server, entities, module)
+
+    # Lets make an connection to the server with username and password
+    try:
+        org = entities.Organization(server)
+        org.search()
+    except Exception as e:
+        module.fail_json(msg="Failed to connect to Foreman server: %s " % e)
+
+    try:
+        changed = ng.sync(product, organization, repository)
+        module.exit_json(changed=changed)
+    except Exception as e:
+        module.fail_json(msg=e)
+
+# import module snippets
+from ansible.module_utils.basic import *
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
…dules

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
foreman
katello

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This begins to deprecate the "all in one" Foreman and Katello modules in favor of direct and specific modules targeted at entities that live within Foreman or Katello. This starts by adding the necessary modules to be able to create an Organization, Product and Repository while also adding supporting to upload content into a Katello repository.
