### PR TITLE
Re-enable module comparisons in validate-modules

### DIFF
--- a/test/runner/lib/changes.py
+++ b/test/runner/lib/changes.py
@@ -57,7 +57,6 @@ class ShippableChanges(object):
 
         try:
             self.branch = os.environ['BRANCH']
-            self.fork_branch = os.environ['BASE_BRANCH']
             self.is_pr = os.environ['IS_PULL_REQUEST'] == 'true'
             self.is_tag = os.environ['IS_GIT_TAG'] == 'true'
             self.commit = os.environ['COMMIT']

--- a/test/runner/lib/changes.py
+++ b/test/runner/lib/changes.py
@@ -57,6 +57,7 @@ class ShippableChanges(object):
 
         try:
             self.branch = os.environ['BRANCH']
+            self.fork_branch = os.environ['BASE_BRANCH']
             self.is_pr = os.environ['IS_PULL_REQUEST'] == 'true'
             self.is_tag = os.environ['IS_GIT_TAG'] == 'true'
             self.commit = os.environ['COMMIT']

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -796,6 +796,22 @@ def command_sanity_validate_modules(args, targets):
     if skip_paths:
         cmd += ['--exclude', '^(%s)' % '|'.join(skip_paths)]
 
+    # Find fork_branch
+    git = Git(args)
+    try:
+        if is_shippable():
+            changes = ShippableChanges(args, git)
+        else:
+            changes = LocalChanges(args, git)
+    except:
+        fork_branch = 'devel'
+    else:
+        fork_branch = changes.fork_branch
+
+    cmd.extend([
+        '--base-branch', fork_branch
+    ])
+
     run_command(args, cmd, env=env)
 
 

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -799,11 +799,8 @@ def command_sanity_validate_modules(args, targets):
     # Find fork_branch
     git = Git(args)
     try:
-        if is_shippable():
-            changes = ShippableChanges(args, git)
-        else:
-            changes = LocalChanges(args, git)
-    except:
+        changes = ShippableChanges(args, git) if is_shippable() else LocalChanges(args, git)
+    except ApplicationError:
         fork_branch = 'devel'
     else:
         fork_branch = changes.fork_branch

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -796,18 +796,12 @@ def command_sanity_validate_modules(args, targets):
     if skip_paths:
         cmd += ['--exclude', '^(%s)' % '|'.join(skip_paths)]
 
-    # Find fork_branch
-    git = Git(args)
-    try:
-        changes = ShippableChanges(args, git) if is_shippable() else LocalChanges(args, git)
-    except ApplicationError:
-        fork_branch = 'devel'
+    if is_shippable():
+        cmd.extend([
+            '--base-branch', os.environ['BASE_BRANCH']
+        ])
     else:
-        fork_branch = changes.fork_branch
-
-    cmd.extend([
-        '--base-branch', fork_branch
-    ])
+        display.warning("Cannot perform module comparison against the base branch when running locally")
 
     run_command(args, cmd, env=env)
 

--- a/test/sanity/validate-modules/validate-modules
+++ b/test/sanity/validate-modules/validate-modules
@@ -24,7 +24,9 @@ import argparse
 import ast
 import os
 import re
+import subprocess
 import sys
+import tempfile
 
 from distutils.version import StrictVersion
 from fnmatch import fnmatch
@@ -134,7 +136,7 @@ class ModuleValidator(Validator):
         'setup.ps1'
     ))
 
-    def __init__(self, path, analyze_arg_spec=False):
+    def __init__(self, path, analyze_arg_spec=False, base_branch='devel'):
         super(ModuleValidator, self).__init__()
 
         self.path = path
@@ -142,6 +144,8 @@ class ModuleValidator(Validator):
         self.name, _ = os.path.splitext(self.basename)
 
         self.analyze_arg_spec = analyze_arg_spec
+
+        self.base_branch = base_branch
 
         self._python_module_override = False
 
@@ -152,6 +156,20 @@ class ModuleValidator(Validator):
             self.ast = ast.parse(self.text)
         except:
             self.ast = None
+
+        self.base_module = self._get_base_file()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if not self.base_module:
+            return
+
+        try:
+            os.remove(self.base_module)
+        except:
+            pass
 
     @property
     def object_name(self):
@@ -180,12 +198,22 @@ class ModuleValidator(Validator):
         except AttributeError:
             return False
 
+    def _get_base_file(self):
+        command = ['git', 'show', '%s:%s' % (self.base_branch, self.path)]
+        p = subprocess.Popen(command, stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+        if int(p.returncode) != 0:
+            return None
+
+        t = tempfile.NamedTemporaryFile(delete=False)
+        t.write(stdout)
+        t.close()
+
+        return t.name
+
     def _is_new_module(self):
-        if self.name.startswith("_") and not os.path.islink(self.name):
-            # This is a deprecated module, so look up the *old* name
-            return not module_loader.has_plugin(self.name[1:])
-        else:
-            return not module_loader.has_plugin(self.name)
+        return not bool(self.base_module)
 
     def _check_interpreter(self, powershell=False):
         if powershell:
@@ -549,8 +577,7 @@ class ModuleValidator(Validator):
 
         with CaptureStd():
             try:
-                existing = module_loader.find_plugin(self.name, mod_type='.py')
-                existing_doc, _, _, _ = get_docstring(existing, verbose=True)
+                existing_doc, _, _, _ = get_docstring(self.base_module, verbose=True)
                 existing_options = existing_doc.get('options', {})
             except AssertionError:
                 fragment = doc['extends_documentation_fragment']
@@ -712,6 +739,10 @@ def main():
                         type=re_compile)
     parser.add_argument('--arg-spec', help='Analyze module argument spec',
                         action='store_true', default=False)
+    parser.add_argument('--base-branch', default='devel',
+                        help='Used in determining if new options were added. '
+                             'Default: "%(default)s"')
+
     args = parser.parse_args()
 
     args.modules[:] = [m.rstrip('/') for m in args.modules]
@@ -723,9 +754,10 @@ def main():
             path = module
             if args.exclude and args.exclude.search(path):
                 sys.exit(0)
-            mv = ModuleValidator(path, analyze_arg_spec=args.arg_spec)
-            mv.validate()
-            exit.append(mv.report(args.warnings))
+            with ModuleValidator(path, analyze_arg_spec=args.arg_spec,
+                                 base_branch=args.base_branch) as mv:
+                mv.validate()
+                exit.append(mv.report(args.warnings))
 
         for root, dirs, files in os.walk(module):
             basedir = root[len(module)+1:].split('/', 1)[0]
@@ -745,9 +777,10 @@ def main():
                 path = os.path.join(root, filename)
                 if args.exclude and args.exclude.search(path):
                     continue
-                mv = ModuleValidator(path, analyze_arg_spec=args.arg_spec)
-                mv.validate()
-                exit.append(mv.report(args.warnings))
+                with ModuleValidator(path, analyze_arg_spec=args.arg_spec,
+                                     base_branch=args.base_branch) as mv:
+                    mv.validate()
+                    exit.append(mv.report(args.warnings))
 
     sys.exit(sum(exit))
 

--- a/test/sanity/validate-modules/validate-modules
+++ b/test/sanity/validate-modules/validate-modules
@@ -136,7 +136,7 @@ class ModuleValidator(Validator):
         'setup.ps1'
     ))
 
-    def __init__(self, path, analyze_arg_spec=False, base_branch='devel'):
+    def __init__(self, path, analyze_arg_spec=False, base_branch=None):
         super(ModuleValidator, self).__init__()
 
         self.path = path
@@ -157,7 +157,10 @@ class ModuleValidator(Validator):
         except:
             self.ast = None
 
-        self.base_module = self._get_base_file()
+        if base_branch:
+            self.base_module = self._get_base_file()
+        else:
+            self.base_module = None
 
     def __enter__(self):
         return self
@@ -213,7 +216,7 @@ class ModuleValidator(Validator):
         return t.name
 
     def _is_new_module(self):
-        return not bool(self.base_module)
+        return self.base_branch and not bool(self.base_module)
 
     def _check_interpreter(self, powershell=False):
         if powershell:
@@ -739,9 +742,8 @@ def main():
                         type=re_compile)
     parser.add_argument('--arg-spec', help='Analyze module argument spec',
                         action='store_true', default=False)
-    parser.add_argument('--base-branch', default='devel',
-                        help='Used in determining if new options were added. '
-                             'Default: "%(default)s"')
+    parser.add_argument('--base-branch', default=None,
+                        help='Used in determining if new options were added')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
validate-modules

##### ANSIBLE VERSION

```
devel
```

##### SUMMARY
Then we merged the repositories, the manner in which we were doing comparison of the original module, and the changed module stopped working.

This change, instead of looking at 2 different ansible installs, will use git to fetch the file out of the base branch (fork branch)

This re-enables new-module detection, and re-enables detection of new arguments for a module.

We have been ignoring the following things since the merge as a result of this functionality effectively being disabled:

1. Validating `RETURN` exists and is properly formatted (a few new modules have made it in without `RETURN` lately
2. Making sure new modules use the correct `version_added`
3. Looking for new arguments and ensuring they have the correct `version_added`
4. Ensuring that `requests` and `boto` should not be used in new modules.
