### PR TITLE
Added option cached to pip module

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -68,7 +68,7 @@ options:
     description:
       - The state of module
       - The 'forcereinstall' option is only available in Ansible 2.1 and above.
-    choices: [ absent, forcereinstall, latest, present ]
+    choices: [ "present", "absent", "latest", "forcereinstall", "downloaded" ]
     default: present
   extra_args:
     description:
@@ -182,6 +182,11 @@ EXAMPLES = '''
 - pip:
     name: bottle
     state: forcereinstall
+
+# Download (Bottle) without installing it
+- pip:
+    name: bottle
+    state: downloaded
 
 # Install (Bottle) while ensuring the umask is 0022 (to ensure other users can use it)
 - pip:
@@ -348,6 +353,7 @@ def main():
         absent='uninstall -y',
         latest='install -U',
         forcereinstall='install -U --force-reinstall',
+        downloaded='download',
     )
 
     module = AnsibleModule(

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -183,3 +183,14 @@
   assert:
     that:
       - "pip_install_venv.changed"
+
+# Download case
+- name: check for download isort package
+  pip: name=isort state=downloaded
+  register: download_package
+
+# fishy way to verify the package presence
+- name: ensure the download package is present
+  assert:
+    that:
+      - "'Successfully downloaded isort' in download_package.stdout"


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
pip

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (pip-cached-state f8801ed8cb) last updated 2017/02/17 11:05:56 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added a new state 'cached' to the pip module that runs `pip download pkgname` to locally cache the package. The particular use case for which I need it is caching packages from Artifactory separate to the install step. Currently I am having to use `command: pip download ...` when it would be cleaner to use the pip module for all steps.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
> ./test-module -m ../lib/ansible/modules/packaging/language/pip.py -a "name=bottle state=cached"

***********************************
RAW OUTPUT

{"virtualenv": null, "changed": false, "requirements": null, "name": ["bottle"], "stdout": "Collecting bottle\n  Downloading bottle-0.12.13.tar.gz (70kB)\n  Saved ./bottle-0.12.13.tar.gz\nSuccessfully downloaded bottle\n", "cmd": "/usr/local/bin/pip2 download bottle", "state": "cached", "version": null, "stderr": "You are using pip version 8.0.2, however version 9.0.1 is available.\nYou should consider upgrading via the 'pip install --upgrade pip' command.\n", "invocation": {"module_args": {"virtualenv": null, "virtualenv_site_packages": false, "virtualenv_command": "virtualenv", "chdir": null, "requirements": null, "name": ["bottle"], "virtualenv_python": null, "editable": true, "umask": null, "executable": null, "use_mirrors": true, "extra_args": null, "state": "cached", "version": null}}}


***********************************
PARSED OUTPUT
{
    "changed": false, 
    "cmd": "/usr/local/bin/pip2 download bottle", 
    "invocation": {
        "module_args": {
            "chdir": null, 
            "editable": true, 
            "executable": null, 
            "extra_args": null, 
            "name": [
                "bottle"
            ], 
            "requirements": null, 
            "state": "cached", 
            "umask": null, 
            "use_mirrors": true, 
            "version": null, 
            "virtualenv": null, 
            "virtualenv_command": "virtualenv", 
            "virtualenv_python": null, 
            "virtualenv_site_packages": false
        }
    }, 
    "name": [
        "bottle"
    ], 
    "requirements": null, 
    "state": "cached", 
    "stderr": "You are using pip version 8.0.2, however version 9.0.1 is available.\nYou should consider upgrading via the 'pip install --upgrade pip' command.\n", 
    "stdout": "Collecting bottle\n  Downloading bottle-0.12.13.tar.gz (70kB)\n  Saved ./bottle-0.12.13.tar.gz\nSuccessfully downloaded bottle\n", 
    "version": null, 
    "virtualenv": null
}
```
