### PR TITLE
maps ios provider ssh_keyfile to play_context

### DIFF
--- a/lib/ansible/plugins/action/ios.py
+++ b/lib/ansible/plugins/action/ios.py
@@ -56,6 +56,7 @@ class ActionModule(_ActionModule):
         pc.port = provider['port'] or self._play_context.port or 22
         pc.remote_user = provider['username'] or self._play_context.connection_user
         pc.password = provider['password'] or self._play_context.password
+        pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
         pc.timeout = provider['timeout'] or self._play_context.timeout
         pc.become = provider['authorize'] or False
         pc.become_pass = provider['auth_pass']


### PR DESCRIPTION
This allows the key file to be specified in the playbook for the ios
module provider argument
