### PR TITLE
Fix ansible-test handling of deleted test targets.

### DIFF
--- a/test/runner/lib/classification.py
+++ b/test/runner/lib/classification.py
@@ -322,6 +322,9 @@ class PathMapper(object):
             return minimal
 
         if path.startswith('test/integration/targets/'):
+            if not os.path.exists(path):
+                return minimal
+
             target = self.integration_targets_by_name[path.split('/')[3]]
 
             if 'hidden/' in target.aliases:


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (at-fix daf8b700d3) last updated 2017/02/17 10:50:58 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Fix ansible-test handling of deleted test targets.