### PR TITLE
Switch from using inspect to globals()

### DIFF
--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -23,7 +23,6 @@ __metaclass__ = type
 
 import glob
 import imp
-import inspect
 import os
 import os.path
 import sys
@@ -49,7 +48,7 @@ PLUGIN_PATH_CACHE = {}
 
 
 def get_all_plugin_loaders():
-    return [(name, obj) for (name, obj) in inspect.getmembers(sys.modules[__name__]) if isinstance(obj, PluginLoader)]
+    return [(name, obj) for (name, obj) in globals().items() if isinstance(obj, PluginLoader)]
 
 
 class PluginLoader:


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

##### SUMMARY
inspect is slow and typically means that the code is doing something the wrong way.  In this case, we can simplify by using globals() instead.