### PR TITLE
[cloud] ec2_elb_facts fails on accounts with to many ELBs

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
@@ -78,6 +78,8 @@ EXAMPLES = '''
 
 '''
 
+import traceback
+
 try:
     import boto.ec2.elb
     from boto.ec2.tag import Tag
@@ -201,20 +203,28 @@ class ElbInformation(object):
 
 
     def list_elbs(self):
-        elb_array = []
+        elb_array, token = [], None
 
-        try:
-            all_elbs = self.connection.get_all_load_balancers()
-        except BotoServerError as err:
-            self.module.fail_json(msg = "%s: %s" % (err.error_code, err.error_message))
+        while True:
+            try:
+                all_elbs = self.connection.get_all_load_balancers(marker=token)
+                token = all_elbs.next_token
+            except BotoServerError as err:
+                self.module.fail_json(msg = "%s: %s" % (err.error_code, err.error_message),
+                    exception=traceback.format_exc())
 
-        if all_elbs:
-            if self.names:
-                for existing_lb in all_elbs:
-                    if existing_lb.name in self.names:
-                        elb_array.append(existing_lb)
+            if all_elbs:
+                if self.names:
+                    for existing_lb in all_elbs:
+                        if existing_lb.name in self.names:
+                            elb_array.append(existing_lb)
+                else:
+                    elb_array.extend(all_elbs)
             else:
-                elb_array = all_elbs
+                break
+
+            if token is None:
+                break
 
         return list(map(self._get_elb_info, elb_array))
 


### PR DESCRIPTION
The list_elbs call to boto doesn't use any pagination, so any time there
are more ELBs than the API page size, this module will fail. This change
uses the `next_token` attribute of `ResultSet` to check if there are
still more ELBs to return.

Fixes #21361

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ec2_elb_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (paginate-elbs 712787a1de) last updated 2017/02/17 15:50:25 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This change adds pagination to the listing/searching of ELBs. In accounts with >400 ELBs, this module couldn't retrieve facts for all load balancers. 

Closes #21361 