### PR TITLE
Typo: Remove useless # in ConfigureRemotingForAnsible.ps1 comment

### DIFF
--- a/examples/scripts/ConfigureRemotingForAnsible.ps1
+++ b/examples/scripts/ConfigureRemotingForAnsible.ps1
@@ -4,7 +4,7 @@
 # -----------------------------------------------------------
 #
 # This script checks the current WinRM (PS Remoting) configuration and makes
-# the # necessary changes to allow Ansible to connect, authenticate and
+# the necessary changes to allow Ansible to connect, authenticate and
 # execute PowerShell commands.
 #
 # All events are logged to the Windows EventLog, useful for unattended runs.


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ConfigureRemotingForAnsible.ps1 

##### ANSIBLE VERSION
```
ansible 2.2.1.0
```

##### SUMMARY
Just a typo in a comment line