### PR TITLE
Fix ansible_virtualization_role fact for DigitalOcean guests

### DIFF
--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -142,6 +142,13 @@ class LinuxVirtual(Virtual):
             virtual_facts['virtualization_role'] = 'guest'
             return virtual_facts
 
+        chassis_vendor = get_file_content('/sys/devices/virtual/dmi/id/chassis_vendor')
+
+        if chassis_vendor == 'Bochs':
+            self.facts['virtualization_type'] = 'kvm'
+            self.facts['virtualization_role'] = 'guest'
+            return
+
         if os.path.exists('/proc/self/status'):
             for line in get_file_lines('/proc/self/status'):
                 if re.match('^VxID: \d+', line):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/facts.py

##### SUMMARY
DigitalOcean guests show 'host' for ansible_virtualization_role fact  at the moment. This commit fixes that. It might fix it for other cloud providers (and emulators) as well perhaps, but my use case was for DO.

DO guests expose the chassis_vendor as 'Bochs' and considering guest/kvm is already being set for role/type when the product_name is 'Bochs', I've continued using that logic.

Also, my educated guess is dat DigitalOcean uses KVM as virtualization, but I'm not 100% sure. I don't care that much about the type, for me the role was important because I want to do bare metal specific tasks if applicable and skip them otherwise.

Before fix:

```
hb@aramaki ~/git/hyperbaton-ansible (git)-[master] % ansible fedora-test -m setup -u root -a 'filter=ansible_virtualization_*'
138.68.82.12 | SUCCESS => {
    "ansible_facts": {
        "ansible_virtualization_role": "host", 
        "ansible_virtualization_type": "kvm"
    }, 
    "changed": false
}
```
After fix:
```
hb@aramaki ~/git/hyperbaton-ansible (git)-[master] % ansible fedora-test -m setup -u root -a 'filter=ansible_virtualization_*'
138.68.82.12 | SUCCESS => {
    "ansible_facts": {
        "ansible_virtualization_role": "guest", 
        "ansible_virtualization_type": "kvm"
    }, 
    "changed": false
}
```