### PR TITLE
Add better iam role ec2 facts

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_facts.py
@@ -102,6 +102,8 @@ class Ec2Metadata(object):
         new_fields = {}
         for key, value in fields.items():
             split_fields = key[len(uri):].split('/')
+            if len(split_fields) == 3 and split_fields[0:2] == ['iam', 'security-credentials']:
+                new_fields[self._prefix % "iam-instance-profile-role"] = split_fields[2]
             if len(split_fields) > 1 and split_fields[1]:
                 new_key = "-".join(split_fields)
                 new_fields[self._prefix % new_key] = value

--- a/lib/ansible/modules/cloud/amazon/ec2_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_facts.py
@@ -164,6 +164,25 @@ class Ec2Metadata(object):
                     break
             data['ansible_ec2_placement_region'] = region
 
+    def add_ec2_instance_profile(self, data):
+        iam_info_str = data.get('ansible_ec2_iam_info')
+        if not iam_info_str:
+            return
+        try:
+            iam_info = json.loads(iam_info_str)
+        except ValueError:
+            return
+        arn = iam_info.get('InstanceProfileArn')
+        if arn:
+            data['ansible_ec2_iam_instance_profile_arn'] = arn
+            arn_value = arn.split(':')[-1]
+            if arn_value.startswith('instance-profile/'):
+                name = arn_value.lstrip('instance-profile/')
+                data['ansible_ec2_iam_instance_profile'] = name
+        id_ = iam_info.get('InstanceProfileId')
+        if id_:
+            data['ansible_ec2_iam_instance_profile_id'] = id_
+
     def run(self):
         self.fetch(self.uri_meta)  # populate _data
         data = self._mangle_fields(self._data, self.uri_meta)
@@ -171,6 +190,7 @@ class Ec2Metadata(object):
         data[self._prefix % 'public-key'] = self._fetch(self.uri_ssh)
         self.fix_invalid_varnames(data)
         self.add_ec2_region(data)
+        self.add_ec2_instance_profile(data)
         return data
 
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
ec2_facts module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This change explicitly sets a few additional useful facts related to the iam instance profile when parsing the instance metadata in the ec2_facts module. I find these useful to have access to. For instance in an environment where all instances follow a convention of using an iam profile, it can be useful to use these values directly for grouping & configuration behavior instead of having to assign extra tags or something.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
# Before change, the relevant subset of facts set by this module:

        "ansible_ec2_iam_info": "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2017-02-18T10:00:00Z\",\n  \"InstanceProfileArn\" : \"arn:aws:iam::xxxxxxxxxxxx:instance-profile/foobar-instance",\n  \"InstanceProfileId\" : \"12345\"\n}",
        "ansible_ec2_iam_security_credentials_foo_bar": # json object with role credentials

# Now:
        "ansible_ec2_iam_info": "{\n  \"Code\" : \"Success\",\n  \"LastUpdated\" : \"2017-02-18T10:00:00Z\",\n  \"InstanceProfileArn\" : \"arn:aws:iam::xxxxxxxxxxxx:instance-profile/foobar-instance",\n  \"InstanceProfileId\" : \"12345\"\n}",
        "ansible_ec2_iam_instance_profile": "foobar-instance",
        "ansible_ec2_iam_instance_profile_arn": "arn:aws:iam::xxxxxxxxxxxx:instance-profile/foobar-instance",
        "ansible_ec2_iam_instance_profile_id": "12345",
        "ansible_ec2_iam_instance_profile_role": "foo-bar",
        "ansible_ec2_iam_security_credentials_foo_bar": # json object with role credentials
```

(One thing to note - to get the actual role name we have to parse out the role name before the step where the module normalizes all dash and slash characters to underscores. So in this case we know the role is `foo-bar` and not `foo_bar`) 