### PR TITLE
Fixes #21401 file module failing to create links

### DIFF
--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -370,7 +370,7 @@ def main():
             b_relpath = os.path.dirname(b_path)
             relpath = to_native(b_relpath, errors='strict')
 
-        absrc = os.path.join(relpath, src)
+        absrc = os.path.abspath(src)
         b_absrc = to_bytes(absrc, errors='surrogate_or_strict')
         if not force and not os.path.exists(b_absrc):
             module.fail_json(path=path, src=src, msg='src file does not exist, use "force=yes" if you really want to create the link: %s' % absrc)

--- a/test/integration/targets/copy/tasks/main.yml
+++ b/test/integration/targets/copy/tasks/main.yml
@@ -235,7 +235,7 @@
   copy: dest={{output_dir}}/follow_test content="this is the follow test file\n"
 
 - name: create a symlink to the test file
-  file: path={{output_dir}}/follow_link src='./follow_test' state=link
+  file: path={{output_dir}}/follow_link src='{{output_dir}}/follow_test' state=link
 
 - name: update the test file using follow=True to preserve the link
   copy: dest={{output_dir}}/follow_link content="this is the new content\n" follow=yes

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -289,8 +289,8 @@
     that:
       - "file20_result.changed == true"
 
-# previous version has 'src=sub1', sub1 did not exist
-# test was incorrectly linking non-existent file, updated to correctly link dir
+# previous version had 'src=sub1', sub1 did not exist
+# test was incorrectly linking non-existent file without force=yes, updated to correctly link dir
 - name: create soft link to relative directory
   file: src=../sub1 dest={{output_dir}}/sub1-link state=link
   register: file21_result

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -281,7 +281,7 @@
       - 'file19_result.state == "directory"'
 
 - name: create soft link to relative file
-  file: src=../sub1/file1 dest={{output_dir}}/sub2/link1 state=link
+  file: src={{output_dir}}/sub1/file1 dest={{output_dir}}/sub2/link1 state=link
   register: file20_result
 
 - name: verify that the result was marked as changed
@@ -292,7 +292,7 @@
 # previous version had 'src=sub1', sub1 did not exist
 # test was incorrectly linking non-existent file without force=yes, updated to correctly link dir
 - name: create soft link to relative directory
-  file: src=../sub1 dest={{output_dir}}/sub1-link state=link
+  file: src={{output_dir}}/sub1 dest={{output_dir}}/sub1-link state=link
   register: file21_result
 
 - name: verify that the result was marked as changed

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -289,8 +289,10 @@
     that:
       - "file20_result.changed == true"
 
+# previous version has 'src=sub1', sub1 did not exist
+# test was incorrectly linking non-existent file, updated to correctly link dir
 - name: create soft link to relative directory
-  file: src=sub1 dest={{output_dir}}/sub1-link state=link
+  file: src=../sub1 dest={{output_dir}}/sub1-link state=link
   register: file21_result
 
 - name: verify that the result was marked as changed
@@ -458,7 +460,7 @@
   copy: dest={{output_dir}}/test_follow content="this is a test file\n" mode=0666
 
 - name: create a symlink to the test file
-  file: path={{output_dir}}/test_follow_link src="./test_follow" state=link
+  file: path={{output_dir}}/test_follow_link src="{{output_dir}}/test_follow" state=link
 
 - name: modify the permissions on the link using follow=yes
   file: path={{output_dir}}/test_follow_link mode=0644 follow=yes
@@ -479,7 +481,7 @@
     - result.stat.mode == '0644'
 
 - name: attempt to modify the permissions of the link itself
-  file: path={{output_dir}}/test_follow_link src="./test_follow" state=link mode=0600 follow=no
+  file: path={{output_dir}}/test_follow_link src="{{output_dir}}/test_follow" state=link mode=0600 follow=no
   register: result
 
 # Whether the link itself changed is platform dependent! (BSD vs Linux?)
@@ -508,10 +510,10 @@
   file: path={{output_dir}}/test_follow_rec_target_dir/foo state=touch mode=0700
 
 - name: create a symlink to the file
-  file: path={{output_dir}}/test_follow_rec/test_link state=link src="../test_follow_rec_target_file"
+  file: path={{output_dir}}/test_follow_rec/test_link state=link src="{{output_dir}}/test_follow_rec_target_file"
 
 - name: create a symlink to the directory
-  file: path={{output_dir}}/test_follow_rec/test_link_dir state=link src="../test_follow_rec_target_dir"
+  file: path={{output_dir}}/test_follow_rec/test_link_dir state=link src="{{output_dir}}/test_follow_rec_target_dir"
 
 - name: try to change permissions without following symlinks
   file: path={{output_dir}}/test_follow_rec follow=False mode="a-x" recurse=True


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/files/file.py

##### ANSIBLE VERSION
```
[vagrant@localhost ~]$ ansible --version
ansible 2.2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #21401  

Before creating sym/hard link, validation performed on source path. If source path does not exist, force=yes must be set for the link to be created, otherwise linking fails. The module was joining destination and source paths to create a nonsense path that it then attempted to validate. For absolute links, os.path.join, simply returns the second param, in this case, the original source path.

Replaced os.path.join with os.path.abspath. Existing integration testing sufficient, but required updating since testing was creating links from non-existing source without force option.

Task Example:
```
---
  - name: Create a symlink to folder
    file:
      src: "relpath1/sub/dir1"
      dest: "relpath2/sub/dir2"
      state: link
    register: res

  - debug: var=res
```

Before changes, issue user @simonmikkelsen hit:
 ```
[vagrant@localhost test1]$ ansible-playbook a.yml -i 'localhost,'

PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [basic : Create a symlink to folder] **************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "src file does not exist, use \"force=yes\" if you really want to create the link: relpath2/sub/relpath1/sub/dir1", "path": "relpath2/sub/dir2", "src": "relpath1/sub/dir1", "state": "absent"}
	to retry, use: --limit @/home/vagrant/test1/a.retry

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1   
```

After changes:
```
[vagrant@localhost test1]$ PYTHONPATH=../ansible/lib ansible-playbook a.yml -i 'localhost,'

PLAY [localhost] *****************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [basic : Create a symlink to folder] ****************************************************************************************************************************************************************************************************
changed: [localhost]

TASK [basic : debug] *************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "changed": false, 
    "res": {
        "changed": true, 
        "dest": "relpath2/sub/dir2", 
        "diff": {
            "after": {
                "path": "relpath2/sub/dir2", 
                "state": "link"
            }, 
            "before": {
                "path": "relpath2/sub/dir2", 
                "state": "absent"
            }
        }, 
        "src": "relpath1/sub/dir1", 
        "state": "absent"
    }
}

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
localhost                  : ok=3    changed=1    unreachable=0    failed=0   

```