### PR TITLE
Add 'digital_ocean' as group in DigitalOcean dynamic inventory

### DIFF
--- a/contrib/inventory/digital_ocean.py
+++ b/contrib/inventory/digital_ocean.py
@@ -40,6 +40,7 @@ is to use the output of the --env option with export:
 The following groups are generated from --list:
  - ID    (droplet ID)
  - NAME  (droplet NAME)
+ - digital_ocean
  - image_ID
  - image_NAME
  - distro_NAME  (distribution NAME from image)
@@ -378,7 +379,8 @@ or environment variables (DO_API_TOKEN)\n''')
             self.inventory[droplet['name']] = [dest]
 
             # groups that are always present
-            for group in ('region_' + droplet['region']['slug'],
+            for group in ('digital_ocean',
+                          'region_' + droplet['region']['slug'],
                           'image_' + str(droplet['image']['id']),
                           'size_' + droplet['size']['slug'],
                           'distro_' + self.to_safe(droplet['image']['distribution']),


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
contrib/inventory/digital_ocean.py

##### ANSIBLE VERSION
```
N/A
```

##### SUMMARY
This adds a group 'digital_ocean' to the DigitalOcean dynamic inventory (similar to how the EC2 dynamic inventory has the 'ec2' group). All DO hosts are added to this group. This allows for easy identification of DO hosts and allows to easily set group_vars that are applicable only for DO hosts.

My personal use case: 

DigitalOcean hosts have the IP as inventory_hostname by default. This is different from normal hosts in the hosts file. I do however need a way to set the FQDN variable of my hosts across all bare metal and cloud in a consistent manner.

In group_vars/all.yml, I have this:
```
fqdn: "{{ inventory_hostname }}"
```

Now, for DO hosts in group_vars/digital_ocean.yml, I can have this:
```
fqdn: "{{ do_name }}"
```