### PR TITLE
Download remote apt deb file in bytes mode in Python 2 and 3

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -234,7 +234,7 @@ import time
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_bytes, to_native
 from ansible.module_utils.urls import fetch_url
 
 # APT related constants
@@ -716,12 +716,14 @@ def download(module, deb):
 
     try:
         rsp, info = fetch_url(module, deb)
-        f = open(package, 'w')
+        # Ensure file is open in binary mode for Python 3
+        f = open(package, 'wb')
         # Read 1kb at a time to save on ram
         while True:
             data = rsp.read(BUFSIZE)
+            data = to_bytes(data, errors='surrogate_or_strict')
 
-            if data == "":
+            if len(data) < 1:
                 break # End of file, break while loop
 
             f.write(data)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
apt

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file = /home/james/vactive/host/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #19710

I've adjusted the remote deb download for the `apt` module to work explicitly in bytes. Full explanation is in the issue comments: https://github.com/ansible/ansible/issues/19710#issuecomment-280931742

For a playbook that tries to install Dropbox on desktop:

```yml
- name: Install Dropbox installer
  become: true
  apt:
    deb: "https://www.dropbox.com/download?dl=packages/ubuntu/dropbox_2015.10.28_amd64.deb"
```

Before:
```
fatal: [hotbox.lan]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_args": {
            "allow_unauthenticated": false,
            "autoremove": false,
            "cache_valid_time": 0,
            "deb": "https://www.dropbox.com/download?dl=packages/ubuntu/dropbox_2015.10.28_amd64.deb",
            "default_release": null,
            "dpkg_options": "force-confdef,force-confold",
            "force": false,
            "install_recommends": null,
            "only_upgrade": false,
            "package": null,
            "purge": false,
            "state": "present",
            "update_cache": false,
            "upgrade": null
        }
    },
    "msg": "Failure downloading https://www.dropbox.com/download?dl=packages/ubuntu/dropbox_2015.10.28_amd64.deb, write() argument must be str, not bytes"
}
```

After:
```
changed: [hotbox.lan] => {
    "changed": true,
    "diff": {
        "prepared": "Selecting previously unselected package dropbox.\n(Reading database ... 212473 files and directories currently installed.)\nPreparing to unpack .../dropbox_2015.10.28_amd64.deb ...\nUnpacking dropbox (2015.10.28) ...\nSetting up dropbox (2015.10.28) ...\nPlease restart all running instances of Nautilus, or you will experience problems. i.e. nautilus --quit\nDropbox installation successfully completed! You can start Dropbox from your applications menu.\nProcessing triggers for bamfdaemon (0.5.3~bzr0+16.04.20160824-0ubuntu1) ...\nRebuilding /usr/share/applications/bamf-2.index...\nProcessing triggers for gnome-menus (3.13.3-6ubuntu3.1) ...\nProcessing triggers for desktop-file-utils (0.22-1ubuntu5) ...\nProcessing triggers for mime-support (3.59ubuntu1) ...\nProcessing triggers for hicolor-icon-theme (0.15-0ubuntu1) ...\nProcessing triggers for man-db (2.7.5-1) ..."
    },
    "invocation": {
        "module_args": {
            "allow_unauthenticated": false,
            "autoremove": false,
            "cache_valid_time": 0,
            "deb": "/tmp/ansible_ehwdw1ts/dropbox_2015.10.28_amd64.deb",
            "default_release": null,
            "dpkg_options": "force-confdef,force-confold",
            "force": false,
            "install_recommends": null,
            "only_upgrade": false,
            "package": null,
            "purge": false,
            "state": "present",
            "update_cache": false,
            "upgrade": null
        }
    },
    "stderr": "",
    "stderr_lines": [],
    "stdout": "Selecting previously unselected package dropbox.\n(Reading database ... 212473 files and directories currently installed.)\nPreparing to unpack .../dropbox_2015.10.28_amd64.deb ...\nUnpacking dropbox (2015.10.28) ...\nSetting up dropbox (2015.10.28) ...\nPlease restart all running instances of Nautilus, or you will experience problems. i.e. nautilus --quit\nDropbox installation successfully completed! You can start Dropbox from your applications menu.\nProcessing triggers for bamfdaemon (0.5.3~bzr0+16.04.20160824-0ubuntu1) ...\nRebuilding /usr/share/applications/bamf-2.index...\nProcessing triggers for gnome-menus (3.13.3-6ubuntu3.1) ...\nProcessing triggers for desktop-file-utils (0.22-1ubuntu5) ...\nProcessing triggers for mime-support (3.59ubuntu1) ...\nProcessing triggers for hicolor-icon-theme (0.15-0ubuntu1) ...\nProcessing triggers for man-db (2.7.5-1) ...\n",
    "stdout_lines": [
        "Selecting previously unselected package dropbox.",
        "(Reading database ... 212473 files and directories currently installed.)",
        "Preparing to unpack .../dropbox_2015.10.28_amd64.deb ...",
        "Unpacking dropbox (2015.10.28) ...",
        "Setting up dropbox (2015.10.28) ...",
        "Please restart all running instances of Nautilus, or you will experience problems. i.e. nautilus --quit",
        "Dropbox installation successfully completed! You can start Dropbox from your applications menu.",
        "Processing triggers for bamfdaemon (0.5.3~bzr0+16.04.20160824-0ubuntu1) ...",
        "Rebuilding /usr/share/applications/bamf-2.index...",
        "Processing triggers for gnome-menus (3.13.3-6ubuntu3.1) ...",
        "Processing triggers for desktop-file-utils (0.22-1ubuntu5) ...",
        "Processing triggers for mime-support (3.59ubuntu1) ...",
        "Processing triggers for hicolor-icon-theme (0.15-0ubuntu1) ...",
        "Processing triggers for man-db (2.7.5-1) ..."
    ]
}
```