### PR TITLE
cron: don't force changed=True when old crontab was empty

### DIFF
--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -725,7 +725,7 @@ def main():
                 changed = True
 
     # no changes to env/job, but existing crontab needs a terminating newline
-    if not changed:
+    if not changed and not crontab.existing == '':
         if not (crontab.existing.endswith('\r') or crontab.existing.endswith('\n')):
             changed = True
 


### PR DESCRIPTION

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cron

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel d5f7a0181b) last updated 2017/02/19 16:19:28 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
The cron module forces changed=True when there was no real change, but the original crontab did not  contain a final newline, which is mandatory.

When the user has no crontab or the user does not exist at all, crontab -l exits with 1 and the cron module correctly interprets this as "no crontab" and stores the old crontab as "".

However this triggers changed=True, even if we're not going to change anything, e.g. when removing a crontab entry from a user who has no crontabs at all.

Let's special-case the fact that the old crontab is empty and not force changed=True in that case.

before:
```
% ansible -m cron -a "name=whatever state=absent user=userwithemptycrontab" localhost --check
localhost | SUCCESS => {
    "changed": true, 
    "envs": [], 
    "jobs": []
}
```

after:
```
% ansible -m cron -a "name=whatever state=absent user=userwithemptycrontab" localhost --check
localhost | SUCCESS => {
    "changed": false, 
    "envs": [], 
    "jobs": []
}
```