### PR TITLE
Allow ec2.py to be imported

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -1557,5 +1557,6 @@ class Ec2Inventory(object):
             return json.dumps(data)
 
 
-# Run the script
-Ec2Inventory()
+if __name__ == '__main__':
+    # Run the script
+    Ec2Inventory()


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
`contrib/inventory/ec2.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file = 
  configured module search path = Default w/o overrides

```

##### SUMMARY
Context / Rationale:

I have the need to manage inventory across multiple AWS accounts.

Sadly, there are no consistent sets of hosts across accounts, and tag names aren't consistent either. (i.e. I have "Name: preprod_foo_srv" in preprod, and "Name: prod_foo_srv" in prod.)

To deal with this, I created the following structure. (The appropriate boto profile is defined in each `ec2.ini`.)

```
inventories/
 +-- aws_preprod/
 |    +-- inventory
 |    +-- ec2.ini
 |    +-- ec2.py
 +-- aws_prod/
      +-- inventory
      +-- ec2.ini
      +-- ec2.py
```

Usage:

```
export EC2_INI_PATH=/path/to/inventories/aws_preprod/ec2.ini
ansible-playbook do_thing.yml -i inventories/aws_preprod

export EC2_INI_PATH=/path/to/inventories/aws_prod/ec2.ini
ansible-playbook do_thing.yml -i inventories/aws_prod
```

The change in this PR allows my `ec2.py` files to look like this:

```python
#!/usr/bin/env python

from foobar.contrib.ansible.ec2 import Ec2Inventory


if __name__ == "__main__":
    Ec2Inventory()
```

I verified that `./ec2.py --list` and `ansible-playbook -i ec2.py`
continued to work as expected after my change.