### PR TITLE
Fixes#21557-Handled dellos9_facts crash with IPV6 config

### DIFF
--- a/lib/ansible/modules/network/dellos9/dellos9_facts.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_facts.py
@@ -308,13 +308,14 @@ class Interfaces(FactsBase):
 
     def populate_ipv6_interfaces(self, data):
         for key, value in data.items():
-            self.facts['interfaces'][key]['ipv6'] = list()
-            addresses = re.findall(r'\s+(.+), subnet', value, re.M)
-            subnets = re.findall(r', subnet is (\S+)', value, re.M)
-            for addr, subnet in itertools.izip(addresses, subnets):
-                ipv6 = dict(address=addr.strip(), subnet=subnet.strip())
-                self.add_ip_address(addr.strip(), 'ipv6')
-                self.facts['interfaces'][key]['ipv6'].append(ipv6)
+            if key in self.facts['interfaces']:
+                self.facts['interfaces'][key]['ipv6'] = list()
+                addresses = re.findall(r'\s+(.+), subnet', value, re.M)
+                subnets = re.findall(r', subnet is (\S+)', value, re.M)
+                for addr, subnet in itertools.izip(addresses, subnets):
+                    ipv6 = dict(address=addr.strip(), subnet=subnet.strip())
+                    self.add_ip_address(addr.strip(), 'ipv6')
+                    self.facts['interfaces'][key]['ipv6'].append(ipv6)
 
     def add_ip_address(self, address, family):
         if family == 'ipv4':


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - modules/network/dellos9/dellos9_facts

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file =
  configured module search path = Default w/o overrides

```

##### SUMMARY

Handled dellos9_facts module crash with IPV6 configuration.
Playbook executes successfully and retrieves OS9 facts.

These fixes need to go into `devel` as well as being backported to ‘2.2'

[Fixes#21557](https://github.com/ansible/ansible/issues/21557)

