### PR TITLE
Contributing new lib/ansible/plugins/terminal/ce.py module to manage HUAWEI data center CloudEngine switch

### DIFF
--- a/lib/ansible/plugins/terminal/ce.py
+++ b/lib/ansible/plugins/terminal/ce.py
@@ -52,4 +52,3 @@ class TerminalModule(TerminalBase):
             self._exec_cli_command('screen-length 0 temporary')
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')
-

--- a/lib/ansible/plugins/terminal/ce.py
+++ b/lib/ansible/plugins/terminal/ce.py
@@ -1,0 +1,55 @@
+#
+# (c) 2016 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import re
+
+from ansible.plugins.terminal import TerminalBase
+from ansible.errors import AnsibleConnectionFailure
+
+
+class TerminalModule(TerminalBase):
+
+    terminal_prompts_re = [
+        re.compile(r'[\r\n]?<.+>(?:\s*)$'),
+        re.compile(r'[\r\n]?\[.+\](?:\s*)$'),
+    ]
+
+    terminal_errors_re = [
+        re.compile(r"% ?Error: "),
+        re.compile(r"^% \w+", re.M),
+        re.compile(r"% ?Bad secret"),
+        re.compile(r"invalid input", re.I),
+        re.compile(r"(?:incomplete|ambiguous) command", re.I),
+        re.compile(r"connection timed out", re.I),
+        re.compile(r"[^\r\n]+ not found", re.I),
+        re.compile(r"'[^']' +returned error code: ?\d+"),
+        re.compile(r"syntax error"),
+        re.compile(r"unknown command"),
+        re.compile(r"Error\[\d+\]: ", re.I),
+        re.compile(r"Error:", re.I)
+    ]
+
+    def on_open_shell(self):
+        try:
+            self._exec_cli_command('screen-length 0 temporary')
+        except AnsibleConnectionFailure:
+            raise AnsibleConnectionFailure('unable to set terminal parameters')
+

--- a/lib/ansible/plugins/terminal/ce.py
+++ b/lib/ansible/plugins/terminal/ce.py
@@ -27,12 +27,12 @@ from ansible.errors import AnsibleConnectionFailure
 
 class TerminalModule(TerminalBase):
 
-    terminal_prompts_re = [
+    terminal_stdout_re = [
         re.compile(r'[\r\n]?<.+>(?:\s*)$'),
         re.compile(r'[\r\n]?\[.+\](?:\s*)$'),
     ]
 
-    terminal_errors_re = [
+    terminal_stderr_re = [
         re.compile(r"% ?Error: "),
         re.compile(r"^% \w+", re.M),
         re.compile(r"% ?Bad secret"),


### PR DESCRIPTION
commit plugins terminal ce.py module

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/plugins/terminal/ce.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
config file = /etc/ansible/ansible.cfg
configured module search path = ['/home/ansible-2.1.1.0/lib/ansible/modules/core/network/cloudengine', '/home/ansible-2.1.1.0/lib/ansible/module_utils', '/home/ansible-2.1.1.0/lib/ansible/modules', '/home/ansible-2.1.1.0', '/home/ansible-2.1.1.0/lib/ansible/utils/']
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
pull the basic module :  lib/ansible/plugins/terminal/ce.py to support cloudengine
```
