### PR TITLE
Contributing ce_command module to manage HUAWEI data center CloudEngine switch

### DIFF
--- a/lib/ansible/modules/network/cloudengine/ce_command.py
+++ b/lib/ansible/modules/network/cloudengine/ce_command.py
@@ -33,7 +33,7 @@ description:
     the results read from the device.  The ce_command module includes an
     argument that will cause the module to wait for a specific condition
     before returning or timing out if the condition is not met.
-extends_documentation_fragment: cloudengine
+extends_documentation_fragment: ce
 options:
   commands:
     description:
@@ -84,49 +84,42 @@ options:
 EXAMPLES = """
 # Note: examples below use the following provider dict to handle
 #       transport and authentication to the node.
----
-vars:
-  cli:
+
+- name: CloudEngine command test
+  vars:
     host: "{{ inventory_hostname }}"
     username: admin
     password: admin
     transport: cli
 
----
-- name: run display version on remote devices
-  ce_command:
-    commands: display version
-    provider: "{{ cli }}"
+  tasks:
+  - name: run display version on remote devices
+    ce_command:
+      commands: display version
+      provider: "{{ cli }}"
 
-- name: run display version and check to see if output contains HUAWEI
-  ce_command:
-    commands: display version
-    wait_for: result[0] contains HUAWEI
-    provider: "{{ cli }}"
+  - name: run display version and check to see if output contains HUAWEI
+    ce_command:
+      commands: display version
+      wait_for: result[0] contains HUAWEI
+      provider: "{{ cli }}"
 
-- name: run multiple commands on remote nodes
-  ce_command:
-    commands:
-      - display version
-      - display device
-    provider: "{{ cli }}"
+  - name: run multiple commands on remote nodes
+    ce_command:
+      commands:
+        - display version
+        - display device
+      provider: "{{ cli }}"
 
-- name: run multiple commands and evaluate the output
-  ce_command:
-    commands:
-      - display version
-      - display device
-    wait_for:
-      - result[0] contains HUAWEI
-      - result[1] contains Device
-    provider: "{{ cli }}"
-
-- name: run commands and specify the output format
-  ce_command:
-    commands:
-      - command: display version
-        output: json
-    provider: "{{ cli }}"
+  - name: run multiple commands and evaluate the output
+    ce_command:
+      commands:
+        - display version
+        - display device
+      wait_for:
+        - result[0] contains HUAWEI
+        - result[1] contains Device
+      provider: "{{ cli }}"
 """
 
 RETURN = """
@@ -150,46 +143,56 @@ failed_conditions:
 """
 
 
-from ansible.module_utils.basic import get_exception
-from ansible.module_utils.network import NetworkModule, NetworkError
-from ansible.module_utils.netcli import CommandRunner
-from ansible.module_utils.netcli import FailedConditionsError
-from ansible.module_utils.netcli import FailedConditionalError
-from ansible.module_utils.netcli import AddCommandError, AddConditionError
-import ansible.module_utils.cloudengine
+import time
 
-
-VALID_KEYS = ['command', 'output', 'prompt', 'response']
+from ansible.module_utils.ce import run_commands
+from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import string_types
+from ansible.module_utils.netcli import Conditional
+from ansible.module_utils.network_common import ComplexList
+from ansible.module_utils.ce import ce_argument_spec, check_args
 
 
 def to_lines(stdout):
-    """ to lines """
-
+    lines = list()
     for item in stdout:
         if isinstance(item, basestring):
             item = str(item).split('\n')
-        yield item
+        lines.append(item)
+    return lines
 
 
-def parse_commands(module):
-    """ parse commands """
+def parse_commands(module, warnings):
+    transform = ComplexList(dict(
+        command=dict(key=True),
+        output=dict(),
+        prompt=dict(),
+        response=dict()
+    ), module)
 
-    for cmd in module.params['commands']:
-        if isinstance(cmd, basestring):
-            cmd = dict(command=cmd, output=None)
-        elif 'command' not in cmd:
-            module.fail_json(msg='command keyword argument is required')
-        elif cmd.get('output') not in [None, 'text', 'json']:
-            module.fail_json(msg='invalid output specified for command')
-        elif not set(cmd.keys()).issubset(VALID_KEYS):
-            module.fail_json(msg='unknown keyword specified')
-        yield cmd
+    commands = transform(module.params['commands'])
+
+    for index, item in enumerate(commands):
+        if module.check_mode and not item['command'].startswith('dis'):
+            warnings.append(
+                'Only display commands are supported when using check_mode, not '
+                'executing %s' % item['command']
+            )
+
+    return commands
+
+
+def to_cli(obj):
+    cmd = obj['command']
+    return cmd
 
 
 def main():
-    """ main """
-
-    spec = dict(
+    """entry point for module execution
+    """
+    argument_spec = dict(
+        # { command: <str>, output: <str>, prompt: <str>, response: <str> }
         commands=dict(type='list', required=True),
 
         wait_for=dict(type='list', aliases=['waitfor']),
@@ -199,67 +202,55 @@ def main():
         interval=dict(default=1, type='int')
     )
 
-    module = NetworkModule(argument_spec=spec,
+    argument_spec.update(ce_argument_spec)
+
+    module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
 
-    commands = list(parse_commands(module))
-    conditionals = module.params['wait_for'] or list()
+    result = {'changed': False}
 
     warnings = list()
-
-    runner = CommandRunner(module)
-
-    for cmd in commands:
-        if module.check_mode and not cmd['command'].startswith('dis'):
-            warnings.append('only display commands are supported when using '
-                            'check mode, not executing `%s`' % cmd['command'])
-        else:
-            if cmd['command'].startswith('sys'):
-                module.fail_json(msg='ce_command does not support running '
-                                     'config mode commands.  Please use '
-                                     'ce_config instead')
-            try:
-                runner.add_command(**cmd)
-            except AddCommandError:
-                exc = get_exception()
-                warnings.append('duplicate command detected: %s' % cmd)
-
-    try:
-        for item in conditionals:
-            runner.add_conditional(item)
-    except AddConditionError:
-        exc = get_exception()
-        module.fail_json(msg=str(exc), condition=exc.condition)
-
-    runner.retries = module.params['retries']
-    runner.interval = module.params['interval']
-    runner.match = module.params['match']
-
-    try:
-        runner.run()
-    except FailedConditionsError:
-        exc = get_exception()
-        module.fail_json(msg=str(exc), failed_conditions=exc.failed_conditions)
-    except FailedConditionalError:
-        exc = get_exception()
-        module.fail_json(
-            msg=str(exc), failed_conditional=exc.failed_conditional)
-    except NetworkError:
-        exc = get_exception()
-        module.fail_json(msg=str(exc), **exc.kwargs)
-
-    result = dict(changed=False)
-
-    result['stdout'] = list()
-    for cmd in commands:
-        try:
-            output = runner.get_command(cmd['command'], cmd.get('output'))
-        except ValueError:
-            output = 'command not executed due to check_mode, see warnings'
-        result['stdout'].append(output)
-
+    check_args(module, warnings)
+    commands = parse_commands(module, warnings)
     result['warnings'] = warnings
-    result['stdout_lines'] = list(to_lines(result['stdout']))
+
+    wait_for = module.params['wait_for'] or list()
+
+    try:
+        conditionals = [Conditional(c) for c in wait_for]
+    except AttributeError:
+        exc = get_exception()
+        module.fail_json(msg=str(exc))
+
+    retries = module.params['retries']
+    interval = module.params['interval']
+    match = module.params['match']
+
+    while retries > 0:
+        responses = run_commands(module, commands)
+
+        for item in list(conditionals):
+            if item(responses):
+                if match == 'any':
+                    conditionals = list()
+                    break
+                conditionals.remove(item)
+
+        if not conditionals:
+            break
+
+        time.sleep(interval)
+        retries -= 1
+
+    if conditionals:
+        failed_conditions = [item.raw for item in conditionals]
+        msg = 'One or more conditional statements have not be satisfied'
+        module.fail_json(msg=msg, failed_conditions=failed_conditions)
+
+    result.update({
+        'stdout': responses,
+        'stdout_lines': to_lines(responses)
+    })
 
     module.exit_json(**result)
 


### PR DESCRIPTION
commit ce_command module

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ce_command 

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
config file = /etc/ansible/ansible.cfg
configured module search path = ['/home/ansible-2.1.1.0/lib/ansible/modules/core/network/cloudengine', '/home/ansible-2.1.1.0/lib/ansible/module_utils', '/home/ansible-2.1.1.0/lib/ansible/modules', '/home/ansible-2.1.1.0', '/home/ansible-2.1.1.0/lib/ansible/utils/']
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [display device] **********************************************************
task path: /usr1/code/OpenNESS/code/current/KVM/intg/test/testcases/test-ce_command.yml:15
Using module file /usr/local/lib/python2.7/site-packages/ansible-2.3.0-py2.7.egg/ansible/modules/core/network/cloudengine/ce_command.py
<ce_6850> ESTABLISH LOCAL CONNECTION FOR USER: root
<ce_6850> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1487042701.29-103196937398986 `" && echo ansible-tmp-1487042701.29-103196937398986="` echo $HOME/.ansible/tmp/ansible-tmp-1487042701.29-103196937398986 `" ) && sleep 0'
<ce_6850> PUT /tmp/tmpsr4Rqm TO /root/.ansible/tmp/ansible-tmp-1487042701.29-103196937398986/ce_command.py
<ce_6850> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1487042701.29-103196937398986/ /root/.ansible/tmp/ansible-tmp-1487042701.29-103196937398986/ce_command.py && sleep 0'
<ce_6850> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1487042701.29-103196937398986/ce_command.py; rm -rf "/root/.ansible/tmp/ansible-tmp-1487042701.29-103196937398986/" > /dev/null 2>&1 && sleep 0'
ok: [ce_6850] => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "auth_pass": null, 
            "authorize": false, 
            "commands": [
                "display device"
            ], 
            "host": "ce_6850", 
            "interval": 1, 
            "match": "all", 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 12345, 
            "provider": null, 
            "retries": 10, 
            "ssh_keyfile": null, 
            "timeout": 10, 
            "transport": null, 
            "use_ssl": false, 
            "username": "rootDC", 
            "validate_certs": true, 
            "wait_for": null
        }, 
        "module_name": "ce_command"
    }, 
    "stdout": [
        "Device status:\n--------------------------------------------------------------------------------\nSlot  Card   Type                     Online   Power Register     Alarm     Primary        \n--------------------------------------------------------------------------------\n1     -      CE6850U-48S6Q-HI         Present  On    Registered   Normal    Master         \n      FAN1   FAN-060A-B               Present  On    Registered   Normal    NA             \n      PWR2   PAC-600WB-B              Present  On    Registered   Normal    NA             \n--------------------------------------------------------------------------------"
    ], 
    "stdout_lines": [
        [
            "Device status:", 
            "--------------------------------------------------------------------------------", 
            "Slot  Card   Type                     Online   Power Register     Alarm     Primary        ", 
            "--------------------------------------------------------------------------------", 
            "1     -      CE6850U-48S6Q-HI         Present  On    Registered   Normal    Master         ", 
            "      FAN1   FAN-060A-B               Present  On    Registered   Normal    NA             ", 
            "      PWR2   PAC-600WB-B              Present  On    Registered   Normal    NA             ", 
            "--------------------------------------------------------------------------------"
        ]
    ], 
    "warnings": []
}
```
