### PR TITLE
Fixes#18663-Bad Handling of existing config in OS6 module

### DIFF
--- a/lib/ansible/module_utils/dellos6.py
+++ b/lib/ansible/module_utils/dellos6.py
@@ -1,3 +1,4 @@
+
 #
 # (c) 2015 Peter Sprygada, <psprygada@ansible.com>
 #
@@ -38,28 +39,24 @@ from ansible.module_utils.netcfg import NetworkConfig, ConfigLine, ignore_line, 
 
 def get_config(module):
     contents = module.params['config']
-
     if not contents:
         contents = module.config.get_config()
         module.params['config'] = contents
-
-    return Dellos6NetworkConfig(indent=0, contents=contents[0])
-
+        return Dellos6NetworkConfig(indent=0, contents=contents[0])
+    else:
+        return Dellos6NetworkConfig(indent=0, contents=contents)
 
 def get_sublevel_config(running_config, module):
     contents = list()
     current_config_contents = list()
     sublevel_config = Dellos6NetworkConfig(indent=0)
-
     obj = running_config.get_object(module.params['parents'])
     if obj:
         contents = obj.children
-
     for c in contents:
         if isinstance(c, ConfigLine):
             current_config_contents.append(c.raw)
     sublevel_config.add(current_config_contents, module.params['parents'])
-
     return sublevel_config
 
 
@@ -68,6 +65,7 @@ def os6_parse(lines, indent=None, comment_tokens=None):
         re.compile(r'^vlan.*$'),
         re.compile(r'^stack.*$'),
         re.compile(r'^interface.*$'),
+        re.compile(r'datacenter-bridging.*$'),
         re.compile(r'line (console|telnet|ssh).*$'),
         re.compile(r'ip ssh !(server).*$'),
         re.compile(r'ip (dhcp|vrf).*$'),
@@ -85,61 +83,87 @@ def os6_parse(lines, indent=None, comment_tokens=None):
         re.compile(r'banner motd.*$'),
         re.compile(r'openflow.*$'),
         re.compile(r'support-assist.*$'),
+        re.compile(r'template.*$'),
+        re.compile(r'address-family.*$'),
+        re.compile(r'spanning-tree mst.*$'),
+        re.compile(r'logging.*$'),
         re.compile(r'(radius-server|tacacs-server) host.*$')]
 
     childline = re.compile(r'^exit$')
-
     config = list()
-    inSubLevel = False
-    parent = None
-    children = list()
-    subcommandcount = 0
-
+    parent = list()
+    children = []
+    parent_match = False
     for line in str(lines).split('\n'):
         text = str(re.sub(r'([{};])', '', line)).strip()
-
         cfg = ConfigLine(text)
         cfg.raw = line
-
         if not text or ignore_line(text, comment_tokens):
-            parent = None
-            children = list()
-            inSubLevel = False
+            parent = list()
+            children = []
             continue
 
-        if inSubLevel is False:
-            for pr in sublevel_cmds:
-                if pr.match(line):
-                    parent = cfg
-                    config.append(parent)
-                    inSubLevel = True
-                    continue
-            if parent is None:
-                config.append(cfg)
+        else:
+          parent_match=False
+          # handle sublevel parent
+          for pr in sublevel_cmds:
+              if pr.match(line):
+                 if len(parent) != 0:
+                     cfg.parents.extend(parent)
+                 parent.append(cfg)
+                 config.append(cfg)
+                 if children:
+                   children.insert(len(parent)-1,[])
+                   children[len(parent)-2].append(cfg)
+                 parent_match=True
+                 continue
+          # handle exit
+          if childline.match(line):
+            if children:
+              parent[len(children)-1].children.extend(children[len(children)-1])
+              if len(children)>1:
+                parent[len(children)-2].children.extend(parent[len(children)-1].children)
+              cfg.parents.extend(parent)
+              children.pop()
+              parent.pop()
 
-        # handle sub level commands
-        elif inSubLevel and childline.match(line):
-            parent.children = children
-            inSubLevel = False
-            children = list()
-            parent = None
-
-        # handle top level commands
-        elif inSubLevel:
-            children.append(cfg)
-            cfg.parents = [parent]
+            if not children:
+              children = list()
+              if parent:
+                  cfg.parents.extend(parent)
+              parent = list()
             config.append(cfg)
-
-        else:  # global level
+          # handle sublevel children
+          elif parent_match is False and len(parent)>0 :
+            if not children:
+              cfglist=[cfg]
+              children.append(cfglist)
+            else:
+              children[len(parent)-1].append(cfg)
+            cfg.parents.extend(parent)
             config.append(cfg)
-
-    return config
+          # handle global commands
+          elif not parent:
+            config.append(cfg)
+    return config             
 
 
 class Dellos6NetworkConfig(NetworkConfig):
 
     def load(self, contents):
         self._config = os6_parse(contents, self.indent, DEFAULT_COMMENT_TOKENS)
+
+    def diff_line(self, other, path=None):
+        diff = list()
+        for item in self.items:
+            if str(item) == "exit":
+                for diff_item in diff:
+                    if item.parents == diff_item.parents:
+                        diff.append(item)
+                        break
+            elif item not in other:
+                diff.append(item)
+        return diff
 
 
 class Cli(CliBase):

--- a/lib/ansible/module_utils/dellos6.py
+++ b/lib/ansible/module_utils/dellos6.py
@@ -104,48 +104,47 @@ def os6_parse(lines, indent=None, comment_tokens=None):
             continue
 
         else:
-          parent_match=False
-          # handle sublevel parent
-          for pr in sublevel_cmds:
-              if pr.match(line):
-                 if len(parent) != 0:
-                     cfg.parents.extend(parent)
-                 parent.append(cfg)
-                 config.append(cfg)
-                 if children:
-                   children.insert(len(parent)-1,[])
-                   children[len(parent)-2].append(cfg)
-                 parent_match=True
-                 continue
-          # handle exit
-          if childline.match(line):
-            if children:
-              parent[len(children)-1].children.extend(children[len(children)-1])
-              if len(children)>1:
-                parent[len(children)-2].children.extend(parent[len(children)-1].children)
-              cfg.parents.extend(parent)
-              children.pop()
-              parent.pop()
-
-            if not children:
-              children = list()
-              if parent:
-                  cfg.parents.extend(parent)
-              parent = list()
-            config.append(cfg)
-          # handle sublevel children
-          elif parent_match is False and len(parent)>0 :
-            if not children:
-              cfglist=[cfg]
-              children.append(cfglist)
-            else:
-              children[len(parent)-1].append(cfg)
-            cfg.parents.extend(parent)
-            config.append(cfg)
-          # handle global commands
-          elif not parent:
-            config.append(cfg)
-    return config             
+            parent_match=False
+            # handle sublevel parent
+            for pr in sublevel_cmds:
+                if pr.match(line):
+                    if len(parent) != 0:
+                        cfg.parents.extend(parent)
+                    parent.append(cfg)
+                    config.append(cfg)
+                    if children:
+                        children.insert(len(parent) - 1,[])
+                        children[len(parent) - 2].append(cfg)
+                    parent_match=True
+                    continue
+            # handle exit
+            if childline.match(line):
+                if children:
+                    parent[len(children) - 1].children.extend(children[len(children) - 1])
+                    if len(children)>1:
+                        parent[len(children) - 2].children.extend(parent[len(children) - 1].children)
+                    cfg.parents.extend(parent)
+                    children.pop()
+                    parent.pop()
+                if not children:
+                    children = list()
+                    if parent:
+                        cfg.parents.extend(parent)
+                    parent = list()
+                    config.append(cfg)
+            # handle sublevel children
+            elif parent_match is False and len(parent)>0 :
+                if not children:
+                    cfglist=[cfg]
+                    children.append(cfglist)
+                else:
+                    children[len(parent) - 1].append(cfg)
+                cfg.parents.extend(parent)
+                config.append(cfg)
+            # handle global commands
+            elif not parent:
+                config.append(cfg)
+    return config
 
 
 class Dellos6NetworkConfig(NetworkConfig):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible.module_utils.dellos6

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file =
  configured module search path = Default w/o overrides

```

##### SUMMARY
Handled the parsing of existing configs in OS6 module. 
Parses the configs correctly, hence doesn't apply changes if existing configs are same as the configs you are trying to push into device.

[Fixes#18663](https://github.com/ansible/ansible/issues/18663)

