### PR TITLE
vmware_inventory: permit to skip nopermission error on guest subkeys

### DIFF
--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -685,12 +685,15 @@ class VMWareInventory(object):
                 if self.lowerkeys:
                     method = method.lower()
                 if level + 1 <= self.maxlevel:
-                    rdata[method] = self._process_object_types(
-                        methodToCall,
-                        thisvm=thisvm,
-                        inkey=inkey + '.' + method,
-                        level=(level + 1)
-                    )
+                    try:
+                        rdata[method] = self._process_object_types(
+                            methodToCall,
+                            thisvm=thisvm,
+                            inkey=inkey + '.' + method,
+                            level=(level + 1)
+                        )
+                    except vim.fault.NoPermission:
+                        self.debugl("Skipping method %s (NoPermission)" % method)
         else:
             pass
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vmware_inventory.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0 (backported vmware_inventory.py from devel)
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
permit to skip nopermission error on guest subkeys
notify user in debug mode

example use case: you have rights on guest but you cannot see the VMWare host
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
2017-02-20 11:41:39.098261 get facts for vm_guest_001
2017-02-20 11:41:39.311693 Skipping method host (NoPermission)
```

