### PR TITLE
Fix vault cli errors on 'encrypt_string_read_stdin'

### DIFF
--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -109,13 +109,14 @@ class VaultCLI(CLI):
             if self.options.output_file and len(self.args) > 1:
                 raise AnsibleOptionsError("At most one input file may be used with the --output option")
 
-        if '-' in self.args or len(self.args) == 0 or self.options.encrypt_string_stdin_name:
-            self.encrypt_string_read_stdin = True
+        if self.action == 'encrypt_string':
+            if '-' in self.args or len(self.args) == 0 or self.options.encrypt_string_stdin_name:
+                self.encrypt_string_read_stdin = True
 
-        # TODO: prompting from stdin and reading from stdin seem
-        #       mutually exclusive, but verify that.
-        if self.options.encrypt_string_prompt and self.encrypt_string_read_stdin:
-            raise AnsibleOptionsError('The --prompt option is not supported if also reading input from stdin')
+            # TODO: prompting from stdin and reading from stdin seem
+            #       mutually exclusive, but verify that.
+            if self.options.encrypt_string_prompt and self.encrypt_string_read_stdin:
+                raise AnsibleOptionsError('The --prompt option is not supported if also reading input from stdin')
 
     def run(self):
 


### PR DESCRIPTION
'encrypt_string' only options were being referenced when using
other vault subcommands. That code is moved inside a check
for 'encrypt_string' action now.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/cli/vault.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (vault_cli_encrypt_string_error ba5cfb9236) last updated 2017/02/20 10:53:13 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']


```

##### SUMMARY
