### PR TITLE
hponcfg: Configure HP iLO mgmt board (in-band)

### DIFF
--- a/lib/ansible/modules/remote_management/hpilo/hponcfg.py
+++ b/lib/ansible/modules/remote_management/hpilo/hponcfg.py
@@ -1,0 +1,105 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2012, Dag Wieers <dag@wieers.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = r'''
+---
+module: hponcfg
+author: Dag Wieers (@dagwieers)
+version_added: "2.3"
+short_description: Configure HP iLO interface using hponcfg
+description:
+- This modules configures the HP iLO interface using hponcfg.
+options:
+  path:
+    description:
+    - The XML file as accepted by hponcfg
+    required: true
+    aliases: ['src']
+  minfw:
+    description:
+    - The minimum firmware level needed
+requirements:
+- hponcfg tool
+notes:
+- You need a working hponcfg on the target system.
+'''
+
+EXAMPLES = r'''
+- name: Example hponcfg configuration XML
+  copy:
+    content: |
+      <ribcl VERSION="2.0">
+        <login USER_LOGIN="user" PASSWORD="password">
+          <rib_info MODE="WRITE">
+            <mod_global_settings>
+              <session_timeout value="0"/>
+              <ssh_status value="Y"/>
+              <ssh_port value="22"/>
+              <serial_cli_status value="3"/>
+              <serial_cli_speed value="5"/>
+            </mod_global_settings>
+          </rib_info>
+        </login>
+      </ribcl>
+    dest: /tmp/enable-ssh.xml
+
+- name: Configure HP iLO using enable-ssh.xml
+  hponcfg:
+    src: /tmp/enable-ssh.xml
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec = dict(
+            src = dict(required=True, type='path', aliases=['path']),
+            minfw = dict(type='str'),
+        )
+    )
+
+    # Consider every action a change (not idempotent yet!)
+    changed = True
+
+    src = module.params['src']
+    minfw = module.params['minfw']
+
+    options = ' -f %s' % src
+
+    # Add -v for debugging
+#    options += ' -v'
+
+    if minfw:
+        option += ' -m %s' % minfw
+
+    rc, stdout, stderr = module.run_command('hponcfg %s' % options)
+
+    if rc != 0:
+        module.fail_json(rc=rc, msg="Failed to run hponcfg", stdout=stdout, stderr=stderr)
+
+    module.exit_json(changed=changed, stdout=stdout, stderr=stderr)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
hponcfg

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
This is the original `hponcfg` module that was once accepted in
Ansible but had been removed subsequently because it could not be tested
by the Ansible project.

Since then it was moved to the ansible-provisioning project and
maintained by HP engineers going forward.

Now we are trying to get it upstreamed again.