### PR TITLE
correct traceback.format_exc; doesn't take an error parameter

### DIFF
--- a/lib/ansible/module_utils/gcp.py
+++ b/lib/ansible/module_utils/gcp.py
@@ -384,4 +384,4 @@ def check_min_pkg_version(pkg_name, minimum_version):
 
 def unexpected_error_msg(error):
     """Create an error string based on passed in error."""
-    return 'Unexpected response: (%s). Detail: %s' % (str(error), traceback.format_exc(error))
+    return 'Unexpected response: (%s). Detail: %s' % (str(error), traceback.format_exc())

--- a/lib/ansible/modules/cloud/amazon/aws_kms.py
+++ b/lib/ansible/modules/cloud/amazon/aws_kms.py
@@ -264,7 +264,7 @@ def main():
         kms = ansible.module_utils.ec2.boto3_conn(module, conn_type='client', resource='kms', region=region, endpoint=ec2_url, **aws_connect_kwargs)
         iam = ansible.module_utils.ec2.boto3_conn(module, conn_type='client', resource='iam', region=region, endpoint=ec2_url, **aws_connect_kwargs)
     except botocore.exceptions.NoCredentialsError as e:
-        module.fail_json(msg='cannot connect to AWS', exception=traceback.format_exc(e))
+        module.fail_json(msg='cannot connect to AWS', exception=traceback.format_exc())
 
 
     try:
@@ -289,7 +289,7 @@ def main():
 
     except Exception as err:
         error_msg = boto_exception(err)
-        module.fail_json(msg=error_msg, exception=traceback.format_exc(err))
+        module.fail_json(msg=error_msg, exception=traceback.format_exc())
 
     module.exit_json(**result)
 

--- a/lib/ansible/modules/cloud/amazon/cloudformation_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation_facts.py
@@ -167,7 +167,7 @@ class CloudFormationServiceManager:
         except botocore.exceptions.NoRegionError:
             self.module.fail_json(msg="Region must be specified as a parameter, in AWS_DEFAULT_REGION environment variable or in boto configuration file")
         except Exception as e:
-            self.module.fail_json(msg="Can't establish connection - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Can't establish connection - " + str(e), exception=traceback.format_exc())
 
     def describe_stack(self, stack_name):
         try:
@@ -177,21 +177,21 @@ class CloudFormationServiceManager:
                 return response[0]
             self.module.fail_json(msg="Error describing stack - an empty response was returned")
         except Exception as e:
-            self.module.fail_json(msg="Error describing stack - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error describing stack - " + str(e), exception=traceback.format_exc())
 
     def list_stack_resources(self, stack_name):
         try:
             func = partial(self.client.list_stack_resources,StackName=stack_name)
             return self.paginated_response(func, 'StackResourceSummaries')
         except Exception as e:
-            self.module.fail_json(msg="Error listing stack resources - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error listing stack resources - " + str(e), exception=traceback.format_exc())
 
     def describe_stack_events(self, stack_name):
         try:
             func = partial(self.client.describe_stack_events,StackName=stack_name)
             return self.paginated_response(func, 'StackEvents')
         except Exception as e:
-            self.module.fail_json(msg="Error describing stack events - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error describing stack events - " + str(e), exception=traceback.format_exc())
 
     def get_stack_policy(self, stack_name):
         try:
@@ -201,14 +201,14 @@ class CloudFormationServiceManager:
                 return json.loads(stack_policy)
             return dict()
         except Exception as e:
-            self.module.fail_json(msg="Error getting stack policy - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error getting stack policy - " + str(e), exception=traceback.format_exc())
 
     def get_template(self, stack_name):
         try:
             response = self.client.get_template(StackName=stack_name)
             return response.get('TemplateBody')
         except Exception as e:
-            self.module.fail_json(msg="Error getting stack template - " + str(e), exception=traceback.format_exc(e))
+            self.module.fail_json(msg="Error getting stack template - " + str(e), exception=traceback.format_exc())
 
     def paginated_response(self, func, result_key, next_token=None):
         '''

--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -236,7 +236,7 @@ class CloudFrontServiceManager:
             self.module.fail_json(msg="Region must be specified as a parameter, in AWS_DEFAULT_REGION environment variable or in boto configuration file")
         except Exception as e:
             self.module.fail_json(msg="Can't establish connection - " + str(e),
-                                  exception=traceback.format_exc(e))
+                                  exception=traceback.format_exc())
 
     def get_distribution(self, distribution_id):
         try:
@@ -244,7 +244,7 @@ class CloudFrontServiceManager:
             return self.paginated_response(func)
         except Exception as e:
             self.module.fail_json(msg="Error describing distribution - " + str(e),
-                                  exception=traceback.format_exc(e))
+                                  exception=traceback.format_exc())
 
     def get_distribution_config(self, distribution_id):
         try:
@@ -252,7 +252,7 @@ class CloudFrontServiceManager:
             return self.paginated_response(func)
         except Exception as e:
             self.module.fail_json(msg="Error describing distribution configuration - " + str(e),
-                                  exception=traceback.format_exec(e))
+                                  exception=traceback.format_exec())
 
     def get_origin_access_identity(self, origin_access_identity_id):
         try:
@@ -260,7 +260,7 @@ class CloudFrontServiceManager:
             return self.paginated_response(func)
         except Exception as e:
             self.module.fail_json(msg="Error describing origin access identity - " + str(e),
-                                  exception=traceback.format_exc(e))
+                                  exception=traceback.format_exc())
 
     def get_origin_access_identity_config(self, origin_access_identity_id):
         try:
@@ -268,7 +268,7 @@ class CloudFrontServiceManager:
             return self.paginated_response(func)
         except Exception as e:
             self.module.fail_json(msg="Error describing origin access identity configuration - " + str(e),
-                                  exception=traceback.format_exc(e))
+                                  exception=traceback.format_exc())
 
     def get_invalidation(self, distribution_id, invalidation_id):
         try:
@@ -276,7 +276,7 @@ class CloudFrontServiceManager:
             return self.paginated_response(func)
         except Exception as e:
             self.module.fail_json(msg="Error describing invalidation - " + str(e),
-                                  exception=traceback.format_exc(e))
+                                  exception=traceback.format_exc())
 
     def get_streaming_distribution(self, distribution_id):
         try:
@@ -284,7 +284,7 @@ class CloudFrontServiceManager:
             return self.paginated_response(func)
         except Exception as e:
             self.module.fail_json(msg="Error describing streaming distribution - " + str(e),
-                                  exception=traceback.format_exc(e))
+                                  exception=traceback.format_exc())
 
     def get_streaming_distribution_config(self, distribution_id):
         try:
@@ -292,7 +292,7 @@ class CloudFrontServiceManager:
             return self.paginated_response(func)
         except Exception as e:
             self.module.fail_json(msg="Error describing streaming distribution - " + str(e),
-                                  exception=traceback.format_exc(e))
+                                  exception=traceback.format_exc())
 
     def list_origin_access_identities(self):
         try:
@@ -303,7 +303,7 @@ class CloudFrontServiceManager:
             return {}
         except Exception as e:
             self.module.fail_json(msg="Error listing cloud front origin access identities - " + str(e),
-                                  exception=traceback.format_exc(e))
+                                  exception=traceback.format_exc())
 
     def list_distributions(self, keyed=True):
         try:
@@ -318,7 +318,7 @@ class CloudFrontServiceManager:
             return self.keyed_list_helper(distribution_list)
         except Exception as e:
             self.module.fail_json(msg="Error listing distributions - " + str(e),
-                                  exception=traceback.format_exc(e))
+                                  exception=traceback.format_exc())
 
     def list_distributions_by_web_acl_id(self, web_acl_id):
         try:
@@ -331,7 +331,7 @@ class CloudFrontServiceManager:
             return self.keyed_list_helper(distribution_list)
         except Exception as e:
             self.module.fail_json(msg="Error listing distributions by web acl id - " + str(e),
-                                  exception=traceback.format_exc(e))
+                                  exception=traceback.format_exc())
 
     def list_invalidations(self, distribution_id):
         try:
@@ -342,7 +342,7 @@ class CloudFrontServiceManager:
             return {}
         except Exception as e:
             self.module.fail_json(msg="Error listing invalidations - " + str(e),
-                                  exception=traceback.format_exc(e))
+                                  exception=traceback.format_exc())
 
     def list_streaming_distributions(self, keyed=True):
         try:
@@ -357,7 +357,7 @@ class CloudFrontServiceManager:
             return self.keyed_list_helper(streaming_distribution_list)
         except Exception as e:
             self.module.fail_json(msg="Error listing streaming distributions - " + str(e),
-                                  exception=traceback.format_exc(e))
+                                  exception=traceback.format_exc())
 
     def summary(self):
         summary_dict = {}
@@ -378,7 +378,7 @@ class CloudFrontServiceManager:
             return origin_access_identity_list
         except Exception as e:
             self.module.fail_json(msg="Error generating summary of origin access identities - " + str(e),
-                                  exception=traceback.format_exc(e))
+                                  exception=traceback.format_exc())
 
     def summary_get_distribution_list(self, streaming=False):
         try:
@@ -404,7 +404,7 @@ class CloudFrontServiceManager:
             return distribution_list
         except Exception as e:
             self.module.fail_json(msg="Error generating summary of distributions - " + str(e),
-                                  exception=traceback.format_exc(e))
+                                  exception=traceback.format_exc())
 
     def get_etag_from_distribution_id(self, distribution_id, streaming):
         distribution = {}
@@ -423,7 +423,7 @@ class CloudFrontServiceManager:
             return invalidation_ids
         except Exception as e:
             self.module.fail_json(msg="Error getting list of invalidation ids - " + str(e),
-                                  exception=traceback.format_exc(e))
+                                  exception=traceback.format_exc())
 
     def get_distribution_id_from_domain_name(self, domain_name):
         try:
@@ -439,7 +439,7 @@ class CloudFrontServiceManager:
             return distribution_id
         except Exception as e:
             self.module.fail_json(msg="Error getting distribution id from domain name - " + str(e),
-                                  exception=traceback.format_exc(e))
+                                  exception=traceback.format_exc())
 
     def get_aliases_from_distribution_id(self, distribution_id):
         aliases = []
@@ -453,7 +453,7 @@ class CloudFrontServiceManager:
             return aliases
         except Exception as e:
             self.module.fail_json(msg="Error getting list of aliases from distribution_id - " + str(e),
-                                  exception=traceback.format_exc(e))
+                                  exception=traceback.format_exc())
 
     def paginated_response(self, func, result_key=""):
         '''

--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -1407,7 +1407,7 @@ def startstop_instances(module, ec2, instance_ids, state, instance_tags):
                             changed = True
                 else:
                     module.fail_json(msg='Failed to handle source_dest_check state for instance {0}, error: {1}'.format(inst.id, exc),
-                                     exception=traceback.format_exc(exc))
+                                     exception=traceback.format_exc())
 
             # Check "termination_protection" attribute
             if (inst.get_attribute('disableApiTermination')['disableApiTermination'] != termination_protection
@@ -1514,7 +1514,7 @@ def restart_instances(module, ec2, instance_ids, state, instance_tags):
                             changed = True
                 else:
                     module.fail_json(msg='Failed to handle source_dest_check state for instance {0}, error: {1}'.format(inst.id, exc),
-                                     exception=traceback.format_exc(exc))
+                                     exception=traceback.format_exc())
 
             # Check "termination_protection" attribute
             if (inst.get_attribute('disableApiTermination')['disableApiTermination'] != termination_protection

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -506,7 +506,7 @@ def create_autoscaling_group(connection, module):
             changed = True
             return(changed, asg_properties)
         except BotoServerError as e:
-            module.fail_json(msg="Failed to create Autoscaling Group: %s" % str(e), exception=traceback.format_exc(e))
+            module.fail_json(msg="Failed to create Autoscaling Group: %s" % str(e), exception=traceback.format_exc())
     else:
         as_group = as_groups[0]
         changed = False
@@ -566,13 +566,13 @@ def create_autoscaling_group(connection, module):
             try:
                 as_group.update()
             except BotoServerError as e:
-                module.fail_json(msg="Failed to update Autoscaling Group: %s" % str(e), exception=traceback.format_exc(e))
+                module.fail_json(msg="Failed to update Autoscaling Group: %s" % str(e), exception=traceback.format_exc())
 
         if notification_topic:
             try:
                 as_group.put_notification_configuration(notification_topic, notification_types)
             except BotoServerError as e:
-                module.fail_json(msg="Failed to update Autoscaling Group notifications: %s" % str(e), exception=traceback.format_exc(e))
+                module.fail_json(msg="Failed to update Autoscaling Group notifications: %s" % str(e), exception=traceback.format_exc())
 
         if wait_for_instances:
             wait_for_new_inst(module, connection, group_name, wait_timeout, desired_capacity, 'viable_instances')
@@ -581,7 +581,7 @@ def create_autoscaling_group(connection, module):
             as_group = connection.get_all_groups(names=[group_name])[0]
             asg_properties = get_properties(as_group)
         except BotoServerError as e:
-            module.fail_json(msg="Failed to read existing Autoscaling Groups: %s" % str(e), exception=traceback.format_exc(e))
+            module.fail_json(msg="Failed to read existing Autoscaling Groups: %s" % str(e), exception=traceback.format_exc())
         return(changed, asg_properties)
 
 

--- a/lib/ansible/modules/cloud/amazon/ec2_group_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group_facts.py
@@ -145,7 +145,7 @@ def main():
             Filters=ansible_dict_to_boto3_filter_list(sanitized_filters)
         )
     except ClientError as e:
-        module.fail_json(msg=e.message, exception=traceback.format_exc(e))
+        module.fail_json(msg=e.message, exception=traceback.format_exc())
 
     # Turn the boto3 result in to ansible_friendly_snaked_names
     snaked_security_groups = []

--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -131,7 +131,7 @@ def create(module, conn, name, group_family, description):
         response = conn.create_cache_parameter_group(CacheParameterGroupName=name, CacheParameterGroupFamily=group_family, Description=description)
         changed = True
     except boto.exception.BotoServerError as e:
-        module.fail_json(msg="Unable to create cache parameter group.", exception=traceback.format_exc(e))
+        module.fail_json(msg="Unable to create cache parameter group.", exception=traceback.format_exc())
     return response, changed
 
 def delete(module, conn, name):
@@ -141,7 +141,7 @@ def delete(module, conn, name):
         response = {}
         changed = True
     except boto.exception.BotoServerError as e:
-        module.fail_json(msg="Unable to delete cache parameter group.", exception=traceback.format_exc(e))
+        module.fail_json(msg="Unable to delete cache parameter group.", exception=traceback.format_exc())
     return response, changed
 
 def make_current_modifiable_param_dict(module, conn, name):
@@ -215,7 +215,7 @@ def modify(module, conn, name, values):
     try:
         response = conn.modify_cache_parameter_group(CacheParameterGroupName=name, ParameterNameValues=format_parameters)
     except boto.exception.BotoServerError as e:
-        module.fail_json(msg="Unable to modify cache parameter group.", exception=traceback.format_exc(e))
+        module.fail_json(msg="Unable to modify cache parameter group.", exception=traceback.format_exc())
     return response
 
 def reset(module, conn, name, values):
@@ -238,7 +238,7 @@ def reset(module, conn, name, values):
     try:
         response = conn.reset_cache_parameter_group(CacheParameterGroupName=name, ParameterNameValues=format_parameters, ResetAllParameters=all_parameters)
     except boto.exception.BotoServerError as e:
-        module.fail_json(msg="Unable to reset cache parameter group.", exception=traceback.format_exc(e))
+        module.fail_json(msg="Unable to reset cache parameter group.", exception=traceback.format_exc())
 
     # determine changed
     new_parameters_dict = make_current_modifiable_param_dict(module, conn, name)

--- a/lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
@@ -151,7 +151,7 @@ def create(module, connection, replication_id, cluster_id, name):
             response = {}
             changed = False
         else:
-            module.fail_json(msg="Unable to create the snapshot.", exception=traceback.format_exc(e))
+            module.fail_json(msg="Unable to create the snapshot.", exception=traceback.format_exc())
     return response, changed
 
 def copy(module, connection, name, target, bucket):
@@ -162,7 +162,7 @@ def copy(module, connection, name, target, bucket):
                                             TargetBucket=bucket)
         changed = True
     except botocore.exceptions.ClientError as e:
-        module.fail_json(msg="Unable to copy the snapshot.", exception=traceback.format_exc(e))
+        module.fail_json(msg="Unable to copy the snapshot.", exception=traceback.format_exc())
     return response, changed
 
 def delete(module, connection, name):
@@ -178,7 +178,7 @@ def delete(module, connection, name):
             module.fail_json(msg="Error: InvalidSnapshotState. The snapshot is not in an available state or failed state to allow deletion."
                              "You may need to wait a few minutes.")
         else:
-            module.fail_json(msg="Unable to delete the snapshot.", exception=traceback.format_exc(e))
+            module.fail_json(msg="Unable to delete the snapshot.", exception=traceback.format_exc())
     return response, changed
 
 

--- a/lib/ansible/modules/cloud/amazon/execute_lambda.py
+++ b/lib/ansible/modules/cloud/amazon/execute_lambda.py
@@ -189,7 +189,7 @@ def main():
         client = boto3_conn(module, conn_type='client', resource='lambda',
                             region=region, endpoint=ec2_url, **aws_connect_kwargs)
     except (botocore.exceptions.ClientError, botocore.exceptions.ValidationError) as e:
-        module.fail_json(msg="Failure connecting boto3 to AWS", exception=traceback.format_exc(e))
+        module.fail_json(msg="Failure connecting boto3 to AWS", exception=traceback.format_exc())
 
     invoke_params = {}
 
@@ -230,15 +230,15 @@ def main():
             module.fail_json(msg="Could not find Lambda to execute. Make sure "
                              "the ARN is correct and your profile has "
                              "permissions to execute this function.",
-                             exception=traceback.format_exc(ce))
+                             exception=traceback.format_exc())
         module.fail_json("Client-side error when invoking Lambda, check inputs and specific error",
-                         exception=traceback.format_exc(ce))
+                         exception=traceback.format_exc())
     except botocore.exceptions.ParamValidationError as ve:
         module.fail_json(msg="Parameters to `invoke` failed to validate",
                          exception=traceback.format_exc(ve))
     except Exception as e:
         module.fail_json(msg="Unexpected failure while invoking Lambda function",
-                         exception=traceback.format_exc(e))
+                         exception=traceback.format_exc())
 
     results ={
         'logs': '',
@@ -251,13 +251,13 @@ def main():
             # logs are base64 encoded in the API response
             results['logs'] = base64.b64decode(response.get('LogResult', ''))
         except Exception as e:
-            module.fail_json(msg="Failed while decoding logs", exception=traceback.format_exc(e))
+            module.fail_json(msg="Failed while decoding logs", exception=traceback.format_exc())
 
     if invoke_params['InvocationType'] == 'RequestResponse':
         try:
             results['output'] = json.loads(response['Payload'].read())
         except Exception as e:
-            module.fail_json(msg="Failed while decoding function return value", exception=traceback.format_exc(e))
+            module.fail_json(msg="Failed while decoding function return value", exception=traceback.format_exc())
 
         if isinstance(results.get('output'), dict) and any(
                 [results['output'].get('stackTrace'), results['output'].get('errorMessage')]):

--- a/lib/ansible/modules/cloud/smartos/vmadm.py
+++ b/lib/ansible/modules/cloud/smartos/vmadm.py
@@ -466,7 +466,7 @@ def new_vm(module, uuid, vm_state):
         # if we cannot remove the file so the operator knows about it.
         module.fail_json(
             msg='Could not remove temporary JSON payload file {0}'.format(payload_file),
-            exception=traceback.format_exc(e))
+            exception=traceback.format_exc())
 
     return changed, vm_uuid
 
@@ -530,7 +530,7 @@ def create_payload(module, uuid):
         vmdef_json = json.dumps(vmdef)
     except Exception as e:
         module.fail_json(
-            msg='Could not create valid JSON payload', exception=traceback.format_exc(e))
+            msg='Could not create valid JSON payload', exception=traceback.format_exc())
 
     # Create the temporary file that contains our payload, and set tight
     # permissions for it may container sensitive information.
@@ -545,7 +545,7 @@ def create_payload(module, uuid):
         fh.close()
     except Exception as e:
         module.fail_json(
-            msg='Could not save JSON payload', exception=traceback.format_exc(e))
+            msg='Could not save JSON payload', exception=traceback.format_exc())
 
     return fname
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Anywhere I found traceback.format_exc() taking an error variable.
lib/ansible/module_utils/gcp.py, lib/ansible/modules/cloud/amazon/aws_kms.py, lib/ansible/modules/cloud/amazon/cloudformation_facts.py, lib/ansible/modules/cloud/amazon/cloudfront_facts.py, lib/ansible/modules/cloud/amazon/ec2.py, lib/ansible/modules/cloud/amazon/ec2_asg.py, lib/ansible/modules/cloud/amazon/ec2_group_facts.py, lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py, lib/ansible/modules/cloud/amazon/elasticache_snapshot.py, lib/ansible/modules/cloud/amazon/execute_lambda.py, lib/ansible/modules/cloud/smartos/vmadm.py.

##### ANSIBLE VERSION
```
ansible 2.3.0 (fix-exception a2065eac88) last updated 2017/02/20 11:32:43 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
traceback.format_exc doesn't take an error