### PR TITLE
Add smoke/intg tests for vault cli

### DIFF
--- a/test/integration/targets/vault/runme.sh
+++ b/test/integration/targets/vault/runme.sh
@@ -21,27 +21,29 @@ ansible-vault decrypt --vault-password-file vault-password "${TEST_FILE}"
 NEW_VAULT_PASSWORD="${MYTMPDIR}/new-vault-password"
 echo "newpassword" > "${NEW_VAULT_PASSWORD}"
 
-ansible-vault encrypt --vault-password-file vault-password "${TEST_FILE}"
+ansible-vault encrypt "$@" --vault-password-file vault-password "${TEST_FILE}"
 
-ansible-vault rekey --vault-password-file vault-password --new-vault-password-file "${NEW_VAULT_PASSWORD}" "${TEST_FILE}"
+ansible-vault rekey "$@" --vault-password-file vault-password --new-vault-password-file "${NEW_VAULT_PASSWORD}" "${TEST_FILE}"
 
-ansible-vault view --vault-password-file "${NEW_VAULT_PASSWORD}" "${TEST_FILE}"
+ansible-vault view "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" "${TEST_FILE}"
 
-ansible-vault decrypt --vault-password-file "${NEW_VAULT_PASSWORD}" "${TEST_FILE}"
+ansible-vault decrypt "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" "${TEST_FILE}"
 
-ansible-vault encrypt_string --vault-password-file "${NEW_VAULT_PASSWORD}" "a test string"
+ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" "a test string"
 
-ansible-vault encrypt_string --vault-password-file "${NEW_VAULT_PASSWORD}" --name "blippy" "a test string names blippy"
+ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --name "blippy" "a test string names blippy"
 
 
 # from stdin
-ansible-vault encrypt_string --vault-password-file "${NEW_VAULT_PASSWORD}" < "${TEST_FILE}"
+ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" < "${TEST_FILE}"
 
-ansible-vault encrypt_string --vault-password-file "${NEW_VAULT_PASSWORD}" --stdin-name "the_var_from_stdin" < "${TEST_FILE}"
+ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --stdin-name "the_var_from_stdin" < "${TEST_FILE}"
 
 # write to file
-ansible-vault encrypt_string --vault-password-file "${NEW_VAULT_PASSWORD}" --name "blippy" "a test string names blippy" --output "${MYTMPDIR}/enc_string_test_file"
+ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --name "blippy" "a test string names blippy" --output "${MYTMPDIR}/enc_string_test_file"
 
+
+# test playbooks using vaulted files
 ansible-playbook test_vault.yml          -i ../../inventory -v "$@" --vault-password-file vault-password --list-tasks
 ansible-playbook test_vault.yml          -i ../../inventory -v "$@" --vault-password-file vault-password --list-hosts
 ansible-playbook test_vault.yml          -i ../../inventory -v "$@" --vault-password-file vault-password --syntax-check

--- a/test/integration/targets/vault/runme.sh
+++ b/test/integration/targets/vault/runme.sh
@@ -9,13 +9,12 @@ trap 'rm -rf "${MYTMPDIR}"' EXIT
 TEST_FILE="${MYTMPDIR}/test_file"
 echo "This is a test file" > "${TEST_FILE}"
 
-
 # encrypt it
-ansible-vault encrypt --vault-password-file vault-password "${TEST_FILE}"
+ansible-vault encrypt "$@" --vault-password-file vault-password "${TEST_FILE}"
 
-ansible-vault view --vault-password-file vault-password "${TEST_FILE}"
+ansible-vault view "$@" --vault-password-file vault-password "${TEST_FILE}"
 
-ansible-vault decrypt --vault-password-file vault-password "${TEST_FILE}"
+ansible-vault decrypt "$@" --vault-password-file vault-password "${TEST_FILE}"
 
 # new password file for rekeyed file
 NEW_VAULT_PASSWORD="${MYTMPDIR}/new-vault-password"

--- a/test/integration/targets/vault/runme.sh
+++ b/test/integration/targets/vault/runme.sh
@@ -2,6 +2,45 @@
 
 set -eux
 
+MYTMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
+trap 'rm -rf "${MYTMPDIR}"' EXIT
+
+# create a test file
+TEST_FILE="${MYTMPDIR}/test_file"
+echo "This is a test file" > "${TEST_FILE}"
+
+
+# encrypt it
+ansible-vault encrypt --vault-password-file vault-password "${TEST_FILE}"
+
+ansible-vault view --vault-password-file vault-password "${TEST_FILE}"
+
+ansible-vault decrypt --vault-password-file vault-password "${TEST_FILE}"
+
+# new password file for rekeyed file
+NEW_VAULT_PASSWORD="${MYTMPDIR}/new-vault-password"
+echo "newpassword" > "${NEW_VAULT_PASSWORD}"
+
+ansible-vault encrypt --vault-password-file vault-password "${TEST_FILE}"
+
+ansible-vault rekey --vault-password-file vault-password --new-vault-password-file "${NEW_VAULT_PASSWORD}" "${TEST_FILE}"
+
+ansible-vault view --vault-password-file "${NEW_VAULT_PASSWORD}" "${TEST_FILE}"
+
+ansible-vault decrypt --vault-password-file "${NEW_VAULT_PASSWORD}" "${TEST_FILE}"
+
+ansible-vault encrypt_string --vault-password-file "${NEW_VAULT_PASSWORD}" "a test string"
+
+ansible-vault encrypt_string --vault-password-file "${NEW_VAULT_PASSWORD}" --name "blippy" "a test string names blippy"
+
+
+# from stdin
+ansible-vault encrypt_string --vault-password-file "${NEW_VAULT_PASSWORD}" < "${TEST_FILE}"
+
+ansible-vault encrypt_string --vault-password-file "${NEW_VAULT_PASSWORD}" --stdin-name "the_var_from_stdin" < "${TEST_FILE}"
+
+# write to file
+ansible-vault encrypt_string --vault-password-file "${NEW_VAULT_PASSWORD}" --name "blippy" "a test string names blippy" --output "${MYTMPDIR}/enc_string_test_file"
 
 ansible-playbook test_vault.yml          -i ../../inventory -v "$@" --vault-password-file vault-password --list-tasks
 ansible-playbook test_vault.yml          -i ../../inventory -v "$@" --vault-password-file vault-password --list-hosts


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Tests pull request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
test/integration/targets/vault
lib/ansible/cli/vault

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (vault_cli_intg_tests 1b0a9ecf8a) last updated 2017/02/20 11:40:12 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']


```

##### SUMMARY
Add some 'ansible-vault' invocations to the 'vault' intg test target, to catch bugs like https://github.com/ansible/ansible/pull/21675