### PR TITLE
Add doc link to aos_login module

### DIFF
--- a/lib/ansible/modules/network/aos/aos_asn_pool.py
+++ b/lib/ansible/modules/network/aos/aos_asn_pool.py
@@ -37,7 +37,7 @@ requirements:
 options:
   session:
     description:
-      - An existing AOS session as obtained by aos_login module.
+      - An existing AOS session as obtained by M(aos_login) module.
     required: true
   name:
     description:

--- a/lib/ansible/modules/network/aos/aos_blueprint.py
+++ b/lib/ansible/modules/network/aos/aos_blueprint.py
@@ -38,7 +38,7 @@ requirements:
 options:
   session:
     description:
-      - An existing AOS session as obtained by aos_login module.
+      - An existing AOS session as obtained by M(aos_login) module.
     required: true
   name:
     description:

--- a/lib/ansible/modules/network/aos/aos_blueprint_param.py
+++ b/lib/ansible/modules/network/aos/aos_blueprint_param.py
@@ -39,7 +39,7 @@ requirements:
 options:
   session:
     description:
-      - An existing AOS session as obtained by aos_login module.
+      - An existing AOS session as obtained by M(aos_login) module.
     required: true
   blueprint:
     description:

--- a/lib/ansible/modules/network/aos/aos_blueprint_virtnet.py
+++ b/lib/ansible/modules/network/aos/aos_blueprint_virtnet.py
@@ -37,7 +37,7 @@ requirements:
 options:
   session:
     description:
-      - An existing AOS session as obtained by aos_login module.
+      - An existing AOS session as obtained by M(aos_login) module.
     required: true
   blueprint:
     description:

--- a/lib/ansible/modules/network/aos/aos_device.py
+++ b/lib/ansible/modules/network/aos/aos_device.py
@@ -39,7 +39,7 @@ requirements:
 options:
   session:
     description:
-      - An existing AOS session as obtained by aos_login module.
+      - An existing AOS session as obtained by M(aos_login) module.
     required: true
   name:
     description:

--- a/lib/ansible/modules/network/aos/aos_external_router.py
+++ b/lib/ansible/modules/network/aos/aos_external_router.py
@@ -37,7 +37,7 @@ requirements:
 options:
   session:
     description:
-      - An existing AOS session as obtained by aos_login module.
+      - An existing AOS session as obtained by M(aos_login) module.
     required: true
   name:
     description:

--- a/lib/ansible/modules/network/aos/aos_ip_pool.py
+++ b/lib/ansible/modules/network/aos/aos_ip_pool.py
@@ -37,7 +37,7 @@ requirements:
 options:
   session:
     description:
-      - An existing AOS session as obtained by aos_login module.
+      - An existing AOS session as obtained by M(aos_login) module.
     required: true
   name:
     description:

--- a/lib/ansible/modules/network/aos/aos_logical_device.py
+++ b/lib/ansible/modules/network/aos/aos_logical_device.py
@@ -38,7 +38,7 @@ requirements:
 options:
   session:
     description:
-      - An existing AOS session as obtained by aos_login module.
+      - An existing AOS session as obtained by M(aos_login) module.
     required: true
   name:
     description:

--- a/lib/ansible/modules/network/aos/aos_logical_device_map.py
+++ b/lib/ansible/modules/network/aos/aos_logical_device_map.py
@@ -37,7 +37,7 @@ requirements:
 options:
   session:
     description:
-      - An existing AOS session as obtained by aos_login module.
+      - An existing AOS session as obtained by M(aos_login) module.
     required: true
   name:
     description:

--- a/lib/ansible/modules/network/aos/aos_rack_type.py
+++ b/lib/ansible/modules/network/aos/aos_rack_type.py
@@ -38,7 +38,7 @@ requirements:
 options:
   session:
     description:
-      - An existing AOS session as obtained by aos_login module.
+      - An existing AOS session as obtained by M(aos_login) module.
     required: true
   name:
     description:

--- a/lib/ansible/modules/network/aos/aos_template.py
+++ b/lib/ansible/modules/network/aos/aos_template.py
@@ -37,7 +37,7 @@ requirements:
 options:
   session:
     description:
-      - An existing AOS session as obtained by aos_login module.
+      - An existing AOS session as obtained by M(aos_login) module.
     required: true
   name:
     description:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
network/aos_*

##### ANSIBLE VERSION
```
ansible 2.3.0 (fix-aos-doc 4633178ba1) last updated 2017/02/20 09:50:49 (GMT -700)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
several new modules (network/aos_*) have been merged recently including a module named `aos_login` that other modules depend on. 
This PR is to update modules's documentation to add a doc-link to the module `aos_login`
