### PR TITLE
synchronize: Use private_key and ssh_user with delegate_to (#16215)

### DIFF
--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -467,7 +467,7 @@ def main():
     if is_rsh_needed(source, dest):
         ssh_cmd = [module.get_bin_path('ssh', required=True), '-S', 'none']
         if private_key is not None:
-            ssh_cmd.extend(['-i', private_key])
+            ssh_cmd.extend(['-i', os.path.expanduser(private_key) ])
         # If the user specified a port value
         # Note:  The action plugin takes care of setting this to a port from
         # inventory if the user didn't specify an explicit dest_port

--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -317,6 +317,8 @@ class ActionModule(ActionBase):
                 if use_delegate:
                     user = task_vars.get('ansible_delegated_vars', dict()).get('ansible_ssh_user', None)
                     if not user:
+                        user = task_vars.get('ansible_ssh_user') or self._play_context.remote_user
+                    if not user:
                         user = C.DEFAULT_REMOTE_USER
 
                 else:
@@ -326,7 +328,6 @@ class ActionModule(ActionBase):
             private_key = self._play_context.private_key_file
 
             if private_key is not None:
-                private_key = os.path.expanduser(private_key)
                 _tmp_args['private_key'] = private_key
 
             # use the mode to define src and dest's url

--- a/test/units/plugins/action/fixtures/synchronize/delegate_remote/meta.yaml
+++ b/test/units/plugins/action/fixtures/synchronize/delegate_remote/meta.yaml
@@ -23,4 +23,4 @@ asserts:
     - "self.execute_called"
     - "self.final_module_args['_local_rsync_path'] == 'rsync'"
     - "self.final_module_args['src'] == '/tmp/deleteme'"
-    - "self.final_module_args['dest'] == 'el6host:/tmp/deleteme'"
+    - "self.final_module_args['dest'] == 'root@el6host:/tmp/deleteme'"

--- a/test/units/plugins/action/fixtures/synchronize/delegate_remote_su/meta.yaml
+++ b/test/units/plugins/action/fixtures/synchronize/delegate_remote_su/meta.yaml
@@ -30,4 +30,4 @@ asserts:
     - "self.execute_called"
     - "self.final_module_args['_local_rsync_path'] == 'rsync'"
     - "self.final_module_args['src'] == '/tmp/deleteme'"
-    - "self.final_module_args['dest'] == 'el6host:/tmp/deleteme'"
+    - "self.final_module_args['dest'] == 'root@el6host:/tmp/deleteme'"


### PR DESCRIPTION
##### SUMMARY

Fixes #16215

When using `delegate_to` with synchronize, the `~` in the private key path is
expanded relative to the machine from which ansible is run and not the host
from which the synchronize is actually run.

Also, the variables `ansible_ssh_user` and `ansible_ssh_private_key_file`
present from the inventory are ignored, leading to inaccessible machine.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME

synchronize

##### ANSIBLE VERSION

```
ansible 2.4.0 (synchronize_module c35fb67ef2) last updated 2017/04/10 19:17:58 (GMT +200)
  config file = /home/nporcel/tools/perf-ansible/ansible.cfg
  configured module search path = [u'/home/nporcel/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/nporcel/tools/ansible/lib/ansible
  executable location = /home/nporcel/.virtualenvs/perf-ansible-local/bin/ansible
  python version = 2.7.12 (default, Jul 18 2016, 15:02:52) [GCC 4.8.4]
```

The problem was also present in ansible 2.2 and 2.3.

##### ADDITIONAL INFORMATION

For instance, let's consider this playbook:

```
- hosts: test
  tasks:
    - name: Send fstab to host
      synchronize:
        src: /etc/fstab
        dest: /tmp
        mode: push
      delegate_to: jumper
```

In the inventory, we have:

```
# test.yml
---
ansible_host: 1.2.3.4
ansible_user: admin
ansible_ssh_private_key_file: ~/.ssh/id_rsa

# jumper.yml
---
ansible_host: 5.6.7.8
ansible_user: jumper
ansible_ssh_private_key_file: ~/.ssh/id_rsa
```

First, without the fix, we get the following rsync command, assuming we are running ansible with user `user`:

```
/usr/bin/rsync (...) -i /home/user/.ssh/id_rsa /etc/fstab 1.2.3.4:/tmp
```

With the fix, the user and ssh key are correctly filled:

```
/usr/bin/rsync (...) -i /home/jumper/.ssh/id_rsa /etc/fstab admin@1.2.3.4:/tmp
```

As you can see, the user is added and the ssh key path is expanded on the jumper instead of the machine where `ansible-playbook` is executed.