### PR TITLE
Fix py3 issue in nagios_livestatus inv script.

### DIFF
--- a/contrib/inventory/nagios_livestatus.py
+++ b/contrib/inventory/nagios_livestatus.py
@@ -53,7 +53,8 @@ class NagiosLivestatusInventory(object):
         config = configparser.SafeConfigParser()
         config.read(os.path.dirname(os.path.realpath(__file__)) + '/nagios_livestatus.ini')
         for section in config.sections():
-            if not config.has_option(section, 'livestatus_uri'): continue
+            if not config.has_option(section, 'livestatus_uri'):
+                continue
 
             # If fields_to_retrieve is not set, using default fields
             fields_to_retrieve = self.default_fields_to_retrieve
@@ -63,10 +64,10 @@ class NagiosLivestatusInventory(object):
 
             # default section values
             section_values = {
-              'var_prefix' : 'livestatus_',
-              'host_filter': None,
-              'host_field' : 'name',
-              'group_field': 'groups'
+                'var_prefix': 'livestatus_',
+                'host_filter': None,
+                'host_field': 'name',
+                'group_field': 'groups'
             }
             for key, value in section_values.items():
                 if config.has_option(section, key):

--- a/contrib/inventory/nagios_livestatus.py
+++ b/contrib/inventory/nagios_livestatus.py
@@ -68,7 +68,7 @@ class NagiosLivestatusInventory(object):
               'host_field' : 'name',
               'group_field': 'groups'
             }
-            for key,value in section_values.iteritems():
+            for key, value in section_values.items():
                 if config.has_option(section, key):
                     section_values[key] = config.get(section, key).strip()
 
@@ -93,7 +93,7 @@ class NagiosLivestatusInventory(object):
             # Updating backend_definition with current value
             backend_definition['name']   = section
             backend_definition['fields'] = fields_to_retrieve
-            for key, value in section_values.iteritems():
+            for key, value in section_values.items():
                 backend_definition[key] = value
 
             self.backends.append(backend_definition)


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

nagios_livestatus inventory script

##### ANSIBLE VERSION

```
ansible 2.3.0 (py3-fix 01f2d6ff67) last updated 2017/02/20 11:35:56 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Use `dict.items()` instead of `dict.iteritems()` for python 3 compatibility.