### PR TITLE
[cloud][docs] Fix misleading Route53 `value` example

### DIFF
--- a/lib/ansible/modules/cloud/amazon/route53.py
+++ b/lib/ansible/modules/cloud/amazon/route53.py
@@ -207,7 +207,7 @@ EXAMPLES = '''
       "zone": "foo.com"
       "record": "_example-service._tcp.foo.com"
       "type": "SRV"
-      "value": ["0 0 22222 host1.foo.com", "0 0 22222 host2.foo.com"]
+      "value": "0 0 22222 host1.foo.com,0 0 22222 host2.foo.com"
 
 # Add a TXT record. Note that TXT and SPF records must be surrounded
 # by quotes when sent to Route 53:


### PR DESCRIPTION
The `route53` module uses a comma-separated string for records
containing more than one value. Fixes #21134

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
route53

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3 (devel)
```

##### SUMMARY

Using a list as the input to `value` on the Route53 module fails because the module expects a comma-separated string, like `  value: 5 0 5269 xmpp-server.l.google.com,20 0 5269 xmpp-server1.l.google.com,20 0 5269 xmpp-server2.l.google.com,20 0 5269 xmpp-server3.l.google.com,20 0 5269 xmpp-server4.l.google.com`