### PR TITLE
Fix firewalld get_masquerade_enabled_permanent error

### DIFF
--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -991,9 +991,9 @@ def main():
         if immediate and permanent:
             is_enabled_permanent = action_handler(
                 get_masquerade_enabled_permanent,
-                (zone)
+                (zone,)
             )
-            is_enabled_immediate = action_handler(get_masquerade_enabled, (zone))
+            is_enabled_immediate = action_handler(get_masquerade_enabled, (zone,))
             msgs.append('Permanent and Non-Permanent(immediate) operation')
 
             if desired_state == "enabled":
@@ -1023,7 +1023,7 @@ def main():
                     msgs.append("Removed masquerade from zone %s" % (zone))
 
         elif permanent and not immediate:
-            is_enabled = action_handler(get_masquerade_enabled_permanent, (zone))
+            is_enabled = action_handler(get_masquerade_enabled_permanent, (zone,))
             msgs.append('Permanent operation')
 
             if desired_state == "enabled":
@@ -1043,7 +1043,7 @@ def main():
                     changed=True
                     msgs.append("Removed masquerade from zone %s" % (zone))
         elif immediate and not permanent:
-            is_enabled = action_handler(get_masquerade_enabled, (zone))
+            is_enabled = action_handler(get_masquerade_enabled, (zone,))
             msgs.append('Non-permanent operation')
 
             if desired_state == "enabled":


### PR DESCRIPTION
get_masquerade_* functions only take one arg. The action_handler
wrapper function expected a tuple, but was being passed (zone)
instead of (zone,) making for an ambiquous tuple. The
(zone) arg was being treated as a tuple/list of six chars
(the zone name) instead of a tuple of one string.

This would cause errors like:

        get_masquerade_enabled_permanent() takes exactly 1 argument (6 given)

Fixes #21632

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/system/firewalld.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (firewalld_tuple_21632 d58a9ee7c3) last updated 2017/02/20 16:28:14 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']

```

##### SUMMARY
