### PR TITLE
Fix snmp_facts error on decode_hex()

### DIFF
--- a/lib/ansible/modules/network/snmp_facts.py
+++ b/lib/ansible/modules/network/snmp_facts.py
@@ -98,6 +98,7 @@ EXAMPLES = '''
 import binascii
 
 from ansible.module_utils.basic import *
+from ansible.module_utils._text import to_text
 
 from collections import defaultdict
 
@@ -144,7 +145,7 @@ def decode_hex(hexstring):
     if len(hexstring) < 3:
         return hexstring
     if hexstring[:2] == "0x":
-        return binascii.unhexlify(hexstring[2:])
+        return to_text(binascii.unhexlify(hexstring[2:]))
     else:
         return hexstring
 

--- a/lib/ansible/modules/network/snmp_facts.py
+++ b/lib/ansible/modules/network/snmp_facts.py
@@ -95,7 +95,10 @@ EXAMPLES = '''
   delegate_to: localhost
 '''
 
+import binascii
+
 from ansible.module_utils.basic import *
+
 from collections import defaultdict
 
 try:
@@ -141,7 +144,7 @@ def decode_hex(hexstring):
     if len(hexstring) < 3:
         return hexstring
     if hexstring[:2] == "0x":
-        return hexstring[2:].decode("hex")
+        return binascii.unhexlify(hexstring[2:])
     else:
         return hexstring
 


### PR DESCRIPTION

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/network/snmp_facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (snmp_facts_21668 e2b7904575) last updated 2017/02/20 16:59:27 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']

```

##### SUMMARY
Remove use of some_string.decode('hex') that fails on py3, and
replace with to_text(int(some_string, 16))

Fixes #21668
