### PR TITLE
Wrap vault encrypt_strings zip() result in list for py3

### DIFF
--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -234,7 +234,7 @@ class VaultCLI(CLI):
         # use any leftover args as strings to encrypt
         # Try to match args up to --name options
         if hasattr(self.options, 'encrypt_string_names') and self.options.encrypt_string_names:
-            name_and_text_list = zip(self.options.encrypt_string_names, args)
+            name_and_text_list = list(zip(self.options.encrypt_string_names, args))
 
             # Some but not enough --name's to name each var
             if len(args) > len(name_and_text_list):


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/cli/vault.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (vault_encrypt_string_zip_py3 fb989cae58) last updated 2017/02/20 17:33:58 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']
```

##### SUMMARY
py3 zip() results are not lists, so list'ify the result
for py2/py3 compat.
