### PR TITLE
Provide stdout/stderr on open_shell exception

### DIFF
--- a/lib/ansible/plugins/action/ios.py
+++ b/lib/ansible/plugins/action/ios.py
@@ -68,7 +68,8 @@ class ActionModule(_ActionModule):
             # start the connection if it isn't started
             rc, out, err = connection.exec_command('open_shell()')
             if not rc == 0:
-                return {'failed': True, 'msg': 'unable to open shell', 'rc': rc}
+                return {'failed': True, 'msg': 'unable to open shell', 'rc': rc,
+                        'err': err, 'out': out}
         else:
             # make sure we are in the right cli context which should be
             # enable mode and not config module

--- a/lib/ansible/plugins/action/iosxr.py
+++ b/lib/ansible/plugins/action/iosxr.py
@@ -66,7 +66,8 @@ class ActionModule(_ActionModule):
             # start the connection if it isn't started
             rc, out, err = connection.exec_command('open_shell()')
             if rc != 0:
-                return {'failed': True, 'msg': 'unable to open shell', 'rc': rc}
+                return {'failed': True, 'msg': 'unable to open shell', 'rc': rc,
+                        'out': out, 'err': err}
 
         task_vars['ansible_socket'] = socket_path
 


### PR DESCRIPTION
At least we get more info besides the 'unable to open shell' message.

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

action/ios
action/iosxr

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (show_stdout_stderr_open_shell_failure_ios_iosxr 8d6e49dc22) last updated 2017/02/21 11:37:18 (GMT +200)

```