### PR TITLE
Fix git clone tag with depth=1

### DIFF
--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -423,12 +423,17 @@ def clone(git_path, module, repo, dest, remote, depth, version, bare,
     else:
         cmd.extend([ '--origin', remote ])
     if depth:
-        if version == 'HEAD' \
-           or refspec  \
-           or is_remote_branch(git_path, module, dest, repo, version) \
-           or is_remote_tag(git_path, module, dest, repo, version):
-            # only use depth if the remote object is branch or tag (i.e. fetchable)
+        if version == 'HEAD' or refspec:
             cmd.extend([ '--depth', str(depth) ])
+        elif is_remote_branch(git_path, module, dest, repo, version) \
+                or is_remote_tag(git_path, module, dest, repo, version):
+            cmd.extend([ '--depth', str(depth) ])
+            cmd.extend(['--branch', version])
+        else:
+            # only use depth if the remote object is branch or tag (i.e. fetchable)
+            module.warn("Ignoring depth argument. "
+                        "Shallow clones are only available for "
+                        "HEAD, branches, tags or in combination with refspec.")
     if reference:
         cmd.extend([ '--reference', str(reference) ])
     cmd.extend([ repo, dest ])

--- a/test/integration/targets/git/tasks/depth.yml
+++ b/test/integration/targets/git/tasks/depth.yml
@@ -64,6 +64,28 @@
   args:
     chdir: '{{ checkout_dir }}'
 
+- name: clear checkout_dir
+  file:
+    state: absent
+    path: "{{ checkout_dir }}"
+
+# Test for https://github.com/ansible/ansible/issues/21316
+- name: Shallow clone with tag
+  git:
+    repo: 'file://{{ repo_dir|expanduser }}/shallow'
+    dest: '{{ checkout_dir }}'
+    depth: 1
+    version: earlytag
+  register: cloneold
+
+- assert:
+    that: "cloneold|success"
+
+- name: clear checkout_dir
+  file:
+    state: absent
+    path: "{{ checkout_dir }}"
+
 
   # Test for https://github.com/ansible/ansible-modules-core/issues/3456
   # clone a repo with depth and version specified


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
git

##### ANSIBLE VERSION
devel, potentially cherry-pick to 2.2, since this is a regression from 2.1

##### SUMMARY

* Fixes #21316, add testcase based on this
* Add option `--branch NAME` to git clone command in case of branch or tag in combination with depth=1
  * This option should work back to at least git 1.8 and thus on all supported distributions
* Provide better warning if depth is dropped
