### PR TITLE
fixs command dict to be sent to connection socket

### DIFF
--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -332,7 +332,7 @@ def to_command(module, commands):
         command=dict(key=True),
         output=dict(default=default_output),
         prompt=dict(),
-        response=dict()
+        answer=dict()
     ), module)
 
     commands = transform(to_list(commands))

--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -259,7 +259,7 @@ class CliBase(object):
             transform = ComplexDict(dict(
                 command=dict(key=True),
                 prompt=dict(),
-                response=dict(),
+                answer=dict(),
                 sendonly=dict(default=False)
             ))
             return transform(obj)

--- a/lib/ansible/modules/network/eos/eos_command.py
+++ b/lib/ansible/modules/network/eos/eos_command.py
@@ -147,7 +147,7 @@ def parse_commands(module, warnings):
         command=dict(key=True),
         output=dict(),
         prompt=dict(),
-        response=dict()
+        answer=dict()
     )
 
     transform = ComplexList(spec, module)

--- a/lib/ansible/modules/network/ios/_ios_template.py
+++ b/lib/ansible/modules/network/ios/_ios_template.py
@@ -111,9 +111,7 @@ updates:
 from ansible.module_utils.ios import load_config, get_config
 from ansible.module_utils.ios import ios_argument_spec, check_args
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network_common import ComplexList
 from ansible.module_utils.netcli import Conditional
-from ansible.module_utils.six import string_types
 from ansible.module_utils.netcfg import NetworkConfig, dumps
 
 def get_current_config(module):

--- a/lib/ansible/modules/network/ios/ios_command.py
+++ b/lib/ansible/modules/network/ios/ios_command.py
@@ -148,7 +148,7 @@ def parse_commands(module, warnings):
     command = ComplexList(dict(
         command=dict(key=True),
         prompt=dict(),
-        response=dict()
+        answer=dict()
     ), module)
     commands = command(module.params['commands'])
     for index, item in enumerate(commands):

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -209,9 +209,7 @@ from ansible.module_utils.ios import run_commands, get_config, load_config
 from ansible.module_utils.ios import ios_argument_spec
 from ansible.module_utils.ios import check_args as ios_check_args
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network_common import ComplexList
 from ansible.module_utils.netcli import Conditional
-from ansible.module_utils.six import string_types
 from ansible.module_utils.netcfg import NetworkConfig, dumps
 from ansible.module_utils.six import iteritems
 

--- a/lib/ansible/modules/network/iosxr/iosxr_command.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_command.py
@@ -146,7 +146,7 @@ def parse_commands(module, warnings):
     command = ComplexList(dict(
         command=dict(key=True),
         prompt=dict(),
-        response=dict()
+        answer=dict()
     ), module)
     commands = command(module.params['commands'])
 

--- a/lib/ansible/modules/network/nxos/nxos_command.py
+++ b/lib/ansible/modules/network/nxos/nxos_command.py
@@ -178,7 +178,7 @@ def parse_commands(module, warnings):
         command=dict(key=True),
         output=dict(),
         prompt=dict(),
-        response=dict()
+        answer=dict()
     ), module)
 
     commands = transform(module.params['commands'])

--- a/lib/ansible/modules/network/vyos/vyos_command.py
+++ b/lib/ansible/modules/network/vyos/vyos_command.py
@@ -151,7 +151,7 @@ def parse_commands(module, warnings):
     command = ComplexList(dict(
         command=dict(key=True),
         prompt=dict(),
-        response=dict(),
+        answer=dict(),
     ), module)
     commands = command(module.params['commands'])
 


### PR DESCRIPTION
There as an invalid key in the command dict that would cause failure
using prompts.  This changes the key from response to answer which is
what is expected by network_cli
