### PR TITLE
[aos_login] Fix variable name to return to match latest lib version

### DIFF
--- a/lib/ansible/modules/network/aos/aos_login.py
+++ b/lib/ansible/modules/network/aos/aos_login.py
@@ -106,8 +106,8 @@ def aos_login(module):
         module.fail_json(msg="AOS-server login credentials failed")
 
     module.exit_json(changed=False,
-                     ansible_facts=dict( aos_session=dict(url=aos.api.url, headers=aos.api.headers)),
-                     aos_session=dict(url=aos.api.url, headers=aos.api.headers))
+                     ansible_facts=dict(aos_session=aos.session),
+                     aos_session=dict(aos_session=aos.session))
 
 def main():
     module = AnsibleModule(


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
aos_login

##### ANSIBLE VERSION
```
ansible 2.3.0 (fix-aos-login cc16903b5c) last updated 2017/02/20 13:08:42 (GMT -700)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
The name of the variables returned is not valid anymore with the latest version of aos-pyez. `aos.api.url` an `aos.api.headers` have been replaced with `aos.session`
