### PR TITLE
inventory/Aos - Add session information to group all variables

### DIFF
--- a/contrib/inventory/apstra_aos.ini
+++ b/contrib/inventory/apstra_aos.ini
@@ -8,7 +8,7 @@
 
 [aos]
 
-aos_server = 172.20.117.3
+aos_server = 172.20.62.3
 port = 8888
 username = admin
 password = admin

--- a/contrib/inventory/apstra_aos.ini
+++ b/contrib/inventory/apstra_aos.ini
@@ -8,7 +8,7 @@
 
 [aos]
 
-aos_server = 172.20.62.3
+aos_server = 172.20.117.3
 port = 8888
 username = admin
 password = admin

--- a/contrib/inventory/apstra_aos.py
+++ b/contrib/inventory/apstra_aos.py
@@ -310,6 +310,9 @@ class AosInventory(object):
 
         aos.login()
 
+        # Save session information in variables of group all
+        self.add_var_to_group('all', 'aos_session', aos.session)
+        
         # ----------------------------------------------------
         # Build the inventory
         #  2 modes are supported: device based or blueprint based
@@ -482,7 +485,6 @@ class AosInventory(object):
         except:
             pass
 
-
     def parse_cli_args(self):
         """ Command line argument processing """
 
@@ -516,6 +518,16 @@ class AosInventory(object):
             self.inventory['_meta']['hostvars'][host] = {}
 
         self.inventory['_meta']['hostvars'][host][var] = value
+
+    def add_var_to_group(self, group, var, value):
+
+        # Check if the group exist, if not initialize it
+        if group not in self.inventory.keys():
+            self.inventory[group] = {}
+            self.inventory[group]['hosts'] = []
+            self.inventory[group]['vars'] = {}
+
+        self.inventory[group]['vars'][var] = value
 
     def add_device_facts_to_var(self, device_name, device):
 

--- a/contrib/inventory/apstra_aos.py
+++ b/contrib/inventory/apstra_aos.py
@@ -312,7 +312,7 @@ class AosInventory(object):
 
         # Save session information in variables of group all
         self.add_var_to_group('all', 'aos_session', aos.session)
-        
+
         # ----------------------------------------------------
         # Build the inventory
         #  2 modes are supported: device based or blueprint based


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
contrib/inventory/apstra_aos.py 

##### ANSIBLE VERSION
```
ansible 2.3.0 (fix-aos-login cc16903b5c) last updated 2017/02/20 13:08:42 (GMT -700)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Add session information in group `all` variables, it replace `aos_login` when the dynamic inventory is used. 
