### PR TITLE
add dead letter option for lambda module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -103,6 +103,12 @@ options:
     default: None
     aliases: [ 'environment' ]
     version_added: "2.3"
+  dead_letter_arn:
+    description:
+      - The parent object that contains the target Amazon Resource Name (ARN) of an Amazon SQS queue or Amazon SNS topic.
+    required: false
+    default: None
+    version_added: "2.3"
 author:
     - 'Steyn Huizinga (@steynovich)'
 extends_documentation_fragment:
@@ -236,6 +242,7 @@ def main():
         vpc_subnet_ids=dict(type='list', default=None),
         vpc_security_group_ids=dict(type='list', default=None),
         environment_variables=dict(type='dict', default=None),
+        dead_letter_arn=dict(type='str', default=None),
         )
     )
 
@@ -266,6 +273,7 @@ def main():
     vpc_subnet_ids = module.params.get('vpc_subnet_ids')
     vpc_security_group_ids = module.params.get('vpc_security_group_ids')
     environment_variables = module.params.get('environment_variables')
+    dead_letter_arn = module.params.get('dead_letter_arn')
 
     check_mode = module.check_mode
     changed = False
@@ -324,6 +332,12 @@ def main():
             func_kwargs.update({'MemorySize': memory_size})
         if (environment_variables is not None) and (current_config['Environment']['Variables'] != environment_variables):
             func_kwargs.update({'Environment':{'Variables': environment_variables}})
+        if dead_letter_arn:
+            if current_config.get('DeadLetterConfig'):
+                if current_config['DeadLetterConfig']['TargetArn'] != dead_letter_arn:
+                    func_kwargs.update({'DeadLetterConfig': {'TargetArn': dead_letter_arn}})
+            else:
+                func_kwargs.update({'DeadLetterConfig': {'TargetArn': dead_letter_arn}})
 
         # Check for unsupported mutation
         if current_config['Runtime'] != runtime:
@@ -441,6 +455,9 @@ def main():
                        'MemorySize': memory_size,
                        'Environment':{'Variables': environment_variables}
                        }
+
+        if dead_letter_arn:
+            func_kwargs.update({'DeadLetterConfig': {'TargetARN': dead_letter_arn}})
 
         # If VPC configuration is given
         if vpc_subnet_ids or vpc_security_group_ids:

--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -332,12 +332,13 @@ def main():
             func_kwargs.update({'MemorySize': memory_size})
         if (environment_variables is not None) and (current_config['Environment']['Variables'] != environment_variables):
             func_kwargs.update({'Environment':{'Variables': environment_variables}})
-        if dead_letter_arn:
+        if dead_letter_arn is not None:
             if current_config.get('DeadLetterConfig'):
                 if current_config['DeadLetterConfig']['TargetArn'] != dead_letter_arn:
                     func_kwargs.update({'DeadLetterConfig': {'TargetArn': dead_letter_arn}})
             else:
-                func_kwargs.update({'DeadLetterConfig': {'TargetArn': dead_letter_arn}})
+                if dead_letter_arn != "":
+                    func_kwargs.update({'DeadLetterConfig': {'TargetArn': dead_letter_arn}})
 
         # Check for unsupported mutation
         if current_config['Runtime'] != runtime:


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/lambda.py

##### ANSIBLE VERSION
```
ansible 2.3.0 (lambda-add-dead-letter 84c285fcc1) last updated 2017/02/21 09:49:11 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Allows user to set, modify, and delete lambda's DeadLetterConfig.
To delete set dead_letter_arn to an empty string: "".
Closes #21032.

Playbook used to test:
```
---
- hosts: localhost
  tasks:
  - name: looped creation
    lambda:
      name: '{{ name }}'
      state: present
      zip_file: '{{ zipfile }}'
      runtime: 'python2.7'
      role: '{{ role }}'
      dead_letter_arn: '{{ sns_arn }}'
      handler: '{{ handler }}'
```
