### PR TITLE
Inventory default groups 'all' and 'ungrouped': add tests and documentation

### DIFF
--- a/docs/docsite/rst/intro_inventory.rst
+++ b/docs/docsite/rst/intro_inventory.rst
@@ -141,6 +141,15 @@ It is also possible to make groups of groups using the ``:children`` suffix. Jus
 If you need to store lists or hash data, or prefer to keep host and group specific variables
 separate from the inventory file, see the next section.
 
+.. _default_groups:
+
+Default groups
+++++++++++++++
+
+There are two default groups: ``all`` and ``ungrouped``. ``all`` contains every hosts.
+``ungrouped`` contains all hosts declared without an explicit section, even if they belongs to
+an other group.
+
 .. _splitting_out_vars:
 
 Splitting Out Host and Group Specific Data

--- a/docs/docsite/rst/intro_inventory.rst
+++ b/docs/docsite/rst/intro_inventory.rst
@@ -146,9 +146,9 @@ separate from the inventory file, see the next section.
 Default groups
 ++++++++++++++
 
-There are two default groups: ``all`` and ``ungrouped``. ``all`` contains every hosts.
-``ungrouped`` contains all hosts declared without an explicit section, even if they belongs to
-an other group.
+There are two default groups: ``all`` and ``ungrouped``. ``all`` contains every host.
+``ungrouped`` contains all hosts declared without an explicit section, even if they belong to
+another group.
 
 .. _splitting_out_vars:
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- Test Pull Request 
- Docs Pull Request

##### COMPONENT NAME
docs and unit tests

The goals of this PR is to describe the expected behavior concerning default groups. This will be useful when [inventory plugins](https://github.com/pilou-/ansible/blob/27cd18246a79a2cc7f43e11ff884015dd51801d8/lib/ansible/inventory/__init__.py#L145) are implemented. Besides it will be helpful in order to fix bugs related to yaml inventories.