### PR TITLE
fix for #21729, use VERSION_ID instead of PRETTY_NAME to get release

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -892,7 +892,7 @@ class Distribution(object):
                 if distribution_version:
                     self.facts['distribution_version'] = distribution_version.group(1)
                 if 'open' in data.lower():
-                    release = re.search("^PRETTY_NAME=[^(]+ \(?([^)]+?)\)", line)
+                    release = re.search('^VERSION_ID="?[0-9]+\.?([0-9]*)"?', line)
                     if release:
                         self.facts['distribution_release'] = release.groups()[0]
                 elif 'enterprise' in data.lower() and 'VERSION_ID' in line:

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -153,7 +153,7 @@ CODENAME = Malachite
         "result":{
             "distribution": "openSUSE Leap",
             "distribution_major_version": "42",
-            "distribution_release": "x86_64",
+            "distribution_release": "1",
             "os_family": "Suse",
             "distribution_version": "42.1",
         }

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -179,7 +179,7 @@ ID_LIKE="suse"
         'platform.dist': ('SuSE', '13.2', 'x86_64'),
         'result': {'distribution': u'openSUSE',
                    'distribution_major_version': u'13',
-                   'distribution_release': u'Harlequin',
+                   'distribution_release': u'2',
                    'os_family': u'Suse',
                    'distribution_version': u'13.2'}
     },
@@ -196,7 +196,7 @@ ID_LIKE="suse"
         },
         "name": "openSUSE Tumbleweed 20160917",
         "result": {
-            "distribution_release": "NA",
+            "distribution_release": "",
             "distribution": "openSUSE Tumbleweed",
             "distribution_major_version": "NA",
             "os_family": "Suse",


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible/module_utils/facts.py
test/units/module_utils/test_distribution_version.py

##### ANSIBLE VERSION
```
ansible 2.2.1.0
```

##### SUMMARY
see #21729 