### PR TITLE
Consul: make service_port optional in service definition, like specified in Consul docs

### DIFF
--- a/lib/ansible/modules/clustering/consul.py
+++ b/lib/ansible/modules/clustering/consul.py
@@ -242,8 +242,8 @@ try:
 except ImportError:
     python_consul_installed = False
 
-def register_with_consul(module):
 
+def register_with_consul(module):
     state = module.params.get('state')
 
     if state == 'present':
@@ -367,7 +367,6 @@ def get_service_by_id_or_name(consul_api, service_id_or_name):
 
 
 def parse_check(module):
-
     if len(filter(None, [module.params.get('script'), module.params.get('ttl'), module.params.get('http')])) > 1:
         module.fail_json(
             msg='check are either script, http or ttl driven, supplying more than one does not make sense')
@@ -390,7 +389,6 @@ def parse_check(module):
 
 
 def parse_service(module):
-
     if module.params.get('service_name'):
         return ConsulService(
             module.params.get('service_id'),
@@ -400,8 +398,7 @@ def parse_service(module):
             module.params.get('tags'),
         )
     elif module.params.get('service_port') and not module.params.get('service_name'):
-
-        module.fail_json( msg="service_port supplied but no service_name, a name is required to configure a service." )
+        module.fail_json(msg="service_port supplied but no service_name, a name is required to configure a service.")
 
 
 class ConsulService():
@@ -447,11 +444,11 @@ class ConsulService():
         return len(self.checks) > 0
 
     def __eq__(self, other):
-        return (isinstance(other, self.__class__)
-                and self.id == other.id
-                and self.name == other.name
-                and self.port == other.port
-                and self.tags == other.tags)
+        return (isinstance(other, self.__class__) and
+                self.id == other.id and
+                self.name == other.name and
+                self.port == other.port and
+                self.tags == other.tags)
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -470,7 +467,7 @@ class ConsulService():
 class ConsulCheck():
 
     def __init__(self, check_id, name, node=None, host='localhost',
-                    script=None, interval=None, ttl=None, notes=None, http=None, timeout=None, service_id=None):
+                 script=None, interval=None, ttl=None, notes=None, http=None, timeout=None, service_id=None):
         self.check_id = self.name = name
         if check_id:
             self.check_id = check_id
@@ -499,7 +496,6 @@ class ConsulCheck():
 
             self.check = consul.Check.http(http, self.interval, self.timeout)
 
-
     def validate_duration(self, name, duration):
         if duration:
             duration_units = ['ns', 'us', 'ms', 's', 'm', 'h']
@@ -513,12 +509,12 @@ class ConsulCheck():
                                         check=self.check)
 
     def __eq__(self, other):
-        return (isinstance(other, self.__class__)
-                and self.check_id == other.check_id
-                and self.service_id == other.service_id
-                and self.name == other.name
-                and self.script == script
-                and self.interval == interval)
+        return (isinstance(other, self.__class__) and
+                self.check_id == other.check_id and
+                self.service_id == other.service_id and
+                self.name == other.name and
+                self.script == script and
+                self.interval == interval)
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -546,9 +542,11 @@ class ConsulCheck():
         except:
             pass
 
+
 def test_dependencies(module):
     if not python_consul_installed:
         module.fail_json(msg="python-consul required for this module. see http://python-consul.readthedocs.org/en/latest/#installation")
+
 
 def main():
     module = AnsibleModule(

--- a/test/integration/roles/test_consul_service/tasks/main.yml
+++ b/test/integration/roles/test_consul_service/tasks/main.yml
@@ -5,6 +5,7 @@
   with_items:
       - service1
       - service2
+      - service3
       - http_check
       - with_check
       - with_tags
@@ -45,6 +46,20 @@
         - basic2_result.service_port == 80
         - basic2_result.service_id == 'service2'
         - basic2_result.service_name == 'Basic Service'
+
+- name: register very basic service without service_port
+  consul:
+    service_name: Basic Service Without Port
+    service_id: service3
+  register: basic3_result
+
+- name: verify service3 registration
+  assert:
+    that:
+        - basic3_result.changed
+        - basic3_result.service_port == None
+        - basic3_result.service_id == 'service3'
+        - basic3_result.service_name == 'Basic Service Without Port'
 
 - name: register a service with an http check
   consul:

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -378,7 +378,6 @@ lib/ansible/modules/cloud/webfaction/webfaction_db.py
 lib/ansible/modules/cloud/webfaction/webfaction_domain.py
 lib/ansible/modules/cloud/webfaction/webfaction_mailbox.py
 lib/ansible/modules/cloud/webfaction/webfaction_site.py
-lib/ansible/modules/clustering/consul.py
 lib/ansible/modules/clustering/consul_acl.py
 lib/ansible/modules/clustering/consul_kv.py
 lib/ansible/modules/clustering/consul_session.py


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request, fixes #21727 

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Consul module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Fixes #21727 – Consul service definitions do not require a port. See https://www.consul.io/docs/agent/services.html
Still, the consul module requires me to provide the service_port parameter.

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
Before: service_name supplied but no service_port, a port is required to configure a service. Did you configure the 'port' argument meaning 'service_port'?

After: It just creates the service.
```