### PR TITLE
DOC options must be a dict when used with extends_documentation_fragment

### DIFF
--- a/lib/ansible/utils/module_docs.py
+++ b/lib/ansible/utils/module_docs.py
@@ -117,7 +117,7 @@ def get_docstring(filename, verbose=False):
                                     elif isinstance(doc[key], MutableSequence):
                                         doc[key] = sorted(frozenset(doc[key] + value))
                                     else:
-                                        raise Exception("Attempt to extend a documentation fragement (%s) of unknown type: %s" (fragment_name, filename))
+                                        raise Exception("Attempt to extend a documentation fragement (%s) of unknown type: %s" % (fragment_name, filename))
 
                     elif 'EXAMPLES' == theid:
                         plainexamples = child.value.s[1:]  # Skip first empty line

--- a/test/sanity/validate-modules/validate-modules
+++ b/test/sanity/validate-modules/validate-modules
@@ -577,6 +577,13 @@ class ModuleValidator(Validator):
                             'Unknown DOCUMENTATION error, see TRACE'
                         ))
 
+                if doc.get('options') is None and doc.get('extends_documentation_fragment'):
+                    self.errors.append((
+                        305,
+                        ('DOCUMENTATION.options must be a dictionary/hash when used '
+                         'with DOCUMENTATION.extends_documentation_fragment')
+                    ))
+
                 self._validate_docs_schema(doc, doc_schema, 'DOCUMENTATION', 305)
                 self._check_version_added(doc)
                 self._check_for_new_args(doc)

--- a/test/sanity/validate-modules/validate-modules
+++ b/test/sanity/validate-modules/validate-modules
@@ -28,6 +28,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import traceback
 
 from collections import OrderedDict
 from contextlib import contextmanager
@@ -569,8 +570,8 @@ class ModuleValidator(Validator):
                             303,
                             'DOCUMENTATION fragment missing: %s' % fragment
                         ))
-                    except Exception as e:
-                        self.traces.append(e)
+                    except Exception:
+                        self.traces.append(traceback.format_exc())
                         self.errors.append((
                             304,
                             'Unknown DOCUMENTATION error, see TRACE'
@@ -760,8 +761,8 @@ class ModuleValidator(Validator):
             self.errors.append((401, 'Python SyntaxError while parsing module'))
             try:
                 compile(self.text, self.path, 'exec')
-            except Exception as e:
-                self.traces.append(e)
+            except Exception:
+                self.traces.append(traceback.format_exc())
             return
 
         if self._python_module():

--- a/test/sanity/validate-modules/validate-modules
+++ b/test/sanity/validate-modules/validate-modules
@@ -577,7 +577,7 @@ class ModuleValidator(Validator):
                             'Unknown DOCUMENTATION error, see TRACE'
                         ))
 
-                if doc.get('options') is None and doc.get('extends_documentation_fragment'):
+                if 'options' in doc and doc['options'] is None and doc.get('extends_documentation_fragment'):
                     self.errors.append((
                         305,
                         ('DOCUMENTATION.options must be a dictionary/hash when used '


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
various

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

##### SUMMARY
* fix string formatting
* Provide better tracebacks
* When options is None and extends_documentation_fragment is in use, add an error that options must be a dict