### PR TITLE
Test www.redhat.com instead of docs.ansible.com.

### DIFF
--- a/test/integration/targets/win_get_url/defaults/main.yml
+++ b/test/integration/targets/win_get_url/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-test_win_get_url_link: http://docs.ansible.com
-test_win_get_url_invalid_link: http://docs.ansible.com/skynet_module.html
+test_win_get_url_link: https://www.redhat.com
+test_win_get_url_invalid_link: https://www.redhat.com/skynet_module.html
 test_win_get_url_invalid_path: "Q:\\Filez\\Cyberdyne.html"
 test_win_get_url_path: "{{ test_win_get_url_dir_path }}\\docs_index.html"


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

win_get_url integration test

##### ANSIBLE VERSION

```
ansible 2.3.0 (get-url-test d37aac2890) last updated 2017/02/21 20:15:42 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Test www.redhat.com instead of docs.ansible.com. This should avoid test failures due to timeouts accessing docs.ansible.com.