### PR TITLE
Add interface timestamping facts on Linux

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2658,7 +2658,7 @@ class LinuxNetwork(Network):
             parse_ip_output(primary_data)
             parse_ip_output(secondary_data, secondary=True)
 
-            interfaces[device]['features'] = self.get_ethtool_data(device)
+            interfaces[device].update(self.get_ethtool_data(device))
 
         # replace : by _ in interface name since they are hard to use in template
         new_interfaces = {}
@@ -2671,12 +2671,13 @@ class LinuxNetwork(Network):
 
     def get_ethtool_data(self, device):
 
-        features = {}
+        data = {}
         ethtool_path = self.module.get_bin_path("ethtool")
         if ethtool_path:
             args = [ethtool_path, '-k', device]
             rc, stdout, stderr = self.module.run_command(args, errors='surrogate_then_replace')
             if rc == 0:
+                features = {}
                 for line in stdout.strip().splitlines():
                     if not line or line.endswith(":"):
                         continue
@@ -2684,7 +2685,18 @@ class LinuxNetwork(Network):
                     if not value:
                         continue
                     features[key.strip().replace('-','_')] = value.strip()
-        return features
+                data['features'] = features
+
+            args = [ethtool_path, '-T', device]
+            rc, stdout, stderr = self.module.run_command(args, errors='surrogate_then_replace')
+            if rc == 0:
+                data['timestamping'] = [m.lower() for m in re.findall('SOF_TIMESTAMPING_(\w+)', stdout)]
+                data['hw_timestamp_filters'] = [m.lower() for m in re.findall('HWTSTAMP_FILTER_(\w+)', stdout)]
+                m = re.search('PTP Hardware Clock: (\d+)', stdout)
+                if m:
+                    data['phc_index'] = int(m.groups()[0])
+
+        return data
 
 
 class GenericBsdIfconfigNetwork(Network):


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module_utils/facts.py

##### ANSIBLE VERSION
```
ansible 2.3.0 (timestamping-facts d135557a81) last updated 2017/02/22 11:40:35 (GMT +200)
```

##### SUMMARY

This extends facts about network interfaces on Linux with data from the ethtool -T command. It includes supported timestamping options, hardware receive filters, and the index of the PTP hardware clock (PHC) when hardware timestamping is supported on the interface.

This is useful for configuration of PTP and NTP.

An example:
```
        "ansible_eth0": {
            "hw_timestamp_filters": [
                "none", 
                "all", 
                "ptp_v1_l4_sync", 
                "ptp_v1_l4_delay_req", 
                "ptp_v2_l4_sync", 
                "ptp_v2_l4_delay_req", 
                "ptp_v2_l2_sync", 
                "ptp_v2_l2_delay_req", 
                "ptp_v2_event", 
                "ptp_v2_sync", 
                "ptp_v2_delay_req"
            ], 
            "phc_index": 0,
            "timestamping": [
                "tx_hardware", 
                "tx_software", 
                "rx_hardware", 
                "rx_software", 
                "software", 
                "raw_hardware"
            ], 
        }, 
```