### PR TITLE
#21440. Win_Regedit curly brace fix

### DIFF
--- a/lib/ansible/modules/windows/win_regedit.ps1
+++ b/lib/ansible/modules/windows/win_regedit.ps1
@@ -58,7 +58,7 @@ Function Test-ValueData {
     )
 
     try {
-        Get-ItemProperty -Path $Path -Name $Name
+        Get-ItemProperty -Path $Path -Name $Name | Out-Null
         return $true
     } catch {
         return $false
@@ -188,7 +188,7 @@ if ($state -eq "present") {
                             $null = $(Get-Item -Path $path -ErrorAction 'Stop').OpenSubKey('','ReadWriteSubTree').SetValue($null,$data)
                         } else {
                             Remove-ItemProperty -Path $path -Name $name
-                            New-ItemProperty -Path $path -Name $name -Value $data -PropertyType $type -Force
+                            New-ItemProperty -Path $path -Name $name -Value $data -PropertyType $type -Force | Out-Null
                         }
                     } catch {
                         Fail-Json $result $_.Exception.Message
@@ -209,7 +209,7 @@ if ($state -eq "present") {
                     try {
                         if ($type -eq "none") {
                             Remove-ItemProperty -Path $path -Name $name
-                            New-ItemProperty -Path $path -Name $name -Value $data -PropertyType $type -Force
+                            New-ItemProperty -Path $path -Name $name -Value $data -PropertyType $type -Force | Out-Null
                         } else {
                             Set-ItemProperty -Path $path -Name $name -Value $data
                         }
@@ -233,7 +233,7 @@ if ($state -eq "present") {
             # Add missing entry
             if (-not $check_mode) {
                 try {
-                    New-ItemProperty -Path $path -Name $name -Value $data -PropertyType $type
+                    New-ItemProperty -Path $path -Name $name -Value $data -PropertyType $type | Out-Null
                 } Catch {
                     Fail-Json $result $_.Exception.Message
                 }
@@ -251,7 +251,7 @@ if ($state -eq "present") {
             try {
                 $new_path = New-Item $path -Type directory -Force
                 if ($name -ne $null) {
-                    $new_path | New-ItemProperty -Name $name -Value $data -PropertyType $type -Force
+                    $new_path | New-ItemProperty -Name $name -Value $data -PropertyType $type -Force | Out-Null
                 }
             } catch {
                 Fail-Json $result $_.Exception.Message


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Win_Regedit

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel b2bd75a408) last updated 2017/02/22 09:07:36 (GMT +100)
  config file = /root/.ansible.cfg
  configured module search path = [u'/root/github/ansible/lib/ansible/modules']
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #21440
Using the Win_Regedit module, when trying to add an entry where the name begins with a curly brace, the entry is added but we get a module failure error as described in detail [here](https://github.com/ansible/ansible/issues/21440).

If we use the example in the issue, the actual command that Win_Regedit is calling is;
```powershell
New-ItemProperty -Path HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanel -Name "{20D04FE0-3AEA-1069-A2D8-08002B30309D}" -Value 00000000 -PropertyType dword
```

This generates some output in powershell;

```
{20D04FE0-3AEA-1069-A2D8-08002B30309D} : 0
PSPath                                 : Microsoft.PowerShell.Core\Registry::HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanel
PSParentPath                           : Microsoft.PowerShell.Core\Registry::HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons
PSChildName                            : NewStartPanel
PSDrive                                : HKCU
PSProvider                             : Microsoft.PowerShell.Core\Registry
```

I'm not sure exactly why, but it looks like Ansible is trying to do something with this output which is causing the error. If you pipe the command to `Out-Null`, the issue goes away and we still retain all of the info we need to send to Exit-Json. This PR pipes all calls which would generate this output to `Out-Null`
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
##### EXAMPLE PLAYBOOK
```yaml
---
- name: Initial setting of Windows Server 2012 R2
  hosts: windows
  vars:
    vars_icon_computer: '{20D04FE0-3AEA-1069-A2D8-08002B30309D}'
    vars_icon_network: '{F02C1A0D-BE21-4350-88B0-7367FC96EF3C}'

  tasks:
    - name: Add Desktop Icon - My Computer
      win_regedit:
        path: 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanel'
        value: "{{ vars_icon_computer }}"
        data: 00000000
        datatype: dword
        state: present

    - name: Add Desktop Icon - Network
      win_regedit:
        path: 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\HideDesktopIcons\NewStartPanel'
        value: "{{ vars_icon_network }}"
        data: 00000000
        datatype: dword
        state: present
```
##### BEFORE CHANGE
```
PLAY [Initial setting of Windows Server 2012 R2] ***********************************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************************************************************
ok: [10.1.1.13]

TASK [Add Desktop Icon - My Computer] **********************************************************************************************************************************
 [WARNING]: Removed unexpected internal key in module return: _ansible_parsed = False

fatal: [10.1.1.13]: FAILED! => {"changed": false, "failed": true, "module_stderr": "#< CLIXML\r\n<Objs Version=\"1.1.0.1\" xmlns=\"http://schemas.microsoft.com/powershell/2004/04\"><S S=\"warning\">The names of some imported commands from the module 'powershell' include unapproved verbs that might make them less discoverable. To find the commands with unapproved verbs, run the Import-Module command again with the Verbose parameter. For a list of approved verbs, type Get-Verb.</S></Objs>", "module_stdout": "\r\nName           Used (GB)     Free (GB) Provider      Root                      \r\n----           ---------     --------- --------      ----                      \r\nHKCR                                   Registry      HKEY_CLASSES_ROOT         \r\nHKU                                    Registry      HKEY_USERS                \r\nHKCC                                   Registry      HKEY_CURRENT_CONFIG       \r\n\r\n{20D04FE0-3AEA-1069-A2D8-08002B30309D} : 0\r\nPSPath                                 : Microsoft.PowerShell.Core\\Registry::HK\r\n                                         EY_CURRENT_USER\\Software\\Microsoft\\Win\r\n                                         dows\\CurrentVersion\\Explorer\\HideDeskt\r\n                                         opIcons\\NewStartPanel\r\nPSParentPath                           : Microsoft.PowerShell.Core\\Registry::HK\r\n                                         EY_CURRENT_USER\\Software\\Microsoft\\Win\r\n                                         dows\\CurrentVersion\\Explorer\\HideDeskt\r\n                                         opIcons\r\nPSChildName                            : NewStartPanel\r\nPSDrive                                : HKCU\r\nPSProvider                             : Microsoft.PowerShell.Core\\Registry\r\n\r\n{\"data_type_changed\":false,\"diff\":{\"prepared\":\" [HKCU:\\\\Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Explorer\\\\HideDesktopIcons\\\\NewStartPanel]\\r\\n+\\\"{20D04FE0-3AEA-1069-A2D8-08002B30309D}\\\" = \\\"dword:0\\\"\"},\"warnings\":[],\"changed\":true,\"data_changed\":false}\r\n\r\n\r\n", "msg": "MODULE FAILURE", "rc": 0}
        to retry, use: --limit @/root/github/ansible/sites/testlab/issue.retry

PLAY RECAP *************************************************************************************************************************************************************
10.1.1.13                  : ok=1    changed=0    unreachable=0    failed=1
```
The first entry is added to the Windows machine

##### AFTER CHANGE
```
PLAY [Initial setting of Windows Server 2012 R2] ***********************************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************************************************************
ok: [10.1.1.13]

TASK [Add Desktop Icon - My Computer] **********************************************************************************************************************************
changed: [10.1.1.13]

TASK [Add Desktop Icon - Network] **************************************************************************************************************************************
changed: [10.1.1.13]

PLAY RECAP *************************************************************************************************************************************************************
10.1.1.13                  : ok=3    changed=2    unreachable=0    failed=0
```
Both entries are added to the Windows machine