### PR TITLE
fixes play context connection user

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -443,7 +443,7 @@ class PlayContext(Base):
         # additionally, we need to do this check after final connection has been
         # correctly set above ...
         if new_info.connection == 'local':
-            new_info.connection_user = self.remote_user
+            new_info.connection_user = new_info.remote_user
             new_info.remote_user = pwd.getpwuid(os.getuid()).pw_name
 
         # set no_log to default if it was not previouslly set
@@ -595,6 +595,10 @@ class PlayContext(Base):
         for prop, var_list in MAGIC_VARIABLE_MAPPING.items():
             try:
                 if 'become' in prop:
+                    continue
+
+                # perserves the user var for local connections
+                if self.connection == 'local' and 'remote_user' in prop:
                     continue
 
                 var_val = getattr(self, prop)


### PR DESCRIPTION
Does't map remote_user back into vars if connection is local to preserve
the user variable.  This is done to be able to set connection_user
prop in play_context for the network_cli plugin connection
