### PR TITLE
Ec2_tag module should support state 'list' in check mode

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_tag.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_tag.py
@@ -135,7 +135,7 @@ def main():
         state = dict(default='present', choices=['present', 'absent', 'list']),
     )
     )
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     if not HAS_BOTO:
         module.fail_json(msg='boto required for this module')
@@ -167,8 +167,8 @@ def main():
             for (key, value) in set(tags.items()):
                 if (key, value) not in set(tagdict.items()):
                     dictadd[key] = value
-        tagger = ec2.create_tags(resource, dictadd)
-        gettags = ec2.get_all_tags(filters=filters)
+        if not module.check_mode:
+            ec2.create_tags(resource, dictadd)
         module.exit_json(msg="Tags %s created for resource %s." % (dictadd,resource), changed=True)
 
     if state == 'absent':
@@ -182,8 +182,8 @@ def main():
         for (key, value) in set(tags.items()):
             if (key, value) in set(tagdict.items()):
                 dictremove[key] = value
-        tagger = ec2.delete_tags(resource, dictremove)
-        gettags = ec2.get_all_tags(filters=filters)
+        if not module.check_mode:
+            ec2.delete_tags(resource, dictremove)
         module.exit_json(msg="Tags %s removed for resource %s." % (dictremove,resource), changed=True)
 
     if state == 'list':


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module/ec2_tag

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY

Listing ec2 tags should be allowed in check mode. Removing/Adding tags is forbidden.

This change allows the user to list tags even in check mode.