### PR TITLE
Fixes for missing aliases files sanity test.

### DIFF
--- a/test/sanity/code-smell/integration-aliases.py
+++ b/test/sanity/code-smell/integration-aliases.py
@@ -22,7 +22,7 @@ def main():
             continue
 
         # don't require aliases for support directories
-        if any(os.path.splitext(f)[0] == 'test' for f in files):
+        if any(os.path.splitext(f)[0] == 'test' and os.access(os.path.join(target_dir, f), os.X_OK) for f in files):
             continue
 
         # don't require aliases for setup_ directories

--- a/test/sanity/code-smell/integration-aliases.py
+++ b/test/sanity/code-smell/integration-aliases.py
@@ -41,7 +41,7 @@ def main():
         missing_aliases.append(target_dir)
 
     if missing_aliases:
-        message = '''
+        message = textwrap.dedent('''
         The following integration target directories are missing `aliases` files:
 
         %s
@@ -66,9 +66,9 @@ def main():
         skip/python3
 
         Take a look at existing `aliases` files to see what aliases are available and how they're used.
-        ''' % '\n'.join(missing_aliases)
+        ''').strip() % '\n'.join(missing_aliases)
 
-        print(textwrap.dedent(message).strip())
+        print(message)
 
         exit(1)
 


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

test/sanity/code-smell/integration-aliases.py 

##### ANSIBLE VERSION

```
ansible 2.3.0 (test-fix 4789fdd1f8) last updated 2017/02/22 11:43:47 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Fixes for missing aliases file sanity test:

- Refine test for missing aliases files. This should reduce false negatives.
- Fix formatting of missing aliases message.