### PR TITLE
Avoid crash when module diff has non utf8 translatable text

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -136,8 +136,10 @@ class TaskExecutor:
                 elif isinstance(res, binary_type):
                     try:
                         return to_text(res, errors='surrogate_or_strict')
-                    except:
-                        return bytes(res)
+                    except UnicodeDecodeError:
+                        display.warning("We were unable to decode all characters, skipped some in effort to return as much as possible")
+                        # If text contains non-utf8 characters, we replace them by there hex code if over 128 (Fix #21804)
+                        return to_text(''.join([i if ord(i) < 128 else ("\\x%x" % ord(i)) for i in res]), errors='surrogate_or_strict')
                 elif isinstance(res, dict):
                     for k in res:
                         res[k] = _clean_res(res[k])

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -134,7 +134,10 @@ class TaskExecutor:
                 if isinstance(res, UnsafeProxy):
                     return res._obj
                 elif isinstance(res, binary_type):
-                    return to_text(res, errors='surrogate_or_strict')
+                    try:
+                        return to_text(res, errors='surrogate_or_strict')
+                    except:
+                        return bytes(res)
                 elif isinstance(res, dict):
                     for k in res:
                         res[k] = _clean_res(res[k])


### PR DESCRIPTION
Try to call to_text against result. If we get an exception, we return the text as bytes.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

Crash when using diff option with iso8859-15 files.

##### ANSIBLE VERSION

```
ansible 2.3.0 (diff-iso8859-15 2d2d12f0cc) last updated 2017/02/22 23:45:17 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

Fixes #21803. Try to call to_text against result string. If we get an exception, we return text as bytes.

```
ansible-playbook crash-diff.yml --diff
PLAY [Crash when using --diff option] ***********************************************************************************************************

TASK [Copy a dummy iso8859-15 file] *************************************************************************************************************
--- before: /tmp/test.txt
+++ after: /home/drayan/dev/yannig-ansible-playbooks/diff-iso8859-15/iso8859-15.txt
@@ -1,3 +1,3 @@
-Un super fichier avec é en iso8859-15
+Un super fichier avec � en iso8859-15
 
-A super file with é in iso8859-15
+A super file with � in iso8859-15

changed: [localhost]
```
