### PR TITLE
casts the bridge id to a str prior to building command

### DIFF
--- a/lib/ansible/modules/network/ovs/openvswitch_bridge.py
+++ b/lib/ansible/modules/network/ovs/openvswitch_bridge.py
@@ -193,7 +193,7 @@ class OVSBridge(object):
         '''Create the bridge'''
         cmd = ['add-br', self.bridge]
         if self.parent and self.vlan: # Add fake bridge
-            cmd += [self.parent, self.vlan]
+            cmd += [self.parent, str(self.vlan)]
 
         if self.set and self.set_opt:
             cmd += ["--", "set"]
@@ -296,6 +296,7 @@ class OVSBridge(object):
                             changed = True
 
         except Exception:
+            raise
             earg = get_exception()
             self.module.fail_json(msg=str(earg))
         # pylint: enable=W0703


### PR DESCRIPTION
This will prevent exception from being raise when calling _vsctl and
extending the cmd with the bridge information

ref: #21245 