### PR TITLE
fixes issue with setting transport to nxapi

### DIFF
--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -72,9 +72,9 @@ def get_connection(module):
     global _DEVICE_CONNECTION
     if not _DEVICE_CONNECTION:
         load_params(module)
-        if 'transport' not in module.params:
-            conn = Cli(module)
-        elif module.params['transport'] == 'nxapi':
+        transport = module.params['transport']
+        provider_transport = (module.params['provider'] or {}).get('transport')
+        if 'nxapi' in (transport, provider_transport):
             conn = Nxapi(module)
         else:
             conn = Cli(module)

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -87,6 +87,7 @@ class ActionModule(_ActionModule):
 
         else:
             provider_arg = {
+                'transport': 'nxapi',
                 'host': self._play_context.remote_addr,
                 'port': provider.get('port'),
                 'username': provider.get('username') or self._play_context.connection_user,


### PR DESCRIPTION
The nxos action handler did not map the nxapi value to the provider
argument properly.  There as an additional fix in the nxos shared lib
to properly detect nxapi being set
