### PR TITLE
sends save command in text mode otherwise it fails

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -332,7 +332,8 @@ def main():
 
     if module.params['save']:
         if not module.check_mode:
-            run_commands(module, ['copy running-config startup-config'])
+            cmd = {'command': 'copy running-config startup-config', 'output': 'text'}
+            run_commands(module, [cmd])
         result['changed'] = True
 
     module.exit_json(**result)


### PR DESCRIPTION
Sending the save command over nxapi requires text mode otherwise nxapi
will reject the command.  This commit ensures that the command is always
sent in text mode

fixes #18971
