### PR TITLE
ec2_vpc_subnet: cope with empty tags

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py
@@ -233,7 +233,7 @@ def main():
             az = dict(default=None, required=False),
             cidr = dict(default=None, required=True),
             state = dict(default='present', choices=['present', 'absent']),
-            tags = dict(default=None, required=False, type='dict', aliases=['resource_tags']),
+            tags = dict(default={}, required=False, type='dict', aliases=['resource_tags']),
             vpc_id = dict(default=None, required=True)
         )
     )


### PR DESCRIPTION

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc_subnet

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 730bd682c6) last updated 2017/02/23 13:50:45 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
`ensure_tags` fails if `tags` is `None` rather than an empty dict. Ensure that not passing `tags` parameter is equivalent to passing an empty dict.

Fixes #21778
