### PR TITLE
Revert syntax change of set_fact example for strings and booleans.

### DIFF
--- a/lib/ansible/modules/utilities/logic/set_fact.py
+++ b/lib/ansible/modules/utilities/logic/set_fact.py
@@ -47,9 +47,7 @@ notes:
 
 EXAMPLES = '''
 # Example setting host facts using key=value pairs, note that this always creates strings or booleans
-- set_fact:
-    one_fact: "something"
-    other_fact: "{{ local_var }}"
+- set_fact: one_fact="something" other_fact="{{ local_var }}"
 
 # Example setting host facts using complex arguments
 - set_fact:


### PR DESCRIPTION
	modified:   lib/ansible/modules/utilities/logic/set_fact.py

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
set_fact

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

##### SUMMARY
The reverted change (Examples syntax batch7 (#5624), 99de7f0) makes the
example not match its description.