### PR TITLE
Add pv_options to lvg module so that, for example, metadatasize can b…

### DIFF
--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -46,6 +46,12 @@ options:
     - The size of the physical extent in megabytes. Must be a power of 2.
     default: 4
     required: false
+  pv_options:
+    description:
+    - Additional options to pass to C(pvcreate) when creating the volume group.
+    default: null
+    required: false
+    version_added: "2.2"
   vg_options:
     description:
     - Additional options to pass to C(vgcreate) when creating the volume group.
@@ -129,6 +135,7 @@ def main():
             vg=dict(required=True),
             pvs=dict(type='list'),
             pesize=dict(type='int', default=4),
+            pv_options=dict(default=''),
             vg_options=dict(default=''),
             state=dict(choices=["absent", "present"], default='present'),
             force=dict(type='bool', default='no'),
@@ -140,6 +147,7 @@ def main():
     state = module.params['state']
     force = module.boolean(module.params['force'])
     pesize = module.params['pesize']
+    pvoptions = module.params['pv_options'].split()
     vgoptions = module.params['vg_options'].split()
 
     dev_list = []
@@ -196,7 +204,7 @@ def main():
                 ### create PV
                 pvcreate_cmd = module.get_bin_path('pvcreate', True)
                 for current_dev in dev_list:
-                    rc,_,err = module.run_command("%s -f %s" % (pvcreate_cmd,current_dev))
+                    rc,_,err = module.run_command([pvcreate_cmd] + pvoptions + ['-f', str(current_dev)])
                     if rc == 0:
                         changed = True
                     else:
@@ -237,7 +245,7 @@ def main():
                     ### create PV
                     pvcreate_cmd = module.get_bin_path('pvcreate', True)
                     for current_dev in devs_to_add:
-                        rc,_,err = module.run_command("%s -f %s" % (pvcreate_cmd, current_dev))
+                        rc,_,err = module.run_command([pvcreate_cmd] + pvoptions + ['-f', str(current_dev)])
                         if rc == 0:
                             changed = True
                         else:

--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -51,7 +51,7 @@ options:
     - Additional options to pass to C(pvcreate) when creating the volume group.
     default: null
     required: false
-    version_added: "2.2"
+    version_added: "2.3"
   vg_options:
     description:
     - Additional options to pass to C(vgcreate) when creating the volume group.


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module/system/lvg

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add pv_options to lvg module so that, for example, metadatasize can be specified (e.g. for openstack cinder volumes)

