### PR TITLE
Fixes #21796 : s3 delete vs delobj mode ambiguity

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3.py
+++ b/lib/ansible/modules/cloud/amazon/s3.py
@@ -511,6 +511,10 @@ def main():
     if module.params.get('object'):
         obj = module.params['object']
 
+    # Bucket deletion does not require obj.  Prevents ambiguity with delobj.
+    if obj and mode == "delete":
+        module.fail_json(msg='Parameter obj cannot be used with mode=delete')
+
     # allow eucarc environment variables to be used if ansible vars aren't set
     if not s3_url and 'S3_URL' in os.environ:
         s3_url = os.environ['S3_URL']


### PR DESCRIPTION
Fixes ansible#21796.  Prevents users from deleting buckets rather than objects by making ``object`` param and ``mode=delobj`` mutually exclusive.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
s3

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

##### SUMMARY
Minimal change to prevent deletion of bucket when ``obj`` is specified.  Aside from tasks with superfluous parameters this does not affect the current use of the module.  Ansible allows for deletion of buckets containing objects (unlike when deleting bucket via AWS CLI) which can be dangerous when documentation has been misread.