### PR TITLE
returns xml as a display option to junos_command

### DIFF
--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -183,7 +183,7 @@ class Connection(_Connection):
         cleaned = []
         command = obj.get('command') if obj else None
         for line in resp.splitlines():
-            if (command and line.startswith(command.strip())) or self._find_prompt(line):
+            if (command and line.startswith(command.strip())) or self._matched_prompt.strip() in line:
                 continue
             cleaned.append(line)
         return str("\n".join(cleaned)).strip()

--- a/lib/ansible/plugins/terminal/junos.py
+++ b/lib/ansible/plugins/terminal/junos.py
@@ -36,7 +36,6 @@ class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
         re.compile(r"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
-        re.compile(r"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|%) ?$"),
     ]
 
     terminal_stderr_re = [


### PR DESCRIPTION
The display option xml as accidentially removed from the display
argument.  This patch adds xml back as an option.

fixes #21823

