### PR TITLE
In cronvar only use '-u {user}' if self.user is not the current user

### DIFF
--- a/lib/ansible/modules/system/cronvar.py
+++ b/lib/ansible/modules/system/cronvar.py
@@ -314,7 +314,7 @@ class CronVar(object):
                 return "%s -l %s" % (pipes.quote(CRONCMD), pipes.quote(self.user))
             elif platform.system() == 'HP-UX':
                 return "%s %s %s" % (CRONCMD , '-l', pipes.quote(self.user))
-            else:
+            elif pwd.getpwuid(os.getuid())[0] != self.user:
                 user = '-u %s' % pipes.quote(self.user)
         return "%s %s %s" % (CRONCMD , user, '-l')
 
@@ -326,7 +326,7 @@ class CronVar(object):
         if self.user:
             if platform.system() in ['SunOS', 'HP-UX', 'AIX']:
                 return "chown %s %s ; su '%s' -c '%s %s'" % (pipes.quote(self.user), pipes.quote(path), pipes.quote(self.user), CRONCMD, pipes.quote(path))
-            else:
+            elif pwd.getpwuid(os.getuid())[0] != self.user:
                 user = '-u %s' % pipes.quote(self.user)
         return "%s %s %s" % (CRONCMD , user, pipes.quote(path))
 


### PR DESCRIPTION
Use the same logic as in the cron module.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cronvar

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
In my case the ansible_user is not allowed to user `-u`. When it tried to edit its own crontab the cron module correctly uses the users own crontab, without any unnecessary `-u {user}` argument. However the cronvar module *does* include the `-u {user}` option, causing an error. Currently the solution is to explicitly define the user option, but to set it to an empty string (not `None`).

<!-- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
fatal: [user]: FAILED! => {"changed": false, "failed": true, "msg": "must be privileged to use -u\n"}
```

After:
```
changed: [user]
```
