### PR TITLE
cast http_port, https_port to int from config

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_nxapi.py
+++ b/lib/ansible/modules/network/nxos/nxos_nxapi.py
@@ -192,14 +192,14 @@ def map_obj_to_commands(updates, module):
 def parse_http(data):
     match = re.search('HTTP Port:\s+(\d+)', data, re.M)
     if match:
-        return {'http': True, 'http_port': match.group(1)}
+        return {'http': True, 'http_port': int(match.group(1))}
     else:
         return {'http': False, 'http_port': None}
 
 def parse_https(data):
     match = re.search('HTTPS Port:\s+(\d+)', data, re.M)
     if match:
-        return {'https': True, 'https_port': match.group(1)}
+        return {'https': True, 'https_port': int(match.group(1))}
     else:
         return {'https': False, 'https_port': None}
 


### PR DESCRIPTION
When retrieving the http_port, https_port values from the configuration
of the device, the values need to cast to int in order to correctly
compare against the argspec values.  This patch fixes that problem.

fixes #21832

