### PR TITLE
fixes issue in nxos_config when retrieving current config

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -235,7 +235,7 @@ def get_running_config(module):
         if module.params['defaults']:
             flags.append('all')
         contents = get_config(module, flags=flags)
-    return NetworkConfig(indent=1, contents=contents)
+    return NetworkConfig(indent=2, contents=contents)
 
 def get_candidate(module):
     candidate = NetworkConfig(indent=2)

--- a/test/integration/targets/nxos_config/tests/cli/src_basic.yaml
+++ b/test/integration/targets/nxos_config/tests/cli/src_basic.yaml
@@ -14,6 +14,7 @@
 - name: configure device with config
   nxos_config:
     src: basic/config.j2
+    defaults: yes
     provider: "{{ cli }}"
   register: result
 
@@ -26,6 +27,7 @@
 - name: check device with config
   nxos_config:
     src: basic/config.j2
+    defaults: yes
     provider: "{{ cli }}"
   register: result
 

--- a/test/integration/targets/nxos_config/tests/cli/src_match_none.yaml
+++ b/test/integration/targets/nxos_config/tests/cli/src_match_none.yaml
@@ -16,6 +16,7 @@
     src: basic/config.j2
     provider: "{{ cli }}"
     match: none
+    defaults: yes
   register: result
 
 - assert:
@@ -28,6 +29,7 @@
   nxos_config:
     src: basic/config.j2
     provider: "{{ cli }}"
+    defaults: yes
   register: result
 
 - assert:


### PR DESCRIPTION
When parsing the configuration, the wrong indent level was set so the
configurations could not be properly compared.  Also noted that
defaults: yes needed to be added to the integration tests to make the
test cases valid, which is also included in this patch

fixes #21828

