### PR TITLE
Add 9p to list of special filesystems for selinux

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -372,7 +372,7 @@
 # file systems that require special treatment when dealing with security context
 # the default behaviour that copies the existing context or uses the user default
 # needs to be changed to use the file system dependent context.
-#special_context_filesystems=nfs,vboxsf,fuse,ramfs
+#special_context_filesystems=nfs,vboxsf,fuse,ramfs,9p
 
 # Set this to yes to allow libvirt_lxc connections to work without SELinux.
 #libvirt_lxc_noseclabel = yes

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -246,7 +246,7 @@ DEFAULT_NO_TARGET_SYSLOG   = get_config(p, DEFAULTS, 'no_target_syslog', 'ANSIBL
 ALLOW_WORLD_READABLE_TMPFILES = get_config(p, DEFAULTS, 'allow_world_readable_tmpfiles', None, False, value_type='boolean')
 
 # selinux
-DEFAULT_SELINUX_SPECIAL_FS = get_config(p, 'selinux', 'special_context_filesystems', None, 'fuse, nfs, vboxsf, ramfs', value_type='list')
+DEFAULT_SELINUX_SPECIAL_FS = get_config(p, 'selinux', 'special_context_filesystems', None, 'fuse, nfs, vboxsf, ramfs, 9p', value_type='list')
 DEFAULT_LIBVIRT_LXC_NOSECLABEL = get_config(p, 'selinux', 'libvirt_lxc_noseclabel', 'LIBVIRT_LXC_NOSECLABEL', False, value_type='boolean')
 
 ### PRIVILEGE ESCALATION ###


### PR DESCRIPTION
When trying to copy files onto a Virtio-9p filesystem[1][2] int the host
using something like the template module, ansible throws an error that
says something like:

    invalid selinux context: [Errno 95] Operation not supported

Adding 9p to the list of exceptional filesystems forces ansible to not
try to set an SELinux context on copied files.

[1] such as one mounted in a qemu VM, using:

    # http://www.linux-kvm.org/page/9p_virtio
    qemu-kvm [...] -virtfs local,id=apps_dev,path=/host/dir,security_model=passthrough,mount_tag=host_dir

[2] https://www.kernel.org/doc/Documentation/filesystems/9p.txt

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
core

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (selinux-9p-fix c6b5ca421d) last updated 2017/02/10 21:29:48 (GMT +550)
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This change adds 9p to the list of exceptional filesystems that don't play well with selinux.

Ansible is unable to set selinux attributes/context for files it copies over onto a 9p filesystem.

With a (qemu) VM running a 9p mounted filesystem, running a simple command to copy a file, such as:

```
[ffledgling@ffledglinglinux ~ ]$ ansible -i /spare/local/ffledgling/ansible-cm/hosts -vvv vm -m copy -a "src=/tmp/a dest=/spare/local/ffledgling/vm_data/jenkins_home/a" -e ansible_ssh_port=10023 

```

Will result in an error like so:
```
default | FAILED! => {
    "changed": false, 
    "checksum": "cebb4cb1c1672e127205550c8390414e9b70f6a4", 
    "cur_context": [
        "system_u", 
        "object_r", 
        "nfs_t", 
        "s0"
    ], 
    "failed": true, 
    "gid": 0, 
    "group": "root", 
    "input_was": [
        "system_u", 
        "object_r", 
        "default_t", 
        "s0"
    ], 
    "invocation": {
        "module_args": {
            "attributes": null, 
            "backup": false, 
            "content": null, 
            "delimiter": null, 
            "dest": "/spare/local/ffledgling/vm_data/jenkins_home/a", 
            "directory_mode": null, 
            "follow": false, 
            "force": true, 
            "group": null, 
            "mode": null, 
            "original_basename": "a", 
            "owner": null, 
            "regexp": null, 
            "remote_src": null, 
            "selevel": null, 
            "serole": null, 
            "setype": null, 
            "seuser": null, 
            "src": "/root/.ansible/tmp/ansible-tmp-1487772105.17-212553510817589/source", 
            "unsafe_writes": null, 
            "validate": null
        }
    }, 
    "mode": "0744", 
    "msg": "invalid selinux context: [Errno 95] Operation not supported", 
    "new_context": [
        "system_u", 
        "object_r", 
        "default_t", 
        "s0"
    ], 
    "owner": "root", 
    "path": "/spare/local/ffledgling/vm_data/jenkins_home/.ansible_tmpDfQmMDa", 
    "secontext": "system_u:object_r:nfs_t:s0", 
    "size": 34, 
    "state": "file", 
    "uid": 0
}
```

After the patch:
```
default | SUCCESS => {
    "changed": true, 
    "checksum": "9fcd8d054757dbf77fcf8f2406aa80d43d35ca68", 
    "dest": "/spare/local/ffledgling/vm_data/jenkins_home/a", 
    "gid": 0, 
    "group": "root", 
    "invocation": {
        "module_args": {
            "attributes": null, 
            "backup": false, 
            "content": null, 
            "delimiter": null, 
            "dest": "/spare/local/ffledgling/vm_data/jenkins_home/a", 
            "directory_mode": null, 
            "follow": false, 
            "force": true, 
            "group": null, 
            "mode": null, 
            "original_basename": "a", 
            "owner": null, 
            "regexp": null, 
            "remote_src": null, 
            "selevel": null, 
            "serole": null, 
            "setype": null, 
            "seuser": null, 
            "src": "/root/.ansible/tmp/ansible-tmp-1487857673.94-126685857824262/source", 
            "unsafe_writes": null, 
            "validate": null
        }
    }, 
    "md5sum": "bf3049ce62093d1fcde76a039deaffb9", 
    "mode": "0644", 
    "owner": "root", 
    "secontext": "system_u:object_r:nfs_t:s0", 
    "size": 17, 
    "src": "/root/.ansible/tmp/ansible-tmp-1487857673.94-126685857824262/source", 
    "state": "file", 
    "uid": 0
}

```


Full debug output:
```
[ffledgling@ffledglinglinux ~ ]$ ansible -i /spare/local/ffledgling/ansible-cm/hosts -vvv vm -m copy -a "src=/tmp/a dest=/spare/local/ffledgling/vm_data/jenkins_home/a" -e ansible_ssh_port=10023 
No config file found; using defaults
META: ran handlers
Using module file /spare/local/ffledgling/ansible/lib/ansible/modules/files/stat.py
<hostname> ESTABLISH SSH CONNECTION FOR USER: root
<hostname> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o Port=10023 -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/apps/infrafs1/ffledgling/.ansible/cp/768c282648 hostname '/bin/sh -c '"'"'echo ~ && sleep 0'"'"''
<hostname> ESTABLISH SSH CONNECTION FOR USER: root
<hostname> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o Port=10023 -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/apps/infrafs1/ffledgling/.ansible/cp/768c282648 hostname '/bin/sh -c '"'"'( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1487772104.9-90501929370998 `" && echo ansible-tmp-1487772104.9-90501929370998="` echo /root/.ansible/tmp/ansible-tmp-1487772104.9-90501929370998 `" ) && sleep 0'"'"''
<hostname> PUT /tmp/tmpLVvVn7 TO /root/.ansible/tmp/ansible-tmp-1487772104.9-90501929370998/stat.py
<hostname> SSH: EXEC sftp -b - -C -o ControlMaster=auto -o ControlPersist=60s -o Port=10023 -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/apps/infrafs1/ffledgling/.ansible/cp/768c282648 '[hostname]'
<hostname> ESTABLISH SSH CONNECTION FOR USER: root
<hostname> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o Port=10023 -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/apps/infrafs1/ffledgling/.ansible/cp/768c282648 hostname '/bin/sh -c '"'"'chmod u+x /root/.ansible/tmp/ansible-tmp-1487772104.9-90501929370998/ /root/.ansible/tmp/ansible-tmp-1487772104.9-90501929370998/stat.py && sleep 0'"'"''
<hostname> ESTABLISH SSH CONNECTION FOR USER: root
<hostname> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o Port=10023 -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/apps/infrafs1/ffledgling/.ansible/cp/768c282648 -tt hostname '/bin/sh -c '"'"'/usr/bin/python /root/.ansible/tmp/ansible-tmp-1487772104.9-90501929370998/stat.py; rm -rf "/root/.ansible/tmp/ansible-tmp-1487772104.9-90501929370998/" > /dev/null 2>&1 && sleep 0'"'"''
<hostname> ESTABLISH SSH CONNECTION FOR USER: root
<hostname> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o Port=10023 -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/apps/infrafs1/ffledgling/.ansible/cp/768c282648 hostname '/bin/sh -c '"'"'echo ~ && sleep 0'"'"''
<hostname> ESTABLISH SSH CONNECTION FOR USER: root
<hostname> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o Port=10023 -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/apps/infrafs1/ffledgling/.ansible/cp/768c282648 hostname '/bin/sh -c '"'"'( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1487772105.17-212553510817589 `" && echo ansible-tmp-1487772105.17-212553510817589="` echo /root/.ansible/tmp/ansible-tmp-1487772105.17-212553510817589 `" ) && sleep 0'"'"''
<hostname> PUT /tmp/a TO /root/.ansible/tmp/ansible-tmp-1487772105.17-212553510817589/source
<hostname> SSH: EXEC sftp -b - -C -o ControlMaster=auto -o ControlPersist=60s -o Port=10023 -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/apps/infrafs1/ffledgling/.ansible/cp/768c282648 '[hostname]'
<hostname> ESTABLISH SSH CONNECTION FOR USER: root
<hostname> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o Port=10023 -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/apps/infrafs1/ffledgling/.ansible/cp/768c282648 hostname '/bin/sh -c '"'"'chmod u+x /root/.ansible/tmp/ansible-tmp-1487772105.17-212553510817589/ /root/.ansible/tmp/ansible-tmp-1487772105.17-212553510817589/source && sleep 0'"'"''
Using module file /spare/local/ffledgling/ansible/lib/ansible/modules/files/copy.py
<hostname> PUT /tmp/tmp_sTS2w TO /root/.ansible/tmp/ansible-tmp-1487772105.17-212553510817589/copy.py
<hostname> SSH: EXEC sftp -b - -C -o ControlMaster=auto -o ControlPersist=60s -o Port=10023 -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/apps/infrafs1/ffledgling/.ansible/cp/768c282648 '[hostname]'
<hostname> ESTABLISH SSH CONNECTION FOR USER: root
<hostname> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o Port=10023 -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/apps/infrafs1/ffledgling/.ansible/cp/768c282648 hostname '/bin/sh -c '"'"'chmod u+x /root/.ansible/tmp/ansible-tmp-1487772105.17-212553510817589/ /root/.ansible/tmp/ansible-tmp-1487772105.17-212553510817589/copy.py && sleep 0'"'"''
<hostname> ESTABLISH SSH CONNECTION FOR USER: root
<hostname> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o Port=10023 -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/apps/infrafs1/ffledgling/.ansible/cp/768c282648 -tt hostname '/bin/sh -c '"'"'/usr/bin/python /root/.ansible/tmp/ansible-tmp-1487772105.17-212553510817589/copy.py; rm -rf "/root/.ansible/tmp/ansible-tmp-1487772105.17-212553510817589/" > /dev/null 2>&1 && sleep 0'"'"''
default | FAILED! => {
    "changed": false, 
    "checksum": "cebb4cb1c1672e127205550c8390414e9b70f6a4", 
    "cur_context": [
        "system_u", 
        "object_r", 
        "nfs_t", 
        "s0"
    ], 
    "failed": true, 
    "gid": 0, 
    "group": "root", 
    "input_was": [
        "system_u", 
        "object_r", 
        "default_t", 
        "s0"
    ], 
    "invocation": {
        "module_args": {
            "attributes": null, 
            "backup": false, 
            "content": null, 
            "delimiter": null, 
            "dest": "/spare/local/ffledgling/vm_data/jenkins_home/a", 
            "directory_mode": null, 
            "follow": false, 
            "force": true, 
            "group": null, 
            "mode": null, 
            "original_basename": "a", 
            "owner": null, 
            "regexp": null, 
            "remote_src": null, 
            "selevel": null, 
            "serole": null, 
            "setype": null, 
            "seuser": null, 
            "src": "/root/.ansible/tmp/ansible-tmp-1487772105.17-212553510817589/source", 
            "unsafe_writes": null, 
            "validate": null
        }
    }, 
    "mode": "0744", 
    "msg": "invalid selinux context: [Errno 95] Operation not supported", 
    "new_context": [
        "system_u", 
        "object_r", 
        "default_t", 
        "s0"
    ], 
    "owner": "root", 
    "path": "/spare/local/ffledgling/vm_data/jenkins_home/.ansible_tmpDfQmMDa", 
    "secontext": "system_u:object_r:nfs_t:s0", 
    "size": 34, 
    "state": "file", 
    "uid": 0
}
```
