### PR TITLE
VyOS: Provide message instead of backtrace on bad operator

### DIFF
--- a/lib/ansible/modules/network/vyos/vyos_command.py
+++ b/lib/ansible/modules/network/vyos/vyos_command.py
@@ -134,6 +134,7 @@ warnings:
 import time
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.netcli import Conditional
 from ansible.module_utils.network_common import ComplexList
 from ansible.module_utils.six import string_types
@@ -185,7 +186,11 @@ def main():
     commands = parse_commands(module, warnings)
 
     wait_for = module.params['wait_for'] or list()
-    conditionals = [Conditional(c) for c in wait_for]
+    try:
+        conditionals = [Conditional(c) for c in wait_for]
+    except AttributeError:
+        exc = get_exception()
+        module.fail_json(msg=str(exc))
 
     retries = module.params['retries']
     interval = module.params['interval']


### PR DESCRIPTION


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vyos_command

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```

##### SUMMARY

Fixes #21847