### PR TITLE
Fixed typo s/simple fail/simply fail

### DIFF
--- a/lib/ansible/modules/utilities/logic/fail.py
+++ b/lib/ansible/modules/utilities/logic/fail.py
@@ -34,7 +34,7 @@ options:
   msg:
     description:
       - The customized message used for failing execution. If omitted,
-        fail will simple bail out with a generic message.
+        fail will simply bail out with a generic message.
     required: false
     default: "'Failed as requested from task'"
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Module: fail.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.1.1.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Replacement of typo "simple" in sentence "will simple bail" in the parameter description, which should read "will simply bail".
