### PR TITLE
Fix regression: allow with_items with delegate_to

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -238,7 +238,8 @@ class StrategyBase:
 
     def get_delegated_hosts(self, result, task):
 
-        host_name = task.delegate_to
+        templar = Templar(loader=self._loader, variables=result)
+        host_name = templar.template(task.delegate_to)
         actual_host = self._inventory.get_host(host_name)
         if actual_host is None:
             actual_host = Host(name=host_name)


### PR DESCRIPTION
Before templating a delegate_to containing `"{{ item }}"`, we must invalidate the template engine cache, otherwise it would be replaced by the hostname of a previous host instead of the current one.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
strategy plugin

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
The following construction, [which should work according to the docs](http://docs.ansible.com/ansible/playbooks_delegation.html#delegated-facts), does not work due to a regression in recent versions of Ansible.

```yaml
    - name: Gather facts
      setup:
      delegate_to: "{{ item }}"
      delegate_facts: True
      with_items: "{{ groups[server_group] }}"
      when: item not in play_hosts

    - debug: msg="{{ hostvars[item]['ansible_fqdn'] }}"
      with_items: "{{ groups[server_group] }}"
```

**Before:**
```
TASK [Gather facts] ************************************************************
ok: [server-3 -> 2001:db8:::1] => (item=server-1)
skipping: [server-3] => (item=server-3) 
ok: [server-3 -> 2001:db8:::2] => (item=server-2)

TASK [debug] *******************************************************************
ok: [server-3] => (item=server-1) => {
    "item": "server-1", 
    "msg": "server-2"
}
ok: [server-3] => (item=server-3) => {
    "item": "server-3", 
    "msg": "server-3"
}
fatal: [server-3]: FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'dict object' has no attribute 'ansible_fqdn'\n\nThe error appears to have been in '/xxxx/playbook.yml': line 15, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n      when: item not in play_hosts\n    - debug: msg=\"{{ hostvars[item]['ansible_fqdn'] }}\"\n      ^ here\nWe could be wrong, but this one looks like it might be an issue with\nmissing quotes.  Always quote template expression brackets when they\nstart a value. For instance:\n\n    with_items:\n      - {{ foo }}\n\nShould be written as:\n\n    with_items:\n      - \"{{ foo }}\"\n"}
```

Please note that server-1 receives `server-2` as its `ansible_fqdn` fact, i.e. server-1 facts are overridden by those from server-2. The actual facts from server-1 are lost.

**After:**
```
TASK [Gather facts] ************************************************************
ok: [server-3 -> 2001:db8:::1] => (item=server-1)
skipping: [server-3] => (item=server-3) 
ok: [server-3 -> 2001:db8:::2] => (item=server-2)

TASK [debug] *******************************************************************
ok: [server-3] => (item=server-1) => {
    "item": "server-1", 
    "msg": "server-1"
}
ok: [server-3] => (item=server-3) => {
    "item": "server-3", 
    "msg": "server-3"
}
ok: [server-3] => (item=server-2) => {
    "item": "server-2", 
    "msg": "server-2"
}
```