### PR TITLE
Document returned values of module pause

### DIFF
--- a/lib/ansible/modules/utilities/logic/pause.py
+++ b/lib/ansible/modules/utilities/logic/pause.py
@@ -61,3 +61,31 @@ EXAMPLES = '''
 - pause:
     prompt: "Make sure org.foo.FooOverload exception is not present"
 '''
+
+RETURN = '''
+user_input:
+  description: User input from interactive console
+  returned: if no waiting time set
+  type: string
+  sample: Example user input
+start:
+  description: Time when started pausing
+  returned: always
+  type: string
+  sample: 2017-02-23 14:35:07.298862
+stop:
+  description: Time when ended pausing
+  returned: always
+  type: string
+  sample: 2017-02-23 14:35:09.552594
+delta:
+  description: Time paused in seconds
+  returned: always
+  type: string
+  sample: 2
+stdout:
+  description: Output of pause module
+  returned: always
+  type: string
+  sample: Paused for 0.04 minutes
+'''


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
pause

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Adds missing documentation of the return values of `pause`. I think this information is important to know, especially for how to retrieve user input.

Fixes #17446 eventually.