### PR TITLE
[WIP] documentation: Remove assemble from list of windows modules, plus tweaks

### DIFF
--- a/docs/docsite/rst/intro_windows.rst
+++ b/docs/docsite/rst/intro_windows.rst
@@ -312,8 +312,8 @@ What modules are available
 Most of the Ansible modules in core Ansible are written for a combination of Linux/Unix machines and arbitrary web services, though there are various
 Windows-only modules. These are listed in the `"windows" subcategory of the Ansible module index <http://docs.ansible.com/list_of_windows_modules.html>`_.
 
-In addition, the following core modules work with Windows:
-    assemble
+In addition, the following core modules work with Windows::
+
     fetch
     raw
     script
@@ -329,7 +329,10 @@ In addition, the following core modules work with Windows:
     pause
     set_fact
 
-Browse this index to see what is available.
+
+Some modules can be utilised in playbooks that target windows by delegating to localhost, depending on what you are
+attempting to achieve.  For example assemble can be used to create a file on your ansible controller that is then 
+sent to your windows targets using win_copy.
 
 In many cases, it may not be necessary to even write or use an Ansible module.
 

--- a/docs/docsite/rst/intro_windows.rst
+++ b/docs/docsite/rst/intro_windows.rst
@@ -331,7 +331,7 @@ In addition, the following core modules work with Windows::
 
 
 Some modules can be utilised in playbooks that target windows by delegating to localhost, depending on what you are
-attempting to achieve.  For example assemble can be used to create a file on your ansible controller that is then 
+attempting to achieve.  For example, assemble can be used to create a file on your ansible controller that is then 
 sent to your windows targets using win_copy.
 
 In many cases, it may not be necessary to even write or use an Ansible module.


### PR DESCRIPTION
Also adds that you can delegate appropriate modules to localhost in playbooks that target windows hosts.  Try to fix list of usable on windows modules to appear as a list instead of on one line.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
intro_windows.rst
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (win_assemble_docfix 3a80e55802) last updated 2017/02/23 17:26:49 (GMT +100)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes https://github.com/ansible/ansible/issues/20700 by taking 'assemble' out of the list of modules that work on windows, but adding advice that you can use modules such as 'assemble' by using delegate_to: localhost
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
Work in Progress right now as I can't seem to get the docs to build on my machine at the moment.