### PR TITLE
fix bug that would cause stack trace in nxos_nxapi

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_nxapi.py
+++ b/lib/ansible/modules/network/nxos/nxos_nxapi.py
@@ -205,7 +205,10 @@ def parse_https(data):
 
 def parse_sandbox(data):
     match = re.search('Sandbox:\s+(.+)$', data, re.M)
-    return {'sandbox': match.group(1) == 'Enabled'}
+    value = None
+    if match:
+        value = match.group(1) == 'Enabled'
+    return {'sandbox': value}
 
 def map_config_to_obj(module):
     out = run_commands(module, ['show nxapi'], check_rc=False)


### PR DESCRIPTION
The parse_sandbox function will generate a stack trace if the command
is not supported.  This patch will resolve that issue.

