### PR TITLE
Contributing lib/ansible/modules/network/cloudengine/ce_acl_interface.py module to manage HUAWEI data center CloudEngine

### DIFF
--- a/lib/ansible/modules/network/cloudengine/ce_acl_interface.py
+++ b/lib/ansible/modules/network/cloudengine/ce_acl_interface.py
@@ -18,15 +18,15 @@
 
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
-                    'version': '1.0'}
+                    'metadata_version': '1.0'}
 
 DOCUMENTATION = '''
 ---
 module: ce_acl_interface
-version_added: "2.3"
-short_description: Manages applying ACLs to interfaces.
+version_added: "2.4"
+short_description: Manages applying ACLs to interfaces on HUAWEI CloudEngine switches.
 description:
-    - Manages applying ACLs to interfaces on CloudEngine switches.
+    - Manages applying ACLs to interfaces on HUAWEI CloudEngine switches.
 author:
     - wangdezhuang (@CloudEngine-Ansible)
 options:
@@ -103,8 +103,8 @@ proposed:
              "interface": "40GE2/0/1",
              "state": "present"}
 existing:
-    description:
-        - k/v pairs of existing aaa server
+    description: k/v pairs of existing aaa server
+    returned: always
     type: dict
     sample: {"acl interface": "traffic-filter acl lb inbound"}
 end_state:

--- a/lib/ansible/modules/network/cloudengine/ce_acl_interface.py
+++ b/lib/ansible/modules/network/cloudengine/ce_acl_interface.py
@@ -1,0 +1,291 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = '''
+---
+module: ce_acl_interface
+version_added: "2.3"
+short_description: Manages applying ACLs to interfaces.
+description:
+    - Manages applying ACLs to interfaces on CloudEngine switches.
+author:
+    - wangdezhuang (@CloudEngine-Ansible)
+options:
+    acl_name:
+        description:
+            - ACL number or name.
+              For a numbered rule group, the value ranging from 2000 to 4999.
+              For a named rule group, the value is a string of 1 to 32 case-sensitive characters starting
+              with a letter, spaces not supported.
+        required: true
+    interface:
+        description:
+            - Interface name.
+              Only support interface full name, such as "40GE2/0/1".
+        required: true
+    direction:
+        description:
+            - Direction ACL to be applied in on the interface.
+        required: true
+        choices: ['inbound', 'outbound']
+    state:
+        description:
+            - Determines whether the config should be present or not on the device.
+        required: false
+        default: present
+        choices: ['present', 'absent']
+'''
+
+EXAMPLES = '''
+
+- name: CloudEngine acl interface test
+  vars:
+    host: "{{ inventory_hostname }}"
+    username: admin
+    password: admin
+    transport: cli
+
+  tasks:
+
+  - name: "Apply acl to interface"
+    ce_acl_interface:
+      state:  present
+      acl_name:  2000
+      interface:  40GE2/0/1
+      direction:  outbound
+      provider: "{{ cli }}"
+
+  - name: "Undo acl from interface"
+    ce_acl_interface:
+      state:  absent
+      acl_name:  2000
+      interface:  40GE2/0/1
+      direction:  outbound
+      provider: "{{ cli }}"
+'''
+
+RETURN = '''
+changed:
+    description: check to see if a change was made on the device
+    returned: always
+    type: boolean
+    sample: true
+proposed:
+    description: k/v pairs of parameters passed into module
+    returned: always
+    type: dict
+    sample: {"acl_name": "2000",
+             "direction": "outbound",
+             "interface": "40GE2/0/1",
+             "state": "present"}
+existing:
+    description:
+        - k/v pairs of existing aaa server
+    type: dict
+    sample: {"acl interface": "traffic-filter acl lb inbound"}
+end_state:
+    description: k/v pairs of aaa params after module execution
+    returned: always
+    type: dict
+    sample: {"acl interface": ["traffic-filter acl lb inbound", "traffic-filter acl 2000 outbound"]}
+updates:
+    description: command sent to the device
+    returned: always
+    type: list
+    sample: ["interface 40ge2/0/1",
+             "traffic-filter acl 2000 outbound"]
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ce import get_config, load_config
+from ansible.module_utils.ce import ce_argument_spec
+
+
+class AclInterface(object):
+    """ Manages acl interface configuration """
+
+    def __init__(self, **kwargs):
+        """ Class init """
+
+        # argument spec
+        argument_spec = kwargs["argument_spec"]
+        self.spec = argument_spec
+        self.module = AnsibleModule(argument_spec=self.spec, supports_check_mode=True)
+
+        # config
+        self.cur_cfg = dict()
+        self.cur_cfg["acl interface"] = []
+
+        # module args
+        self.state = self.module.params['state']
+        self.acl_name = self.module.params['acl_name']
+        self.interface = self.module.params['interface']
+        self.direction = self.module.params['direction']
+
+        # state
+        self.changed = False
+        self.updates_cmd = list()
+        self.results = dict()
+        self.proposed = dict()
+        self.existing = dict()
+        self.end_state = dict()
+
+    def check_args(self):
+        """ Check args """
+
+        if self.acl_name:
+            if self.acl_name.isdigit():
+                if int(self.acl_name) < 2000 or int(self.acl_name) > 4999:
+                    self.module.fail_json(
+                        msg='Error: The value of acl_name is out of [2000 - 4999].')
+            else:
+                if len(self.acl_name) < 1 or len(self.acl_name) > 32:
+                    self.module.fail_json(
+                        msg='Error: The len of acl_name is out of [1 - 32].')
+
+        if self.interface:
+            regular = "| ignore-case section include ^interface %s$" % self.interface
+            result = self.cli_get_config(regular)
+            if not result:
+                self.module.fail_json(
+                    msg='Error: The interface %s is not in the device.' % self.interface)
+
+    def get_proposed(self):
+        """ Get proposed config """
+
+        self.proposed["state"] = self.state
+
+        if self.acl_name:
+            self.proposed["acl_name"] = self.acl_name
+
+        if self.interface:
+            self.proposed["interface"] = self.interface
+
+        if self.direction:
+            self.proposed["direction"] = self.direction
+
+    def get_existing(self):
+        """ Get existing config """
+
+        regular = "| ignore-case section include ^interface %s$ | include traffic-filter" % self.interface
+        result = self.cli_get_config(regular)
+
+        end = []
+        if result:
+            tmp = result.split('\n')
+            for item in tmp:
+                end.append(item)
+            self.cur_cfg["acl interface"] = end
+            self.existing["acl interface"] = end
+
+    def get_end_state(self):
+        """ Get config end state """
+
+        regular = "| ignore-case section include ^interface %s$ | include traffic-filter" % self.interface
+        result = self.cli_get_config(regular)
+        end = []
+        if result:
+            tmp = result.split('\n')
+            for item in tmp:
+                item = item[1:-1]
+                end.append(item)
+            self.end_state["acl interface"] = end
+
+    def cli_load_config(self, commands):
+        """ Cli method to load config """
+
+        if not self.module.check_mode:
+            load_config(self.module, commands)
+
+    def cli_get_config(self, regular):
+        """ Cli method to get config """
+
+        flags = list()
+        flags.append(regular)
+        tmp_cfg = get_config(self.module, flags)
+
+        return tmp_cfg
+
+    def work(self):
+        """ Work function """
+
+        self.check_args()
+        self.get_proposed()
+        self.get_existing()
+
+        cmds = list()
+        tmp_cmd = "traffic-filter acl %s %s" % (self.acl_name, self.direction)
+        undo_tmp_cmd = "undo traffic-filter acl %s %s" % (
+            self.acl_name, self.direction)
+
+        if self.state == "present":
+            if tmp_cmd not in self.cur_cfg["acl interface"]:
+                interface_cmd = "interface %s" % self.interface.lower()
+                cmds.append(interface_cmd)
+                cmds.append(tmp_cmd)
+
+                self.cli_load_config(cmds)
+
+                self.changed = True
+                self.updates_cmd.append(interface_cmd)
+                self.updates_cmd.append(tmp_cmd)
+
+        else:
+            if tmp_cmd in self.cur_cfg["acl interface"]:
+                interface_cmd = "interface %s" % self.interface
+                cmds.append(interface_cmd)
+                cmds.append(undo_tmp_cmd)
+                self.cli_load_config(cmds)
+
+                self.changed = True
+                self.updates_cmd.append(interface_cmd)
+                self.updates_cmd.append(undo_tmp_cmd)
+
+        self.get_end_state()
+
+        self.results['changed'] = self.changed
+        self.results['proposed'] = self.proposed
+        self.results['existing'] = self.existing
+        self.results['end_state'] = self.end_state
+        self.results['updates'] = self.updates_cmd
+
+        self.module.exit_json(**self.results)
+
+
+def main():
+    """ Module main """
+
+    argument_spec = dict(
+        state=dict(choices=['present', 'absent'], default='present'),
+        acl_name=dict(type='str', required=True),
+        interface=dict(type='str', required=True),
+        direction=dict(choices=['inbound', 'outbound'], required=True)
+    )
+
+    argument_spec.update(ce_argument_spec)
+    module = AclInterface(argument_spec=argument_spec)
+    module.work()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/cloudengine/ce_acl_interface.py
+++ b/lib/ansible/modules/network/cloudengine/ce_acl_interface.py
@@ -58,11 +58,16 @@ options:
 EXAMPLES = '''
 
 - name: CloudEngine acl interface test
+  hosts: cloudengine
+  connection: local
+  gather_facts: no
   vars:
-    host: "{{ inventory_hostname }}"
-    username: admin
-    password: admin
-    transport: cli
+    cli:
+      host: "{{ inventory_hostname }}"
+      port: "{{ ansible_ssh_port }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      transport: cli
 
   tasks:
 
@@ -70,7 +75,7 @@ EXAMPLES = '''
     ce_acl_interface:
       state:  present
       acl_name:  2000
-      interface:  40GE2/0/1
+      interface:  40GE1/0/1
       direction:  outbound
       provider: "{{ cli }}"
 
@@ -78,7 +83,7 @@ EXAMPLES = '''
     ce_acl_interface:
       state:  absent
       acl_name:  2000
-      interface:  40GE2/0/1
+      interface:  40GE1/0/1
       direction:  outbound
       provider: "{{ cli }}"
 '''


### PR DESCRIPTION
add ce_acl_interface module

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ce_acl_interface.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
config file = /etc/ansible/ansible.cfg
configured module search path = ['/home/ansible-2.1.1.0/lib/ansible/modules/core/network/cloudengine', '/home/ansible-2.1.1.0/lib/ansible/module_utils', '/home/ansible-2.1.1.0/lib/ansible/modules', '/home/ansible-2.1.1.0', '/home/ansible-2.1.1.0/lib/ansible/utils/']
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [config acl] **************************************************************
task path: /usr1/code/OpenNESS/code/current/KVM/intg/test/testcases/test-ce_acl_interface.yml:27
Using module file /usr/local/lib/python2.7/site-packages/ansible-2.3.0-py2.7.egg/ansible/modules/core/network/cloudengine/ce_acl_interface.py
<ce_6850> ESTABLISH LOCAL CONNECTION FOR USER: root
<ce_6850> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1487042275.6-10215434498194 `" && echo ansible-tmp-1487042275.6-10215434498194="` echo $HOME/.ansible/tmp/ansible-tmp-1487042275.6-10215434498194 `" ) && sleep 0'
<ce_6850> PUT /tmp/tmpAXggHS TO /root/.ansible/tmp/ansible-tmp-1487042275.6-10215434498194/ce_acl_interface.py
<ce_6850> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1487042275.6-10215434498194/ /root/.ansible/tmp/ansible-tmp-1487042275.6-10215434498194/ce_acl_interface.py && sleep 0'
<ce_6850> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1487042275.6-10215434498194/ce_acl_interface.py; rm -rf "/root/.ansible/tmp/ansible-tmp-1487042275.6-10215434498194/" > /dev/null 2>&1 && sleep 0'
changed: [ce_6850] => {
    "changed": true, 
    "end_state": {
        "acl interface": [
            "traffic-filter acl 2200 inbound"
        ]
    }, 
    "existing": {}, 
    "invocation": {
        "module_args": {
            "acl_name": "2200", 
            "auth_pass": null, 
            "authorize": false, 
            "direction": "inbound", 
            "host": "ce_6850", 
            "interface": "40GE1/0/1", 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 12345, 
            "provider": null, 
            "ssh_keyfile": null, 
            "state": "present", 
            "timeout": 10, 
            "transport": null, 
            "use_ssl": false, 
            "username": "rootDC", 
            "validate_certs": true
        }, 
        "module_name": "ce_acl_interface"
    }, 
    "proposed": {
        "acl_name": "2200", 
        "direction": "inbound", 
        "interface": "40GE1/0/1", 
        "state": "present"
    }, 
    "updates": [
        "interface 40ge1/0/1", 
        "traffic-filter acl 2200 inbound"
    ]
}
```
