### PR TITLE
Windows: Make winrm connection output less verbose

### DIFF
--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -255,9 +255,10 @@ class Connection(ConnectionBase):
             self.protocol = self._winrm_connect()
             self._connected = True
         if from_exec:
-            display.vvvvv("WINRM EXEC %r %r" % (command, args), host=self._winrm_host)
+            display.vvvvv("WINRM EXEC %r" % command, host=self._winrm_host)
         else:
-            display.vvvvvv("WINRM EXEC %r %r" % (command, args), host=self._winrm_host)
+            display.vvvvvv("WINRM EXEC %r" % command, host=self._winrm_host)
+        display.debug("<%s> WINRM EXEC %r %r" % (self._winrm_host, command, args))
         command_id = None
         try:
             stdin_push_failed = False
@@ -342,7 +343,7 @@ class Connection(ConnectionBase):
         cmd_parts = self._shell._encode_script(cmd, as_list=True, strict_mode=False, preserve_rc=False)
 
         # TODO: display something meaningful here
-        display.vvv("EXEC (via pipeline wrapper)")
+        display.vvv("WINRM EXEC (via pipeline wrapper)")
 
         stdin_iterator = None
 
@@ -384,9 +385,9 @@ class Connection(ConnectionBase):
         if '-EncodedCommand' in cmd_parts:
             encoded_cmd = cmd_parts[cmd_parts.index('-EncodedCommand') + 1]
             decoded_cmd = to_text(base64.b64decode(encoded_cmd).decode('utf-16-le'))
-            display.vvv("EXEC %s" % decoded_cmd, host=self._winrm_host)
+            display.vvv("WINRM EXEC %s" % decoded_cmd, host=self._winrm_host)
         else:
-            display.vvv("EXEC %s" % cmd, host=self._winrm_host)
+            display.vvv("WINRM EXEC %s" % cmd, host=self._winrm_host)
         try:
             result = self._winrm_exec(cmd_parts[0], cmd_parts[1:], from_exec=True)
         except Exception:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
winrm

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
The WINRM output is quite verbose, mostly because of the encoded
payload. This is an attempt to improve the situation without losing
context. And everything remains available with ANSIBLE_DEBUG=1.