### PR TITLE
Remove superflous iosxr config import

### DIFF
--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -180,7 +180,7 @@ backup_path:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.netcfg import NetworkConfig, dumps
 from ansible.module_utils.iosxr import load_config,get_config
-from ansible.module_utils.iosxr import iosxr_argument_spec, check_args
+from ansible.module_utils.iosxr import iosxr_argument_spec
 
 DEFAULT_COMMIT_COMMENT = 'configured by iosxr_config'
 


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

iosxr_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (remove_superflous_iosxr_config_import a2f82f692e) last updated 2017/02/24 17:19:38 (GMT +200)
```