### PR TITLE
fix argument name in nxos shared lib

### DIFF
--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -306,7 +306,7 @@ class Nxapi:
 
         return responses
 
-    def load_config(self, config):
+    def load_config(self, commands):
         """Sends the ordered set of commands to the device
         """
         cmds = ['configure terminal']


### PR DESCRIPTION
fixes #21895

