### PR TITLE
Treat deprecated modules as old during validation.

### DIFF
--- a/test/sanity/validate-modules/validate-modules
+++ b/test/sanity/validate-modules/validate-modules
@@ -277,7 +277,7 @@ class ModuleValidator(Validator):
         return t.name
 
     def _is_new_module(self):
-        return bool(self.base_branch) and not bool(self.base_module)
+        return not self.object_name.startswith('_') and bool(self.base_branch) and not bool(self.base_module)
 
     def _check_interpreter(self, powershell=False):
         if powershell:


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

module validator

##### ANSIBLE VERSION

```
ansible 2.3.0 (validate-deprecated faedc73f4f) last updated 2017/02/24 12:34:59 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Treat deprecated modules as old during validation.