### PR TITLE
fixes issue that caused eapi transport setting to get lost

### DIFF
--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -79,9 +79,9 @@ def get_connection(module):
     global _DEVICE_CONNECTION
     if not _DEVICE_CONNECTION:
         load_params(module)
-        if 'transport' not in module.params:
-            conn = Cli(module)
-        elif module.params['transport'] == 'eapi':
+        transport = module.params['transport']
+        provider_transport = (module.params['provider'] or {}).get('transport')
+        if 'eapi' in (transport, provider_transport):
             conn = Eapi(module)
         else:
             conn = Cli(module)

--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -87,6 +87,7 @@ class ActionModule(_ActionModule):
 
         else:
             provider_arg = {
+                'transport': 'eapi',
                 'host': provider.get('host') or self._play_context.remote_addr,
                 'port': provider.get('port'),
                 'username': provider.get('username') or self._play_context.connection_user,


### PR DESCRIPTION
The eos action didn't properly set provider transport argument for the
module.  This patch fixes that problem

fixes #21902 

