### PR TITLE
hashi_vault: fix token logic

### DIFF
--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -55,18 +55,6 @@ class HashiVault:
 
         self.url = kwargs.get('url', ANSIBLE_HASHI_VAULT_ADDR)
 
-        self.token = kwargs.get('token', os.environ.get('VAULT_TOKEN', None))
-        if self.token is None and os.environ.get('HOME'):
-            token_filename = os.path.join(
-                os.environ.get('HOME'),
-                '.vault-token'
-            )
-            if os.path.exists(token_filename):
-                with open(token_filename) as token_file:
-                    self.token = token_file.read().strip()
-        if self.token is None:
-            raise AnsibleError("No Vault Token specified")
-
         # split secret arg, which has format 'secret/hello:value' into secret='secret/hello' and secret_field='value'
         s = kwargs.get('secret')
         if s is None:
@@ -94,7 +82,16 @@ class HashiVault:
             except AttributeError:
                 raise AnsibleError("Authentication method '%s' not supported" % self.auth_method)
         else:
-            self.token = kwargs.get('token')
+            self.token = kwargs.get('token', os.environ.get('VAULT_TOKEN', None))
+            if self.token is None and os.environ.get('HOME'):
+                token_filename = os.path.join(
+                    os.environ.get('HOME'),
+                    '.vault-token'
+                )
+                if os.path.exists(token_filename):
+                    with open(token_filename) as token_file:
+                        self.token = token_file.read().strip()
+
             if self.token is None:
                 raise AnsibleError("No Vault Token specified")
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
hashi_vault

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel 7798297317) last updated 2017/02/24 15:54:44 (GMT -400)
  config file = /home/ec2-user/ansible-aws-dev/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
e2e4a69425a4128738846be24e16544b56a7cda9 (which added the ability to automatically set the authentication token from an environment variable or the default Vault credential file) is broken due to 65f561e496582024812aa97fb8acb717ef169c33, which was applied before it and added a second place where `self.token` is set and checked. The new authentication flow makes `token` into an optional setting, so I consolidated the two set/check stanzas into the second one.

<!-- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
TASK [debug] *******************************************************************
fatal: [localhost]: FAILED! => {"failed": true, "msg": "{{ lookup('hashi_vault', 'secret=secret/ping') }}: An unhandled exception occurred while running the lookup plugin 'hashi_vault'. Error was a <class 'ansible.errors.AnsibleError'>, original message: No Vault Token specified"}

```
After:
```
TASK [debug] *******************************************************************
ok: [localhost] => {
    "changed": false, 
    "test": "pong"
}
```