### PR TITLE
Make the metadata docs agree with what's currently implemented

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -59,7 +59,7 @@ Format::
 
   ANSIBLE_METADATA = {
       'version': '1.0',
-      'supported_by': 'core|community|core_curated',
+      'supported_by': 'core|community|unmaintained|committer',
       'status': ['stableinterface|preview|deprecated|removed']
   }
 


### PR DESCRIPTION
The Proposal which this documentation was copied from had an inconsistency as it was updated after approval.  Unable to disentangle what changes are supposed to be the latest so make this all consistent by using the definition that was in the post-approval script which added the metadata values to the modules.

##### ISSUE TYPE

 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
developing_modules_documenting.rst

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```
