### PR TITLE
AWS Elasticache module check mode, replication group, and security group names

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elasticache.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache.py
@@ -518,7 +518,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec=argument_spec,
-        supports_check_mode = True,
+        supports_check_mode=True,
     )
 
     if not HAS_BOTO3:
@@ -559,7 +559,7 @@ def main():
             security_groups = get_ec2_security_group_ids_from_names(security_group_names, conn)
         except botocore.exceptions.ClientError as e:
             module.fail_json(msg="Unable to get security groups ids for groups {0}: {1}".format(security_group_names, to_native(e)),
-                             exception=format_exc(), **response)
+                             exception=format_exc(), **camel_dict_to_snake_dict(e.response))
         except botocore.exceptions.BotoCoreError as e:
             module.fail_json(msg="Unable to get security groups ids for groups {0}: {1}".format(security_group_names, to_native(e)),
                              exception=format_exc())


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
AWS elasticache module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 1.9.1
  configured module search path = None
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The module previously had not supported check mode, so this pull request was partly made to address that by only making API calls when check mode is not activated. Also, there was no support for managing replication groups for elasticache clusters, so this pull request also attempts to address that. Also, it may be useful to pass in security group names instead of ids (assuming security groups are uniquely named per-VPC), since you might not want to hardcode security group ids in your configuration management, so the module can query for the ids using these names.

