### PR TITLE
fixes issue with config parents on eos modules

### DIFF
--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -28,16 +28,13 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 import os
-import re
 import time
 
-from ansible.module_utils.basic import env_fallback, get_exception
-from ansible.module_utils.network_common import to_list
-from ansible.module_utils.netcli import Command
-from ansible.module_utils.six import iteritems
-from ansible.module_utils.network import NetworkError
-from ansible.module_utils.urls import fetch_url
+from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.connection import exec_command
+from ansible.module_utils.network_common import to_list, ComplexList
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.urls import fetch_url
 
 _DEVICE_CONNECTION = None
 
@@ -57,7 +54,7 @@ eos_argument_spec = {
     'validate_certs': dict(type='bool'),
     'timeout': dict(type='int'),
 
-    'provider': dict(type='dict', no_log=True),
+    'provider': dict(type='dict'),
     'transport': dict(choices=['cli', 'eapi'])
 }
 
@@ -225,7 +222,7 @@ class Cli:
             self._module.fail_json(msg=err, commands=commands)
 
         rc, out, err = self.exec_command('show session-config diffs')
-        if rc == 0:
+        if rc == 0 and out:
             result['diff'] = out.strip()
 
         if commit:
@@ -327,7 +324,7 @@ class Eapi:
                 item['command'] = str(item['command']).replace('| json', '')
                 item['output'] == 'json'
 
-            if output != item['output']:
+            if output and output != item['output']:
                 responses.extend(_send(queue, output))
                 queue = list()
 
@@ -407,7 +404,7 @@ class Eapi:
 
         response = self.send_request(commands, output='text')
         diff = response['result'][1]['output']
-        if diff:
+        if len(diff) > 0:
             result['diff'] = diff
 
         return result
@@ -417,13 +414,41 @@ is_text = lambda x: not str(x).endswith('| json')
 
 supports_sessions = lambda x: get_connection(module).supports_sessions
 
+def is_eapi(module):
+    transport = module.params['transport']
+    provider_transport = (module.params['provider'] or {}).get('transport')
+    return 'eapi' in (transport, provider_transport)
+
+def to_command(module, commands):
+    if is_eapi(module):
+        default_output = 'json'
+    else:
+        default_output = 'text'
+
+    transform = ComplexList(dict(
+        command=dict(key=True),
+        output=dict(default=default_output),
+        prompt=dict(),
+        answer=dict()
+    ), module)
+
+    commands = transform(to_list(commands))
+
+    for index, item in enumerate(commands):
+        if is_json(item['command']):
+            item['output'] = 'json'
+        elif is_text(item['command']):
+            item['output'] = 'text'
+
+    return commands
+
 def get_config(module, flags=[]):
     conn = get_connection(module)
     return conn.get_config(flags)
 
 def run_commands(module, commands):
     conn = get_connection(module)
-    return conn.run_commands(commands)
+    return conn.run_commands(to_command(module, commands))
 
 def load_config(module, config, commit=False, replace=False):
     conn = get_connection(module)

--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -226,6 +226,12 @@ def get_candidate(module):
         candidate.add(module.params['lines'], parents=parents)
     return candidate
 
+def get_running_config(module):
+    flags = []
+    if module.params['defaults'] is True:
+        flags.append('all')
+    return get_config(module, flags)
+
 def run(module, result):
     match = module.params['match']
     replace = module.params['replace']
@@ -233,9 +239,10 @@ def run(module, result):
     candidate = get_candidate(module)
 
     if match != 'none' and replace != 'config':
-        config_text = get_config(module)
+        config_text = get_running_config(module)
         config = NetworkConfig(indent=3, contents=config_text)
-        configobjs = candidate.difference(config, match=match, replace=replace)
+        path = module.params['parents']
+        configobjs = candidate.difference(config, match=match, replace=replace, path=path)
     else:
         configobjs = candidate.items
 
@@ -256,8 +263,10 @@ def run(module, result):
         commit = not module.check_mode
 
         response = load_config(module, commands, replace=replace, commit=commit)
+
         if 'diff' in response:
             result['diff'] = {'prepared': response['diff']}
+
         if 'session' in response:
             result['session'] = response['session']
 

--- a/test/integration/targets/eos_config/tests/cli/backup.yaml
+++ b/test/integration/targets/eos_config/tests/cli/backup.yaml
@@ -34,7 +34,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - "result.updates is not defined"
+      - "result.updates is defined"
 
 - name: collect any backup files
   find:

--- a/test/integration/targets/eos_config/tests/cli/config.yaml
+++ b/test/integration/targets/eos_config/tests/cli/config.yaml
@@ -35,7 +35,6 @@
 - assert:
     that:
       - "result.changed == false"
-      - "'hostname foo' in result.updates"
 
 - name: teardown
   eos_config:

--- a/test/integration/targets/eos_config/tests/cli/defaults.yaml
+++ b/test/integration/targets/eos_config/tests/cli/defaults.yaml
@@ -23,7 +23,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - "result.updates is not defined"
+      - "result.updates is defined"
 
 - name: check device with defaults included
   eos_config:

--- a/test/integration/targets/eos_config/tests/cli/src_basic.yaml
+++ b/test/integration/targets/eos_config/tests/cli/src_basic.yaml
@@ -21,11 +21,12 @@
     that:
       - "result.changed == true"
 # https://github.com/ansible/ansible-modules-core/issues/4807
-      - "result.updates is not defined"
+      - "result.updates is defined"
 
 - name: check device with config
   eos_config:
     src: basic/config.j2
+    defaults: yes
     provider: "{{ cli }}"
   register: result
 

--- a/test/integration/targets/eos_config/tests/cli/src_match_none.yaml
+++ b/test/integration/targets/eos_config/tests/cli/src_match_none.yaml
@@ -22,13 +22,13 @@
     that:
       - "result.changed == true"
 # https://github.com/ansible/ansible-modules-core/issues/4807
-      - "result.updates is not defined"
+      #- "result.updates is not defined"
 
 - name: check device with config
   eos_config:
     src: basic/config.j2
+    defaults: yes
     provider: "{{ cli }}"
-    match: none
   register: result
 
 - assert:

--- a/test/integration/targets/eos_config/tests/eapi/backup.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/backup.yaml
@@ -34,7 +34,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - "result.updates is not defined"
+      - "result.updates is defined"
 
 - name: collect any backup files
   find:

--- a/test/integration/targets/eos_config/tests/eapi/defaults.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/defaults.yaml
@@ -23,7 +23,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - "result.updates is not defined"
+      - "result.updates is defined"
 
 - name: check device with defaults included
   eos_config:

--- a/test/integration/targets/eos_config/tests/eapi/src_basic.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/src_basic.yaml
@@ -21,7 +21,7 @@
     that:
       - "result.changed == true"
 # https://github.com/ansible/ansible-modules-core/issues/4807
-      - "result.updates is not defined"
+      - "result.updates is defined"
 
 - name: check device with config
   eos_config:

--- a/test/integration/targets/eos_config/tests/eapi/src_match_none.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/src_match_none.yaml
@@ -22,13 +22,12 @@
     that:
       - "result.changed == true"
 # https://github.com/ansible/ansible-modules-core/issues/4807
-      - "result.updates is not defined"
+      - "result.updates is defined"
 
 - name: check device with config
   eos_config:
     src: basic/config.j2
     provider: "{{ eapi }}"
-    match: none
   register: result
 
 - assert:


### PR DESCRIPTION
eos_config module wasn't respecting config block path (parents).  This
patch fixes that problem.  Also fixes a number of integration tests
cases

fixes #21903

