### PR TITLE
VAULT_TOKEN is ignored when set as env var or from $HOME/.vault-token file

### DIFF
--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -94,7 +94,6 @@ class HashiVault:
             except AttributeError:
                 raise AnsibleError("Authentication method '%s' not supported" % self.auth_method)
         else:
-            self.token = kwargs.get('token')
             if self.token is None:
                 raise AnsibleError("No Vault Token specified")
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
hashi_vault lookup plugin

##### ANSIBLE VERSION
```
# ansible --version
ansible 2.3.0
  config file = /root/.ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

This actually patches #18659

<!-- Paste verbatim command output below, e.g. before and after your change -->

Environment
```
# cat vault.yml 
---

- hosts: 127.0.0.1
  connection: local
  tasks:
  - name:
    shell: "echo {{ lookup('hashi_vault', 'secret=secret/foo:bar') }}"

# export | grep VAULT_
declare -x VAULT_ADDR="http://xxxxxxxxxx:8200"
declare -x VAULT_TOKEN="ab0fd063xxxxxxxxb06f9"

```

Before
```
root@c02b4846c9e1:/# ansible-playbook -i 'localhost,' vault.yml

PLAY [127.0.0.1] *****************************************************************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************************************
ok: [localhost]

TASK [command] *******************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"failed": true, "msg": "An unhandled exception occurred while running the lookup plugin 'hashi_vault'. Error was a <class 'ansible.errors.AnsibleError'>, original message: yy No Vault Token specified"}
	to retry, use: --limit @/vault.retry

PLAY RECAP ***********************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1   

root@c02b4846c9e1:/# 
```

After:
```
# ansible-playbook -i 'localhost,' vault.yml

PLAY [127.0.0.1] *****************************************************************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************************************
ok: [localhost]

TASK [command] *******************************************************************************************************************************************************************************************
changed: [localhost]

PLAY RECAP ***********************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0   

root@c02b4846c9e1:/#
```


The same behavior was experienced when `.vault-token` existed - it was also ignored.