### PR TITLE
Added check for avi SDK version as suggested in review.

### DIFF
--- a/lib/ansible/module_utils/avi_ansible_utils.py
+++ b/lib/ansible/module_utils/avi_ansible_utils.py
@@ -28,6 +28,19 @@
 #
 
 import os
+from pkg_resources import parse_version
+
+HAS_AVI = True
+try:
+    import avi.sdk
+    sdk_version = getattr(avi.sdk, '__version__', None)
+    if ((sdk_version is None) or (sdk_version and
+            (parse_version(sdk_version) < parse_version('16.3.5.post1')))):
+        # It allows the __version__ to be '' as that value is used in development builds
+        raise ImportError
+    from avi.sdk.utils.ansible_utils import avi_ansible_api
+except ImportError:
+    HAS_AVI = False
 
 
 def avi_common_argument_spec():

--- a/lib/ansible/module_utils/avi_ansible_utils.py
+++ b/lib/ansible/module_utils/avi_ansible_utils.py
@@ -27,6 +27,12 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
+# This module initially matched the namespace of network module avi. However,
+# that causes namespace import error when other modules from avi namespaces
+# are imported. In order to avoid the import collisions this was renamed to
+# avi_ansible_utils to allow this module to be ceterpiece of all integration
+# with external avi modules.
+
 import os
 from pkg_resources import parse_version
 

--- a/lib/ansible/modules/network/avi/avi_api_session.py
+++ b/lib/ansible/modules/network/avi/avi_api_session.py
@@ -116,11 +116,11 @@ obj:
 import json
 import time
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.avi import avi_common_argument_spec, ansible_return
 from copy import deepcopy
 
-HAS_AVI = True
 try:
+    from ansible.module_utils.avi_ansible_utils import (
+        avi_common_argument_spec, ansible_return, HAS_AVI)
     from avi.sdk.avi_api import ApiSession
     from avi.sdk.utils.ansible_utils import avi_obj_cmp, cleanup_absent_fields
 except ImportError:

--- a/lib/ansible/modules/network/avi/avi_healthmonitor.py
+++ b/lib/ansible/modules/network/avi/avi_healthmonitor.py
@@ -132,12 +132,18 @@ obj:
     type: dict
 '''
 
+from pkg_resources import parse_version
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.avi import avi_common_argument_spec
 
-
 HAS_AVI = True
 try:
+    import avi.sdk
+    sdk_version = getattr(avi.sdk, '__version__', None)
+    if ((sdk_version is None) or (sdk_version and
+            (parse_version(sdk_version) < parse_version('16.3.5.post1')))):
+        # It allows the __version__ to be '' as that value is used in development builds
+        raise ImportError
     from avi.sdk.utils.ansible_utils import avi_ansible_api
 except ImportError:
     HAS_AVI = False
@@ -170,7 +176,7 @@ def main():
         argument_spec=argument_specs, supports_check_mode=True)
     if not HAS_AVI:
         return module.fail_json(msg=(
-            'Avi python API SDK (avisdk) is not installed. '
+            'Avi python API SDK (avisdk>=16.3.5.post1) is not installed. '
             'For more details visit https://github.com/avinetworks/sdk.'))
     return avi_ansible_api(module, 'healthmonitor',
                            set([]))

--- a/lib/ansible/modules/network/avi/avi_healthmonitor.py
+++ b/lib/ansible/modules/network/avi/avi_healthmonitor.py
@@ -132,19 +132,11 @@ obj:
     type: dict
 '''
 
-from pkg_resources import parse_version
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.avi import avi_common_argument_spec
 
-HAS_AVI = True
 try:
-    import avi.sdk
-    sdk_version = getattr(avi.sdk, '__version__', None)
-    if ((sdk_version is None) or (sdk_version and
-            (parse_version(sdk_version) < parse_version('16.3.5.post1')))):
-        # It allows the __version__ to be '' as that value is used in development builds
-        raise ImportError
-    from avi.sdk.utils.ansible_utils import avi_ansible_api
+    from ansible.module_utils.avi_ansible_utils import (
+        avi_common_argument_spec, HAS_AVI, avi_ansible_api)
 except ImportError:
     HAS_AVI = False
 

--- a/lib/ansible/modules/network/avi/avi_pool.py
+++ b/lib/ansible/modules/network/avi/avi_pool.py
@@ -288,12 +288,18 @@ obj:
     type: dict
 '''
 
+from pkg_resources import parse_version
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.avi import avi_common_argument_spec
 
-
 HAS_AVI = True
 try:
+    import avi.sdk
+    sdk_version = getattr(avi.sdk, '__version__', None)
+    if ((sdk_version is None) or (sdk_version and
+            (parse_version(sdk_version) < parse_version('16.3.5.post1')))):
+        # It allows the __version__ to be '' as that value is used in development builds
+        raise ImportError
     from avi.sdk.utils.ansible_utils import avi_ansible_api
 except ImportError:
     HAS_AVI = False
@@ -362,7 +368,7 @@ def main():
         argument_spec=argument_specs, supports_check_mode=True)
     if not HAS_AVI:
         return module.fail_json(msg=(
-            'Avi python API SDK (avisdk) is not installed. '
+            'Avi python API SDK (avisdk>=16.3.5.post1) is not installed. '
             'For more details visit https://github.com/avinetworks/sdk.'))
     return avi_ansible_api(module, 'pool',
                            set([]))

--- a/lib/ansible/modules/network/avi/avi_pool.py
+++ b/lib/ansible/modules/network/avi/avi_pool.py
@@ -288,19 +288,11 @@ obj:
     type: dict
 '''
 
-from pkg_resources import parse_version
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.avi import avi_common_argument_spec
 
-HAS_AVI = True
 try:
-    import avi.sdk
-    sdk_version = getattr(avi.sdk, '__version__', None)
-    if ((sdk_version is None) or (sdk_version and
-            (parse_version(sdk_version) < parse_version('16.3.5.post1')))):
-        # It allows the __version__ to be '' as that value is used in development builds
-        raise ImportError
-    from avi.sdk.utils.ansible_utils import avi_ansible_api
+    from ansible.module_utils.avi_ansible_utils import (
+        avi_common_argument_spec, HAS_AVI, avi_ansible_api)
 except ImportError:
     HAS_AVI = False
 

--- a/lib/ansible/modules/network/avi/avi_poolgroup.py
+++ b/lib/ansible/modules/network/avi/avi_poolgroup.py
@@ -93,7 +93,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = """
-- name: Example Adds/Deletes PoolGroup configuration from Avi Controller
+- name: Example to create PoolGroup object
   avi_poolgroup:
     controller: 10.10.25.42
     username: admin

--- a/lib/ansible/modules/network/avi/avi_poolgroup.py
+++ b/lib/ansible/modules/network/avi/avi_poolgroup.py
@@ -109,19 +109,11 @@ obj:
     type: dict
 '''
 
-from pkg_resources import parse_version
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.avi import avi_common_argument_spec
 
-HAS_AVI = True
 try:
-    import avi.sdk
-    sdk_version = getattr(avi.sdk, '__version__', None)
-    if ((sdk_version is None) or (sdk_version and
-            (parse_version(sdk_version) < parse_version('16.3.5.post1')))):
-        # It allows the __version__ to be '' as that value is used in development builds
-        raise ImportError
-    from avi.sdk.utils.ansible_utils import avi_ansible_api
+    from ansible.module_utils.avi_ansible_utils import (
+        avi_common_argument_spec, HAS_AVI, avi_ansible_api)
 except ImportError:
     HAS_AVI = False
 

--- a/lib/ansible/modules/network/avi/avi_poolgroup.py
+++ b/lib/ansible/modules/network/avi/avi_poolgroup.py
@@ -109,12 +109,18 @@ obj:
     type: dict
 '''
 
+from pkg_resources import parse_version
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.avi import avi_common_argument_spec
 
-
 HAS_AVI = True
 try:
+    import avi.sdk
+    sdk_version = getattr(avi.sdk, '__version__', None)
+    if ((sdk_version is None) or (sdk_version and
+            (parse_version(sdk_version) < parse_version('16.3.5.post1')))):
+        # It allows the __version__ to be '' as that value is used in development builds
+        raise ImportError
     from avi.sdk.utils.ansible_utils import avi_ansible_api
 except ImportError:
     HAS_AVI = False
@@ -143,7 +149,7 @@ def main():
         argument_spec=argument_specs, supports_check_mode=True)
     if not HAS_AVI:
         return module.fail_json(msg=(
-            'Avi python API SDK (avisdk) is not installed. '
+            'Avi python API SDK (avisdk>=16.3.5.post1) is not installed. '
             'For more details visit https://github.com/avinetworks/sdk.'))
     return avi_ansible_api(module, 'poolgroup',
                            set([]))

--- a/lib/ansible/modules/network/avi/avi_sslkeyandcertificate.py
+++ b/lib/ansible/modules/network/avi/avi_sslkeyandcertificate.py
@@ -127,12 +127,18 @@ obj:
     type: dict
 '''
 
+from pkg_resources import parse_version
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.avi import avi_common_argument_spec
 
-
 HAS_AVI = True
 try:
+    import avi.sdk
+    sdk_version = getattr(avi.sdk, '__version__', None)
+    if ((sdk_version is None) or (sdk_version and
+            (parse_version(sdk_version) < parse_version('16.3.5.post1')))):
+        # It allows the __version__ to be '' as that value is used in development builds
+        raise ImportError
     from avi.sdk.utils.ansible_utils import avi_ansible_api
 except ImportError:
     HAS_AVI = False
@@ -164,7 +170,7 @@ def main():
         argument_spec=argument_specs, supports_check_mode=True)
     if not HAS_AVI:
         return module.fail_json(msg=(
-            'Avi python API SDK (avisdk) is not installed. '
+            'Avi python API SDK (avisdk>=16.3.5.post1) is not installed. '
             'For more details visit https://github.com/avinetworks/sdk.'))
     return avi_ansible_api(module, 'sslkeyandcertificate',
                            set(['key']))

--- a/lib/ansible/modules/network/avi/avi_sslkeyandcertificate.py
+++ b/lib/ansible/modules/network/avi/avi_sslkeyandcertificate.py
@@ -127,19 +127,11 @@ obj:
     type: dict
 '''
 
-from pkg_resources import parse_version
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.avi import avi_common_argument_spec
 
-HAS_AVI = True
 try:
-    import avi.sdk
-    sdk_version = getattr(avi.sdk, '__version__', None)
-    if ((sdk_version is None) or (sdk_version and
-            (parse_version(sdk_version) < parse_version('16.3.5.post1')))):
-        # It allows the __version__ to be '' as that value is used in development builds
-        raise ImportError
-    from avi.sdk.utils.ansible_utils import avi_ansible_api
+    from ansible.module_utils.avi_ansible_utils import (
+        avi_common_argument_spec, HAS_AVI, avi_ansible_api)
 except ImportError:
     HAS_AVI = False
 

--- a/lib/ansible/modules/network/avi/avi_virtualservice.py
+++ b/lib/ansible/modules/network/avi/avi_virtualservice.py
@@ -352,19 +352,11 @@ obj:
     type: dict
 '''
 
-from pkg_resources import parse_version
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.avi import avi_common_argument_spec
 
-HAS_AVI = True
 try:
-    import avi.sdk
-    sdk_version = getattr(avi.sdk, '__version__', None)
-    if ((sdk_version is None) or (sdk_version and
-            (parse_version(sdk_version) < parse_version('16.3.5.post1')))):
-        # It allows the __version__ to be '' as that value is used in development builds
-        raise ImportError
-    from avi.sdk.utils.ansible_utils import avi_ansible_api
+    from ansible.module_utils.avi_ansible_utils import (
+        avi_common_argument_spec, HAS_AVI, avi_ansible_api)
 except ImportError:
     HAS_AVI = False
 

--- a/lib/ansible/modules/network/avi/avi_virtualservice.py
+++ b/lib/ansible/modules/network/avi/avi_virtualservice.py
@@ -352,12 +352,18 @@ obj:
     type: dict
 '''
 
+from pkg_resources import parse_version
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.avi import avi_common_argument_spec
 
-
 HAS_AVI = True
 try:
+    import avi.sdk
+    sdk_version = getattr(avi.sdk, '__version__', None)
+    if ((sdk_version is None) or (sdk_version and
+            (parse_version(sdk_version) < parse_version('16.3.5.post1')))):
+        # It allows the __version__ to be '' as that value is used in development builds
+        raise ImportError
     from avi.sdk.utils.ansible_utils import avi_ansible_api
 except ImportError:
     HAS_AVI = False
@@ -445,7 +451,7 @@ def main():
         argument_spec=argument_specs, supports_check_mode=True)
     if not HAS_AVI:
         return module.fail_json(msg=(
-            'Avi python API SDK (avisdk) is not installed. '
+            'Avi python API SDK (avisdk>=16.3.5.post1) is not installed. '
             'For more details visit https://github.com/avinetworks/sdk.'))
     return avi_ansible_api(module, 'virtualservice',
                            set([]))


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
network.avi

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = /home/grastogi/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Ansible modules have tight dependency on the avisdk. Added version check for avisdk to inform user of the proper versions they need to use for avisdk.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
before: no message when avisdk<=16.3.5.post1

after: when avisdk<=16.3.5.post1
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Avi python API SDK (avisdk>=16.3.5.post1) is not installed. For more details visit https://github.com/avinetworks/sdk."}
```
