### PR TITLE
Alternative decoding/encoding support for templates.

### DIFF
--- a/lib/ansible/modules/files/template.py
+++ b/lib/ansible/modules/files/template.py
@@ -53,6 +53,18 @@ options:
     required: false
     choices: [ "yes", "no" ]
     default: "no"
+  decode:
+    description:
+      - read template using a different encoding (iso8859-15, cp1252)
+    required: false
+    default: null
+    version_added: "2.3"
+  encode:
+    description:
+      - write file using a alternative encoding (iso8859-15, cp1252)
+    required: false
+    default: null
+    version_added: "2.3"
   force:
     description:
       - the default is C(yes), which will replace the remote file when contents

--- a/lib/ansible/modules/files/template.py
+++ b/lib/ansible/modules/files/template.py
@@ -55,15 +55,13 @@ options:
     default: "no"
   decode:
     description:
-      - read template using a different encoding (iso8859-15, cp1252)
-    required: false
-    default: null
+      - Read template using a different encoding (iso8859-15, cp1252).
+    default: "utf-8"
     version_added: "2.3"
   encode:
     description:
-      - write file using a alternative encoding (iso8859-15, cp1252)
-    required: false
-    default: null
+      - Write file using a alternative encoding (iso8859-15, cp1252).
+    default: "utf-8"
     version_added: "2.3"
   force:
     description:

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -906,7 +906,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         display.debug(u"_low_level_execute_command() done: rc=%d, stdout=%s, stderr=%s" % (rc, out, err))
         return dict(rc=rc, stdout=out, stdout_lines=out.splitlines(), stderr=err)
 
-    def _get_diff_data(self, destination, source, task_vars, source_file=True):
+    def _get_diff_data(self, destination, source, task_vars, source_file=True, encoding = 'utf-8'):
 
         diff = {}
         display.debug("Going to peek to see if file has changed permissions")
@@ -940,7 +940,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                     display.debug("Reading local copy of the file %s" % source)
                     try:
                         src = open(source)
-                        src_contents = src.read()
+                        src_contents = to_text(src.read(), encoding=encoding)
                     except Exception as e:
                         raise AnsibleError("Unexpected error while reading source (%s) for diff: %s " % (source, str(e)))
 
@@ -959,7 +959,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 diff["before"] = ""
             if 'after' in diff:
                 diff["after"] = " [[ Diff output has been hidden because 'no_log: true' was specified for this result ]]\n"
-
+        diff["after"] = to_text(diff["after"], encoding=encoding)
         return diff
 
     def _find_needle(self, dirname, needle):


### PR DESCRIPTION
Option decode/encode allow to read/write template in non utf8 format (ex: iso8859-15, cp1252).

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

template

##### ANSIBLE VERSION

```
ansible 2.3.0 (template-encoding ee26c5a9fa) last updated 2017/02/25 00:25:43 (GMT +200)
```

##### SUMMARY

This pull request introduce 2 new options for template module: encode and decode options.

This allow ansible to create file using template using alternative encoding like iso8859-15 or any encoding supported by python.

You can have a look at the playbook at the following location: https://github.com/Yannig/yannig-ansible-playbooks/tree/master/template-iso8859-15
