### PR TITLE
Split up unit tests on Shippable.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -9,7 +9,11 @@ matrix:
     - env: TEST=none
   include:
     - env: TEST=other
-    - env: TEST=units
+
+    - env: TEST=units/2.6
+    - env: TEST=units/2.7
+    - env: TEST=units/3.5
+    - env: TEST=units/3.6
 
     - env: TEST=osx/10.11
 

--- a/test/runner/lib/cover.py
+++ b/test/runner/lib/cover.py
@@ -41,7 +41,12 @@ def command_coverage_combine(args):
     ansible_path = os.path.abspath('lib/ansible/') + '/'
     root_path = os.getcwd() + '/'
 
+    counter = 0
+
     for coverage_file in coverage_files:
+        counter += 1
+        display.info('[%4d/%4d] %s' % (counter, len(coverage_files), coverage_file), verbosity=2)
+
         original = coverage.CoverageData()
 
         if os.path.getsize(coverage_file) == 0:

--- a/test/utils/shippable/shippable.sh
+++ b/test/utils/shippable/shippable.sh
@@ -29,7 +29,7 @@ find lib/ansible/modules -type d -empty -print -delete
 function cleanup
 {
     if [ "$(ls test/results/coverage/)" ]; then
-        ansible-test coverage xml --color -v --requirements
+        ansible-test coverage xml --color -vv --requirements
         cp -av test/results/reports/coverage.xml shippable/codecoverage/coverage.xml
     fi
 

--- a/test/utils/shippable/units.sh
+++ b/test/utils/shippable/units.sh
@@ -2,16 +2,23 @@
 
 set -o pipefail
 
-retry.py add-apt-repository 'ppa:ubuntu-toolchain-r/test'
-retry.py add-apt-repository 'ppa:fkrull/deadsnakes'
+declare -a args
+IFS='/:' read -ra args <<< "${TEST}"
 
-retry.py apt-get update -qq
-retry.py apt-get install -qq \
-    g++-4.9 \
-    python3.6-dev \
+version="${args[1]}"
 
-ln -sf x86_64-linux-gnu-gcc-4.9 /usr/bin/x86_64-linux-gnu-gcc
+if [ "${version}" = "3.6" ]; then
+    retry.py add-apt-repository 'ppa:ubuntu-toolchain-r/test'
+    retry.py add-apt-repository 'ppa:fkrull/deadsnakes'
+
+    retry.py apt-get update -qq
+    retry.py apt-get install -qq \
+        g++-4.9 \
+        python3.6-dev \
+
+    ln -sf x86_64-linux-gnu-gcc-4.9 /usr/bin/x86_64-linux-gnu-gcc
+fi
 
 retry.py pip install tox --disable-pip-version-check
 
-ansible-test units --color -v --tox --coverage
+ansible-test units --color -v --tox --coverage --python "${version}"


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

CI unit tests

##### ANSIBLE VERSION

```
ansible 2.3.0 (units 12c18118de) last updated 2017/02/24 16:25:21 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

- Add more verbose output to coverage combine.
- Run unit tests on CI separately by version.