### PR TITLE
Disable broken tests.

### DIFF
--- a/test/units/modules/cloud/amazon/test_lambda.py
+++ b/test/units/modules/cloud/amazon/test_lambda.py
@@ -144,6 +144,8 @@ def test_update_lambda_if_config_changed(monkeypatch):
     assert(len(fake_lambda_connection.update_function_code.mock_calls) == 0), \
         "updated lambda code when no change should have happened"
 
+
+@pytest.mark.skip(reason='test broken, fails when run in isolation')
 def test_update_lambda_if_only_one_config_item_changed(monkeypatch):
 
     fake_lambda_connection = MagicMock()
@@ -175,6 +177,8 @@ def test_update_lambda_if_only_one_config_item_changed(monkeypatch):
     assert(len(fake_lambda_connection.update_function_code.mock_calls) == 0), \
         "updated lambda code when no change should have happened"
 
+
+@pytest.mark.skip(reason='test broken, fails when run in isolation')
 def test_dont_update_lambda_if_nothing_changed(monkeypatch):
 
     fake_lambda_connection = MagicMock()


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

lambda unit tests

##### ANSIBLE VERSION

```
ansible 2.3.0 (units-broken b2f9502af9) last updated 2017/02/24 16:24:53 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Disable broken tests. If the disabled tests are run individually, they will fail.