### PR TITLE
Let inventory directories store files

### DIFF
--- a/lib/ansible/inventory/dir.py
+++ b/lib/ansible/inventory/dir.py
@@ -110,7 +110,7 @@ class InventoryDirectory(object):
             if i.startswith('.') and not i.startswith('./'):
                 continue
             # These are things inside of an inventory basedir
-            if i in ("host_vars", "group_vars", "vars_plugins"):
+            if i in ("host_vars", "group_vars", "vars_plugins", "files"):
                 continue
             fullpath = os.path.join(self.directory, i)
             if os.path.isdir(fullpath):


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
inventory/dir

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Files that I want to, for example, copy to the remote environment that vary per inventory actually needs to be outside of the inventory because it is processed. This commit lets a special folder (named "files") in inventory dir to store these files, so they could be used in our inventory vars.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
