### PR TITLE
roll up of fixes from nxos integration tests

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_nxapi.py
+++ b/lib/ansible/modules/network/nxos/nxos_nxapi.py
@@ -134,6 +134,11 @@ from ansible.module_utils.netcfg import NetworkConfig
 from ansible.module_utils.six import iteritems
 
 def check_args(module, warnings):
+    transport = module.params['transport']
+    provider_transport = (module.params['provider'] or {}).get('transport')
+    if 'nxapi' in (transport, provider_transport):
+        module.fail_json(msg='transport=nxapi is not supporting when configuring nxapi')
+
     nxos_check_args(module, warnings)
 
     state = module.params['state']

--- a/test/integration/targets/nxos_nxapi/tests/cli/config.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/config.yaml
@@ -82,6 +82,6 @@
     that:
       - "config.changed == false"
 # FIXME: https://github.com/ansible/ansible-modules-core/issues/4955
-  ignore_erros: yes
+  ignore_errors: yes
 
 - debug: msg="END cli/config.yaml"

--- a/test/integration/targets/nxos_nxapi/tests/cli/enable.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/enable.yaml
@@ -22,7 +22,7 @@
 
 - name: Assert NXAPI is enabled
   assert:
-      that: result.result[0] | search('enabled')
+      that: result.stdout[0] | search('enabled')
 
 - name: Enable NXAPI again
   nxos_nxapi:


### PR DESCRIPTION
* now fails nxos_nxapi if the transport=nxapi
* fixes typos in nxos_nxapi integration tests cases

