### PR TITLE
Aws lambda tests fix

### DIFF
--- a/test/units/modules/cloud/amazon/test_lambda.py
+++ b/test/units/modules/cloud/amazon/test_lambda.py
@@ -1,5 +1,5 @@
 #
-# (c) 2016 Michael De La Rue
+# (c) 2017 Michael De La Rue
 #
 # This file is part of Ansible
 #

--- a/test/units/modules/cloud/amazon/test_lambda.py
+++ b/test/units/modules/cloud/amazon/test_lambda.py
@@ -144,8 +144,6 @@ def test_update_lambda_if_config_changed(monkeypatch):
     assert(len(fake_lambda_connection.update_function_code.mock_calls) == 0), \
         "updated lambda code when no change should have happened"
 
-
-@pytest.mark.skip(reason='test broken, fails when run in isolation')
 def test_update_lambda_if_only_one_config_item_changed(monkeypatch):
 
     fake_lambda_connection = MagicMock()
@@ -177,8 +175,6 @@ def test_update_lambda_if_only_one_config_item_changed(monkeypatch):
     assert(len(fake_lambda_connection.update_function_code.mock_calls) == 0), \
         "updated lambda code when no change should have happened"
 
-
-@pytest.mark.skip(reason='test broken, fails when run in isolation')
 def test_dont_update_lambda_if_nothing_changed(monkeypatch):
 
     fake_lambda_connection = MagicMock()


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

lambda module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (aws_lambda_tests_fix e258b88628) last updated 2017/02/25 14:39:03 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

This hopefully fixes the tests disabled in https://github.com/ansible/ansible/pull/21932 and re-enables them.  I managed to reproduce tests failing when run individually and now they don't.  

I have done some cleanup and eliminated any pytest depencency at the same time.  

No ansible functionality changes.  