### PR TITLE
Write downloaded file as binary

### DIFF
--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -145,7 +145,7 @@ import time
 import binascii
 import codecs
 from zipfile import ZipFile, BadZipfile
-from ansible.module_utils._text import to_text
+from ansible.module_utils._text import to_text, to_bytes
 
 try:  # python 3.3+
     from shlex import quote
@@ -799,12 +799,12 @@ def main():
                 # If download fails, raise a proper exception
                 if rsp is None:
                     raise Exception(info['msg'])
-                f = open(package, 'w')
+                f = open(package, 'wb')
                 # Read 1kb at a time to save on ram
                 while True:
                     data = rsp.read(BUFSIZE)
 
-                    if data == "":
+                    if data == to_bytes(""):
                         break # End of file, break while loop
 
                     f.write(data)


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
unarchive

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel 01ac1bc6e5) last updated 2017/02/25 17:18:32 (GMT +200)
  config file = /home/thom/git/dotfiles-ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This fixes #21951 by having the write() expect bytes on Py3.

I haven't dealt with all the other code smells (unused imports, variables, other stuff).