### PR TITLE
bump lsblk timeout to 60

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -876,7 +876,7 @@ class LinuxHardware(Hardware):
                 else:
                     self.facts[k] = 'NA'
 
-    @timeout(10)
+    @timeout(60)
     def get_mount_facts(self):
         self.facts['mounts'] = []
         mtab = get_file_content('/etc/mtab', '')


### PR DESCRIPTION
# Summary
Change fact gathering timeout for mount facts to 60 seconds, to handle lsblk timeouts

# Reviewers
@shmettu