### PR TITLE
Fixing issue related to writing ini files

### DIFF
--- a/lib/ansible/module_utils/redhat.py
+++ b/lib/ansible/module_utils/redhat.py
@@ -66,7 +66,7 @@ class RegistrationBase(object):
                 cfg.set('main', 'enabled', 1)
             else:
                 cfg.set('main', 'enabled', 0)
-            fd = open(plugin_conf, 'rwa+')
+            fd = open(plugin_conf, 'w+')
             cfg.write(fd)
             fd.close()
 


### PR DESCRIPTION
When the file is opened with rwa+ and the update file size is smaller than the original the ini file can become corrupt.  The issue was noticed when we had comments at the top of /etc/yum/pluginconf.d/rhnplugin.conf after using the rhn_register module the file became correct.

rwa+ also make no sense as the file is only written too and why would any appending need to happen?

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
redhat

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file = /Users/greg/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
When using the rhn_register module /etc/yum/pluginconf.d/rhnplugin.conf was becoming corrupt.  We had a comment at the beginning of the file before the [main] section.  The python ConfigParser module would throw these away when reading the file.  This caused the file to be smaller when the ConfigParser was called to write the file which left remnants of the old ini file at the end of the updated file. Switching the file mode from wra+ to w+ solves this issue. w+ also makes more sense since the file is not being read or appended too.

