### PR TITLE
Adds latest to portage module (#21918)

### DIFF
--- a/lib/ansible/modules/packaging/os/portage.py
+++ b/lib/ansible/modules/packaging/os/portage.py
@@ -45,7 +45,7 @@ options:
       - State of the package atom
     required: false
     default: "present"
-    choices: [ "present", "installed", "emerged", "absent", "removed", "unmerged" ]
+    choices: [ "present", "installed", "emerged", "absent", "removed", "unmerged", "latest" ]
 
   update:
     description:
@@ -196,7 +196,7 @@ EXAMPLES = '''
     package: foo
     state: absent
 
-# Update package foo to the "best" version
+# Update package foo to the "latest" version ( os specific alternative to latest )
 - portage:
     package: foo
     update: yes
@@ -298,7 +298,7 @@ def sync_repositories(module, webrsync=False):
 def emerge_packages(module, packages):
     p = module.params
 
-    if not (p['update'] or p['noreplace']):
+    if not (p['update'] or p['noreplace'] or p['state']=='latest'):
         for package in packages:
             if not query_package(module, package, 'emerge'):
                 break
@@ -327,6 +327,9 @@ def emerge_packages(module, packages):
     for flag, arg in emerge_flags.items():
         if p[flag]:
             args.append(arg)
+
+    if p['state'] and p['state']=='latest':
+        args.append("--update")
 
     if p['usepkg'] and p['usepkgonly']:
         module.fail_json(msg='Use only one of usepkg, usepkgonly')
@@ -449,7 +452,7 @@ def run_emerge(module, packages, *args):
     return cmd, module.run_command(cmd)
 
 
-portage_present_states = ['present', 'emerged', 'installed']
+portage_present_states = ['present', 'emerged', 'installed', 'latest']
 portage_absent_states = ['absent', 'unmerged', 'removed']
 
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Module Pull Request

##### COMPONENT NAME
portage

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Added support for ```state:latest```, adds --update to portage arguments. Feature request in #21918.
Needs some testing, but seems to work as intended. The package module does not seem to have support for this module.

This will not work
```json
package:
  name: "{{ item }}"
   state: latest
``` 

This does work for update and no action if latest
```json
portage:
   name: "{{ item }}"
    state: latest
``` 
