### PR TITLE
iptables module: match=conntrack with ctstate not working

### DIFF
--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -399,8 +399,15 @@ def construct_rule(params):
         False)
     append_match(rule, params['comment'], 'comment')
     append_param(rule, params['comment'], '--comment', False)
-    append_match(rule, params['ctstate'], 'state')
-    append_csv(rule, params['ctstate'], '--state')
+    if 'conntrack' in params['match']:
+        append_csv(rule, params['ctstate'], '--ctstate')
+    elif 'state' in params['match']:
+        append_csv(rule, params['ctstate'], '--state')
+    elif params['ctstate']:
+        append_match(rule, params['ctstate'], 'conntrack')
+        append_csv(rule, params['ctstate'], '--ctstate')
+    else:
+        return False
     append_match(rule, params['limit'] or params['limit_burst'], 'limit')
     append_param(rule, params['limit'], '--limit', False)
     append_param(rule, params['limit_burst'], '--limit-burst', False)


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The PR will allow both "state" and "ctstate" as parameters.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #21467 
<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
