### PR TITLE
jira: comply with current pep8 rule set

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jira.py
+++ b/lib/ansible/modules/web_infrastructure/jira.py
@@ -116,7 +116,9 @@ options:
   fields:
     required: false
     description:
-     - This is a free-form data structure that can contain arbitrary data. This is passed directly to the JIRA REST API (possibly after merging with other required data, as when passed to create). See examples for more information, and the JIRA REST API for the structure required for various fields.
+     - This is a free-form data structure that can contain arbitrary data. This is passed directly to the JIRA REST API
+       (possibly after merging with other required data, as when passed to create). See examples for more information,
+       and the JIRA REST API for the structure required for various fields.
 
   timeout:
     required: false

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -198,7 +198,6 @@ lib/ansible/modules/utilities/logic/set_fact.py
 lib/ansible/modules/utilities/logic/wait_for.py
 lib/ansible/modules/web_infrastructure/apache2_mod_proxy.py
 lib/ansible/modules/web_infrastructure/django_manage.py
-lib/ansible/modules/web_infrastructure/jira.py
 lib/ansible/modules/windows/win_acl.py
 lib/ansible/modules/windows/win_acl_inheritance.py
 lib/ansible/modules/windows/win_command.py


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
/lib/ansible/modules/web_infrastructure/jira.py

##### ANSIBLE VERSION
```
ansible 2.3.0 (pep8 d537c8d67a) last updated 2017/02/27 13:45:36 (GMT +300)
  config file = /home/e.slezhuk/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Comply with current pep8 rules.