### PR TITLE
Add support for pip list format=columns

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -277,8 +277,6 @@ def _get_packages(module, pip, chdir):
 def _is_present(name, version, installed_pkgs, pkg_command):
     '''Return whether or not package is installed.'''
     for pkg in installed_pkgs:
-        # Package listing will be different depending on which pip
-        # command was used ('pip list' vs. 'pip freeze').
         if '==' in pkg:
             pkg_name, pkg_version = pkg.split('==')
         else:

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -260,7 +260,7 @@ def _get_full_name(name, version=None):
 def _get_packages(module, pip, chdir):
     '''Return results of pip command to get packages.'''
     # Try 'pip list' command first.
-    command = '%s list' % pip
+    command = '%s list --format=freeze' % pip
     lang_env = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C')
     rc, out, err = module.run_command(command, cwd=chdir, environ_update=lang_env)
 
@@ -279,17 +279,8 @@ def _is_present(name, version, installed_pkgs, pkg_command):
     for pkg in installed_pkgs:
         # Package listing will be different depending on which pip
         # command was used ('pip list' vs. 'pip freeze').
-        if 'list' in pkg_command:
-            pkg = pkg.replace('(', '').replace(')', '')
-            if ',' in pkg:
-                pkg_name, pkg_version, _ = pkg.replace(',', '').split(' ')
-            else:
-                pkg_name, pkg_version = pkg.split()
-        elif 'freeze' in pkg_command:
-            if '==' in pkg:
-                pkg_name, pkg_version = pkg.split('==')
-            else:
-                continue
+        if '==' in pkg:
+            pkg_name, pkg_version = pkg.split('==')
         else:
             continue
 

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -284,7 +284,7 @@ def _is_present(name, version, installed_pkgs, pkg_command):
             if ',' in pkg:
                 pkg_name, pkg_version, _ = pkg.replace(',', '').split(' ')
             else:
-                pkg_name, pkg_version = pkg.split(' ')
+                pkg_name, pkg_version = pkg.split()
         elif 'freeze' in pkg_command:
             if '==' in pkg:
                 pkg_name, pkg_version = pkg.split('==')


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
pip

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Running 'pip list' gives a warning:

DEPRECATION: The default format will switch to columns in the future. You can use --format=(legacy|columns) (or define a format=(legacy|columns) in your pip.conf under the [list] section) to disable this warning.

When setting format=columns in pip.conf ansible isn't able to find the correct package version from the pip list output any more.
 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
ipython sample output:

a = 'redis (2.10.5)'  # format=legacy
b = 'redis                    2.10.5'  # format=column

c = a.replace('(', '').replace(')', '')
'redis 2.10.5'
d = b.replace('(', '').replace(')', '')
'redis                    2.10.5'

c.split(' ')
['redis', '2.10.5']

d.split(' ')
['redis',
 '',
 '',
 '',
 '',
 '',
 '',
 '',
 '',
 '',
 '',
 '',
 '',
 '',
 '',
 '',
 '',
 '',
 '',
 '',
 '2.10.5']

d.split()
['redis', '2.10.5']
```
