### PR TITLE
Network action plugin misusing display.debug

### DIFF
--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -79,7 +79,7 @@ class ActionModule(_ActionModule):
                 # enable mode and not config module
                 rc, out, err = connection.exec_command('prompt()')
                 while str(out).strip().endswith(')#'):
-                    display.debug('wrong context, sending exit to device', self._play_context.remote_addr)
+                    display.debug('<%s> wrong context, sending exit to device' % self._play_context.remote_addr)
                     connection.exec_command('exit')
                     rc, out, err = connection.exec_command('prompt()')
 

--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -79,7 +79,7 @@ class ActionModule(_ActionModule):
                 # enable mode and not config module
                 rc, out, err = connection.exec_command('prompt()')
                 while str(out).strip().endswith(')#'):
-                    display.debug('<%s> wrong context, sending exit to device' % self._play_context.remote_addr)
+                    display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
                     connection.exec_command('exit')
                     rc, out, err = connection.exec_command('prompt()')
 

--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -87,7 +87,7 @@ class ActionModule(_ActionModule):
             # enable mode and not config module
             rc, out, err = connection.exec_command('prompt()')
             while str(out).strip().endswith(')#'):
-                display.debug('wrong context, sending exit to device', self._play_context.remote_addr)
+                display.debug('<%s> wrong context, sending exit to device' % self._play_context.remote_addr)
                 connection.exec_command('exit')
                 rc, out, err = connection.exec_command('prompt()')
 

--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -87,7 +87,7 @@ class ActionModule(_ActionModule):
             # enable mode and not config module
             rc, out, err = connection.exec_command('prompt()')
             while str(out).strip().endswith(')#'):
-                display.debug('<%s> wrong context, sending exit to device' % self._play_context.remote_addr)
+                display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
                 connection.exec_command('exit')
                 rc, out, err = connection.exec_command('prompt()')
 

--- a/lib/ansible/plugins/action/vyos.py
+++ b/lib/ansible/plugins/action/vyos.py
@@ -73,7 +73,7 @@ class ActionModule(_ActionModule):
             # enable mode and not config module
             rc, out, err = connection.exec_command('prompt()')
             while str(out).strip().endswith('#'):
-                display.debug('<%s> wrong context, sending exit to device' % self._play_context.remote_addr)
+                display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
                 connection.exec_command('exit')
                 rc, out, err = connection.exec_command('prompt()')
 

--- a/lib/ansible/plugins/action/vyos.py
+++ b/lib/ansible/plugins/action/vyos.py
@@ -73,7 +73,7 @@ class ActionModule(_ActionModule):
             # enable mode and not config module
             rc, out, err = connection.exec_command('prompt()')
             while str(out).strip().endswith('#'):
-                display.debug('wrong context, sending exit to device', self._play_context.remote_addr)
+                display.debug('<%s> wrong context, sending exit to device' % self._play_context.remote_addr)
                 connection.exec_command('exit')
                 rc, out, err = connection.exec_command('prompt()')
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
plugins/action/{e,jun,vy}os.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```

##### SUMMARY

`display.debug` takes only one positional argument

Or it could be switched to one of the `vv[...]` methods?