### PR TITLE
Fix Passlib example in FAQ

### DIFF
--- a/docs/docsite/rst/faq.rst
+++ b/docs/docsite/rst/faq.rst
@@ -299,7 +299,7 @@ Once the library is ready, SHA512 password values can then be generated as follo
 
 .. code-block:: shell-session
 
-    python -c "from passlib.hash import sha512_crypt; import getpass; print sha512_crypt.using(rounds=5000).encrypt(getpass.getpass())"
+    python -c "from passlib.hash import sha512_crypt; import getpass; print sha512_crypt.using(rounds=5000).hash(getpass.getpass())"
 
 Use the integrated :ref:`hash_filters` to generate a hashed version of a password.
 You shouldn't put plaintext passwords in your playbook or host_vars; instead, use :doc:`playbooks_vault` to encrypt sensitive data.

--- a/docs/docsite/rst/faq.rst
+++ b/docs/docsite/rst/faq.rst
@@ -299,7 +299,7 @@ Once the library is ready, SHA512 password values can then be generated as follo
 
 .. code-block:: shell-session
 
-    python -c "from passlib.hash import sha512_crypt; import getpass; print sha512_crypt.encrypt(getpass.getpass())"
+    python -c "from passlib.hash import sha512_crypt; import getpass; print sha512_crypt.using(rounds=5000).encrypt(getpass.getpass())"
 
 Use the integrated :ref:`hash_filters` to generate a hashed version of a password.
 You shouldn't put plaintext passwords in your playbook or host_vars; instead, use :doc:`playbooks_vault` to encrypt sensitive data.


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- Passlib (example in FAQ)

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I spend few hours yesterday trying to understand why ansible was taking almost x3 the time to run a playbook when using a user with sudo and password (comparared to sudo with NOPASSWD set). Well, it was because the user was created using ansible and the passlib example found in the docs' FAQ. Computing 656000 rounds of sha512 does take a while, especially when you do it multiple times in a row (for every task with ansible).

I reduce the numbers of rounds to 5000 in the example to ensure a better experience with ansible for newcomers when using sudo with a password.

I also took the time to reflect the API changes in passlib 1.7, where the method encrypt() was deprecated in 1.7 and renamed to hash().
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
fixes #15326