### PR TITLE
Added 'easy_install' --no-deps and --find-links options.

### DIFF
--- a/lib/ansible/modules/packaging/language/easy_install.py
+++ b/lib/ansible/modules/packaging/language/easy_install.py
@@ -82,14 +82,14 @@ options:
     choices: [present, latest]
     default: present
   no_deps:
-    version_added: "2.0"
+    version_added: "2.2"
     description:
       - don't install dependencies
     required: false
     choices: ["yes", "no"]
     default: no
   find_links:
-    version_added: "2.0"
+    version_added: "2.2"
     description:
       - additional URL(s) to search for packages
     required: false

--- a/lib/ansible/modules/packaging/language/easy_install.py
+++ b/lib/ansible/modules/packaging/language/easy_install.py
@@ -82,14 +82,14 @@ options:
     choices: [present, latest]
     default: present
   no_deps:
-    version_added: "2.2"
+    version_added: "2.3"
     description:
       - don't install dependencies
     required: false
     choices: ["yes", "no"]
     default: no
   find_links:
-    version_added: "2.2"
+    version_added: "2.3"
     description:
       - additional URL(s) to search for packages
     required: false

--- a/lib/ansible/modules/packaging/language/easy_install.py
+++ b/lib/ansible/modules/packaging/language/easy_install.py
@@ -81,6 +81,19 @@ options:
     required: false
     choices: [present, latest]
     default: present
+  no_deps:
+    version_added: "2.0"
+    description:
+      - don't install dependencies
+    required: false
+    choices: ["yes", "no"]
+    default: no
+  find_links:
+    version_added: "2.0"
+    description:
+      - additional URL(s) to search for packages
+    required: false
+    default: null
 notes:
     - Please note that the M(easy_install) module can only install Python
       libraries. Thus this module is not able to remove libraries. It is
@@ -144,6 +157,8 @@ def main():
                    default='present',
                    choices=['present','latest'],
                    type='str'),
+        no_deps=dict(default='no', required=False, type='bool'),
+        find_links=dict(default=None, required=False),
         virtualenv=dict(default=None, required=False),
         virtualenv_site_packages=dict(default='no', type='bool'),
         virtualenv_command=dict(default='virtualenv', required=False),
@@ -160,7 +175,11 @@ def main():
     executable_arguments = []
     if module.params['state'] == 'latest':
         executable_arguments.append('--upgrade')
-
+    if module.params['no_deps']:
+        executable_arguments.append('--no-deps')
+    if module.params['find_links']:
+        executable_arguments.append('--find-links %s' %
+                                    module.params['find_links'])
     rc = 0
     err = ''
     out = ''


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

language/easy_install.py
##### ANSIBLE VERSION

ansible 2.0.0
##### SUMMARY

Exposes two usefull 'easy_install' options (--no-deps and --find-links)
