### PR TITLE
S3 tests check for boto, but then ask for boto3 on skip

### DIFF
--- a/test/units/modules/cloud/amazon/test_s3.py
+++ b/test/units/modules/cloud/amazon/test_s3.py
@@ -7,7 +7,7 @@ except ImportError:
     HAS_BOTO = False
 
 if not HAS_BOTO:
-    raise SkipTest("test_s3.py requires the python module 'boto3' and 'botocore'")
+    raise SkipTest("test_s3.py requires the python module 'boto'")
 
 import unittest
 import ansible.modules.cloud.amazon.s3 as s3


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request
 
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
s3 module tests

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

##### SUMMARY

Minor fixup of an error message that doesn't match the library that raises it. 