### PR TITLE
Run destructive win tests when creating instances.

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -1426,6 +1426,9 @@ class WindowsIntegrationConfig(IntegrationConfig):
 
         self.windows = args.windows  # type: list [str]
 
+        if self.windows:
+            self.allow_destructive = True
+
 
 class NetworkIntegrationConfig(IntegrationConfig):
     """Configuration for the network integration command."""


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (win-destructive a7a931206c) last updated 2017/02/27 09:33:12 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Run destructive win tests when creating instances.