### PR TITLE
Add win_msg module 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,6 +256,7 @@ Ansible Changes By Release
   * jenkins_script
 - windows:
   * win_find
+  * win_msg
   * win_path
   * win_psexec
   * win_reg_stat

--- a/lib/ansible/modules/windows/win_msg.ps1
+++ b/lib/ansible/modules/windows/win_msg.ps1
@@ -1,0 +1,64 @@
+#!powershell
+# This file is part of Ansible
+#
+# Copyright 2016, Jon Hawkesworth (@jhawkesworth) <figs@unity.demon.co.uk>
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# WANT_JSON
+# POWERSHELL_COMMON
+
+$stopwatch = [system.diagnostics.stopwatch]::startNew()
+
+$params = Parse-Args $args
+$result = New-Object PSObject
+Set-Attr $result "changed" $False
+$to = Get-Attr -obj $params -name to -default "*" -failifempty $False -resultobj $result
+$display_seconds = Get-Attr -obj $params -name display_seconds -default "10" -failifempty $False -resultobj $result
+$wait = Get-Attr -obj $params -name wait -default $False -failifempty $False -resultobj $result
+$msg = Get-Attr -obj $params -name msg -failifempty $True -resultobj $result
+
+If($msg.Length -lt 1) {
+
+    Fail-Json $result "msg was empty, please supply message text"
+}
+
+$msg_args = @($to, "/TIME:$display_seconds")
+
+If ($wait) 
+{
+  $msg_args += "/W"
+}
+
+$msg_args += $msg
+$ret = & msg.exe $msg_args 2>&1
+Set-Attr $result "rc" $LASTEXITCODE
+$endsend_at = Get-Date| Out-String
+$stopwatch.Stop()
+If ($LASTEXITCODE -eq 0) 
+{
+    Set-Attr $result "changed" $True
+    Set-Attr $result "runtime_seconds" $stopwatch.Elapsed.TotalSeconds
+    Set-Attr $result "display_seconds" $display_seconds
+    Set-Attr $result "msg" $msg
+    Set-Attr $result "sent_localtime" $endsend_at.Trim()
+    Set-Attr $result "wait" $wait
+} 
+Else 
+{
+    Fail-Json $result "$ret"
+}
+  
+Exit-Json $result
+

--- a/lib/ansible/modules/windows/win_msg.ps1
+++ b/lib/ansible/modules/windows/win_msg.ps1
@@ -36,8 +36,7 @@ $result = @{
 
 $msg_args = @($to, "/TIME:$display_seconds")
 
-If ($wait) 
-{
+If ($wait) {
   $msg_args += "/W"
 }
 
@@ -57,8 +56,7 @@ $result.runtime_seconds = $stopwatch.Elapsed.TotalSeconds
 $result.sent_localtime = $endsend_at.Trim()
 $result.wait = $wait
 
-If (-not $result.rc -eq 0 ) 
-{
+If (-not $result.rc -eq 0 ) {
     Fail-Json $result "$ret"
 }
   

--- a/lib/ansible/modules/windows/win_msg.py
+++ b/lib/ansible/modules/windows/win_msg.py
@@ -43,7 +43,9 @@ options:
     default: 10
   wait:
     description:
-      - Whether to wait for users to respond.  Module will only wait for the number of seconds specified in display_seconds or 10 seconds if not specified.  However, if I(wait) is true, the message is sent to each logged on user in turn, waiting for the user to either press 'ok' or for the timeout to elapse before moving on to the next user.
+      - Whether to wait for users to respond.  Module will only wait for the number of seconds specified in display_seconds or 10 seconds if not specified.  
+        However, if I(wait) is true, the message is sent to each logged on user in turn, waiting for the user to either press 'ok' or for 
+        the timeout to elapse before moving on to the next user.
     required: false
     default: false
   msg:
@@ -51,7 +53,7 @@ options:
       - The text of the message to be displayed.
     default: Hello world!
 author: "Jon Hawkesworth (@jhawkesworth)"
-notes: 
+notes:
    - This module must run on a windows host, so ensure your play targets windows
      hosts, or delegates to a windows host.
    - Messages are only sent to the local host where the module is run.

--- a/lib/ansible/modules/windows/win_msg.py
+++ b/lib/ansible/modules/windows/win_msg.py
@@ -21,7 +21,11 @@
 # this is a windows documentation stub.  actual code lives in the .ps1
 # file of the same name
 
-DOCUMENTATION = '''
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = r'''
 ---
 module: win_msg
 version_added: "2.3"
@@ -32,12 +36,10 @@ options:
   to:
     description:
       - Who to send the message to. Can be a username, sessionname or sessionid.
-    required: false
-    default: all logged in users on the windows target.
+    default: '*'
   display_seconds:
     description:
       - How long to wait for receiver to acknowledge message.
-    required: false
     default: 10
   wait:
     description:
@@ -47,8 +49,7 @@ options:
   msg:
     description:
       - The text of the message to be displayed.
-    required: true
-    default: no default
+    default: Hello world!
 author: "Jon Hawkesworth (@jhawkesworth)"
 notes: 
    - This module must run on a windows host, so ensure your play targets windows
@@ -58,14 +59,14 @@ notes:
    - Setting wait to true can result in long run times on systems with many logged in users.
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
   # Warn logged in users of impending upgrade
   win_msg:
     display_seconds: 60
     msg: "Automated upgrade about to start.  Please save your work and log off before {{ deployment_start_time  }}"
 '''
 
-RETURN = '''
+RETURN = r'''
 msg:
     description: Test of the message that was sent.
     returned: changed

--- a/lib/ansible/modules/windows/win_msg.py
+++ b/lib/ansible/modules/windows/win_msg.py
@@ -39,7 +39,7 @@ options:
     default: '*'
   display_seconds:
     description:
-      - How long to wait for receiver to acknowledge message.
+      - How long to wait for receiver to acknowledge message, in seconds.
     default: 10
   wait:
     description:

--- a/lib/ansible/modules/windows/win_msg.py
+++ b/lib/ansible/modules/windows/win_msg.py
@@ -1,0 +1,95 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Jon Hawkesworth (@jhawkesworth) <figs@unity.demon.co.uk>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+DOCUMENTATION = '''
+---
+module: win_msg
+version_added: "2.3"
+short_description: Sends a message to logged in users on Windows hosts.
+description:
+    - Wraps the msg.exe command in order to send messages to Windows hosts.
+options:
+  to:
+    description:
+      - Who to send the message to. Can be a username, sessionname or sessionid.
+    required: false
+    default: all logged in users on the windows target.
+  display_seconds:
+    description:
+      - How long to wait for receiver to acknowledge message.
+    required: false
+    default: 10
+  wait:
+    description:
+      - Whether to wait for users to respond.  Module will only wait for the number of seconds specified in display_seconds or 10 seconds if not specified.  However, if I(wait) is true, the message is sent to each logged on user in turn, waiting for the user to either press 'ok' or for the timeout to elapse before moving on to the next user.
+    required: false
+    default: false
+  msg:
+    description:
+      - The text of the message to be displayed.
+    required: true
+    default: no default
+author: "Jon Hawkesworth (@jhawkesworth)"
+notes: 
+   - This module must run on a windows host, so ensure your play targets windows
+     hosts, or delegates to a windows host.
+   - Messages are only sent to the local host where the module is run.
+   - The module does not support sending to users listed in a file.
+   - Setting wait to true can result in long run times on systems with many logged in users.
+'''
+
+EXAMPLES = '''
+  # Warn logged in users of impending upgrade
+  win_msg:
+    display_seconds: 60
+    msg: "Automated upgrade about to start.  Please save your work and log off before {{ deployment_start_time  }}"
+'''
+
+RETURN = '''
+msg:
+    description: Test of the message that was sent.
+    returned: changed
+    type: string
+    sample: "Automated upgrade about to start.  Please save your work and log off before 22 July 2016 18:00:00"
+display_seconds:
+    description: Value of display_seconds module parameter.
+    returned: success
+    type: string
+    sample: 10
+runtime_seconds:
+    description: How long the module took to run on the remote windows host.
+    returned: success
+    type: string
+    sample: 22 July 2016 17:45:51
+sent_localtime:
+    description: local time from windows host when the message was sent.
+    returned: success
+    type: string
+    sample: 22 July 2016 17:45:51
+wait:
+    description: Value of wait module parameter.
+    returned: success
+    type: boolean
+    sample: false
+'''
+

--- a/lib/ansible/modules/windows/win_msg.py
+++ b/lib/ansible/modules/windows/win_msg.py
@@ -43,8 +43,8 @@ options:
     default: 10
   wait:
     description:
-      - Whether to wait for users to respond.  Module will only wait for the number of seconds specified in display_seconds or 10 seconds if not specified.  
-        However, if I(wait) is true, the message is sent to each logged on user in turn, waiting for the user to either press 'ok' or for 
+      - Whether to wait for users to respond.  Module will only wait for the number of seconds specified in display_seconds or 10 seconds if not specified.
+        However, if I(wait) is true, the message is sent to each logged on user in turn, waiting for the user to either press 'ok' or for
         the timeout to elapse before moving on to the next user.
     required: false
     default: false


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_msg

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (win_msg_new ad7cb10fc6) last updated 2017/02/27 17:15:23 (GMT +100)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In keeping with the current zeitgeist of reviving all things nineties https://www.theregister.co.uk/2017/02/14/hmd_nokia_nostalgia/, this module adds the ability to irritate windows users just like you used to using pop up messages.

No tests at this time, but easy enough to test using ad-hoc ansible.

Due to the curious and ancient nature of the msg.exe messages are sent in turn to logged on users, which can result in long run times if you set the 'wait' parameter to 'true'.  For this reason I have added module runtime info to the module return output.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

This change fixes nothing.

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
