### PR TITLE
Add intg tests for delegate_to/delegate_facts/run_once together

### DIFF
--- a/test/integration/inventory
+++ b/test/integration/inventory
@@ -64,3 +64,7 @@ localhost ansible_ssh_host=127.0.0.1 ansible_connection=local
 
 [azure]
 localhost ansible_ssh_host=127.0.0.1 ansible_connection=local
+
+[test_hosts]
+testhost
+testhost[2:3]

--- a/test/integration/targets/delegate_to/test_delegate_to.yml
+++ b/test/integration/targets/delegate_to/test_delegate_to.yml
@@ -1,4 +1,3 @@
-
 - hosts: testhost3
   vars:
     - template_role: ./roles/test_template
@@ -59,8 +58,10 @@
       file: path={{ output_dir }}/tmp.txt state=absent
 
 
-# For testing the case that hit the traceback at https://github.com/ansible/ansible/issues/15365#issuecomment-282752186
-- hosts: testhost3
+# The next set of tests are for coverage of the code paths related to
+# https://github.com/ansible/ansible/issues/15365#issuecomment-282752186
+- name: "Test delegate_to in a loop ala issue #15365"
+  hosts: testhost3
   tasks:
     - name: Test delegate_to in a loop
       setup:
@@ -68,21 +69,22 @@
       with_items: "{{ groups.test_hosts }}"
 
 
-# For testing the case that hit the traceback at https://github.com/ansible/ansible/issues/15365#issuecomment-282752186
-- hosts: testhost3
+- name: "Test delegate_to in a loop with run_once=true ala issue #15365"
+  hosts: testhost3
+  gather_facts: false
   tasks:
-    - name: Test delegate_to in a loop with run_once is true
+    - name: "Test delegate_to in a loop with run_once=true"
       setup:
       delegate_to: "{{ item }}"
       with_items: "{{ groups.test_hosts }}"
       run_once: true
 
 
-# For testing the case that hit the traceback at https://github.com/ansible/ansible/issues/15365#issuecomment-282752186
-- name: Test delegate_to each testhost and delegate_facts is true and run_once is true and in a loop for a single host
+- name: "Test delegate_to each testhost and delegate_facts=true and run_once=true and in a loop for a single host"
   hosts: testhost3
+  gather_facts: false
   tasks:
-    - name: Gather facts from each host in test_hosts with delegate_to and delegate_facts is true and run once
+    - name: "Gather facts from each host in test_hosts with delegate_to=item and delegate_facts=true and run_once=true"
       setup:
       delegate_to: "{{ item }}"
       delegate_facts: true
@@ -90,11 +92,11 @@
       run_once: true
 
 
-# For testing the case that hit the traceback at https://github.com/ansible/ansible/issues/15365#issuecomment-282752186
-- name: Test delegate_to testhost4 and delegate_facts is true and run_once is true and in a loop for multiple hosts
+- name: "Test delegate_to testhost4 and delegate_facts=true and run_once=true and in a loop for multiple hosts"
   hosts: test_hosts
+  gather_facts: false
   tasks:
-    - name: Gather facts from other test hosts with run_once and delegate_to testhost4 and delegate_facts is false
+    - name: "Run setup on other test hosts with run_once=true and delegate_to=testhost4 and delegate_facts=false"
       setup:
       delegate_to: "{{ item }}"
       delegate_facts: true
@@ -103,16 +105,17 @@
       ignore_errors: true
 
 
-- name: Test delegate_to testhost4 and delegate_facts is true and run_once is true
+- name: "Test delegate_to=testhost4 and delegate_facts=true and run_once=true"
   hosts: test_hosts
+  gather_facts: false
   tasks:
-    - name: Gather facts from other test hosts with run_once and delegate_to testhost4
+    - name: "Run setup on other hosts with run_once=true and delegate_to=testhost4"
       setup:
       delegate_to: testhost4
       delegate_facts: true
       run_once: true
 
-    - name: Assert that the facts for testhost4 are delegated from testhost4 with delegate_facts is true and run_once is true
+    - name: "Assert that the facts for testhost4 are delegated from testhost4 with delegate_facts=true and run_once=true"
       assert:
         that:
           - '"127.0.0.4" in hostvars["testhost4"].ansible_env["SSH_CONNECTION"]'
@@ -120,23 +123,25 @@
 
 - name: Test delegate_to testhost4 and delegate_facts is false and run_once is true
   hosts: test_hosts
+  gather_facts: false
   tasks:
-    - name: Gather facts from other test hosts with run_once and delegate_to testhost4 and delegate_facts is false
+    - name: "Run setup on other test hosts with run_once=true and delegate_to=testhost4 and delegate_facts=false"
       setup:
       delegate_to: testhost4
       delegate_facts: false
       run_once: true
 
-    - name: Assert that the facts for testhost4 are delegated from testhost4 with delegate_facts is false and run_once is true
+    - name: "Assert that the facts for testhost4 are delegated from testhost4 with delegate_facts=false and run_once=true"
       assert:
         that:
           - '"127.0.0.4" in hostvars["testhost4"].ansible_env["SSH_CONNECTION"]'
 
 
-- hosts: testhost3
+- name: "Test delegate_to=testhost4 and delegate_facts=true when run for testhost3"
+  hosts: testhost3
   gather_facts: false
   tasks:
-    - name: Test delegate_to and delegate_facts
+    - name: "Test delegate_to=testhost4 and delegate_facts=true"
       setup:
         gather_subset:
             - "!network"
@@ -144,12 +149,17 @@
       delegate_to: testhost4
       delegate_facts: True
 
-    - name: Assert that the facts for testhost4 are delegated from testhost4 with delegate_facts is true
+    - name: "Assert that the facts for testhost4 are delegated from testhost4 with delegate_facts=true"
       assert:
         that:
           - '"127.0.0.4" in hostvars["testhost4"].ansible_env["SSH_CONNECTION"]'
 
-    - name: Test delegate_to and delegate_facts no delegate_facts
+
+- name: "Test delegate_to=testhost4 and delegate_facts=false when run for testhost3"
+  hosts: testhost3
+  gather_facts: false
+  tasks:
+    - name: "Test delegate_to=testhost4 and delegate_facts=false"
       setup:
         gather_subset:
             - "!network"
@@ -157,8 +167,7 @@
       delegate_to: testhost4
       delegate_facts: False
 
-    - name: Assert that the facts for testhost3 are delegated from testhost4 with delegate_facts is false
+    - name: "Assert that the facts for testhost3 are delegated from testhost4 with delegate_facts=false"
       assert:
         that:
           - '"127.0.0.4" in hostvars["testhost3"].ansible_env["SSH_CONNECTION"]'
-

--- a/test/integration/targets/delegate_to/test_delegate_to.yml
+++ b/test/integration/targets/delegate_to/test_delegate_to.yml
@@ -1,3 +1,4 @@
+
 - hosts: testhost3
   vars:
     - template_role: ./roles/test_template
@@ -30,7 +31,9 @@
     - assert:
         that:
           - '"127.0.0.254" in setup_results.ansible_facts.ansible_env["SSH_CONNECTION"]'
-#
+
+
+            #
 # Smoketest some other modules do not error as a canary
 #
     - name: Test file works with delegate_to and a host in inventory
@@ -54,3 +57,108 @@
 
     - name: remove test file
       file: path={{ output_dir }}/tmp.txt state=absent
+
+
+# For testing the case that hit the traceback at https://github.com/ansible/ansible/issues/15365#issuecomment-282752186
+- hosts: testhost3
+  tasks:
+    - name: Test delegate_to in a loop
+      setup:
+      delegate_to: "{{ item }}"
+      with_items: "{{ groups.test_hosts }}"
+
+
+# For testing the case that hit the traceback at https://github.com/ansible/ansible/issues/15365#issuecomment-282752186
+- hosts: testhost3
+  tasks:
+    - name: Test delegate_to in a loop with run_once is true
+      setup:
+      delegate_to: "{{ item }}"
+      with_items: "{{ groups.test_hosts }}"
+      run_once: true
+
+
+# For testing the case that hit the traceback at https://github.com/ansible/ansible/issues/15365#issuecomment-282752186
+- name: Test delegate_to each testhost and delegate_facts is true and run_once is true and in a loop for a single host
+  hosts: testhost3
+  tasks:
+    - name: Gather facts from each host in test_hosts with delegate_to and delegate_facts is true and run once
+      setup:
+      delegate_to: "{{ item }}"
+      delegate_facts: true
+      with_items: "{{ groups.test_hosts }}"
+      run_once: true
+
+
+# For testing the case that hit the traceback at https://github.com/ansible/ansible/issues/15365#issuecomment-282752186
+- name: Test delegate_to testhost4 and delegate_facts is true and run_once is true and in a loop for multiple hosts
+  hosts: test_hosts
+  tasks:
+    - name: Gather facts from other test hosts with run_once and delegate_to testhost4 and delegate_facts is false
+      setup:
+      delegate_to: "{{ item }}"
+      delegate_facts: true
+      run_once: true
+      with_items: "{{ groups.test_hosts }}"
+      ignore_errors: true
+
+
+- name: Test delegate_to testhost4 and delegate_facts is true and run_once is true
+  hosts: test_hosts
+  tasks:
+    - name: Gather facts from other test hosts with run_once and delegate_to testhost4
+      setup:
+      delegate_to: testhost4
+      delegate_facts: true
+      run_once: true
+
+    - name: Assert that the facts for testhost4 are delegated from testhost4 with delegate_facts is true and run_once is true
+      assert:
+        that:
+          - '"127.0.0.4" in hostvars["testhost4"].ansible_env["SSH_CONNECTION"]'
+
+
+- name: Test delegate_to testhost4 and delegate_facts is false and run_once is true
+  hosts: test_hosts
+  tasks:
+    - name: Gather facts from other test hosts with run_once and delegate_to testhost4 and delegate_facts is false
+      setup:
+      delegate_to: testhost4
+      delegate_facts: false
+      run_once: true
+
+    - name: Assert that the facts for testhost4 are delegated from testhost4 with delegate_facts is false and run_once is true
+      assert:
+        that:
+          - '"127.0.0.4" in hostvars["testhost4"].ansible_env["SSH_CONNECTION"]'
+
+
+- hosts: testhost3
+  gather_facts: false
+  tasks:
+    - name: Test delegate_to and delegate_facts
+      setup:
+        gather_subset:
+            - "!network"
+            - "!hardware"
+      delegate_to: testhost4
+      delegate_facts: True
+
+    - name: Assert that the facts for testhost4 are delegated from testhost4 with delegate_facts is true
+      assert:
+        that:
+          - '"127.0.0.4" in hostvars["testhost4"].ansible_env["SSH_CONNECTION"]'
+
+    - name: Test delegate_to and delegate_facts no delegate_facts
+      setup:
+        gather_subset:
+            - "!network"
+            - "!hardware"
+      delegate_to: testhost4
+      delegate_facts: False
+
+    - name: Assert that the facts for testhost3 are delegated from testhost4 with delegate_facts is false
+      assert:
+        that:
+          - '"127.0.0.4" in hostvars["testhost3"].ansible_env["SSH_CONNECTION"]'
+


### PR DESCRIPTION
Cover some of the cases related to issue #15365 and
in particular, exercise the code path that hit
https://github.com/ansible/ansible/issues/15365#issuecomment-282752186

Note: run_once in a 'with_items: {{ groups.some_group }}' likely
doesn't do anything practical since those contradict. But this
tests covers it to avoid any regressions.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- Test pull request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
test/integration/targets/delegate_to

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (intg_test_delegate_facts_15365 9e65740488) last updated 2017/02/27 13:06:02 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']

```

##### SUMMARY
Cover some of the cases related to issue #15365 and
in particular, exercise the code path that hit
https://github.com/ansible/ansible/issues/15365#issuecomment-282752186

Note: run_once in a 'with_items: {{ groups.some_group }}' likely
doesn't do anything practical since those contradict. But this
tests covers it to avoid any regressions.

NOTE: This will fail intg tests until https://github.com/ansible/ansible/pull/22003/ is merged.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
