### PR TITLE
Fix the issue that apk module is failed when new/upgrade packages are installed at one time

### DIFF
--- a/lib/ansible/modules/packaging/os/apk.py
+++ b/lib/ansible/modules/packaging/os/apk.py
@@ -190,7 +190,7 @@ def install_packages(module, names, state):
         upgrade = True
     if not to_install and not upgrade:
         module.exit_json(changed=False, msg="package(s) already installed")
-    packages = " ".join(to_install) + " ".join(to_upgrade)
+    packages = " ".join(to_install) + " " + " ".join(to_upgrade)
     if upgrade:
         if module.check_mode:
             cmd = "%s add --upgrade --simulate %s" % (APK_PATH, packages)

--- a/test/units/modules/packaging/os/test_apk.py
+++ b/test/units/modules/packaging/os/test_apk.py
@@ -1,0 +1,38 @@
+import functools
+import sys
+
+from ansible.compat.tests import mock
+from ansible.compat.tests import unittest
+
+try:
+    import ansible.modules.packaging.os.apk
+except:
+    # Need some more module_utils work (porting urls.py) before we can test
+    # modules.  So don't error out in this case.
+    if sys.version_info[0] >= 3:
+        pass
+
+
+class ApkInstallPackagesTestCase(unittest.TestCase):
+
+    @mock.patch('ansible.modules.packaging.os.apk.APK_PATH', 'apkpath', create=True)
+    @mock.patch('ansible.modules.packaging.os.apk.query_package')
+    @mock.patch('ansible.modules.packaging.os.apk.query_latest', return_value=False)
+    @mock.patch('ansible.modules.packaging.os.apk.query_virtual', return_value=False)
+    def test_both_toInstall_and_toUpgrade_latest(self, _mock1, _mock2, mock_query_package):
+        mock_module = mock.MagicMock()
+        mock_module.check_mode = False
+
+        def result_run_command(cmd, check_rc, mock):
+            mock.cmd = cmd
+            return (0, '', '')
+        mock_module.run_command.side_effect = functools.partial(result_run_command, mock=mock_module)
+
+        def result_query_package(module, name):
+            if name == 'toInstall':
+                return False
+            return True
+        mock_query_package.side_effect = result_query_package
+
+        ansible.modules.packaging.os.apk.install_packages(mock_module, ['toInstall', 'toUpgrade'], 'latest')
+        assert mock_module.cmd == 'apkpath add --upgrade toInstall toUpgrade'


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

apk module (`lib/ansible/modules/packaging/os/apk.py`)

##### ANSIBLE VERSION

```
ansible 2.3.0 (apk_add_space_in_join_packages f681158985) last updated 2017/02/28 04:19:40 (GMT +900)
  config file =
  configured module search path = Default w/o overrides

```

##### SUMMARY

This PR resolves the failure of apk module when a playbook installs both new packages and upgrade packages at one time.

```
# Settings
$ cat inventory
testcontainer   ansible_connection=docker

$  cat playbook.yml
---
- hosts: all
  remote_user: root
  tasks:
    - name: Install both new packages and upgrade packages
      apk: name={{ item }} state=latest update_cache=yes
      with_items:
        - openssl
        - ca-certificates

# Use container for playbook target
$ docker run -d -it --name testcontainer python:2-alpine /bin/sh
$ docker exec -it testcontainer ln -s /usr/local/bin/python /usr/bin/python



# Before change
$ ansible-playbook playbook.yml -i inventory

PLAY [all] *******************************************************************************

TASK [Gathering Facts] *******************************************************************
ok: [testcontainer]

TASK [Install both new packages and upgrade packages] ************************************
failed: [testcontainer] (item=[u'openssl', u'ca-certificates']) => {"failed": true, "item": ["openssl", "ca-certificates"], "msg": "failed to install opensslca-certificates"}
        to retry, use: --limit @/Users/FGtatsuro/repos/ansible/playbook.retry

PLAY RECAP *******************************************************************************
testcontainer              : ok=1    changed=0    unreachable=0    failed=1




# After change
$ ansible-playbook playbook.yml -i inventory

PLAY [all] *******************************************************************************

TASK [Gathering Facts] *******************************************************************
ok: [testcontainer]

TASK [Install both new packages and upgrade packages] ************************************
changed: [testcontainer] => (item=[u'openssl', u'ca-certificates'])

PLAY RECAP *******************************************************************************
testcontainer              : ok=2    changed=1    unreachable=0    failed=0
```
