### PR TITLE
Extended bool filter to support python truthiness (#21914).

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -114,15 +114,20 @@ def to_nice_json(a, indent=4, *args, **kw):
         return to_json(a, *args, **kw)
 
 
-def to_bool(a):
+def to_bool(a, style='yaml'):
     ''' return a bool for the arg '''
-    if a is None or isinstance(a, bool):
-        return a
-    if isinstance(a, string_types):
-        a = a.lower()
-    if a in ('yes', 'on', '1', 'true', 1):
-        return True
-    return False
+    if style == 'python':
+        return bool(a)
+    elif style == 'yaml':
+        if a is None or isinstance(a, bool):
+            return a
+        if isinstance(a, string_types):
+            a = a.lower()
+        if a in ('yes', 'on', '1', 'true', 1):
+            return True
+        return False
+    else:
+        raise errors.AnsibleFilterError('Unknown argument')
 
 
 def to_datetime(string, format="%Y-%d-%m %H:%M:%S"):


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (filter_bool_python 5904636d35) last updated 2017/02/27 23:23:58 (GMT +200)
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Discussed in #21914
Adds functionality to utilize python truthiness while using ```|bool``` filter by providing filter style choice in a similar way as in ```|comment``` filter.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
Playbook example:
```yaml
- hosts: localhost
  tasks:
    - set_fact:
        yaml_dict_empty: "{{ {}|bool }}"
        yaml_dict_not_empty: "{{ {'key': 1}|bool }}"
        yaml_str_empty: "{{ ''|bool }}"
        yaml_str_not_empty: "{{ 'aaa'|bool }}"
        yaml_str_eq_yes: "{{ 'yes'|bool }}"
        yaml_int_0: "{{ 0|bool }}"
        yaml_int_1: "{{ 1|bool }}"
        yaml_int_negative: "{{ -7|bool }}"
        python_dict_empty: "{{ {}|bool('python') }}"
        python_dict_not_empty: "{{ {'key': 1}|bool('python') }}"
        python_str_empty: "{{ ''|bool('python') }}"
        python_str_not_empty: "{{ 'aaa'|bool('python') }}"
        python_str_eq_yes: "{{ 'yes'|bool('python') }}"
        python_int_0: "{{ 0|bool('python') }}"
        python_int_1: "{{ 1|bool('python') }}"
        python_int_negative: "{{ -7|bool('python') }}"
    - debug:
        var: hostvars[inventory_hostname]
```
Result:
```bash
        "python_dict_empty": false,
        "python_dict_not_empty": true,
        "python_int_0": false,
        "python_int_1": true,
        "python_int_negative": true,
        "python_str_empty": false,
        "python_str_eq_yes": true,
        "python_str_not_empty": true,
        "yaml_dict_empty": false,
        "yaml_dict_not_empty": false,
        "yaml_int_0": false,
        "yaml_int_1": true,
        "yaml_int_negative": false,
        "yaml_str_empty": false,
        "yaml_str_eq_yes": true,
        "yaml_str_not_empty": false
```