### PR TITLE
Deduplicate arcs when combining coverage data.

### DIFF
--- a/test/runner/lib/cover.py
+++ b/test/runner/lib/cover.py
@@ -60,7 +60,7 @@ def command_coverage_combine(args):
             continue
 
         for filename in original.measured_files():
-            arcs = original.arcs(filename)
+            arcs = set(original.arcs(filename))
 
             if '/ansible_modlib.zip/ansible/' in filename:
                 new_name = re.sub('^.*/ansible_modlib.zip/ansible/', ansible_path, filename)
@@ -77,9 +77,9 @@ def command_coverage_combine(args):
                 filename = new_name
 
             if filename not in arc_data:
-                arc_data[filename] = []
+                arc_data[filename] = set()
 
-            arc_data[filename] += arcs
+            arc_data[filename].update(arcs)
 
     updated = coverage.CoverageData()
 
@@ -88,7 +88,7 @@ def command_coverage_combine(args):
             display.warning('Invalid coverage path: %s' % filename)
             continue
 
-        updated.add_arcs({filename: arc_data[filename]})
+        updated.add_arcs({filename: list(arc_data[filename])})
 
     if not args.explain:
         updated.write_file(COVERAGE_FILE)


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (coverage-fix e7c68f64b9) last updated 2017/02/27 15:18:22 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Deduplicate arcs when combining coverage data.