### PR TITLE
Add boto to units requirements for s3 test.

### DIFF
--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -1,3 +1,4 @@
+boto
 boto3
 jinja2
 mock


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

unit tests

##### ANSIBLE VERSION

```
ansible 2.3.0 (units-boto 1e30cdf975) last updated 2017/02/27 18:29:31 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Add boto to units requirements for s3 test.