### PR TITLE
Fix log_invocation function to pass unittests on python3

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1832,14 +1832,7 @@ class AnsibleModule(object):
                     param_val = param_val.encode('utf-8')
                 log_args[param] = heuristic_log_sanitize(param_val, self.no_log_values)
 
-        msg = []
-        for arg in log_args:
-            arg_val = log_args[arg]
-            if not isinstance(arg_val, (text_type, binary_type)):
-                arg_val = str(arg_val)
-            elif isinstance(arg_val, text_type):
-                arg_val = arg_val.encode('utf-8')
-            msg.append('%s=%s' % (arg, arg_val))
+        msg = ['%s=%s' % (to_native(arg), to_native(val)) for arg, val in log_args.items()]
         if msg:
             msg = 'Invoked with %s' % ' '.join(msg)
         else:

--- a/test/units/module_utils/basic/test__log_invocation.py
+++ b/test/units/module_utils/basic/test__log_invocation.py
@@ -30,7 +30,6 @@ from ansible.compat.tests.mock import MagicMock
 
 
 class TestModuleUtilsBasic(unittest.TestCase):
-    @unittest.skipIf(sys.version_info[0] >= 3, "Python 3 is not supported on targets (yet)")
     def test_module_utils_basic__log_invocation(self):
         with swap_stdin_and_argv(stdin_data=json.dumps(
             dict(


### PR DESCRIPTION
Normalize this function to use native strings.  Native strings won't
display an extra "u" or "b" character to denote py2 unicode or py3 bytes
types.

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/module_utils/basic.py

and associated log_invocation test

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```
