### PR TITLE
Add retries for ansible-test docker run.

### DIFF
--- a/test/runner/lib/delegation.py
+++ b/test/runner/lib/delegation.py
@@ -246,7 +246,15 @@ def docker_run(args, image, options):
     if not options:
         options = []
 
-    return docker_command(args, ['run'] + options + [image], capture=True)
+    for _ in range(1, 3):
+        try:
+            return docker_command(args, ['run'] + options + [image], capture=True)
+        except SubprocessError as ex:
+            display.error(ex)
+            display.warning('Failed to run docker image "%s". Waiting a few seconds before trying again.' % image)
+            time.sleep(3)
+
+    raise ApplicationError('Failed to run docker image "%s".' % image)
 
 
 def docker_rm(args, container_id):


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (docker-retry 930fec3325) last updated 2017/02/27 21:58:49 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Add retries for ansible-test docker run.