### PR TITLE
Contributing lib/ansible/modules/network/cloudengine/ce_netconf.py module to manage HUAWEI data center CloudEngine

### DIFF
--- a/lib/ansible/modules/network/cloudengine/ce_netconf.py
+++ b/lib/ansible/modules/network/cloudengine/ce_netconf.py
@@ -18,25 +18,22 @@
 
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
-                    'version': '1.0'}
+                    'metadata_version': '1.0'}
 
 DOCUMENTATION = '''
 ---
 module: ce_netconf
-version_added: "2.3"
-short_description: Run arbitrary netconf command on cloudengine devices.
+version_added: "2.4"
+short_description: Run an arbitrary netconf command on HUAWEI CloudEngine switches.
 description:
-    - Sends an arbitrary netconf command to a cloudengine node and returns the results read from the device.
+    - Sends an arbitrary netconf command on HUAWEI CloudEngine switches.
 author:
     - wangdezhuang (@CloudEngine-Ansible)
-notes:
-    - The rpc parameter is always required.
 options:
     rpc:
         description:
             - The type of rpc.
-        required: false
-        default: null
+        required: true
         choices: ['get', 'edit-config', 'execute-action', 'execute-cli']
     cfg_xml:
         description:
@@ -131,7 +128,7 @@ def main():
 
     argument_spec = dict(
         rpc=dict(choices=['get', 'edit-config',
-                          'execute-action', 'execute-cli'], default=None),
+                          'execute-action', 'execute-cli'], required=True),
         cfg_xml=dict(required=True)
     )
 

--- a/lib/ansible/modules/network/cloudengine/ce_netconf.py
+++ b/lib/ansible/modules/network/cloudengine/ce_netconf.py
@@ -137,10 +137,6 @@ def main():
 
     rpc = module.params['rpc']
     cfg_xml = module.params['cfg_xml']
-
-    if not rpc or not cfg_xml:
-        module.fail_json(msg='please input rpc and cfg_xml.')
-
     changed = False
     end_state = dict()
 

--- a/lib/ansible/modules/network/cloudengine/ce_netconf.py
+++ b/lib/ansible/modules/network/cloudengine/ce_netconf.py
@@ -20,7 +20,6 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
-
 DOCUMENTATION = '''
 ---
 module: ce_netconf
@@ -122,7 +121,6 @@ end_state:
     sample: {"result": ["ok"]}
 '''
 
-import sys
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ce import get_nc_config, set_nc_config
 from ansible.module_utils.ce import execute_nc_action, ce_argument_spec, execute_nc_cli

--- a/lib/ansible/modules/network/cloudengine/ce_netconf.py
+++ b/lib/ansible/modules/network/cloudengine/ce_netconf.py
@@ -20,6 +20,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
 
+
 DOCUMENTATION = '''
 ---
 module: ce_netconf

--- a/lib/ansible/modules/network/cloudengine/ce_netconf.py
+++ b/lib/ansible/modules/network/cloudengine/ce_netconf.py
@@ -1,0 +1,208 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = '''
+---
+module: ce_netconf
+version_added: "2.3"
+short_description: Run arbitrary netconf command on cloudengine devices.
+description:
+    - Sends an arbitrary netconf command to a cloudengine node and returns the results read from the device.
+author:
+    - wangdezhuang (@CloudEngine-Ansible)
+notes:
+    - The rpc parameter is always required.
+options:
+    rpc:
+        description:
+            - The type of rpc.
+        required: false
+        default: null
+        choices: ['get', 'edit-config', 'execute-action', 'execute-cli']
+    cfg_xml:
+        description:
+            - The config xml string.
+        required: true
+'''
+
+EXAMPLES = '''
+
+- name: CloudEngine netconf test
+  hosts: cloudengine
+  connection: local
+  gather_facts: no
+  vars:
+    cli:
+      host: "{{ inventory_hostname }}"
+      port: "{{ ansible_ssh_port }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      transport: cli
+
+  tasks:
+
+  - name: "Netconf get operation"
+    ce_netconf:
+      rpc: get
+      cfg_xml: '<filter type=\"subtree\">
+                  <vlan xmlns=\"http://www.huawei.com/netconf/vrp\" content-version=\"1.0\" format-version=\"1.0\">
+                    <vlans>
+                      <vlan>
+                        <vlanId>10</vlanId>
+                        <vlanif>
+                          <ifName></ifName>
+                          <cfgBand></cfgBand>
+                          <dampTime></dampTime>
+                        </vlanif>
+                      </vlan>
+                    </vlans>
+                  </vlan>
+                </filter>'
+      provider: "{{ cli }}"
+
+  - name: "Netconf edit-config operation"
+    ce_netconf:
+      rpc: edit-config
+      cfg_xml: '<config>
+                    <aaa xmlns=\"http://www.huawei.com/netconf/vrp\" content-version=\"1.0\" format-version=\"1.0\">
+                      <authenticationSchemes>
+                        <authenticationScheme operation=\"create\">
+                          <authenSchemeName>default_wdz</authenSchemeName>
+                          <firstAuthenMode>local</firstAuthenMode>
+                          <secondAuthenMode>invalid</secondAuthenMode>
+                        </authenticationScheme>
+                      </authenticationSchemes>
+                    </aaa>
+                   </config>'
+      provider: "{{ cli }}"
+
+  - name: "Netconf execute-action operation"
+    ce_netconf:
+      rpc: execute-action
+      cfg_xml: '<action>
+                     <l2mc xmlns=\"http://www.huawei.com/netconf/vrp\" content-version=\"1.0\" format-version=\"1.0\">
+                       <l2McResetAllVlanStatis>
+                         <addrFamily>ipv4unicast</addrFamily>
+                       </l2McResetAllVlanStatis>
+                     </l2mc>
+                   </action>'
+      provider: "{{ cli }}"
+'''
+
+RETURN = '''
+changed:
+    description: check to see if a change was made on the device
+    returned: always
+    type: boolean
+    sample: true
+end_state:
+    description: k/v pairs of aaa params after module execution
+    returned: always
+    type: dict
+    sample: {"result": ["ok"]}
+'''
+
+import sys
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ce import get_nc_config, set_nc_config
+from ansible.module_utils.ce import execute_nc_action, ce_argument_spec, execute_nc_cli
+
+
+def main():
+    """ main """
+
+    argument_spec = dict(
+        rpc=dict(choices=['get', 'edit-config',
+                          'execute-action', 'execute-cli'], default=None),
+        cfg_xml=dict(required=True)
+    )
+
+    argument_spec.update(ce_argument_spec)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    rpc = module.params['rpc']
+    cfg_xml = module.params['cfg_xml']
+
+    if not rpc or not cfg_xml:
+        module.fail_json(msg='please input rpc and cfg_xml.')
+
+    changed = False
+    end_state = dict()
+
+    if rpc == "get":
+
+        response = get_nc_config(module, cfg_xml)
+
+        if "<data/>" in response:
+            end_state["result"] = "<data/>"
+        else:
+            tmp1 = response.split(r"<data>")
+            tmp2 = tmp1[1].split(r"</data>")
+            result = tmp2[0].split("\n")
+
+            end_state["result"] = result
+
+    elif rpc == "edit-config":
+
+        response = set_nc_config(module, cfg_xml)
+
+        if "<ok/>" not in response:
+            module.fail_json(msg='rpc edit-config failed.')
+
+        changed = True
+        end_state["result"] = "ok"
+
+    elif rpc == "execute-action":
+
+        response = execute_nc_action(module, cfg_xml)
+
+        if "<ok/>" not in response:
+            module.fail_json(msg='rpc execute-action failed.')
+
+        changed = True
+        end_state["result"] = "ok"
+
+    elif rpc == "execute-cli":
+
+        response = execute_nc_cli(module, cfg_xml)
+
+        if "<data/>" in response:
+            end_state["result"] = "<data/>"
+        else:
+            tmp1 = response.xml.split(r"<data>")
+            tmp2 = tmp1[1].split(r"</data>")
+            result = tmp2[0].split("\n")
+
+            end_state["result"] = result
+
+    else:
+        module.fail_json(msg='please input correct rpc.')
+
+    results = dict()
+    results['changed'] = changed
+    results['end_state'] = end_state
+
+    module.exit_json(**results)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
add ce_netconf

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ce_netconf.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
config file = /etc/ansible/ansible.cfg
configured module search path = ['/home/ansible-2.1.1.0/lib/ansible/modules/core/network/cloudengine', '/home/ansible-2.1.1.0/lib/ansible/module_utils', '/home/ansible-2.1.1.0/lib/ansible/modules', '/home/ansible-2.1.1.0', '/home/ansible-2.1.1.0/lib/ansible/utils/']
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [edit-config operation] ***************************************************
task path: /usr1/code/OpenNESS/code/current/KVM/intg/test/testcases/test-ce_netconf.yml:34
Using module file /usr/local/lib/python2.7/site-packages/ansible-2.3.0-py2.7.egg/ansible/modules/core/network/cloudengine/ce_netconf.py
<ce_6850> ESTABLISH LOCAL CONNECTION FOR USER: root
<ce_6850> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1487043783.51-104602864594431 `" && echo ansible-tmp-1487043783.51-104602864594431="` echo $HOME/.ansible/tmp/ansible-tmp-1487043783.51-104602864594431 `" ) && sleep 0'
<ce_6850> PUT /tmp/tmpMgRxvr TO /root/.ansible/tmp/ansible-tmp-1487043783.51-104602864594431/ce_netconf.py
<ce_6850> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1487043783.51-104602864594431/ /root/.ansible/tmp/ansible-tmp-1487043783.51-104602864594431/ce_netconf.py && sleep 0'
<ce_6850> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1487043783.51-104602864594431/ce_netconf.py; rm -rf "/root/.ansible/tmp/ansible-tmp-1487043783.51-104602864594431/" > /dev/null 2>&1 && sleep 0'
changed: [ce_6850] => {
    "changed": true, 
    "end_state": {
        "result": "ok"
    }, 
    "invocation": {
        "module_args": {
            "auth_pass": null, 
            "authorize": false, 
            "cfg_xml": "<config><aaa xmlns=\"http://www.huawei.com/netconf/vrp\" content-version=\"1.0\" format-version=\"1.0\"><authenticationSchemes><authenticationScheme  operation=\"create\"><authenSchemeName>default_wdz</authenSchemeName><firstAuthenMode>local</firstAuthenMode><secondAuthenMode>invalid</secondAuthenMode></authenticationScheme></authenticationSchemes></aaa></config>", 
            "host": "ce_6850", 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 12345, 
            "provider": null, 
            "rpc": "edit-config", 
            "ssh_keyfile": null, 
            "timeout": 10, 
            "transport": null, 
            "use_ssl": false, 
            "username": "rootDC", 
            "validate_certs": true
        }, 
        "module_name": "ce_netconf"
    }
}
```
