### PR TITLE
Contributing lib/ansible/modules/network/cloudengine/ce_reboot.py module to manage HUAWEI data center CloudEngine

### DIFF
--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -18,25 +18,29 @@
 
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
-                    'version': '1.0'}
+                    'metadata_version': '1.0'}
 
 DOCUMENTATION = '''
 ---
 module: ce_reboot
-version_added: 2.3
-short_description: Reboot a network device.
+version_added: 2.4
+short_description: Reboot a HUAWEI CloudEngine switches.
 description:
-    - Reboot a network device.
+    - Reboot a HUAWEI CloudEngine switches.
 author: Gong Jianjun (@CloudEngine-Ansible)
+requirements: ncclient
 options:
     confirm:
         description:
             - Safeguard boolean. Set to true if you're sure you want to reboot.
         required: true
+        type: bool
+        default: false
     save_config:
         description:
             - Flag indicating whether to save the configuration.
         required: false
+        type: bool
         default: false
 '''
 
@@ -123,7 +127,7 @@ class Reboot(object):
             self.network_module.fail_json(
                 msg='Error: Confirm must be set to true for this module to work.')
 
-        xml_str = CE_NC_XML_EXECUTE_REBOOT % self.save_config
+        xml_str = CE_NC_XML_EXECUTE_REBOOT % str(self.save_config).lower()
         self.netconf_set_action(xml_str)
 
 
@@ -131,9 +135,8 @@ def main():
     """ main """
 
     argument_spec = dict(
-        confirm=dict(required=True, type='bool'),
-        save_config=dict(required=False, default='false',
-                         type='str', choices=['true', 'false'])
+        confirm=dict(required=True, type='bool', default='false'),
+        save_config=dict(required=False, type='bool', default='false')
     )
 
     argument_spec.update(ce_argument_spec)

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -28,7 +28,7 @@ short_description: Reboot a HUAWEI CloudEngine switches.
 description:
     - Reboot a HUAWEI CloudEngine switches.
 author: Gong Jianjun (@CloudEngine-Ansible)
-requirements: ncclient
+requirements: ["ncclient"]
 options:
     confirm:
         description:

--- a/lib/ansible/modules/network/cloudengine/ce_reboot.py
+++ b/lib/ansible/modules/network/cloudengine/ce_reboot.py
@@ -1,0 +1,161 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = '''
+---
+module: ce_reboot
+version_added: 2.3
+short_description: Reboot a network device.
+description:
+    - Reboot a network device.
+author: Gong Jianjun (@CloudEngine-Ansible)
+options:
+    confirm:
+        description:
+            - Safeguard boolean. Set to true if you're sure you want to reboot.
+        required: true
+    save_config:
+        description:
+            - Flag indicating whether to save the configuration.
+        required: false
+        default: false
+'''
+
+EXAMPLES = '''
+- name: reboot module test
+  hosts: cloudengine
+  connection: local
+  gather_facts: no
+  vars:
+    cli:
+      host: "{{ inventory_hostname }}"
+      port: "{{ ansible_ssh_port }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      transport: cli
+
+  tasks:
+  - name: Reboot the device
+    ce_reboot:
+      confirm: true
+      save_config: true
+      provider: "{{ cli }}"
+'''
+
+RETURN = '''
+rebooted:
+    description: Whether the device was instructed to reboot.
+    returned: success
+    type: boolean
+    sample: true
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ce import execute_nc_action, ce_argument_spec
+
+try:
+    from ncclient.operations.errors import TimeoutExpiredError
+    HAS_NCCLIENT = True
+except ImportError:
+    HAS_NCCLIENT = False
+
+CE_NC_XML_EXECUTE_REBOOT = """
+    <action>
+      <devm xmlns="http://www.huawei.com/netconf/vrp" content-version="1.0" format-version="1.0">
+        <reboot>
+            <saveConfig>%s</saveConfig>
+        </reboot>
+      </devm>
+    </action>
+"""
+
+
+class Reboot(object):
+    """ Reboot a network device """
+
+    def __init__(self, **kwargs):
+        """ __init___ """
+
+        self.network_module = None
+        self.netconf = None
+        self.init_network_module(**kwargs)
+
+        self.confirm = self.network_module.params['confirm']
+        self.save_config = self.network_module.params['save_config']
+
+    def init_network_module(self, **kwargs):
+        """ init network module """
+
+        self.network_module = AnsibleModule(**kwargs)
+
+    def netconf_set_action(self, xml_str):
+        """ netconf execute action """
+
+        try:
+            execute_nc_action(self.network_module, xml_str)
+        except TimeoutExpiredError:
+            pass
+
+    def work(self):
+        """ start to work """
+
+        if not self.confirm:
+            self.network_module.fail_json(
+                msg='Error: Confirm must be set to true for this module to work.')
+
+        xml_str = CE_NC_XML_EXECUTE_REBOOT % self.save_config
+        self.netconf_set_action(xml_str)
+
+
+def main():
+    """ main """
+
+    argument_spec = dict(
+        confirm=dict(required=True, type='bool'),
+        save_config=dict(required=False, default='false',
+                         type='str', choices=['true', 'false'])
+    )
+
+    argument_spec.update(ce_argument_spec)
+    module = Reboot(argument_spec=argument_spec, supports_check_mode=True)
+
+    if not HAS_NCCLIENT:
+        module.network_module.fail_json(msg='Error: The ncclient library is required.')
+
+    changed = False
+    rebooted = False
+
+    module.work()
+
+    changed = True
+    rebooted = True
+
+    results = dict()
+    results['changed'] = changed
+    results['rebooted'] = rebooted
+
+    module.network_module.exit_json(**results)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
add ce_reboot

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ce_reboot.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
config file = /etc/ansible/ansible.cfg
configured module search path = ['/home/ansible-2.1.1.0/lib/ansible/modules/core/network/cloudengine', '/home/ansible-2.1.1.0/lib/ansible/module_utils', '/home/ansible-2.1.1.0/lib/ansible/modules', '/home/ansible-2.1.1.0', '/home/ansible-2.1.1.0/lib/ansible/utils/']
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
ansible -vvv -m ce_reboot -a 'host=10.135.182.157 port=12347 username=rootDC password=Admin@123 confirm=true save_config=true' localhost --connection local
Using /etc/ansible/ansible.cfg as config file
Using module file /usr1/wangdz/ansible-iSource/lib/ansible/modules/core/network/cloudengine/ce_reboot.py
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1487054756.28-94911482560641 `" && echo ansible-tmp-1487054756.28-94911482560641="` echo $HOME/.ansible/tmp/ansible-tmp-1487054756.28-94911482560641 `" ) && sleep 0'
<127.0.0.1> PUT /tmp/tmp4aUB3k TO /root/.ansible/tmp/ansible-tmp-1487054756.28-94911482560641/ce_reboot.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1487054756.28-94911482560641/ /root/.ansible/tmp/ansible-tmp-1487054756.28-94911482560641/ce_reboot.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1487054756.28-94911482560641/ce_reboot.py; rm -rf "/root/.ansible/tmp/ansible-tmp-1487054756.28-94911482560641/" > /dev/null 2>&1 && sleep 0'
localhost | SUCCESS => {
    "changed": true, 
    "invocation": {
        "module_args": {
            "auth_pass": null, 
            "authorize": false, 
            "confirm": true, 
            "host": "10.135.182.157", 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 12347, 
            "provider": null, 
            "save_config": "true", 
            "ssh_keyfile": null, 
            "timeout": 10, 
            "transport": null, 
            "use_ssl": false, 
            "username": "rootDC", 
            "validate_certs": true
        }, 
        "module_name": "ce_reboot"
    }, 
    "rebooted": true
}

```
