### PR TITLE
Contributing lib/ansible/modules/network/cloudengine/ce_snmp_contact.py module to manage HUAWEI data center CloudEngine

### DIFF
--- a/lib/ansible/modules/network/cloudengine/ce_snmp_contact.py
+++ b/lib/ansible/modules/network/cloudengine/ce_snmp_contact.py
@@ -18,15 +18,15 @@
 
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
-                    'version': '1.0'}
+                    'metadata_version': '1.0'}
 
 DOCUMENTATION = '''
 ---
 module: ce_snmp_contact
-version_added: "2.3"
-short_description: Manages SNMP contact configuration.
+version_added: "2.4"
+short_description: Manages SNMP contact configuration on HUAWEI CloudEngine switches.
 description:
-    - Manages SNMP contact configurations on CloudEngine switches.
+    - Manages SNMP contact configurations on HUAWEI CloudEngine switches.
 author:
     - wangdezhuang (@CloudEngine-Ansible)
 options:
@@ -35,6 +35,12 @@ options:
             - Contact information.
         required: true
         default: null
+    state:
+        description:
+            - Manage the state of the resource.
+        required: false
+        default: present
+        choices: ['present','absent']
 '''
 
 EXAMPLES = '''
@@ -79,8 +85,8 @@ proposed:
     sample: {"contact": "call Operator at 010-99999999",
              "state": "present"}
 existing:
-    description:
-        - k/v pairs of existing aaa server
+    description: k/v pairs of existing aaa server
+    returned: always
     type: dict
     sample: {}
 end_state:

--- a/lib/ansible/modules/network/cloudengine/ce_snmp_contact.py
+++ b/lib/ansible/modules/network/cloudengine/ce_snmp_contact.py
@@ -1,0 +1,245 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = '''
+---
+module: ce_snmp_contact
+version_added: "2.3"
+short_description: Manages SNMP contact configuration.
+description:
+    - Manages SNMP contact configurations on CloudEngine switches.
+author:
+    - wangdezhuang (@CloudEngine-Ansible)
+options:
+    contact:
+        description:
+            - Contact information.
+        required: true
+        default: null
+'''
+
+EXAMPLES = '''
+
+- name: CloudEngine snmp contact test
+  hosts: cloudengine
+  connection: local
+  gather_facts: no
+  vars:
+    cli:
+      host: "{{ inventory_hostname }}"
+      port: "{{ ansible_ssh_port }}"
+      username: "{{ username }}"
+      password: "{{ password }}"
+      transport: cli
+
+  tasks:
+
+  - name: "Config SNMP contact"
+    ce_snmp_contact:
+      state:  present
+      contact:  call Operator at 010-99999999
+      provider: "{{ cli }}"
+
+  - name: "Undo SNMP contact"
+    ce_snmp_contact:
+      state:  absent
+      contact:  call Operator at 010-99999999
+      provider: "{{ cli }}"
+'''
+
+RETURN = '''
+changed:
+    description: check to see if a change was made on the device
+    returned: always
+    type: boolean
+    sample: true
+proposed:
+    description: k/v pairs of parameters passed into module
+    returned: always
+    type: dict
+    sample: {"contact": "call Operator at 010-99999999",
+             "state": "present"}
+existing:
+    description:
+        - k/v pairs of existing aaa server
+    type: dict
+    sample: {}
+end_state:
+    description: k/v pairs of aaa params after module execution
+    returned: always
+    type: dict
+    sample: {"contact": "call Operator at 010-99999999"}
+updates:
+    description: command sent to the device
+    returned: always
+    type: list
+    sample: ["snmp-agent sys-info contact call Operator at 010-99999999"]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ce import get_config, load_config, ce_argument_spec
+
+
+class SnmpContact(object):
+    """ Manages SNMP contact configuration """
+
+    def __init__(self, **kwargs):
+        """ Class init """
+
+        # module
+        argument_spec = kwargs["argument_spec"]
+        self.spec = argument_spec
+        self.module = AnsibleModule(argument_spec=self.spec, supports_check_mode=True)
+
+        # config
+        self.cur_cfg = dict()
+
+        # module args
+        self.state = self.module.params['state']
+        self.contact = self.module.params['contact']
+
+        # state
+        self.changed = False
+        self.updates_cmd = list()
+        self.results = dict()
+        self.proposed = dict()
+        self.existing = dict()
+        self.end_state = dict()
+
+    def check_args(self):
+        """ Check invalid args """
+
+        if self.contact:
+            if len(self.contact) > 255 or len(self.contact) < 1:
+                self.module.fail_json(
+                    msg='Error: The len of contact %s is out of [1 - 255].' % self.contact)
+        else:
+            self.module.fail_json(
+                msg='Error: The len of contact is 0.')
+
+    def get_proposed(self):
+        """ Get proposed state """
+
+        self.proposed["state"] = self.state
+
+        if self.contact:
+            self.proposed["contact"] = self.contact
+
+    def get_existing(self):
+        """ Get existing state """
+
+        tmp_cfg = self.cli_get_config()
+        if tmp_cfg:
+            temp_data = tmp_cfg.split(r"contact ")
+            self.cur_cfg["contact"] = temp_data[1]
+            self.existing["contact"] = temp_data[1]
+
+    def get_end_state(self):
+        """ Get end state """
+
+        tmp_cfg = self.cli_get_config()
+        if tmp_cfg:
+            temp_data = tmp_cfg.split(r"contact ")
+            self.end_state["contact"] = temp_data[1]
+
+    def cli_load_config(self, commands):
+        """ Load configure by cli """
+
+        if not self.module.check_mode:
+            load_config(self.module, commands)
+
+    def cli_get_config(self):
+        """ Get configure by cli """
+
+        regular = "| include snmp | include contact"
+        flags = list()
+        flags.append(regular)
+        tmp_cfg = get_config(self.module, flags)
+
+        return tmp_cfg
+
+    def set_config(self):
+        """ Set configure by cli """
+
+        cmd = "snmp-agent sys-info contact %s" % self.contact
+        self.updates_cmd.append(cmd)
+
+        cmds = list()
+        cmds.append(cmd)
+
+        self.cli_load_config(cmds)
+        self.changed = True
+
+    def undo_config(self):
+        """ Undo configure by cli """
+
+        cmd = "undo snmp-agent sys-info contact"
+        self.updates_cmd.append(cmd)
+
+        cmds = list()
+        cmds.append(cmd)
+
+        self.cli_load_config(cmds)
+        self.changed = True
+
+    def work(self):
+        """ Main work function """
+
+        self.check_args()
+        self.get_proposed()
+        self.get_existing()
+
+        if self.state == "present":
+            if "contact" in self.cur_cfg.keys() and self.contact == self.cur_cfg["contact"]:
+                pass
+            else:
+                self.set_config()
+        else:
+            if "contact" in self.cur_cfg.keys() and self.contact == self.cur_cfg["contact"]:
+                self.undo_config()
+
+        self.get_end_state()
+
+        self.results['changed'] = self.changed
+        self.results['proposed'] = self.proposed
+        self.results['existing'] = self.existing
+        self.results['end_state'] = self.end_state
+        self.results['updates'] = self.updates_cmd
+
+        self.module.exit_json(**self.results)
+
+
+def main():
+    """ Module main """
+
+    argument_spec = dict(
+        state=dict(choices=['present', 'absent'], default='present'),
+        contact=dict(type='str', required=True)
+    )
+
+    argument_spec.update(ce_argument_spec)
+    module = SnmpContact(argument_spec=argument_spec)
+    module.work()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
add ce_snmp_connect

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ce_snmp_contact.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
config file = /etc/ansible/ansible.cfg
configured module search path = ['/home/ansible-2.1.1.0/lib/ansible/modules/core/network/cloudengine', '/home/ansible-2.1.1.0/lib/ansible/module_utils', '/home/ansible-2.1.1.0/lib/ansible/modules', '/home/ansible-2.1.1.0', '/home/ansible-2.1.1.0/lib/ansible/utils/']
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [config snmp contact] *****************************************************
task path: /usr1/code/OpenNESS/code/current/KVM/intg/test/testcases/test-ce_snmp_contact.yml:22
Using module file /usr/local/lib/python2.7/site-packages/ansible-2.3.0-py2.7.egg/ansible/modules/core/network/cloudengine/ce_snmp_contact.py
<ce_6850> ESTABLISH LOCAL CONNECTION FOR USER: root
<ce_6850> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1487053602.44-179342278832205 `" && echo ansible-tmp-1487053602.44-179342278832205="` echo $HOME/.ansible/tmp/ansible-tmp-1487053602.44-179342278832205 `" ) && sleep 0'
<ce_6850> PUT /tmp/tmpF8rr5q TO /root/.ansible/tmp/ansible-tmp-1487053602.44-179342278832205/ce_snmp_contact.py
<ce_6850> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1487053602.44-179342278832205/ /root/.ansible/tmp/ansible-tmp-1487053602.44-179342278832205/ce_snmp_contact.py && sleep 0'
<ce_6850> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1487053602.44-179342278832205/ce_snmp_contact.py; rm -rf "/root/.ansible/tmp/ansible-tmp-1487053602.44-179342278832205/" > /dev/null 2>&1 && sleep 0'
changed: [ce_6850] => {
    "changed": true, 
    "end_state": {
        "contact": "call Operator at 010-99999999"
    }, 
    "existing": {}, 
    "invocation": {
        "module_args": {
            "auth_pass": null, 
            "authorize": false, 
            "contact": "call Operator at 010-99999999", 
            "host": "ce_6850", 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 12345, 
            "provider": null, 
            "ssh_keyfile": null, 
            "state": "present", 
            "timeout": 10, 
            "transport": null, 
            "use_ssl": false, 
            "username": "rootDC", 
            "validate_certs": true
        }, 
        "module_name": "ce_snmp_contact"
    }, 
    "proposed": {
        "contact": "call Operator at 010-99999999", 
        "state": "present"
    }, 
    "updates": [
        "snmp-agent sys-info contact call Operator at 010-99999999"
    ]
}
```
