### PR TITLE
Add support for generating full chain certificates from LetsEncrypt.

### DIFF
--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -101,6 +101,11 @@ options:
     description: The destination file for the certificate.
     required: true
     aliases: ['cert']
+  fullchain:
+    description: Include the full certificate chain in the destination file.
+    required: false
+    default: false
+    version_added: 2.3
   remaining_days:
     description:
       - "The number of days the certificate must have left being valid.

--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -722,7 +722,7 @@ class ACMEClient(object):
             if parsed_link and parsed_link.group(2) == "up":
                 chain_link = parsed_link.group(1)
                 chain_result, chain_info = fetch_url(self.module, chain_link, method='GET')
-                if chain_info['status'] in [200,201]:
+                if chain_info['status'] in [200, 201]:
                     chain = [chain_result.read()]
 
         if info['status'] not in [200, 201]:

--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -105,7 +105,7 @@ options:
     description: Include the full certificate chain in the destination file.
     required: false
     default: false
-    version_added: 2.3
+    version_added: 2.4
   remaining_days:
     description:
       - "The number of days the certificate must have left being valid.


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
letsencrypt

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Fixes #18996. Adds an option to generate a full chain certificate from LetsEncrypt
giving better compatibility with browsers. 

Follows the `link` header provided with the certificate response and appends the
chain certificate to the output when the `fullchain` option is set.

Before `dest` file contains a single certificate.
After `dest` file contains the certificate and the chain concatenated if `fullchain` option was true. If `fullchain` was false there is no change in output. There is no other change in module output.
