### PR TITLE
add python version info to --version

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -476,6 +476,7 @@ class CLI(with_metaclass(ABCMeta, object)):
         else:
             cpath = C.DEFAULT_MODULE_PATH
         result = result + "\n  configured module search path = %s" % cpath
+        result = result + "\n  python version = %s" % ''.join(sys.version.splitlines())
         return result
 
     @staticmethod

--- a/test/units/cli/test_cli.py
+++ b/test/units/cli/test_cli.py
@@ -1,0 +1,41 @@
+# (c) 2017, Adrian Likins <alikins@redhat.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.compat.tests import unittest
+
+from ansible.release import __version__
+from ansible import cli
+
+
+class TestCliVersion(unittest.TestCase):
+
+    def test_version(self):
+        ver = cli.CLI.version('ansible-cli-test')
+        self.assertIn('ansible-cli-test', ver)
+        self.assertIn('python version', ver)
+
+    def test_version_info(self):
+        version_info = cli.CLI.version_info()
+        self.assertEqual(version_info['string'], __version__)
+
+    def test_version_info_gitinfo(self):
+        version_info = cli.CLI.version_info(gitinfo=True)
+        self.assertIn('python version', version_info['string'])


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (python_info_in_version 28d22a2a5e) last updated 2017/02/28 10:35:18 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```
^^ Note the python version info 

##### SUMMARY
Add python version info to 'ansible --version' output. ie

```
ansible 2.3.0 (python_info_in_version 28d22a2a5e) last updated 2017/02/28 10:35:18 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```

Since we support py2.7, 3.5, 3.6 now, and it is often useful to know which is in used for a bug report.