### PR TITLE
Show the ansible version if invoked with more than one -v

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -156,6 +156,9 @@ class CLI(with_metaclass(ABCMeta, object)):
         running an Ansible command.
         """
 
+        if self.options.verbosity > 1:
+            display.display(self.parser.get_version())
+
         if self.options.verbosity > 0:
             if C.CONFIG_FILE:
                 display.display(u"Using %s as config file" % to_text(C.CONFIG_FILE))

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -156,14 +156,12 @@ class CLI(with_metaclass(ABCMeta, object)):
         running an Ansible command.
         """
 
-        if self.options.verbosity > 1:
-            display.display(self.parser.get_version())
+        display.vv(self.parser.get_version())
 
-        if self.options.verbosity > 0:
-            if C.CONFIG_FILE:
-                display.display(u"Using %s as config file" % to_text(C.CONFIG_FILE))
-            else:
-                display.display(u"No config file found; using defaults")
+        if C.CONFIG_FILE:
+            display.v(u"Using %s as config file" % to_text(C.CONFIG_FILE))
+        else:
+            display.v(u"No config file found; using defaults")
 
     @staticmethod
     def ask_vault_passwords():


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/cli/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (show_version_when_verbose 43cbe5adb9) last updated 2017/02/28 10:58:36 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']

```

##### SUMMARY
When ansible is invoked with more than one '-v', include the ansible version info in the verbose info shown.