### PR TITLE
fix issue with nmcli not parsing dns4 param properly

### DIFF
--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -569,7 +569,7 @@ class Nmcli(object):
         self.type=module.params['type']
         self.ip4=module.params['ip4']
         self.gw4=module.params['gw4']
-        self.dns4=module.params['dns4']
+        self.dns4=' '.join(module.params['dns4'])
         self.ip6=module.params['ip6']
         self.gw6=module.params['gw6']
         self.dns6=module.params['dns6']
@@ -1105,7 +1105,7 @@ def main():
             type=dict(required=False, default=None, choices=['ethernet', 'team', 'team-slave', 'bond', 'bond-slave', 'bridge', 'vlan'], type='str'),
             ip4=dict(required=False, default=None, type='str'),
             gw4=dict(required=False, default=None, type='str'),
-            dns4=dict(required=False, default=None, type='str'),
+            dns4=dict(required=False, default=None, type='list'),
             ip6=dict(required=False, default=None, type='str'),
             gw6=dict(required=False, default=None, type='str'),
             dns6=dict(required=False, default=None, type='str'),


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nmcli
##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file = /home/jdavila/Tech/stackspace/deploy/ansible.cfg
  configured module search path = Default w/o overrides
```
used nmcli from current devel for testing

##### SUMMARY
Fixes https://github.com/ansible/ansible/issues/22093

You can now specify values for the `dns4` parameter as a list, as the documentation specified originally.
