### PR TITLE
Fix broken --container-enabled option on galaxy init command

### DIFF
--- a/lib/ansible/galaxy/data/container_enabled/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/container_enabled/meta/main.yml.j2
@@ -30,18 +30,19 @@ galaxy_info:
   #github_branch:
 
   #
-  # Below are all platforms currently available in Galaxy. Uncomment any that match the base images
-  # of the services defined in meta/container.yml
+  # platforms is a list of platforms, and each platform has a name and a list of versions.
   #
-  #platforms:
-  {%- for platform,versions in platforms.items() %}
-  #- name: {{ platform }}
-  #  versions:
-  #  - all
-    {%- for version in versions %}
-  #  - {{ version }}
-    {%- endfor -%}
-  {%- endfor %}
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
 
   galaxy_tags:
     - container


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/galaxy/data/container_enabled/meta/main.yml.j2

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 4386ad42f7) last updated 2017/02/28 11:23:29 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

Removes references to the `platform` variable. This was already done in `default/meta/main.yml.j2`.