### PR TITLE
route53: Avoid throttling errors and unnecessary processing when checking rrsets for existing record

### DIFF
--- a/lib/ansible/modules/cloud/amazon/route53.py
+++ b/lib/ansible/modules/cloud/amazon/route53.py
@@ -549,7 +549,14 @@ def main():
                 record['values'] = sorted(rset.resource_records)
             if command_in == 'create' and rset.to_xml() == wanted_rset.to_xml():
                 module.exit_json(changed=False)
-            break
+
+        # We need to look only at the first rrset returned by the above call,
+        # so break here. The returned elements begin with the one matching our
+        # requested name, type, and identifier, if such an element exists,
+        # followed by all others that come after it in alphabetical order.
+        # Therefore, if the first set does not match, no subsequent set will
+        # match either.
+        break
 
     if command_in == 'get':
         if type_in == 'NS':


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
route53.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
This change resolves AWS API throttling we are still observing while the Ansible route53 module loops over the `sets` object returned by `get_all_rrsets()`. The `sets` object itself continues to make AWS API calls as it it is iterated upon, to retrieve additional batches of records.

It turns out that this looping is unnecessary.

The first record set returned by `sets` as we iterate will be the one matching the name, type, and identifier specified as arguments to `get_all_rrsets()`, followed by _all_ subsequent sets in alphabetical order based on name. If the specified set does not exist, the method will still return all the sets that _would_ have come after it. Searching through these sets that we know will not match is a waste but, more importantly, often triggers AWS API throttling when used on zones with large numbers of records.

Instead, we can break after the first iteration - we have either found a match, or we will never find one.

Error output shown below:
```
fatal: [localhost -> localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):
  File \"/tmp/ansible_zQamSC/ansible_module_route53.py\", line 597, in <module>
    main()
  File \"/tmp/ansible_zQamSC/ansible_module_route53.py\", line 512, in main
    for rset in sets:
  File \"/usr/lib/python2.7/dist-packages/awx/lib/site-packages/boto/route53/record.py\", line 187, in __iter__
    for obj in results:
  File \"/usr/lib/python2.7/dist-packages/awx/lib/site-packages/boto/route53/record.py\", line 187, in __iter__
    for obj in results:
  File \"/usr/lib/python2.7/dist-packages/awx/lib/site-packages/boto/route53/record.py\", line 187, in __iter__

...snip 110 lines...

  File \"/usr/lib/python2.7/dist-packages/awx/lib/site-packages/boto/route53/record.py\", line 187, in __iter__
    for obj in results:
  File \"/usr/lib/python2.7/dist-packages/awx/lib/site-packages/boto/route53/record.py\", line 193, in __iter__
    identifier=self.next_record_identifier)
  File \"/usr/lib/python2.7/dist-packages/awx/lib/site-packages/boto/route53/connection.py\", line 445, in get_all_rrsets
    body)
boto.route53.exception.DNSServerError: DNSServerError: 400 Bad Request
<?xml version=\"1.0\"?>
<ErrorResponse xmlns=\"https://route53.amazonaws.com/doc/2013-04-01/\"><Error><Type>Sender</Type><Code>Throttling</Code><Message>Rate exceeded</Message></Error><RequestId>77fedd87-faa8-11e6-9beb-f3d90ff717ab</RequestId></ErrorResponse>
", "module_stdout": "", "msg": "MODULE FAILURE", "parsed": false}
'''
