### PR TITLE
fix unquoted dict key in github_key.delete_keys

### DIFF
--- a/lib/ansible/modules/source_control/github_key.py
+++ b/lib/ansible/modules/source_control/github_key.py
@@ -169,7 +169,7 @@ def delete_keys(session, to_delete, check_mode):
         return
 
     for key in to_delete:
-        session.request('DELETE', API_BASE + '/user/keys/%s' % key[id])
+        session.request('DELETE', API_BASE + '/user/keys/%s' % key["id"])
 
 
 def ensure_key_absent(session, name, check_mode):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
github_key

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
A dictionary key in `delete_keys` was unquoted, resulting in a KeyError. Quoting this fixes the error and restore functionality.

Command:
```yaml
- name: Read SSH public key to authorize github
  shell: "cat ~/.ssh/{{ ansible_hostname }}.pub"
  become_user: "{{ item }}"
  when: ansible_hostname in groups['unix']
  with_items:
    - root
    - nihlaeth
  register: ssh_pub_key
- name: Authorize key with GitHub
  local_action:
    module: github_key
    name: "{{ ansible_hostname }}-{{ item.0 }}"
    token: '{{ github_access_token }}'
    pubkey: '{{ item.1 }}'
  become_user: "{{ item.0 }}"
  when:
    - ansible_hostname in groups['unix']
  with_together:
    - "{{ ['root', 'nihlaeth'] }}"
    - - "{{ ssh_pub_key.results[0].stdout }}"
      - "{{ ssh_pub_key.results[1].stdout }}"
  ignore_errors: yes
```
Before fix:
```
[WARNING]: Removed unexpected internal key in module return: _ansible_parsed = False

...ignoring
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_soYehs/ansible_module_github_key.py", line 247, in <module>
    main()
  File "/tmp/ansible_soYehs/ansible_module_github_key.py", line 237, in main
    check_mode=module.check_mode)
  File "/tmp/ansible_soYehs/ansible_module_github_key.py", line 188, in ensure_key_present
    delete_keys(session, matching_keys, check_mode=check_mode)
  File "/tmp/ansible_soYehs/ansible_module_github_key.py", line 172, in delete_keys
    session.request('DELETE', API_BASE + '/user/keys/%s' % key[id])
KeyError: <built-in function id>

failed: [dayea -> localhost] (item=[u'nihlaeth', u'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDd3ipOHOuOqt9Um/kBohQDhmzPUdZF3OVfMcRTO1ARVUPNKMWmjWN6uQYRKXK6VmwnkNhDXaBGWWfTDpQ4UHWAQ4pwOZzdQoOZtaD/tNqOpO9ovSvmZSjsU/INAwEwpn4XGdJMtZlj5oQtaTfKw0wDskwlnecNn60JB9VI1n5JSYrE6C5Drr9BV1d8EkZHV6hEJukjHs5gSi5XhEGRBQJpr8yQ7NQ244Jm890qs+npwXXDyuV7mcIvaT4zhVZd21UAQslqVFd396l1LxWOFLg6n6f7jXczi7ADAtiAIpkwArNjoU9MiWRLhEumipfmjyM7UMipiy6qXPJDUQKHrdnH ansible-generated on dayea']) => {
    "failed": true, 
    "item": [
        "nihlaeth", 
        "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDd3ipOHOuOqt9Um/kBohQDhmzPUdZF3OVfMcRTO1ARVUPNKMWmjWN6uQYRKXK6VmwnkNhDXaBGWWfTDpQ4UHWAQ4pwOZzdQoOZtaD/tNqOpO9ovSvmZSjsU/INAwEwpn4XGdJMtZlj5oQtaTfKw0wDskwlnecNn60JB9VI1n5JSYrE6C5Drr9BV1d8EkZHV6hEJukjHs5gSi5XhEGRBQJpr8yQ7NQ244Jm890qs+npwXXDyuV7mcIvaT4zhVZd21UAQslqVFd396l1LxWOFLg6n6f7jXczi7ADAtiAIpkwArNjoU9MiWRLhEumipfmjyM7UMipiy6qXPJDUQKHrdnH ansible-generated on dayea"
    ], 
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_soYehs/ansible_module_github_key.py\", line 247, in <module>\n    main()\n  File \"/tmp/ansible_soYehs/ansible_module_github_key.py\", line 237, in main\n    check_mode=module.check_mode)\n  File \"/tmp/ansible_soYehs/ansible_module_github_key.py\", line 188, in ensure_key_present\n    delete_keys(session, matching_keys, check_mode=check_mode)\n  File \"/tmp/ansible_soYehs/ansible_module_github_key.py\", line 172, in delete_keys\n    session.request('DELETE', API_BASE + '/user/keys/%s' % key[id])\nKeyError: <built-in function id>\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE", 
    "rc": 0
}
```
After fix:
```
ok: [dayea -> localhost] => (item=[u'nihlaeth', u'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn5YUpJTF2Plvc1sVW4TpXViYiNdboKzHyOKlpxtCmCr9wbh/9fsq+GDcrXfiqx+uMbTIHMceavQ4voYH15fP1wwYpGwS3pTeHHqwT7cWxvxrgBxRXBy4/lkIB+XDIp1I7cyAtVnWjqUFynh8xXnTbKcgX3NOQlW+fS+0cJ/PRXnObJx9nVuEJ0iDHc0efv2yOHqiQVNK/V1k+VoqfD6KYP6zpUvnAItR2FII5QQ3bVtVCWhcc9XCDn4lycYGQwAhqsPObNdsTriy1QfvYZnjM1rgNOKp5mTxEXbwOLSVJbPhu/TzissdpYSJ8Wt2Cpr8ejD7d2wERn71GpUXphwap ansible-generated on dayea']) => {
    "changed": false, 
    "deleted_keys": [], 
    "invocation": {
        "module_args": {
            "force": true, 
            "name": "dayea-nihlaeth", 
            "pubkey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn5YUpJTF2Plvc1sVW4TpXViYiNdboKzHyOKlpxtCmCr9wbh/9fsq+GDcrXfiqx+uMbTIHMceavQ4voYH15fP1wwYpGwS3pTeHHqwT7cWxvxrgBxRXBy4/lkIB+XDIp1I7cyAtVnWjqUFynh8xXnTbKcgX3NOQlW+fS+0cJ/PRXnObJx9nVuEJ0iDHc0efv2yOHqiQVNK/V1k+VoqfD6KYP6zpUvnAItR2FII5QQ3bVtVCWhcc9XCDn4lycYGQwAhqsPObNdsTriy1QfvYZnjM1rgNOKp5mTxEXbwOLSVJbPhu/TzissdpYSJ8Wt2Cpr8ejD7d2wERn71GpUXphwap ansible-generated on dayea", 
            "state": "present", 
            "token": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
        }
    }, 
    "item": [
        "nihlaeth", 
        "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn5YUpJTF2Plvc1sVW4TpXViYiNdboKzHyOKlpxtCmCr9wbh/9fsq+GDcrXfiqx+uMbTIHMceavQ4voYH15fP1wwYpGwS3pTeHHqwT7cWxvxrgBxRXBy4/lkIB+XDIp1I7cyAtVnWjqUFynh8xXnTbKcgX3NOQlW+fS+0cJ/PRXnObJx9nVuEJ0iDHc0efv2yOHqiQVNK/V1k+VoqfD6KYP6zpUvnAItR2FII5QQ3bVtVCWhcc9XCDn4lycYGQwAhqsPObNdsTriy1QfvYZnjM1rgNOKp5mTxEXbwOLSVJbPhu/TzissdpYSJ8Wt2Cpr8ejD7d2wERn71GpUXphwap ansible-generated on dayea"
    ], 
    "key": {
        "created_at": "2017-02-28T17:37:45Z", 
        "id": 21997916, 
        "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn5YUpJTF2Plvc1sVW4TpXViYiNdboKzHyOKlpxtCmCr9wbh/9fsq+GDcrXfiqx+uMbTIHMceavQ4voYH15fP1wwYpGwS3pTeHHqwT7cWxvxrgBxRXBy4/lkIB+XDIp1I7cyAtVnWjqUFynh8xXnTbKcgX3NOQlW+fS+0cJ/PRXnObJx9nVuEJ0iDHc0efv2yOHqiQVNK/V1k+VoqfD6KYP6zpUvnAItR2FII5QQ3bVtVCWhcc9XCDn4lycYGQwAhqsPObNdsTriy1QfvYZnjM1rgNOKp5mTxEXbwOLSVJbPhu/TzissdpYSJ8Wt2Cpr8ejD7d2wERn71GpUXphwap", 
        "read_only": false, 
        "title": "dayea-nihlaeth", 
        "url": "https://api.github.com/user/keys/21997916", 
        "verified": true
    }, 
    "matching_keys": [
        {
            "created_at": "2017-02-28T17:37:45Z", 
            "id": 21997916, 
            "key": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCn5YUpJTF2Plvc1sVW4TpXViYiNdboKzHyOKlpxtCmCr9wbh/9fsq+GDcrXfiqx+uMbTIHMceavQ4voYH15fP1wwYpGwS3pTeHHqwT7cWxvxrgBxRXBy4/lkIB+XDIp1I7cyAtVnWjqUFynh8xXnTbKcgX3NOQlW+fS+0cJ/PRXnObJx9nVuEJ0iDHc0efv2yOHqiQVNK/V1k+VoqfD6KYP6zpUvnAItR2FII5QQ3bVtVCWhcc9XCDn4lycYGQwAhqsPObNdsTriy1QfvYZnjM1rgNOKp5mTxEXbwOLSVJbPhu/TzissdpYSJ8Wt2Cpr8ejD7d2wERn71GpUXphwap", 
            "read_only": false, 
            "title": "dayea-nihlaeth", 
            "url": "https://api.github.com/user/keys/21997916", 
            "verified": true
        }
    ]
}
```
