### PR TITLE
docs: add missing colon character

### DIFF
--- a/docs/docsite/rst/playbooks_loops.rst
+++ b/docs/docsite/rst/playbooks_loops.rst
@@ -520,7 +520,7 @@ Subsequent loops over the registered variable to inspect the results may look li
       when: item.rc != 0
       with_items: "{{ echo.results }}"
 
-During iteration, the result of the current item will be placed in the variable:
+During iteration, the result of the current item will be placed in the variable::
 
     - shell: echo "{{ item }}"
       with_items:


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
`docs/docsite/rst/playbooks_loops.rst`

##### SUMMARY
Without the missing colon character, the code block that followed
wasn't rendering properly.

Signed-off-by: Micah Abbott <miabbott@redhat.com>
