### PR TITLE
Handle errors in jmespath in json_query better

### DIFF
--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -28,7 +28,7 @@ from functools import partial
 from jinja2.exceptions import UndefinedError
 
 from ansible.module_utils.six import iteritems, string_types, with_metaclass
-from ansible.errors import AnsibleParserError, AnsibleUndefinedVariable
+from ansible.errors import AnsibleParserError, AnsibleUndefinedVariable, AnsibleFilterError
 from ansible.module_utils._text import to_text
 from ansible.playbook.attribute import Attribute, FieldAttribute
 from ansible.parsing.dataloader import DataLoader
@@ -438,7 +438,6 @@ class Base(with_metaclass(BaseMeta, object)):
 
                 # and assign the massaged value back to the attribute field
                 setattr(self, name, value)
-
             except (TypeError, ValueError) as e:
                 raise AnsibleParserError("the field '%s' has an invalid value (%s), and could not be converted to an %s. "
                                          "The error was: %s" % (name, value, attribute.isa, e), obj=self.get_ds())

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -28,7 +28,7 @@ from functools import partial
 from jinja2.exceptions import UndefinedError
 
 from ansible.module_utils.six import iteritems, string_types, with_metaclass
-from ansible.errors import AnsibleParserError, AnsibleUndefinedVariable, AnsibleFilterError
+from ansible.errors import AnsibleParserError, AnsibleUndefinedVariable
 from ansible.module_utils._text import to_text
 from ansible.playbook.attribute import Attribute, FieldAttribute
 from ansible.parsing.dataloader import DataLoader

--- a/lib/ansible/plugins/filter/json_query.py
+++ b/lib/ansible/plugins/filter/json_query.py
@@ -18,9 +18,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.errors import AnsibleError
-from ansible.plugins.lookup import LookupBase
-from ansible.utils.listify import listify_lookup_plugin_terms
+from ansible.errors import AnsibleError, AnsibleFilterError
 
 try:
     import jmespath
@@ -37,7 +35,14 @@ def json_query(data, expr):
         raise AnsibleError('You need to install "jmespath" prior to running '
                            'json_query filter')
 
-    return jmespath.search(expr, data)
+    try:
+        return jmespath.search(expr, data)
+    except jmespath.exceptions.JMESPathError as e:
+        raise AnsibleFilterError('JMESPathError in json_query filter plugin:\n%s' % e)
+    except Exception as e:
+        # For older jmespath, we can get ValueError and TypeError without much info.
+        raise AnsibleFilterError('Error in jmespath.search in json_query filter plugin:\n%s' % e)
+
 
 
 class FilterModule(object):

--- a/lib/ansible/plugins/filter/json_query.py
+++ b/lib/ansible/plugins/filter/json_query.py
@@ -44,7 +44,6 @@ def json_query(data, expr):
         raise AnsibleFilterError('Error in jmespath.search in json_query filter plugin:\n%s' % e)
 
 
-
 class FilterModule(object):
     ''' Query filter '''
 

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -120,6 +120,20 @@
     that:
       - "users | json_query('[*].hosts[].host') == ['host_a', 'host_b', 'host_c', 'host_d']"
 
+- name: "20379 - set_fact app_var_git_branch "
+  set_fact:
+    app_var_git_branch: multi-deployment-400-743
+
+- name: "20379 - trigger a error in jmespath via json_query filter to test error handling"
+  debug:
+    msg: "{{ example_20379 | json_query('ApplicationVersions[].VersionLabel[] | [?starts_with(@, `multi`)]') }}"
+  ignore_errors: true
+
+- name: "20379 - Test errors related to https://github.com/ansible/ansible/issues/20379"
+  assert:
+    that: "example_20379 | json_query('ApplicationVersions[].VersionLabel[] | [?starts_with(@, '+app_var_git_branch+')] | [2:]') == multisdfsdf"
+  ignore_errors: true
+
 - name: Test hash filter
   assert:
     that:

--- a/test/integration/targets/filters/vars/main.yml
+++ b/test/integration/targets/filters/vars/main.yml
@@ -16,3 +16,103 @@ users:
       - host: host_c
         password: default
       - host: host_d
+
+other_data:
+  level1:
+    foo: bar
+    blip: baz
+    nested:
+        abc: def
+        ghi: xyz
+        alist:
+          - alpha
+          - beta
+          - charlie
+          - delta
+  level2:
+    asd: df
+    xc: dsdfsfsd
+    nested:
+      abc: foo
+      alist:
+        - zebra
+        - yellow
+        - xray
+
+# from https://github.com/ansible/ansible/issues/20379#issuecomment-280492883
+example_20379: {
+    "ApplicationVersions": [
+        {
+            "ApplicationName": "gitlab_ci_elasticbeanstalk",
+            "Status": "UNPROCESSED",
+            "VersionLabel": "test-npm-check-626-1313",
+            "Description": "bla",
+            "DateCreated": "2017-01-22T02:02:31.798Z",
+            "DateUpdated": "2017-01-22T02:02:31.798Z",
+            "SourceBundle": {
+                "S3Bucket": "bla",
+                "S3Key": "ci/beanstalk/gitlab_ci_elasticbeanstalk/gitlab_ci_elasticbeanstalk-626-1313.war"
+            }
+        },
+        {
+            "ApplicationName": "gitlab_ci_elasticbeanstalk",
+            "Status": "UNPROCESSED",
+            "VersionLabel": "terminate-611-1289",
+            "Description": "bla",
+            "DateCreated": "2017-01-20T00:34:29.864Z",
+            "DateUpdated": "2017-01-20T00:34:29.864Z",
+            "SourceBundle": {
+                "S3Bucket": "bla",
+                "S3Key": "ci/beanstalk/gitlab_ci_elasticbeanstalk/gitlab_ci_elasticbeanstalk-611-1289.war"
+            }
+        },
+        {
+            "ApplicationName": "gitlab_ci_elasticbeanstalk",
+            "Status": "UNPROCESSED",
+            "VersionLabel": "terminate-610-1286",
+            "Description": "bla",
+            "DateCreated": "2017-01-20T00:22:02.229Z",
+            "DateUpdated": "2017-01-20T00:22:02.229Z",
+            "SourceBundle": {
+                "S3Bucket": "bla",
+                "S3Key": "ci/beanstalk/gitlab_ci_elasticbeanstalk/gitlab_ci_elasticbeanstalk-610-1286.war"
+            }
+        },
+        {
+            "ApplicationName": "gitlab_ci_elasticbeanstalk",
+            "Status": "UNPROCESSED",
+            "VersionLabel": "master-609-1284",
+            "Description": "bla",
+            "DateCreated": "2017-01-19T23:54:32.902Z",
+            "DateUpdated": "2017-01-19T23:54:32.902Z",
+            "SourceBundle": {
+                "S3Bucket": "bla",
+                "S3Key": "ci/beanstalk/gitlab_ci_elasticbeanstalk/gitlab_ci_elasticbeanstalk-609-1284.war"
+            }
+        },
+        {
+            "ApplicationName": "gitlab_ci_elasticbeanstalk",
+            "Status": "UNPROCESSED",
+            "VersionLabel": "master-608-1282",
+            "Description": "bla",
+            "DateCreated": "2017-01-19T23:02:44.902Z",
+            "DateUpdated": "2017-01-19T23:02:44.902Z",
+            "SourceBundle": {
+                "S3Bucket": "bla",
+                "S3Key": "ci/beanstalk/gitlab_ci_elasticbeanstalk/gitlab_ci_elasticbeanstalk-608-1282.war"
+            }
+        },
+        {
+            "ApplicationName": "gitlab_ci_elasticbeanstalk",
+            "Status": "UNPROCESSED",
+            "VersionLabel": "master-606-1278",
+            "Description": "bla'",
+            "DateCreated": "2017-01-19T22:47:57.741Z",
+            "DateUpdated": "2017-01-19T22:47:57.741Z",
+            "SourceBundle": {
+                "S3Bucket": "bla",
+                "S3Key": "ci/beanstalk/gitlab_ci_elasticbeanstalk/gitlab_ci_elasticbeanstalk-606-1278.war"
+            }
+        }
+    ]
+}


### PR DESCRIPTION

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/filter/json_query.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (json_query_20379 4538e66685) last updated 2017/02/28 16:52:46 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']

```

##### SUMMARY
Catch any exceptions raised from jmespath and raise
an AnsibleFilterError instead.

Avoid a traceback.

Fixes #20379

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
