### PR TITLE
Renamed the avi_ansible_utils to avi. Fixed the import error and clea…

### DIFF
--- a/lib/ansible/module_utils/avi.py
+++ b/lib/ansible/module_utils/avi.py
@@ -29,10 +29,10 @@
 
 # This module initially matched the namespace of network module avi. However,
 # that causes namespace import error when other modules from avi namespaces
-# are imported. In order to avoid the import collisions this was renamed to
-# avi_ansible_utils to allow this module to be ceterpiece of all integration
-# with external avi modules.
+# are imported. Added import of absolute_import to avoid import collisions for
+# avi.sdk.
 
+from __future__ import absolute_import
 import os
 from pkg_resources import parse_version
 

--- a/lib/ansible/modules/network/avi/avi_analyticsprofile.py
+++ b/lib/ansible/modules/network/avi/avi_analyticsprofile.py
@@ -389,19 +389,11 @@ obj:
     type: dict
 '''
 
-from pkg_resources import parse_version
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.avi import avi_common_argument_spec
 
-HAS_AVI = True
 try:
-    import avi.sdk
-    sdk_version = getattr(avi.sdk, '__version__', None)
-    if ((sdk_version is None) or (sdk_version and
-            (parse_version(sdk_version) < parse_version('16.3.5.post1')))):
-        # It allows the __version__ to be '' as that value is used in development builds
-        raise ImportError
-    from avi.sdk.utils.ansible_utils import avi_ansible_api
+    from ansible.module_utils.avi import (
+        avi_common_argument_spec, HAS_AVI, avi_ansible_api)
 except ImportError:
     HAS_AVI = False
 

--- a/lib/ansible/modules/network/avi/avi_api_session.py
+++ b/lib/ansible/modules/network/avi/avi_api_session.py
@@ -119,7 +119,7 @@ from ansible.module_utils.basic import AnsibleModule
 from copy import deepcopy
 
 try:
-    from ansible.module_utils.avi_ansible_utils import (
+    from ansible.module_utils.avi import (
         avi_common_argument_spec, ansible_return, HAS_AVI)
     from avi.sdk.avi_api import ApiSession
     from avi.sdk.utils.ansible_utils import avi_obj_cmp, cleanup_absent_fields

--- a/lib/ansible/modules/network/avi/avi_applicationpersistenceprofile.py
+++ b/lib/ansible/modules/network/avi/avi_applicationpersistenceprofile.py
@@ -113,19 +113,11 @@ obj:
     type: dict
 '''
 
-from pkg_resources import parse_version
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.avi import avi_common_argument_spec
 
-HAS_AVI = True
 try:
-    import avi.sdk
-    sdk_version = getattr(avi.sdk, '__version__', None)
-    if ((sdk_version is None) or (sdk_version and
-            (parse_version(sdk_version) < parse_version('16.3.5.post1')))):
-        # It allows the __version__ to be '' as that value is used in development builds
-        raise ImportError
-    from avi.sdk.utils.ansible_utils import avi_ansible_api
+    from ansible.module_utils.avi import (
+        avi_common_argument_spec, HAS_AVI, avi_ansible_api)
 except ImportError:
     HAS_AVI = False
 

--- a/lib/ansible/modules/network/avi/avi_applicationprofile.py
+++ b/lib/ansible/modules/network/avi/avi_applicationprofile.py
@@ -152,19 +152,11 @@ obj:
     type: dict
 '''
 
-from pkg_resources import parse_version
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.avi import avi_common_argument_spec
 
-HAS_AVI = True
 try:
-    import avi.sdk
-    sdk_version = getattr(avi.sdk, '__version__', None)
-    if ((sdk_version is None) or (sdk_version and
-            (parse_version(sdk_version) < parse_version('16.3.5.post1')))):
-        # It allows the __version__ to be '' as that value is used in development builds
-        raise ImportError
-    from avi.sdk.utils.ansible_utils import avi_ansible_api
+    from ansible.module_utils.avi import (
+        avi_common_argument_spec, HAS_AVI, avi_ansible_api)
 except ImportError:
     HAS_AVI = False
 

--- a/lib/ansible/modules/network/avi/avi_certificatemanagementprofile.py
+++ b/lib/ansible/modules/network/avi/avi_certificatemanagementprofile.py
@@ -83,19 +83,11 @@ obj:
     type: dict
 '''
 
-from pkg_resources import parse_version
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.avi import avi_common_argument_spec
 
-HAS_AVI = True
 try:
-    import avi.sdk
-    sdk_version = getattr(avi.sdk, '__version__', None)
-    if ((sdk_version is None) or (sdk_version and
-            (parse_version(sdk_version) < parse_version('16.3.5.post1')))):
-        # It allows the __version__ to be '' as that value is used in development builds
-        raise ImportError
-    from avi.sdk.utils.ansible_utils import avi_ansible_api
+    from ansible.module_utils.avi import (
+        avi_common_argument_spec, HAS_AVI, avi_ansible_api)
 except ImportError:
     HAS_AVI = False
 

--- a/lib/ansible/modules/network/avi/avi_healthmonitor.py
+++ b/lib/ansible/modules/network/avi/avi_healthmonitor.py
@@ -135,7 +135,7 @@ obj:
 from ansible.module_utils.basic import AnsibleModule
 
 try:
-    from ansible.module_utils.avi_ansible_utils import (
+    from ansible.module_utils.avi import (
         avi_common_argument_spec, HAS_AVI, avi_ansible_api)
 except ImportError:
     HAS_AVI = False

--- a/lib/ansible/modules/network/avi/avi_networkprofile.py
+++ b/lib/ansible/modules/network/avi/avi_networkprofile.py
@@ -89,19 +89,11 @@ obj:
     type: dict
 '''
 
-from pkg_resources import parse_version
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.avi import avi_common_argument_spec
 
-HAS_AVI = True
 try:
-    import avi.sdk
-    sdk_version = getattr(avi.sdk, '__version__', None)
-    if ((sdk_version is None) or (sdk_version and
-            (parse_version(sdk_version) < parse_version('16.3.5.post1')))):
-        # It allows the __version__ to be '' as that value is used in development builds
-        raise ImportError
-    from avi.sdk.utils.ansible_utils import avi_ansible_api
+    from ansible.module_utils.avi import (
+        avi_common_argument_spec, HAS_AVI, avi_ansible_api)
 except ImportError:
     HAS_AVI = False
 

--- a/lib/ansible/modules/network/avi/avi_pkiprofile.py
+++ b/lib/ansible/modules/network/avi/avi_pkiprofile.py
@@ -99,19 +99,11 @@ obj:
     type: dict
 '''
 
-from pkg_resources import parse_version
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.avi import avi_common_argument_spec
 
-HAS_AVI = True
 try:
-    import avi.sdk
-    sdk_version = getattr(avi.sdk, '__version__', None)
-    if ((sdk_version is None) or (sdk_version and
-            (parse_version(sdk_version) < parse_version('16.3.5.post1')))):
-        # It allows the __version__ to be '' as that value is used in development builds
-        raise ImportError
-    from avi.sdk.utils.ansible_utils import avi_ansible_api
+    from ansible.module_utils.avi import (
+        avi_common_argument_spec, HAS_AVI, avi_ansible_api)
 except ImportError:
     HAS_AVI = False
 

--- a/lib/ansible/modules/network/avi/avi_pool.py
+++ b/lib/ansible/modules/network/avi/avi_pool.py
@@ -291,7 +291,7 @@ obj:
 from ansible.module_utils.basic import AnsibleModule
 
 try:
-    from ansible.module_utils.avi_ansible_utils import (
+    from ansible.module_utils.avi import (
         avi_common_argument_spec, HAS_AVI, avi_ansible_api)
 except ImportError:
     HAS_AVI = False

--- a/lib/ansible/modules/network/avi/avi_poolgroup.py
+++ b/lib/ansible/modules/network/avi/avi_poolgroup.py
@@ -112,7 +112,7 @@ obj:
 from ansible.module_utils.basic import AnsibleModule
 
 try:
-    from ansible.module_utils.avi_ansible_utils import (
+    from ansible.module_utils.avi import (
         avi_common_argument_spec, HAS_AVI, avi_ansible_api)
 except ImportError:
     HAS_AVI = False

--- a/lib/ansible/modules/network/avi/avi_role.py
+++ b/lib/ansible/modules/network/avi/avi_role.py
@@ -79,19 +79,11 @@ obj:
     type: dict
 '''
 
-from pkg_resources import parse_version
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.avi import avi_common_argument_spec
 
-HAS_AVI = True
 try:
-    import avi.sdk
-    sdk_version = getattr(avi.sdk, '__version__', None)
-    if ((sdk_version is None) or (sdk_version and
-            (parse_version(sdk_version) < parse_version('16.3.5.post1')))):
-        # It allows the __version__ to be '' as that value is used in development builds
-        raise ImportError
-    from avi.sdk.utils.ansible_utils import avi_ansible_api
+    from ansible.module_utils.avi import (
+        avi_common_argument_spec, HAS_AVI, avi_ansible_api)
 except ImportError:
     HAS_AVI = False
 

--- a/lib/ansible/modules/network/avi/avi_sslkeyandcertificate.py
+++ b/lib/ansible/modules/network/avi/avi_sslkeyandcertificate.py
@@ -130,7 +130,7 @@ obj:
 from ansible.module_utils.basic import AnsibleModule
 
 try:
-    from ansible.module_utils.avi_ansible_utils import (
+    from ansible.module_utils.avi import (
         avi_common_argument_spec, HAS_AVI, avi_ansible_api)
 except ImportError:
     HAS_AVI = False

--- a/lib/ansible/modules/network/avi/avi_sslprofile.py
+++ b/lib/ansible/modules/network/avi/avi_sslprofile.py
@@ -150,19 +150,11 @@ obj:
     type: dict
 '''
 
-from pkg_resources import parse_version
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.avi import avi_common_argument_spec
 
-HAS_AVI = True
 try:
-    import avi.sdk
-    sdk_version = getattr(avi.sdk, '__version__', None)
-    if ((sdk_version is None) or (sdk_version and
-            (parse_version(sdk_version) < parse_version('16.3.5.post1')))):
-        # It allows the __version__ to be '' as that value is used in development builds
-        raise ImportError
-    from avi.sdk.utils.ansible_utils import avi_ansible_api
+    from ansible.module_utils.avi import (
+        avi_common_argument_spec, HAS_AVI, avi_ansible_api)
 except ImportError:
     HAS_AVI = False
 

--- a/lib/ansible/modules/network/avi/avi_systemconfiguration.py
+++ b/lib/ansible/modules/network/avi/avi_systemconfiguration.py
@@ -106,7 +106,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = """
-- name: Example Adds/Deletes SystemConfiguration configuration from Avi Controller
+- name: Example to create SystemConfiguration object
   avi_systemconfiguration:
     controller: 10.10.25.42
     username: admin
@@ -122,19 +122,11 @@ obj:
     type: dict
 '''
 
-from pkg_resources import parse_version
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.avi import avi_common_argument_spec
 
-HAS_AVI = True
 try:
-    import avi.sdk
-    sdk_version = getattr(avi.sdk, '__version__', None)
-    if ((sdk_version is None) or (sdk_version and
-            (parse_version(sdk_version) < parse_version('16.3.5.post1')))):
-        # It allows the __version__ to be '' as that value is used in development builds
-        raise ImportError
-    from avi.sdk.utils.ansible_utils import avi_ansible_api
+    from ansible.module_utils.avi import (
+        avi_common_argument_spec, HAS_AVI, avi_ansible_api)
 except ImportError:
     HAS_AVI = False
 

--- a/lib/ansible/modules/network/avi/avi_tenant.py
+++ b/lib/ansible/modules/network/avi/avi_tenant.py
@@ -91,19 +91,11 @@ obj:
     type: dict
 '''
 
-from pkg_resources import parse_version
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.avi import avi_common_argument_spec
 
-HAS_AVI = True
 try:
-    import avi.sdk
-    sdk_version = getattr(avi.sdk, '__version__', None)
-    if ((sdk_version is None) or (sdk_version and
-            (parse_version(sdk_version) < parse_version('16.3.5.post1')))):
-        # It allows the __version__ to be '' as that value is used in development builds
-        raise ImportError
-    from avi.sdk.utils.ansible_utils import avi_ansible_api
+    from ansible.module_utils.avi import (
+        avi_common_argument_spec, HAS_AVI, avi_ansible_api)
 except ImportError:
     HAS_AVI = False
 

--- a/lib/ansible/modules/network/avi/avi_virtualservice.py
+++ b/lib/ansible/modules/network/avi/avi_virtualservice.py
@@ -355,7 +355,7 @@ obj:
 from ansible.module_utils.basic import AnsibleModule
 
 try:
-    from ansible.module_utils.avi_ansible_utils import (
+    from ansible.module_utils.avi import (
         avi_common_argument_spec, HAS_AVI, avi_ansible_api)
 except ImportError:
     HAS_AVI = False

--- a/test/compile/python2.4-skip.txt
+++ b/test/compile/python2.4-skip.txt
@@ -32,6 +32,7 @@
 /lib/ansible/modules/web_infrastructure/ansible_tower/
 /lib/ansible/module_utils/a10.py
 /lib/ansible/module_utils/ansible_tower.py
+/lib/ansible/module_utils/avi.py
 /lib/ansible/module_utils/azure_rm_common.py
 /lib/ansible/module_utils/cloud.py
 /lib/ansible/module_utils/docker_common.py


### PR DESCRIPTION
…ned up code.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils.avi_ansible_utils

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = /home/grastogi/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Renamed module_utils.avi_ansible_utils back to module_utils.avi. Fixed the import collision for avi.sdk issue by importing absolute_import.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
