### PR TITLE
ovirt and rhevm are (sort of?) deprecated, point to ovirt_vms

### DIFF
--- a/lib/ansible/modules/cloud/misc/ovirt.py
+++ b/lib/ansible/modules/cloud/misc/ovirt.py
@@ -27,7 +27,8 @@ module: ovirt
 author: "Vincent Van der Kussen (@vincentvdk)"
 short_description: oVirt/RHEV platform management
 description:
-    - allows you to create new instances, either from scratch or an image, in addition to deleting or stopping instances on the oVirt/RHEV platform
+    - This module only supports oVirt/RHEV version 3. A newer module M(ovirt_vms) supports oVirt/RHV version 4.
+    - Allows you to create new instances, either from scratch or an image, in addition to deleting or stopping instances on the oVirt/RHEV platform.
 version_added: "1.4"
 options:
   user:

--- a/lib/ansible/modules/cloud/misc/rhevm.py
+++ b/lib/ansible/modules/cloud/misc/rhevm.py
@@ -27,6 +27,7 @@ module: rhevm
 author: Timothy Vandenbrande
 short_description: RHEV/oVirt automation
 description:
+    - This module only supports oVirt/RHEV version 3. A newer module M(ovirt_vms) supports oVirt/RHV version 4.
     - Allows you to create/remove/update or powermanage virtual machines on a RHEV/oVirt platform.
 version_added: "2.2"
 requirements:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt
rhevm

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This patch adds a note that the modules `ovirt` and `rhevm` was replaced by new `ovirt_vms` module.