### PR TITLE
Change `OS` to `VyOS` in vyos_facts module's short description.

### DIFF
--- a/lib/ansible/modules/network/vyos/vyos_facts.py
+++ b/lib/ansible/modules/network/vyos/vyos_facts.py
@@ -26,7 +26,7 @@ DOCUMENTATION = """
 module: vyos_facts
 version_added: "2.2"
 author: "Nathaniel Case (@qalthos)"
-short_description: Collect facts from remote devices running OS
+short_description: Collect facts from remote devices running VyOS
 description:
   - Collects a base set of device facts from a remote device that
     is running VyOS.  This module prepends all of the


### PR DESCRIPTION
	modified:   lib/ansible/modules/network/vyos/vyos_facts.py

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
vyos_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The short description says 

> Collect facts from remote devices running OS

since module creation but I think what was meant is

> Collect facts from remote devices running VyOS

Anyway it is more precise.
