### PR TITLE
Windows module win_get_url uses proxy when "force: no" used

### DIFF
--- a/lib/ansible/modules/windows/win_get_url.ps1
+++ b/lib/ansible/modules/windows/win_get_url.ps1
@@ -81,6 +81,14 @@ Else {
 
     Try {
         $webRequest = [System.Net.HttpWebRequest]::Create($url)
+        if ($proxy_url) {
+          $proxy_server = New-Object System.Net.WebProxy($proxy_url, $true)
+          if ($proxy_username -and $proxy_password) {
+            $proxy_credential = New-Object System.Net.NetworkCredential($proxy_username, $proxy_password)
+            $proxy_server.Credentials = $proxy_credential
+          }
+          $webRequest.Proxy = $proxy_server
+        }
 
         if($username -and $password){
             $webRequest.Credentials = New-Object System.Net.NetworkCredential($username, $password)


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
windows/win_get_url

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (win_get_url_force_with_proxy 76c46e9039) last updated 2017/03/01 12:57:19 (GMT +300)
  config file = /home/art/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add proxy support proxy when `force: no` setting used:
```
- name: Download earthrise.jpg to specified path through a proxy server only if modified.
  win_get_url:
    url: http://www.example.com/earthrise.jpg
    dest: C:\Users\RandomUser\earthrise.jpg
    force: no
    proxy_url: http://10.0.0.1:8080
    proxy_username: username
    proxy_password: password
```

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
