### PR TITLE
Fix #22130 (ini_file crash when destination file don't exists or is e…

### DIFF
--- a/lib/ansible/modules/files/ini_file.py
+++ b/lib/ansible/modules/files/ini_file.py
@@ -178,8 +178,8 @@ def do_ini(module, filename, section=None, option=None, value=None,
 
     # ini file could be empty
     if not ini_lines:
-      ini_lines.append('\n')
-    
+        ini_lines.append('\n')
+
     # last line of file may not contain a trailing newline
     if ini_lines[-1] == "" or ini_lines[-1][-1] != '\n':
         ini_lines[-1] += '\n'

--- a/lib/ansible/modules/files/ini_file.py
+++ b/lib/ansible/modules/files/ini_file.py
@@ -176,6 +176,10 @@ def do_ini(module, filename, section=None, option=None, value=None,
 
     changed = False
 
+    # ini file could be empty
+    if not ini_lines:
+      ini_lines.append('\n')
+    
     # last line of file may not contain a trailing newline
     if ini_lines[-1] == "" or ini_lines[-1][-1] != '\n':
         ini_lines[-1] += '\n'


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ini_file

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (ini_file_bug 9e62cbcd43) last updated 2017/03/01 12:40:49 (GMT +200)
  config file = /home/ben/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Just add \n line in the ini_lines list before the line that throw "IndexError: list index out of range" error.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #22130

