### PR TITLE
iosxr tests: result.commands (not .updates)

### DIFF
--- a/test/integration/targets/iosxr_config/tests/cli/sublevel.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/sublevel.yaml
@@ -16,8 +16,8 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'ipv4 access-list test' in result.updates"
-      - "'10 permit ipv4 any any log' in result.updates"
+      - "'ipv4 access-list test' in result.commands"
+      - "'10 permit ipv4 any any log' in result.commands"
 
 - name: configure sub level command idempotent check
   iosxr_config:

--- a/test/integration/targets/iosxr_config/tests/cli/sublevel_block.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/sublevel_block.yaml
@@ -27,11 +27,11 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'ipv4 access-list test' in result.updates"
-      - "'10 permit ipv4 host 1.1.1.1 any log' in result.updates"
-      - "'20 permit ipv4 host 2.2.2.2 any log' in result.updates"
-      - "'30 permit ipv4 host 3.3.3.3 any log' in result.updates"
-      - "'40 permit ipv4 host 4.4.4.4 any log' in result.updates"
+      - "'ipv4 access-list test' in result.commands"
+      - "'10 permit ipv4 host 1.1.1.1 any log' in result.commands"
+      - "'20 permit ipv4 host 2.2.2.2 any log' in result.commands"
+      - "'30 permit ipv4 host 3.3.3.3 any log' in result.commands"
+      - "'40 permit ipv4 host 4.4.4.4 any log' in result.commands"
 
 - name: check sub level command using block replace
   iosxr_config:

--- a/test/integration/targets/iosxr_config/tests/cli/sublevel_exact.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/sublevel_exact.yaml
@@ -29,12 +29,12 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'ipv4 access-list test' in result.updates"
-      - "'10 permit ipv4 host 1.1.1.1 any log' in result.updates"
-      - "'20 permit ipv4 host 2.2.2.2 any log' in result.updates"
-      - "'30 permit ipv4 host 3.3.3.3 any log' in result.updates"
-      - "'40 permit ipv4 host 4.4.4.4 any log' in result.updates"
-      - "'50 permit ipv4 host 5.5.5.5 any log' not in result.updates"
+      - "'ipv4 access-list test' in result.commands"
+      - "'10 permit ipv4 host 1.1.1.1 any log' in result.commands"
+      - "'20 permit ipv4 host 2.2.2.2 any log' in result.commands"
+      - "'30 permit ipv4 host 3.3.3.3 any log' in result.commands"
+      - "'40 permit ipv4 host 4.4.4.4 any log' in result.commands"
+      - "'50 permit ipv4 host 5.5.5.5 any log' not in result.commands"
 
 - name: check sub level command using exact match
   iosxr_config:

--- a/test/integration/targets/iosxr_config/tests/cli/sublevel_strict.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/sublevel_strict.yaml
@@ -31,12 +31,12 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'ipv4 access-list test' in result.updates"
-      - "'10 permit ipv4 host 1.1.1.1 any log' in result.updates"
-      - "'20 permit ipv4 host 2.2.2.2 any log' in result.updates"
-      - "'30 permit ipv4 host 3.3.3.3 any log' in result.updates"
-      - "'40 permit ipv4 host 4.4.4.4 any log' in result.updates"
-      - "'50 permit ipv4 host 5.5.5.5 any log' not in result.updates"
+      - "'ipv4 access-list test' in result.commands"
+      - "'10 permit ipv4 host 1.1.1.1 any log' in result.commands"
+      - "'20 permit ipv4 host 2.2.2.2 any log' in result.commands"
+      - "'30 permit ipv4 host 3.3.3.3 any log' in result.commands"
+      - "'40 permit ipv4 host 4.4.4.4 any log' in result.commands"
+      - "'50 permit ipv4 host 5.5.5.5 any log' not in result.commands"
 
 - name: check sub level command using strict match
   iosxr_config:

--- a/test/integration/targets/iosxr_config/tests/cli/toplevel.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/toplevel.yaml
@@ -14,7 +14,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'hostname foo' in result.updates"
+      - "'hostname foo' in result.commands"
 
 - name: configure top level command idempotent check
   iosxr_config:

--- a/test/integration/targets/iosxr_config/tests/cli/toplevel_after.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/toplevel_after.yaml
@@ -17,8 +17,8 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'hostname foo' in result.updates"
-      - "'cdp' in result.updates"
+      - "'hostname foo' in result.commands"
+      - "'cdp' in result.commands"
 
 - name: configure top level command with before idempotent check
   iosxr_config:

--- a/test/integration/targets/iosxr_config/tests/cli/toplevel_before.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/toplevel_before.yaml
@@ -17,8 +17,8 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'hostname foo' in result.updates"
-      - "'cdp' in result.updates"
+      - "'hostname foo' in result.commands"
+      - "'cdp' in result.commands"
 
 - name: configure top level command with before idempotent check
   iosxr_config:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
iosxr_config
iosxr_template

##### ANSIBLE VERSION
```
ansible 2.3.0 (test-iosxr b3592c18a2) last updated 2017/03/01 12:55:27 (GMT +100)
```

##### SUMMARY
We use `.commands` now

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/22139)
<!-- Reviewable:end -->
