### PR TITLE
Ansible Tower job cancel module

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_cancel.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_cancel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #coding: utf-8 -*-
 
 # (c) 2017, Wayne Witzel III <wayne@riotousliving.com>

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_cancel.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_cancel.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+#coding: utf-8 -*-
+
+# (c) 2017, Wayne Witzel III <wayne@riotousliving.com>
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = '''
+---
+module: tower_job_cancel
+version_added: "2.3"
+short_description: Cancel an Ansible Tower Job.
+description:
+    - Cancel Ansible Tower jobs. See
+      U(https://www.ansible.com/tower) for an overview.
+options:
+    job_id:
+      description:
+        - ID of the job to cancel
+      required: True
+    fail_if_not_running:
+      description:
+        - Fail loudly if the job_id does not reference a running job.
+      default: False
+extends_documentation_fragment: tower
+'''
+
+EXAMPLES = '''
+- name: Cancel job
+  tower_job_cancel:
+    job_id: job.id
+'''
+
+RETURN = '''
+id:
+    description: job id requesting to cancel
+    returned: success
+    type: int
+    sample: 94
+status:
+    description: status of the cancel request
+    returned: success
+    type: string
+    sample: canceled
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+
+try:
+    import tower_cli
+    import tower_cli.utils.exceptions as exc
+
+    from tower_cli.conf import settings
+    from ansible.module_utils.ansible_tower import (
+        tower_auth_config,
+        tower_check_mode,
+        tower_argument_spec,
+    )
+
+    HAS_TOWER_CLI = True
+except ImportError:
+    HAS_TOWER_CLI = False
+
+
+def main():
+    argument_spec = tower_argument_spec()
+    argument_spec.update(dict(
+        job_id = dict(type='int', required=True),
+        fail_if_not_running = dict(type='bool', default=False),
+    ))
+
+    module = AnsibleModule(
+        argument_spec = argument_spec,
+        supports_check_mode=True,
+    )
+
+    if not HAS_TOWER_CLI:
+        module.fail_json(msg='ansible-tower-cli required for this module')
+
+    job_id = module.params.get('job_id')
+    json_output = {}
+
+    tower_auth = tower_auth_config(module)
+    with settings.runtime_values(**tower_auth):
+        tower_check_mode(module)
+        job = tower_cli.get_resource('job')
+        params = module.params.copy()
+
+        try:
+            result = job.cancel(job_id, **params)
+            json_output['id'] = job_id
+        except (exc.ConnectionError, exc.BadRequest, exc.TowerCLIError) as excinfo:
+            module.fail_json(msg='Unable to cancel job_id/{0}: {1}'.format(job_id, excinfo), changed=False)
+
+    json_output['changed'] = result['changed']
+    json_output['status'] = result['status']
+    module.exit_json(**json_output)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Ansible Tower job cancel module (tower_job_cancel)

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (tower_module_job_wait 5cad32e3e1) last updated 2017/03/01 15:29:19 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Allows playbook authors to cancel Tower jobs.
