### PR TITLE
win_chocolatey: Add example to upgrade all installed software

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -106,19 +106,25 @@ EXAMPLES = r'''
   # Install git
   win_chocolatey:
     name: git
+    state: present
+
+  # Upgrade installed packages
+  win_chocolatey:
+    name: all
+    state: latest
 
   # Install notepadplusplus version 6.6
   win_chocolatey:
     name: notepadplusplus.install
     version: '6.6'
 
-  # Uninstall git
-  win_chocolatey:
-    name: git
-    state: absent
-
   # Install git from specified repository
   win_chocolatey:
     name: git
     source: https://someserver/api/v2/
+
+  # Uninstall git
+  win_chocolatey:
+    name: git
+    state: absent
 '''


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
chocolatey

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Add a missing example on how to upgrade all installed software using win_chocolatey.

I also logically re-ordered the examples, so removing packages is the last example listed.

This fixes #21559