### PR TITLE
Support ansible commands in sanity tests.

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -769,9 +769,11 @@ def command_sanity_code_smell(args, _):
                    and os.path.isfile(p)
                    and os.path.basename(p) not in skip_tests)
 
+    env = ansible_environment(args)
+
     for test in tests:
         display.info('Code smell check using %s' % os.path.basename(test))
-        run_command(args, [test])
+        run_command(args, [test], env=env)
 
 
 def command_sanity_validate_modules(args, targets):


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (sanity-env 85e15516ab) last updated 2017/03/01 15:24:27 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY

Support ansible commands in sanity tests.