### PR TITLE
win_reboot: Implement transport_test and win_ping test

### DIFF
--- a/lib/ansible/modules/windows/win_reboot.py
+++ b/lib/ansible/modules/windows/win_reboot.py
@@ -53,7 +53,7 @@ options:
   test_command:
     description:
     - Command to expect success for to determine the machine is ready for management
-    default: whoami
+    - By default C(win_reboot) will try the M(win_ping) module for determining end-to-end connectivity
   msg:
     description:
     - Message to display to users
@@ -86,4 +86,10 @@ rebooted:
     returned: always
     type: boolean
     sample: true
+
+elapsed:
+  description: The number of seconds that elapsed waiting for the system to be rebooted.
+  returned: always
+  type: integer
+  sample: 23
 '''

--- a/lib/ansible/modules/windows/win_reboot.py
+++ b/lib/ansible/modules/windows/win_reboot.py
@@ -23,7 +23,6 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['stableinterface'],
                     'supported_by': 'core'}
 
-
 DOCUMENTATION = r'''
 ---
 module: win_reboot
@@ -41,7 +40,7 @@ options:
     - Seconds to wait after the reboot was successful and the connection was re-established
     - This is useful if you want wait for something to settle despite your connection already working
     default: 0
-    version_added: '2.3'
+    version_added: '2.4'
   shutdown_timeout_sec:
     description:
     - Maximum seconds to wait for shutdown to occur
@@ -96,6 +95,6 @@ rebooted:
 elapsed:
   description: The number of seconds that elapsed waiting for the system to be rebooted.
   returned: always
-  type: integer
+  type: int
   sample: 23
 '''

--- a/lib/ansible/modules/windows/win_reboot.py
+++ b/lib/ansible/modules/windows/win_reboot.py
@@ -36,6 +36,12 @@ options:
     description:
     - Seconds for shutdown to wait before requesting reboot
     default: 2
+  post_reboot_delay_sec:
+    description:
+    - Seconds to wait after the reboot was successful and the connection was re-established
+    - This is useful if you want wait for something to settle despite your connection already working
+    default: 0
+    version_added: '2.3'
   shutdown_timeout_sec:
     description:
     - Maximum seconds to wait for shutdown to occur

--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -22,7 +22,6 @@ __metaclass__ = type
 import time
 from datetime import datetime, timedelta
 
-from ansible.module_utils.pycompat24 import get_exception
 from ansible.plugins.action import ActionBase
 
 try:
@@ -53,13 +52,12 @@ class ActionModule(ActionBase):
                 if what_desc:
                     display.debug("wait_for_connection: %s success" % what_desc)
                 return
-            except Exception:
-                e = get_exception()
+            except Exception as e:
                 if what_desc:
                     display.debug("wait_for_connection: %s fail (expected), retrying in %d seconds..." % (what_desc, sleep))
                 time.sleep(sleep)
 
-        raise TimedOutException("timed out waiting for %s: %s" % (what_desc, str(e)))
+        raise TimedOutException("timed out waiting for %s: %s" % (what_desc, e))
 
     def run(self, tmp=None, task_vars=None):
         if task_vars is None:
@@ -108,8 +106,7 @@ class ActionModule(ActionBase):
             # Use the ping module test to determine end-to-end connectivity
             self.do_until_success_or_timeout(ping_module_test, timeout, connect_timeout, what_desc="ping module test success", sleep=sleep)
 
-        except TimedOutException:
-            e = get_exception()
+        except TimedOutException as e:
             result['failed'] = True
             result['msg'] = str(e)
 

--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -46,6 +46,7 @@ class ActionModule(ActionBase):
     def do_until_success_or_timeout(self, what, timeout, connect_timeout, what_desc, sleep=1):
         max_end_time = datetime.utcnow() + timedelta(seconds=timeout)
 
+        e = None
         while datetime.utcnow() < max_end_time:
             try:
                 what(connect_timeout)

--- a/lib/ansible/plugins/action/win_reboot.py
+++ b/lib/ansible/plugins/action/win_reboot.py
@@ -42,12 +42,14 @@ class ActionModule(ActionBase):
     DEFAULT_REBOOT_TIMEOUT_SEC = 600
     DEFAULT_CONNECT_TIMEOUT_SEC = 5
     DEFAULT_PRE_REBOOT_DELAY_SEC = 2
-    DEFAULT_TEST_COMMAND = None
+    DEFAULT_POST_REBOOT_DELAY_SEC = 0
+    DEFAULT_TEST_COMMAND = 'whoami'
     DEFAULT_REBOOT_MESSAGE = 'Reboot initiated by Ansible.'
 
     def do_until_success_or_timeout(self, what, timeout_sec, connect_timeout, what_desc, fail_sleep_sec=1):
         max_end_time = datetime.utcnow() + timedelta(seconds=timeout_sec)
 
+        e = None
         while datetime.utcnow() < max_end_time:
             try:
                 what(connect_timeout)
@@ -56,7 +58,7 @@ class ActionModule(ActionBase):
                 return
             except Exception as e:
                 if what_desc:
-                    display.debug("win_reboot: %s fail (expected), sleeping before retry..." % what_desc)
+                    display.debug("win_reboot: %s fail (expected), retrying in %d seconds..." % (what_desc, fail_sleep_sec))
                 time.sleep(fail_sleep_sec)
 
         raise TimedOutException("timed out waiting for %s: %s" % (what_desc, e))
@@ -69,6 +71,7 @@ class ActionModule(ActionBase):
         reboot_timeout_sec = int(self._task.args.get('reboot_timeout_sec', self.DEFAULT_REBOOT_TIMEOUT_SEC))
         connect_timeout_sec = int(self._task.args.get('connect_timeout_sec', self.DEFAULT_CONNECT_TIMEOUT_SEC))
         pre_reboot_delay_sec = int(self._task.args.get('pre_reboot_delay_sec', self.DEFAULT_PRE_REBOOT_DELAY_SEC))
+        post_reboot_delay_sec = int(self._task.args.get('post_reboot_delay_sec', self.DEFAULT_POST_REBOOT_DELAY_SEC))
         test_command = str(self._task.args.get('test_command', self.DEFAULT_TEST_COMMAND))
         msg = str(self._task.args.get('msg', self.DEFAULT_REBOOT_MESSAGE))
 
@@ -77,14 +80,13 @@ class ActionModule(ActionBase):
             return dict(skipped=True)
 
         result = super(ActionModule, self).run(tmp, task_vars)
-        result['warnings'] = []
 
         # Initiate reboot
         (rc, stdout, stderr) = self._connection.exec_command('shutdown /r /t %d /c "%s"' % (pre_reboot_delay_sec, msg))
 
         # Test for "A system shutdown has already been scheduled. (1190)" and handle it gracefully
         if rc == 1190:
-            result['warnings'].append('A scheduled reboot was pre-empted by Ansible.')
+            display.warning('A scheduled reboot was pre-empted by Ansible.')
 
             # Try to abort (this may fail if it was already aborted)
             (rc, stdout1, stderr1) = self._connection.exec_command('shutdown /a')
@@ -102,7 +104,7 @@ class ActionModule(ActionBase):
 
         def ping_module_test(connect_timeout):
             ''' Test ping module, if available '''
-            display.vvv("wait_for_connection: attempting ping module test")
+            display.vvv("win_reboot: attempting ping module test")
             # call connection reset between runs if it's there
             try:
                 self._connection._reset()
@@ -134,17 +136,17 @@ class ActionModule(ActionBase):
         try:
             # If the connection has a transport_test method, use it first
             if hasattr(self._connection, 'transport_test'):
-                self.do_until_success_or_timeout(self._connection.transport_test, reboot_timeout_sec, connect_timeout,
-                    what_desc="connection port up", sleep=sleep)
+                self.do_until_success_or_timeout(self._connection.transport_test, reboot_timeout_sec, connect_timeout_sec,
+                    what_desc="connection port up")
 
             # FUTURE: ensure that a reboot has actually occurred by watching for change in last boot time fact
             # FUTURE: add a stability check (system must remain up for N seconds) to deal with self-multi-reboot updates
 
             # Use the ping module test to determine end-to-end connectivity
-            if not test_command:
-                self.do_until_success_or_timeout(ping_module_test, reboot_timeout_sec, connect_timeout, what_desc="ping module test success", sleep=sleep)
+            if test_command:
+                self.do_until_success_or_timeout(run_test_command, reboot_timeout_sec, connect_timeout_sec, what_desc="post-reboot test command success")
             else:
-                self.do_until_success_or_timeout(run_test_command, reboot_timeout_sec, connect_timeout, what_desc="post-reboot test command success")
+                self.do_until_success_or_timeout(ping_module_test, reboot_timeout_sec, connect_timeout_sec, what_desc="ping module test success")
 
             result['rebooted'] = True
             result['changed'] = True
@@ -153,6 +155,10 @@ class ActionModule(ActionBase):
             result['failed'] = True
             result['rebooted'] = True
             result['msg'] = toex.message
+
+        if post_reboot_delay_sec != 0:
+            display.vvv("win_reboot: waiting an additional %d seconds" % post_reboot_delay_sec)
+            time.sleep(post_reboot_delay_sec)
 
         elapsed = datetime.now() - start
         result['elapsed'] = elapsed.seconds

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -94,7 +94,7 @@ class Connection(ConnectionBase):
         ''' Test the transport mechanism, if available '''
         host = self._winrm_host
         port = int(self._winrm_port)
-        display.vvv("attempting transport test to %s:%s" % (host, port))
+        display.vvv("attempting transport test to %s:%d" % (host, port))
         sock = socket.create_connection((host, port), connect_timeout)
         sock.close()
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_reboot

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
This PR brings win_reboot and wait_for_connection closer together by using the new connection-plugin transport_test functionality.

Another change is that by default the win_ping module is run, instead of running whoami. Backward compatibility is guaranteed for users that still want to run a different command.

The module now also returns the elapsed time, like the wait_for and wait_for_connection modules.

And a small cleanup of wait_for_connection based on win_reboot.

This fixes #18108 and potentially fixes #23835 