### PR TITLE
Add supports_check_mode to ec2_ami_find

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_ami_find.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami_find.py
@@ -330,6 +330,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec=argument_spec,
+        supports_check_mode=True,
     )
 
     if not HAS_BOTO:


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ec2_ami_find

##### ANSIBLE VERSION

```
ansible 2.3.0 (devel c98647ccf8) last updated 2017/03/02 14:54:11 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
ec2_ami_find is a facts module, and makes no
changes, so trivially supports check mode
