### PR TITLE
add new (broken) integration tests for copy and template modules

### DIFF
--- a/test/integration/targets/copy/tasks/main.yml
+++ b/test/integration/targets/copy/tasks/main.yml
@@ -283,15 +283,6 @@
     src: foo.txt
     dest: /tmp/10834_test/test_file
 
-- name: check if the hard link we're about to make already exists
-  stat: path=/tmp/10834_test/test_file_hardlink
-  register: hardlink_stat
-
-- name: assert hard link does not exist
-  assert:
-    that:
-      - "hardlink_stat.stat.exists == False"
-
 - name: make hard link
   file:
     src: /tmp/10834_test/test_file

--- a/test/integration/targets/copy/tasks/main.yml
+++ b/test/integration/targets/copy/tasks/main.yml
@@ -262,24 +262,29 @@
 ## demonstrate copy module failing to overwrite a file that's been hard linked
 ## https://github.com/ansible/ansible/issues/10834
 
-- name: init
+- name: ensure test dir is absent
   file:
-    path: /tmp/10834
+    path: /tmp/10834_test
     state: absent
+
+- name: create test dir
+  file:
+    path: /tmp/10834_test
+    state: directory
 
 - name: copy test file to system 1
   copy:
     src: foo.txt
-    dest: /tmp/10834
+    dest: /tmp/10834_test/test_file
 
 # not an issue when not hard linked
 - name: copy test file to system 2
   copy:
     src: foo.txt
-    dest: /tmp/10834
+    dest: /tmp/10834_test/test_file
 
 - name: check if the hard link we're about to make already exists
-  stat: path=/tmp/10834_hardlink
+  stat: path=/tmp/10834_test/test_file_hardlink
   register: hardlink_stat
 
 - name: assert hard link does not exist
@@ -289,16 +294,16 @@
 
 - name: make hard link
   file:
-    src: /tmp/10834
-    dest: /tmp/10834_hardlink
+    src: /tmp/10834_test/test_file
+    dest: /tmp/10834_test/test_file_hardlink
     state: hard
 
 - name: copy test file to system 3
   copy:
     src: foo.txt
-    dest: /tmp/10834
+    dest: /tmp/10834_test/test_file
 
 - name: cleanup
   file:
-    path: /tmp/10834
+    path: /tmp/10834_test
     state: absent

--- a/test/integration/targets/copy/tasks/main.yml
+++ b/test/integration/targets/copy/tasks/main.yml
@@ -258,3 +258,38 @@
   assert:
     that:
     - replace_follow_result.checksum == target_file_result.stdout
+
+## demonstrate copy module failing to overwrite a file that's been hard linked
+## https://github.com/ansible/ansible/issues/10834
+
+- name: init
+  file:
+    path: /tmp/10834
+    state: absent
+
+- name: copy test file to system 1
+  copy:
+    src: foo.txt
+    dest: /tmp/10834
+
+# not an issue when not hard linked
+- name: copy test file to system 2
+  copy:
+    src: foo.txt
+    dest: /tmp/10834
+
+- name: make hard link to test_file
+  file:
+    src: /tmp/10834
+    dest: /tmp/10834_hardlink
+    state: hard
+
+- name: copy test file to system 3
+  copy:
+    src: foo.txt
+    dest: /tmp/10834
+
+- name: cleanup
+  file:
+    path: /tmp/10834
+    state: absent

--- a/test/integration/targets/copy/tasks/main.yml
+++ b/test/integration/targets/copy/tasks/main.yml
@@ -278,7 +278,16 @@
     src: foo.txt
     dest: /tmp/10834
 
-- name: make hard link to test_file
+- name: check if the hard link we're about to make already exists
+  stat: path=/tmp/10834_hardlink
+  register: hardlink_stat
+
+- name: assert hard link does not exist
+  assert:
+    that:
+      - "hardlink_stat.stat.exists == False"
+
+- name: make hard link
   file:
     src: /tmp/10834
     dest: /tmp/10834_hardlink

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -135,6 +135,19 @@
     that:
       - "file6_touch_result.changed == true"
 
+- name: stat1
+  stat: path={{output_file}}
+  register: hlstat1
+
+- name: stat2
+  stat: path={{output_dir}}/hard.txt
+  register: hlstat2
+
+- name: verify that hard link was made
+  assert:
+    that:
+      - "hlstat1.stat.inode == hlstat2.stat.inode"
+
 - name: create a directory
   file: path={{output_dir}}/foobar state=directory
   register: file7_result

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -148,6 +148,9 @@
     that:
       - "hlstat1.stat.inode == hlstat2.stat.inode"
 
+- name: create hard link to file 2
+  file: src={{output_file}} dest={{output_dir}}/hard.txt state=hard
+
 - name: create a directory
   file: path={{output_dir}}/foobar state=directory
   register: file7_result

--- a/test/integration/targets/template/tasks/main.yml
+++ b/test/integration/targets/template/tasks/main.yml
@@ -66,10 +66,10 @@
   register: diff_result
 
 - name: verify templated file matches known good
-  assert:
-    that:
-        - 'diff_result.stdout == ""'
-        - "diff_result.rc == 0"
+  assert:  
+    that: 
+        - 'diff_result.stdout == ""' 
+        - "diff_result.rc == 0" 
 
 # VERIFY MODE
 
@@ -251,6 +251,46 @@
   assert:
     that:
     - "template_result|changed"
+
+## demonstrate copy module failing to overwrite a file that's been hard linked
+## https://github.com/ansible/ansible/issues/10834
+
+- name: ensure test dir is absent
+  file:
+    path: /tmp/10834.2_test
+    state: absent
+
+- name: create test dir
+  file:
+    path: /tmp/10834.2_test
+    state: directory
+
+- name: template out test file to system 1
+  template:
+    src: foo.j2
+    dest: /tmp/10834.2_test/test_file
+
+# not an issue when not hard linked
+- name: template out test file to system 2
+  template:
+    src: foo.j2
+    dest: /tmp/10834.2_test/test_file
+
+- name: make hard link
+  file:
+    src: /tmp/10834.2_test/test_file
+    dest: /tmp/10834.2_test/test_file_hardlink
+    state: hard
+
+- name: template out test file to system 3
+  template:
+    src: foo.j2
+    dest: /tmp/10834.2_test/test_file
+
+- name: cleanup
+  file:
+    path: /tmp/10834.2_test
+    state: absent
 
 - name: change var for the template
   set_fact:


### PR DESCRIPTION
##### ISSUE TYPE
 - Test Pull Request

##### COMPONENT NAME
copy and template modules

##### ANSIBLE VERSION
```
ansible 2.3.0 (add_breaking_test 6fd0632c15) last updated 2017/03/01 22:14:06 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Adds tests that demonstrates issues that the copy and template modules have when a file being updated has been the source of hard link. Related to https://github.com/ansible/ansible/issues/10834. These changes are included in https://github.com/ansible/ansible/pull/22028 (where I'm trying to fix the bug).

Run with:
```
test/runner/ansible-test integration copy --docker
test/runner/ansible-test integration template --docker
```

Errors:
```
TASK [copy : copy test file to system 3] ***************************************
fatal: [testhost]: FAILED! => {"changed": false, "checksum": "c79a6506c1c948be0d456ab5104d5e753ab2f3e6", "failed": true, "gid": 0, "group": "root", "mode": "0644", "msg": "src file does not exist, use \"force=yes\" if you really want to create the link: /tmp/10834_test/foo.txt", "owner": "root", "path": "/tmp/10834_test/test_file", "size": 8, "src": "foo.txt", "state": "hard", "uid": 0}
        to retry, use: --limit @/root/ansible/test/integration/copy-bx6L1G.retry
```

```
TASK [template : template out test file to system 3] ***************************
fatal: [testhost]: FAILED! => {"changed": false, "failed": true, "msg": "src and dest are required for creating links"}
        to retry, use: --limit @/root/ansible/test/integration/template-DpjUvO.retry
```

Full Output: https://gist.github.com/aerickson/ed651bd6b18c438d5010962ae4ab0745
