### PR TITLE
module aix_inittab added new RETURN block fixes #21983

### DIFF
--- a/lib/ansible/modules/system/aix_inittab.py
+++ b/lib/ansible/modules/system/aix_inittab.py
@@ -113,7 +113,21 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-
+name:
+    description: name of the adjusted inittab entry
+    returned: always
+    type: string
+    sample: startmyservice
+mgs:
+    description: action done with the inittab entry
+    returned: changed
+    type: string
+    sample: changed inittab entry startmyservice
+changed:
+    description: whether the inittab changed or not
+    return: always
+    type: boolean
+    sample: true
 '''
 
 # Import necessary libraries


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
aix_inittab

##### ANSIBLE VERSION

ansible 2.3.0 (devel 3edb484cf9) last updated 2017/03/02 08:11:42 (GMT +200)
config file = /etc/ansible/ansible.cfg
configured module search path = Default w/o overrides


##### SUMMARY


fixes #21983
Added a new ```RETURN``` block according to the documentation rules

