### PR TITLE
Added userns support on docker_container module Fixes #20648

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -271,7 +271,7 @@ options:
        - User namespace to use
      default: null
      required: false
-     version_added: "2.3"
+     version_added: "2.5"
   networks:
      description:
        - List of networks the container belongs to.

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -271,7 +271,7 @@ options:
        - User namespace to use
      default: null
      required: false
-     version_added: "2.2"
+     version_added: "2.3"
   networks:
      description:
        - List of networks the container belongs to.

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -266,6 +266,12 @@ options:
       - none
     default: null
     required: false
+  userns_mode:
+     description:
+       - User namespace to use
+     default: null
+     required: false
+     version_added: "2.2"
   networks:
      description:
        - List of networks the container belongs to.
@@ -727,6 +733,7 @@ class TaskParameters(DockerBaseClass):
         self.memory_swappiness = None
         self.name = None
         self.network_mode = None
+        self.userns_mode = None
         self.networks = None
         self.oom_killer = None
         self.oom_score_adj = None
@@ -916,6 +923,7 @@ class TaskParameters(DockerBaseClass):
             binds='volume_binds',
             volumes_from='volumes_from',
             network_mode='network_mode',
+            userns_mode='userns_mode',
             cap_add='capabilities',
             extra_hosts='etc_hosts',
             read_only='read_only',
@@ -1242,6 +1250,7 @@ class Container(DockerBaseClass):
             mac_address=network.get('MacAddress'),
             memory_swappiness=host_config.get('MemorySwappiness'),
             network_mode=host_config.get('NetworkMode'),
+            userns_mode=host_config.get('UsernsMode'),
             oom_killer=host_config.get('OomKillDisable'),
             oom_score_adj=host_config.get('OomScoreAdj'),
             pid_mode=host_config.get('PidMode'),
@@ -1975,6 +1984,7 @@ def main():
         memory_swappiness=dict(type='int'),
         name=dict(type='str', required=True),
         network_mode=dict(type='str'),
+        userns_mode=dict(type='str'),
         networks=dict(type='list'),
         oom_killer=dict(type='bool'),
         oom_score_adj=dict(type='int'),


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
modules/cloud/docker/docker_container

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel_docker_container_userns f8fd45238f) last updated 2017/03/02 14:53:34 (GMT +300)
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Defining userns in the docker_container module is useful in certain scenarios. 
Currently docker-py module only supports userns_mode = host, so the most useful case for this is when you have defined userns on your docker daemon and you need to start a container with network_mode = host (which also requires userns_mode = host). 
Fixes #20648

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
Before: 
fatal: [127.0.0.1]: FAILED! => {"changed": false, "failed": true, "msg": "unsupported parameter for module: userns_mode"}

After:
changed: [127.0.0.1]
```
