### PR TITLE
Aws lambda empty env bugfix

### DIFF
--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -454,8 +454,10 @@ def main():
                        'Code': code,
                        'Timeout': timeout,
                        'MemorySize': memory_size,
-                       'Environment':{'Variables': environment_variables}
                        }
+
+        if (environment_variables is not None):
+            func_kwargs['Environment'] = {'Variables': environment_variables}
 
         if dead_letter_arn:
             func_kwargs.update({'DeadLetterConfig': {'TargetARN': dead_letter_arn}})

--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -456,8 +456,8 @@ def main():
                        'MemorySize': memory_size,
                        }
 
-        if (environment_variables is not None):
-            func_kwargs['Environment'] = {'Variables': environment_variables}
+        if environment_variables:
+            func_kwargs.update({'Environment': {'Variables': environment_variables}})
 
         if dead_letter_arn:
             func_kwargs.update({'DeadLetterConfig': {'TargetARN': dead_letter_arn}})

--- a/test/units/modules/cloud/amazon/test_lambda.py
+++ b/test/units/modules/cloud/amazon/test_lambda.py
@@ -136,9 +136,9 @@ def test_create_lambda_if_not_exist():
 
     try:
         # For now I assume that we should NOT send an empty environment.  It might
-        # be okay / better to explicitly send an empty environment.  However `None' 
+        # be okay / better to explicitly send an empty environment.  However `None'
         # is not acceptable - mikedlr
-        my_env=create_kwargs["Environment"]
+        create_kwargs["Environment"]
         raise(Exception("Environment sent to boto when none expected"))
     except KeyError:
         pass #We are happy, no environment is fine

--- a/test/units/modules/cloud/amazon/test_lambda.py
+++ b/test/units/modules/cloud/amazon/test_lambda.py
@@ -68,6 +68,20 @@ base_module_args={
 }
 
 
+def make_mock_no_connection_connection(config):
+    """return a mock of ansible's boto3_conn ready to return a mock AWS API client"""
+    lambda_client_double = MagicMock()
+    lambda_client_double.get_function.configure_mock(
+        return_value=False
+    )
+    lambda_client_double.update_function_configuration.configure_mock(
+        return_value={
+            'Version' : 1
+        }
+    )
+    fake_boto3_conn=Mock(return_value=lambda_client_double)
+    return (fake_boto3_conn, lambda_client_double)
+
 def make_mock_connection(config):
     """return a mock of ansible's boto3_conn ready to return a mock AWS API client"""
     lambda_client_double = MagicMock()
@@ -97,6 +111,37 @@ def fail_json_double(*args, **kwargs):
 
 #TODO: def test_handle_different_types_in_config_params():
 
+
+def test_create_lambda_if_not_exist():
+
+    set_module_args(base_module_args)
+    (boto3_conn_double, lambda_client_double)=make_mock_no_connection_connection(code_change_lambda_config)
+
+    with patch.object(lda, 'boto3_conn', boto3_conn_double):
+        try:
+            lda.main()
+        except SystemExit:
+            pass
+
+    # guard against calling other than for a lambda connection (e.g. IAM)
+    assert(len(boto3_conn_double.mock_calls) == 1), "multiple boto connections used unexpectedly"
+    assert(len(lambda_client_double.update_function_configuration.mock_calls) == 0), \
+        "unexpectedly updated lambda configuration when should have only created"
+    assert(len(lambda_client_double.update_function_code.mock_calls) == 0), \
+        "update lambda function code when function should have been created only"
+    assert(len(lambda_client_double.create_function.mock_calls) > 0), \
+        "failed to call create_function "
+    (create_args, create_kwargs)=lambda_client_double.create_function.call_args
+    assert (len(create_kwargs) > 0), "expected create called with keyword args, none found"
+
+    try:
+        # For now I assume that we should NOT send an empty environment.  It might
+        # be okay / better to explicitly send an empty environment.  However `None' 
+        # is not acceptable - mikedlr
+        my_env=create_kwargs["Environment"]
+        raise(Exception("Environment sent to boto when none expected"))
+    except KeyError:
+        pass #We are happy, no environment is fine
 
 def test_update_lambda_if_code_changed():
 


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

lambda module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (aws_lambda_empty_env_bugfix 0a42a6fe72) last updated 2017/03/02 13:06:11 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

This adds a test case which demonstrates a bug when creating a new lambda function without giving the environment.  Then it fixes the case.  

Bug doesn't yet exist.  

```
before:
"msg": "Parameter validation failed:\nInvalid type for parameter Environment.Variables, value: None, type: <type 'NoneType'>, valid types: <type 'dict'>"

after: 
works as normal
```
