### PR TITLE
Adds --role-skeleton to ansible-galaxy man page

### DIFF
--- a/docs/man/man1/ansible-galaxy.1.asciidoc.in
+++ b/docs/man/man1/ansible-galaxy.1.asciidoc.in
@@ -129,6 +129,14 @@ Don't query the galaxy API when creating roles
 
 Initialize the new role with files appropriate for a Container Enabled role.
 
+*--role-skeleton=*'ROLE_SKELETON'::
+
+By default a new role is based on a template delivered with Ansible. Use 
+this option to provide an alternate template. Specify a path to a directory 
+that contains subdirectories and Jinja templates from which to base the new 
+role. Alternatively, the role_skeleton option can be configured in 
+*ansible.cfg*. 
+
 LIST
 ----
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ansible-galaxy.1.asciidoc.in

##### ANSIBLE VERSION
```
ansible-galaxy 2.3.0 (galaxy-man-page f4a4f720fb) last updated 2017/03/02 10:04:47 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

Adds some words for `--role-skeleton` option on the `init` command.
