### PR TITLE
openssl_privatekey: Add publickey fingerprint

### DIFF
--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+#
+# (c) 2016, Yanis Guenane <yanis+ansible@guenane.org>
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+try:
+    from OpenSSL import crypto
+except ImportError:
+    # An error will be raised in the calling class to let the end
+    # user know that OpenSSL couldn't be found.
+    pass
+
+import hashlib
+
+
+def get_fingerprint(path):
+    """Generate the fingerprint of the public key. """
+
+    fingerprint = {}
+
+    privatekey = crypto.load_privatekey(crypto.FILETYPE_PEM, open(path, 'r').read())
+
+    try:
+        publickey = crypto.dump_publickey(crypto.FILETYPE_ASN1, privatekey)
+        for algo in hashlib.algorithms:
+            f = getattr(hashlib, algo)
+            pubkey_digest = f(publickey).hexdigest()
+            fingerprint[algo] = ':'.join(pubkey_digest[i:i + 2] for i in range(0, len(pubkey_digest), 2))
+    except AttributeError:
+        # If PyOpenSSL < 16.0 crypto.dump_publickey() will fail.
+        # By doing this we prevent the code from raising an error
+        # yet we return no value in the fingerprint hash.
+        pass
+
+    return fingerprint

--- a/lib/ansible/modules/crypto/openssl_privatekey.py
+++ b/lib/ansible/modules/crypto/openssl_privatekey.py
@@ -101,9 +101,24 @@ filename:
     returned: changed or success
     type: string
     sample: /etc/ssl/private/ansible.com.pem
+fingerprint:
+    description: The fingerprint of the public key. Fingerprint will be generated for each hashlib.algorithms available.
+                 Requires PyOpenSSL >= 16.0 for meaningful output.
+    returned: changed or success
+    type: dict
+    sample:
+      md5: "84:75:71:72:8d:04:b5:6c:4d:37:6d:66:83:f5:4c:29"
+      sha1: "51:cc:7c:68:5d:eb:41:43:88:7e:1a:ae:c7:f8:24:72:ee:71:f6:10"
+      sha224: "b1:19:a6:6c:14:ac:33:1d:ed:18:50:d3:06:5c:b2:32:91:f1:f1:52:8c:cb:d5:75:e9:f5:9b:46"
+      sha256: "41:ab:c7:cb:d5:5f:30:60:46:99:ac:d4:00:70:cf:a1:76:4f:24:5d:10:24:57:5d:51:6e:09:97:df:2f:de:c7"
+      sha384: "85:39:50:4e:de:d9:19:33:40:70:ae:10:ab:59:24:19:51:c3:a2:e4:0b:1c:b1:6e:dd:b3:0c:d9:9e:6a:46:af:da:18:f8:ef:ae:2e:c0:9a:75:2c:9b:b3:0f:3a:5f:3d"
+      sha512: "fd:ed:5e:39:48:5f:9f:fe:7f:25:06:3f:79:08:cd:ee:a5:e7:b3:3d:13:82:87:1f:84:e1:f5:c7:28:77:53:94:86:56:38:69:f0:d9:35:22:01:1e:a6:60:...:0f:9b"
 '''
 
-from ansible.module_utils.basic import *
+import errno
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.crypto import get_fingerprint
+from ansible.module_utils.pycompat24 import get_exception
 
 try:
     from OpenSSL import crypto
@@ -111,7 +126,6 @@ except ImportError:
     pyopenssl_found = False
 else:
     pyopenssl_found = True
-
 
 import os
 
@@ -131,6 +145,8 @@ class PrivateKey(object):
         self.path = module.params['path']
         self.mode = module.params['mode']
         self.changed = True
+        self.privatekey = None
+        self.fingerprint = {}
         self.check_mode = module.check_mode
 
 
@@ -163,6 +179,7 @@ class PrivateKey(object):
         else:
             self.changed = False
 
+        self.fingerprint = get_fingerprint(self.path)
         file_args = module.load_file_common_arguments(module.params)
         if module.set_fs_attributes_if_different(file_args, False):
             self.changed = True
@@ -189,6 +206,7 @@ class PrivateKey(object):
             'type': self.type,
             'filename': self.path,
             'changed': self.changed,
+            'fingerprint': self.fingerprint,
         }
 
         return result

--- a/lib/ansible/modules/crypto/openssl_publickey.py
+++ b/lib/ansible/modules/crypto/openssl_publickey.py
@@ -86,9 +86,24 @@ filename:
     returned: changed or success
     type: string
     sample: /etc/ssl/public/ansible.com.pem
+fingerprint:
+    description: The fingerprint of the public key. Fingerprint will be generated for each hashlib.algorithms available.
+                 Requires PyOpenSSL >= 16.0 for meaningful output.
+    returned: changed or success
+    type: dict
+    sample:
+      md5: "84:75:71:72:8d:04:b5:6c:4d:37:6d:66:83:f5:4c:29"
+      sha1: "51:cc:7c:68:5d:eb:41:43:88:7e:1a:ae:c7:f8:24:72:ee:71:f6:10"
+      sha224: "b1:19:a6:6c:14:ac:33:1d:ed:18:50:d3:06:5c:b2:32:91:f1:f1:52:8c:cb:d5:75:e9:f5:9b:46"
+      sha256: "41:ab:c7:cb:d5:5f:30:60:46:99:ac:d4:00:70:cf:a1:76:4f:24:5d:10:24:57:5d:51:6e:09:97:df:2f:de:c7"
+      sha384: "85:39:50:4e:de:d9:19:33:40:70:ae:10:ab:59:24:19:51:c3:a2:e4:0b:1c:b1:6e:dd:b3:0c:d9:9e:6a:46:af:da:18:f8:ef:ae:2e:c0:9a:75:2c:9b:b3:0f:3a:5f:3d"
+      sha512: "fd:ed:5e:39:48:5f:9f:fe:7f:25:06:3f:79:08:cd:ee:a5:e7:b3:3d:13:82:87:1f:84:e1:f5:c7:28:77:53:94:86:56:38:69:f0:d9:35:22:01:1e:a6:60:...:0f:9b"
 '''
 
-from ansible.module_utils.basic import *
+import errno
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.crypto import get_fingerprint
+from ansible.module_utils.pycompat24 import get_exception
 
 try:
     from OpenSSL import crypto
@@ -96,7 +111,6 @@ except ImportError:
     pyopenssl_found = False
 else:
     pyopenssl_found = True
-
 
 import os
 
@@ -113,19 +127,22 @@ class PublicKey(object):
         self.name = os.path.basename(module.params['path'])
         self.path = module.params['path']
         self.privatekey_path = module.params['privatekey_path']
+        self.privatekey = None
         self.changed = True
+        self.fingerprint = {}
         self.check_mode = module.check_mode
 
 
     def generate(self, module):
-        """Generate the public key.."""
+        """Generate the public key."""
 
         if not os.path.exists(self.path) or self.force:
             try:
                 privatekey_content = open(self.privatekey_path, 'r').read()
-                privatekey = crypto.load_privatekey(crypto.FILETYPE_PEM, privatekey_content)
+                self.privatekey = crypto.load_privatekey(crypto.FILETYPE_PEM, privatekey_content)
+                publickey_content = crypto.dump_publickey(crypto.FILETYPE_PEM, self.privatekey)
                 publickey_file = open(self.path, 'w')
-                publickey_file.write(crypto.dump_publickey(crypto.FILETYPE_PEM, privatekey))
+                publickey_file.write(publickey_content)
                 publickey_file.close()
             except (IOError, OSError):
                 e = get_exception()
@@ -137,6 +154,7 @@ class PublicKey(object):
             self.changed = False
 
         file_args = module.load_file_common_arguments(module.params)
+        self.fingerprint = get_fingerprint(self.privatekey_path)
         if module.set_fs_attributes_if_different(file_args, False):
             self.changed = True
 
@@ -159,6 +177,7 @@ class PublicKey(object):
             'privatekey': self.privatekey_path,
             'filename': self.path,
             'changed': self.changed,
+            'fingerprint': self.fingerprint,
         }
 
         return result


### PR DESCRIPTION
##### SUMMARY

This commit adds the fingerprint of the public key in openssl_privatekey
and openssl_publickey returned values.

Fixes #21974 

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

  * openssl_privatekey
  * openssl_publickey

##### ANSIBLE VERSION

```
ansible 2.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o override
```

##### ADDITIONAL INFORMATION

Sample output:

```
{
  "changed": false,
  "filename": "/tmp/cert.pem",
  "fingerprint": {
    "md5": "31:22:14:58:c6:b1:7b:2a:48:89:b5:02:43:0a:d7:88",
    "sha1": "ed:e5:59:ba:9b:98:5b:e1:01:ef:4b:eb:f0:d1:1d:ee:84:88:c7:78",
    "sha224": "e1:c0:a6:bd:20:30:40:5b:c0:32:14:4a:01:3c:4b:c3:8a:49:a5:1f:ed:39:75:a4:57:e6:93:87",
    "sha256": "8a:18:86:88:79:e5:57:ca:c3:3c:89:92:ae:54:7f:ac:94:12:e2:c7:aa:c2:7c:97:77:cb:e7:8b:5e:1f:af:28",
    "sha384": "7a:5d:c2:49:cc:84:f4:74:ed:76:c7:03:e5:8d:aa:3b:31:b0:ba:0e:29:d2:76:3c:0e:3c:e5:d2:fd:b4:36:b1:70:b5:a6:bb:17:f4:db:ac:d6:75:81:36:42:dd:61:0c",
    "sha512": "da:0a:14:52:c6:c0:ab:fa:52:55:2a:85:65:35:7a:f6:5d:95:1d:d3:95:ae:bd:b9:d8:e0:75:dd:4f:0c:c9:3c:59:82:64:fa:d8:50:26:4f:b7:3a:5d:e8:6f:5d:de:9a:fe:ef:c2:c8:57:9d:e3:c0:c9:dd:4a:a9:bd:7a:77:f3"
  },
  "size": 4096,
  "type": "RSA"
}
```
