### PR TITLE
Add update_only parameter for yum module

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -102,7 +102,7 @@ options:
     default: "no"
     choices: ["yes", "no"]
     aliases: []
-    version_added: "2.4"
+    version_added: "2.5"
 
   installroot:
     description:

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -427,3 +427,32 @@
     that:
         - "'changed' in yum_result"
         - "'msg' in yum_result"
+
+- name: use latest to install httpd
+  yum:
+    name: httpd
+    state: latest
+  register: yum_result
+
+- name: verify httpd was installed
+  assert:
+    that:
+      - "'changed' in yum_result"
+
+- name: uninstall httpd
+  yum:
+    name: httpd
+    state: removed
+
+- name: update httpd only if it exists
+  yum:
+    name: httpd
+    state: latest
+    update_only: yes
+  register: yum_result
+
+- name: verify httpd not installed
+  assert:
+    that:
+      - "not yum_result.changed"
+      - "'Packages providing httpd not installed due to update_only specified' in yum_result.results"


### PR DESCRIPTION
When using latest, `update_only: yes` will ensure that only existing
packages are updated and no additional packages are installed.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
`ansible/lib/ansible/modules/packaging/os/yum.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/sadams/code/ansible/lib/ansible/modules']
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adding an `update_only` boolean parameter to the yum module. Affects the module only when using `state: latest.`  
The idea being that if you run across systems where you do not want the package installed, you can specify that the package should only be updated if it already exists.
```
yum:
  name: httpd
  state: latest
  update_only: yes
```
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
Both tests performed with httpd NOT installed on the machine.  
**Before**
```
➔ ansible -m yum -a "name=httpd state=latest" rhel7 --become 
192.168.33.10 | SUCCESS => {
    "changed": true, 
    "msg": "", 
    "rc": 0, 
    "results": [
        "Loaded plugins: product-id, search-disabled-repos, subscription-manager\nResolving Dependencies\n--> Running transaction check\n---> Package httpd.x86_64 0:2.4.6-45.el7 will be installed\n--> Processing Dependency: httpd-tools = 2.4.6-45.el7 for package: httpd-2.4.6-45.el7.x86_64\n--> Running transaction check\n---> Package httpd-tools.x86_64 0:2.4.6-45.el7 will be installed\n--> Finished Dependency Resolution\n\nDependencies Resolved\n\n================================================================================\n Package          Arch        Version             Repository               Size\n================================================================================\nInstalling:\n httpd            x86_64      2.4.6-45.el7        rhel-7-server-rpms      1.2 M\nInstalling for dependencies:\n httpd-tools      x86_64      2.4.6-45.el7        rhel-7-server-rpms       84 k\n\nTransaction Summary\n================================================================================\nInstall  1 Package (+1 Dependent package)\n\nTotal download size: 1.3 M\nInstalled size: 3.9 M\nDownloading packages:\n--------------------------------------------------------------------------------\nTotal                                              1.7 MB/s | 1.3 MB  00:00     \nRunning transaction check\nRunning transaction test\nTransaction test succeeded\nRunning transaction\n  Installing : httpd-tools-2.4.6-45.el7.x86_64                              1/2 \n  Installing : httpd-2.4.6-45.el7.x86_64                                    2/2 \n  Verifying  : httpd-tools-2.4.6-45.el7.x86_64                              1/2 \n  Verifying  : httpd-2.4.6-45.el7.x86_64                                    2/2 \n\nInstalled:\n  httpd.x86_64 0:2.4.6-45.el7                                                   \n\nDependency Installed:\n  httpd-tools.x86_64 0:2.4.6-45.el7                                             \n\nComplete!\n"
    ]
}
```  
**After**
```
➔ ansible -m yum -a "name=httpd state=latest update_only=yes" rhel7 --become
192.168.33.10 | SUCCESS => {
    "changed": false, 
    "msg": "", 
    "rc": 0, 
    "results": [
        "Packages providing httpd not installed due to update_only specified", 
        ""
    ]
}
```
