### PR TITLE
virt.py: autostart VM attribute

### DIFF
--- a/lib/ansible/modules/cloud/misc/virt.py
+++ b/lib/ansible/modules/cloud/misc/virt.py
@@ -349,8 +349,8 @@ class Virt(object):
         self.conn = self.__get_conn()
         # Change autostart flag only if needed
         if self.conn.get_autostart(vmid) != as_flag:
-                self.conn.set_autostart(vmid, as_flag)
-                return True
+            self.conn.set_autostart(vmid, as_flag)
+            return True
 
         return False
 

--- a/lib/ansible/modules/cloud/misc/virt.py
+++ b/lib/ansible/modules/cloud/misc/virt.py
@@ -461,7 +461,7 @@ def core(module):
 
         res['changed'] = False
         autostart_res = v.autostart(guest, autostart)
-        if autostart_res != False:
+        if autostart_res is not False:
             res['changed'] = True
             res['msg'] = autostart_res
 

--- a/lib/ansible/modules/cloud/misc/virt.py
+++ b/lib/ansible/modules/cloud/misc/virt.py
@@ -53,6 +53,7 @@ options:
     description:
       - start VM at host startup
     choices: [True, False]
+    version_added: "2.3"
   uri:
     description:
       - libvirt connection uri

--- a/lib/ansible/modules/cloud/misc/virt.py
+++ b/lib/ansible/modules/cloud/misc/virt.py
@@ -54,6 +54,7 @@ options:
       - start VM at host startup
     choices: [True, False]
     version_added: "2.3"
+    default: False
   uri:
     description:
       - libvirt connection uri
@@ -441,7 +442,7 @@ class Virt(object):
 def core(module):
 
     state      = module.params.get('state', None)
-    autostart  = module.params.get('autostart', False)
+    autostart  = module.params.get('autostart')
     guest      = module.params.get('name', None)
     command    = module.params.get('command', None)
     uri        = module.params.get('uri', None)
@@ -461,10 +462,8 @@ def core(module):
             module.fail_json(msg = "state change requires a guest specified")
 
         res['changed'] = False
-        autostart_res = v.autostart(guest, autostart)
-        if autostart_res is not False:
+        if v.autostart(guest, autostart):
             res['changed'] = True
-            res['msg'] = autostart_res
 
         if state == 'running':
             if v.status(guest) is 'paused':


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
cloud/misc/virt

##### ANSIBLE VERSION
```
ansible 2.2.1.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
autostart is now an idempotent VM attribute instead of a non idempotent forced autostart attribute set to True

