### PR TITLE
Bumping docs footer copyright year

### DIFF
--- a/docs/docsite/_themes/srtd/footer.html
+++ b/docs/docsite/_themes/srtd/footer.html
@@ -22,7 +22,7 @@
 </script>
 
   <p>
-  Copyright © 2016 Red Hat, Inc.
+  Copyright © 2017 Red Hat, Inc.
   <br>
 
   {%- if last_updated %}


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Setting the copyright year to 2017 in the docs footer.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
