### PR TITLE
Update dead support link

### DIFF
--- a/docs/docsite/rst/community.rst
+++ b/docs/docsite/rst/community.rst
@@ -248,7 +248,7 @@ Tower Support Questions
 
 Ansible `Tower <https://ansible.com/tower>`_ is a UI, Server, and REST endpoint for Ansible, produced by Ansible, Inc.
 
-If you have a question about Tower, visit `support.ansible.com <https://support.ansible.com/>`_ rather than using the IRC
+If you have a question about Tower, visit `Red Hat support <https://access.redhat.com/products/ansible-tower-red-hat/>`_ rather than using the IRC
 channel or the general project mailing list.
 
 IRC Channel

--- a/docs/docsite/rst/community.rst
+++ b/docs/docsite/rst/community.rst
@@ -77,7 +77,7 @@ To be respectful of reviewers' time and allow us to help everyone efficiently, p
 provide minimal well-reduced and well-commented examples versus sharing your entire production
 playbook.  Include playbook snippets and output where possible.  
 
-When sharing YAML in playbooks, formatting can be preserved by using `code blocks <https://help.github.com/articles/github-flavored-markdown#fenced-code-blocks>`_.
+When sharing YAML in playbooks, formatting can be preserved by using `code blocks <https://help.github.com/articles/creating-and-highlighting-code-blocks/>`_.
 
 For multiple-file content, we encourage use of gist.github.com.  Online pastebin content can expire, so it's nice to have things around for a longer term if they
 are referenced in a ticket.


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docssite community page, link to Tower support

##### ANSIBLE VERSION
N/A

##### SUMMARY
Visit https://www.ansible.com/, and you'll find the support link points to this URL, https://access.redhat.com/products/ansible-tower-red-hat/.

The current link is a dead link, but the docs site is still driving traffic there.

Please let me know if this change needs to be made to any other branch to get the change out there faster.

Also, there was an outdated link for code blocks going to a redirect, so I added another commit that points to the appropriate current page for markdown syntax highlighting.