### PR TITLE
update junos_command integration tests

### DIFF
--- a/lib/ansible/modules/network/junos/junos_command.py
+++ b/lib/ansible/modules/network/junos/junos_command.py
@@ -229,15 +229,17 @@ def main():
     while retries > 0:
         responses = run_commands(module, commands)
 
-        for item in list(conditionals):
-
-            for index, (resp, cmd) in enumerate(zip(responses, commands)):
-                if cmd['output'] == 'xml':
-                    if not HAS_JXMLEASE:
-                        module.fail_json(msg='jxmlease is required but does not appear to '
-                            'be installed.  It can be installed using `pip install jxmlease`')
+        for index, (resp, cmd) in enumerate(zip(responses, commands)):
+            if cmd['output'] == 'xml':
+                if not HAS_JXMLEASE:
+                    module.fail_json(msg='jxmlease is required but does not appear to '
+                        'be installed.  It can be installed using `pip install jxmlease`')
+                try:
                     responses[index] = jxmlease.parse(resp)
+                except:
+                    raise ValueError(resp)
 
+        for item in list(conditionals):
             try:
                 if item(responses):
                     if match == 'any':

--- a/test/integration/targets/junos_command/tests/netconf_xml/bad_operator.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/bad_operator.yaml
@@ -7,7 +7,7 @@
       - show version
       - show interfaces fxp0
     wait_for:
-      - "result[1].interface-information[0].physical-interface[0].name[0].data foo fxp0"
+      - "result[1].rpc-reply.interface-information[0].physical-interface[0].name[0].data foo fxp0"
     format: xml
     provider: "{{ netconf }}"
   register: result

--- a/test/integration/targets/junos_command/tests/netconf_xml/contains.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/contains.yaml
@@ -8,8 +8,8 @@
       - show interfaces fxp0
     format: xml
     wait_for:
-      - "result[0].software-information.host-name contains {{ inventory_hostname_short }}"
-      - "result[1].interface-information.physical-interface.name contains fxp0"
+      - "result[0].rpc-reply.software-information.host-name contains {{ inventory_hostname_short }}"
+      - "result[1].rpc-reply.interface-information.physical-interface.name contains fxp0"
     provider: "{{ netconf }}"
   register: result
 

--- a/test/integration/targets/junos_command/tests/netconf_xml/equal.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/equal.yaml
@@ -7,8 +7,8 @@
       - show version
       - show interfaces fxp0
     wait_for:
-      - "result[0].software-information.host-name == {{ inventory_hostname_short }}"
-      - "result[1].interface-information.physical-interface.name == fxp0"
+      - "result[0].rpc-reply.software-information.host-name == {{ inventory_hostname_short }}"
+      - "result[1].rpc-reply.interface-information.physical-interface.name == fxp0"
     format: xml
     provider: "{{ netconf }}"
   register: result
@@ -25,8 +25,8 @@
       - show version
       - show interfaces fxp0
     wait_for:
-      - "result[0].software-information.host-name eq {{ inventory_hostname_short }}"
-      - "result[1].interface-information.physical-interface.name eq fxp0"
+      - "result[0].rpc-reply.software-information.host-name eq {{ inventory_hostname_short }}"
+      - "result[1].rpc-reply.interface-information.physical-interface.name eq fxp0"
     format: xml
     provider: "{{ netconf }}"
   register: result

--- a/test/integration/targets/junos_command/tests/netconf_xml/greaterthan.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/greaterthan.yaml
@@ -8,7 +8,7 @@
       - show interfaces fxp0
     format: xml
     wait_for:
-      - "result[1].interface-information.physical-interface.mtu gt 1500"
+      - "result[1].rpc-reply.interface-information.physical-interface.mtu gt 1500"
     provider: "{{ netconf }}"
   register: result
 
@@ -25,7 +25,7 @@
       - show interfaces fxp0
     format: xml
     wait_for:
-      - "result[1].interface-information.physical-interface.mtu > 1500"
+      - "result[1].rpc-reply.interface-information.physical-interface.mtu > 1500"
     provider: "{{ netconf }}"
   register: result
 

--- a/test/integration/targets/junos_command/tests/netconf_xml/greaterthanorequal.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/greaterthanorequal.yaml
@@ -8,7 +8,7 @@
       - show interfaces fxp0
     format: xml
     wait_for:
-      - "result[1].interface-information.physical-interface.mtu ge 1514"
+      - "result[1].rpc-reply.interface-information.physical-interface.mtu ge 1514"
     provider: "{{ netconf }}"
   register: result
 
@@ -25,7 +25,7 @@
       - show interfaces fxp0
     format: xml
     wait_for:
-      - "result[1].interface-information.physical-interface.mtu >= 1514"
+      - "result[1].rpc-reply.interface-information.physical-interface.mtu >= 1514"
     provider: "{{ netconf }}"
   register: result
 

--- a/test/integration/targets/junos_command/tests/netconf_xml/lessthan.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/lessthan.yaml
@@ -8,7 +8,7 @@
       - show interfaces fxp0
     format: xml
     wait_for:
-      - "result[1].interface-information.physical-interface.mtu lt 9000"
+      - "result[1].rpc-reply.interface-information.physical-interface.mtu lt 9000"
     provider: "{{ netconf }}"
   register: result
 
@@ -25,7 +25,7 @@
       - show interfaces fxp0
     format: xml
     wait_for:
-      - "result[1].interface-information.physical-interface.mtu lt 9000"
+      - "result[1].rpc-reply.interface-information.physical-interface.mtu lt 9000"
     provider: "{{ netconf }}"
   register: result
 

--- a/test/integration/targets/junos_command/tests/netconf_xml/lessthanorequal.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/lessthanorequal.yaml
@@ -8,7 +8,7 @@
       - show interfaces fxp0
     format: xml
     wait_for:
-      - "result[1].interface-information.physical-interface.mtu le 1514"
+      - "result[1].rpc-reply.interface-information.physical-interface.mtu le 1514"
     provider: "{{ netconf }}"
   register: result
 
@@ -25,7 +25,7 @@
       - show interfaces fxp0
     format: xml
     wait_for:
-      - "result[1].interface-information.physical-interface.mtu <= 1514"
+      - "result[1].rpc-reply.interface-information.physical-interface.mtu <= 1514"
     provider: "{{ netconf }}"
   register: result
 

--- a/test/integration/targets/junos_command/tests/netconf_xml/notequal.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/notequal.yaml
@@ -8,7 +8,7 @@
       - show interfaces fxp0
     format: xml
     wait_for:
-      - "result[0].software-information.host-name neq localhost"
+      - "result[0].rpc-reply.software-information.host-name neq localhost"
     provider: "{{ netconf }}"
   register: result
 
@@ -25,7 +25,7 @@
       - show interfaces fxp0
     format: xml
     wait_for:
-      - "result[0].software-information.host-name != localhost"
+      - "result[0].rpc-reply.software-information.host-name != localhost"
     provider: "{{ netconf }}"
   register: result
 


### PR DESCRIPTION
fixes integration test to check for full rpc-reply string when
converted from xml.  This is a change from 2.2 as the rpc-reply tag
is no longer stripped off

