### PR TITLE
Mongo Inventory

### DIFF
--- a/contrib/inventory/mongo.ini
+++ b/contrib/inventory/mongo.ini
@@ -1,0 +1,17 @@
+# Ansible external inventory script settings for Mongo DB
+#
+[mongo]
+#
+# Define an Mongo DB URI. This module uses 'pymongo' for Mongo DB Connection.
+#
+database_uri=mongodb://localhost:27017/
+#
+# A single instance of MongoDB can support multiple independent databases.
+# Specify the database used for Ansible Inventory
+#
+db=ansible
+#
+# A collection is a group of documents stored in MongoDB, and can be thought 
+# of as roughly the equivalent of a table in a relational database.
+#
+collection=inventory

--- a/contrib/inventory/mongo.py
+++ b/contrib/inventory/mongo.py
@@ -91,7 +91,7 @@ class MongoInventory(object):
                         hostname = res.group(1) + str(counter).zfill(pad) + res.group(4)
                         self.result[hostgroup].append(hostname)
                         self.result['_meta']['hostvars'][hostname] = {}
-                        for key, value in iter(host.items()):
+                        for key, value in host.items():
                             if key in ('_id', 'host', 'group', 'updated_at', 'created_at'):
                                 next
                             else:

--- a/contrib/inventory/mongo.py
+++ b/contrib/inventory/mongo.py
@@ -1,0 +1,137 @@
+# (c) 2015, Prakritish Sen Eshore
+#
+# This file is part of Ansible,
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+######################################################################
+
+'''
+MongoDB external inventory script
+=================================
+Generates inventory that Ansible can understand by making API request to
+Mongo Database.
+NOTE: This script also assumes there is an mongo.ini file alongside it.
+
+Returns hosts and hostgroups from Mongo DB.
+
+Following Fields are needed:
+    * host
+    * group
+
+Other Fields non mandatory fields:
+    * updated_at
+    * created_at
+    
+All other fields will be used as Host Variables.
+    
+'''
+
+#!/usr/bin/env python
+
+import os
+import argparse
+try:
+    import configparser
+except ImportError:
+    import ConfigParser
+    configparser = ConfigParser
+import json
+import re
+
+try:
+    from pymongo import MongoClient
+except ImportError:
+    print("Error: pymongo is needed. Try something like: pip install pymongo")
+    exit(1)
+
+class MongoInventory(object):
+
+    def read_settings(self):
+        config = configparser.SafeConfigParser()
+        config.read(os.path.dirname(os.path.realpath(__file__)) + '/mongo.ini')
+        if config.has_option('mongo', 'database_uri'):
+            self.mongo_database_uri = config.get('mongo', 'database_uri')
+
+        if config.has_option('mongo', 'db'):
+            self.mongo_db = config.get('mongo', 'db')
+
+        if config.has_option('mongo', 'collection'):
+            self.mongo_collection = config.get('mongo', 'collection')
+
+    def read_cli(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--host', nargs=1)
+        parser.add_argument('--list', action='store_true')
+        self.options = parser.parse_args()
+
+    def get_hosts(self):
+        client = MongoClient(self.mongo_database_uri)
+        db = client[self.mongo_db]
+        collection = db[self.mongo_collection]
+        host_groups = collection.find().distinct("group")
+        for hostgroup in host_groups:
+            self.result[hostgroup] = []
+            for host in collection.find({"group" : hostgroup}):
+                res = re.search('^(.*)\[(\d+):(\d+)\](.*)$', host['host'])
+                if res:
+                    pad = len(res.group(2))
+                    for counter in range(int(res.group(2)), int(res.group(3)) + 1):
+                        hostname = res.group(1) + str(counter).zfill(pad) + res.group(4)
+                        self.result[hostgroup].append(hostname)
+                        self.result['_meta']['hostvars'][hostname] = {}
+                        for key, value in host.iteritems():
+                            if key in ('_id', 'host', 'group', 'updated_at', 'created_at'):
+                                next
+                            else:
+                                self.result['_meta']['hostvars'][hostname][key] = value
+                else:            
+                    self.result[hostgroup].append(host['host'])
+                    self.result['_meta']['hostvars'][host['host']] = {}
+                    for key, value in host.iteritems():
+                        if key in ('_id', 'host', 'group', 'updated_at', 'created_at'):
+                            next
+                        else:
+                            self.result['_meta']['hostvars'][host['host']][key] = value
+
+    def __init__(self):
+
+        self.defaultgroup = 'group_all'
+        self.ndo_database_uri = None
+        self.options = None
+
+        self.read_settings()
+        self.read_cli()
+
+        self.result = {}
+        self.result['_meta'] = {}
+        self.result['_meta']['hostvars'] = {}
+
+        if self.mongo_database_uri:
+            self.get_hosts()
+            if self.options.host:
+                if self.options.host[0] in self.result['_meta']['hostvars']:
+                    print(json.dumps(self.result['_meta']['hostvars'][self.options.host[0]]))
+                else:
+                    exit(1)
+            elif self.options.list:
+                print(json.dumps(self.result))
+            else:
+                print("usage: --list or --host HOSTNAME")
+                exit(1)
+        else:
+            print("Error: Database configuration is missing. See mongo.ini.")
+            exit(1)
+
+MongoInventory()

--- a/contrib/inventory/mongo.py
+++ b/contrib/inventory/mongo.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+#
 # (c) 2015, Prakritish Sen Eshore
 #
 # This file is part of Ansible,
@@ -37,8 +39,6 @@ Other Fields non mandatory fields:
 All other fields will be used as Host Variables.
     
 '''
-
-#!/usr/bin/env python
 
 import os
 import argparse

--- a/contrib/inventory/mongo.py
+++ b/contrib/inventory/mongo.py
@@ -99,7 +99,7 @@ class MongoInventory(object):
                 else:
                     self.result[hostgroup].append(host['host'])
                     self.result['_meta']['hostvars'][host['host']] = {}
-                    for key, value in host.iteritems():
+                    for key, value in host.items():
                         if key in ('_id', 'host', 'group', 'updated_at', 'created_at'):
                             next
                         else:

--- a/contrib/inventory/mongo.py
+++ b/contrib/inventory/mongo.py
@@ -35,9 +35,9 @@ Following Fields are needed:
 Other Fields non mandatory fields:
     * updated_at
     * created_at
-    
+
 All other fields will be used as Host Variables.
-    
+
 '''
 
 import os
@@ -91,12 +91,12 @@ class MongoInventory(object):
                         hostname = res.group(1) + str(counter).zfill(pad) + res.group(4)
                         self.result[hostgroup].append(hostname)
                         self.result['_meta']['hostvars'][hostname] = {}
-                        for key, value in host.iteritems():
+                        for key, value in iter(host.items()):
                             if key in ('_id', 'host', 'group', 'updated_at', 'created_at'):
                                 next
                             else:
                                 self.result['_meta']['hostvars'][hostname][key] = value
-                else:            
+                else:
                     self.result[hostgroup].append(host['host'])
                     self.result['_meta']['hostvars'][host['host']] = {}
                     for key, value in host.iteritems():


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
mongo.py
mongo.ini

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
[root@prakritish1 ~]# ansible --version
ansible 2.2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
[root@prakritish1 ~]#
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This is an inventory module which allows users to user Mongo DB to
store inventory information. As ansible allows various hostvars, I thought
it's much more simpler to use Mongo to store relevant information in a
collection rather than using SQL with empty columns.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
[root@prakritish1 inventory]# ./mongo.py --list
{"web": ["prakritish3.mylabserver.com"], "_meta": {"hostvars": {"prakritish3.mylabserver.com": {"ansible_become_user": "root", "ansible_become": true, "ansible_ssh_pass": "abcde12345", "ansible_user": "user", "ansible_become_pass": "abcde12345"}}}}
[root@prakritish1 inventory]# ./mongo.py --host prakritish3.mylabserver.com
{"ansible_become_user": "root", "ansible_become": true, "ansible_ssh_pass": "abcde12345", "ansible_user": "user", "ansible_become_pass": "abcde12345"}
[root@prakritish1 inventory]# ansible -i ./mongo.py prakritish3.mylabserver.com -m command -a "/sbin/ifconfig"
prakritish3.mylabserver.com | SUCCESS | rc=0 >>
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 9001
        inet 172.31.31.229  netmask 255.255.240.0  broadcast 172.31.31.255
        inet6 fe80::4f3:58ff:fe4a:4d67  prefixlen 64  scopeid 0x20<link>
        ether 06:f3:58:4a:4d:67  txqueuelen 1000  (Ethernet)
        RX packets 1173  bytes 337505 (329.5 KiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 1225  bytes 150710 (147.1 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
        inet 127.0.0.1  netmask 255.0.0.0
        inet6 ::1  prefixlen 128  scopeid 0x10<host>
        loop  txqueuelen 0  (Local Loopback)
        RX packets 18  bytes 1136 (1.1 KiB)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 18  bytes 1136 (1.1 KiB)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

[root@prakritish1 inventory]#
```
