### PR TITLE
npm: fix idempotence

### DIFF
--- a/lib/ansible/modules/packaging/language/npm.py
+++ b/lib/ansible/modules/packaging/language/npm.py
@@ -1,16 +1,17 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-
-# (c) 2013, Chris Hoffman <christopher.hoffman@gmail.com>
+# Copyright (c) 2017 Chris Hoffman <christopher.hoffman@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
 
 
 DOCUMENTATION = '''
@@ -115,11 +116,19 @@ EXAMPLES = '''
     state: present
 '''
 
-import json
 import os
 import re
 
 from ansible.module_utils.basic import AnsibleModule
+
+try:
+    import json
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        # Let snippet from module_utils/basic.py return a proper error in this case
+        pass
 
 
 class Npm(object):
@@ -132,13 +141,14 @@ class Npm(object):
         self.registry = kwargs['registry']
         self.production = kwargs['production']
         self.ignore_scripts = kwargs['ignore_scripts']
+        self.state = kwargs['state']
 
         if kwargs['executable']:
             self.executable = kwargs['executable'].split(' ')
         else:
             self.executable = [module.get_bin_path('npm', True)]
 
-        if kwargs['version']:
+        if kwargs['version'] and self.state != 'absent':
             self.name_version = self.name + '@' + str(self.version)
         else:
             self.name_version = self.name
@@ -149,7 +159,7 @@ class Npm(object):
 
             if self.glbl:
                 cmd.append('--global')
-            if self.production and args[0] == 'install':
+            if self.production and ('install' in cmd or 'update' in cmd):
                 cmd.append('--production')
             if self.ignore_scripts:
                 cmd.append('--ignore-scripts')
@@ -159,7 +169,7 @@ class Npm(object):
                 cmd.append('--registry')
                 cmd.append(self.registry)
 
-            #If path is specified, cd into that path and run the command.
+            # If path is specified, cd into that path and run the command.
             cwd = None
             if self.path:
                 if not os.path.exists(self.path):
@@ -188,7 +198,7 @@ class Npm(object):
                     installed.append(dep)
             if self.name and self.name not in installed:
                 missing.append(self.name)
-        #Named dependency not installed
+        # Named dependency not installed
         else:
             missing.append(self.name)
 
@@ -248,8 +258,8 @@ def main():
     if state == 'absent' and not name:
         module.fail_json(msg='uninstalling a package is only available for named packages')
 
-    npm = Npm(module, name=name, path=path, version=version, glbl=glbl, production=production, \
-              executable=executable, registry=registry, ignore_scripts=ignore_scripts)
+    npm = Npm(module, name=name, path=path, version=version, glbl=glbl, production=production,
+              executable=executable, registry=registry, ignore_scripts=ignore_scripts, state=state)
 
     changed = False
     if state == 'present':
@@ -266,7 +276,7 @@ def main():
         if len(outdated):
             changed = True
             npm.update()
-    else: #absent
+    else:  # absent
         installed, missing = npm.list()
         if name in installed:
             changed = True

--- a/lib/ansible/modules/packaging/language/npm.py
+++ b/lib/ansible/modules/packaging/language/npm.py
@@ -149,7 +149,7 @@ class Npm(object):
 
             if self.glbl:
                 cmd.append('--global')
-            if self.production:
+            if self.production and args[0] == 'install':
                 cmd.append('--production')
             if self.ignore_scripts:
                 cmd.append('--ignore-scripts')

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -370,7 +370,6 @@ lib/ansible/modules/packaging/language/cpanm.py
 lib/ansible/modules/packaging/language/easy_install.py
 lib/ansible/modules/packaging/language/gem.py
 lib/ansible/modules/packaging/language/maven_artifact.py
-lib/ansible/modules/packaging/language/npm.py
 lib/ansible/modules/packaging/language/pear.py
 lib/ansible/modules/packaging/language/pip.py
 lib/ansible/modules/packaging/os/apk.py


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
npm module

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
There's basically only one variant of where calling npm with "--production" and without scope/package (which is what Ansible does) is useful: installing a module  

Right now, the "npm-handling"-code trivially appends all given attributes to the cmd, no matter what. In the case of listing modules without scope/package this leads to a fundamental difference of outcome, since it breaks idempotence, though.

Let's take the following minimal example:

```
---
- hosts: all

  tasks:
    - name: install pm2
      npm:
        name: "pm2"
        production: "yes"
        global: "yes"
        version: "2.4.2"
```

This snippet does time and again install 'pm2' when being run, simply because it is going to be evaluated to:

`npm list --json --global --production` which always results correctly in `{}` (which in turn, the actual package name becomes appended to within the module's logic, and thus 'missing' will always be 'pm2').

This PR provides a rather dirty fix on this, though.
