### PR TITLE
Show diff when file: state=link changes the symlink target

### DIFF
--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -392,6 +392,8 @@ def main():
         elif prev_state == 'link':
             b_old_src = os.readlink(b_path)
             if b_old_src != b_src:
+                diff['before']['src'] = to_native(b_old_src, errors='strict')
+                diff['after']['src'] = src
                 changed = True
         elif prev_state == 'hard':
             if not (state == 'hard' and os.stat(b_path).st_ino == os.stat(b_src).st_ino):

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -97,6 +97,17 @@
     that:
       - "file5_result.changed == true"
 
+- name: change soft link to relative
+  file: src={{output_file|basename}} dest={{output_dir}}/soft.txt state=link
+  register: file5a_result
+
+- name: verify that the file was marked as changed
+  assert:
+    that:
+      - "file5a_result.changed == true"
+      - "file5a_result.diff.before.src == output_file|expanduser"
+      - "file5a_result.diff.after.src == output_file|basename"
+
 - name: create hard link to file
   file: src={{output_file}} dest={{output_dir}}/hard.txt state=hard
   register: file6_result

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -108,6 +108,15 @@
       - "file5a_result.diff.before.src == output_file|expanduser"
       - "file5a_result.diff.after.src == output_file|basename"
 
+- name: soft link idempotency check
+  file: src={{output_file|basename}} dest={{output_dir}}/soft.txt state=link
+  register: file5b_result
+
+- name: verify that the file was not marked as changed
+  assert:
+    that:
+      - "file5b_result.changed == false"
+
 - name: create hard link to file
   file: src={{output_file}} dest={{output_dir}}/hard.txt state=hard
   register: file6_result


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
file

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 5cccb7a5d7) last updated 2017/03/03 14:31:47 (GMT +300)
  config file = /home/mg/src/tilaajavastuu/bolagsfakta/deployment/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
When you have a task like the following

```yaml
- file: state=link dest=/etc/uwsgi/apps-enabled/myapp.ini src=/etc/uwsgi/apps-available/myapp.ini
```

and you run `ansible-playbook -CD` to see what happens, Ansible shows you

```
TASK [myapp : Generate uwsgi app symlinks] *************************************
changed: [myserver.example.com]
```

and you can't easily see why the symlink needs to change.  With this PR the output changes to

```
TASK [myapp : Generate uwsgi app symlinks] *************************************
--- before
+++ after
@@ -1,4 +1,4 @@
 {
     "path": "/etc/uwsgi/apps-enabled/myapp.ini",
-    "src": "../apps-available/myapp.ini"
+    "src": "/etc/uwsgi/apps-available/myapp.ini"
 }

changed: [myserver.example.com]
```

and you can immediatelly see that Ansible wants to change a relative symlink to an absolute one, and it's fine.