### PR TITLE
Prevent hostname to be set

### DIFF
--- a/lib/ansible/modules/cloud/lxc/lxc_container.py
+++ b/lib/ansible/modules/cloud/lxc/lxc_container.py
@@ -541,6 +541,7 @@ ATTACH_TEMPLATE = """#!/usr/bin/env bash
 pushd "$(getent passwd $(whoami)|cut -f6 -d':')"
     if [[ -f ".bashrc" ]];then
         source .bashrc
+        unset HOSTNAME
     fi
 popd
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lxc_container module

##### ANSIBLE VERSION
```
ansible 2.2.1.0
```

Applies to all ansible versions shipping this module.

##### SUMMARY
If the host .bashrc holds a var named HOSTNAME, the container
where the lxc_container module will attach to will inherit from
this var, potentially breaking some applications (like rabbitmqctl)
due to an incorrect $HOSTNAME reported in the container.