### PR TITLE
Fixes #22249 - allow nmcli to modify bond connection

### DIFF
--- a/lib/ansible/modules/network/nmcli.py
+++ b/lib/ansible/modules/network/nmcli.py
@@ -65,7 +65,7 @@ options:
     mode:
         required: False
         choices: [ "balance-rr", "active-backup", "balance-xor", "broadcast", "802.3ad", "balance-tlb", "balance-alb" ]
-        default: balence-rr
+        default: balance-rr
         description:
             - This is the type of device or network connection that you wish to create for a bond, team or bridge.
     master:
@@ -859,6 +859,8 @@ class Nmcli(object):
         cmd.append('con')
         cmd.append('mod')
         cmd.append(self.conn_name)
+        cmd.append('mode')
+        cmd.append(self.mode)
         if self.ip4 is not None:
             cmd.append('ipv4.address')
             cmd.append(self.ip4)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nmcli

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
```

##### SUMMARY
Adding default parameter to modify bond so module will not fail if no network parameters provided
Now even if no mode is provided it will not fail.

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
Before:
failed: [XXXXXX] (item={u'conn_name': u'bond0', u'state': u'present', u'mode': u'active-backup'}) => {
    "failed": true,                                                                                                                                                                                                                                     
    "invocation": {                                                                                                                                                                                                                                     
        "module_args": {                                                                                                                                                                                                                                
            "ageingtime": "300",                                                                                                                                                                                                                        
            "arp_interval": null,                                                                                                                                                                                                                       
            "arp_ip_target": null,                                                                                                                                                                                                                      
            "autoconnect": null,                                                                                                                                                                                                                        
            "conn_name": "bond0",                                                                                                                                                                                                                       
            "dns4": null,                                                                                                                                                                                                                               
            "dns6": null,                                                                                                                                                                                                                               
            "downdelay": null,                                                                                                                                                                                                                          
            "egress": null,                                                                                                                                                                                                                             
            "flags": null,                                                                                                                                                                                                                              
            "forwarddelay": "15",                                                                                                                                                                                                                       
            "gw4": null,                                                                                                                                                                                                                                
            "gw6": null,                                                                                                                                                                                                                                
            "hellotime": "2",                                                                                                                                                                                                                           
            "ifname": null,                                                                                                                                                                                                                             
            "ingress": null,                                                                                                                                                                                                                            
            "ip4": null,                                                                                                                                                                                                                                
            "ip6": null,                                                                                                                                                                                                                                
            "mac": null,                                                                                                                                                                                                                                
            "master": null,                                                                                                                                                                                                                             
            "maxage": "20",                                                                                                                                                                                                                             
            "miimon": null,                                                                                                                                                                                                                             
            "mode": "active-backup",                                                                                                                                                                                                                      
            "mtu": null,                                                                                                                                                                                                                                
            "priority": "128",                                                                                                                                                                                                                          
            "slavepriority": "32",                                                                                                                                                                                                                      
            "state": "present",                                                                                                                                                                                                                         
            "stp": true,                                                                                                                                                                                                                                
            "type": "bond",                                                                                                                                                                                                                             
            "updelay": null,                                                                                                                                                                                                                            
            "vlandev": null,                                                                                                                                                                                                                            
            "vlanid": null                                                                                                                                                                                                                              
        },                                                                                                                                                                                                                                              
        "module_name": "nmcli"                                                                                                                                                                                                                         
    },                                                                                                                                                                                                                                                  
    "item": {                                                                                                                                                                                                                                           
        "conn_name": "bond0",                                                                                                                                                                                                                           
        "mode": "active-backup",                                                                                                                                                                                                                          
        "state": "present"                                                                                                                                                                                                                              
    },                                                                                                                                                                                                                                                  
    "msg": "Error: <setting>.<property> argument is missing.\n",                                                                                                                                                                                        
    "name": "bond0",                                                                                                                                                                                                                                    
    "rc": 2                                                                                                                                                                                                                                             
}

After:
changed: [XXXXXX] => (item={u'conn_name': u'bond0', u'state': u'present'}) => {
    "Exists": "Connections do exist so we are modifying them",                                                                                                                                                                                          
    "changed": true,                                                                                                                                                                                                                                    
    "conn_name": "bond0",                                                                                                                                                                                                                               
    "invocation": {                                                                                                                                                                                                                                     
        "module_args": {                                                                                                                                                                                                                                
            "ageingtime": "300", 
            "arp_interval": null, 
            "arp_ip_target": null, 
            "autoconnect": null, 
            "conn_name": "bond0", 
            "dns4": null, 
            "dns6": null, 
            "downdelay": null, 
            "egress": null, 
            "flags": null, 
            "forwarddelay": "15", 
            "gw4": null, 
            "gw6": null, 
            "hellotime": "2", 
            "ifname": null, 
            "ingress": null, 
            "ip4": null, 
            "ip6": null, 
            "mac": null, 
            "master": null, 
            "maxage": "20", 
            "miimon": null, 
            "mode": "balance-rr", 
            "mtu": null, 
            "priority": "128", 
            "slavepriority": "32", 
            "state": "present", 
            "stp": true, 
            "type": "bond", 
            "updelay": null, 
            "vlandev": null, 
            "vlanid": null
        }, 
        "module_name": "nmcli"
    }, 
    "item": {
        "conn_name": "bond0", 
        "state": "present"
    }, 
    "state": "present"
}
```
