### PR TITLE
Fix reading role skeleton path from config/env

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -178,7 +178,10 @@ class GalaxyCLI(CLI):
 
         init_path  = self.get_opt('init_path', './')
         force      = self.get_opt('force', False)
-        role_skeleton = self.get_opt('role_skeleton', C.GALAXY_ROLE_SKELETON)
+        role_skeleton = self.get_opt('role_skeleton', None)
+
+        if not role_skeleton:
+            role_skeleton = C.GALAXY_ROLE_SKELETON
 
         role_name = self.args.pop(0).strip() if self.args else None
         if not role_name:

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -432,3 +432,20 @@ class TestGalaxyInitSkeleton(unittest.TestCase, ValidRoleTests):
 
     def test_skeleton_option(self):
         self.assertEquals(self.role_skeleton_path, self.gc.get_opt('role_skeleton'), msg='Skeleton path was not parsed properly from the command line')
+
+
+class TestGalaxyInitSkeletonConfigEnv(unittest.TestCase, ValidRoleTests):
+
+    @classmethod
+    def setUpClass(cls):
+        role_skeleton_path = os.path.join(os.path.split(__file__)[0], 'test_data', 'role_skeleton')
+        with patch('ansible.constants.GALAXY_ROLE_SKELETON', role_skeleton_path):
+            cls.setUpRole('delete_me_skeleton')
+            # role_skeleton_path is normally set from the argument passed to setUpRole,
+            # In this case, we're mocking the skeleton path being passed in from the config file or environment
+            # so we'll override it here.
+            cls.role_skeleton_path = role_skeleton_path
+
+    def test_correct_skeleton_used(self):
+        self.assertTrue(os.path.exists(os.path.join(self.role_dir, 'test_role_marker')),
+                        msg="test_role_marker file not found, skeleton path wasn't loaded correctly from the config/environment")


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy

##### ANSIBLE VERSION
```
ansible 2.3.0 (fix_skeleton_config 75ccfd23ed) last updated 2017/03/03 09:27:57 (GMT -500)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
CLI.get_opt() will only use the passed default value if an exception is raised
while trying to read the option value from the parsed values.  As a
result, the C.GALAXY_ROLE_SKELETON value was never read.  Instead of
relying on the default value, we explicitly check to see if
role_skeleton was set, and use C.GALAXY_ROLE_SKELETON if it isn't.

This is tested by patching C.GALAXY_ROLE_SKELETON to point to the role
skeleton in our test_data folder, and not supplying a role skeleton
argument.