### PR TITLE
doc: Document --syntax-check flag for ansible-playbook

### DIFF
--- a/docs/docsite/rst/playbooks_intro.rst
+++ b/docs/docsite/rst/playbooks_intro.rst
@@ -453,6 +453,9 @@ There's also a `clever playbook <https://github.com/ansible/ansible-examples/blo
 Tips and Tricks
 ```````````````
 
+To check the syntax of a playbook, use ``ansible-playbook`` with the ``--syntax-check`` flag. This will run the
+playbook file through the parser to ensure its included files, roles, etc. have no syntax problems.
+
 Look at the bottom of the playbook execution for a summary of the nodes that were targeted
 and how they performed.   General failures and fatal "unreachable" communication attempts are
 kept separate in the counts.


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
`ansible-playbook`

##### ANSIBLE VERSION
All, since `--syntax-check` was introduced a long time ago.

##### SUMMARY

It wasn't previously documented outside of the help / manpage, which made it less discoverable. It's a good tool for CI on Ansible code, it should be more visible.