### PR TITLE
[inventory/aos] Few fixes and small tweaks 

### DIFF
--- a/contrib/inventory/apstra_aos.ini
+++ b/contrib/inventory/apstra_aos.ini
@@ -8,12 +8,12 @@
 
 [aos]
 
-aos_server = 172.20.62.3
-port = 8888
-username = admin
-password = admin
+# aos_server = 172.20.62.3
+# port = 8888
+# username = admin
+# password = admin
 
-# Blueprint Mode
+## Blueprint Mode
 # to use the inventory in mode Blueprint, you need to define the blueprint name you want to use
 
 # blueprint = my-blueprint-l2

--- a/contrib/inventory/apstra_aos.py
+++ b/contrib/inventory/apstra_aos.py
@@ -313,6 +313,12 @@ class AosInventory(object):
         # Save session information in variables of group all
         self.add_var_to_group('all', 'aos_session', aos.session)
 
+        # Add the AOS server itself in the inventory
+        self.add_host_to_group("all", 'aos' )
+        self.add_var_to_host("aos", "ansible_ssh_host", self.aos_server )
+        self.add_var_to_host("aos", "ansible_ssh_pass", self.aos_password )
+        self.add_var_to_host("aos", "ansible_ssh_user", self.aos_username )
+
         # ----------------------------------------------------
         # Build the inventory
         #  2 modes are supported: device based or blueprint based

--- a/contrib/inventory/apstra_aos.py
+++ b/contrib/inventory/apstra_aos.py
@@ -341,6 +341,13 @@ class AosInventory(object):
                 if 'facts' in device.value.keys():
                     self.add_device_facts_to_var(dev_name, device)
 
+                # Define admin State and Status
+                if 'user_config' in device.value.keys():
+                    if 'admin_state' in device.value['user_config'].keys():
+                        self.add_var_to_host(dev_name, 'admin_state', device.value['user_config']['admin_state'] )
+
+                self.add_device_status_to_var(device.name, device)
+
                 # Go over the contents data structure
                 for node in bp.contents['system']['nodes']:
                     if node['display_name'] == dev_name:
@@ -405,9 +412,7 @@ class AosInventory(object):
                 self.add_host_to_group('all', device.name)
 
                 # populate information for this host
-                if 'status' in device.value.keys():
-                    for key, value in device.value['status'].items():
-                        self.add_var_to_host(device.name, key, value)
+                self.add_device_status_to_var(device.name, device)
 
                 if 'user_config' in device.value.keys():
                     for key, value in device.value['user_config'].items():
@@ -550,7 +555,7 @@ class AosInventory(object):
                              device.value['facts']['mgmt_ipaddr'])
 
         self.add_var_to_host(device_name,'id', device.id)
-        
+
         # self.add_host_to_group('all', device.name)
         for key, value in device.value['facts'].items():
             self.add_var_to_host(device_name, key, value)
@@ -571,6 +576,12 @@ class AosInventory(object):
         clean_group = rx.sub('_', group_name).lower()
 
         return clean_group
+
+    def add_device_status_to_var(self, device_name, device):
+
+        if 'status' in device.value.keys():
+            for key, value in device.value['status'].items():
+                self.add_var_to_host(device.name, key, value)
 
 # Run the script
 if __name__ == '__main__':

--- a/contrib/inventory/apstra_aos.py
+++ b/contrib/inventory/apstra_aos.py
@@ -549,6 +549,8 @@ class AosInventory(object):
                              'ansible_ssh_host',
                              device.value['facts']['mgmt_ipaddr'])
 
+        self.add_var_to_host(device_name,'id', device.id)
+        
         # self.add_host_to_group('all', device.name)
         for key, value in device.value['facts'].items():
             self.add_var_to_host(device_name, key, value)

--- a/contrib/inventory/apstra_aos.py
+++ b/contrib/inventory/apstra_aos.py
@@ -346,7 +346,7 @@ class AosInventory(object):
                     if 'admin_state' in device.value['user_config'].keys():
                         self.add_var_to_host(dev_name, 'admin_state', device.value['user_config']['admin_state'] )
 
-                self.add_device_status_to_var(device.name, device)
+                self.add_device_status_to_var(dev_name, device)
 
                 # Go over the contents data structure
                 for node in bp.contents['system']['nodes']:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
contrib/inventory/apstra_aos.py

##### ANSIBLE VERSION
```
ansible 2.3.0 (apstra 3d3b2b00d7) last updated 2017/03/01 22:45:34 (GMT -700)
  config file = /Users/damien/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

This PR include few small fixes and small tweaks to the Dynamic Inventory for Apstra. 
- Add the server itself in the inventory
- Comment out value in the confif file provided as an example
- Add device ID in the variable list
- Centralize code to add device status in the variable list

@privateip / @gundalow please can you take a look
Thanks
Damien
