### PR TITLE
Add ansible executable path (argv[0]) to --version

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -485,6 +485,7 @@ class CLI(with_metaclass(ABCMeta, object)):
             cpath = C.DEFAULT_MODULE_PATH
         result = result + "\n  configured module search path = %s" % cpath
         result = result + "\n  ansible python module location = %s" % ':'.join(ansible.__path__)
+        result = result + "\n  executable location = %s" % sys.argv[0]
         result = result + "\n  python version = %s" % ''.join(sys.version.splitlines())
         return result
 


### PR DESCRIPTION


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/cli/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (python_info_in_version 7f487fb16a) last updated 2017/03/03 13:37:26 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 3.6.0 (default, Feb  3 2017, 15:57:19) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### SUMMARY
Add ansible executable path (argv[0]) to --version

For example:

    ansible 2.3.0 (argv0_in_version f53921093f) last updated 2017/03/03 13:33:31 (GMT -400)
      config file = /home/adrian/.ansible.cfg
      configured module search path = Default w/o overrides
      executable path = /home/adrian/src/ansible/bin/ansible

This should help troubleshooting install issues.

More or less an extension of https://github.com/ansible/ansible/pull/22089