### PR TITLE
adding ability to set openstack image ids

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_image.py
+++ b/lib/ansible/modules/cloud/openstack/os_image.py
@@ -37,6 +37,11 @@ options:
         - Name that has to be given to the image
      required: true
      default: None
+   id:
+     description:
+       - The Id of the image
+      required: false
+      default: None
    disk_format:
      description:
         - The format of the disk that is getting uploaded
@@ -130,6 +135,7 @@ def main():
 
     argument_spec = openstack_full_argument_spec(
         name              = dict(required=True),
+        id                = dict(default=None),
         disk_format       = dict(default='qcow2', choices=['ami', 'ari', 'aki', 'vhd', 'vmdk', 'raw', 'qcow2', 'vdi', 'iso', 'vhdx', 'ploop']),
         container_format  = dict(default='bare', choices=['ami', 'aki', 'ari', 'bare', 'ovf', 'ova', 'docker']),
         owner             = dict(default=None),
@@ -158,6 +164,7 @@ def main():
             if not image:
                 image = cloud.create_image(
                     name=module.params['name'],
+                    id=module.params['id'],
                     filename=module.params['filename'],
                     disk_format=module.params['disk_format'],
                     container_format=module.params['container_format'],


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- module/cloud/openstack/os_image -->
module/cloud/openstack/os_image

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added support for setting Id when uploading an OpenStack image using the os_image module.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

