### PR TITLE
Show 'ansible' python module paths in --version

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -31,6 +31,7 @@ import getpass
 import subprocess
 from abc import ABCMeta, abstractmethod
 
+import ansible
 from ansible.release import __version__
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleOptionsError
@@ -483,6 +484,7 @@ class CLI(with_metaclass(ABCMeta, object)):
         else:
             cpath = C.DEFAULT_MODULE_PATH
         result = result + "\n  configured module search path = %s" % cpath
+        result = result + "\n  ansible python module path = %s" % ':'.join(ansible.__path__)
         result = result + "\n  python version = %s" % ''.join(sys.version.splitlines())
         return result
 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -484,7 +484,7 @@ class CLI(with_metaclass(ABCMeta, object)):
         else:
             cpath = C.DEFAULT_MODULE_PATH
         result = result + "\n  configured module search path = %s" % cpath
-        result = result + "\n  ansible python module path = %s" % ':'.join(ansible.__path__)
+        result = result + "\n  ansible python module location = %s" % ':'.join(ansible.__path__)
         result = result + "\n  python version = %s" % ''.join(sys.version.splitlines())
         return result
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/cli/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (ansible_python_module_path_in_version d12cce8341) last updated 2017/03/03 13:31:28 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides
  ansible python module path = /home/adrian/src/ansible/lib/ansible


```

##### SUMMARY
Show 'ansible' python module paths in --version

For ex:

```
ansible 2.3.0 (ansible_python_module_path_in_version d12cce8341) last updated 2017/03/03 13:31:28 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides
  ansible python module path = /home/adrian/src/ansible/lib/ansible
```

Based on https://github.com/ansible/ansible/pull/22089#issuecomment-283444754  
The location of the 'ansible' python module helps when troubleshooting ansible issues
(especially issues with python path issues or virtualenv)

https://github.com/ansible/ansible/pull/22262  is also related.
