### PR TITLE
[WIP] fix azure_rm version checks

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -26,7 +26,7 @@ import copy
 import importlib
 import inspect
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 from os.path import expanduser
 
 from ansible.module_utils.basic import AnsibleModule
@@ -73,9 +73,18 @@ AZURE_FAILED_STATE = "Failed"
 HAS_AZURE = True
 HAS_AZURE_EXC = None
 
+HAS_MSRESTAZURE = True
+HAS_MSRESTAZURE_EXC = None
+
+# NB: packaging issue sometimes cause msrestazure not to be installed, check it separately
+try:
+    from msrest.serialization import Serializer
+except ImportError as exc:
+    HAS_MSRESTAZURE_EXC = exc
+    HAS_MSRESTAZURE = False
+
 try:
     from enum import Enum
-    from msrest.serialization import Serializer
     from msrestazure.azure_exceptions import CloudError
     from azure.mgmt.network.models import PublicIPAddress, NetworkSecurityGroup, SecurityRule, NetworkInterface, \
         NetworkInterfaceIPConfiguration, Subnet
@@ -92,7 +101,6 @@ try:
 except ImportError as exc:
     HAS_AZURE_EXC = exc
     HAS_AZURE = False
-
 
 def azure_id_to_dict(id):
     pieces = re.sub(r'^\/', '', id).split('/')
@@ -143,8 +151,12 @@ class AzureRMModuleBase(object):
                                     supports_check_mode=supports_check_mode,
                                     required_if=merged_required_if)
 
+        if not HAS_MSRESTAZURE:
+            self.fail("Do you have msrestazure installed? Try `pip install msrestazure`"
+                      "- {0}".format(HAS_MSRESTAZURE_EXC))
+
         if not HAS_AZURE:
-            self.fail("Do you have azure=={1} installed? Try `pip install azure=={1}`"
+            self.fail("Do you have azure>={1} installed? Try `pip install 'azure>={1}' --upgrade`"
                       "- {0}".format(HAS_AZURE_EXC, AZURE_MIN_RELEASE))
 
         self._network_client = None
@@ -186,10 +198,10 @@ class AzureRMModuleBase(object):
         self.module.exit_json(**res)
 
     def check_client_version(self, client_name, client_version, expected_version):
-        # Pinning Azure modules to 2.0.0rc5.
-        if LooseVersion(client_version) < LooseVersion(expected_version):
+        # Ensure Azure modules are at least 2.0.0rc5.
+        if Version(client_version) < Version(expected_version):
             self.fail("Installed {0} client version is {1}. The supported version is {2}. Try "
-                      "`pip install azure>={3}`".format(client_name, client_version, expected_version,
+                      "`pip install azure>={3} --upgrade`".format(client_name, client_version, expected_version,
                                                         AZURE_MIN_RELEASE))
 
     def exec_module(self, **kwargs):


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_common.py

##### SUMMARY
* Use packaging.version.Version instead of LooseVersion for better support of prerelease tags (eg, 0.30.0 > 0.30.0rc6)
* Add explicit check/error for msrestazure package
