### PR TITLE
Add warning if playbook references a var that shadows a builtin method

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -157,6 +157,9 @@ def _count_newlines_from_end(in_str):
         return i
 
 
+BAD_ATTRS = set(['get', 'when', 'items', 'copy', 'blippy'])
+
+
 class AnsibleContext(Context):
     '''
     A custom context, which intercepts resolve() calls and sets a flag
@@ -205,7 +208,7 @@ class AnsibleContext(Context):
         self._update_unsafe(val)
         return val
 
-
+import types
 class AnsibleEnvironment(Environment):
     '''
     Our custom environment, which simply allows us to override the class-level
@@ -213,6 +216,23 @@ class AnsibleEnvironment(Environment):
     '''
     context_class = AnsibleContext
     template_class = AnsibleJ2Template
+
+    def getattr(self, obj, attribute):
+        #if attribute in BAD_ATTRS:
+        #    display.warning("obj.attribute access with the attr named '%s' should be avoided."
+        #                    "See http://docs.ansible.com/ansible/playbooks_variables.html#what-makes-a-valid-variable-name" % attribute)
+
+        # We could just warn, or we could just always prefer getitem to DWIM
+        ret = super(AnsibleEnvironment, self).getattr(obj, attribute)
+        #ret = super(AnsibleEnvironment, self).getitem(obj=obj, argument=attribute)
+        print(type(ret))
+        if isinstance(ret, (types.BuiltinMethodType,
+                            types.BuiltinFunctionType,
+                            types.MethodType,
+                            types.FunctionType)):
+            display.warning("obj.attribute access with the attr named '%s' should be avoided."
+                            "See http://docs.ansible.com/ansible/playbooks_variables.html#what-makes-a-valid-variable-name" % attribute)
+        return ret
 
 
 class Templar:

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -158,7 +158,6 @@ def _count_newlines_from_end(in_str):
         return i
 
 
-
 class AnsibleContext(Context):
     '''
     A custom context, which intercepts resolve() calls and sets a flag

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -230,6 +230,7 @@ class AnsibleEnvironment(Environment):
                             types.FunctionType)):
             display.warning("obj.attribute access with the attr named '%s' should be avoided."
                             "See http://docs.ansible.com/ansible/playbooks_variables.html#what-makes-a-valid-variable-name" % attribute)
+            return super(AnsibleEnvironment, self).getitem(obj=obj, argument=attribute)
         return ret
 
 

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -26,6 +26,7 @@ import os
 import pwd
 import re
 import time
+import types
 
 from io import StringIO
 from numbers import Number
@@ -157,8 +158,6 @@ def _count_newlines_from_end(in_str):
         return i
 
 
-BAD_ATTRS = set(['get', 'when', 'items', 'copy', 'blippy'])
-
 
 class AnsibleContext(Context):
     '''
@@ -208,7 +207,7 @@ class AnsibleContext(Context):
         self._update_unsafe(val)
         return val
 
-import types
+
 class AnsibleEnvironment(Environment):
     '''
     Our custom environment, which simply allows us to override the class-level
@@ -225,7 +224,6 @@ class AnsibleEnvironment(Environment):
         # We could just warn, or we could just always prefer getitem to DWIM
         ret = super(AnsibleEnvironment, self).getattr(obj, attribute)
         #ret = super(AnsibleEnvironment, self).getitem(obj=obj, argument=attribute)
-        print(type(ret))
         if isinstance(ret, (types.BuiltinMethodType,
                             types.BuiltinFunctionType,
                             types.MethodType,

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -222,15 +222,20 @@ class AnsibleEnvironment(Environment):
                             types.MethodType,
                             types.FunctionType)):
             try:
-                item = obj.__getitem__(attribute)
+                obj.__getitem__(attribute)
             except (TypeError, KeyError):
                 # getattr, got a method, but there is no item by that name so the method
                 # is ok
                 return ret
+            # the attr name is also a name for a data/dict item
 
-            display.warning("The attribute '%s' for this object shadows a builtin method name. Returning the data item instead. "
-                            "See http://docs.ansible.com/ansible/playbooks_variables.html#what-makes-a-valid-variable-name" % (attribute))
-            return item
+            msg = "The attribute '%s' for this object shadows a builtin method name." \
+                " This means a reference to the objects method will be returned, possibly" \
+                " resulting in templating getting a string of the methods repr." \
+                " See http://docs.ansible.com/ansible/playbooks_variables.html#what-makes-a-valid-variable-name" % attribute
+            display.warning(msg)
+            return ret
+
         return ret
 
 

--- a/test/integration/targets/template_getattr/aliases
+++ b/test/integration/targets/template_getattr/aliases
@@ -1,0 +1,1 @@
+posix/ci/group2

--- a/test/integration/targets/template_getattr/tasks/main.yml
+++ b/test/integration/targets/template_getattr/tasks/main.yml
@@ -152,12 +152,25 @@
       - valid_test.confused_for_a_list.popitem()[0] in ['pop', 'soda']
       - valid_test.confused_for_a_list.popitem()[1] in ['cheerwine', 'RC']
 
-# these fail with or without the patch
-#    - debug:
-#        msg: "valid_test.endswith('r_v'): {{ valid_test.endswith('r_v') }}"
+      # these fail with or without the pat
+- debug:
+    msg: "valid_test.endswith: {{ valid_test.endswith }}"
 
-#    - debug:
-#        msg: "valid_test.confused.endswith('r_v'): {{ valid_test.confused.endswith('r_v') }}"
+- debug:
+    msg: "valid_test.some_var.endswith: {{ valid_test.some_var.endswith }}"
 
-#    - debug:
-#        msg: "valid_test.confused.startswith('r_v'): {{ valid_test.confused.startsswith('r_v') }}"
+- debug:
+    msg: "valid_test.some_var.endswith('r_v'): {{ valid_test.some_var.endswith('r_v') }}"
+
+- assert:
+    that:
+      - valid_test.some_var.endswith is callable
+      - valid_test.some_var.endswith('r_v') == True
+      - valid_test.some_var.endswith('the_end') == False
+
+- name: try confused.endswith
+  assert:
+    that:
+      - valid_test.confused.endswith is not callable
+      - valid_test.confused.endswith == "not the endswith method"
+

--- a/test/integration/targets/template_getattr/tasks/main.yml
+++ b/test/integration/targets/template_getattr/tasks/main.yml
@@ -2,35 +2,36 @@
   debug:
     var: valid_test
 
+
 - name: "Try to access a data item called 'get' that shows a builtin. Expect it to return the item and a warning"
   debug:
     msg: "valid_test.get {{ valid_test.get }}"
+
 
 - name: "Try to access a data item called 'get' via ['get'] that shadows a builtin. Expect it to return the item but without a warning"
   debug:
     msg: "valid_test['get'] {{ valid_test['get'] }}"
 
+
 - name: "Try to access a nested dict with via .get. This shadows a builtin so expect the item returned and a warning"
   debug:
     msg: "l4.get: {{ valid_test.level2.level3.level4.get }}"
+
 
 - name: "Try to access a nested dict with via ['item']. This shadows a builtin but uses getitem so expect the item returned and no warning"
   debug:
     msg: "l4 item: {{valid_test['level2']['level3']['level4']['get'] }}"
 
-- debug:
-    var: some_var
-
-- debug:
-    var: some_var()
 
 - name: "Try to access and valid_test['some_var'].startswith and call it (builtin). Not shadowed, so no warning."
   debug:
     msg: "valid_test['some_var'].startswith('fo'): {{ valid_test['some_var'].startswith('fo') }}"
 
+
 - name: "Try to access and valid_test.some_var.startswith and call it (builtin). Not shadowed, so no warning."
   debug:
     msg: "valid_test.some_var.startswith('r_v'): {{ valid_test.some_var.startswith('r_v') }}"
+
 
 - name: "Try to access and call a builtin method (upper). This is not shadowed so expect it to return can call without a warning."
   debug:
@@ -42,17 +43,19 @@
     var: valid_test.get()
   ignore_errors: true
 
+
 - debug:
     var: valid_test.values
 
+
 - debug:
     var: valid_test.values()
+
 
 - name: Try to access a item that doesnt exist as attr or item so it fails.
   debug:
     msg: "valid_test.not_a_key: {{ valid_test.not_a_key }}"
   ignore_errors: true
-  register: result1
 
 
 - name: "Try to access a item via ['not_a_key'] but not_a_key does not exist as attr or item so it fails."
@@ -60,49 +63,47 @@
     msg: "valid_test['not_a_key']: {{ valid_test['not_a_key'] }}"
   ignore_errors: true
 
-    #    - debug:
-    #msg: "valid_test.a_list[0]: {{ valid_test.a_list[0] }}"
-
-    #- debug:
-    #msg: "valid_test.a_list[13]: {{ valid_test.a_list[13] }}"
-    #- debug:
-    #msg: "valid_test.a_list['blip']: {{ valid_test.a_list['blip'] }}"
-
-    #- debug:
-    #  msg: "valid_test.confused_for_a_list[0]: {{ valid_test.confused_for_a_list[0] }}"
 
 - name: "Try to access valid_list.a_list.count (builtin method) but it is not shadowed so it works"
   debug:
     msg: "valid_test.a_list.count: {{ valid_test.a_list.count }}"
 
+
 - name: "Try to access and call valid_list.a_list.count() (builtin method) but it is not shadowed so it works"
   debug:
     msg: "valid_test.a_list.count(): {{ valid_test.a_list.count('thing 1') }}"
+
 
 - name: "Try to access valid_list.a_list.pop (builtin method) but it is not shadowed so it works"
   debug:
     msg: "valid_test.a_list.pop: {{ valid_test.a_list.pop }}"
 
+
 - name: "Try to access and call valid_list.a_list.pop() (builtin method) but it is not shadowed so it works"
   debug:
     msg: "valid_test.a_list.pop(): {{ valid_test.a_list.pop() }}"
+
 
 - name: "Try to access and call valid_test.confused_for_a_list.pop() (builtin method) but it is shadowed with an item so it we expect the ['pop'] item to be returned with a warning and call to fail"
   debug:
     msg: "valid_test.confused_for_a_list.pop(): {{ valid_test.confused_for_a_list.pop() }}"
   ignore_errors: true
 
+
 - name: "Try to access valid_list.confused_for_list.pop which is an item so expect ['pop'] to be returned with a warning"
   debug:
     msg: "valid_test.confused_for_a_list.pop: {{ valid_test.confused_for_a_list.pop }}"
+
 
 - name: "Try to access valid_list.confused_for_list.popitem (builtin method) and expect the method to be returned without a warning"
   debug:
     msg: "valid_test.confused_for_a_list.popitem: {{ valid_test.confused_for_a_list.popitem }}"
 
+
 - name: "Try to access and call valid_list.confused_for_list.popitem (builtin method) and expect the method to be returned and called without a warning"
   debug:
     msg: "valid_test.confused_for_a_list.popitem(): {{ valid_test.confused_for_a_list.popitem() }}"
+
 
 # these fail with or without the patch
 #    - debug:
@@ -111,18 +112,6 @@
 #    - debug:
 #        msg: "valid_test.confused.endswith('r_v'): {{ valid_test.confused.endswith('r_v') }}"
 
-    #    - debug:
-    #        msg: "valid_test.confused.startswith('r_v'): {{ valid_test.confused.startsswith('r_v') }}"
+#    - debug:
+#        msg: "valid_test.confused.startswith('r_v'): {{ valid_test.confused.startsswith('r_v') }}"
 
-    #    - include_vars:
-    #    file: "vars/blns_vars.yml"
-    #name: blns
-
-    #  - debug:
-    #var: blns
-
-    #    - debug:
-    #        msg: "{{ item.key }}  {{ item.value }}"
-    #      with_dict: blns.blns
-    #    - debug:
-    #msg: "minus {{ valid_test-some_var }}"

--- a/test/integration/targets/template_getattr/tasks/main.yml
+++ b/test/integration/targets/template_getattr/tasks/main.yml
@@ -10,7 +10,8 @@
 - name: "Try to access a data item called 'get' that shows a builtin. Expect it to return the item and a warning"
   assert:
     that:
-      - valid_test.get == "is_get_valid"
+      - valid_test.get != "is_get_valid"
+      - valid_test.get is callable
 
 
 - name: "Try to access a data item called 'get' via ['get'] that shadows a builtin. Expect it to return the item but without a warning"
@@ -27,10 +28,11 @@
   debug:
     msg: "l4.get: {{ valid_test.level2.level3.level4.get }}"
 
-- name: "Assert access to a nested dict with via .get. This shadows a builtin so expect the item returned and a warning"
+- name: "Assert access to a nested dict with via .get. This shadows a builtin so expect the method returned and a warning"
   assert:
     that:
-      - valid_test.level2.level3.level4.get == "level4_get"
+      - valid_test.level2.level3.level4.get != "level4_get"
+      - valid_test.level2.level3.level4.get is callable
 
 
 - name: "Try to access a nested dict with via ['item']. This shadows a builtin but uses getitem so expect the item returned and no warning"
@@ -73,37 +75,30 @@
     that:
       - valid_test.some_var.upper() == "SOME_VAR_V"
 
-
-- name: "Try to call valid_test.get(), but 'get' is a data item that shadows a builtin method and we return the data so call fails"
-  debug:
-    var: valid_test.get()
-  ignore_errors: true
-
+- name: "Try to call valid_test.get(), but 'get' is a data item that shadows a builtin method and the method is returned and called and a warning"
+  assert:
+    that:
+      - valid_test.get('some_var') == 'some_var_v'
 
 - debug:
     var: valid_test.values
 
-
 - debug:
     var: valid_test.values()
-
 
 - name: Try to access a item that doesnt exist as attr or item so it fails.
   debug:
     msg: "valid_test.not_a_key: {{ valid_test.not_a_key }}"
   ignore_errors: true
 
-
 - name: "Try to access a item via ['not_a_key'] but not_a_key does not exist as attr or item so it fails."
   debug:
     msg: "valid_test['not_a_key']: {{ valid_test['not_a_key'] }}"
   ignore_errors: true
 
-
 - name: "Try to access valid_list.a_list.count (builtin method) but it is not shadowed so it works"
   debug:
     msg: "valid_test.a_list.count: {{ valid_test.a_list.count }}"
-
 
 - name: "Try to access and call valid_list.a_list.count() (builtin method) but it is not shadowed so it works"
   debug:
@@ -118,7 +113,6 @@
   debug:
     msg: "valid_test.a_list.pop: {{ valid_test.a_list.pop }}"
 
-
 - name: "Try to access and call valid_list.a_list.pop() (builtin method) but it is not shadowed so it works"
   debug:
     msg: "valid_test.a_list.pop(): {{ valid_test.a_list.pop() }}"
@@ -128,22 +122,15 @@
     that:
       - valid_test.a_list.pop() == "thing 3"
 
-
-- name: "Try to access and call valid_test.confused_for_a_list.pop() (builtin method) but it is shadowed with an item so it we expect the ['pop'] item to be returned with a warning and call to fail"
-  debug:
-    msg: "valid_test.confused_for_a_list.pop(): {{ valid_test.confused_for_a_list.pop() }}"
-  ignore_errors: true
-
-
-- name: "Try to access valid_list.confused_for_list.pop which is an item so expect ['pop'] to be returned with a warning"
+- name: "Try to access valid_list.confused_for_list.pop which is an item so expect the 'pop' method to be returned with a warning"
   debug:
     msg: "valid_test.confused_for_a_list.pop: {{ valid_test.confused_for_a_list.pop }}"
 
-- name: "Try to access valid_list.confused_for_list.pop which is an item so expect ['pop'] to be returned with a warning"
+- name: "Try to access valid_list.confused_for_list.pop which is an item so expect the 'pop' method to be returned with a warning"
   assert:
     that:
-      - valid_test.confused_for_a_list.pop == "cheerwine"
-
+      - valid_test.confused_for_a_list.pop != "cheerwine"
+      - valid_test.confused_for_a_list.pop is callable
 
 - name: "Try to access valid_list.confused_for_list.popitem (builtin method) and expect the method to be returned without a warning"
   debug:
@@ -153,7 +140,6 @@
   assert:
     that:
       - valid_test.confused_for_a_list.popitem != "foo"
-
 
 - name: "Try to access and call valid_list.confused_for_list.popitem (builtin method) and expect the method to be returned and called without a warning"
   debug:

--- a/test/integration/targets/template_getattr/tasks/main.yml
+++ b/test/integration/targets/template_getattr/tasks/main.yml
@@ -1,0 +1,128 @@
+- name: "show the valid_test data for reference"
+  debug:
+    var: valid_test
+
+- name: "Try to access a data item called 'get' that shows a builtin. Expect it to return the item and a warning"
+  debug:
+    msg: "valid_test.get {{ valid_test.get }}"
+
+- name: "Try to access a data item called 'get' via ['get'] that shadows a builtin. Expect it to return the item but without a warning"
+  debug:
+    msg: "valid_test['get'] {{ valid_test['get'] }}"
+
+- name: "Try to access a nested dict with via .get. This shadows a builtin so expect the item returned and a warning"
+  debug:
+    msg: "l4.get: {{ valid_test.level2.level3.level4.get }}"
+
+- name: "Try to access a nested dict with via ['item']. This shadows a builtin but uses getitem so expect the item returned and no warning"
+  debug:
+    msg: "l4 item: {{valid_test['level2']['level3']['level4']['get'] }}"
+
+- debug:
+    var: some_var
+
+- debug:
+    var: some_var()
+
+- name: "Try to access and valid_test['some_var'].startswith and call it (builtin). Not shadowed, so no warning."
+  debug:
+    msg: "valid_test['some_var'].startswith('fo'): {{ valid_test['some_var'].startswith('fo') }}"
+
+- name: "Try to access and valid_test.some_var.startswith and call it (builtin). Not shadowed, so no warning."
+  debug:
+    msg: "valid_test.some_var.startswith('r_v'): {{ valid_test.some_var.startswith('r_v') }}"
+
+- name: "Try to access and call a builtin method (upper). This is not shadowed so expect it to return can call without a warning."
+  debug:
+    msg: "valid_test.some_var.upper(): {{ valid_test.some_var.upper() }}"
+
+
+- name: "Try to call valid_test.get(), but 'get' is a data item that shadows a builtin method and we return the data so call fails"
+  debug:
+    var: valid_test.get()
+  ignore_errors: true
+
+- debug:
+    var: valid_test.values
+
+- debug:
+    var: valid_test.values()
+
+- name: Try to access a item that doesnt exist as attr or item so it fails.
+  debug:
+    msg: "valid_test.not_a_key: {{ valid_test.not_a_key }}"
+  ignore_errors: true
+  register: result1
+
+
+- name: "Try to access a item via ['not_a_key'] but not_a_key does not exist as attr or item so it fails."
+  debug:
+    msg: "valid_test['not_a_key']: {{ valid_test['not_a_key'] }}"
+  ignore_errors: true
+
+    #    - debug:
+    #msg: "valid_test.a_list[0]: {{ valid_test.a_list[0] }}"
+
+    #- debug:
+    #msg: "valid_test.a_list[13]: {{ valid_test.a_list[13] }}"
+    #- debug:
+    #msg: "valid_test.a_list['blip']: {{ valid_test.a_list['blip'] }}"
+
+    #- debug:
+    #  msg: "valid_test.confused_for_a_list[0]: {{ valid_test.confused_for_a_list[0] }}"
+
+- name: "Try to access valid_list.a_list.count (builtin method) but it is not shadowed so it works"
+  debug:
+    msg: "valid_test.a_list.count: {{ valid_test.a_list.count }}"
+
+- name: "Try to access and call valid_list.a_list.count() (builtin method) but it is not shadowed so it works"
+  debug:
+    msg: "valid_test.a_list.count(): {{ valid_test.a_list.count('thing 1') }}"
+
+- name: "Try to access valid_list.a_list.pop (builtin method) but it is not shadowed so it works"
+  debug:
+    msg: "valid_test.a_list.pop: {{ valid_test.a_list.pop }}"
+
+- name: "Try to access and call valid_list.a_list.pop() (builtin method) but it is not shadowed so it works"
+  debug:
+    msg: "valid_test.a_list.pop(): {{ valid_test.a_list.pop() }}"
+
+- name: "Try to access and call valid_test.confused_for_a_list.pop() (builtin method) but it is shadowed with an item so it we expect the ['pop'] item to be returned with a warning and call to fail"
+  debug:
+    msg: "valid_test.confused_for_a_list.pop(): {{ valid_test.confused_for_a_list.pop() }}"
+  ignore_errors: true
+
+- name: "Try to access valid_list.confused_for_list.pop which is an item so expect ['pop'] to be returned with a warning"
+  debug:
+    msg: "valid_test.confused_for_a_list.pop: {{ valid_test.confused_for_a_list.pop }}"
+
+- name: "Try to access valid_list.confused_for_list.popitem (builtin method) and expect the method to be returned without a warning"
+  debug:
+    msg: "valid_test.confused_for_a_list.popitem: {{ valid_test.confused_for_a_list.popitem }}"
+
+- name: "Try to access and call valid_list.confused_for_list.popitem (builtin method) and expect the method to be returned and called without a warning"
+  debug:
+    msg: "valid_test.confused_for_a_list.popitem(): {{ valid_test.confused_for_a_list.popitem() }}"
+
+# these fail with or without the patch
+#    - debug:
+#        msg: "valid_test.endswith('r_v'): {{ valid_test.endswith('r_v') }}"
+
+#    - debug:
+#        msg: "valid_test.confused.endswith('r_v'): {{ valid_test.confused.endswith('r_v') }}"
+
+    #    - debug:
+    #        msg: "valid_test.confused.startswith('r_v'): {{ valid_test.confused.startsswith('r_v') }}"
+
+    #    - include_vars:
+    #    file: "vars/blns_vars.yml"
+    #name: blns
+
+    #  - debug:
+    #var: blns
+
+    #    - debug:
+    #        msg: "{{ item.key }}  {{ item.value }}"
+    #      with_dict: blns.blns
+    #    - debug:
+    #msg: "minus {{ valid_test-some_var }}"

--- a/test/integration/targets/template_getattr/tasks/main.yml
+++ b/test/integration/targets/template_getattr/tasks/main.yml
@@ -160,12 +160,11 @@
     msg: "valid_test.confused_for_a_list.popitem(): {{ valid_test.confused_for_a_list.popitem() }}"
     # built-in method popitem
 
-
 - name: "Try to access and call valid_list.confused_for_list.popitem (builtin method) and expect the method to be accessed and called without a warning"
   assert:
     that:
-      - valid_test.confused_for_a_list.popitem()[0] == "pop"
-      - valid_test.confused_for_a_list.popitem()[1] == "cheerwine"
+      - valid_test.confused_for_a_list.popitem()[0] in ['pop', 'soda']
+      - valid_test.confused_for_a_list.popitem()[1] in ['cheerwine', 'RC']
 
 # these fail with or without the patch
 #    - debug:

--- a/test/integration/targets/template_getattr/tasks/main.yml
+++ b/test/integration/targets/template_getattr/tasks/main.yml
@@ -7,35 +7,71 @@
   debug:
     msg: "valid_test.get {{ valid_test.get }}"
 
+- name: "Try to access a data item called 'get' that shows a builtin. Expect it to return the item and a warning"
+  assert:
+    that:
+      - valid_test.get == "is_get_valid"
+
 
 - name: "Try to access a data item called 'get' via ['get'] that shadows a builtin. Expect it to return the item but without a warning"
   debug:
     msg: "valid_test['get'] {{ valid_test['get'] }}"
+
+- name: "Assert access to a data item called 'get' via ['get'] that shadows a builtin. Expect it to return the item but without a warning"
+  assert:
+    that:
+      - valid_test['get'] == "is_get_valid"
 
 
 - name: "Try to access a nested dict with via .get. This shadows a builtin so expect the item returned and a warning"
   debug:
     msg: "l4.get: {{ valid_test.level2.level3.level4.get }}"
 
+- name: "Assert access to a nested dict with via .get. This shadows a builtin so expect the item returned and a warning"
+  assert:
+    that:
+      - valid_test.level2.level3.level4.get == "level4_get"
+
 
 - name: "Try to access a nested dict with via ['item']. This shadows a builtin but uses getitem so expect the item returned and no warning"
   debug:
     msg: "l4 item: {{valid_test['level2']['level3']['level4']['get'] }}"
+
+- name: "Assert access to a nested dict with via ['item']. This shadows a builtin but uses getitem so expect the item returned and no warning"
+  assert:
+    that:
+      - valid_test['level2']['level3']['level4']['get'] == "level4_get"
 
 
 - name: "Try to access and valid_test['some_var'].startswith and call it (builtin). Not shadowed, so no warning."
   debug:
     msg: "valid_test['some_var'].startswith('fo'): {{ valid_test['some_var'].startswith('fo') }}"
 
+- name: "Assert access to valid_test['some_var'].startswith and call it (builtin). Not shadowed, so no warning."
+  assert:
+    that:
+      - valid_test['some_var'].startswith('fo') == false
+
 
 - name: "Try to access and valid_test.some_var.startswith and call it (builtin). Not shadowed, so no warning."
   debug:
     msg: "valid_test.some_var.startswith('r_v'): {{ valid_test.some_var.startswith('r_v') }}"
 
+- name: "Assert access to valid_test.some_var.startswith and call it (builtin). Not shadowed, so no warning."
+  assert:
+    that:
+      - valid_test.some_var.startswith('r_v') == false
+
 
 - name: "Try to access and call a builtin method (upper). This is not shadowed so expect it to return can call without a warning."
   debug:
     msg: "valid_test.some_var.upper(): {{ valid_test.some_var.upper() }}"
+
+
+- name: "Assert access and call a builtin method (upper). This is not shadowed so expect it to be accessed and called without a warning."
+  assert:
+    that:
+      - valid_test.some_var.upper() == "SOME_VAR_V"
 
 
 - name: "Try to call valid_test.get(), but 'get' is a data item that shadows a builtin method and we return the data so call fails"
@@ -73,6 +109,10 @@
   debug:
     msg: "valid_test.a_list.count(): {{ valid_test.a_list.count('thing 1') }}"
 
+- name: "Assert that access and call valid_list.a_list.count() (builtin method) but it is not shadowed so it works"
+  assert:
+    that:
+      - valid_test.a_list.count('thing 1') == 1
 
 - name: "Try to access valid_list.a_list.pop (builtin method) but it is not shadowed so it works"
   debug:
@@ -82,6 +122,11 @@
 - name: "Try to access and call valid_list.a_list.pop() (builtin method) but it is not shadowed so it works"
   debug:
     msg: "valid_test.a_list.pop(): {{ valid_test.a_list.pop() }}"
+
+- name: "Try to access and call valid_list.a_list.pop() (builtin method) but it is not shadowed so it works"
+  assert:
+    that:
+      - valid_test.a_list.pop() == "thing 3"
 
 
 - name: "Try to access and call valid_test.confused_for_a_list.pop() (builtin method) but it is shadowed with an item so it we expect the ['pop'] item to be returned with a warning and call to fail"
@@ -94,16 +139,33 @@
   debug:
     msg: "valid_test.confused_for_a_list.pop: {{ valid_test.confused_for_a_list.pop }}"
 
+- name: "Try to access valid_list.confused_for_list.pop which is an item so expect ['pop'] to be returned with a warning"
+  assert:
+    that:
+      -  valid_test.confused_for_a_list.pop == "cheerwine"
+
 
 - name: "Try to access valid_list.confused_for_list.popitem (builtin method) and expect the method to be returned without a warning"
   debug:
     msg: "valid_test.confused_for_a_list.popitem: {{ valid_test.confused_for_a_list.popitem }}"
 
+- name: "Try to access valid_list.confused_for_list.popitem (builtin method) and expect the method object to be returned without a warning"
+  assert:
+    that:
+      - valid_test.confused_for_a_list.popitem != "foo"
+
 
 - name: "Try to access and call valid_list.confused_for_list.popitem (builtin method) and expect the method to be returned and called without a warning"
   debug:
     msg: "valid_test.confused_for_a_list.popitem(): {{ valid_test.confused_for_a_list.popitem() }}"
+    # built-in method popitem
 
+
+- name: "Try to access and call valid_list.confused_for_list.popitem (builtin method) and expect the method to be accessed and called without a warning"
+  assert:
+    that:
+      - valid_test.confused_for_a_list.popitem()[0] == "pop"
+      - valid_test.confused_for_a_list.popitem()[1] == "cheerwine"
 
 # these fail with or without the patch
 #    - debug:

--- a/test/integration/targets/template_getattr/tasks/main.yml
+++ b/test/integration/targets/template_getattr/tasks/main.yml
@@ -142,7 +142,7 @@
 - name: "Try to access valid_list.confused_for_list.pop which is an item so expect ['pop'] to be returned with a warning"
   assert:
     that:
-      -  valid_test.confused_for_a_list.pop == "cheerwine"
+      - valid_test.confused_for_a_list.pop == "cheerwine"
 
 
 - name: "Try to access valid_list.confused_for_list.popitem (builtin method) and expect the method to be returned without a warning"
@@ -175,4 +175,3 @@
 
 #    - debug:
 #        msg: "valid_test.confused.startswith('r_v'): {{ valid_test.confused.startsswith('r_v') }}"
-

--- a/test/integration/targets/template_getattr/vars/main.yml
+++ b/test/integration/targets/template_getattr/vars/main.yml
@@ -1,0 +1,23 @@
+ oops: "{{ this_is_not_declared }}"
+ valid_test:
+    get: "is_get_valid"
+    endswith: 'not the method endswith'
+    items: "is_items_valid"
+    when: "is_when_valid"
+    some_var: "some_var_v"
+    level2:
+        foo2: 'foo2 v'
+        level3:
+          foo3: 'foo3 v'
+          level4:
+              foo4: 'foo4 v'
+              get: 'level4_get'
+    confused:
+      startswith: "not the startswith method"
+      endswith: "not the endswith method"
+    a_list:
+        - 'thing 1'
+        - 'thing 2'
+    confused_for_a_list:
+        pop: 'cheerwine'
+        soda: 'RC'

--- a/test/integration/targets/template_getattr/vars/main.yml
+++ b/test/integration/targets/template_getattr/vars/main.yml
@@ -16,8 +16,10 @@
       startswith: "not the startswith method"
       endswith: "not the endswith method"
     a_list:
+        # these get 'pop()'ed' in the intg test, so the count matters
         - 'thing 1'
         - 'thing 2'
+        - 'thing 3'
     confused_for_a_list:
         pop: 'cheerwine'
         soda: 'RC'


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/template/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (warn_on_invalid_var_getattr 3ecac85b92) last updated 2017/03/03 16:27:40 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
There is a silent gotcha lurking in http://docs.ansible.com/ansible/playbooks_variables.html#what-makes-a-valid-variable-name

If playbook yaml data structures contain fields with any ~80 var names listed there, and the playbook references them via dot/getattr access ( "{{ my_data.my_field }}"), instead of returning the data item set in the data structure, a reference to the python builtin methods of the same names will be returned.

There is a way to avoid that (using {{ my_data['my_field'] }} to prefer the getitem()), but it is very easy to accidentally use a shadowed builtin and the getattr/dot access method and end up with a the method reference which caused very confusing error messages and other weird failures.
ie, if my_data:

``` yaml
my_data:
   get: http://www.ansible.com
   update: http://www.ansible.com/releases
   blippy: 37
```

If playbook uses '{{ my_data.get }}', the result   will be something like '<built-in method get of dict object at 0x7fdef81cc050>' instead of 'http://www.ansible.com'

This pr adds a warning message for that case. It also changes the behavior to prefer the data item ('http://www.ansible.com') for cases where data items shadow built in methods. A reference to
'{{ my_data.popitem }}' will still return the method reference (popitem is not shadowed).

The patch detects if a getattr is used on the object could also reference a data item. If so, it warns and returns the data item.