### PR TITLE
Fix encoding issue in shippable downloader.

### DIFF
--- a/test/utils/shippable/download.py
+++ b/test/utils/shippable/download.py
@@ -138,7 +138,7 @@ def extract_contents(args, path, output_dir):
             items = json.load(json_fd)
 
             for item in items:
-                contents = item['contents']
+                contents = item['contents'].encode('utf-8')
                 path = output_dir + '/' + re.sub('^/*', '', item['path'])
 
                 directory = os.path.dirname(path)


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

test/utils/shippable/download.py

##### ANSIBLE VERSION

```
ansible 2.3.0 (download-fix ba847192ad) last updated 2017/03/03 16:00:00 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```

##### SUMMARY

Fix encoding issue in shippable downloader.