### PR TITLE
Support option renaming in validate-modules.

### DIFF
--- a/test/sanity/validate-modules/validate-modules
+++ b/test/sanity/validate-modules/validate-modules
@@ -798,8 +798,9 @@ class ModuleValidator(Validator):
         strict_ansible_version = StrictVersion(should_be)
 
         for option, details in options.items():
-            new = not bool(existing_options.get(option))
-            if not new:
+            names = [option] + details.get('aliases', [])
+
+            if any(name in existing_options for name in names):
                 continue
 
             try:


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

validate-modules

##### ANSIBLE VERSION

```
ansible 2.3.0 (validate-rename-opt 51f41465b5) last updated 2017/03/03 16:11:41 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```

##### SUMMARY

Support option renaming in validate-modules.