### PR TITLE
Add task firewall/blocker strategy plugin

### DIFF
--- a/lib/ansible/plugins/strategy/task_firewall.py
+++ b/lib/ansible/plugins/strategy/task_firewall.py
@@ -110,7 +110,7 @@ class Firewall:
 
             # is the entire action blocked?
             # NOTE: we expect a dict, but future-proof and check for list too
-            if not isinstance(self.policy[task.action], list) and not isinstance(self.policy[task.action], dict):
+            if not isinstance(self.policy[task.action], dict) and not isinstance(self.policy[task.action], list):
                 raise AnsibleError('firewall policy: module [%s] blocked' % task.action)
 
             display.v('firewall rule passed: module [%s] generally allowed' % task.action)
@@ -118,11 +118,8 @@ class Firewall:
             # now check the action args
             for key in self.policy[task.action]:
 
-                if key not in task.args:
-                    continue
-
                 # is an arg of this action blocked?
-                if not isinstance(self.policy[task.action][key], list):
+                if key in task.args:
                     raise AnsibleError('firewall policy: module [%s] arg [%s] blocked' % (task.action, key))
 
-                display.v('firewall rule passed: [%s:%s] against %s' % (self.policy[task.action], self.policy[task.action][key], task.args[key]))
+                display.v('firewall rule passed: [%s:%s] against %s' % (task.action, key, task.args))

--- a/lib/ansible/plugins/strategy/task_firewall.py
+++ b/lib/ansible/plugins/strategy/task_firewall.py
@@ -1,0 +1,130 @@
+# file: ./ansible/plugins/strategy/task_firewall.py
+
+# A strategy plugin for Ansible (2.2+) to enforce task action restrictions 
+# by policy.  
+#
+# NOTE: Enforcement of the plugin itself can be implemented in various ways,
+# but currently needs to be done outside of Ansible itself (eg, git commit
+# hook to modify playbooks, etc). If you need this sort of plugin then that
+# won't be an issue.
+#
+# Copyright (C) 2017  Doug Bridgens, https://github.com/thisdougb
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.   
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import cmd
+import sys
+import yaml
+import pprint
+
+from ansible.plugins.strategy.linear import StrategyModule as LinearStrategyModule
+from ansible.errors import AnsibleError
+
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
+class StrategyModule(LinearStrategyModule):
+    def __init__(self, tqm):
+
+        # NOTE: hard coded because, being a firewall, this should not
+        #       be overriden by a local ansible.cfg var.   Still feels
+        #       a dirty way to do it.
+        self.firewall = Firewall('/etc/ansible/task_firewall_policy.yml')
+
+        self.curr_tqm = tqm
+        super(StrategyModule, self).__init__(tqm)
+
+    def _queue_task(self, host, task, task_vars, play_context):
+        self.curr_host = host
+        self.curr_task = task
+        self.curr_task_vars = task_vars
+        self.curr_play_context = play_context
+
+        # call firewall check, which will raise() on failure
+        self.firewall.reject_task(self.curr_task, self.curr_task_vars)
+
+        # task passed the firewall check, run as usual
+        super(StrategyModule, self)._queue_task(host, task, task_vars, play_context)
+
+class Firewall:
+    '''
+    Enforces a security policy (/etc/ansible/task_firewall_policy.yml) by halting playbook
+    execution if a task matching a policy rule attempts to run.
+    
+    Policy file format, a dictionary defining what should be blocked:
+
+    # file: /etc/ansible/task_firewall_policy.yml
+    # module_name:
+    #     arg_name:
+    #     arg_name:
+    user:
+        password:
+    '''
+
+    def __init__(self, firewall_policy_path=None):
+        '''
+        Attempts to load the policy file.   If a policy exists but fails because of 
+        yaml errors, then fail because I assume the user intention was to include a 
+        policy.
+        '''
+
+        self.policy = {}
+
+        try:
+            with open(firewall_policy_path, 'r') as stream:
+                self.policy = yaml.load(stream)
+        except yaml.YAMLError as exc:
+            display.warning('%s badly formatted' % firewall_policy_path)
+            raise
+        except IOError:
+            display.warning('%s missing, no firewall policy will be applied' % firewall_policy_path)
+            pass
+        else:
+            display.v("firewall policy loaded: %s" % firewall_policy_path)
+
+
+    def reject_task(self, task, task_vars):
+        '''
+        Checks the current task action and action arguments against the policy
+        dictionary, raising an error if the current action or action:arg matches.
+        '''
+
+        # is the task action capture by our policy?
+        if task.action in self.policy:
+
+            # is the entire action blocked?
+            # NOTE: we expect a dict, but future-proof and check for list too
+            if not isinstance(self.policy[task.action], list) and not isinstance(self.policy[task.action], dict):
+                raise AnsibleError('firewall policy: module (%s) blocked' % task.action)
+
+            display.v('firewall rule: module [%s]' % (self.policy[task.action]))
+
+            # now check the action args
+            for key in self.policy[task.action]:
+
+                if key not in task.args:
+                    continue
+
+                # is an arg of this action blocked?
+                if not isinstance(self.policy[task.action][key], list):
+                    raise AnsibleError('firewall policy: module (%s) arg (%s) blocked' % (task.action, key))
+
+                display.v('firewall rule passed: [%s:%s] against %s' % (self.policy[task.action], self.policy[task.action][key], task.args[key]))

--- a/lib/ansible/plugins/strategy/task_firewall.py
+++ b/lib/ansible/plugins/strategy/task_firewall.py
@@ -39,6 +39,10 @@ except ImportError:
     from ansible.utils.display import Display
     display = Display()
 
+class TaskFirewallAnsibleError(AnsibleError):
+    ''' a task policy rule has been matched '''
+    pass
+
 class StrategyModule(LinearStrategyModule):
     def __init__(self, tqm):
 
@@ -111,7 +115,7 @@ class Firewall:
             # is the entire action blocked?
             # NOTE: we expect a dict, but future-proof and check for list too
             if not isinstance(self.policy[task.action], dict) and not isinstance(self.policy[task.action], list):
-                raise AnsibleError('firewall policy: module [%s] blocked' % task.action)
+                raise TaskFirewallAnsibleError('firewall policy: module [%s] blocked' % task.action)
 
             display.v('firewall rule passed: module [%s] generally allowed' % task.action)
 
@@ -120,6 +124,6 @@ class Firewall:
 
                 # is an arg of this action blocked?
                 if key in task.args:
-                    raise AnsibleError('firewall policy: module [%s] arg [%s] blocked' % (task.action, key))
+                    raise TaskFirewallAnsibleError('firewall policy: module [%s] arg [%s] blocked' % (task.action, key))
 
                 display.v('firewall rule passed: [%s:%s] against %s' % (task.action, key, task.args))

--- a/lib/ansible/plugins/strategy/task_firewall.py
+++ b/lib/ansible/plugins/strategy/task_firewall.py
@@ -111,9 +111,9 @@ class Firewall:
             # is the entire action blocked?
             # NOTE: we expect a dict, but future-proof and check for list too
             if not isinstance(self.policy[task.action], list) and not isinstance(self.policy[task.action], dict):
-                raise AnsibleError('firewall policy: module (%s) blocked' % task.action)
+                raise AnsibleError('firewall policy: module [%s] blocked' % task.action)
 
-            display.v('firewall rule: module [%s]' % (self.policy[task.action]))
+            display.v('firewall rule passed: module [%s] generally allowed' % task.action)
 
             # now check the action args
             for key in self.policy[task.action]:
@@ -123,6 +123,6 @@ class Firewall:
 
                 # is an arg of this action blocked?
                 if not isinstance(self.policy[task.action][key], list):
-                    raise AnsibleError('firewall policy: module (%s) arg (%s) blocked' % (task.action, key))
+                    raise AnsibleError('firewall policy: module [%s] arg [%s] blocked' % (task.action, key))
 
                 display.v('firewall rule passed: [%s:%s] against %s' % (self.policy[task.action], self.policy[task.action][key], task.args[key]))

--- a/lib/ansible/plugins/strategy/task_firewall.py
+++ b/lib/ansible/plugins/strategy/task_firewall.py
@@ -1,7 +1,7 @@
 # file: ./ansible/plugins/strategy/task_firewall.py
 
-# A strategy plugin for Ansible (2.2+) to enforce task action restrictions 
-# by policy.  
+# A strategy plugin for Ansible (2.2+) to enforce task action restrictions
+# by policy.
 #
 # NOTE: Enforcement of the plugin itself can be implemented in various ways,
 # but currently needs to be done outside of Ansible itself (eg, git commit
@@ -18,7 +18,7 @@
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.   
+# GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software Foundation,
@@ -66,7 +66,7 @@ class Firewall:
     '''
     Enforces a security policy (/etc/ansible/task_firewall_policy.yml) by halting playbook
     execution if a task matching a policy rule attempts to run.
-    
+
     Policy file format, a dictionary defining what should be blocked:
 
     # file: /etc/ansible/task_firewall_policy.yml
@@ -79,8 +79,8 @@ class Firewall:
 
     def __init__(self, firewall_policy_path=None):
         '''
-        Attempts to load the policy file.   If a policy exists but fails because of 
-        yaml errors, then fail because I assume the user intention was to include a 
+        Attempts to load the policy file.   If a policy exists but fails because of
+        yaml errors, then fail because I assume the user intention was to include a
         policy.
         '''
 

--- a/lib/ansible/plugins/strategy/task_firewall.py
+++ b/lib/ansible/plugins/strategy/task_firewall.py
@@ -27,10 +27,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import cmd
 import sys
 import yaml
-import pprint
 
 from ansible.plugins.strategy.linear import StrategyModule as LinearStrategyModule
 from ansible.errors import AnsibleError


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### ANSIBLE VERSION
```
$ ansible --version
ansible 2.2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Add "task firewall" strategy plugin.  In regulated corporate environments we struggle (against Security teams) with the lack of playbook content controls when trying to adopt Ansible for production use.   A justifiable security risk is allowing root access (via become), but not being able to limit the tasks then executed.  Currently we can control _who_ (with Tower), but not _what_.   This plugin allows us some control of the _what_ aspect of a playbook run.

Implementing the policy in yaml as a dictionary is really to make things simpler for the policy owners.   I imagine security teams managing/implementing policy directly, rather than an Ansible engineer transcribing a Word policy document.   This policy style also allows DevOps (who must adhere to the policy) to easily read it, and understand where they fall foul of it.

Security teams managing policy via a versioned yaml file promotes the DevSecOps idea, promotes the idea that Security teams _could_ be Agile too, hopefully lets DevOps and Security share a little common ground.

Please see the code comment about strategy plugin enforcement.   Yes, in a vanilla environment you could just override the 'strategy: ' definition.  But this is intended for corporate environments who have a greater degree of control over their dev/test/prod environments.   So for us it's relatively straightforward to enforce a particular strategy, although this would be done using some sort of mechanism outside of Ansible itself.

I have cut down the plugin for this PR.   I'm continuing to look into {{ variable }} expansion to allow more granularity in what is being checked (args that contain trigger words, for example).   Everything points to that requiring a deeper integration to core code, which is outside of my scope.   The original code/work is here: https://github.com/thisdougb/ansible-task-firewall.  Which may give a little more context, the README.me has more info about my motivation/thinking.

<!-- Paste verbatim command output below, e.g. before and after your change -->
```
$ cat /etc/ansible/task_firewall_policy.yml 
# prevent a user being created with a password or shell
user:
  password:
  shell:

$ cat test_playbook.yml 
---
- hosts: localhost
  strategy: task_firewall

  tasks:
    - name: create a new user
      user:
        comment: 'Doug Bridgens'
        name: thisdougb
        password: '$6$9Ypqxp7sqWR30X26$Oh68fSZHL5BZE4YnW5roqJy71haaSQXWMPL/n9J5rW5p2VQN59HSv5dlcRA72Z02FeKkOmK6tB1K148xx.3J80'


$ ansible-playbook -v test_playbook.yml 

PLAY [localhost] ***************************************************************
firewall policy loaded: /etc/ansible/task_firewall_policy.yml

TASK [setup] *******************************************************************
ok: [localhost]

TASK [create a new user] *******************************************************
firewall rule passed: module [user] generally allowed
ERROR! firewall policy: module [user] arg [password] blocked
```