### PR TITLE
Don't remove comment from public key, and improve error message for duplicate keys (github_key)

### DIFF
--- a/lib/ansible/modules/source_control/github_key.py
+++ b/lib/ansible/modules/source_control/github_key.py
@@ -234,9 +234,6 @@ def main():
         # Keys consist of a protocol, the key data, and an optional comment.
         if len(pubkey_parts) < 2:
             module.fail_json(msg='"pubkey" parameter has an invalid format')
-
-        # Strip out comment so we can compare to the keys GitHub returns.
-        pubkey = ' '.join(pubkey_parts[:2])
     elif state == 'present':
         module.fail_json(msg='"pubkey" is required when state=present')
 

--- a/lib/ansible/modules/source_control/github_key.py
+++ b/lib/ansible/modules/source_control/github_key.py
@@ -188,12 +188,12 @@ def ensure_key_present(module, session, name, pubkey, force, check_mode):
     new_signature = pubkey.split(' ')[1]
     for key in all_keys:
         existing_signature = key['key'].split(' ')[1]
-        if new_signature == existing_signature:
+        if new_signature == existing_signature and key['title'] != name:
             module.fail_json(msg=(
                 "another key with the same content is already registered "
                 "under the name |{}|").format(key['title']))
 
-    if matching_keys and force and matching_keys[0]['key'] != pubkey:
+    if matching_keys and force and matching_keys[0]['key'].split(' ')[1] != new_signature:
         delete_keys(session, matching_keys, check_mode=check_mode)
         (deleted_keys, matching_keys) = (matching_keys, [])
 

--- a/lib/ansible/modules/source_control/github_key.py
+++ b/lib/ansible/modules/source_control/github_key.py
@@ -136,12 +136,12 @@ class GitHubSession(object):
 
 def get_all_keys(session):
     url = API_BASE + '/user/keys'
+    result = []
     while url:
         r = session.request('GET', url)
-        for key in r.json():
-            yield key
-
+        result.extend(r.json())
         url = r.links().get('next')
+    return result
 
 
 def create_key(session, name, pubkey, check_mode):
@@ -180,9 +180,18 @@ def ensure_key_absent(session, name, check_mode):
             'deleted_keys': to_delete}
 
 
-def ensure_key_present(session, name, pubkey, force, check_mode):
-    matching_keys = [k for k in get_all_keys(session) if k['title'] == name]
+def ensure_key_present(module, session, name, pubkey, force, check_mode):
+    all_keys = get_all_keys(session)
+    matching_keys = [k for k in all_keys if k['title'] == name]
     deleted_keys = []
+
+    new_signature = pubkey.split(' ')[1]
+    for key in all_keys:
+        existing_signature = key['key'].split(' ')[1]
+        if new_signature == existing_signature:
+            module.fail_json(msg=(
+                "another key with the same content is already registered "
+                "under the name |{}|").format(key['title']))
 
     if matching_keys and force and matching_keys[0]['key'] != pubkey:
         delete_keys(session, matching_keys, check_mode=check_mode)
@@ -233,7 +242,7 @@ def main():
 
     session = GitHubSession(module, token)
     if state == 'present':
-        result = ensure_key_present(session, name, pubkey, force=force,
+        result = ensure_key_present(module, session, name, pubkey, force=force,
                                     check_mode=module.check_mode)
     elif state == 'absent':
         result = ensure_key_absent(session, name, check_mode=module.check_mode)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
github_key

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Note: this is a resubmit of #22142 because I messed up my repository before the pull request could be accepted. Apologies for that.
###### Don't remove comment from public key
Currently the module removes the comment part of the public key. The comment that goes with this states it's for comparison reasons, only no comparison is made before this pull request. I chose to only remove the comment at the actual comparison, so the information is not lost.
###### Improve error message for duplicate keys
Github doesn't allow duplicate keys, but the current error message is rather cryptic (`failed to send request POST to https://api.github.com/user/keys: HTTP Error 422: Unprocessable Entity` becomes: `another key with the same content is already registered under the name |dayea-root|`) and doesn't report under which name the keys already registered. Comparison with the naked eye is not a good alternative, especially with a large number of keys.
```yaml
- name: Authorize key with GitHub
  local_action:
    module: github_key
    name: "{{ ansible_hostname }}-{{ item.user }}"
    token: '{{ github_access_token }}'
    pubkey: '{{ item.key }}'
  become_user: "{{ item.user }}"
  become: true
  when:
    - ansible_hostname in groups['unix']
  with_items:
    - {'user': 'root', 'key': "{{ ssh_pub_key.results[0].stdout }}"}
    - {'user': 'nihlaeth', 'key': "{{ ssh_pub_key.results[1].stdout }}"}
  ignore_errors: yes
```
Before:
```
failed: [dayea -> localhost] (item=[u'nihlaeth', u'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDd3ipOHOuOqt9Um/kBohQDhmzPUdZF3OVfMcRTO1ARVUPNKMWmjWN6uQYRKXK6VmwnkNhDXaBGWWfTDpQ4UHWAQ4pwOZzdQoOZtaD/tNqOpO9ovSvmZSjsU/INAwEwpn4XGdJMtZlj5oQtaTfKw0wDskwlnecNn60JB9VI1n5JSYrE6C5Drr9BV1d8EkZHV6hEJukjHs5gSi5XhEGRBQJpr8yQ7NQ244Jm890qs+npwXXDyuV7mcIvaT4zhVZd21UAQslqVFd396l1LxWOFLg6n6f7jXczi7ADAtiAIpkwArNjoU9MiWRLhEumipfmjyM7UMipiy6qXPJDUQKHrdnH ansible-generated on dayea']) => {"failed": true, "item": ["nihlaeth", "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDd3ipOHOuOqt9Um/kBohQDhmzPUdZF3OVfMcRTO1ARVUPNKMWmjWN6uQYRKXK6VmwnkNhDXaBGWWfTDpQ4UHWAQ4pwOZzdQoOZtaD/tNqOpO9ovSvmZSjsU/INAwEwpn4XGdJMtZlj5oQtaTfKw0wDskwlnecNn60JB9VI1n5JSYrE6C5Drr9BV1d8EkZHV6hEJukjHs5gSi5XhEGRBQJpr8yQ7NQ244Jm890qs+npwXXDyuV7mcIvaT4zhVZd21UAQslqVFd396l1LxWOFLg6n6f7jXczi7ADAtiAIpkwArNjoU9MiWRLhEumipfmjyM7UMipiy6qXPJDUQKHrdnH ansible-generated on dayea"], "msg": " failed to send request POST to https://api.github.com/user/keys: HTTP Error 422: Unprocessable Entity"}
```
After:
```
failed: [dayea -> localhost] (item=[u'nihlaeth', u'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDd3ipOHOuOqt9Um/kBohQDhmzPUdZF3OVfMcRTO1ARVUPNKMWmjWN6uQYRKXK6VmwnkNhDXaBGWWfTDpQ4UHWAQ4pwOZzdQoOZtaD/tNqOpO9ovSvmZSjsU/INAwEwpn4XGdJMtZlj5oQtaTfKw0wDskwlnecNn60JB9VI1n5JSYrE6C5Drr9BV1d8EkZHV6hEJukjHs5gSi5XhEGRBQJpr8yQ7NQ244Jm890qs+npwXXDyuV7mcIvaT4zhVZd21UAQslqVFd396l1LxWOFLg6n6f7jXczi7ADAtiAIpkwArNjoU9MiWRLhEumipfmjyM7UMipiy6qXPJDUQKHrdnH ansible-generated on dayea']) => {"failed": true, "item": ["nihlaeth", "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDd3ipOHOuOqt9Um/kBohQDhmzPUdZF3OVfMcRTO1ARVUPNKMWmjWN6uQYRKXK6VmwnkNhDXaBGWWfTDpQ4UHWAQ4pwOZzdQoOZtaD/tNqOpO9ovSvmZSjsU/INAwEwpn4XGdJMtZlj5oQtaTfKw0wDskwlnecNn60JB9VI1n5JSYrE6C5Drr9BV1d8EkZHV6hEJukjHs5gSi5XhEGRBQJpr8yQ7NQ244Jm890qs+npwXXDyuV7mcIvaT4zhVZd21UAQslqVFd396l1LxWOFLg6n6f7jXczi7ADAtiAIpkwArNjoU9MiWRLhEumipfmjyM7UMipiy6qXPJDUQKHrdnH ansible-generated on dayea"], "msg": "another key with the same content is already registered under the name |dayea-root|"}
```
