### PR TITLE
exact package matching, better performance, correct reporting of change, and blacklist feature for slackpkg

### DIFF
--- a/lib/ansible/modules/packaging/os/slackpkg.py
+++ b/lib/ansible/modules/packaging/os/slackpkg.py
@@ -190,10 +190,20 @@ def upgrade_packages(module, slackpkg_path, packages):
 
 
 def update_cache(module, slackpkg_path):
-    rc, out, err = module.run_command("%s -batch=on update" % (slackpkg_path))
-    if rc != 0:
-        module.fail_json(msg="Could not update package cache")
-
+    rc, out, err = module.run_command("%s check-updates" % (slackpkg_path))
+    for line in out.split('\n'):
+        if "News on ChangeLog.txt" in line:
+            rc, out, err = module.run_command(
+                "%s -batch=on update" % (slackpkg_path))
+            if rc != 0:
+                module.fail_json(msg="Could not update package cache")
+            return
+        if "No news is good news" in line:
+            return
+    module.fail_json(
+        msg="Could not check on change lock state",
+        out=out,
+        err=err)
 
 def main():
     module = AnsibleModule(

--- a/lib/ansible/modules/packaging/os/slackpkg.py
+++ b/lib/ansible/modules/packaging/os/slackpkg.py
@@ -91,6 +91,14 @@ EXAMPLES = '''
     state: latest
 '''
 
+import re
+import glob
+import platform
+from distutils.version import LooseVersion
+
+# import module snippets
+from ansible.module_utils.basic import *
+
 
 def query_package(name):
     machine = platform.machine()

--- a/lib/ansible/modules/packaging/os/slackpkg.py
+++ b/lib/ansible/modules/packaging/os/slackpkg.py
@@ -68,7 +68,7 @@ options:
         required: false
         default: false
         choices: [ true, false ]
-        version_added: "2.3"
+        version_added: "2.4"
 
 author: Kim Nørgaard (@KimNorgaard)
 requirements: [ "Slackware >= 12.2", "slackpkg" ]

--- a/lib/ansible/modules/packaging/os/slackpkg.py
+++ b/lib/ansible/modules/packaging/os/slackpkg.py
@@ -24,7 +24,7 @@
 import re
 import glob
 import platform
-from packaging import version
+from distutils.version import LooseVersion, StrictVersion
 
 # import module snippets
 from ansible.module_utils.basic import *
@@ -177,7 +177,7 @@ def upgrade_packages(module, slackpkg_path, packages):
                     slackpkg_path,
                     current_version[0]))
         elif not module.check_mode and newer_version is not None:
-            if version.parse(newer_version[1]) < version.parse(current_version[1]):
+            if LooseVersion(newer_version[1]) < LooseVersion(current_version[1]):
                 # don't do anything if a newer version than the one in the
                 # repository is installed already
                 continue

--- a/lib/ansible/modules/packaging/os/slackpkg.py
+++ b/lib/ansible/modules/packaging/os/slackpkg.py
@@ -21,14 +21,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this software.  If not, see <http://www.gnu.org/licenses/>.
 
-import re
-import glob
-import platform
-from distutils.version import LooseVersion
-
-# import module snippets
-from ansible.module_utils.basic import *
-
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/packaging/os/slackpkg.py
+++ b/lib/ansible/modules/packaging/os/slackpkg.py
@@ -102,6 +102,7 @@ def query_package(name):
             return package
     return False
 
+
 def query_repository(module, slackpkg_path, name):
     rc, out, err = module.run_command("%s search %s" % (slackpkg_path, name))
     if rc != 0:
@@ -116,6 +117,7 @@ def query_repository(module, slackpkg_path, name):
             return (matches[0], matches[1])
     module.fail_json(
         msg="failed to locate package {} in repository".format(name))
+
 
 def remove_packages(module, slackpkg_path, blacklist, ignore_blacklist, packages):
     remove_c = 0
@@ -162,6 +164,7 @@ def remove_packages(module, slackpkg_path, blacklist, ignore_blacklist, packages
             msg="package(s) already absent, %s blacklisted" % blacklisted_c)
     else:
         module.exit_json(changed=False, msg="package(s) already absent")
+
 
 def install_packages(module, slackpkg_path, blacklist, packages):
 
@@ -223,7 +226,7 @@ def upgrade_packages(module, slackpkg_path, blacklist, packages):
                     current_version[0]))
         elif not module.check_mode and newer_version is not None:
             if (
-                    not current_version[1].endswith('git') and \
+                    not current_version[1].endswith('git') and
                     LooseVersion(newer_version[1]) < LooseVersion(current_version[1])):
                 # don't do anything if a newer version than the one in the
                 # repository is installed already
@@ -275,6 +278,7 @@ def update_cache(module, slackpkg_path):
         out=out,
         err=err)
 
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(
@@ -296,7 +300,7 @@ def main():
     f = open('/etc/slackpkg/blacklist', 'r')
     try:
         blacklist = [
-            line.strip() for line in f.read().split('\n') \
+            line.strip() for line in f.read().split('\n')
             if not line.strip().startswith('#') and len(line.strip()) > 0]
     finally:
         f.close()

--- a/lib/ansible/modules/packaging/os/slackpkg.py
+++ b/lib/ansible/modules/packaging/os/slackpkg.py
@@ -291,10 +291,15 @@ def main():
         supports_check_mode=True)
 
     slackpkg_path = module.get_bin_path('slackpkg', True)
-    with open('/etc/slackpkg/blacklist', 'r') as f:
+
+    f = open('/etc/slackpkg/blacklist', 'r')
+    try:
         blacklist = [
             line.strip() for line in f.read().split('\n') \
             if not line.strip().startswith('#') and len(line.strip()) > 0]
+    finally:
+        f.close()
+
     p = module.params
 
     pkgs = p['name']


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
slackpkg

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Note on code style: I haven't been able to find a style guide for ansible, so I hope I didn't step on anyone's toes by adhering to some of my own preferences with rewriting this module. I'd be happy to fix that if anyone takes issue.

There are several things I improved. They basically all come down to this: slackpkg is a very minimal package manager, and because of this many tasks are left up to the user. This makes it's use with a tool such as ansible less straightforward. I attempted to correct some of this so it functions more reliably and to expectation.

###### PACKAGE NAME MATCHING
slackpkg presents you with a list of packages which contain your upgrade argument (hyphens are used as word boundaries). Because running it from a script requires you to define `default-answer=y` all of them get installed.

Specified package: `openssl`
Currently mutated: `openssl` `openssl-solibs` `hypothetical-unwanted-package-openssl`
Expected: `openssl`

###### ENSURE UPGRADE INSTALLS NEWEST VERSION
If the version of the package in the repository is older than the one you currently have installed, specifying `state: latest` downgrades it.

This is actually a common occurrence, because of the popularity of slackbuilds (the slackware repository is pretty minimal, and only contains very stable packages).

I had the slackpkg module compare version strings, and only run upgrade if that will result in a newer version.

###### ONLY RUN UPDATE IF THERE ARE CHANGES
Running `slackpkg update` can take up to several minutes depending on the current mirror load. If `update_cache` is specified, I run `slackpkg check-update` first (of which the runtime is counted by seconds, not minutes), and only update if there are actual changes.

###### CORRECTLY REPORT CHANGED STATE FOR UPGRADED PACKAGES
If `state: latest` was specified, the state would always be reported as changed. The example below was run on a server which had already been upgraded.
```yaml
- name: update ssh slackware
  slackpkg:
    name: openssl,openssh,libssh,openssl-solibs
    state: latest
    update_cache: true
  become: true
  when:
    - ansible_hostname in groups['slackware']
  notify:
    - restart ssh
```
Actual result:
```
changed: [arthemis] => {"changed": true, "msg": "present 4 package(s)"}
```
Expected:
```
ok: [arthemis] => {"changed": false, "msg": "package(s) already present"}
```
###### BLACKLIST FEATURE
If you install a package with `installpkg` instead of `upgradepkg` when a version of it is already present in your system, slackpkg refused to deal with you because it cannot reliably manage your system state when two versions of the same package are present. You can then either remove both versions, or add it to the slackpkg blacklist. If you go with the blacklist option, slackpkg will from then on ignore the package.

But the slackpkg module will throw an error if you try to install, upgrade or remove a blacklisted package, when it should really be ignoring this. I had the module check the blacklist before ever calling slackpkg, and report the number of blacklisted packages it was instructed to manage.

I also added the `ignore_blacklist` option, which when specified together with `state: absent` will cause all versions of a blacklisted package to be removed with `removepkg`.

I wrote a [test](https://github.com/nihlaeth/my-ansible/blob/master/roles/testslack/tasks/main.yml) for this (only the blacklist feature), which I ran on a number of slackware 14.0, 14.1 and 14.2 servers in various stages of disarray, no problems found. I would love to add the test to ansible, but I am unsure how to do that. Could someone point me in the right direction? Is there documentation available other than [this](https://github.com/nihlaeth/ansible/tree/devel/test/integration#contributing-test-cases)?