### PR TITLE
Add extends_documentation_fragment back

### DIFF
--- a/lib/ansible/modules/network/eos/_eos_template.py
+++ b/lib/ansible/modules/network/eos/_eos_template.py
@@ -34,6 +34,7 @@ description:
     by evaluating the current running-config and only pushing configuration
     commands that are not already configured.  The config source can
     be a set of commands or a template.
+extends_documentation_fragment: eos
 deprecated: Deprecated in 2.2. Use M(eos_config) instead
 options:
   src:

--- a/lib/ansible/modules/network/eos/eos_banner.py
+++ b/lib/ansible/modules/network/eos/eos_banner.py
@@ -24,7 +24,7 @@ ANSIBLE_METADATA = {
 
 DOCUMENTATION = """
 ---
-module: eos_banner_
+module: eos_banner
 version_added: "2.3"
 author: "Peter Sprygada (@privateip)"
 short_description: Manage multiline banners on Arista EOS devices
@@ -32,6 +32,7 @@ description:
   - This will configure both login and motd banners on remote devices
     running Arista EOS.  It allows playbooks to add or remote
     banner text from the active running configuration.
+extends_documentation_fragment: eos
 options:
   banner:
     description:

--- a/lib/ansible/modules/network/eos/eos_command.py
+++ b/lib/ansible/modules/network/eos/eos_command.py
@@ -33,6 +33,7 @@ description:
     read from the device.  This module includes an
     argument that will cause the module to wait for a specific condition
     before returning or timing out if the condition is not met.
+extends_documentation_fragment: eos
 options:
   commands:
     description:

--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -34,6 +34,7 @@ description:
     an implementation for working with eos configuration sections in
     a deterministic way.  This module works with either CLI or eAPI
     transports.
+extends_documentation_fragment: eos
 options:
   lines:
     description:

--- a/lib/ansible/modules/network/eos/eos_eapi.py
+++ b/lib/ansible/modules/network/eos/eos_eapi.py
@@ -38,6 +38,7 @@ description:
     Unix socket server. Use the options listed below to override the
     default configuration.
   - Requires EOS v4.12 or greater.
+extends_documentation_fragment: eos
 options:
   http:
     description:

--- a/lib/ansible/modules/network/eos/eos_facts.py
+++ b/lib/ansible/modules/network/eos/eos_facts.py
@@ -34,6 +34,7 @@ description:
     base network fact keys with C(ansible_net_<fact>).  The facts
     module will always collect a base set of facts from the device
     and can enable or disable collection of additional facts.
+extends_documentation_fragment: eos
 options:
   gather_subset:
     description:

--- a/lib/ansible/modules/network/eos/eos_system.py
+++ b/lib/ansible/modules/network/eos/eos_system.py
@@ -33,6 +33,7 @@ description:
     on Arista EOS devices.  It provides an option to configure host system
     parameters or remove those parameters from the device active
     configuration.
+extends_documentation_fragment: eos
 options:
   hostname:
     description:

--- a/lib/ansible/modules/network/eos/eos_user.py
+++ b/lib/ansible/modules/network/eos/eos_user.py
@@ -32,6 +32,7 @@ description:
     either individual usernames or the collection of usernames in the
     current running config.  It also supports purging usernames from the
     configuration that are not explicitly defined.
+extends_documentation_fragment: eos
 options:
   users:
     description:

--- a/lib/ansible/modules/network/ios/_ios_template.py
+++ b/lib/ansible/modules/network/ios/_ios_template.py
@@ -35,6 +35,7 @@ description:
     commands that are not already configured.  The config source can
     be a set of commands or a template.
 deprecated: Deprecated in 2.2. Use M(ios_config) instead.
+extends_documentation_fragment: ios
 options:
   src:
     description:

--- a/lib/ansible/modules/network/ios/ios_command.py
+++ b/lib/ansible/modules/network/ios/ios_command.py
@@ -35,6 +35,7 @@ description:
     before returning or timing out if the condition is not met.
   - This module does not support running commands in configuration mode.
     Please use M(ios_config) to configure IOS devices.
+extends_documentation_fragment: ios
 options:
   commands:
     description:

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -33,6 +33,7 @@ description:
     for segmenting configuration into sections.  This module provides
     an implementation for working with IOS configuration sections in
     a deterministic way.
+extends_documentation_fragment: ios
 options:
   lines:
     description:

--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -33,6 +33,7 @@ description:
     base network fact keys with C(ansible_net_<fact>).  The facts
     module will always collect a base set of facts from the device
     and can enable or disable collection of additional facts.
+extends_documentation_fragment: ios
 options:
   gather_subset:
     description:

--- a/lib/ansible/modules/network/ios/ios_system.py
+++ b/lib/ansible/modules/network/ios/ios_system.py
@@ -33,6 +33,7 @@ description:
     on Cisco IOS devices.  It provides an option to configure host system
     parameters or remove those parameters from the device active
     configuration.
+extends_documentation_fragment: ios
 options:
   hostname:
     description:

--- a/lib/ansible/modules/network/ios/ios_vrf.py
+++ b/lib/ansible/modules/network/ios/ios_vrf.py
@@ -33,6 +33,7 @@ description:
     Cisco IOS devices.  It allows playbooks to manage individual or
     the entire VRF collection.  It also supports purging VRF definitions from
     the configuration that are not explicitly defined.
+extends_documentation_fragment: ios
 options:
   vrfs:
     description:

--- a/lib/ansible/modules/network/iosxr/_iosxr_template.py
+++ b/lib/ansible/modules/network/iosxr/_iosxr_template.py
@@ -34,6 +34,7 @@ description:
     commands that are not already configured.  The config source can
     be a set of commands or a template.
 deprecated: Deprecated in 2.2. Use M(iosxr_config) instead.
+extends_documentation_fragment: iosxr
 options:
   src:
     description:

--- a/lib/ansible/modules/network/iosxr/iosxr_command.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_command.py
@@ -33,6 +33,7 @@ description:
     before returning or timing out if the condition is not met.
   - This module does not support running commands in configuration mode.
     Please use M(iosxr_config) to configure iosxr devices.
+extends_documentation_fragment: iosxr
 options:
   commands:
     description:

--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -31,6 +31,7 @@ description:
     for segmenting configuration into sections.  This module provides
     an implementation for working with IOS XR configuration sections in
     a deterministic way.
+extends_documentation_fragment: iosxr
 options:
   lines:
     description:

--- a/lib/ansible/modules/network/iosxr/iosxr_facts.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_facts.py
@@ -31,6 +31,7 @@ description:
     base network fact keys with C(ansible_net_<fact>).  The facts
     module will always collect a base set of facts from the device
     and can enable or disable collection of additional facts.
+extends_documentation_fragment: iosxr
 options:
   gather_subset:
     description:

--- a/lib/ansible/modules/network/iosxr/iosxr_system.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_system.py
@@ -33,6 +33,7 @@ description:
     on Cisco IOS-XR devices.  It provides an option to configure host system
     parameters or remove those parameters from the device active
     configuration.
+extends_documentation_fragment: iosxr
 options:
   hostname:
     description:

--- a/lib/ansible/modules/network/junos/junos_command.py
+++ b/lib/ansible/modules/network/junos/junos_command.py
@@ -33,6 +33,7 @@ description:
     read from the device.  This module includes an
     argument that will cause the module to wait for a specific condition
     before returning or timing out if the condition is not met.
+extends_documentation_fragment: junos
 options:
   commands:
     description:

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -33,6 +33,7 @@ description:
     configuration running on Juniper JUNOS devices.  It provides a set
     of arguments for loading configuration, performing rollback operations
     and zeroing the active configuration on the device.
+extends_documentation_fragment: junos
 options:
   lines:
     description:

--- a/lib/ansible/modules/network/junos/junos_rpc.py
+++ b/lib/ansible/modules/network/junos/junos_rpc.py
@@ -33,6 +33,7 @@ description:
     specified RPC using the NetConf transport.  The reply is then
     returned to the playbook in the c(xml) key.  If an alternate output
     format is requested, the reply is transformed to the requested output.
+extends_documentation_fragment: junos
 options:
   rpc:
     description:

--- a/lib/ansible/modules/network/junos/junos_user.py
+++ b/lib/ansible/modules/network/junos/junos_user.py
@@ -33,6 +33,7 @@ description:
     network devices running the JUNOS operating system.  It provides
     a set of arguments for creating, removing and updating locally
     defined accounts
+extends_documentation_fragment: junos
 options:
   users:
     description:

--- a/lib/ansible/modules/network/vyos/vyos_command.py
+++ b/lib/ansible/modules/network/vyos/vyos_command.py
@@ -38,6 +38,7 @@ description:
     use a custom pager that can cause this module to hang.  If the
     value of the environment variable C(ANSIBLE_VYOS_TERMINAL_LENGTH)
     is not set, the default number of 10000 is used.
+extends_documentation_fragment: vyos
 options:
   commands:
     description:

--- a/lib/ansible/modules/network/vyos/vyos_config.py
+++ b/lib/ansible/modules/network/vyos/vyos_config.py
@@ -34,6 +34,7 @@ description:
     configuration file and state of the active configuration.   All
     configuration statements are based on `set` and `delete` commands
     in the device configuration.
+extends_documentation_fragment: vyos
 options:
   lines:
     description:

--- a/lib/ansible/modules/network/vyos/vyos_facts.py
+++ b/lib/ansible/modules/network/vyos/vyos_facts.py
@@ -33,6 +33,7 @@ description:
     base network fact keys with U(ansible_net_<fact>).  The facts
     module will always collect a base set of facts from the device
     and can enable or disable collection of additional facts.
+extends_documentation_fragment: vyos
 options:
   gather_subset:
     description:

--- a/lib/ansible/modules/network/vyos/vyos_system.py
+++ b/lib/ansible/modules/network/vyos/vyos_system.py
@@ -33,6 +33,7 @@ description:
   - Runs one or more commands on remote devices running VyOS.
     This module can also be introspected to validate key parameters before
     returning successfully.
+extends_documentation_fragment: vyos
 options:
   hostname:
     description:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
eos_command

##### SUMMARY
Need to document the `transport:` options again.

This adds it back to everything apart from `nxos_*`, which I need to check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/22293)
<!-- Reviewable:end -->
