### PR TITLE
ec2_elb_facts - Fixes #21553 empty health_check path error

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
@@ -143,7 +143,10 @@ class ElbInformation(object):
         protocol, port_path = health_check.target.split(':')
         try:
             port, path = port_path.split('/', 1)
-            path = '/{}'.format(path)
+            if path == '':
+                path = '/'  
+            else:
+                path = '/{}'.format(path)
         except ValueError:
             port = port_path
             path = None


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ec2_elb_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0 (stable-2.2 c92ce0c2ca) last updated 2017/02/16 13:25:38 (GMT +1000)
  lib/ansible/modules/core: (detached HEAD 72194a29dc) last updated 2017/02/16 13:26:51 (GMT +1000)
  lib/ansible/modules/extras: (detached HEAD 994349b647) last updated 2017/02/16 13:27:50 (GMT +1000)
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This change was made after troubleshooting errors for ELBs that have a Health Check path that is just a slash - i.e. HTTP:2000/

In these cases the port_path.split('/', 1) will leave 'path' as an empty var and an error is thrown when it then tries to format this empty string. In dealing with this error, the whole port_path var is then asserted as an INT and set as the 'port' value. This obviously throws a module failure as the port value still has a slash in it - i.e. '2000/'

To get around this I've added a check that will set 'path' as a slash if the path var appears empty, therefore the format will still work and the error isn't thrown which would result in an incorrect INT assertion.

<!-- Paste verbatim command output below, e.g. before and after your change -->
**Before:**
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ValueError: invalid literal for int() wit
fatal: [127.0.0.1]: FAILED! => {"attempts": 1, "changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  Flb_facts_adam.py\", line 256, in <module>\n    main()\n  File \"/tmp/ansible_axwNhr/ansible_module_ec2_elb_facts_adam.py\", line 248, in mFile \"/tmp/ansible_axwNhr/ansible_module_ec2_elb_facts_adam.py\", line 222, in list_elbs\n    return list(map(self._get_elb_info, elb_arrule_ec2_elb_facts_adam.py\", line 170, in _get_elb_info\n    'health_check': self._get_health_check(elb.health_check),\n  File \"/tmp/ansiy\", line 146, in _get_health_check\n    'ping_port': int(port),\nValueError: invalid literal for int() with base 10: '80/'\n", "module_st
```

**After:**
```
ok: [127.0.0.1] => {"attempts": 1, "changed": false, "elbs": [{"canonical_hosted_zone_name": null, "canonical_hosted_zone_name_id": "Z1GM3OXH4ZPM65", "dns_name": "internal-adam-test-bug-787573477.ap-southeast-2.elb.amazonaws.com", "health_check": {"healthy_threshold": 10, "interval": 30, "ping_path": "/", "ping_port": 80, "ping_protocol": "http", "response_timeout": 5, "unhealthy_threshold": 2}, "hosted_zone_id": "Z1GM3OXH4ZPM65", "hosted_zone_name": null, "instances": ["i-cfe2be60", "i-e5d4804a"], "instances_inservice": [], "instances_inservice_count": 0, "instances_inservice_percent": 0.0, "instances_outofservice": ["i-cfe2be60", "i-e5d4804a"], "instances_outofservice_count": 2, "listeners": [{"instance_port": 80, "load_balancer_port": 80, "protocol": "HTTP"}], "name": "adam-test-bug", "scheme": "internal", "security_groups": ["sg-e7fe8982"], "subnets": ["subnet-a78f24d0", "subnet-b9189adc"], "tags": {}, "vpc_id": "vpc-8952ffec", "zones": ["ap-southeast-2b", "ap-southeast-2a"]}]}
```