### PR TITLE
dellos* modules- Documentation Update

### DIFF
--- a/lib/ansible/modules/network/dellos10/dellos10_config.py
+++ b/lib/ansible/modules/network/dellos10/dellos10_config.py
@@ -29,11 +29,11 @@ DOCUMENTATION = """
 module: dellos10_config
 version_added: "2.2"
 author: "Senthil Kumar Ganesan (@skg-net)"
-short_description: Manage Dell OS10 configuration sections
+short_description: Manage Dell EMC Networking OS10 configuration sections
 description:
-  - Dell OS10 configurations use a simple block indent file syntax
+  - OS10 configurations use a simple block indent file syntax
     for segmenting configuration into sections.  This module provides
-    an implementation for working with Dell OS10 configuration sections in
+    an implementation for working with OS10 configuration sections in
     a deterministic way.
 extends_documentation_fragment: dellos10
 options:
@@ -41,17 +41,15 @@ options:
     description:
       - The ordered set of commands that should be configured in the
         section.  The commands must be the exact same commands as found
-        in the device running-config.  Be sure to note the configuration
-        command syntax as some commands are automatically modified by the
-        device config parser. This argument is mutually exclusive with I(src).
+        in the device running-config. Note the configuration
+        command syntax as the device config parser automatically modifies some commands. This argument is mutually exclusive with I(src).
     required: false
     default: null
     aliases: ['commands']
   parents:
     description:
       - The ordered set of parents that uniquely identify the section
-        the commands should be checked against.  If the parents argument
-        is omitted, the commands are checked against the set of top
+        the commands should be checked against.  If you omit the parents argument, the commands are checked against the set of top
         level or global commands.
     required: false
     default: null
@@ -67,8 +65,8 @@ options:
   before:
     description:
       - The ordered set of commands to push on to the command stack if
-        a change needs to be made.  This allows the playbook designer
-        the opportunity to perform configuration commands prior to pushing
+        a change needs to be made.  The playbook designer can  use this argument
+        to perform configuration commands prior to pushing
         any changes without affecting how the set of commands are matched
         against the system.
     required: false
@@ -76,20 +74,20 @@ options:
   after:
     description:
       - The ordered set of commands to append to the end of the command
-        stack if a change needs to be made.  Just like with I(before) this
-        allows the playbook designer to append a set of commands to be
+        stack if a change needs to be made.  As with I(before),
+        the playbook designer can use this argument  to append a set of commands to be
         executed after the command set.
     required: false
     default: null
   match:
     description:
       - Instructs the module on the way to perform the matching of
-        the set of commands against the current device config.  If
-        match is set to I(line), commands are matched line by line.  If
-        match is set to I(strict), command lines are matched with respect
-        to position.  If match is set to I(exact), command lines
-        must be an equal match.  Finally, if match is set to I(none), the
-        module will not attempt to compare the source configuration with
+        the set of commands against the current device config.  If you set
+        match to I(line), commands match line by line.  If you set
+        match to I(strict), command lines match by
+        position.  If you set match to I(exact), command lines
+        must be an equal match.  Finally, if you set match to I(none), the
+        module does not attempt to compare the source configuration with
         the running configuration on the remote device.
     required: false
     default: line
@@ -97,10 +95,10 @@ options:
   replace:
     description:
       - Instructs the module on the way to perform the configuration
-        on the device.  If the replace argument is set to I(line) then
-        the modified lines are pushed to the device in configuration
-        mode.  If the replace argument is set to I(block) then the entire
-        command block is pushed to the device in configuration mode if any
+        on the device. If you set the replace argument to I(line), then
+        the modified lines push to the device in configuration
+        mode.  If you set the replace argument to I(block), then the entire
+        command block pushes to the device in configuration mode if any
         line is not correct.
     required: false
     default: line
@@ -109,9 +107,9 @@ options:
     description:
       - The I(update) argument controls how the configuration statements
         are processed on the remote device.  Valid choices for the I(update)
-        argument are I(merge) and I(check).  When the argument is set to
-        I(merge), the configuration changes are merged with the current
-        device running configuration.  When the argument is set to I(check)
+        argument are I(merge) and I(check).  When you set the argument to
+        I(merge), the configuration changes merge with the current
+        device running configuration.  When you set the argument to I(check),
         the configuration updates are determined but not actually configured
         on the remote device.
     required: false
@@ -121,21 +119,21 @@ options:
     description:
       - The C(save) argument instructs the module to save the running-
         config to the startup-config at the conclusion of the module
-        running.  If check mode is specified, this argument is ignored.
+        running.  If you specify check mode, this argument is ignored.
     required: false
     default: no
     choices: ['yes', 'no']
   config:
     description:
-      - The C(config) argument allows the playbook designer to supply
-        the base configuration to be used to validate configuration
-        changes necessary.  If this argument is provided, the module
-        will not download the running-config from the remote node.
+      - The playbook designer can use the C(config) argument to supply
+        the base configuration to be used to validate necessary configuration
+        changes.  If you specify this argument, the module
+        does not download the running-config from the remote node.
     required: false
     default: null
   backup:
     description:
-      - This argument will cause the module to create a full backup of
+      - This argument causes the module to create a full backup of
         the current C(running-config) from the remote device before any
         changes are made.  The backup file is written to the C(backup)
         folder in the playbook root directory.  If the directory does not
@@ -177,21 +175,21 @@ EXAMPLES = """
 
 RETURN = """
 updates:
-  description: The set of commands that will be pushed to the remote device
-  returned: always
+  description: The set of commands pushed to the remote device.
+  returned: Always.
   type: list
   sample: ['...', '...']
 
 responses:
-  description: The set of responses from issuing the commands on the device
-  returned: when not check_mode
+  description: The set of responses from issuing the commands on the device.
+  returned: When not check_mode.
   type: list
   sample: ['...', '...']
 
 saved:
   description: Returns whether the configuration is saved to the startup
                configuration or not.
-  returned: when not check_mode
+  returned: When not check_mode.
   type: bool
   sample: True
 

--- a/lib/ansible/modules/network/dellos10/dellos10_facts.py
+++ b/lib/ansible/modules/network/dellos10/dellos10_facts.py
@@ -28,22 +28,21 @@ DOCUMENTATION = """
 module: dellos10_facts
 version_added: "2.2"
 author: "Senthil Kumar Ganesan (@skg-net)"
-short_description: Collect facts from remote devices running Dell OS10
+short_description: Collect facts from remote devices running Dell EMC Networking OS10
 description:
   - Collects a base set of device facts from a remote device that
-    is running Dell OS10.  This module prepends all of the
+    is running OS10.  This module prepends all of the
     base network fact keys with C(ansible_net_<fact>).  The facts
-    module will always collect a base set of facts from the device
+    module always collects a base set of facts from the device
     and can enable or disable collection of additional facts.
 extends_documentation_fragment: dellos10
 options:
   gather_subset:
     description:
-      - When supplied, this argument will restrict the facts collected
+      - When supplied, this argument restricts the facts collected
         to a given subset.  Possible values for this argument include
-        all, hardware, config, and interfaces.  Can specify a list of
-        values to include a larger subset.  Values can also be used
-        with an initial C(M(!)) to specify that a specific subset should
+        all, hardware, config, and interfaces.  You can specify a list of
+        values to include a larger subset.  You can also use values with an initial M(!) to specify that a specific subset should
         not be collected.
     required: false
     default: '!config'
@@ -67,68 +66,68 @@ EXAMPLES = """
 
 RETURN = """
 ansible_net_gather_subset:
-  description: The list of fact subsets collected from the device
-  returned: always
+  description: The list of fact subsets collected from the device.
+  returned: Always.
   type: list
 
 # default
 ansible_net_name:
-  description: The name of the OS which is running
-  returned: always
+  description: The name of the OS that is running.
+  returned: Always.
   type: str
 ansible_net_version:
-  description: The operating system version running on the remote device
-  returned: always
+  description: The operating system version running on the remote device.
+  returned: Always.
   type: str
 ansible_net_servicetag:
-  description: The service tag number of the remote device
-  returned: always
+  description: The service tag number of the remote device.
+  returned: Always.
   type: str
 ansible_net_model:
-  description: The model name returned from the device
-  returned: always
+  description: The model name returned from the device.
+  returned: Always.
   type: str
 ansible_net_hostname:
-  description: The configured hostname of the device
-  returned: always
+  description: The configured hostname of the device.
+  returned: Always.
   type: str
 
 # hardware
 ansible_net_cpu_arch:
-  description: Cpu Architecture of the remote device
-  returned: when hardware is configured
+  description: CPU Architecture of the remote device.
+  returned: When hardware is configured.
   type: str
 ansible_net_memfree_mb:
-  description: The available free memory on the remote device in Mb
-  returned: when hardware is configured
+  description: The available free memory on the remote device in MB.
+  returned: When hardware is configured.
   type: int
 ansible_net_memtotal_mb:
-  description: The total memory on the remote device in Mb
-  returned: when hardware is configured
+  description: The total memory on the remote device in MB.
+  returned: When hardware is configured.
   type: int
 
 # config
 ansible_net_config:
-  description: The current active config from the device
-  returned: when config is configured
+  description: The current active config from the device.
+  returned: When config is configured.
   type: str
 
 # interfaces
 ansible_net_all_ipv4_addresses:
-  description: All IPv4 addresses configured on the device
-  returned: when interfaces is configured
+  description: All IPv4 addresses configured on the device.
+  returned: When interfaces is configured
   type: list
 ansible_net_all_ipv6_addresses:
-  description: All IPv6 addresses configured on the device
-  returned: when interfaces is configured
+  description: All IPv6 addresses configured on the device.
+  returned: When interfaces is configured.
   type: list
 ansible_net_interfaces:
-  description: A hash of all interfaces running on the system
-  returned: when interfaces is configured
+  description: A hash of all interfaces running on the system.
+  returned: When interfaces is configured.
   type: dict
 ansible_net_neighbors:
-  description: The list of LLDP neighbors from the remote device
-  returned: when interfaces is configured
+  description: The list of LLDP neighbors from the remote device.
+  returned: When interfaces is configured.
   type: dict
 """
 
@@ -304,7 +303,7 @@ class Interfaces(FactsBase):
                 intf = int_facts[name]
                 intf['mediatype'] = mediatype
             else:
-                #TODO: Loop for the exact subport
+                # TODO: Loop for the exact subport
                 for subport in xrange(1, 5):
                     name = "ethernet" + sname + ":" + str(subport)
                     intf = int_facts[name]

--- a/lib/ansible/modules/network/dellos6/dellos6_config.py
+++ b/lib/ansible/modules/network/dellos6/dellos6_config.py
@@ -29,11 +29,11 @@ DOCUMENTATION = """
 module: dellos6_config
 version_added: "2.2"
 author: "Abirami N(@abirami-n)"
-short_description: Manage Dell OS6 configuration sections
+short_description: Manage Dell EMC Networking OS6 configuration sections
 description:
-  - Dell OS6 configurations use a simple block indent file syntax
+  - OS6 configurations use a simple block indent file syntax
     for segmenting configuration into sections.  This module provides
-    an implementation for working with Dell OS6 configuration sections in
+    an implementation for working with OS6 configuration sections in
     a deterministic way.
 extends_documentation_fragment: dellos6
 options:
@@ -41,17 +41,15 @@ options:
     description:
       - The ordered set of commands that should be configured in the
         section.  The commands must be the exact same commands as found
-        in the device running-config.  Be sure to note the configuration
-        command syntax as some commands are automatically modified by the
-        device config parser. This argument is mutually exclusive with I(src).
+        in the device running-config. Note the configuration
+        command syntax as the device config parser automatically modifies some commands. This argument is mutually exclusive with I(src).
     required: false
     default: null
     aliases: ['commands']
   parents:
     description:
       - The ordered set of parents that uniquely identify the section
-        the commands should be checked against.  If the parents argument
-        is omitted, the commands are checked against the set of top
+        the commands should be checked against.  If you do not specify the parents argument, the commands are checked against the set of top
         level or global commands.
     required: false
     default: null
@@ -76,20 +74,19 @@ options:
   after:
     description:
       - The ordered set of commands to append to the end of the command
-        stack if a change needs to be made.  Just like with I(before) this
-        allows the playbook designer to append a set of commands to be
+        stack if a change needs to be made.  As with I(before), the playbook desinger can use this to append a set of commands to be
         executed after the command set.
     required: false
     default: null
   match:
     description:
       - Instructs the module on the way to perform the matching of
-        the set of commands against the current device config.  If
-        match is set to I(line), commands are matched line by line.  If
-        match is set to I(strict), command lines are matched with respect
-        to position.  If match is set to I(exact), command lines
-        must be an equal match.  Finally, if match is set to I(none), the
-        module will not attempt to compare the source configuration with
+        the set of commands against the current device config.  If you set
+        match to I(line), commands match line by line.  If you set
+        match to I(strict), command lines matched by respect
+        to position.  If you set match to I(exact), command lines
+        must be an equal match.  Finally, if you set match to I(none), the
+        module does  not attempt to compare the source configuration with
         the running configuration on the remote device.
     required: false
     default: line
@@ -97,9 +94,9 @@ options:
   replace:
     description:
       - Instructs the module on the way to perform the configuration
-        on the device.  If the replace argument is set to I(line) then
+        on the device.  If you set the replace argument to I(line), then
         the modified lines are pushed to the device in configuration
-        mode.  If the replace argument is set to I(block) then the entire
+        mode.  If you set the replace argument to I(block) then the entire
         command block is pushed to the device in configuration mode if any
         line is not correct.
     required: false
@@ -109,9 +106,9 @@ options:
     description:
       - The I(update) argument controls how the configuration statements
         are processed on the remote device.  Valid choices for the I(update)
-        argument are I(merge) and I(check).  When the argument is set to
-        I(merge), the configuration changes are merged with the current
-        device running configuration.  When the argument is set to I(check)
+        argument are I(merge) and I(check).  When you set this argument to
+        I(merge), the configuration changes merge with the current
+        device running configuration.  When you set this argument to I(check)
         the configuration updates are determined but not actually configured
         on the remote device.
     required: false
@@ -121,21 +118,21 @@ options:
     description:
       - The C(save) argument instructs the module to save the running-
         config to the startup-config at the conclusion of the module
-        running.  If check mode is specified, this argument is ignored.
+        running.  If you specify check mode, this argument is ignored.
     required: false
     default: no
     choices: ['yes', 'no']
   config:
     description:
-      - The C(config) argument allows the playbook designer to supply
-        the base configuration to be used to validate configuration
-        changes necessary.  If this argument is provided, the module
-        will not download the running-config from the remote node.
+      - The playbook designer can use the C(config) argument to supply
+        the base configuration to be used to validate necessary configuration
+        changes.  If you specify this argument, the module
+        does not download the running-config from the remote node.
     required: false
     default: null
   backup:
     description:
-      - This argument will cause the module to create a full backup of
+      - This argument causes the module to create a full backup of
         the current C(running-config) from the remote device before any
         changes are made.  The backup file is written to the C(backup)
         folder in the playbook root directory.  If the directory does not
@@ -177,21 +174,21 @@ EXAMPLES = """
 
 RETURN = """
 updates:
-  description: The set of commands that will be pushed to the remote device
-  returned: always
+  description: The set of commands pushed to the remote device.
+  returned: Always.
   type: list
   sample: ['...', '...']
 
 responses:
-  description: The set of responses from issuing the commands on the device
-  returned: when not check_mode
+  description: The set of responses from issuing the commands on the device.
+  returned: When not check_mode.
   type: list
   sample: ['...', '...']
 
 saved:
   description: Returns whether the configuration is saved to the startup
                configuration or not.
-  returned: when not check_mode
+  returned: When not check_mode.
   type: bool
   sample: True
 

--- a/lib/ansible/modules/network/dellos6/dellos6_facts.py
+++ b/lib/ansible/modules/network/dellos6/dellos6_facts.py
@@ -19,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
+
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
@@ -28,22 +29,21 @@ DOCUMENTATION = """
 module: dellos6_facts
 version_added: "2.2"
 author: "Abirami N(@abirami-n)"
-short_description: Collect facts from remote devices running Dell OS6
+short_description: Collect facts from remote devices running Dell EMC Networking OS6
 description:
   - Collects a base set of device facts from a remote device that
     is running OS6.  This module prepends all of the
     base network fact keys with C(ansible_net_<fact>).  The facts
-    module will always collect a base set of facts from the device
+    module always collects a base set of facts from the device
     and can enable or disable collection of additional facts.
 extends_documentation_fragment: dellos6
 options:
   gather_subset:
     description:
-      - When supplied, this argument will restrict the facts collected
+      - When specified, this argument restricts the facts collected
         to a given subset.  Possible values for this argument include
-        all, hardware, config, and interfaces.  Can specify a list of
-        values to include a larger subset.  Values can also be used
-        with an initial C(M(!)) to specify that a specific subset should
+        all, hardware, config, and interfaces.  You can specify a list of
+        values to include a larger subset.  You can also use values with an initial M(!) to specify that a specific subset should
         not be collected.
     required: false
     default: '!config'
@@ -67,56 +67,56 @@ EXAMPLES = """
 
 RETURN = """
 ansible_net_gather_subset:
-  description: The list of fact subsets collected from the device
-  returned: always
+  description: The list of fact subsets collected from the device.
+  returned: Always.
   type: list
 
 # default
 ansible_net_model:
-  description: The model name returned from the device
-  returned: always
+  description: The model name returned from the device.
+  returned: Always.
   type: str
 ansible_net_serialnum:
-  description: The serial number of the remote device
-  returned: always
+  description: The serial number of the remote device.
+  returned: Always.
   type: str
 ansible_net_version:
-  description: The operating system version running on the remote device
-  returned: always
+  description: The operating system version running on the remote device.
+  returned: Always.
   type: str
 ansible_net_hostname:
-  description: The configured hostname of the device
-  returned: always
+  description: The configured hostname of the device.
+  returned: Always.
   type: string
 ansible_net_image:
-  description: The image file the device is running
-  returned: always
+  description: The image file that the device is running.
+  returned: Always
   type: string
 
 # hardware
 ansible_net_memfree_mb:
-  description: The available free memory on the remote device in Mb
-  returned: when hardware is configured
+  description: The available free memory on the remote device in MB.
+  returned: When hardware is configured.
   type: int
 ansible_net_memtotal_mb:
-  description: The total memory on the remote device in Mb
-  returned: when hardware is configured
+  description: The total memory on the remote device in MB.
+  returned: When hardware is configured.
   type: int
 
 # config
 ansible_net_config:
-  description: The current active config from the device
-  returned: when config is configured
+  description: The current active config from the device.
+  returned: When config is configured.
   type: str
 
 # interfaces
 ansible_net_interfaces:
-  description: A hash of all interfaces running on the system
-  returned: when interfaces is configured
+  description: A hash of all interfaces running on the system.
+  returned: When interfaces is configured.
   type: dict
 ansible_net_neighbors:
-  description: The list of LLDP neighbors from the remote device
-  returned: when interfaces is configured
+  description: The list of LLDP neighbors from the remote device.
+  returned: When interfaces is configured.
   type: dict
 
 """

--- a/lib/ansible/modules/network/dellos9/dellos9_config.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_config.py
@@ -29,11 +29,11 @@ DOCUMENTATION = """
 module: dellos9_config
 version_added: "2.2"
 author: "Dhivya P (@dhivyap)"
-short_description: Manage Dell OS9 configuration sections
+short_description: Manage Dell EMC Networking OS9 configuration sections
 description:
-  - Dell OS9 configurations use a simple block indent file syntax
+  - OS9 configurations use a simple block indent file syntax
     for segmenting configuration into sections.  This module provides
-    an implementation for working with Dell OS9 configuration sections in
+    an implementation for working with OS9 configuration sections in
     a deterministic way.
 extends_documentation_fragment: dellos9
 options:
@@ -41,17 +41,15 @@ options:
     description:
       - The ordered set of commands that should be configured in the
         section.  The commands must be the exact same commands as found
-        in the device running-config.  Be sure to note the configuration
-        command syntax as some commands are automatically modified by the
-        device config parser. This argument is mutually exclusive with I(src).
+        in the device running-config. Note the configuration
+        command syntax as the device config parser automatically modifies some commands. This argument is mutually exclusive with I(src).
     required: false
     default: null
     aliases: ['commands']
   parents:
     description:
       - The ordered set of parents that uniquely identify the section
-        the commands should be checked against.  If the parents argument
-        is omitted, the commands are checked against the set of top
+        the commands should be checked against.  If you omit the parents argument, the commands are checked against the set of top
         level or global commands.
     required: false
     default: null
@@ -67,8 +65,7 @@ options:
   before:
     description:
       - The ordered set of commands to push on to the command stack if
-        a change needs to be made.  This allows the playbook designer
-        the opportunity to perform configuration commands prior to pushing
+        a change needs to be made.  The playbook designer can use this opportunity to perform configuration commands prior to pushing
         any changes without affecting how the set of commands are matched
         against the system.
     required: false
@@ -76,20 +73,19 @@ options:
   after:
     description:
       - The ordered set of commands to append to the end of the command
-        stack if a change needs to be made.  Just like with I(before) this
-        allows the playbook designer to append a set of commands to be
+        stack if a change needs to be made. As with I(before), this
+        the playbook designer can append a set of commands to be
         executed after the command set.
     required: false
     default: null
   match:
     description:
       - Instructs the module on the way to perform the matching of
-        the set of commands against the current device config.  If
-        match is set to I(line), commands are matched line by line.  If
-        match is set to I(strict), command lines are matched with respect
-        to position.  If match is set to I(exact), command lines
-        must be an equal match.  Finally, if match is set to I(none), the
-        module will not attempt to compare the source configuration with
+        the set of commands against the current device config.  If you set
+        match to I(line), commands match line by line.  If you set
+        match to I(strict), command lines match by position.  If you set match to I(exact), command lines
+        must be an equal match.  Finally, if you set match to I(none), the
+        module does  not attempt to compare the source configuration with
         the running configuration on the remote device.
     required: false
     default: line
@@ -97,10 +93,10 @@ options:
   replace:
     description:
       - Instructs the module on the way to perform the configuration
-        on the device.  If the replace argument is set to I(line) then
-        the modified lines are pushed to the device in configuration
-        mode.  If the replace argument is set to I(block) then the entire
-        command block is pushed to the device in configuration mode if any
+        on the device.  If you set the replace argument to I(line), then
+        the modified lines push to the device in configuration
+        mode.  If you set the replace argument to I(block), then the entire
+        command block pushes to the device in configuration mode if any
         line is not correct.
     required: false
     default: line
@@ -109,9 +105,9 @@ options:
     description:
       - The I(update) argument controls how the configuration statements
         are processed on the remote device.  Valid choices for the I(update)
-        argument are I(merge) and I(check).  When the argument is set to
-        I(merge), the configuration changes are merged with the current
-        device running configuration.  When the argument is set to I(check)
+        argument are I(merge) and I(check).  When you set this argument to
+        I(merge), the configuration changes merge with the current
+        device running configuration.  When you set this argument to I(check)
         the configuration updates are determined but not actually configured
         on the remote device.
     required: false
@@ -127,15 +123,15 @@ options:
     choices: ['yes', 'no']
   config:
     description:
-      - The C(config) argument allows the playbook designer to supply
-        the base configuration to be used to validate configuration
-        changes necessary.  If this argument is provided, the module
-        will not download the running-config from the remote node.
+      - The playbook designer can use the  C(config) argument to supply
+        the base configuration to be used to validate necessary configuration
+        changes.  If you provide this argument, the module
+        does not download the running-config from the remote node.
     required: false
     default: null
   backup:
     description:
-      - This argument will cause the module to create a full backup of
+      - This argument causes the module to create a full backup of
         the current C(running-config) from the remote device before any
         changes are made.  The backup file is written to the C(backup)
         folder in the playbook root directory.  If the directory does not
@@ -149,8 +145,7 @@ notes:
 
   - This module requires to increase the ssh connection rate limit.
     Use the following command I(ip ssh connection-rate-limit 60)
-    to configure the same. This can be done via C(dellos9_config) module
-    as well.
+    to configure the same. This can also be done with the M(dellos9_config) module.
 """
 
 EXAMPLES = """
@@ -185,21 +180,22 @@ EXAMPLES = """
 
 RETURN = """
 updates:
-  description: The set of commands that will be pushed to the remote device
-  returned: always
+  description: The set of commands that will be pushed to the remote device.
+  returned: Always.
   type: list
   sample: ['...', '...']
 
 responses:
-  description: The set of responses from issuing the commands on the device
-  returned: when not check_mode
+  description: The set of responses from issuing the commands on the device.
+  returned: When not check_mode.
   type: list
   sample: ['...', '...']
 
 saved:
   description: Returns whether the configuration is saved to the startup
                configuration or not.
-  returned: when not check_mode
+  returned: When not check_mode.
+
   type: bool
   sample: True
 

--- a/lib/ansible/modules/network/dellos9/dellos9_facts.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_facts.py
@@ -19,6 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
+
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.0'}
@@ -28,32 +29,31 @@ DOCUMENTATION = """
 module: dellos9_facts
 version_added: "2.2"
 author: "Dhivya P (@dhivyap)"
-short_description: Collect facts from remote devices running Dell OS9
+short_description: Collect facts from remote devices running Dell EMC Networking OS9
 description:
   - Collects a base set of device facts from a remote device that
-    is running Dell OS9.  This module prepends all of the
+    is running OS9.  This module prepends all of the
     base network fact keys with C(ansible_net_<fact>).  The facts
-    module will always collect a base set of facts from the device
+    module always collects  a base set of facts from the device
     and can enable or disable collection of additional facts.
 extends_documentation_fragment: dellos9
 options:
   gather_subset:
     description:
-      - When supplied, this argument will restrict the facts collected
+      - When supplied, this argument restricts the facts collected
         to a given subset.  Possible values for this argument include
-        all, hardware, config, and interfaces.  Can specify a list of
-        values to include a larger subset.  Values can also be used
-        with an initial C(M(!)) to specify that a specific subset should
+        all, hardware, config, and interfaces.  You can specify a list of
+        values to include a larger subset.  You can also use values
+        with an initial M(!) to specify that a specific subset should
         not be collected.
     required: false
     default: '!config'
 notes:
-  - This module requires Dell OS9 version 9.10.0.1P13 or above.
+  - This module requires OS9 version 9.10.0.1P13 or above.
 
-  - This module requires to increase the ssh connection rate limit.
+  - This module requires an increase of the SSH connection rate limit.
     Use the following command I(ip ssh connection-rate-limit 60)
-    to configure the same. This can be done via M(dellos9_config) module
-    as well.
+    to configure the same. This can be also be done with the M(dellos9_config) module.
 """
 
 EXAMPLES = """
@@ -74,68 +74,68 @@ EXAMPLES = """
 
 RETURN = """
 ansible_net_gather_subset:
-  description: The list of fact subsets collected from the device
-  returned: always
+  description: The list of fact subsets collected from the device.
+  returned: Always.
   type: list
 
 # default
 ansible_net_model:
-  description: The model name returned from the device
-  returned: always
+  description: The model name returned from the device.
+  returned: Always.
   type: str
 ansible_net_serialnum:
-  description: The serial number of the remote device
-  returned: always
+  description: The serial number of the remote device.
+  returned: Always.
   type: str
 ansible_net_version:
-  description: The operating system version running on the remote device
-  returned: always
+  description: The operating system version running on the remote device.
+  returned: Always.
   type: str
 ansible_net_hostname:
-  description: The configured hostname of the device
-  returned: always
+  description: The configured hostname of the device.
+  returned: Always.
   type: string
 ansible_net_image:
-  description: The image file the device is running
-  returned: always
+  description: The image file the device is running.
+  returned: Always.
   type: string
 
 # hardware
 ansible_net_filesystems:
-  description: All file system names available on the device
-  returned: when hardware is configured
+  description: All file system names available on the device.
+  returned: When hardware is configured.
   type: list
 ansible_net_memfree_mb:
-  description: The available free memory on the remote device in Mb
-  returned: when hardware is configured
+  description: The available free memory on the remote device in MB.
+  returned: When hardware is configured.
   type: int
 ansible_net_memtotal_mb:
-  description: The total memory on the remote device in Mb
-  returned: when hardware is configured
+  description: The total memory on the remote device in MB.
+  returned: When hardware is configured.
   type: int
 
 # config
 ansible_net_config:
-  description: The current active config from the device
-  returned: when config is configured
+  description: The current active config from the device.
+  returned: When config is configured.
   type: str
 
 # interfaces
 ansible_net_all_ipv4_addresses:
-  description: All IPv4 addresses configured on the device
-  returned: when interfaces is configured
+  description: All IPv4 addresses configured on the device.
+  returned: When interfaces is configured.
   type: list
 ansible_net_all_ipv6_addresses:
-  description: All IPv6 addresses configured on the device
-  returned: when interfaces is configured
+  description: All IPv6 addresses configured on the device.
+  returned: When interfaces is configured.
   type: list
 ansible_net_interfaces:
-  description: A hash of all interfaces running on the system
-  returned: when interfaces is configured
+  description: A hash of all interfaces running on the system.
+  returned: When interfaces is configured.
   type: dict
 ansible_net_neighbors:
   description: The list of LLDP neighbors from the remote device
-  returned: when interfaces is configured
+  returned: When interfaces is configured.
   type: dict
 """
 import re


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
- modules/network/dellos9/dellos9_facts
- modules/network/dellos9/dellos9_config
- modules/network/dellos10/dellos10_facts
- modules/network/dellos10/dellos10_config
- modules/network/dellos6/dellos6_facts
- modules/network/dellos6/dellos6_config

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file =
  configured module search path = Default w/o overrides

```

##### SUMMARY

Fix Documentation sentence structure in multiple description sections of dellos* modules.
