### PR TITLE
Explicitly mention that Packet "device" is a bare metal server

### DIFF
--- a/lib/ansible/modules/cloud/packet/packet_device.py
+++ b/lib/ansible/modules/cloud/packet/packet_device.py
@@ -26,10 +26,10 @@ DOCUMENTATION = '''
 ---
 module: packet_device
 
-short_description: create, destroy, start, stop, and reboot a Packet Host machine.
+short_description: create, destroy, start, stop, and reboot a bare metal server at Packet.
 
 description:
-    - create, destroy, update, start, stop, and reboot a Packet Host machine. When the machine is created it can optionally wait for it to have an IP address before returning. This module has a dependency on packet >= 1.0.
+    - create, destroy, update, start, stop, and reboot a bare metal server at Packet. Bare metal server is a "device" in Packet API terms. When the device is created, the module can optionally wait for public IP address assignment before returning. This module has a dependency on packet >= 1.0.
     - API is documented at U(https://www.packet.net/help/api/#page:devices,header:devices-devices-post).
 
 version_added: 2.3


### PR DESCRIPTION
##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

modules/cloud/packet_device

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0 (packet-mention-baremetal afaeaedd0a) last updated 2017/03/06 13:43:10 (GMT +300)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]

```

##### SUMMARY

This PR updates short and long description of the packet_device module. All the types of Packet devices are, in fact, bare metal servers (https://www.packet.net/bare-metal/servers/), so this is both a factual improvement, and an exposure of one of the key features of the Packet Host.