### PR TITLE
win_service: Cleanup of Add-AnsibleParam and -Whatif

### DIFF
--- a/lib/ansible/modules/windows/win_service.ps1
+++ b/lib/ansible/modules/windows/win_service.ps1
@@ -22,23 +22,22 @@
 $ErrorActionPreference = "Stop"
 
 $params = Parse-Args $args -supports_check_mode $true
-$check_mode = Get-AnsibleParam -obj $params "_ansible_check_mode" -type "bool" -default $false
+$check_mode = Get-AnsibleParam -obj $params "_ansible_check_mode" -type 'bool' -default $false
 
-$dependencies = Get-AnsibleParam -obj $params -name 'dependencies' -failifempty $false -default $null
-$dependency_action = Get-AnsibleParam -obj $params -name 'dependency_action' -failifempty $false -ValidateSet 'add', 'remove', 'set' -default 'set'
-$description = Get-AnsibleParam -obj $params -name 'description' -failifempty $false -default $null
-$desktop_interact = Get-AnsibleParam -obj $params -name 'desktop_interact' -type "bool" -failifempty $false -default $false
-$display_name = Get-AnsibleParam -obj $params -name 'display_name' -failifempty $false -default $null
-$name = Get-AnsibleParam -obj $params -name 'name' -failifempty $true
-$password = Get-AnsibleParam -obj $params -name 'password' -failifempty $false -default $null
-$path = Get-AnsibleParam -obj $params -name 'path' -failifempty $false -default $null
-$start_mode = Get-AnsibleParam -obj $params -name 'start_mode' -failifempty $false -ValidateSet 'auto', 'manual', 'disabled', 'delayed'
-$state = Get-AnsibleParam -obj $params -name 'state' -failifempty $false -ValidateSet 'started', 'stopped', 'restarted', 'absent'
-$username = Get-AnsibleParam -obj $params -name 'username' -failifempty $false -default $null
+$dependencies = Get-AnsibleParam -obj $params -name 'dependencies' -type 'list'
+$dependency_action = Get-AnsibleParam -obj $params -name 'dependency_action' -type 'str' -default 'set' -validateset 'add','remove','set'
+$description = Get-AnsibleParam -obj $params -name 'description' -type 'str'
+$desktop_interact = Get-AnsibleParam -obj $params -name 'desktop_interact' -type 'bool' -default $false
+$display_name = Get-AnsibleParam -obj $params -name 'display_name' -type 'str'
+$name = Get-AnsibleParam -obj $params -name 'name' -type 'str' -failifempty $true
+$password = Get-AnsibleParam -obj $params -name 'password' -type 'str'
+$path = Get-AnsibleParam -obj $params -name 'path' -type 'path'
+$start_mode = Get-AnsibleParam -obj $params -name 'start_mode' -type 'str' -validateset 'auto','manual','disabled','delayed'
+$state = Get-AnsibleParam -obj $params -name 'state' -type 'str' -validateset 'started','stopped','restarted','absent'
+$username = Get-AnsibleParam -obj $params -name 'username' -type 'str'
 
 $result = @{
     changed = $false
-    warnings = @()
 }
 
 # Check if dependencies is a string and convert to a list
@@ -141,32 +140,19 @@ Function Set-ServiceStartMode($svc, $start_mode) {
         try {
             $delayed_key = "HKLM:\System\CurrentControlSet\Services\$($svc.Name)"
 
-            if ($check_mode) {
-                # Original start up type was auto (delayed) and we want auto, need to removed delayed key
-                if ($start_mode -eq 'auto' -and $result.start_mode -eq 'delayed') {
-                    Set-ItemProperty -Path $delayed_key -Name "DelayedAutostart" -Value 0 -Type DWORD -WhatIf
-                # Original start up type was auto and we want auto (delayed), need to add delayed key
-                } elseif ($start_mode -eq 'delayed' -and $result.start_mode -eq 'auto') {
-                    Set-ItemProperty -Path $delayed_key -Name "DelayedAutostart" -Value 1 -Type DWORD -WhatIf
-                # Original start up type was not auto or auto (delayed), need to change to auto and add delayed key
-                } elseif ($start_mode -eq 'delayed') {
-                    $svc | Set-Service -StartupType "auto" -WhatIf
-                    Set-ItemProperty -Path $delayed_key -Name "DelayedAutostart" -Value 1 -Type DWORD -WhatIf
-                # Original start up type was not what we were looking for, just change to that type
-                } else {
-                    $svc | Set-Service -StartupType $start_mode -WhatIf
-                }
+            # Original start up type was auto (delayed) and we want auto, need to removed delayed key
+            if ($start_mode -eq 'auto' -and $result.start_mode -eq 'delayed') {
+                Set-ItemProperty -Path $delayed_key -Name "DelayedAutostart" -Value 0 -Type DWORD -WhatIf:$check_mode
+            # Original start up type was auto and we want auto (delayed), need to add delayed key
+            } elseif ($start_mode -eq 'delayed' -and $result.start_mode -eq 'auto') {
+                Set-ItemProperty -Path $delayed_key -Name "DelayedAutostart" -Value 1 -Type DWORD -WhatIf:$check_mode
+            # Original start up type was not auto or auto (delayed), need to change to auto and add delayed key
+            } elseif ($start_mode -eq 'delayed') {
+                $svc | Set-Service -StartupType "auto" -WhatIf:$check_mode
+                Set-ItemProperty -Path $delayed_key -Name "DelayedAutostart" -Value 1 -Type DWORD -WhatIf:$check_mode
+            # Original start up type was not what we were looking for, just change to that type
             } else {
-                if ($start_mode -eq 'auto' -and $result.start_mode -eq 'delayed') {
-                    Set-ItemProperty -Path $delayed_key -Name "DelayedAutostart" -Value 0 -Type DWORD
-                } elseif ($start_mode -eq 'delayed' -and $result.start_mode -eq 'auto') {
-                    Set-ItemProperty -Path $delayed_key -Name "DelayedAutostart" -Value 1 -Type DWORD
-                } elseif ($start_mode -eq 'delayed') {
-                    $svc | Set-Service -StartupType "auto"
-                    Set-ItemProperty -Path $delayed_key -Name "DelayedAutostart" -Value 1 -Type DWORD
-                } else {
-                    $svc | Set-Service -StartupType $start_mode
-                }
+                $svc | Set-Service -StartupType $start_mode -WhatIf:$check_mode
             }
         } catch {
             Fail-Json $result $_.Exception.Message
@@ -206,11 +192,7 @@ Function Set-ServiceDesktopInteract($wmi_svc, $desktop_interact) {
 Function Set-ServiceDisplayName($svc, $display_name) {
     if ($result.display_name -ne $display_name) {
         try {
-            if ($check_mode) {
-                $svc | Set-Service -DisplayName $display_name -WhatIf
-            } else {
-                $svc | Set-Service -DisplayName $display_name
-            }
+            $svc | Set-Service -DisplayName $display_name -WhatIf:$check_mode
         } catch {
             Fail-Json $result $_.Exception.Message
         }
@@ -222,11 +204,7 @@ Function Set-ServiceDisplayName($svc, $display_name) {
 Function Set-ServiceDescription($svc, $description) {
     if ($result.description -ne $description) {
         try {
-            if ($check_mode) {
-                $svc | Set-Service -Description $description -WhatIf
-            } else {
-                $svc | Set-Service -Description $description
-            }
+            $svc | Set-Service -Description $description -WhatIf:$check_mode
         } catch {
             Fail-Json $result $_.Exception.Message
         }
@@ -238,11 +216,7 @@ Function Set-ServiceDescription($svc, $description) {
 Function Set-ServicePath($name, $path) {
     if ($result.path -ne $path) {
         try {
-            if ($check_mode) {
-                Set-ItemProperty -Path "HKLM:\System\CurrentControlSet\Services\$name" -Name ImagePath -Value $path -WhatIf
-            } else {
-                Set-ItemProperty -Path "HKLM:\System\CurrentControlSet\Services\$name" -Name ImagePath -Value $path
-            }
+            Set-ItemProperty -Path "HKLM:\System\CurrentControlSet\Services\$name" -Name ImagePath -Value $path -WhatIf:$check_mode
         } catch {
             Fail-Json $result $_.Exception.Message
         }
@@ -299,11 +273,7 @@ Function Set-ServiceDependencies($wmi_svc, $dependency_action, $dependencies) {
 Function Set-ServiceState($svc, $wmi_svc, $state) {
     if ($state -eq "started" -and $result.state -ne "running") {
         try {
-            if ($check_mode) {
-                Start-Service -Name $svc.Name -WhatIf
-            } else {
-                Start-Service -Name $svc.Name
-            }
+            Start-Service -Name $svc.Name -WhatIf:$check_mode
         } catch {
             Fail-Json $result $_.Exception.Message
         }
@@ -313,11 +283,7 @@ Function Set-ServiceState($svc, $wmi_svc, $state) {
 
     if ($state -eq "stopped" -and $result.state -ne "stopped") {
         try {
-            if ($check_mode) {
-                Stop-Service -Name $svc.Name -Force -WhatIf
-            } else {
-                Stop-Service -Name $svc.Name -Force
-            }
+            Stop-Service -Name $svc.Name -Force -WhatIf:$check_mode
         } catch {
             Fail-Json $result $_.Exception.Message
         }
@@ -327,11 +293,7 @@ Function Set-ServiceState($svc, $wmi_svc, $state) {
 
     if ($state -eq "restarted") {
         try {
-            if ($check_mode) {
-                Restart-Service -Name $svc.Name -Force -WhatIf
-            } else {
-                Restart-Service -Name $svc.Name -Force
-            }
+            Restart-Service -Name $svc.Name -Force -WhatIf:$check_mode
         } catch {
             Fail-Json $result $_.Exception.Message
         }
@@ -341,11 +303,7 @@ Function Set-ServiceState($svc, $wmi_svc, $state) {
 
     if ($state -eq "absent") {
         try {
-            if ($check_mode) {
-                Stop-Service -Name $svc.Name -Force -WhatIf
-            } else {
-                Stop-Service -Name $svc.Name -Force
-            }
+            Stop-Service -Name $svc.Name -Force -WhatIf:$check_mode
         } catch {
             Fail-Json $result $_.Exception.Message
         }
@@ -409,11 +367,7 @@ if ($svc) {
         # Check if path is defined, if so create the service
         if ($path -ne $null) {
             try {
-                if ($check_mode) {
-                    New-Service -Name $name -BinaryPathname $path -WhatIf
-                } else {
-                    New-Service -Name $name -BinaryPathname $path
-                }
+                New-Service -Name $name -BinaryPathname $path -WhatIf:$check_mode
             } catch {
                 Fail-Json $result $_.Exception.Message
             }
@@ -443,10 +397,8 @@ if ($svc) {
 if ($state -eq 'absent') {
     # Recreate result so it doesn't have the extra meta data now that is has been deleted
     $changed = $result.changed
-    $warnings = $result.warnings
     $result = @{
         changed = $changed
-        warnings = $warnings
         exists = $false
     }
 } elseif ($svc -ne $null) {

--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -40,7 +40,6 @@ options:
       service.
     - This works by C(dependency_action) to either add/remove or set the
       services in this list.
-    required: False
     version_added: "2.3"
   dependency_action:
     description:
@@ -49,7 +48,6 @@ options:
     - Remove the dependencies to the existing dependencies.
     - Set the dependencies to only the values in the list replacing the
       existing dependencies.
-    required: False
     default: set
     choices:
     - set
@@ -60,18 +58,15 @@ options:
     description:
       - Whether to allow the service user to interact with the desktop.
       - This should only be set to true when using the LocalSystem username.
-    required: False
     default: False
     version_added: "2.3"
   description:
     description:
       - The description to set for the service.
-    required: False
     version_added: "2.3"
   display_name:
     description:
       - The display name to set for the service.
-    required: False
     version_added: "2.3"
   name:
     description:
@@ -80,7 +75,6 @@ options:
   path:
     description:
       - The path to the executable to set for the service.
-    required: False
     version_added: "2.3"
   password:
     description:
@@ -88,13 +82,11 @@ options:
       - This and the C(username) argument must be supplied together.
       - If specifying LocalSystem, NetworkService or LocalService this field
         must be an empty string and not null.
-    required: False
     version_added: "2.3"
   start_mode:
     description:
       - Set the startup type for the service.
       - C(delayed) added in Ansible 2.3
-    required: false
     choices:
       - auto
       - manual
@@ -106,7 +98,6 @@ options:
         commands unless necessary.
       - C(restarted) will always bounce the service.
       - C(absent) added in Ansible 2.3
-    required: false
     choices:
       - started
       - stopped
@@ -116,7 +107,6 @@ options:
     description:
       - The username to set the service to start as.
       - This and the C(password) argument must be supplied together.
-    required: False
     version_added: "2.3"
 author: "Chris Hoffman (@chrishoffman)"
 '''


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_service

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Various changes including:
- Cleanup of Add-AnsibleParam
- Remove unused warnings list
- Implemented -WhatIf:$check_mode
- Cleanup redundant required: false