### PR TITLE
Restore extends_documentation_fragment: nxos

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_aaa_server.py
+++ b/lib/ansible/modules/network/nxos/nxos_aaa_server.py
@@ -24,6 +24,7 @@ DOCUMENTATION = '''
 ---
 
 module: nxos_aaa_server
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages AAA server global configuration.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_aaa_server_host.py
+++ b/lib/ansible/modules/network/nxos/nxos_aaa_server_host.py
@@ -24,6 +24,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_aaa_server_host
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages AAA server host-specific configuration.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_acl.py
+++ b/lib/ansible/modules/network/nxos/nxos_acl.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_acl
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages access list entries for ACLs.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_acl_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_acl_interface.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_acl_interface
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages applying ACLs to interfaces.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_bgp.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_bgp
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages BGP configuration.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_bgp_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_af.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_bgp_af
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages BGP Address-family configuration.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_bgp_neighbor
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages BGP neighbors configurations.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_bgp_neighbor_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_neighbor_af.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_bgp_neighbor_af
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages BGP address-family's neighbors configuration.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_command.py
+++ b/lib/ansible/modules/network/nxos/nxos_command.py
@@ -25,6 +25,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: nxos_command
+extends_documentation_fragment: nxos
 version_added: "2.1"
 author: "Peter Sprygada (@privateip)"
 short_description: Run arbitrary command on Cisco NXOS devices

--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -25,6 +25,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: nxos_config
+extends_documentation_fragment: nxos
 version_added: "2.1"
 author: "Peter Sprygada (@privateip)"
 short_description: Manage Cisco NXOS configuration sections

--- a/lib/ansible/modules/network/nxos/nxos_evpn_global.py
+++ b/lib/ansible/modules/network/nxos/nxos_evpn_global.py
@@ -25,6 +25,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: nxos_evpn_global
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Handles the EVPN control plane for VXLAN.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_evpn_vni.py
+++ b/lib/ansible/modules/network/nxos/nxos_evpn_vni.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_evpn_vni
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages Cisco EVPN VXLAN Network Identifier (VNI).
 description:

--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -162,7 +162,6 @@ kickstart:
   returned: when legacy is configured
   type: str
 module:
-extends_documentation_fragment: nxos
   description: A hash of facts about the modules in a remote device
   returned: when legacy is configured
   type: dict

--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -25,6 +25,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: nxos_facts
+extends_documentation_fragment: nxos
 version_added: "2.1"
 short_description: Gets facts about NX-OS switches
 description:
@@ -34,7 +35,6 @@ description:
     with C(ansible_net_<fact>).  The facts module will always collect a
     base set of facts from the device and can enable or disable
     collection of additional facts.
-extends_documentation_fragment: nxos
 author:
     - Jason Edelman (@jedelman8)
     - Gabriele Gerbino (@GGabriele)
@@ -162,6 +162,7 @@ kickstart:
   returned: when legacy is configured
   type: str
 module:
+extends_documentation_fragment: nxos
   description: A hash of facts about the modules in a remote device
   returned: when legacy is configured
   type: dict

--- a/lib/ansible/modules/network/nxos/nxos_feature.py
+++ b/lib/ansible/modules/network/nxos/nxos_feature.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_feature
+extends_documentation_fragment: nxos
 version_added: "2.1"
 short_description: Manage features in NX-OS switches.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_file_copy
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Copy a file to a remote NXOS device over SCP.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_gir.py
+++ b/lib/ansible/modules/network/nxos/nxos_gir.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_gir
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Trigger a graceful removal or insertion (GIR) of the switch.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_gir_profile_management.py
+++ b/lib/ansible/modules/network/nxos/nxos_gir_profile_management.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_gir_profile_management
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Create a maintenance-mode or normal-mode profile for GIR.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_hsrp.py
+++ b/lib/ansible/modules/network/nxos/nxos_hsrp.py
@@ -24,6 +24,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_hsrp
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages HSRP configuration on NX-OS switches.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_igmp.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_igmp
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages IGMP global configuration.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_igmp_interface
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages IGMP interface configuration.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_igmp_snooping.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp_snooping.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_igmp_snooping
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages IGMP snooping global configuration.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_install_os
+extends_documentation_fragment: nxos
 short_description: Set boot options like boot image and kickstart image.
 description:
     - Install an operating system by setting the boot options like boot

--- a/lib/ansible/modules/network/nxos/nxos_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_interface
+extends_documentation_fragment: nxos
 version_added: "2.1"
 short_description: Manages physical attributes of interfaces.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_interface_ospf
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages configuration of an OSPF interface instance.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_ip_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_ip_interface.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_ip_interface
+extends_documentation_fragment: nxos
 version_added: "2.1"
 short_description: Manages L3 attributes for IPv4 and IPv6 interfaces.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_mtu.py
+++ b/lib/ansible/modules/network/nxos/nxos_mtu.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_mtu
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages MTU settings on Nexus switch.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_ntp.py
+++ b/lib/ansible/modules/network/nxos/nxos_ntp.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_ntp
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages core NTP configuration.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_ntp_auth.py
+++ b/lib/ansible/modules/network/nxos/nxos_ntp_auth.py
@@ -24,6 +24,7 @@ DOCUMENTATION = '''
 ---
 
 module: nxos_ntp_auth
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages NTP authentication.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_ntp_options.py
+++ b/lib/ansible/modules/network/nxos/nxos_ntp_options.py
@@ -24,6 +24,7 @@ DOCUMENTATION = '''
 ---
 
 module: nxos_ntp_options
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages NTP options.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_nxapi.py
+++ b/lib/ansible/modules/network/nxos/nxos_nxapi.py
@@ -25,6 +25,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: nxos_nxapi
+extends_documentation_fragment: nxos
 version_added: "2.1"
 author: "Peter Sprygada (@privateip)"
 short_description: Manage NXAPI configuration on an NXOS device.

--- a/lib/ansible/modules/network/nxos/nxos_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_ospf.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_ospf
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages configuration of an ospf instance.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_ospf_vrf.py
+++ b/lib/ansible/modules/network/nxos/nxos_ospf_vrf.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_ospf_vrf
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages a VRF for an OSPF router.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_overlay_global.py
+++ b/lib/ansible/modules/network/nxos/nxos_overlay_global.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_overlay_global
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Configures anycast gateway MAC of the switch.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_pim.py
+++ b/lib/ansible/modules/network/nxos/nxos_pim.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_pim
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages configuration of a PIM instance.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_pim_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_pim_interface.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_pim_interface
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages PIM interface configuration.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_pim_rp_address.py
+++ b/lib/ansible/modules/network/nxos/nxos_pim_rp_address.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_pim_rp_address
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages configuration of an PIM static RP address instance.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_ping.py
+++ b/lib/ansible/modules/network/nxos/nxos_ping.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_ping
+extends_documentation_fragment: nxos
 version_added: "2.1"
 short_description: Tests reachability using ping from Nexus switch.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_portchannel.py
+++ b/lib/ansible/modules/network/nxos/nxos_portchannel.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_portchannel
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages port-channel interfaces.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_reboot.py
+++ b/lib/ansible/modules/network/nxos/nxos_reboot.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_reboot
+extends_documentation_fragment: nxos
 version_added: 2.2
 short_description: Reboot a network device.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_rollback.py
+++ b/lib/ansible/modules/network/nxos/nxos_rollback.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_rollback
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Set a checkpoint or rollback to a checkpoint.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_smu.py
+++ b/lib/ansible/modules/network/nxos/nxos_smu.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_smu
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Perform SMUs on Cisco NX-OS devices.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_snapshot.py
+++ b/lib/ansible/modules/network/nxos/nxos_snapshot.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_snapshot
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manage snapshots of the running states of selected features.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_snmp_community.py
+++ b/lib/ansible/modules/network/nxos/nxos_snmp_community.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_snmp_community
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages SNMP community configs.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_snmp_contact.py
+++ b/lib/ansible/modules/network/nxos/nxos_snmp_contact.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_snmp_contact
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages SNMP contact info.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_snmp_host.py
+++ b/lib/ansible/modules/network/nxos/nxos_snmp_host.py
@@ -24,6 +24,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_snmp_host
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages SNMP host configuration.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_snmp_location.py
+++ b/lib/ansible/modules/network/nxos/nxos_snmp_location.py
@@ -24,6 +24,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_snmp_location
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages SNMP location information.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_snmp_traps.py
+++ b/lib/ansible/modules/network/nxos/nxos_snmp_traps.py
@@ -24,6 +24,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_snmp_traps
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages SNMP traps.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_snmp_user.py
+++ b/lib/ansible/modules/network/nxos/nxos_snmp_user.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_snmp_user
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages SNMP users for monitoring.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_static_route.py
+++ b/lib/ansible/modules/network/nxos/nxos_static_route.py
@@ -22,6 +22,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_static_route
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages static route configuration
 description:

--- a/lib/ansible/modules/network/nxos/nxos_switchport.py
+++ b/lib/ansible/modules/network/nxos/nxos_switchport.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_switchport
+extends_documentation_fragment: nxos
 version_added: "2.1"
 short_description: Manages Layer 2 switchport interfaces.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_system.py
+++ b/lib/ansible/modules/network/nxos/nxos_system.py
@@ -25,6 +25,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: nxos_system
+extends_documentation_fragment: nxos
 version_added: "2.3"
 author: "Peter Sprygada (@privateip)"
 short_description: Manage the system attributes on Cisco NXOS devices

--- a/lib/ansible/modules/network/nxos/nxos_udld.py
+++ b/lib/ansible/modules/network/nxos/nxos_udld.py
@@ -24,6 +24,7 @@ DOCUMENTATION = '''
 ---
 
 module: nxos_udld
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages UDLD global configuration params.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_udld_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_udld_interface.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_udld_interface
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages UDLD interface configuration params.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_user.py
+++ b/lib/ansible/modules/network/nxos/nxos_user.py
@@ -25,6 +25,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 ---
 module: nxos_user
+extends_documentation_fragment: nxos
 version_added: "2.3"
 author: "Peter Sprygada (@privateip)"
 short_description: Manage the collection of local users on Nexus devices

--- a/lib/ansible/modules/network/nxos/nxos_vlan.py
+++ b/lib/ansible/modules/network/nxos/nxos_vlan.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_vlan
+extends_documentation_fragment: nxos
 version_added: "2.1"
 short_description: Manages VLAN resources and attributes.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_vpc.py
+++ b/lib/ansible/modules/network/nxos/nxos_vpc.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_vpc
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages global VPC configuration
 description:

--- a/lib/ansible/modules/network/nxos/nxos_vpc_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_vpc_interface.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_vpc_interface
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages interface VPC configuration
 description:

--- a/lib/ansible/modules/network/nxos/nxos_vrf.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrf.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_vrf
+extends_documentation_fragment: nxos
 version_added: "2.1"
 short_description: Manages global VRF configuration.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_vrf_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrf_af.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_vrf_af
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages VRF AF.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_vrf_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrf_interface.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_vrf_interface
+extends_documentation_fragment: nxos
 version_added: "2.1"
 short_description: Manages interface specific VRF configuration.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_vrrp.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrrp.py
@@ -24,6 +24,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_vrrp
+extends_documentation_fragment: nxos
 version_added: "2.1"
 short_description: Manages VRRP configuration on NX-OS switches.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_vtp_domain.py
+++ b/lib/ansible/modules/network/nxos/nxos_vtp_domain.py
@@ -22,6 +22,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_vtp_domain
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages VTP domain configuration.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_vtp_password.py
+++ b/lib/ansible/modules/network/nxos/nxos_vtp_password.py
@@ -24,6 +24,7 @@ DOCUMENTATION = '''
 ---
 
 module: nxos_vtp_password
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages VTP password configuration.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_vtp_version.py
+++ b/lib/ansible/modules/network/nxos/nxos_vtp_version.py
@@ -24,6 +24,7 @@ DOCUMENTATION = '''
 ---
 
 module: nxos_vtp_version
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages VTP version configuration.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_vxlan_vtep.py
+++ b/lib/ansible/modules/network/nxos/nxos_vxlan_vtep.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_vxlan_vtep
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Manages VXLAN Network Virtualization Endpoint (NVE).
 description:

--- a/lib/ansible/modules/network/nxos/nxos_vxlan_vtep_vni.py
+++ b/lib/ansible/modules/network/nxos/nxos_vxlan_vtep_vni.py
@@ -23,6 +23,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: nxos_vxlan_vtep_vni
+extends_documentation_fragment: nxos
 version_added: "2.2"
 short_description: Creates a Virtual Network Identifier member (VNI)
 description:


### PR DESCRIPTION
Restore docs links so users know about `provider:` and it's sub options.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible/22312)
<!-- Reviewable:end -->
