### PR TITLE
lambda: Fix adding environment variables to functions previously not having any

### DIFF
--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -330,7 +330,7 @@ def main():
             func_kwargs.update({'Timeout': timeout})
         if memory_size and current_config['MemorySize'] != memory_size:
             func_kwargs.update({'MemorySize': memory_size})
-        if (environment_variables is not None) and (current_config['Environment']['Variables'] != environment_variables):
+        if (environment_variables is not None) and (current_config.get('Environment', {}).get('Variables', {}) != environment_variables):
             func_kwargs.update({'Environment':{'Variables': environment_variables}})
         if dead_letter_arn is not None:
             if current_config.get('DeadLetterConfig'):


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lambda

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file = /home/mmaslowski/ansible/ansible.cfg
  configured module search path = ['./modules/']
```
with `lambda` module copied from newest `devel`.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

I had an AWS Lambda function created without setting any environment variables (e.g. from the `lambda` module from Ansible 2.2 where it did not support setting them). I changed my playbook to invoke the `lambda` module passing environment variables to the function, now I get:
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: KeyError: 'Environment'
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_MXxNLc/ansible_module_lambda.py\", line 510, in <module>\n    main()\n  File \"/tmp/ansible_MXxNLc/ansible_module_lambda.py\", line 333, in main\n    if (environment_variables is not None) and (current_config['Environment']['Variables'] != environment_variables):\nKeyError: 'Environment'\n", "module_stdout": "", "msg": "MODULE FAILURE"}
```
This results from the `Environment` key missing from the config returned by boto3's `get_function`. https://docs.aws.amazon.com/lambda/latest/dg/API_GetFunction.html and linked data types suggest it not being required in the return value.

My commit makes the module consider them empty if they are not returned by the API.

Tested with these versions of boto packages:
```
boto (2.42.0)
boto3 (1.4.4)
botocore (1.5.19)
```

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->