### PR TITLE
Fix get_s3_connection (fixes #22317)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3.py
+++ b/lib/ansible/modules/cloud/amazon/s3.py
@@ -713,6 +713,11 @@ def main():
 def get_s3_connection(aws_connect_kwargs, location, rgw, s3_url):
     if s3_url and rgw:
         rgw = urlparse(s3_url)
+        for kw in ['is_secure', 'host', 'port', 'calling_format']:
+            try:
+                del aws_connect_kwargs[kw]
+            except KeyError:
+                pass
         s3 = boto.connect_s3(
             is_secure=rgw.scheme == 'https',
             host=rgw.hostname,
@@ -722,6 +727,11 @@ def get_s3_connection(aws_connect_kwargs, location, rgw, s3_url):
         )
     elif is_fakes3(s3_url):
         fakes3 = urlparse(s3_url)
+        for kw in ['is_secure', 'host', 'port', 'calling_format']:
+            try:
+                del aws_connect_kwargs[kw]
+            except KeyError:
+                pass
         s3 = S3Connection(
             is_secure=fakes3.scheme == 'fakes3s',
             host=fakes3.hostname,

--- a/lib/ansible/modules/cloud/amazon/s3.py
+++ b/lib/ansible/modules/cloud/amazon/s3.py
@@ -713,7 +713,7 @@ def main():
 def get_s3_connection(aws_connect_kwargs, location, rgw, s3_url):
     if s3_url and rgw:
         rgw = urlparse(s3_url)
-        # ensure none of the named arguments we will pass to boto.connect_s3 
+        # ensure none of the named arguments we will pass to boto.connect_s3
         # are already present in aws_connect_kwargs
         for kw in ['is_secure', 'host', 'port', 'calling_format']:
             try:

--- a/lib/ansible/modules/cloud/amazon/s3.py
+++ b/lib/ansible/modules/cloud/amazon/s3.py
@@ -713,22 +713,18 @@ def main():
 def get_s3_connection(aws_connect_kwargs, location, rgw, s3_url):
     if s3_url and rgw:
         rgw = urlparse(s3_url)
-        s3 = boto.connect_s3(
-            is_secure=rgw.scheme == 'https',
-            host=rgw.hostname,
-            port=rgw.port,
-            calling_format=OrdinaryCallingFormat(),
-            **aws_connect_kwargs
-        )
+        aws_connect_kwargs['is_secure'] = rgw.scheme == 'https'
+        aws_connect_kwargs['host'] = rgw.hostname
+        aws_connect_kwargs['port'] = rgw.port
+        aws_connect_kwargs['calling_format'] = OrdinaryCallingFormat()
+        s3 = boto.connect_s3(**aws_connect_kwargs)
     elif is_fakes3(s3_url):
         fakes3 = urlparse(s3_url)
-        s3 = S3Connection(
-            is_secure=fakes3.scheme == 'fakes3s',
-            host=fakes3.hostname,
-            port=fakes3.port,
-            calling_format=OrdinaryCallingFormat(),
-            **aws_connect_kwargs
-        )
+        aws_connect_kwargs['is_secure'] = fakes3.scheme == 'fakes3s'
+        aws_connect_kwargs['host'] = fakes3.hostname
+        aws_connect_kwargs['port'] = fakes3.port
+        aws_connect_kwargs['calling_format'] = OrdinaryCallingFormat()
+        s3 = S3Connection(**aws_connect_kwargs)
     elif is_walrus(s3_url):
         walrus = urlparse(s3_url).hostname
         s3 = boto.connect_walrus(walrus, **aws_connect_kwargs)

--- a/lib/ansible/modules/cloud/amazon/s3.py
+++ b/lib/ansible/modules/cloud/amazon/s3.py
@@ -713,6 +713,8 @@ def main():
 def get_s3_connection(aws_connect_kwargs, location, rgw, s3_url):
     if s3_url and rgw:
         rgw = urlparse(s3_url)
+        # ensure none of the named arguments we will pass to boto.connect_s3 
+        # are already present in aws_connect_kwargs
         for kw in ['is_secure', 'host', 'port', 'calling_format']:
             try:
                 del aws_connect_kwargs[kw]
@@ -727,6 +729,8 @@ def get_s3_connection(aws_connect_kwargs, location, rgw, s3_url):
         )
     elif is_fakes3(s3_url):
         fakes3 = urlparse(s3_url)
+        # ensure none of the named arguments we will pass to S3Connection
+        # are already present in aws_connect_kwargs
         for kw in ['is_secure', 'host', 'port', 'calling_format']:
             try:
                 del aws_connect_kwargs[kw]

--- a/lib/ansible/modules/cloud/amazon/s3.py
+++ b/lib/ansible/modules/cloud/amazon/s3.py
@@ -713,18 +713,22 @@ def main():
 def get_s3_connection(aws_connect_kwargs, location, rgw, s3_url):
     if s3_url and rgw:
         rgw = urlparse(s3_url)
-        aws_connect_kwargs['is_secure'] = rgw.scheme == 'https'
-        aws_connect_kwargs['host'] = rgw.hostname
-        aws_connect_kwargs['port'] = rgw.port
-        aws_connect_kwargs['calling_format'] = OrdinaryCallingFormat()
-        s3 = boto.connect_s3(**aws_connect_kwargs)
+        s3 = boto.connect_s3(
+            is_secure=rgw.scheme == 'https',
+            host=rgw.hostname,
+            port=rgw.port,
+            calling_format=OrdinaryCallingFormat(),
+            **aws_connect_kwargs
+        )
     elif is_fakes3(s3_url):
         fakes3 = urlparse(s3_url)
-        aws_connect_kwargs['is_secure'] = fakes3.scheme == 'fakes3s'
-        aws_connect_kwargs['host'] = fakes3.hostname
-        aws_connect_kwargs['port'] = fakes3.port
-        aws_connect_kwargs['calling_format'] = OrdinaryCallingFormat()
-        s3 = S3Connection(**aws_connect_kwargs)
+        s3 = S3Connection(
+            is_secure=fakes3.scheme == 'fakes3s',
+            host=fakes3.hostname,
+            port=fakes3.port,
+            calling_format=OrdinaryCallingFormat(),
+            **aws_connect_kwargs
+        )
     elif is_walrus(s3_url):
         walrus = urlparse(s3_url).hostname
         s3 = boto.connect_walrus(walrus, **aws_connect_kwargs)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
s3 module

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Override aws_connect_kwargs rather than prepending to them. Should fix an issue in which `calling_format` is set twice in the kwargs passed to `boto.connect_s3` or `S3Connection` if a bucket name contains a `.`
fixes #22317


