### PR TITLE
Set os_group domain_id default to 'default'

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_group.py
+++ b/lib/ansible/modules/cloud/openstack/os_group.py
@@ -146,7 +146,10 @@ def main():
 
     try:
         cloud = shade.operator_cloud(**module.params)
-        group = cloud.get_group(name, filters={'domain_id': domain_id})
+        if domain_id:
+            group = cloud.get_group(name, filters={'domain_id': domain_id})
+        else:
+            group = cloud.get_group(name)
 
         if module.check_mode:
             module.exit_json(changed=_system_state_change(state, description, group))


### PR DESCRIPTION
Setting it to None causes issues, as get_group call doesn't find groups
on domain 'None'.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

os_group

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (fix_os_group_domain_default dd46238aac) last updated 2017/03/06 17:22:11 (GMT +200)
```
