### PR TITLE
Fixes #22193 - authorize argument is not deprecated for 2.3 fo…

### DIFF
--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -61,7 +61,7 @@ eos_argument_spec = {
 def check_args(module, warnings):
     provider = module.params['provider'] or {}
     for key in eos_argument_spec:
-        if key not in ['provider', 'transport'] and module.params[key]:
+        if key not in ['provider', 'transport', 'authorize'] and module.params[key]:
             warnings.append('argument %s has been deprecated and will be '
                     'removed in a future version' % key)
 

--- a/lib/ansible/module_utils/ios.py
+++ b/lib/ansible/module_utils/ios.py
@@ -46,7 +46,7 @@ ios_argument_spec = {
 def check_args(module, warnings):
     provider = module.params['provider'] or {}
     for key in ios_argument_spec:
-        if key != 'provider' and module.params[key]:
+        if key not in ['provider', 'authorize'] and module.params[key]:
             warnings.append('argument %s has been deprecated and will be '
                     'removed in a future version' % key)
 


### PR DESCRIPTION
…r ios and eos

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
IOS and OES module
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In 2.3 using authorise: yes is the correct way to go into privileged mode on eos and ios.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```

```
