### PR TITLE
Pre-compile regexes to speed up target processing.

### DIFF
--- a/test/runner/lib/target.py
+++ b/test/runner/lib/target.py
@@ -137,6 +137,7 @@ def filter_targets(targets, patterns, include=True, directories=True, errors=Tru
     :rtype: collections.Iterable[CompletionTarget]
     """
     unmatched = set(patterns or ())
+    compiled_patterns = dict((p, re.compile('^%s$' % p)) for p in patterns) if patterns else None
 
     for target in targets:
         matched_directories = set()
@@ -145,7 +146,7 @@ def filter_targets(targets, patterns, include=True, directories=True, errors=Tru
         if patterns:
             for alias in target.aliases:
                 for pattern in patterns:
-                    if re.match('^%s$' % pattern, alias):
+                    if compiled_patterns[pattern].match(alias):
                         match = True
 
                         try:


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (re-compile 973c6cb148) last updated 2017/03/06 12:07:45 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```

##### SUMMARY

Pre-compile regexes to speed up target processing.

Without this, changing a large number of files results in target processing taking a very long time due to repeatedly compiling the same patterns in a loop over many targets.