### PR TITLE
Removes expanduser in favor of type path

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -304,7 +304,6 @@ def _get_pip(module, env=None, executable=None):
 
     pip = None
     if executable is not None:
-        executable = os.path.expanduser(executable)
         if os.path.isabs(executable):
             pip = executable
         else:
@@ -401,7 +400,7 @@ def main():
             extra_args=dict(),
             editable=dict(default=True, type='bool'),
             chdir=dict(type='path'),
-            executable=dict(),
+            executable=dict(type='path'),
             umask=dict(),
         ),
         required_one_of=[['name', 'requirements']],


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/module/packaging/language/pip.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides

```

##### SUMMARY
Removes the usage of expanduser in favor of the type 'path' for
module options. Related to #12263