### PR TITLE
[WIP] azure_rm inventory version comparison fix

### DIFF
--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -191,7 +191,7 @@ import os
 import re
 import sys
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from os.path import expanduser
 
@@ -790,11 +790,11 @@ class AzureInventory(object):
 
 def main():
     if not HAS_AZURE:
-        sys.exit("The Azure python sdk is not installed (try 'pip install azure>=2.0.0rc5') - {0}".format(HAS_AZURE_EXC))
+        sys.exit("The Azure python sdk is not installed (try `pip install 'azure>=2.0.0rc5' --upgrade`) - {0}".format(HAS_AZURE_EXC))
 
-    if LooseVersion(azure_compute_version) < LooseVersion(AZURE_MIN_VERSION):
+    if Version(azure_compute_version) < Version(AZURE_MIN_VERSION):
         sys.exit("Expecting azure.mgmt.compute.__version__ to be {0}. Found version {1} "
-                 "Do you have Azure >= 2.0.0rc5 installed?".format(AZURE_MIN_VERSION, azure_compute_version))
+                 "Do you have Azure >= 2.0.0rc5 installed? (try `pip install 'azure>=2.0.0rc5' --upgrade`)".format(AZURE_MIN_VERSION, azure_compute_version))
 
     AzureInventory()
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm.py

##### SUMMARY
Fixes version comparison to use `packaging.version` instead of `LooseVersion` for proper handling of prerelease values.