### PR TITLE
Remove 'update' param from documentation examples

### DIFF
--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -162,7 +162,6 @@ EXAMPLES = """
 - name: load a config from disk and replace the current config
   iosxr_config:
     src: config.cfg
-    update: replace
     backup: yes
 """
 


### PR DESCRIPTION
The 'update' param is no longer supported, thus removing from docs.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME

iosxr_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (remove_update_from_doc_examples 698d06b38f) last updated 2017/03/07 10:12:09 (GMT +200)
```
