### PR TITLE
Fix invocations of module.fail_json with no msg=

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
@@ -230,7 +230,7 @@ def main():
         module.fail_json(msg="region must be specified")
 
     if dns_hostnames and not dns_support:
-        module.fail_json('In order to enable DNS Hostnames you must also enable DNS support')
+        module.fail_json(msg='In order to enable DNS Hostnames you must also enable DNS support')
 
     if state == 'present':
 

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
@@ -651,7 +651,7 @@ def main():
     state = module.params.get('state', 'present')
 
     if lookup == 'id' and route_table_id is None:
-        module.fail_json("You must specify route_table_id if lookup is set to id")
+        module.fail_json(msg="You must specify route_table_id if lookup is set to id")
 
     try:
         if state == 'present':

--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -167,7 +167,7 @@ def check_valid_modification(module, values, modifiable_params):
 
         # check valid modifiable parameters
         if parameter not in modifiable_params:
-            module.fail_json("%s is not a modifiable parameter. Valid parameters to modify are: %s." % (parameter, modifiable_params.keys()))
+            module.fail_json(msg="%s is not a modifiable parameter. Valid parameters to modify are: %s." % (parameter, modifiable_params.keys()))
 
         # check allowed datatype for modified parameters
         str_to_type = {"integer": int, "string": text_type}

--- a/lib/ansible/modules/cloud/amazon/execute_lambda.py
+++ b/lib/ansible/modules/cloud/amazon/execute_lambda.py
@@ -231,7 +231,7 @@ def main():
                              "the ARN is correct and your profile has "
                              "permissions to execute this function.",
                              exception=traceback.format_exc())
-        module.fail_json("Client-side error when invoking Lambda, check inputs and specific error",
+        module.fail_json(msg="Client-side error when invoking Lambda, check inputs and specific error",
                          exception=traceback.format_exc())
     except botocore.exceptions.ParamValidationError as ve:
         module.fail_json(msg="Parameters to `invoke` failed to validate",

--- a/lib/ansible/modules/cloud/cloudstack/cs_nic.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_nic.py
@@ -191,7 +191,7 @@ class AnsibleCloudStackNic(AnsibleCloudStack):
         if nics:
             self.nic = nics['nic'][0]
             return self.nic
-        self.module.fail_json("NIC for VM %s in network %s not found" (self.get_vm(key='name'), self.get_network(key='name')))
+        self.module.fail_json(msg="NIC for VM %s in network %s not found" %(self.get_vm(key='name'), self.get_network(key='name')))
 
     def get_secondary_ip(self):
         nic = self.get_nic()

--- a/lib/ansible/modules/cloud/openstack/_quantum_floating_ip.py
+++ b/lib/ansible/modules/cloud/openstack/_quantum_floating_ip.py
@@ -232,7 +232,7 @@ def _get_net_id(neutron, module):
     try:
         networks = neutron.list_networks(**kwargs)
     except Exception as e:
-        module.fail_json("Error in listing neutron networks: %s" % e.message)
+        module.fail_json(msg="Error in listing neutron networks: %s" % e.message)
     if not networks['networks']:
         return None
     return networks['networks'][0]['id']

--- a/lib/ansible/modules/cloud/openstack/_quantum_router.py
+++ b/lib/ansible/modules/cloud/openstack/_quantum_router.py
@@ -182,7 +182,7 @@ def _delete_router(module, neutron, router_id):
     try:
         neutron.delete_router(router_id)
     except:
-        module.fail_json("Error in deleting the router")
+        module.fail_json(msg="Error in deleting the router")
     return True
 
 def main():

--- a/lib/ansible/modules/cloud/openstack/_quantum_router_gateway.py
+++ b/lib/ansible/modules/cloud/openstack/_quantum_router_gateway.py
@@ -154,7 +154,7 @@ def _get_net_id(neutron, module):
     try:
         networks = neutron.list_networks(**kwargs)
     except Exception as e:
-        module.fail_json("Error in listing neutron networks: %s" % e.message)
+        module.fail_json(msg="Error in listing neutron networks: %s" % e.message)
     if not networks['networks']:
         return None
     return networks['networks'][0]['id']

--- a/lib/ansible/modules/cloud/openstack/_quantum_subnet.py
+++ b/lib/ansible/modules/cloud/openstack/_quantum_subnet.py
@@ -200,7 +200,7 @@ def _get_net_id(neutron, module):
     try:
         networks = neutron.list_networks(**kwargs)
     except Exception as e:
-        module.fail_json("Error in listing neutron networks: %s" % e.message)
+        module.fail_json(msg="Error in listing neutron networks: %s" % e.message)
     if not networks['networks']:
         return None
     return networks['networks'][0]['id']

--- a/lib/ansible/modules/monitoring/boundary_meter.py
+++ b/lib/ansible/modules/monitoring/boundary_meter.py
@@ -161,7 +161,7 @@ def create_meter(module, name, apiid, apikey):
             try:
                 os.makedirs(config_directory)
             except:
-                module.fail_json("Could not create " + config_directory)
+                module.fail_json(msg="Could not create " + config_directory)
 
 
         # Download both cert files from the api host
@@ -174,7 +174,7 @@ def create_meter(module, name, apiid, apikey):
                 # Now download the file...
                 rc = download_request(module, name, apiid, apikey, cert_type)
                 if rc is False:
-                    module.fail_json("Download request for " + cert_type + ".pem failed")
+                    module.fail_json(msg="Download request for " + cert_type + ".pem failed")
 
         return 0, "Meter " + name + " created"
 
@@ -183,7 +183,7 @@ def search_meter(module, name, apiid, apikey):
     response, info = http_request(module, name, apiid, apikey, action="search")
 
     if info['status'] != 200:
-        module.fail_json("Failed to connect to api host to search for meter")
+        module.fail_json(msg="Failed to connect to api host to search for meter")
 
     # Return meters
     return json.loads(response.read())
@@ -206,7 +206,7 @@ def delete_meter(module, name, apiid, apikey):
     else:
         response, info = http_request(module, name, apiid, apikey, action, meter_id)
         if info['status'] != 200:
-            module.fail_json("Failed to delete meter")
+            module.fail_json(msg="Failed to delete meter")
 
         # Each new meter gets a new key.pem and ca.pem file, so they should be deleted
         types = ['cert', 'key']
@@ -215,7 +215,7 @@ def delete_meter(module, name, apiid, apikey):
                 cert_file = '%s/%s.pem' % (config_directory,cert_type)
                 os.remove(cert_file)
             except OSError:
-                module.fail_json("Failed to remove " + cert_type + ".pem file")
+                module.fail_json(msg="Failed to remove " + cert_type + ".pem file")
 
     return 0, "Meter " + name + " deleted"
 
@@ -227,7 +227,7 @@ def download_request(module, name, apiid, apikey, cert_type):
         action = "certificates"
         response, info = http_request(module, name, apiid, apikey, action, meter_id, cert_type)
         if info['status'] != 200:
-            module.fail_json("Failed to connect to api host to download certificate")
+            module.fail_json(msg="Failed to connect to api host to download certificate")
 
         if result:
             try:
@@ -238,11 +238,11 @@ def download_request(module, name, apiid, apikey, cert_type):
                 cert_file.close()
                 os.chmod(cert_file_path, int('0600', 8))
             except:
-                module.fail_json("Could not write to certificate file")
+                module.fail_json(msg="Could not write to certificate file")
 
         return True
     else:
-        module.fail_json("Could not get meter id")
+        module.fail_json(msg="Could not get meter id")
 
 def main():
 

--- a/lib/ansible/modules/monitoring/icinga2_feature.py
+++ b/lib/ansible/modules/monitoring/icinga2_feature.py
@@ -103,7 +103,7 @@ class Icinga2FeatureHelper:
 
         if self.module.params["state"] == "present":
             if rc != 0:
-                self.module.fail_json("Fail to %s feature %s. icinga2 command returned %s"
+                self.module.fail_json(msg="Fail to %s feature %s. icinga2 command returned %s"
                                       % (feature_enable_str, self.module.params["name"], out))
 
             if re.search("already enabled", out) is None:

--- a/lib/ansible/modules/network/exoscale/exo_dns_record.py
+++ b/lib/ansible/modules/network/exoscale/exo_dns_record.py
@@ -287,7 +287,7 @@ class ExoDnsRecord(ExoDns):
         self.multiple = self.module.params.get('multiple')
         self.record_type = self.module.params.get('record_type')
         if self.multiple and self.record_type != 'A':
-            self.module.fail_json("Multiple is only usable with record_type A")
+            self.module.fail_json(msg="Multiple is only usable with record_type A")
 
     def _create_record(self, record):
         self.result['changed'] = True

--- a/lib/ansible/modules/packaging/os/pkgng.py
+++ b/lib/ansible/modules/packaging/os/pkgng.py
@@ -222,7 +222,7 @@ def annotation_add(module, pkgng_path, package, tag, value, dir_arg):
         rc, out, err = module.run_command('%s %s annotate -y -A %s %s "%s"'
             % (pkgng_path, dir_arg, package, tag, value))
         if rc != 0:
-            module.fail_json("could not annotate %s: %s"
+            module.fail_json(msg="could not annotate %s: %s"
                 % (package, out), stderr=err)
         return True
     elif _value != value:
@@ -241,7 +241,7 @@ def annotation_delete(module, pkgng_path, package, tag, value, dir_arg):
         rc, out, err = module.run_command('%s %s annotate -y -D %s %s'
             % (pkgng_path, dir_arg, package, tag))
         if rc != 0:
-            module.fail_json("could not delete annotation to %s: %s"
+            module.fail_json(msg="could not delete annotation to %s: %s"
                 % (package, out), stderr=err)
         return True
     return False
@@ -250,7 +250,7 @@ def annotation_modify(module, pkgng_path, package, tag, value, dir_arg):
     _value = annotation_query(module, pkgng_path, package, tag, dir_arg)
     if not value:
         # No such tag
-        module.fail_json("could not change annotation to %s: tag %s does not exist"
+        module.fail_json(msg="could not change annotation to %s: tag %s does not exist"
             % (package, tag))
     elif _value == value:
         # No change in value
@@ -259,7 +259,7 @@ def annotation_modify(module, pkgng_path, package, tag, value, dir_arg):
         rc,out,err = module.run_command('%s %s annotate -y -M %s %s "%s"'
             % (pkgng_path, dir_arg, package, tag, value))
         if rc != 0:
-            module.fail_json("could not change annotation annotation to %s: %s"
+            module.fail_json(msg="could not change annotation annotation to %s: %s"
                 % (package, out), stderr=err)
         return True
 

--- a/lib/ansible/modules/packaging/os/sorcery.py
+++ b/lib/ansible/modules/packaging/os/sorcery.py
@@ -238,7 +238,7 @@ def codex_list(module):
     rc, stdout, stderr = module.run_command(cmd_scribe)
 
     if rc != 0:
-        module.fail_json("unable to list grimoire collection, fix your Codex")
+        module.fail_json(msg="unable to list grimoire collection, fix your Codex")
 
     rex = re.compile("^\s*\[\d+\] : (?P<grim>[\w\-\+\.]+) : [\w\-\+\./]+(?: : (?P<ver>[\w\-\+\.]+))?\s*$")
 

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -321,7 +321,7 @@ class User(object):
                 self.expires = time.gmtime(module.params['expires'])
             except Exception:
                 e = get_exception()
-                module.fail_json("Invalid expires time %s: %s" %(self.expires, str(e)))
+                module.fail_json(msg="Invalid expires time %s: %s" %(self.expires, str(e)))
 
         if module.params['ssh_key_file'] is not None:
             self.ssh_file = module.params['ssh_key_file']


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Several modules

##### ANSIBLE VERSION
- Fix is against latest devel (25827c85d26516f7c33686d5f2923e98b311db53)

##### SUMMARY
Fixes many invocations of `module.fail_json` with no `msg=`. I've ran into this issue several times, in several different modules.

Bonus: add missing `%` in `cs_nic.py`.

The instances of this error have been located using the following command, ran in Ansible's git root:

    grep -lRE 'module\.fail_json\([\'\''"]' .

There might be many more such instances, grep is a pretty limited tool.