### PR TITLE
Move summary to be next to where github places the commit message.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,12 @@
+##### SUMMARY
+<!--- Describe the change, including rationale and design decisions -->
+
+<!---
+If you are fixing an existing issue, please include "Fixes #nnn" in your
+commit message and your description; but you should still explain what
+the change does.
+-->
+
 ##### ISSUE TYPE
 <!--- Pick one below and delete the rest: -->
  - Feature Pull Request
@@ -14,16 +23,15 @@
 
 ```
 
-##### SUMMARY
-<!--- Describe the change, including rationale and design decisions -->
 
+##### ADDITIONAL INFORMATION
 <!---
-If you are fixing an existing issue, please include "Fixes #nnn" in your
-commit message and your description; but you should still explain what
-the change does.
--->
+Include additional information to help people understand the change here.
+For bugs that don't have a linked bug report, a step-by-step reproduction
+of the problem is helpful.
+  -->
 
-<!-- Paste verbatim command output below, e.g. before and after your change -->
+<!--- Paste verbatim command output below, e.g. before and after your change -->
 ```
 
 ```


### PR DESCRIPTION
If a user makes a PR with a single, detailed commit message, github will
put that at the top of the PR.  Move our summary field to the top of
the PR template so that it is next to where the commit message is
placed.  Users can then easily merge the two together or supplement the
commit message with additional information that we ask for.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Administrivia

