### PR TITLE
fix 'ungrouped' issue with some inventory formats

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -170,6 +170,11 @@ class Inventory(object):
             host.vars = combine_vars(host.vars, self.get_host_variables(host.name))
             self.get_host_vars(host)
 
+            # clear ungrouped of any incorrectly stored by parser
+            mygroups = host.get_groups()
+            if len(mygroups) > 2 and ungrouped in mygroups:
+                host.remove_group(ungrouped)
+
     def _match(self, str, pattern_str):
         try:
             if pattern_str.startswith('~'):

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -114,6 +114,12 @@ class Group:
         host.add_group(self)
         self.clear_hosts_cache()
 
+    def remove_host(self, host):
+
+        self.hosts.remove(host)
+        host.remove_group(self)
+        self.clear_hosts_cache()
+
     def set_variable(self, key, value):
 
         self.vars[key] = value

--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -110,6 +110,10 @@ class Host:
 
         self.groups.append(group)
 
+    def remove_group(self, group):
+
+        self.groups.remove(group)
+
     def set_variable(self, key, value):
 
         self.vars[key]=value


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
inventory
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

fix issue with some inventory sources not correctly purging 'ungrouped', now done at top level.