### PR TITLE
ec2_eni module - allow attaching a new instance - fixes #19452

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_eni.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eni.py
@@ -570,11 +570,11 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            mutually_exclusive=[
                                ['secondary_private_ip_addresses', 'secondary_private_ip_address_count']
-                               ],
+                           ],
                            required_if=([
                                ('state', 'absent', ['eni_id']),
                                ('attached', True, ['instance_id'])
-                               ])
+                           ])
                            )
 
     if not HAS_BOTO:

--- a/lib/ansible/modules/cloud/amazon/ec2_eni.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eni.py
@@ -426,6 +426,9 @@ def modify_eni(connection, vpc_id, module, eni):
         if attached is True:
             if eni.attachment and eni.attachment.instance_id != instance_id:
                 detach_eni(eni, module)
+                eni.attach(instance_id, device_index)
+                wait_for_eni(eni, "attached")
+                changed = True
             if eni.attachment is None:
                 eni.attach(instance_id, device_index)
                 wait_for_eni(eni, "attached")
@@ -472,10 +475,14 @@ def delete_eni(connection, module):
 
 def detach_eni(eni, module):
 
+    attached = module.params.get("attached")
+
     force_detach = module.params.get("force_detach")
     if eni.attachment is not None:
         eni.detach(force_detach)
         wait_for_eni(eni, "detached")
+        if attached:
+            return
         eni.update()
         module.exit_json(changed=True, interface=get_eni_info(eni))
     else:
@@ -489,6 +496,7 @@ def uniquely_find_eni(connection, module):
     subnet_id = module.params.get('subnet_id')
     instance_id = module.params.get('instance_id')
     device_index = module.params.get('device_index')
+    attached = module.params.get('attached')
 
     try:
         filters = {}
@@ -501,7 +509,7 @@ def uniquely_find_eni(connection, module):
             filters['private-ip-address'] = private_ip_address
             filters['subnet-id'] = subnet_id
 
-        if instance_id and device_index:
+        if not attached and instance_id and device_index:
             filters['attachment.instance-id'] = instance_id
             filters['attachment.device-index'] = device_index
 

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -73,7 +73,6 @@ lib/ansible/modules/cloud/amazon/ec2_eip.py
 lib/ansible/modules/cloud/amazon/ec2_elb.py
 lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
 lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
-lib/ansible/modules/cloud/amazon/ec2_eni.py
 lib/ansible/modules/cloud/amazon/ec2_eni_facts.py
 lib/ansible/modules/cloud/amazon/ec2_key.py
 lib/ansible/modules/cloud/amazon/ec2_lc.py


### PR DESCRIPTION
##### SUMMARY
In find_eni() if instance_id or device_index were specified they would be used in the filter. So when an existing eni was specified in a playbook and given an instance_id to be attached, find_eni() would filter results for those with matching instance_id and device_index. If the instance_id was yet to be attached this would return None and the instance would incorrectly be given a newly created eni. I fixed this by only adding instance_id and device_index to the filter if attached is not true. This fixes #19452.

After find_eni() did not incorrectly return None another bug was enabled in a part of the code not reached. After reaching detach_eni() the module would end. This didn't allow a user's new instance id to be attached. I fixed that by allowing detach_eni() to return if attached was true and then attach the instance.

Also made pep8 and removed from legacy file.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_eni.py

##### ANSIBLE VERSION
```
ansible 2.3.0 (ec2_eni_attach_instance f0f208f728) last updated 2017/03/07 13:36:52 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```

Playbook for testing:
```
---
- hosts: localhost
  connection: local
  tasks:
    - name: associate selected eni to an instance
      ec2_eni:
        attached: yes
        device_index: 1
        region: us-east-1
        instance_id: "{{ first_inst }}"
        # eni should exist and not have an instance_id attached yet
        eni_id: "{{ eni_id }}"
        subnet_id: "{{ subnet }}"
    - name: associate selected eni to a new instance
      ec2_eni:
        attached: yes
        device_index: 1
        region: us-east-1
        instance_id: "{{ second_inst }}"
        eni_id: "{{ eni_id }}"
        subnet_id: "{{ subnet }}"
```
Before the fix a second eni will be created despite eni_id being specified. After the fix the specified eni will be updated with the new instance.