### PR TITLE
Update the comments around Python 3

### DIFF
--- a/docs/docsite/rst/faq.rst
+++ b/docs/docsite/rst/faq.rst
@@ -119,10 +119,9 @@ used when executing python modules.   Thus, you can point to any python you want
 system does not point to a Python 2.X interpreter.  
 
 Some Linux operating systems, such as Arch, may only have Python 3 installed by default.  This is not sufficient and you will
-get syntax errors trying to run modules with Python 3.  Python 3 is essentially not the same
-language as Python 2.  Ansible modules currently need to support older Pythons for users that  still have Enterprise Linux 5 deployed, so they are not yet ported to run under Python 3.0.  This is not a problem though as you can just install Python 2 also on a managed host.
-
-Python 3.0 support will likely be addressed at a later point in time when usage becomes more mainstream.
+get syntax errors trying to run modules with Python 3.  Python 3 is essentially not the same language as Python 2.  Python 3
+support is being worked on but some Ansible modules are not yet ported to run under Python 3.0.  This is not a problem though
+as you can just install Python 2 also on a managed host.
 
 Do not replace the shebang lines of your python modules.  Ansible will do this for you automatically at deploy time.
 


### PR DESCRIPTION
[Enterprise Linux 5 is at the end of "End of Production 3 phase"](https://en.wikipedia.org/wiki/Red_Hat_Enterprise_Linux#Product_life_cycle) so that is no longer a reasonable reason to wait.  Also removed the comments about [Python 3 not being mainstream](http://python3wos.mybluemix.net/201).  Perhaps a link to https://docs.ansible.com/ansible/python_3_support.html would also be a useful addition to this question.