### PR TITLE
ec2_elb_facts: Handle AWS throttling when requesting ELB information

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
@@ -80,6 +80,9 @@ EXAMPLES = '''
 
 import traceback
 
+from ansible.module_utils.basic import *
+from ansible.module_utils.ec2 import *
+
 try:
     import boto.ec2.elb
     from boto.ec2.tag import Tag
@@ -251,8 +254,6 @@ def main():
 
     module.exit_json(**ec2_facts_result)
 
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
@@ -256,7 +256,7 @@ def main():
                                 elbs=elb_information.list_elbs())
 
     except BotoServerError as err:
-        self.module.fail_json(msg="{}: {}".format(err.error_code, err.error_message),
+        self.module.fail_json(msg="{0}: {1}".format(err.error_code, err.error_message),
                               exception=traceback.format_exc())
 
     module.exit_json(**ec2_facts_result)

--- a/lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
@@ -80,8 +80,13 @@ EXAMPLES = '''
 
 import traceback
 
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import (
+    AWSRetry,
+    connect_to_aws,
+    ec2_argument_spec,
+    get_aws_connection_info,
+)
 
 try:
     import boto.ec2.elb
@@ -91,8 +96,9 @@ try:
 except ImportError:
     HAS_BOTO = False
 
+
 class ElbInformation(object):
-    """ Handles ELB information """
+    """Handles ELB information."""
 
     def __init__(self,
                  module,
@@ -219,6 +225,7 @@ class ElbInformation(object):
                 break
 
         return list(map(self._get_elb_info, elb_array))
+
 
 def main():
     argument_spec = ec2_argument_spec()

--- a/lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
@@ -240,9 +240,7 @@ def main():
         module.fail_json(msg='boto required for this module')
 
     try:
-
         region, ec2_url, aws_connect_params = get_aws_connection_info(module)
-
         if not region:
             module.fail_json(msg="region must be specified")
 

--- a/lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
@@ -141,7 +141,7 @@ class ElbInformation(object):
         protocol, port_path = health_check.target.split(':')
         try:
             port, path = port_path.split('/', 1)
-            path = '/{}'.format(path)
+            path = '/{0}'.format(path)
         except ValueError:
             port = port_path
             path = None


### PR DESCRIPTION
##### SUMMARY
Fixes issue where module would fail immediately upon encountering AWS API throttling.
Also makes minor changes to error handling.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_elb_facts.py

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file =
  configured module search path = Default w/o overrides
```


##### ADDITIONAL INFORMATION
Uses the `AWSRetry.backoff` method both as a decorator and, where more efficient, directly as a wrapper function to  handle AWS API throttling for boto methods invoked in the module. 

Various instances of `BotoServerError` exceptions being caught and handled simply by invoking the  `fail_json` method have been removed, and replaced with a similar try/catch block in the `main` function. I'm not sure that this exception handling was particularly useful in the first place (and I'd be open to removing it completely), but moving it into `main` at least provides pretty much equivalent behavior without interfering with use of the `AWSRetry` decorator, which can handle specific cases of `BotoServerError`.

Also, removes questionable 'catch-all' clause on line 111 which would return an empty dict for tags. 