### PR TITLE
Fixes for idempotent issue in cnos_vlan module and fixes for vlag/portchannel tests.

### DIFF
--- a/lib/ansible/module_utils/cnos.py
+++ b/lib/ansible/module_utils/cnos.py
@@ -2179,6 +2179,17 @@ def vlanAccessMapConfig(
 # EOM
 
 
+def checkVlanNameNotAssigned(
+        obj, deviceType, prompt, timeout, vlanId, vlanName):
+    retVal = "ok"
+    command = "display vlan id " + vlanId + " \n"
+    retVal = waitForDeviceResponse(command, prompt, timeout, obj)
+    if(retVal.find(vlanName) != -1):
+        return "Nok"
+    return retVal
+# EOM
+
+
 # Utility Method to create vlan
 def createVlan(
         obj, deviceType, prompt, timeout, vlanArg1, vlanArg2, vlanArg3,
@@ -2194,7 +2205,12 @@ def createVlan(
         command = vlanArg2 + " "
         value = checkSanityofVariable(deviceType, "vlan_name", vlanArg3)
         if(value == "ok"):
-            command = command + vlanArg3
+            value = checkVlanNameNotAssigned(obj, deviceType, prompt, timeout,
+                                             vlanArg1, vlanArg3)
+            if(value == "ok"):
+                command = command + vlanArg3
+            else:
+                command = "\n"
         else:
             retVal = "Error-139"
             return retVal

--- a/lib/ansible/modules/network/lenovo/cnos_backup.py
+++ b/lib/ansible/modules/network/lenovo/cnos_backup.py
@@ -43,7 +43,7 @@ description:
      The results of the operation will be placed in a directory named 'results'
      that must be created by the user in their local directory to where the playbook is run.
      For more information about this module from Lenovo and customizing it usage for your
-     use cases, please visit our [User Guide](http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_backup.html)
+     use cases, please visit U(http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_backup.html)
 version_added: "2.3"
 extends_documentation_fragment: cnos
 options:

--- a/lib/ansible/modules/network/lenovo/cnos_bgp.py
+++ b/lib/ansible/modules/network/lenovo/cnos_bgp.py
@@ -42,7 +42,7 @@ description:
      TThe results of the operation will be placed in a directory named 'results'
      that must be created by the user in their local directory to where the playbook is run.
      For more information about this module from Lenovo and customizing it usage for your
-     use cases, please visit our [User Guide](http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_bgp.html)
+     use cases, please visit U(http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_bgp.html)
 version_added: "2.3"
 extends_documentation_fragment: cnos
 options:

--- a/lib/ansible/modules/network/lenovo/cnos_bgp.py
+++ b/lib/ansible/modules/network/lenovo/cnos_bgp.py
@@ -39,7 +39,7 @@ description:
      bgpArg2, bgpArg3, bgpArg4, bgpArg5, bgpArg6, bgpArg7, and bgpArg8. For more details on
      how to use these arguments, see [Overloaded Variables].
      This module uses SSH to manage network device configuration.
-     TThe results of the operation will be placed in a directory named 'results'
+     The results of the operation will be placed in a directory named 'results'
      that must be created by the user in their local directory to where the playbook is run.
      For more information about this module from Lenovo and customizing it usage for your
      use cases, please visit U(http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_bgp.html)

--- a/lib/ansible/modules/network/lenovo/cnos_command.py
+++ b/lib/ansible/modules/network/lenovo/cnos_command.py
@@ -40,7 +40,7 @@ description:
      The results of the operation will be placed in a directory named 'results'
      that must be created by the user in their local directory to where the playbook is run.
      For more information about this module from Lenovo and customizing it usage for your
-     use cases, please visit our [User Guide](http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_command.html)
+     use cases, please visit U(http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_command.html)
 version_added: "2.3"
 extends_documentation_fragment: cnos
 options:

--- a/lib/ansible/modules/network/lenovo/cnos_conditional_command.py
+++ b/lib/ansible/modules/network/lenovo/cnos_conditional_command.py
@@ -44,8 +44,7 @@ description:
     more devices, it is recommended to use this module.
     This module uses SSH to manage network device configuration.
     For more information about this module from Lenovo and customizing it usage for your
-     use cases, please visit our [User Guide]
-    http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_conditional_command.html)
+    use cases, please visit U(http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_conditional_command.html)
 version_added: "2.3"
 extends_documentation_fragment: cnos
 options:

--- a/lib/ansible/modules/network/lenovo/cnos_conditional_template.py
+++ b/lib/ansible/modules/network/lenovo/cnos_conditional_template.py
@@ -44,8 +44,7 @@ description:
      template on one or more devices, it is recommended to use this module.
      This module uses SSH to manage network device configuration.
      For more information about this module from Lenovo and customizing it usage for your
-     use cases, please visit our [User Guide]
-     (http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_conditional_template.html)
+     use cases, please visit U(http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_conditional_template.html)
 version_added: "2.3"
 extends_documentation_fragment: cnos
 options:

--- a/lib/ansible/modules/network/lenovo/cnos_factory.py
+++ b/lib/ansible/modules/network/lenovo/cnos_factory.py
@@ -37,7 +37,7 @@ description:
      This module uses SSH to manage network device configuration.
      The results of the operation can be viewed in results directory.
      For more information about this module from Lenovo and customizing it usage for your
-     use cases, please visit our [User Guide](http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_factory.html)
+     use cases, please visit U(http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_factory.html)
 version_added: "2.3"
 extends_documentation_fragment: cnos
 options: {}

--- a/lib/ansible/modules/network/lenovo/cnos_facts.py
+++ b/lib/ansible/modules/network/lenovo/cnos_facts.py
@@ -35,7 +35,7 @@ description:
      and returns a file containing all the system information of the target network device. This module uses SSH to
      manage network device configuration. The results of the operation can be viewed in results directory.
      For more information about this module from Lenovo and customizing it usage for your
-     use cases, please visit our [User Guide](http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_facts.html)
+     use cases, please visit U(http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_facts.html)
 version_added: "2.3"
 extends_documentation_fragment: cnos
 options: {}

--- a/lib/ansible/modules/network/lenovo/cnos_image.py
+++ b/lib/ansible/modules/network/lenovo/cnos_image.py
@@ -41,7 +41,7 @@ description:
      The results of the operation will be placed in a directory named 'results'
      that must be created by the user in their local directory to where the playbook is run.
      For more information about this module from Lenovo and customizing it usage for your
-     use cases, please visit our [User Guide](http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_image.html)
+     use cases, please visit U(http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_image.html)
 version_added: "2.3"
 extends_documentation_fragment: cnos
 options:

--- a/lib/ansible/modules/network/lenovo/cnos_interface.py
+++ b/lib/ansible/modules/network/lenovo/cnos_interface.py
@@ -47,7 +47,7 @@ description:
      The results of the operation will be placed in a directory named 'results'
      that must be created by the user in their local directory to where the playbook is run.
      For more information about this module from Lenovo and customizing it usage for your
-     use cases, please visit our [User Guide](http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_interface.html)
+     use cases, please visit U(http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_interface.html)
 version_added: "2.3"
 extends_documentation_fragment: cnos
 options:

--- a/lib/ansible/modules/network/lenovo/cnos_portchannel.py
+++ b/lib/ansible/modules/network/lenovo/cnos_portchannel.py
@@ -40,7 +40,7 @@ description:
      The results of the operation will be placed in a directory named 'results'
      that must be created by the user in their local directory to where the playbook is run.
      For more information about this module from Lenovo and customizing it usage for your
-     use cases, please visit our [User Guide](http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_portchannel.html)
+     use cases, please U(http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_portchannel.html)
 version_added: "2.3"
 extends_documentation_fragment: cnos
 options:

--- a/lib/ansible/modules/network/lenovo/cnos_reload.py
+++ b/lib/ansible/modules/network/lenovo/cnos_reload.py
@@ -36,7 +36,7 @@ description:
      This module uses SSH to manage network device configuration.
      The results of the operation can be viewed in results directory.
      For more information about this module from Lenovo and customizing it usage for your
-     use cases, please visit our [User Guide](http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_reload.html)
+     use cases, please visit U(http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_reload.html)
 version_added: "2.3"
 extends_documentation_fragment: cnos
 options: {}

--- a/lib/ansible/modules/network/lenovo/cnos_rollback.py
+++ b/lib/ansible/modules/network/lenovo/cnos_rollback.py
@@ -43,7 +43,7 @@ description:
      The results of the operation will be placed in a directory named 'results'
      that must be created by the user in their local directory to where the playbook is run.
      For more information about this module from Lenovo and customizing it usage for your
-     use cases, please visit our [User Guide](http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_rollback.html)
+     use cases, please visit U(http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_rollback.html)
 version_added: "2.3"
 extends_documentation_fragment: cnos
 options:

--- a/lib/ansible/modules/network/lenovo/cnos_save.py
+++ b/lib/ansible/modules/network/lenovo/cnos_save.py
@@ -37,7 +37,7 @@ description:
      The results of the operation will be placed in a directory named 'results'
      that must be created by the user in their local directory to where the playbook is run.
      For more information about this module from Lenovo and customizing it usage for your
-     use cases, please visit our [User Guide](http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_save.html)
+     use cases, please visit U(http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_save.html)
 version_added: "2.3"
 extends_documentation_fragment: cnos
 options: {}

--- a/lib/ansible/modules/network/lenovo/cnos_showrun.py
+++ b/lib/ansible/modules/network/lenovo/cnos_showrun.py
@@ -37,7 +37,7 @@ description:
      The results of the operation will be placed in a directory named 'results'
      that must be created by the user in their local directory to where the playbook is run.
      For more information about this module from Lenovo and customizing it usage for your
-     use cases, please visit our [User Guide](http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_showrun.html)
+     use cases, please visit U(http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_showrun.html)
 version_added: "2.3"
 extends_documentation_fragment: cnos
 options: {}

--- a/lib/ansible/modules/network/lenovo/cnos_template.py
+++ b/lib/ansible/modules/network/lenovo/cnos_template.py
@@ -39,7 +39,7 @@ description:
      The results of the operation will be placed in a directory named 'results'
      that must be created by the user in their local directory to where the playbook is run.
      For more information about this module from Lenovo and customizing it usage for your
-     use cases, please visit our [User Guide](http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_template.html)
+     use cases, please visit U(http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_template.html)
 version_added: "2.3"
 extends_documentation_fragment: cnos
 options:

--- a/lib/ansible/modules/network/lenovo/cnos_vlag.py
+++ b/lib/ansible/modules/network/lenovo/cnos_vlag.py
@@ -42,7 +42,7 @@ description:
      The results of the operation will be placed in a directory named 'results'
      that must be created by the user in their local directory to where the playbook is run.
      For more information about this module from Lenovo and customizing it usage for your
-     use cases, please visit our [User Guide](http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_vlag.html)
+     use cases, please visit U(http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_vlag.html)
 version_added: "2.3"
 extends_documentation_fragment: cnos
 options:

--- a/lib/ansible/modules/network/lenovo/cnos_vlan.py
+++ b/lib/ansible/modules/network/lenovo/cnos_vlan.py
@@ -280,7 +280,7 @@ def main():
     # need to add logic to check when changes occur or not
     errorMsg = cnos.checkOutputForError(output)
     if(errorMsg is None):
-        module.exit_json(changed=True, msg="VLAN configuration isaccomplished")
+        module.exit_json(changed=True, msg="VLAN configuration is accomplished")
     else:
         module.fail_json(msg=errorMsg)
 

--- a/lib/ansible/modules/network/lenovo/cnos_vlan.py
+++ b/lib/ansible/modules/network/lenovo/cnos_vlan.py
@@ -45,7 +45,7 @@ description:
      The results of the operation will be placed in a directory named 'results'
      that must be created by the user in their local directory to where the playbook is run.
      For more information about this module from Lenovo and customizing it usage for your
-     use cases, please visit our [User Guide](http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_vlan.html)
+     use cases, please visit U(http://systemx.lenovofiles.com/help/index.jsp?topic=%2Fcom.lenovo.switchmgt.ansible.doc%2Fcnos_vlan.html)
 version_added: "2.3"
 extends_documentation_fragment: cnos
 options:

--- a/test/integration/roles/cnos_portchannel/vars/main.yml
+++ b/test/integration/roles/cnos_portchannel/vars/main.yml
@@ -26,7 +26,7 @@ test_portchannel_data12:
 test_portchannel_data13:
   - {interfaceRange: 33, interfaceArg1: "service-policy", interfaceArg2: "input", interfaceArg3: "Anil"}
 test_portchannel_data14:
-  - {interfaceRange: 33, interfaceArg1: "speed", interfaceArg2: "auto"}
+  - {interfaceRange: 13, interfaceArg1: "speed", interfaceArg2: "auto"}
 test_portchannel_data15:
   - {interfaceRange: 33, interfaceArg1: "storm-control", interfaceArg2: "broadcast", interfaceArg3: 12.5 }
 test_portchannel_data16:

--- a/test/integration/roles/cnos_vlag/vars/main.yml
+++ b/test/integration/roles/cnos_vlag/vars/main.yml
@@ -6,7 +6,7 @@ test_vlag_data2:
 test_vlag_data3:
   - {vlagArg1: "config-consistency", vlagArg2: "strict"}
 test_vlag_data4:
-  - {vlagArg1: "isl", vlagArg2: 23}
+  - {vlagArg1: "isl", vlagArg2: 33}
 test_vlag_data5:
   - {vlagArg1: "mac-address-table"}
 test_vlag_data6:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes for idempotent issue in cnos_vlan module and fixes for vlag/portchannel tests.  No fix#
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
cnos_vlan and tests for cnos_portchannel and cnos_vlag

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
