### PR TITLE
Run all `other` tests on Shippable before failing.

### DIFF
--- a/test/utils/shippable/other.sh
+++ b/test/utils/shippable/other.sh
@@ -17,6 +17,13 @@ ln -sf x86_64-linux-gnu-gcc-4.9 /usr/bin/x86_64-linux-gnu-gcc
 
 retry.py pip install tox --disable-pip-version-check
 
-ansible-test compile --color -v
-ansible-test sanity --color -v --junit --tox --skip-test ansible-doc --python 2.7
-ansible-test sanity --color -v --junit --tox --test ansible-doc --coverage
+errors=0
+
+ansible-test compile --color -v || ((errors++))
+ansible-test sanity --color -v --junit --tox --skip-test ansible-doc --python 2.7 || ((errors++))
+ansible-test sanity --color -v --junit --tox --test ansible-doc --coverage || ((errors++))
+
+if [ ${errors} -gt 0 ]; then
+    echo "${errors} of the above ansible-test command(s) failed."
+    exit 1
+fi


### PR DESCRIPTION
##### SUMMARY

Run all `other` tests on Shippable before failing.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

test/utils/shippable/other.sh

##### ANSIBLE VERSION

```
ansible 2.3.0 (other-continue 852d5031d6) last updated 2017/03/07 19:11:10 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
