### PR TITLE
Added ability to specify destination OU when joining a domain

### DIFF
--- a/lib/ansible/modules/windows/win_domain_membership.ps1
+++ b/lib/ansible/modules/windows/win_domain_membership.ps1
@@ -99,12 +99,13 @@ Function Join-Domain {
         [string] $dns_domain_name,
         [string] $new_hostname,
         [string] $domain_admin_user,
-        [string] $domain_admin_password
+        [string] $domain_admin_password,
+        [string] $domain_ou_path
     )
 
     Write-DebugLog ("Creating credential for user {0}" -f $domain_admin_user)
     $domain_cred = Create-Credential $domain_admin_user $domain_admin_password
-    
+
     $add_args = @{
         ComputerName="."
         Credential=$domain_cred
@@ -117,7 +118,13 @@ Function Join-Domain {
         $add_args["NewName"] = $new_hostname
     }
 
-    Write-DebugLog "calling Add-Computer"
+
+    if($domain_ou_path){
+        Write-DebugLog "adding OU destination arg to Add-Computer args"
+        $add_args["OUPath"] = $domain_ou_path
+    }
+    $argstr = $add_args | Out-String
+    Write-DebugLog "calling Add-Computer with args: $argstr"
     $add_result = Add-Computer @add_args
 
     Write-DebugLog ("Add-Computer result was \n{0}" -f $add_result | Out-String)
@@ -172,6 +179,7 @@ $hostname = Get-AnsibleParam $params "hostname"
 $workgroup_name = Get-AnsibleParam $params "workgroup_name"
 $domain_admin_user = Get-AnsibleParam $params "domain_admin_user" -failifempty $result
 $domain_admin_password = Get-AnsibleParam $params "domain_admin_password" -failifempty $result
+$domain_ou_path = Get-AnsibleParam $params "domain_ou_path"
 
 $log_path = Get-AnsibleParam $params "log_path"
 $_ansible_check_mode = Get-AnsibleParam $params "_ansible_check_mode" -default $false
@@ -220,6 +228,10 @@ Try {
                     If(-not $hostname_match) {
                         Write-DebugLog "adding hostname change to domain-join args"
                         $join_args.new_hostname = $hostname
+                    }
+                    If($domain_ou_path -ne $null){ # If OU Path is not empty
+                        Write-DebugLog "adding domain_ou_path to domain-join args"
+                        $join_args.domain_ou_path = $domain_ou_path
                     }
 
                     $join_result = Join-Domain @join_args
@@ -276,4 +288,3 @@ Catch {
 
     Throw
 }
-

--- a/lib/ansible/modules/windows/win_domain_membership.py
+++ b/lib/ansible/modules/windows/win_domain_membership.py
@@ -46,7 +46,8 @@ options:
       - the desired hostname for the Windows host
   domain_ou_path:
     description:
-      - the desired OU path for adding the computer object
+      - The desired OU path for adding the computer object.
+      - This is only used when adding the target host to a domain, if it is already a member then it is ignored.
     version_added: "2.4"
   state:
     description:

--- a/lib/ansible/modules/windows/win_domain_membership.py
+++ b/lib/ansible/modules/windows/win_domain_membership.py
@@ -44,6 +44,9 @@ options:
   hostname:
     description:
       - the desired hostname for the Windows host
+  domain_ou_path:
+    description:
+      - the desired OU path for adding the computer object
   state:
     description:
       - whether the target host should be a member of a domain or workgroup
@@ -79,6 +82,7 @@ EXAMPLES='''
       hostname: mydomainclient
       domain_admin_user: testguy@ansible.vagrant
       domain_admin_password: password123!
+      domain_ou_path: "OU=Windows,OU=Servers,DC=ansible,DC=vagrant"
       state: domain
     register: domain_state
 

--- a/lib/ansible/modules/windows/win_domain_membership.py
+++ b/lib/ansible/modules/windows/win_domain_membership.py
@@ -47,6 +47,7 @@ options:
   domain_ou_path:
     description:
       - the desired OU path for adding the computer object
+    version_added: "2.4"
   state:
     description:
       - whether the target host should be a member of a domain or workgroup


### PR DESCRIPTION
<!---
Verify first that your issue/request is not already reported on GitHub.
Also test if the latest release, and master branch are affected too.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Idea

##### COMPONENT NAME
win_domain_membership

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```

##### CONFIGURATION
<!---
Mention any settings you have changed/added/removed in ansible.cfg
(or using the ANSIBLE_* environment variables).
-->

##### OS / ENVIRONMENT
<!---
Mention the OS you are running Ansible from, and the OS you are
managing, or say “N/A” for anything that is not platform-specific.
-->

##### SUMMARY
<!--- Explain the problem briefly -->
Add the ability to specify OU destination (OUPath in Add-Computer) when joining to a domain.

Example Config:
- name: Join domain
  win_domain_membership:
      dns_domain_name: "{{ global_domain_name }}"
      hostname: "{{ global_vm_name }}"
      domain_admin_user: "{{ global_domain_join_user }}"
      domain_admin_password: "{{ global_domain_join_user_password }}"
      **domain_ou_path: "OU=Windows,OU=Servers,DC=yourdomain,DC=local"**
      state: domain
  register: domain_state
