### PR TITLE
wait_for_connection: Update the docs to implementation

### DIFF
--- a/lib/ansible/modules/utilities/logic/wait_for_connection.py
+++ b/lib/ansible/modules/utilities/logic/wait_for_connection.py
@@ -53,13 +53,13 @@ author: "Dag Wieers (@dagwieers)"
 '''
 
 EXAMPLES = r'''
-- name: Wait 300 seconds for target connection to become reachable/usable
+- name: Wait 600 seconds for target connection to become reachable/usable
   wait_for_connection:
 
-- name: Wait 600 seconds, but only start checking after 60 seconds
+- name: Wait 300 seconds, but only start checking after 60 seconds
   wait_for_connection:
     delay: 60
-    timeout: 600
+    timeout: 300
 
 # Wake desktops, wait for them to become ready and continue playbook
 - hosts: all
@@ -89,11 +89,12 @@ EXAMPLES = r'''
       customization:
         hostname: '{{ vm_shortname }}'
         runonce:
-        - powershell.exe -ExecutionPolicy Unrestricted -File C:\Windows\Temp\ConfigureRemotingForAnsible.ps1 -CertValidityDays 3650 -ForceNewSSLCert
+        - powershell.exe -ExecutionPolicy Unrestricted -File C:\Windows\Temp\ConfigureRemotingForAnsible.ps1 -ForceNewSSLCert -EnableCredSSP
     delegate_to: localhost
 
   - name: Wait for system to become reachable over WinRM
     wait_for_connection:
+      timeout: 900
 
   - name: Gather facts for first time
     setup:

--- a/lib/ansible/modules/utilities/logic/wait_for_connection.py
+++ b/lib/ansible/modules/utilities/logic/wait_for_connection.py
@@ -48,7 +48,7 @@ options:
   timeout:
     description:
       - Maximum number of seconds to wait for.
-    default: 300
+    default: 600
 author: "Dag Wieers (@dagwieers)"
 '''
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Somehow the docs were still mentioning a default timeout of 300 seconds.
Whereas the implementation defaults to 600 seconds.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
wait_for_connection

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->