### PR TITLE
Fix the eos_banner idempotency

### DIFF
--- a/lib/ansible/modules/network/eos/eos_banner.py
+++ b/lib/ansible/modules/network/eos/eos_banner.py
@@ -102,7 +102,7 @@ def map_obj_to_commands(updates, module):
     want, have = updates
     state = module.params['state']
 
-    if state == 'absent':
+    if state == 'absent' and have['text']:
         commands.append('no banner %s' % module.params['banner'])
 
     elif state == 'present':
@@ -117,7 +117,7 @@ def map_config_to_obj(module):
     output = run_commands(module, ['show banner %s' % module.params['banner']])
     obj = {'banner': module.params['banner'], 'state': 'absent'}
     if output:
-        obj['text'] = output
+        obj['text'] = output[0]
         obj['state'] = 'present'
     return obj
 
@@ -155,7 +155,6 @@ def main():
     result = {'changed': False}
     if warnings:
         result['warnings'] = warnings
-
     want = map_params_to_obj(module)
     have = map_config_to_obj(module)
 

--- a/test/units/modules/network/eos/test_eos_banner.py
+++ b/test/units/modules/network/eos/test_eos_banner.py
@@ -40,7 +40,7 @@ class TestEosBannerModule(TestEosModule):
         self.mock_load_config.stop()
 
     def load_fixtures(self, commands=None):
-        self.run_commands.return_value = load_fixture('eos_banner_show_banner.txt').strip()
+        self.run_commands.return_value = [load_fixture('eos_banner_show_banner.txt').strip()]
         self.load_config.return_value = dict(diff=None, session='session')
 
     def test_eos_banner_create(self):


### PR DESCRIPTION
##### SUMMARY

The map_config_to_obj calls the run_commands  helper function,
which returns a list of results.
However, the map_params_to_obj return a single string.
Therefore, the comparison between the two datasets could never be equal,
breaking idempotency.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

eos_banner

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (fix_eos_banner_idempotency af8f28bdf5) last updated 2017/03/08 16:19:33 (GMT +200)
```