### PR TITLE
Elb fact fixes

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
@@ -80,6 +80,13 @@ EXAMPLES = '''
 
 import traceback
 
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import (
+    connect_to_aws,
+    ec2_argument_spec,
+    get_aws_connection_info,
+)
+
 try:
     import boto.ec2.elb
     from boto.ec2.tag import Tag
@@ -88,8 +95,9 @@ try:
 except ImportError:
     HAS_BOTO = False
 
+
 class ElbInformation(object):
-    """ Handles ELB information """
+    """Handles ELB information."""
 
     def __init__(self,
                  module,
@@ -232,6 +240,7 @@ class ElbInformation(object):
 
         return list(map(self._get_elb_info, elb_array))
 
+
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
@@ -260,8 +269,6 @@ def main():
 
     module.exit_json(**ec2_facts_result)
 
-from ansible.module_utils.basic import *
-from ansible.module_utils.ec2 import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
@@ -143,7 +143,7 @@ class ElbInformation(object):
         protocol, port_path = health_check.target.split(':')
         try:
             port, path = port_path.split('/', 1)
-            path = '/{}'.format(path)
+            path = '/{0}'.format(path)
         except ValueError:
             port = port_path
             path = None


### PR DESCRIPTION
##### SUMMARY

This fixes https://github.com/ansible/ansible/issues/21553 for python2.6 versions. It also changes to use the newer module imports talked about in https://github.com/ansible/ansible/pull/22383#discussion_r104915955

Fixes #21553 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

ec2_elb_facts

##### ANSIBLE VERSION

```
ansible 2.2.1.0
  config file = 
  configured module search path = Default w/o overrides
```

##### ADDITIONAL INFORMATION

Python 2.6 doesn't support bare `{}` format strings, this change uses the positional args in the format string so it can format the port part.