### PR TITLE
ensure all hosts in all

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -140,7 +140,6 @@ class Inventory(object):
                         display.warning("A duplicate localhost-like entry was found (%s). First found localhost was %s" % (h, self.localhost.name))
                     display.vvvv("Set default localhost to %s" % h)
                     self.localhost = new_host
-                all.add_host(new_host)
         elif self._loader.path_exists(host_list):
             # TODO: switch this to a plugin loader and a 'condition' per plugin on which it should be tried, restoring 'inventory pllugins'
             if self.is_directory(host_list):
@@ -170,8 +169,13 @@ class Inventory(object):
             host.vars = combine_vars(host.vars, self.get_host_variables(host.name))
             self.get_host_vars(host)
 
-            # clear ungrouped of any incorrectly stored by parser
             mygroups = host.get_groups()
+
+            # ensure hosts are always in 'all'
+            if all not in mygroups:
+                all.add_host(host)
+
+            # clear ungrouped of any incorrectly stored by parser
             if len(mygroups) > 2 and ungrouped in mygroups:
                 host.remove_group(ungrouped)
 


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
do not rely on 'specific' inventory parsers as they seem to differ on group handling.

fixes #20252

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```


