### PR TITLE
Disable ansible color output on sanity tests.

### DIFF
--- a/test/runner/lib/ansible_util.py
+++ b/test/runner/lib/ansible_util.py
@@ -7,9 +7,10 @@ import os
 from lib.util import common_environment
 
 
-def ansible_environment(args):
+def ansible_environment(args, color=True):
     """
     :type args: CommonConfig
+    :type color: bool
     :rtype: dict[str, str]
     """
     env = common_environment()
@@ -21,7 +22,7 @@ def ansible_environment(args):
         path = ansible_path + os.pathsep + path
 
     ansible = dict(
-        ANSIBLE_FORCE_COLOR='%s' % 'true' if args.color else 'false',
+        ANSIBLE_FORCE_COLOR='%s' % 'true' if args.color and color else 'false',
         ANSIBLE_DEPRECATION_WARNINGS='false',
         ANSIBLE_CONFIG='/dev/null',
         ANSIBLE_HOST_KEY_CHECKING='false',

--- a/test/runner/lib/sanity.py
+++ b/test/runner/lib/sanity.py
@@ -128,10 +128,7 @@ def command_sanity_code_smell(args, _, script):
     test = os.path.splitext(os.path.basename(script))[0]
 
     cmd = [script]
-    env = ansible_environment(args)
-
-    # Since the output from scripts end up in other places besides the console, we don't want color here.
-    env.pop('ANSIBLE_FORCE_COLOR')
+    env = ansible_environment(args, color=False)
 
     try:
         stdout, stderr = run_command(args, cmd, env=env, capture=True)
@@ -155,7 +152,7 @@ def command_sanity_validate_modules(args, targets):
     :rtype: SanityResult
     """
     test = 'validate-modules'
-    env = ansible_environment(args)
+    env = ansible_environment(args, color=False)
 
     paths = [deepest_path(i.path, 'lib/ansible/modules/') for i in targets.include_external]
     paths = sorted(set(p for p in paths if p))
@@ -494,7 +491,7 @@ def command_sanity_ansible_doc(args, targets, python_version):
     if not modules:
         return SanitySkipped(test, python_version=python_version)
 
-    env = ansible_environment(args)
+    env = ansible_environment(args, color=False)
     cmd = ['ansible-doc'] + modules
 
     try:


### PR DESCRIPTION
##### SUMMARY

Disable ansible color output on sanity tests.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.3.0 (at-fix e2086b6dcd) last updated 2017/03/08 11:45:46 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
