### PR TITLE
Drop requirement for setuptools package from setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ jinja2
 PyYAML
 paramiko
 pycrypto >= 2.6
-setuptools


### PR DESCRIPTION
##### SUMMARY

Drop requirement for `setuptools` package from `setup.py`

It is bad form to include `setuptools` as a requirement. pip does not include `setuptools` in freeze. ([A fact acknowledge by Ansible's pip module](https://github.com/ansible/ansible/blob/4554e8d7694f27b9611314bd67c2f0bc1749e6e3/lib/ansible/modules/packaging/language/pip.py#L227-L229))

Further, `setuptools` is only used by Ansible at install time in `setup.py`. If `setup.py` is called without `setuptools` installed, it is too late to use `setuptools` to install `setuptools`.

Tools such as [pip-tools](https://github.com/jazzband/pip-tools) mark Ansible's requirement of `setuptools` as "unsafe".

##### ISSUE TYPE
 - Feature Pull Request

##### ANSIBLE VERSION
```
$ ./venv/bin/ansible --version
ansible 2.3.0 (no-require-setuptools 1d05d10976) last updated 2017/03/08 13:56:36 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
  python version = 3.5.2 (default, Sep 14 2016, 11:28:32) [GCC 6.2.1 20160901 (Red Hat 6.2.1-1)]
```