### PR TITLE
docker_container: add gcplogs to list of supported log_drivers

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -215,6 +215,7 @@ options:
       - fluentd
       - awslogs
       - splunk
+      - gcplogs
     default: null
     required: false
   log_options:
@@ -1969,7 +1970,7 @@ def main():
         labels=dict(type='dict'),
         links=dict(type='list'),
         log_driver=dict(type='str',
-                        choices=['none', 'json-file', 'syslog', 'journald', 'gelf', 'fluentd', 'awslogs', 'splunk'],
+                        choices=['none', 'json-file', 'syslog', 'journald', 'gelf', 'fluentd', 'awslogs', 'splunk', 'gcplogs'],
                         default=None),
         log_options=dict(type='dict', aliases=['log_opt']),
         mac_address=dict(type='str'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Allows the docker_container module to use Docker's Google Cloud Platform logging driver: https://docs.docker.com/engine/admin/logging/gcplogs/
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
docker_container

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel 2a34f0ce4f) last updated 2017/03/08 16:50:20 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
TASK [Start a MySQL database container] ****************************************
fatal: [10.4.20.5]: FAILED! => {"changed": false, "failed": true, "msg": "value of log_driver must be one of: json-file,syslog,journald,gelf,fluentd,awslogs,splunk, got: gcplogs"}
```
After:
```
TASK [Start a MySQL database container] ****************************************
changed: [10.4.20.5]
```