### PR TITLE
Enhance maven_artifact with repository_snapshot_url and unique_snapshot props + removed dependency on lxml

### DIFF
--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -60,24 +60,26 @@ options:
             - The maven type/extension coordinate
         required: false
         default: jar
-    unique_snapshot:
-        description:
-            - Deactivate if your maven repository overwrites snapshot versions instead of timestamping them. (added in version 2.4)
-        required: false
-        default: 'yes'
-        choices: ['yes', 'no']
     repository_url:
         description:
             - The URL of the Maven Repository to download from.
             - Use s3://... if the repository is hosted on Amazon S3, added in version 2.2.
         required: false
         default: http://repo1.maven.org/maven2
-    repository_url:
+    repository_snapshot_url:
         description:
-            - The URL of the Maven Repository to download snapshots from. (added in version 2.4)
-            - Use s3://... if the repository is hosted on Amazon S3, added in version 2.4.
+            - The URL of the Maven Repository to download snapshots from.
+            - Use s3://... if the repository is hosted on Amazon S3.
         required: false
         default: null
+        version_added: "2.3"
+    unique_snapshot:
+        description:
+            - Deactivate if your maven repository overwrites snapshot versions instead of timestamping them.
+        required: false
+        default: 'yes'
+        choices: ['yes', 'no']
+        version_added: "2.3"
     username:
         description:
             - The username to authenticate as to the Maven Repository. Use AWS secret key of the repository is hosted on S3

--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -164,9 +164,12 @@ import os
 import hashlib
 import sys
 import posixpath
-import urlparse
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
+try:
+    from urlparse import urlparse
+except ImportError:
+    from urllib.parse import urlparse
 try:
     import boto3
     HAS_BOTO = True
@@ -259,7 +262,7 @@ class MavenDownloader:
     def _find_latest_version_available(self, artifact):
         path = "/%s/maven-metadata.xml" % (artifact.path(False))
         xml = self._request(self.get_base(artifact) + path, "Failed to download maven-metadata.xml", lambda r: etree.parse(r))
-        v = xml.find("./versioning/versions/version")[-1]
+        v = xml.findall("./versioning/versions/version")[-1]
         return v.text
 
     def find_uri_for_artifact(self, artifact):

--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -259,7 +259,7 @@ class MavenDownloader:
     def _find_latest_version_available(self, artifact):
         path = "/%s/maven-metadata.xml" % (artifact.path(False))
         xml = self._request(self.get_base(artifact) + path, "Failed to download maven-metadata.xml", lambda r: etree.parse(r))
-        v = xml.find("./versioning/versions/version[last()]")
+        v = xml.find("./versioning/versions/version")[-1]
         return v.text
 
     def find_uri_for_artifact(self, artifact):
@@ -272,7 +272,6 @@ class MavenDownloader:
             timestamp = xml.find("./versioning/snapshot/timestamp").text
             buildNumber = xml.find("./versioning/snapshot/buildNumber").text
             for snapshotArtifact in xml.findall("./versioning/snapshotVersions/snapshotVersion"):
-                print snapshotArtifact.find("extension").text
                 classifier = snapshotArtifact.find("classifier") or etree.Element("classifier")
                 extension = snapshotArtifact.find("extension") or etree.Element("extension")
                 if classifier.text == artifact.classifier and extension.text == artifact.extension:

--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -260,8 +260,7 @@ class MavenDownloader:
         path = "/%s/maven-metadata.xml" % (artifact.path(False))
         xml = self._request(self.get_base(artifact) + path, "Failed to download maven-metadata.xml", lambda r: etree.parse(r))
         v = xml.find("./versioning/versions/version[last()]")
-        if v:
-            return v.text
+        return v.text
 
     def find_uri_for_artifact(self, artifact):
         if artifact.version == "latest":
@@ -273,7 +272,10 @@ class MavenDownloader:
             timestamp = xml.find("./versioning/snapshot/timestamp").text
             buildNumber = xml.find("./versioning/snapshot/buildNumber").text
             for snapshotArtifact in xml.findall("./versioning/snapshotVersions/snapshotVersion"):
-                if snapshotArtifact.find("classifier").text == artifact.classifier and snapshotArtifact.find("extension").text == artifact.extension:
+                print snapshotArtifact.find("extension").text
+                classifier = snapshotArtifact.find("classifier") or etree.Element("classifier")
+                extension = snapshotArtifact.find("extension") or etree.Element("extension")
+                if classifier.text == artifact.classifier and extension.text == artifact.extension:
                     return self._uri_for_artifact(artifact, snapshotArtifact.find("value").text)
             return self._uri_for_artifact(artifact, artifact.version.replace("SNAPSHOT", timestamp + "-" + buildNumber))
 

--- a/test/units/modules/packaging/language/test_maven_artifact.py
+++ b/test/units/modules/packaging/language/test_maven_artifact.py
@@ -1,4 +1,4 @@
-from StringIO import StringIO
+from io import StringIO
 from ansible.compat.tests import unittest, mock
 
 from ansible.modules.packaging.language import maven_artifact
@@ -37,7 +37,7 @@ class TestMavenDownloader(unittest.TestCase):
         module = self.AnsibleModuleMock()
         artifact = maven_artifact.Artifact("com.ansible", "test", "1.0")
         downloader = maven_artifact.MavenDownloader(module, base="http://repo.test.org/maven")
-        
+
         assert downloader.find_uri_for_artifact(artifact) == "http://repo.test.org/maven/com/ansible/test/1.0/test-1.0.jar"
 
     @mock.patch('ansible.modules.packaging.language.maven_artifact.fetch_url')
@@ -60,10 +60,10 @@ class TestMavenDownloader(unittest.TestCase):
         """
         downloader = maven_artifact.MavenDownloader(module, base="http://repo.test.org/maven")
         fetch_url_fn.return_value = (StringIO(maven_metadata_xml_str), {"status": 200})
-        
+
         assert downloader.find_uri_for_artifact(artifact) == "http://repo.test.org/maven/com/ansible/test/2.0/test-2.0.jar"
         assert fetch_url_fn.call_args[0] == (module, "http://repo.test.org/maven/com/ansible/test/maven-metadata.xml")
-    
+
     @mock.patch('ansible.modules.packaging.language.maven_artifact.fetch_url')
     def test_find_uri_for_artifact_is_snapshot(self, fetch_url_fn):
         module = self.AnsibleModuleMock()
@@ -92,16 +92,14 @@ class TestMavenDownloader(unittest.TestCase):
         """
         downloader = maven_artifact.MavenDownloader(module, base="http://repo.test.org/maven")
         fetch_url_fn.return_value = (StringIO(maven_metadata_xml_str), {"status": 200})
-        
+
         assert downloader.find_uri_for_artifact(artifact) == "http://repo.test.org/maven/com/ansible/test/1.0-SNAPSHOT/test-1.0-20150330.174014-12.jar"
         assert fetch_url_fn.call_args[0] == (module, "http://repo.test.org/maven/com/ansible/test/1.0-SNAPSHOT/maven-metadata.xml")
 
-    
     def test_find_uri_for_artifact_is_snapshot_nonunique(self):
         module = self.AnsibleModuleMock()
         module.params["unique_snapshot"] = False
         artifact = maven_artifact.Artifact("com.ansible", "test", "1.0-SNAPSHOT")
         downloader = maven_artifact.MavenDownloader(module, base="http://repo.test.org/maven")
-        
+
         assert downloader.find_uri_for_artifact(artifact) == "http://repo.test.org/maven/com/ansible/test/1.0-SNAPSHOT/test-1.0-SNAPSHOT.jar"
-    

--- a/test/units/modules/packaging/language/test_maven_artifact.py
+++ b/test/units/modules/packaging/language/test_maven_artifact.py
@@ -1,0 +1,107 @@
+from StringIO import StringIO
+from ansible.compat.tests import unittest, mock
+
+from ansible.modules.packaging.language import maven_artifact
+
+class TestMavenDownloader(unittest.TestCase):
+
+    class AnsibleModuleMock:
+        def __init__(self):
+            self.params = {}
+
+    def test_get_base_release(self):
+        module = self.AnsibleModuleMock()
+        artifact = maven_artifact.Artifact("com.ansible", "test", "1.0")
+        base = "http://repo.test.org/maven"
+        downloader = maven_artifact.MavenDownloader(module, base=base)
+
+        assert downloader.get_base(artifact) == base
+
+    def test_get_base_snapshot(self):
+        module = self.AnsibleModuleMock()
+        artifact = maven_artifact.Artifact("com.ansible", "test", "1.0-SNAPSHOT")
+        base = "http://repo.test.org/maven"
+        downloader = maven_artifact.MavenDownloader(module, base=base)
+
+        assert downloader.get_base(artifact) == base
+
+    def test_get_base_snapshot_with_base_snapshot(self):
+        module = self.AnsibleModuleMock()
+        module.params["repository_snapshot_url"] = "http://repo.test.org/maven-snapshot"
+        artifact = maven_artifact.Artifact("com.ansible", "test", "1.0-SNAPSHOT")
+        downloader = maven_artifact.MavenDownloader(module, base="http://repo.test.org/maven")
+
+        assert downloader.get_base(artifact) == module.params["repository_snapshot_url"]
+
+    def test_find_uri_for_artifact_release(self):
+        module = self.AnsibleModuleMock()
+        artifact = maven_artifact.Artifact("com.ansible", "test", "1.0")
+        downloader = maven_artifact.MavenDownloader(module, base="http://repo.test.org/maven")
+        
+        assert downloader.find_uri_for_artifact(artifact) == "http://repo.test.org/maven/com/ansible/test/1.0/test-1.0.jar"
+
+    @mock.patch('ansible.modules.packaging.language.maven_artifact.fetch_url')
+    def test_find_uri_for_artifact_release_latest(self, fetch_url_fn):
+        module = self.AnsibleModuleMock()
+        artifact = maven_artifact.Artifact("com.ansible", "test", "latest")
+        maven_metadata_xml_str = """<?xml version="1.0" encoding="UTF-8"?>
+            <metadata>
+              <groupId>com.ansible</groupId>
+              <artifactId>test</artifactId>
+              <version>2.0</version>
+              <versioning>
+                <versions>
+                  <version>1.0</version>
+                  <version>2.0</version>
+                </versions>
+                <lastUpdated>20130724233225</lastUpdated>
+              </versioning>
+            </metadata>
+        """
+        downloader = maven_artifact.MavenDownloader(module, base="http://repo.test.org/maven")
+        fetch_url_fn.return_value = (StringIO(maven_metadata_xml_str), {"status": 200})
+        
+        assert downloader.find_uri_for_artifact(artifact) == "http://repo.test.org/maven/com/ansible/test/2.0/test-2.0.jar"
+        assert fetch_url_fn.call_args[0] == (module, "http://repo.test.org/maven/com/ansible/test/maven-metadata.xml")
+    
+    @mock.patch('ansible.modules.packaging.language.maven_artifact.fetch_url')
+    def test_find_uri_for_artifact_is_snapshot(self, fetch_url_fn):
+        module = self.AnsibleModuleMock()
+        module.params["unique_snapshot"] = True
+        artifact = maven_artifact.Artifact("com.ansible", "test", "1.0-SNAPSHOT")
+        maven_metadata_xml_str = """<?xml version="1.0" encoding="UTF-8"?>
+            <metadata>
+              <groupId>com.ansible</groupId>
+              <artifactId>test</artifactId>
+              <version>1.0-20150302.201629-3</version>
+              <versioning>
+                <snapshot>
+                  <timestamp>20150330.174014</timestamp>
+                  <buildNumber>12</buildNumber>
+                </snapshot>
+                <lastUpdated>20150911205444</lastUpdated>
+                <snapshotVersions>
+                  <snapshotVersion>
+                    <extension>jar</extension>
+                    <value>1.0-20150330.174014-12</value>
+                    <updated>20150330174014</updated>
+                  </snapshotVersion>
+                </snapshotVersions>
+              </versioning>
+            </metadata>
+        """
+        downloader = maven_artifact.MavenDownloader(module, base="http://repo.test.org/maven")
+        fetch_url_fn.return_value = (StringIO(maven_metadata_xml_str), {"status": 200})
+        
+        assert downloader.find_uri_for_artifact(artifact) == "http://repo.test.org/maven/com/ansible/test/1.0-SNAPSHOT/test-1.0-20150330.174014-12.jar"
+        assert fetch_url_fn.call_args[0] == (module, "http://repo.test.org/maven/com/ansible/test/1.0-SNAPSHOT/maven-metadata.xml")
+
+    
+    def test_find_uri_for_artifact_is_snapshot_nonunique(self):
+        module = self.AnsibleModuleMock()
+        module.params["unique_snapshot"] = False
+        artifact = maven_artifact.Artifact("com.ansible", "test", "1.0-SNAPSHOT")
+        downloader = maven_artifact.MavenDownloader(module, base="http://repo.test.org/maven")
+        
+        assert downloader.find_uri_for_artifact(artifact) == "http://repo.test.org/maven/com/ansible/test/1.0-SNAPSHOT/test-1.0-SNAPSHOT.jar"
+    

--- a/test/units/modules/packaging/language/test_maven_artifact.py
+++ b/test/units/modules/packaging/language/test_maven_artifact.py
@@ -44,7 +44,7 @@ class TestMavenDownloader(unittest.TestCase):
     def test_find_uri_for_artifact_release_latest(self, fetch_url_fn):
         module = self.AnsibleModuleMock()
         artifact = maven_artifact.Artifact("com.ansible", "test", "latest")
-        maven_metadata_xml_str = """<?xml version="1.0" encoding="UTF-8"?>
+        maven_metadata_xml_str = u"""<?xml version="1.0" encoding="UTF-8"?>
             <metadata>
               <groupId>com.ansible</groupId>
               <artifactId>test</artifactId>
@@ -69,7 +69,7 @@ class TestMavenDownloader(unittest.TestCase):
         module = self.AnsibleModuleMock()
         module.params["unique_snapshot"] = True
         artifact = maven_artifact.Artifact("com.ansible", "test", "1.0-SNAPSHOT")
-        maven_metadata_xml_str = """<?xml version="1.0" encoding="UTF-8"?>
+        maven_metadata_xml_str = u"""<?xml version="1.0" encoding="UTF-8"?>
             <metadata>
               <groupId>com.ansible</groupId>
               <artifactId>test</artifactId>


### PR DESCRIPTION
Hi,
I've added 2 parameters to improve certain maven workflows regarding snapshot handling and also removed the dependency on lxml for the maven_artifact module.

##### SUMMARY
Added 2 new parameters:
- _maven_snapshot_url_: allows defining an alternative repository for snapshot artifacts
- _unique_snapshot_: allows downloading from snapshot repositories that don't timestamp their artifacts

Also, the second commit of this PR removes the dependency on lxml by using ElementTree from the stdlib.
 
##### RATIONALE

###### maven_snapshot_url
At my workplace we use the maven with different repositories for our release and snapshots by using the `<snapshotRepository>` tag in our pom files, just like so:

```
  <distributionManagement>
    <repository>
      <uniqueVersion>false</uniqueVersion>
      <id>corp1</id>
      <name>Corporate Repository</name>
      <url>http://repo/releases</url>
    </repository>
    <snapshotRepository>
      <id>propSnap</id>
      <name>Propellors Snapshots</name>
      <url>http://repo/snapshots</url>
    </snapshotRepository>
  </distributionManagement>
```
The fact that we effectively have 2 artifactory sources depending on the type makes writing ansible tasks for the module clunkier than necessary, since you need to duplicate them with a conditional linked to the package version you want to download.

By adding the new parameter _maven_snapshot_url_, that behaviour can be built into the module itself, so the use case gets resolved.

###### unique_snapshot
Our snapshot maven repo overwrites snapshot artifacts instead of saving unique, timestamped, versions of them (see [link](https://www.jfrog.com/confluence/display/RTF/Local+Repositories), Nonunique snapshot version behaviour). This means that resolving the uri fails since _maven-metadata.xml_ is missing the `<timestamp>` field on the `<snapshot>` tag.

To fix this issue, if that flag is not active, resolve the uris for snapshots the same way as releases.

###### removal of lxml
In a lot of enterprise setups, even though we might have access rights to execute playbooks, we might be doing so under user accounts with limited permissions. Generally this means that you want to keep additional software to a minimum to avoid bureaucracy. Since the lxml requirement applies to the remote boxes as well, I believe that getting rid of it lowers the adoption bar for the module.

##### COMPONENT NAME
maven_artifact


##### ANSIBLE VERSION
N/A