### PR TITLE
Fixed bug in script module in building powershell command with environment variable

### DIFF
--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -82,8 +82,8 @@ class ActionModule(ActionBase):
 
         # add preparation steps to one ssh roundtrip executing the script
         env_string = self._compute_environment_string()
-        script_cmd = ' '.join([env_string, tmp_src, args])
-        script_cmd = self._connection._shell.wrap_for_exec(script_cmd)
+        script_cmd = ' '.join([tmp_src, args])
+        script_cmd = self._connection._shell.wrap_for_exec(script_cmd, env_string)
 
         result.update(self._low_level_execute_command(cmd=script_cmd, sudoable=True))
 

--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -173,6 +173,8 @@ class ShellBase(object):
 
         return cmd
 
-    def wrap_for_exec(self, cmd):
+    def wrap_for_exec(self, cmd, env_string):
         """wrap script execution with any necessary decoration (eg '&' for quoted powershell script paths)"""
-        return cmd
+        if not env_string:
+            return cmd
+        return '%s %s' % (env_string, cmd)

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -1127,8 +1127,10 @@ class ShellModule(object):
             script = '%s\nFinally { %s }' % (script, rm_cmd)
         return self._encode_script(script, preserve_rc=False)
 
-    def wrap_for_exec(self, cmd):
-        return '& %s' % cmd
+    def wrap_for_exec(self, cmd, env_string):
+        if not env_string:
+            return '& %s' % cmd
+        return '%s ; & %s' % (env_string, cmd)
 
     def _unquote(self, value):
         '''Remove any matching quotes that wrap the given value.'''

--- a/test/integration/targets/win_script/files/test_script_with_env.ps1
+++ b/test/integration/targets/win_script/files/test_script_with_env.ps1
@@ -1,0 +1,4 @@
+# Test script to make sure the Ansible script module works when environment
+# variable passed to the script.
+
+Write-Host $env:testVar;

--- a/test/integration/targets/win_script/tasks/main.yml
+++ b/test/integration/targets/win_script/tasks/main.yml
@@ -192,3 +192,19 @@
     that:
       - "test_script_bool_result.stdout_lines[0] == 'System.Boolean'"
       - "test_script_bool_result.stdout_lines[1] == 'True'"
+
+- name: run test script that takes environment variable
+  script: test_script_with_env.ps1
+  environment:
+    testVar: "Woohoo! We can pass environment variable to the script!"
+  register: test_script_env_result
+
+- name: check that the script ran and the environment variable was passed
+  assert:
+    that:
+      - "test_script_env_result.rc == 0"
+      - "test_script_env_result.stdout"
+      - "'Woohoo' in test_script_env_result.stdout"
+      - "not test_script_env_result.stderr"
+      - "not test_script_env_result|failed"
+      - "test_script_env_result|changed"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I tried to pass environment variable to script module:
```yaml
- name: Test run script
  script: files/test.ps1
  environment:
    testVar: "Test"
```
And I got the error #22441.

I investigated that script module creates invalid powershell command:
```powershell
& $env:testVar='Test' 'C:\\Users\\ansible\\AppData\\Local\\Temp\\ansible-tmp-1489056663.32-148204692702794\\test.ps1'
```

Correct powershell command:
```powershell
$env:testVar='Test' ; & 'C:\\Users\\ansible\\AppData\\Local\\Temp\\ansible-tmp-1489058709.81-112961745098050\\test.ps1'
```

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
action/script

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel 0f82674c0e) last updated 2017/03/09 13:49:25 (GMT +300)
  config file = /home/art/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
