### PR TITLE
Fix bug in 'Building A Simple Module' doc

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -34,7 +34,7 @@ Ok, let's get going with an example.  We'll use Python.  For starters, save this
 
     date = str(datetime.datetime.now())
     print json.dumps({
-        "Hello world!" : date
+        "time" : date
     })
 
 .. _module_testing:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
[Current version](http://docs.ansible.com/ansible/dev_guide/developing_modules_general.html) of `timetest.py` script dumps:
```
***********************************
RAW OUTPUT
{"Hello world!": "2017-03-09 18:04:58.697404"}


***********************************
PARSED OUTPUT
{
    "Hello world!": "2017-03-09 18:04:58.697404"
}
```

Expected key name in doc - `test`:
>You should see output that looks something like this:
>```
> {"time": "2012-03-14 22:13:48.539183"}
>```

In this PR I changed JSON key name from `Hello world!` to `test`.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
dev_guide/developing_modules_general

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel 0f82674c0e) last updated 2017/03/09 13:49:25 (GMT +300)
  config file = /home/art/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
