### PR TITLE
Make vault encrypt/create/etc confirm pass again.

### DIFF
--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -133,7 +133,12 @@ class VaultCLI(CLI):
             self.b_new_vault_pass = CLI.read_vault_password_file(self.options.new_vault_password_file, loader)
 
         if not self.b_vault_pass or self.options.ask_vault_pass:
-            self.b_vault_pass = self.ask_vault_passwords()
+            # the 'read' options dont need to ask for password confirmation.
+            # 'edit' is read/write, but the decrypt will confirm.
+            if self.action in ['decrypt', 'edit', 'view', 'rekey']:
+                self.b_vault_pass = self.ask_vault_passwords()
+            else:
+                self.b_vault_pass = self.ask_new_vault_passwords()
 
         if not self.b_vault_pass:
             raise AnsibleOptionsError("A password is required to use Ansible's Vault")


### PR DESCRIPTION

##### SUMMARY


Make the 'write' modes of vault confirm a new password
before using, again.

This was unintentionally disabled in
309f54b709d489114841530663642b7f3ad262ec previously.

Fixes #22438


<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/cli/vault.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (vault_pass_confirm_22438 25e3627efa) last updated 2017/03/09 12:11:24 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```

