### PR TITLE
ovirt: dyn_inventory fix Python2 and Python3 compat

### DIFF
--- a/contrib/inventory/ovirt4.py
+++ b/contrib/inventory/ovirt4.py
@@ -60,11 +60,15 @@ Author: Ondra Machacek (@machacekondra)
 """
 
 import argparse
-import ConfigParser
 import os
 import sys
 
 from collections import defaultdict
+
+try:
+    import ConfigParser as configparser
+except ImportError:
+    import configparser
 
 try:
     import json
@@ -118,7 +122,7 @@ def create_connection():
     config_path = os.environ.get('OVIRT_INI_PATH', default_path)
 
     # Create parser and add ovirt section if it doesn't exist:
-    config = ConfigParser.SafeConfigParser(
+    config = configparser.SafeConfigParser(
         defaults={
             'ovirt_url': None,
             'ovirt_username': None,
@@ -135,8 +139,8 @@ def create_connection():
         url=config.get('ovirt', 'ovirt_url'),
         username=config.get('ovirt', 'ovirt_username'),
         password=config.get('ovirt', 'ovirt_password'),
-        ca_file=config.get('ovirt', 'ovirt_ca_file', None),
-        insecure=config.get('ovirt', 'ovirt_ca_file', None) is None,
+        ca_file=config.get('ovirt', 'ovirt_ca_file'),
+        insecure=config.get('ovirt', 'ovirt_ca_file') is None,
     )
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR fixes Python2 and Python3 compatibility for ovirt dynamic inventory script.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt4

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
