### PR TITLE
Added example of removing the standard website and port 80 binding

### DIFF
--- a/lib/ansible/modules/windows/win_iis_website.py
+++ b/lib/ansible/modules/windows/win_iis_website.py
@@ -115,6 +115,12 @@ EXAMPLES = r'''
     parameters: logfile.directory:c:\sites\logs
   register: website
 
+# Remove Default Web Site and the standard port 80 binding
+- name: Remove Default Web Site
+  win_iis_website:
+    name: "Default Web Site"
+    state: absent
+
 # Some commandline examples:
 
 # This return information about an existing host


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
By default a "clean" install of IIS contains the Default Web Site, occupying port 80. 
Added example on usage of absent to remove the site and the binding so it can be used by custom sites. 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_iis_website
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
```
