### PR TITLE
show current config and where the config values were set at -vvv and higher

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -162,6 +162,8 @@ class CLI(with_metaclass(ABCMeta, object)):
             else:
                 display.display(u"No config file found; using defaults")
 
+        display.vvv('Current config:\n%s' % C.dumps_config())
+
     @staticmethod
     def ask_vault_passwords():
         ''' prompt for vault password and/or password change '''

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -61,16 +61,20 @@ active_config_dict = defaultdict(dict)
 
 
 class ConfigItem:
-    def __init__(self, section=None, key=None, value=None, source=None):
+    def __init__(self, section=None, key=None, value=None, source=None, default=None):
         self.section = section
         self.key = key
         self.value = value
         self.source = source
+        self.default = default
 
     def __str__(self):
-        buf = '# from %s\n%s = %s\n' % \
-            (self.source, self.key, self.value)
-        return buf
+        lines = []
+        lines.append('# from %s' % self.source)
+        if self.default is not None:
+            lines.append('# default: %s' % self.default)
+        lines.append('%s = %s' % (self.key, self.value))
+        return '\n'.join(lines)
 
 
 def get_config(p, section, key, env_var, default, value_type=None, expand_relative_paths=False):
@@ -147,7 +151,8 @@ def _get_config(p, section, key, env_var, default):
         try:
             value = p.get(section, key, raw=True)
             active_config_dict[section][key] = ConfigItem(section, key, value,
-                                                          source='file %s' % CONFIG_FILE)
+                                                          source='file %s' % CONFIG_FILE,
+                                                          default=default)
         except:
             pass
 
@@ -157,7 +162,8 @@ def _get_config(p, section, key, env_var, default):
             value = env_value
 
             active_config_dict[section][key] = ConfigItem(section, key, value,
-                                                          source='environment variable %s' % env_var)
+                                                          source='environment variable %s' % env_var,
+                                                          default=default)
 
     return to_text(value, errors='surrogate_or_strict', nonstring='passthru')
 
@@ -198,6 +204,7 @@ def dumps_config():
         lines.append('[%s]' % section)
         for config_item in config_dict.values():
             lines.append(str(config_item))
+            lines.append('')
 
     return '\n'.join(lines)
 

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -200,9 +200,10 @@ p, CONFIG_FILE = load_config_file()
 
 def dumps_config():
     lines = []
-    for section, config_dict in active_config_dict.items():
+    # sort by section to get a stable format
+    for section, config_dict in sorted(active_config_dict.items()):
         lines.append('[%s]' % section)
-        for config_item in config_dict.values():
+        for config_item_key, config_item in sorted(config_dict.items()):
             lines.append(str(config_item))
             lines.append('')
 

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -68,7 +68,7 @@ class ConfigItem:
         self.comment = comment
         self.source = source
 
-    def __repr__(self):
+    def __str__(self):
         buf = '# from %s\n%s = %s\n' % \
             (self.source, self.key, self.value)
         return buf
@@ -144,12 +144,9 @@ def _get_config(p, section, key, env_var, default):
     ''' helper function for get_config '''
     value = default
 
-    used_default = True
-
     if p is not None:
         try:
             value = p.get(section, key, raw=True)
-            used_default = False
             active_config_dict[section][key] = ConfigItem(section, key, value,
                                                           source='file %s' % CONFIG_FILE)
         except:
@@ -160,14 +157,9 @@ def _get_config(p, section, key, env_var, default):
         if env_value is not None:
             value = env_value
 
-            used_default = False
             active_config_dict[section][key] = ConfigItem(section, key, value,
                                                           source='env var %s' % env_var,
                                                           comment='the default is %s' % default)
-
-    if used_default:
-        # seems odd to do this last, but we should not be shadowing any set config values
-        active_config_dict[section][key] = ConfigItem(section, key, value, source='default')
 
     return to_text(value, errors='surrogate_or_strict', nonstring='passthru')
 
@@ -204,13 +196,10 @@ p, CONFIG_FILE = load_config_file()
 
 def dumps_config():
     lines = []
-    for section in active_config_dict:
-        config_dict = active_config_dict[section]
-        if [x for x in config_dict.values() if x.source != 'default']:
-            lines.append('[%s]' % section)
+    for section, config_dict in active_config_dict.items():
+        lines.append('[%s]' % section)
         for config_item in config_dict.values():
-            if config_item.source != 'default':
-                lines.append(repr(config_item))
+            lines.append(str(config_item))
 
     return '\n'.join(lines)
 

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -61,11 +61,10 @@ active_config_dict = defaultdict(dict)
 
 
 class ConfigItem:
-    def __init__(self, section=None, key=None, value=None, comment=None, source=None):
+    def __init__(self, section=None, key=None, value=None, source=None):
         self.section = section
         self.key = key
         self.value = value
-        self.comment = comment
         self.source = source
 
     def __str__(self):
@@ -158,8 +157,7 @@ def _get_config(p, section, key, env_var, default):
             value = env_value
 
             active_config_dict[section][key] = ConfigItem(section, key, value,
-                                                          source='env var %s' % env_var,
-                                                          comment='the default is %s' % default)
+                                                          source='environment variable %s' % env_var)
 
     return to_text(value, errors='surrogate_or_strict', nonstring='passthru')
 


### PR DESCRIPTION
##### SUMMARY
At verbosity levels of '-vvv', display a summary of the current config including info about where that config value came from. Output the format in an 'ini' format.

ie, like
``` ini
[defaults]
# from file ./ansible_min.cfg
bin_ansible_callbacks = true

# from file ./ansible_min.cfg
forks = 1

# from file ./ansible_min.cfg
roles_path = $HOME/ansible/galaxy-roles:$HOME/ansible/roles:/etc/ansible/roles

# from file ./ansible_min.cfg
nocows = 1

# from env var ANSIBLE_FILTER_PLUGINS
filter_plugins = /home/adrian/whatever_plugins

# from file ./ansible_min.cfg
action_plugins = $HOME/ansible/my-plugins/action

# from file ./ansible_min.cfg
callback_plugins = $HOME/ansible/my-plugins/callback

[diff]
# from env var ANSIBLE_DIFF_ALWAYS
always = 1

[ssh_connection]
# from env var ANSIBLE_SSH_RETRIES
retries = 2

# from file ./ansible_min.cfg
pipelining = False

# from file ./ansible_min.cfg
ssh_args = -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=600s -o ControlPath=/home/adrian/.ansible/cp/ansible-ssh-%h-%p-%r -o ConnectTimeout=2s
```



##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/constants.py
lib/ansible/cli/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
[fedora-25:ansible (dump_config_source %)]$ ansible --version
ansible 2.3.0 (dump_config_source 71a3d91b9c) last updated 2017/03/09 15:58:12 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]


```


##### ADDITIONAL INFORMATION
example
```
[fedora-25:ansible (dump_config_source %)]$ cat ansible_min.cfg 
[defaults]
roles_path = $HOME/ansible/galaxy-roles:$HOME/ansible/roles:/etc/ansible/roles
forks = 1
nocows = 1
bin_ansible_callbacks = true
callback_plugins   = $HOME/ansible/my-plugins/callback
action_plugins = $HOME/ansible/my-plugins/action
filter_plugins = $HOME/ansible/my-plugins/filter

[ssh_connection]
pipelining = False
ssh_args = -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=600s -o ControlPath=/home/adrian/.ansible/cp/ansible-ssh-%h-%p-%r -o ConnectTimeout=2s

[paramiko]
[fedora-25:ansible (dump_config_source %)]$ env| grep ^ANSIBLE
ANSIBLE_DIFF_ALWAYS=1
ANSIBLE_SRC_DIR=/home/adrian/src/ansible
ANSIBLE_HOME=/home/adrian/src/ansible
ANSIBLE_MODULES_CORE_SRC_DIR=/home/adrian/src/ansible-modules-core
[fedora-25:ansible (dump_config_source %)]$ ANSIBLE_CONFIG=./ansible_min.cfg ANSIBLE_FILTER_PLUGINS=~/whatever_plugins ANSIBLE_SSH_RETRIES=2 ansible -vvv localhost -m ping
Using ./ansible_min.cfg as config file
Current config:
[defaults]
# from file ./ansible_min.cfg
bin_ansible_callbacks = true

# from file ./ansible_min.cfg
forks = 1

# from file ./ansible_min.cfg
roles_path = $HOME/ansible/galaxy-roles:$HOME/ansible/roles:/etc/ansible/roles

# from file ./ansible_min.cfg
nocows = 1

# from env var ANSIBLE_FILTER_PLUGINS
filter_plugins = /home/adrian/whatever_plugins

# from file ./ansible_min.cfg
action_plugins = $HOME/ansible/my-plugins/action

# from file ./ansible_min.cfg
callback_plugins = $HOME/ansible/my-plugins/callback

[diff]
# from env var ANSIBLE_DIFF_ALWAYS
always = 1

[ssh_connection]
# from env var ANSIBLE_SSH_RETRIES
retries = 2

# from file ./ansible_min.cfg
pipelining = False

# from file ./ansible_min.cfg
ssh_args = -o ForwardAgent=yes -o ControlMaster=auto -o ControlPersist=600s -o ControlPath=/home/adrian/.ansible/cp/ansible-ssh-%h-%p-%r -o ConnectTimeout=2s

 [WARNING]: provided hosts list is empty, only localhost is available

META: ran handlers
Using module file /home/adrian/src/ansible/lib/ansible/modules/system/ping.py
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: adrian
<127.0.0.1> EXEC /bin/sh -c 'echo ~ && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/adrian/.ansible/tmp/ansible-tmp-1489093400.91-228155790759657 `" && echo ansible-tmp-1489093400.91-228155790759657="` echo /home/adrian/.ansible/tmp/ansible-tmp-1489093400.91-228155790759657 `" ) && sleep 0'
<127.0.0.1> PUT /tmp/tmp79jutB TO /home/adrian/.ansible/tmp/ansible-tmp-1489093400.91-228155790759657/ping.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/adrian/.ansible/tmp/ansible-tmp-1489093400.91-228155790759657/ /home/adrian/.ansible/tmp/ansible-tmp-1489093400.91-228155790759657/ping.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /home/adrian/.ansible/tmp/ansible-tmp-1489093400.91-228155790759657/ping.py; rm -rf "/home/adrian/.ansible/tmp/ansible-tmp-1489093400.91-228155790759657/" > /dev/null 2>&1 && sleep 0'
localhost | SUCCESS => {
    "changed": false, 
    "invocation": {
        "module_args": {
            "data": null
        }
    }, 
    "ping": "pong"
}
META: ran handlers
META: ran handlers
```

<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
