### PR TITLE
Adding openstack script directory as a valid CONFIG_FILES path

### DIFF
--- a/contrib/inventory/openstack.py
+++ b/contrib/inventory/openstack.py
@@ -61,7 +61,8 @@ import os_client_config
 import shade
 import shade.inventory
 
-CONFIG_FILES = ['/etc/ansible/openstack.yaml', '/etc/ansible/openstack.yml']
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__)) + '/clouds.yaml'
+CONFIG_FILES = ['/etc/ansible/openstack.yaml', '/etc/ansible/openstack.yml', SCRIPT_DIR ]
 
 
 def get_groups_from_server(server_vars, namegroup=True):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Using the `environments/{ENV}`  style Ansible environment easily allows you to keep your environments separated. However, the script currently only searches for the `clouds.yaml` file in the `/etc/ansible`, home directory, CWD, etc.  folders. When running ansible with `-i environments/dev/openstack.py`, it won't look inside the `environments/dev` folder for a clouds.yaml file. 

We needed the ability to have a per-environment `clouds.yaml` file which is stored in the same folder as the `openstack.py` file. This patch will add searching to the directory the script file is located.

The Python documentation doesn't explicitly say anything about Exceptions thrown by these two functions, so I didn't put any Exception catches. 

Please let me know if there's an issue with the coding style..  

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
contrib/inventory/openstack.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file =
  configured module search path = Default w/o overrides
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
$ ls environments/dev/
clouds.yaml  group_vars  openstack.py
$ environments/dev/openstack.py --list
Error fetching server list on defaults::
```

After:
```
$ ls environments/dev/
clouds.yaml  group_vars  openstack.py
$ environments/dev/openstack.py --list
<JSON output of OpenStack server vars>
```