### PR TITLE
Fix root volume security style options for NetApp ONTAP SVM module

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_cdot_svm.py
+++ b/lib/ansible/modules/storage/netapp/na_cdot_svm.py
@@ -105,8 +105,8 @@ class NetAppCDOTSVM(object):
             name=dict(required=True, type='str'),
             root_volume=dict(type='str'),
             root_volume_aggregate=dict(type='str'),
-            root_volume_security_style=dict(type='str', choices=['nfs',
-                                                                 'cifs',
+            root_volume_security_style=dict(type='str', choices=['unix',
+                                                                 'ntfs',
                                                                  'mixed',
                                                                  'unified'
                                                                  ]),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes supported options for security-style of SVM root volumes.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
na_cdot_svm

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
```
