### PR TITLE
add osquery_facts module; closes #14066

### DIFF
--- a/lib/ansible/modules/system/osquery_facts.py
+++ b/lib/ansible/modules/system/osquery_facts.py
@@ -1,0 +1,102 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Richard Metzler
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = r'''
+---
+module: osquery_facts
+version_added: "2.9"
+short_description: get facts from osquery selects
+requirements:
+  - osqueryi
+description:
+  - execute osquery selects and return the values
+options:
+  name:
+    description:
+      - an identifier to namespace the return value under ansible_facts.osquery.<name>
+    type: str
+    required: true
+  query:
+    description:
+      - The SELECT statement which is passed to osqueryi
+    type: str
+    required: true
+author:
+  - "Richard Metzler (@rmetzler)"
+'''
+
+EXAMPLES = r'''
+- name: parse /etc/hosts
+  osquery_facts:
+    name: etc_hosts
+    query: SELECT * FROM etc_hosts
+
+- debug: var=osquery.etc_hosts
+'''
+
+RETURN = r'''
+query:
+    description: query as provided by the caller
+    returned: success
+    type: 'str'
+    sample: SELECT * FROM etc_hosts
+value:
+    description: result as an array of dicts
+    returned: success
+    type: str
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec={
+            'name': {'required': True},
+            'query': {'required': True},
+        },
+        supports_check_mode=True,
+    )
+
+    name = module.params['name']
+    query = module.params['query']
+    command_options = [module.get_bin_path('osqueryi', True), query, '--json']
+    command_result = module.run_command(command_options, check_rc=True)
+    result = module.from_json(command_result[1])
+
+    facts = dict()
+    facts[name] = result
+    args = {
+        'changed': False,
+        'ansible_facts': {'osquery': facts},
+    }
+    module.exit_json(**args)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/system/osquery_facts.py
+++ b/lib/ansible/modules/system/osquery_facts.py
@@ -28,7 +28,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = r'''
 ---
 module: osquery_facts
-version_added: "2.9"
+version_added: "2.10"
 short_description: get facts from osquery selects
 requirements:
   - osqueryi


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This module adds basic support for [osquery](https://osquery.io/).

The queries are run via the `osqueryi` cli with the `--json` flag to enable easy parsing.
I wasn't sure whether to use `set_facts` or return the resulting array of dicts and let the user register the variable. I went with the second option mainly because I think the design is simpler.

This is my first module and I didn't wrote any python for a couple of years. Please let me know what I can improve. 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

There is a feature request #14066, which I hope to close.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

osquery_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /usr/local/etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
