### PR TITLE
Escape synchronize modules's rsync --rsh option value with shlex_quote

### DIFF
--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -457,10 +457,11 @@ def main():
         # If the user specified a port value
         # Note:  The action plugin takes care of setting this to a port from
         # inventory if the user didn't specify an explicit dest_port
+        cmd += " --rsh "
         if dest_port is not None:
-            cmd += " --rsh 'ssh %s %s -o Port=%s'" % (private_key, ssh_opts, dest_port)
+            cmd += shlex_quote("ssh %s %s -o port=%s" % (private_key, ssh_opts, dest_port))
         else:
-            cmd += " --rsh 'ssh %s %s'" % (private_key, ssh_opts)
+            cmd += shlex_quote("ssh %s %s" % (private_key, ssh_opts))
 
     if rsync_path:
         cmd = cmd + " --rsync-path=%s" % (rsync_path)
@@ -502,6 +503,7 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
+from ansible.compat.six.moves import shlex_quote
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### SUMMARY
Resolves conflict with single-quoted options in ssh options.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
files/synchronize
action/synchronize

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = /home/ec2-user/repos/cmb-infosec-ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13+ (default, Feb 24 2017, 13:51:49) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION
