### PR TITLE
ANSIBLE_TIMEOUT= ansible causes OptionValueError traceback #22470

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -85,16 +85,25 @@ def get_config(p, section, key, env_var, default, value_type=None, expand_relati
     if value_type == 'boolean':
         value = mk_boolean(value)
 
-    elif value:
+    elif value is not None:
         if value_type == 'integer':
-            value = int(value)
+            try:
+                value = int(value)
+            except ValueError:
+                value = default
 
         elif value_type == 'float':
-            value = float(value)
+            try:
+                value = float(value)
+            except ValueError:
+                value = default
 
         elif value_type == 'list':
-            if isinstance(value, string_types):
-                value = [x.strip() for x in value.split(',')]
+            try:
+                if isinstance(value, string_types):
+                    value = [x.strip() for x in value.split(',')]
+            except ValueError:
+                value = default
 
         elif value_type == 'none':
             if value == "None":


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
System variables will override the default value even though the value is empty.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #22470 #22469 #22468

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
