### PR TITLE
update task_executor to support HUAWEI data center CloudEngine

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -759,7 +759,7 @@ class TaskExecutor:
         Returns the correct action plugin to handle the requestion task action
         '''
 
-        network_group_modules = frozenset(['eos', 'nxos', 'ios', 'iosxr', 'junos', 'vyos'])
+        network_group_modules = frozenset(['eos', 'nxos', 'ios', 'iosxr', 'junos', 'vyos', 'ce'])
         module_prefix = self._task.action.split('_')[0]
 
         # let action plugin override module, fallback to 'normal' action plugin otherwise


### PR DESCRIPTION
update task_executor

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
update task_executor to support HUAWEI data center CloudEngine
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
config file = /etc/ansible/ansible.cfg
configured module search path = ['/home/ansible-2.1.1.0/lib/ansible/modules/core/network/cloudengine', '/home/ansible-2.1.1.0/lib/ansible/module_utils', '/home/ansible-2.1.1.0/lib/ansible/modules', '/home/ansible-2.1.1.0', '/home/ansible-2.1.1.0/lib/ansible/utils/']
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
update task_executor to support HUAWEI data center CloudEngine
```
