### PR TITLE
Fixes the build issue pertaining to sphinx-build which  is required to build ansible

### DIFF
--- a/docsite_requirements.txt
+++ b/docsite_requirements.txt
@@ -1,0 +1,2 @@
+#pip packages requird to build docssite
+sphinx

--- a/docsite_requirements.txt
+++ b/docsite_requirements.txt
@@ -1,2 +1,2 @@
-#pip packages requird to build docssite
+#pip packages required to build docssite
 sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@
 # packages.  Thus, this should be the loosest set possible (only required
 # packages, not optional ones, and with the widest range of versions that could
 # be suitable)
-sphinx
 jinja2
 PyYAML
 paramiko

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 # packages.  Thus, this should be the loosest set possible (only required
 # packages, not optional ones, and with the widest range of versions that could
 # be suitable)
+sphinx
 jinja2
 PyYAML
 paramiko


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
While trying to build sensible in development branch, makefile complained of sphinx-build not being there on my system. Ideally this should have been listed as a pre-requisite in requirements.txt.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes the build issue pertaining to sphinx-build package
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Build task
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```