### PR TITLE
cloud: ovirt: make the datacenter input compatible

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_clusters.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_clusters.py
@@ -41,7 +41,7 @@ options:
             - "Should the cluster be present or absent"
         choices: ['present', 'absent']
         default: present
-    datacenter:
+    data_center:
         description:
             - "Datacenter name where cluster reside."
     description:
@@ -213,7 +213,7 @@ EXAMPLES = '''
 
 # Create cluster
 - ovirt_clusters:
-    datacenter: mydatacenter
+    data_center: mydatacenter
     name: mycluster
     cpu_type: Intel SandyBridge Family
     description: mycluster
@@ -221,7 +221,7 @@ EXAMPLES = '''
 
 # Create virt service cluster:
 - ovirt_clusters:
-    datacenter: mydatacenter
+    data_center: mydatacenter
     name: mycluster
     cpu_type: Intel Nehalem Family
     description: mycluster
@@ -423,8 +423,8 @@ class ClustersModule(BaseModule):
                 self.param('ksm') is not None
             ) else None,
             data_center=otypes.DataCenter(
-                name=self.param('datacenter'),
-            ) if self.param('datacenter') else None,
+                name=self.param('data_center'),
+            ) if self.param('data_center') else None,
             management_network=otypes.Network(
                 name=self.param('network'),
             ) if self.param('network') else None,
@@ -524,7 +524,7 @@ def main():
         serial_policy=dict(default=None, choices=['vm', 'host', 'custom']),
         serial_policy_value=dict(default=None),
         scheduling_policy=dict(default=None),
-        datacenter=dict(default=None),
+        data_center=dict(default=None),
         description=dict(default=None),
         comment=dict(default=None),
         network=dict(default=None),

--- a/lib/ansible/modules/cloud/ovirt/ovirt_external_providers.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_external_providers.py
@@ -232,7 +232,7 @@ def main():
         password=dict(default=None, no_log=True),
         tenant_name=dict(default=None, aliases=['tenant']),
         authentication_url=dict(default=None, aliases=['auth_url']),
-        data_center=dict(default=None, aliases=['data_center']),
+        data_center=dict(default=None),
         read_only=dict(default=None, type='bool'),
         network_type=dict(
             default='external',

--- a/lib/ansible/modules/cloud/ovirt/ovirt_networks.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_networks.py
@@ -41,7 +41,7 @@ options:
             - "Should the network be present or absent"
         choices: ['present', 'absent']
         default: present
-    datacenter:
+    data_center:
         description:
             - "Datacenter name where network reside."
     description:
@@ -79,7 +79,7 @@ EXAMPLES = '''
 
 # Create network
 - ovirt_networks:
-    datacenter: mydatacenter
+    data_center: mydatacenter
     name: mynetwork
     vlan_tag: 1
     vm_network: true
@@ -129,8 +129,8 @@ class NetworksModule(BaseModule):
             comment=self._module.params['comment'],
             description=self._module.params['description'],
             data_center=otypes.DataCenter(
-                name=self._module.params['datacenter'],
-            ) if self._module.params['datacenter'] else None,
+                name=self._module.params['data_center'],
+            ) if self._module.params['data_center'] else None,
             vlan=otypes.Vlan(
                 self._module.params['vlan_tag'],
             ) if self._module.params['vlan_tag'] else None,
@@ -200,7 +200,7 @@ def main():
             choices=['present', 'absent'],
             default='present',
         ),
-        datacenter=dict(default=None, required=True),
+        data_center=dict(default=None, required=True),
         name=dict(default=None, required=True),
         description=dict(default=None),
         comment=dict(default=None),
@@ -230,7 +230,7 @@ def main():
         network = networks_module.search_entity(
             search_params={
                 'name': module.params['name'],
-                'datacenter': module.params['datacenter'],
+                'datacenter': module.params['data_center'],
             },
         )
         if state == 'present':

--- a/lib/ansible/modules/cloud/ovirt/ovirt_quotas.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_quotas.py
@@ -41,7 +41,7 @@ options:
             - "Should the quota be present/absent."
         choices: ['present', 'absent']
         default: present
-    datacenter:
+    data_center:
         description:
             - "Name of the datacenter where quota should be managed."
         required: true
@@ -83,7 +83,7 @@ EXAMPLES = '''
 # Add cluster quota to cluster cluster1 with memory limit 20GiB and CPU limit to 10:
 ovirt_quotas:
     name: quota1
-    datacenter: dcX
+    data_center: dcX
     clusters:
         - name: cluster1
           memory: 20
@@ -92,7 +92,7 @@ ovirt_quotas:
 # Add cluster quota to all clusters with memory limit 30GiB and CPU limit to 15:
 ovirt_quotas:
     name: quota2
-    datacenter: dcX
+    data_center: dcX
     clusters:
         - memory: 30
           cpu: 15
@@ -100,7 +100,7 @@ ovirt_quotas:
 # Add storage quota to storage data1 with size limit to 100GiB
 ovirt_quotas:
     name: quota3
-    datacenter: dcX
+    data_center: dcX
     storage_grace: 40
     storage_threshold: 60
     storages:
@@ -110,7 +110,7 @@ ovirt_quotas:
 # Remove quota quota1 (Note the quota must not be assigned to any VM/disk):
 ovirt_quotas:
     state: absent
-    datacenter: dcX
+    data_center: dcX
     name: quota1
 '''
 
@@ -222,7 +222,7 @@ def main():
             default='present',
         ),
         name=dict(required=True),
-        datacenter=dict(required=True),
+        data_center=dict(required=True),
         description=dict(default=None),
         cluster_threshold=dict(default=None, type='int', aliases=['cluster_soft_limit']),
         cluster_grace=dict(default=None, type='int', aliases=['cluster_hard_limit']),
@@ -241,7 +241,7 @@ def main():
         auth = module.params.pop('auth')
         connection = create_connection(auth)
         datacenters_service = connection.system_service().data_centers_service()
-        dc_name = module.params['datacenter']
+        dc_name = module.params['data_center']
         dc_id = getattr(search_by_name(datacenters_service, dc_name), 'id', None)
         if dc_id is None:
             raise Exception("Datacenter '%s' was not found." % dc_name)

--- a/lib/ansible/modules/cloud/ovirt/ovirt_quotas_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_quotas_facts.py
@@ -35,7 +35,7 @@ notes:
     - "This module creates a new top-level C(ovirt_quotas) fact, which
        contains a list of quotas."
 options:
-    datacenter:
+    data_center:
         description:
             - "Name of the datacenter where quota resides."
         required: true
@@ -51,7 +51,7 @@ EXAMPLES = '''
 
 # Gather facts about quota named C<myquota> in Default datacenter:
 - ovirt_quotas_facts:
-    datacenter: Default
+    data_center: Default
     name: myquota
 - debug:
     var: ovirt_quotas
@@ -80,7 +80,7 @@ from ansible.module_utils.ovirt import (
 
 def main():
     argument_spec = ovirt_facts_full_argument_spec(
-        datacenter=dict(required=True),
+        data_center=dict(required=True),
         name=dict(default=None),
     )
     module = AnsibleModule(argument_spec)
@@ -90,7 +90,7 @@ def main():
         auth = module.params.pop('auth')
         connection = create_connection(auth)
         datacenters_service = connection.system_service().data_centers_service()
-        dc_name = module.params['datacenter']
+        dc_name = module.params['data_center']
         dc = search_by_name(datacenters_service, dc_name)
         if dc is None:
             raise Exception("Datacenter '%s' was not found." % dc_name)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This patch makes sure that all inputs of datacenter are compatible. So
the user can input either 'datacenter' or 'data_center'.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
