### PR TITLE
Fix issue on nxos modules when transport is passed via provider

### DIFF
--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -99,10 +99,7 @@ class ActionModule(_ActionModule):
             self._task.args['provider'] = provider_arg
 
         # make sure a transport value is set in args
-        transport = self._task.args.get('transport')
-        provider_transport = (self._task.args.get('provider') or {}).get('transport')
-        if all((transport is None, provider_transport is None)):
-            self._task.args['transport'] = 'cli'
+        self._task.args['transport'] = transport
 
         return super(ActionModule, self).run(tmp, task_vars)
 


### PR DESCRIPTION
##### SUMMARY

The nxos modules read the task level transport variable, thus if
the user pass it via provider the all fail with an UnboundLocalError.

Fixes #22355

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
plugins/action/nxos

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (issue_22355.yaml d9ad925dc9) last updated 2017/03/10 13:33:22 (GMT +200)
```
