### PR TITLE
correctly maps task arguments for eapi transport

### DIFF
--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -86,19 +86,33 @@ class ActionModule(_ActionModule):
             task_vars['ansible_socket'] = socket_path
 
         else:
-            provider_arg = {
-                'transport': 'eapi',
-                'host': provider.get('host') or self._play_context.remote_addr,
-                'port': provider.get('port'),
-                'username': provider.get('username') or self._play_context.connection_user,
-                'password': provider.get('password') or self._play_context.password,
-                'authorize': provider.get('authorize') or False,
-                'auth_pass': provider.get('auth_pass'),
-                'timeout': provider.get('timeout') or self._play_context.timeout,
-                'use_ssl': task_vars.get('eapi_use_ssl') or False,
-                'validate_certs': task_vars.get('eapi_validate_certs') or True
-            }
-            self._task.args['provider'] = provider_arg
+            provider['transport'] = 'eapi'
+
+            if provider.get('host') is None:
+                provider['host'] = self._play_context.remote_addr
+
+            if provider.get('port') is None:
+                provider['port'] = 443
+
+            if provider.get('timeout') is None:
+                provider['timeout'] = self._play_context.timeout
+
+            if provider.get('username') is None:
+                provider['username'] = self._play_context.connection_user
+
+            if provider.get('password') is None:
+                provider['password'] = self._play_context.password
+
+            if provider.get('authorize') is None:
+                provider['authorize'] = False
+
+            if provider.get('use_ssl') is None:
+                provider['use_ssl'] = True
+
+            if provider.get('validate_certs') is None:
+                provider['validate_certs'] = True
+
+            self._task.args['provider'] = provider
 
         if self._play_context.become_method == 'enable':
             self._play_context.become = False


### PR DESCRIPTION
The provider arguments where not correctly being mapped in the action
plugin for eapi transport.  This will now correctly map existing
arguments as well as set the correct defaults for values.

fixes #22442

