### PR TITLE
win_chocolatey: Add check-mode support

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -24,7 +24,8 @@ $result = @{
     changed = $false
 }
 
-$params = Parse-Args $args
+$params = Parse-Args $args -supports_check_mode $true
+$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
 
 $package = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true
 $force = Get-AnsibleParam -obj $params -name "force" -type "bool" -default $false
@@ -32,8 +33,8 @@ $upgrade = Get-AnsibleParam -obj $params -name "upgrade" -type "bool" -default $
 $version = Get-AnsibleParam -obj $params -name "version" -type "str"
 $source = Get-AnsibleParam -obj $params -name "source" -type "str"
 $showlog = Get-AnsibleParam -obj $params -name "showlog" -type "bool" -default $false
-$executiontimeout = Get-Attr -obj $params -name execution_timeout -default $null
-$state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present","absent","latest"
+$timeout = Get-AnsibleParam -obj $params -name "timeout" -type "int" -default 2700 -aliases "execution_timeout"
+$state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present","absent","latest","reinstalled"
 $installargs = Get-AnsibleParam -obj $params -name "install_args" -type "str"
 $packageparams = Get-AnsibleParam -obj $params -name "params" -type "str"
 $allowemptychecksums = Get-AnsibleParam -obj $params -name "allow_empty_checksums" -type "bool" -default $false
@@ -143,7 +144,7 @@ Function Choco-Upgrade
         [Parameter(Mandatory=$false, Position=9)]
         [bool]$ignoredependencies,
         [Parameter(Mandatory=$false, Position=10)]
-        [string]$executiontimeout
+        [int]$timeout
     )
 
     if (-not (Choco-IsInstalled $package))
@@ -151,7 +152,12 @@ Function Choco-Upgrade
         throw "$package is not installed, you cannot upgrade"
     }
 
-    $cmd = "$executable upgrade -dv -y $package"
+    $cmd = "$executable upgrade -dv -y $package -timeout $timeout"
+
+    if ($check_mode)
+    {
+        $cmd += " -whatif"
+    }
 
     if ($version)
     {
@@ -191,11 +197,6 @@ Function Choco-Upgrade
     if ($ignoredependencies)
     {
         $cmd += " -ignoredependencies"
-    }
-
-    if ($executiontimeout)
-    {
-        $cmd += " --execution-timeout=$executiontimeout"
     }
 
     $output = invoke-expression $cmd
@@ -243,7 +244,7 @@ Function Choco-Install
         [Parameter(Mandatory=$false, Position=10)]
         [bool]$ignoredependencies,
         [Parameter(Mandatory=$false, Position=11)]
-        [string]$executiontimeout
+        [int]$timeout
     )
 
     if ((Choco-IsInstalled $package) -and -not $force)
@@ -253,7 +254,7 @@ Function Choco-Install
             Choco-Upgrade -package $package -version $version -source $source -force $force `
                 -installargs $installargs -packageparams $packageparams `
                 -allowemptychecksums $allowemptychecksums -ignorechecksums $ignorechecksums `
-                -ignoredependencies $ignoredependencies -executiontimeout $executiontimeout
+                -ignoredependencies $ignoredependencies -timeout $timeout
 
             return
         }
@@ -264,7 +265,12 @@ Function Choco-Install
         }
     }
 
-    $cmd = "$executable install -dv -y $package"
+    $cmd = "$executable install -dv -y $package -timeout $timeout"
+
+    if ($check_mode)
+    {
+        $cmd += " -whatif"
+    }
 
     if ($version)
     {
@@ -306,11 +312,6 @@ Function Choco-Install
         $cmd += " -ignoredependencies"
     }
 
-    if ($executiontimeout)
-    {
-        $cmd += " --execution-timeout=$executiontimeout"
-    }
-
     $results = invoke-expression $cmd
 
     $result.rc = $LastExitCode
@@ -336,7 +337,7 @@ Function Choco-Uninstall
         [Parameter(Mandatory=$false, Position=3)]
         [bool]$force,
         [Parameter(Mandatory=$false, Position=4)]
-        [string]$executiontimeout
+        [int]$timeout
 
     )
 
@@ -345,7 +346,12 @@ Function Choco-Uninstall
         return
     }
 
-    $cmd = "$executable uninstall -dv -y $package"
+    $cmd = "$executable uninstall -dv -y $package -timeout $timeout"
+
+    if ($check_mode)
+    {
+        $cmd += " -whatif"
+    }
 
     if ($version)
     {
@@ -360,11 +366,6 @@ Function Choco-Uninstall
     if ($packageparams)
     {
         $cmd += " -params '$packageparams'"
-    }
-
-    if ($executiontimeout)
-    {
-        $cmd += " --execution-timeout=$executiontimeout"
     }
 
     $results = invoke-expression $cmd
@@ -389,19 +390,27 @@ Try
         Choco-Install -package $package -version $version -source $source -force $force `
             -installargs $installargs -packageparams $packageparams `
             -allowemptychecksums $allowemptychecksums -ignorechecksums $ignorechecksums `
-            -ignoredependencies $ignoredependencies -executiontimeout $executiontimeout
+            -ignoredependencies $ignoredependencies -timeout $timeout
     }
     elseif ($state -eq "latest")
     {
         Choco-Upgrade -package $package -version $version -source $source -force $force `
             -installargs $installargs -packageparams $packageparams `
             -allowemptychecksums $allowemptychecksums -ignorechecksums $ignorechecksums `
-            -ignoredependencies $ignoredependencies
+            -ignoredependencies $ignoredependencies -timeout $timeout
     }
     elseif ($state -eq "absent")
     {
-        Choco-Uninstall -package $package -version $version -force $force `
-            -executiontimeout $executiontimeout
+        Choco-Uninstall -package $package -version $version -force $force -timeout $timeout
+    }
+    elseif ($state -eq "reinstalled")
+    {
+        Choco-Uninstall -package $package -version $version -force $force -timeout $timeout
+
+        Choco-Install -package $package -version $version -source $source -force $force `
+            -installargs $installargs -packageparams $packageparams `
+            -allowemptychecksums $allowemptychecksums -ignorechecksums $ignorechecksums `
+            -ignoredependencies $ignoredependencies -timeout $timeout
     }
 
     Exit-Json $result

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -37,20 +37,21 @@ description:
 options:
   name:
     description:
-      - Name of the package to be installed
+      - Name of the package to be installed.
     required: true
   state:
     description:
-      - State of the package on the system
+      - State of the package on the system.
     choices:
       - present
       - absent
       - latest
+      - reinstalled
     default: present
   force:
     description:
       - Forces install of the package (even if it already exists).
-      - Using C(force) will cause ansible to always report that a change was made
+      - Using C(force) will cause ansible to always report that a change was made.
     choices:
       - yes
       - no
@@ -69,10 +70,10 @@ options:
       - Ignored when C(state) is set to "absent".
   source:
     description:
-      - Specify source rather than using default chocolatey repository
+      - Specify source rather than using default chocolatey repository.
   install_args:
     description:
-      - Arguments to pass to the native installer
+      - Arguments to pass to the native installer.
     version_added: '2.1'
   params:
     description:
@@ -80,24 +81,25 @@ options:
     version_added: '2.1'
   allow_empty_checksums:
     description:
-      - Allow empty Checksums to be used
+      - Allow empty checksums to be used.
     default: false
     version_added: '2.2'
   ignore_checksums:
     description:
-      - Ignore Checksums
+      - Ignore checksums altogether.
     default: false
     version_added: '2.2'
   ignore_dependencies:
     description:
-      - Ignore dependencies, only install/upgrade the package itself
+      - Ignore dependencies, only install/upgrade the package itself.
     default: false
     version_added: '2.1'
-  execution_timeout:
+  timeout:
     description:
-      - Timeout to pass to the native installer
-    required: false
+      - The time to allow chocolatey to finish before timing out.
+    default: 2700
     version_added: '2.3'
+    aliases: [ execution_timeout ]
 author: "Trond Hindenes (@trondhindenes), Peter Mounce (@petemounce), Pepe Barbe (@elventear), Adam Keech (@smadam813)"
 '''
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
This patch implements:
- check-mode support
- add state "reinstalled"
- cleanup of timeout parameter

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_chocolatey

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3