### PR TITLE
docker_network - fixes #5732 - Add support for using network ID

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -217,12 +217,14 @@ class DockerNetworkManager(object):
             self.absent()
 
     def get_existing_network(self):
-        networks = self.client.networks()
-        network = None
-        for n in networks:
-            if n['Name'] == self.parameters.network_name:
-                network = n
-        return network
+        networks = self.client.networks(names=[self.parameters.network_name])
+        # check if a user is trying to find network by its Id
+        if not networks:
+            networks = self.client.networks(ids=[self.parameters.network_name])
+        if not networks:
+            return None
+        else:
+            return networks[0]
 
     def has_different_config(self, net):
         '''


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker_network

##### ANSIBLE VERSION
devel

##### SUMMARY
Ansible currently does not support addressing network by its ID, but docker supports the same.

This check-in makes use of docker-py "names" and "ids" filters, instead of fetching all the networks.

fixes issue #5732 

### Before:

```
$ docker network create test
dd41cb0d0cc7020c339ef2a6ebde6e14f1fc05807cb2fd9dc339da2b53b9aed7

$ ansible -m docker_network -a 'name=dd41cb0d0cc7020c339ef2a6ebde6e14f1fc05807cb2fd9dc339da2b53b9aed7 state=absent' localhost

localhost | SUCCESS => {
    "actions": [], 
    "changed": false
}
```

### After:

**Delete a network by its full ID**

```
$ ansible -m docker_network -a 'name=dd41cb0d0cc7020c339ef2a6ebde6e14f1fc05807cb2fd9dc339da2b53b9aed7 state=absent' localhost

localhost | SUCCESS => {
    "actions": [
        "Removed network dd41cb0d0cc7020c339ef2a6ebde6e14f1fc05807cb2fd9dc339da2b53b9aed7"
    ],
    "changed": true
}
```


**Delete a network by its short ID**

```
$ ansible -m docker_network -a 'name=dd41cb0d0cc7 state=absent' localhost

localhost | SUCCESS => {
    "actions": [
        "Removed network dd41cb0d0cc7"
    ],
    "changed": true
}
```


**Delete a network by its name**

```
$ ansible -m docker_network -a 'name=test state=absent' localhost

localhost | SUCCESS => {
    "actions": [
        "Removed network test"
    ],
    "changed": true
}
```

