### PR TITLE
Support setting a relative log_path without a leading directory

### DIFF
--- a/lib/ansible/config/data/config.yml
+++ b/lib/ansible/config/data/config.yml
@@ -697,6 +697,7 @@ DEFAULT_LOG_PATH:
   default: ''
   desc: 'TODO: write it'
   env: [{name: ANSIBLE_LOG_PATH}]
+  expand_relative_paths: True
   ini:
   - {key: log_path, section: defaults}
   value_type: path


### PR DESCRIPTION
Use more Pythonic pattern "Easier to ask for forgiveness than permission". As
Python already does the error checking, simply catch the exception instead of
reproducing the same checks.

https://docs.python.org/3/glossary.html#term-eafp

Fixes #22500

##### ISSUE TYPE
 - Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
$ $ansible --version
ansible 2.3.0 (devel 4ca7726e75) last updated 2017/03/10 10:16:35 (GMT -700)
```