### PR TITLE
fix false positive 'changed' flag in rabbitmq_user module when using multiple permissions

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq_user.py
@@ -233,7 +233,7 @@ class RabbitMqUser(object):
         return set(self.tags) != set(self._tags)
 
     def has_permissions_modifications(self):
-        return self._permissions != self.permissions
+        return sorted(self._permissions) != sorted(self.permissions)
 
 def main():
     arg_spec = dict(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
rabbitmq_user module sometimes marks task as changed even if parameters weren't really changed.
I've found that code checking permissions for changes is order-dependent.
Fix sorts lists of permissions before comparing them what fixes bug.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
rabbitmq_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file = /opt/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
