### PR TITLE
fixed win_nssm escaping issue

### DIFF
--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -135,7 +135,7 @@ Function Nssm-Install
 
     if (!(Service-Exists -name $name))
     {
-        $results = Nssm-Invoke "install ""$name"" $application"
+        $results = Nssm-Invoke "install ""$name"" ""$application"""
 
         if ($LastExitCode -ne 0)
         {
@@ -159,7 +159,7 @@ Function Nssm-Install
 
         if ($results -cnotlike $application)
         {
-            $cmd = "set ""$name"" Application $application"
+            $cmd = "set ""$name"" Application ""$application"""
 
             $results = Nssm-Invoke $cmd
 
@@ -179,7 +179,7 @@ Function Nssm-Install
      if ($result.changed)
      {
         $applicationPath = (Get-Item $application).DirectoryName
-        $cmd = "nssm set ""$name"" AppDirectory $applicationPath"
+        $cmd = "nssm set ""$name"" AppDirectory ""$applicationPath"""
 
         $results = invoke-expression $cmd
 


### PR DESCRIPTION
* bugfix: applicaiton setting was not properly escaped leading to issues
when picking application under C:\Program Files (x86)\...

##### SUMMARY
Discovered an issue with `win_nssm` module after trying to configure a service that was installed inside of `C:\Program Files (x86)\...`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_nssm

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file =
  configured module search path = ['/Users/cheinzma/ansible-library']
```
NOTE: this also affects 2.3 as that part of the code hasn't changed.


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

**Example Task**
```
- name: Install service
  win_nssm:
    name: tabelau_web_service
    application: "C:\\Program Files (x86)\\nodejs\\node.exe"
    app_parameters:
      _: "{{ install_path }}\\index.js"
    start_mode: auto
    state: started
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
**Before**
```
PLAY [Tableau 10.2 dev server configuration] ***********************************

TASK [setup] *******************************************************************
ok: [lva1-tableau01.linkedin.biz]

TASK [tableau-web-service : Install service] ***********************************
fatal: [lva1-tableau01.linkedin.biz]: FAILED! => {"changed": false, "failed": true, "msg": "an exception occ
urred when invoking NSSM: The term 'x86' is not recognized as the name of a cmdlet, function, script file, o
r operable program. Check the spelling of the name, or if a path was included, verify that the path is corre
ct and try again."}
        to retry, use: --limit @/Users/cheinzma/Documents/tableau-playbook/tableau-102.retry

PLAY RECAP *********************************************************************
lva1-tableau01.linkedin.biz : ok=1    changed=0    unreachable=0    failed=1
```

**After**
```
➜  tableau-playbook git:(master) ✗ ansible-playbook tableau-102.yaml --start-at-task="Install service"

PLAY [Tableau 10.2 dev server configuration] ***********************************

TASK [setup] *******************************************************************
ok: [lva1-tableau01.linkedin.biz]

TASK [tableau-web-service : Install service] ***********************************
changed: [lva1-tableau01.linkedin.biz]

...
```