### PR TITLE
Add win_chocolatey proxy support (#21886)

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -37,6 +37,9 @@ $allowemptychecksums = Get-AnsibleParam -obj $params -name "allow_empty_checksum
 $ignorechecksums = Get-AnsibleParam -obj $params -name "ignore_checksums" -type "bool" -default $false
 $ignoredependencies = Get-AnsibleParam -obj $params -name "ignore_dependencies" -type "bool" -default $false
 $skipscripts = Get-AnsibleParam -obj $params -name "skip_scripts" -type "bool" -default $false
+$proxy_url = Get-AnsibleParam -obj $params -name "proxy_url" -type "str"
+$proxy_username = Get-AnsibleParam -obj $params -name "proxy_username" -type "str"
+$proxy_password = Get-AnsibleParam -obj $params -name "proxy_password" -type "str"
 
 $result = @{
     changed = $false
@@ -69,8 +72,19 @@ Function Chocolatey-Install-Upgrade
     if ($ChocoAlreadyInstalled -eq $null)
     {
 
-        # We need to install chocolatey
-        $install_output = (new-object net.webclient).DownloadString("https://chocolatey.org/install.ps1") | powershell -
+        #We need to install chocolatey
+        $wc = New-Object System.Net.WebClient;
+        if ($proxy_url)
+        {
+            #We need to configure proxy
+            $wp = New-Object System.Net.WebProxy($proxy_url, $true);
+            $wc.proxy = $wp;
+            if ($proxy_username -and $proxy_password) {
+                $passwd = ConvertTo-SecureString $proxy_password -AsPlainText -Force
+                $wp.Credentials = New-Object System.Management.Automation.PSCredential($proxy_username, $passwd)
+            }
+        }
+        $install_output = $wc.DownloadString("https://chocolatey.org/install.ps1") | powershell -
         if ($LASTEXITCODE -ne 0)
         {
             $result.choco_bootstrap_output = $install_output
@@ -432,9 +446,52 @@ Function Choco-Uninstall
     $result.changed = $true
 }
 
+Function Choco-ConfigureProxy
+{
+    [CmdletBinding()]
+
+    param(
+        [Parameter(Mandatory=$false, Position=1)]
+        [string]$proxy_url,
+        [Parameter(Mandatory=$false, Position=2)]
+        [string]$proxy_username,
+        [Parameter(Mandatory=$false, Position=3)]
+        [string]$proxy_password
+    )
+    $hash = @{
+        proxy = $proxy_url
+        proxyUser = $proxy_username
+        proxyPassword = $proxy_password
+    }
+    foreach ($h in $hash.GetEnumerator()) {
+        if ($($h.Value))
+        {
+          $cmd = "$executable config set $($h.Name) $($h.Value)"
+        }
+        else
+        {
+          $cmd = "$executable config unset $($h.Name)"
+        }
+        $results = Invoke-Expression $cmd
+        if ($LastExitCode -ne 0)
+        {
+            Set-Attr $result "choco_error_cmd" $cmd
+            Set-Attr $result "choco_error_log" "$results"
+
+            Throw "Error setting $($h.Name) with $($h.Value)"
+        }
+        If ("$results" -notmatch "Nothing to change. Config already set.")
+        {
+            $result.changed = $true
+        }
+    }
+}
+
 Try
 {
     Chocolatey-Install-Upgrade
+
+    Choco-ConfigureProxy
 
     if ($state -eq "present" -or $state -eq "latest")
     {

--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -478,8 +478,8 @@ Function Choco-ConfigureProxy
         $results = Invoke-Expression $cmd
         if ($LastExitCode -ne 0)
         {
-            Set-Attr $result "choco_error_cmd" $cmd
-            Set-Attr $result "choco_error_log" "$results"
+            $result.choco_error_cmd = $cmd
+            $result.choco_error_log = $results
 
             Throw "Error setting $($h.Name) with $($h.Value)"
         }

--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -77,9 +77,12 @@ Function Chocolatey-Install-Upgrade
         if ($proxy_url)
         {
             #We need to configure proxy
+            $env:chocolateyProxyLocation = $proxy_url
             $wp = New-Object System.Net.WebProxy($proxy_url, $true);
             $wc.proxy = $wp;
             if ($proxy_username -and $proxy_password) {
+                $env:chocolateyProxyUser = $proxy_username
+                $env:chocolateyProxyPassword = $proxy_password
                 $passwd = ConvertTo-SecureString $proxy_password -AsPlainText -Force
                 $wp.Credentials = New-Object System.Management.Automation.PSCredential($proxy_username, $passwd)
             }

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -106,6 +106,18 @@ options:
     type: bool
     default: 'no'
     version_added: '2.4'
+  proxy_url:
+    description:
+      - Proxy url used to install chocolatey and the package
+    version_added: '2.4'
+  proxy_username:
+    description:
+      - Proxy username used to install chocolatey and the package
+    version_added: '2.4'
+  proxy_password:
+    description:
+      - Proxy password used to install chocolatey and the package
+    version_added: '2.4'
 notes:
 - Provide the C(version) parameter value as a string (e.g. C('6.1')), otherwise it
   is considered to be a floating-point number and depending on the locale could
@@ -115,6 +127,7 @@ author:
 - Peter Mounce (@petemounce)
 - Pepe Barbe (@elventear)
 - Adam Keech (@smadam813)
+- Pierre Templier (@ptemplier)
 '''
 
 # TODO:
@@ -164,4 +177,11 @@ EXAMPLES = r'''
   with_items:
     - pscx
     - windirstat
+
+- name: Install curl using proxy
+  win_chocolatey:
+    name: curl
+    proxy_url: http://proxy-server:8080/
+    proxy_username: joe
+    proxy_password: p@ssw0rd
 '''


### PR DESCRIPTION
##### SUMMARY
Add win_chocolatey proxy support.

This fixes #21886

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
win_chocolatey

##### ANSIBLE VERSION

```
ansible 2.3.0 (devel 615a571c8f) last updated 2017/03/10 22:35:20 (GMT +200)
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Oct 10 2016, 12:50:22) [GCC 5.4.0]
```

##### ADDITIONAL INFORMATION

