### PR TITLE
Fix tracebacks on empty config related env vars

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -119,7 +119,7 @@ def get_config(p, section, key, env_var, default, value_type=None, expand_relati
         to True then also change any relative paths into absolute paths.  The
         default is False.
     '''
-    value = _get_config(p, section, key, env_var, default)
+    value = _get_config(p, section, key, env_var, default, value_type)
     if value_type == 'boolean':
         value = mk_boolean(value)
 
@@ -132,7 +132,7 @@ def get_config(p, section, key, env_var, default, value_type=None, expand_relati
     return to_text(value, errors='surrogate_or_strict', nonstring='passthru')
 
 
-def _get_config(p, section, key, env_var, default):
+def _get_config(p, section, key, env_var, default, value_type):
     ''' helper function for get_config '''
     value = default
 
@@ -146,6 +146,10 @@ def _get_config(p, section, key, env_var, default):
         env_value = os.environ.get(env_var, None)
         if env_value is not None and env_value != default:
             value = env_value
+
+            # special case for unsetting type=list if we get an empty string
+            if value_type in ['list', 'pathlist'] and env_value == '':
+                value = []
 
     return to_text(value, errors='surrogate_or_strict', nonstring='passthru')
 

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -57,6 +57,7 @@ def shell_expand(path, expand_relative_paths=False):
             path = os.path.abspath(path)
     return path
 
+
 def _cast_config_value(value, value_type, expand_relative_paths):
     if value_type == 'integer':
         value = int(value)
@@ -84,8 +85,8 @@ def _cast_config_value(value, value_type, expand_relative_paths):
 
     elif value_type == 'pathlist':
         if isinstance(value, string_types):
-            value = [shell_expand(x, expand_relative_paths=expand_relative_paths) \
-                        for x in value.split(os.pathsep)]
+            value = [shell_expand(x, expand_relative_paths=expand_relative_paths)
+                     for x in value.split(os.pathsep)]
 
     elif isinstance(value, string_types):
         value = unquote(value)

--- a/test/units/test_constants.py
+++ b/test/units/test_constants.py
@@ -182,11 +182,33 @@ class TestGetConfig:
         assert constants.get_config(cfgparser, 'defaults', 'unknown', 'ANSIBLE_TEST_VAR', '10', value_type='integer') == 10
         assert constants.get_config(cfgparser, 'defaults', 'unknown', 'ANSIBLE_TEST_VAR', 10, value_type='integer') == 10
 
+    def test_value_type_integer_0(self, cfgparser):
+        assert constants.get_config(cfgparser, 'defaults', 'unknown', 'ANSIBLE_TEST_VAR', '0', value_type='integer') == 0
+        assert constants.get_config(cfgparser, 'defaults', 'unknown', 'ANSIBLE_TEST_VAR', 0, value_type='integer') == 0
+
+    def test_value_type_integer_0_from_env_var_empty_default_int(self, cfgparser):
+        os.environ['ANSIBLE_TEST_VAR'] = ''
+
+        assert constants.get_config(cfgparser, 'unknown', 'defaults_one', 'ANSIBLE_TEST_VAR', 0, value_type='integer') == 0
+        del os.environ['ANSIBLE_TEST_VAR']
+
     def test_value_type_float(self, cfgparser):
         assert constants.get_config(cfgparser, 'defaults', 'unknown', 'ANSIBLE_TEST_VAR', '10', value_type='float') == 10.0
         assert constants.get_config(cfgparser, 'defaults', 'unknown', 'ANSIBLE_TEST_VAR', 10, value_type='float') == 10.0
         assert constants.get_config(cfgparser, 'defaults', 'unknown', 'ANSIBLE_TEST_VAR', '11.5', value_type='float') == 11.5
         assert constants.get_config(cfgparser, 'defaults', 'unknown', 'ANSIBLE_TEST_VAR', 11.5, value_type='float') == 11.5
+
+    def test_value_type_float_0(self, cfgparser):
+        assert constants.get_config(cfgparser, 'defaults', 'unknown', 'ANSIBLE_TEST_VAR', 0.0, value_type='float') == 0.0
+        assert constants.get_config(cfgparser, 'defaults', 'unknown', 'ANSIBLE_TEST_VAR', '0.0', value_type='float') == 0.0
+
+    def test_value_type_float_0_from_env_var_empty(self, cfgparser):
+        os.environ['ANSIBLE_TEST_VAR'] = ''
+
+        assert constants.get_config(cfgparser, 'defaults', 'unknown', 'ANSIBLE_TEST_VAR', 0.0, value_type='float') == 0.0
+        assert constants.get_config(cfgparser, 'unknown_section', 'unknown_key', 'ANSIBLE_TEST_VAR', 0.0, value_type='float') == 0.0
+
+        del os.environ['ANSIBLE_TEST_VAR']
 
     def test_value_type_list(self, cfgparser):
         assert constants.get_config(cfgparser, 'defaults', 'unknown', 'ANSIBLE_TEST_VAR', 'one,two,three', value_type='list') == ['one', 'two', 'three']


### PR DESCRIPTION

##### SUMMARY
Fix tracebacks on empty config related env vars

If an env exists, it's value will override the
default or config value. If the value of the env
var was empty (ANSIBLE_VERBOSIT= ansible...) some
constants.py vars would become an empty string,
regardless of their type and eventually cause errors.
ie, a constants.py value like ANSIBLE_REMOTE_PORT which
is expected to be an int, could instead be ''.

Some options known to cause crashes this way include
ANSIBLE_VERBOSITY, ANSIBLE_TIMEOUT, and
ANSIBLE_REMOTE_PORT.

Fix is two parts.

1) Try to detect if the env var is Falsey and if that
value is also not the default value. This catches some
cases where the default is 0, 0.0, etc.

2) If the env var value appears to be set, try the config
type casting but handle any ValueErrors that result. This
handles cases where the env var value is ''. If the casting
raises an exception, fallback to using using the default value.

Fixes #22468, #22469, #22470

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/constants.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (constants_empty_env_var_22469 ee3a79532c) last updated 2017/03/10 17:31:31 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
