### PR TITLE
Changes command and entrypoint to type list

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -574,7 +574,7 @@ EXAMPLES = '''
   docker_container:
     name: sleepy
     image: ubuntu:14.04
-    command: sleep infinity
+    command: ["sleep", "infinity"]
 
 - name: Add container to networks
   docker_container:
@@ -800,6 +800,14 @@ class TaskParameters(DockerBaseClass):
                     self.fail("Parameter error: network named %s could not be found. Does it exist?" % network['name'])
                 if network.get('links'):
                     network['links'] = self._parse_links(network['links'])
+
+        if self.entrypoint:
+            # convert from list to str.
+            self.entrypoint = ' '.join([str(x) for x in self.entrypoint])
+
+        if self.command:
+            # convert from list to str
+            self.command = ' '.join([str(x) for x in self.command])
 
     def fail(self, msg):
         self.client.module.fail_json(msg=msg)
@@ -1483,7 +1491,6 @@ class Container(DockerBaseClass):
         return expected_devices
 
     def _get_expected_entrypoint(self):
-        self.log('_get_expected_entrypoint')
         if not self.parameters.entrypoint:
             return None
         return shlex.split(self.parameters.entrypoint)
@@ -1940,7 +1947,7 @@ def main():
         blkio_weight=dict(type='int'),
         capabilities=dict(type='list'),
         cleanup=dict(type='bool', default=False),
-        command=dict(type='str'),
+        command=dict(type='list'),
         cpu_period=dict(type='int'),
         cpu_quota=dict(type='int'),
         cpuset_cpus=dict(type='str'),
@@ -1953,7 +1960,7 @@ def main():
         dns_search_domains=dict(type='list'),
         env=dict(type='dict'),
         env_file=dict(type='path'),
-        entrypoint=dict(type='str'),
+        entrypoint=dict(type='list'),
         etc_hosts=dict(type='dict'),
         exposed_ports=dict(type='list', aliases=['exposed', 'expose']),
         force_kill=dict(type='bool', default=False, aliases=['forcekill']),


### PR DESCRIPTION
##### SUMMARY
Defines `command` and `entrypoint` parameters as type `list` in order to support the Docker style of shell command entry that looks like: `["/bin/bash", "-c", "sleep", "100"]`

If either is specified as a string, the module still works as expected. The parameters appear to the module as a single element array, and since the module converts these parameters to strings anyway, a single element array converts just fine. 

Fixes #22510 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/cloud/docker/docker_container.py 

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 82eb9e676f) last updated 2017/03/10 23:47:30 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Oct 11 2016, 05:24:00) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```


##### ADDITIONAL INFORMATION

Here's my test playbook for `entrypoint`:

```
- name: docker_container module entrypoint directive regression
  hosts: localhost
  connection: local

  tasks:
    - name: Remove an existing container
      docker_container:
        state: absent
        name: "{{ item }}"
      with_items:
        - my_test
        - my_test2

    - name: Show that it works as an array
      docker_container:
        image: alpine
        entrypoint: ["/bin/sh", "-c", "date"]
        debug: yes
        name: my_test
        state: present

    - name: Show that it is idempotent as a string
      docker_container:
        image: alpine
        entrypoint: /bin/sh -c date
        debug: yes
        name: my_test
        state: present
      register: output

    - name: Should be idempotent
      assert:
        that: not output.changed

    - name: Show that it works as a string
      docker_container:
        image: alpine
        entrypoint: /bin/sh -c date
        debug: yes
        name: my_test2
        state: present

    - name: Show that it is idempotent as a list
      docker_container:
        image: alpine
        entrypoint: ["/bin/sh", "-c", "date"]
        debug: yes
        name: my_test2
        state: present
      register: output

    - name: Should be idempotent
      assert:
        that: not output.changed
```

And run output:

```
PLAY [docker_container module entrypoint directive regression] *************************************************************************************************************************************************

TASK [Gathering Facts] *****************************************************************************************************************************************************************************************
ok: [localhost]

TASK [Remove an existing container] ****************************************************************************************************************************************************************************
changed: [localhost] => (item=my_test)
changed: [localhost] => (item=my_test2)

TASK [Show that it works as an array] **************************************************************************************************************************************************************************
changed: [localhost]

TASK [Show that it is idempotent as a string] ******************************************************************************************************************************************************************
ok: [localhost]

TASK [Should be idempotent] ************************************************************************************************************************************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [Show that it works as a string] **************************************************************************************************************************************************************************
changed: [localhost]

TASK [Show that it is idempotent as a list] ********************************************************************************************************************************************************************
ok: [localhost]

TASK [Should be idempotent] ************************************************************************************************************************************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "All assertions passed"
}

PLAY RECAP *****************************************************************************************************************************************************************************************************
localhost                  : ok=8    changed=3    unreachable=0    failed=0
```

Run the same playbook replacing `entrypoint` with `command`, and it works as expected.
