### PR TITLE
Add assert filter

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -438,6 +438,12 @@ def skipped(*a, **kw):
     skipped = item.get('skipped', False)
     return skipped
 
+def assert_filter(value, msg=''):
+    ''' Fail if value is falsy, else return empty string i.e. continue evaluation of remaining template '''
+    if not value:
+        raise errors.AnsibleFilterError('assertion failed: %s' % (msg or '<no message given>',))
+    return ''
+
 
 @environmentfilter
 def do_groupby(environment, value, attribute):
@@ -556,6 +562,9 @@ class FilterModule(object):
             # skip testing
             'skipped' : skipped,
             'skip'    : skipped,
+
+            # assertions
+            'assert': assert_filter,
 
             # debug
             'type_debug': lambda o: o.__class__.__name__,


### PR DESCRIPTION
##### SUMMARY
Introduces a new Jinja template filter `assert` to fail on falsy expression or otherwise resolve to nothing (empty string).

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
assert [new filter plugin]

##### ANSIBLE VERSION
```
ansible 2.2.1.0
```


##### ADDITIONAL INFORMATION

Example use case (there are many others): for a missing dict key, Ansible doesn't give great error messages nor location, and even if it did, you may want to provide your own error message.

Usage:
```
user_uid: '{{ (username in dict_of_uids)|assert(username + " not found in dict_of_uids, please add that user") }}{{ dict_of_uids[username] }}'
```

On successful assertion, the filter resolves to an empty string for obvious reasons.

Output:
```
TASK [test assertion] **********************************************************
fatal: [somehostname]: FAILED! => {"failed": true, "msg": "assertion failed: myuser not found in dict_of_uids"}
```
