### PR TITLE
fix #22464 without fully implementing support for ceph bucket update

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -434,7 +434,7 @@ def main():
     state = module.params.get("state")
 
     if state == 'present':
-        create_or_update_bucket(connection, module, location)
+        create_or_update_bucket(connection, module, location, flavour=flavour)
     elif state == 'absent':
         destroy_bucket(connection, module, flavour=flavour)
 


### PR DESCRIPTION
##### SUMMARY
One-line fix for the bug in s3_bucket described in #22464 without refactoring and implementing the missing support for s3_bucket updates in ceph (as suggested by @s-hertel in #22475).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
s3_bucket module

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file =
  configured module search path = Default w/o overrides
  python version = 3.5.2 (default, Sep 19 2016, 11:45:55) [GCC 4.9.1]
```

