### PR TITLE
Redhat subscription proxy support

### DIFF
--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -59,6 +59,30 @@ options:
             - Specify CDN baseurl
         required: False
         default: Current value from C(/etc/rhsm/rhsm.conf) is the default
+    server_proxy_hostname:
+        description:
+            - Specify a HTTP proxy hostname
+        required: False
+        default: Current value from C(/etc/rhsm/rhsm.conf) is the default
+        version_added: "2.3"
+    server_proxy_port:
+        description:
+            - Specify a HTTP proxy port
+        required: False
+        default: Current value from C(/etc/rhsm/rhsm.conf) is the default
+        version_added: "2.3"
+    server_proxy_user:
+        description:
+            - Specify a user for HTTP proxy with basic authentication
+        required: False
+        default: Current value from C(/etc/rhsm/rhsm.conf) is the default
+        version_added: "2.3"
+    server_proxy_password:
+        description:
+            - Specify a password for HTTP proxy with basic authentication
+        required: False
+        default: Current value from C(/etc/rhsm/rhsm.conf) is the default
+        version_added: "2.3"
     autosubscribe:
         description:
             - Upon successful registration, auto-consume available subscriptions


### PR DESCRIPTION
##### SUMMARY
Add support for registration through subscription manager through HTTP proxy

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module `redhat_subscription`

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Oct 11 2016, 05:24:00) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```