### PR TITLE
win_firewall_rule doesn't fail when profile is "any" or remoteip is IPv4 and the task runs more than once.

### DIFF
--- a/lib/ansible/modules/windows/win_firewall_rule.ps1
+++ b/lib/ansible/modules/windows/win_firewall_rule.ps1
@@ -20,6 +20,49 @@
 # WANT_JSON
 # POWERSHELL_COMMON
 
+function convertToNetmask($maskLength) {
+    [IPAddress] $ip = 0;
+    $ip.Address = ([UInt32]::MaxValue) -shl (32 - $maskLength) -shr (32 - $maskLength)
+    return $ip.IPAddressToString
+}
+
+function preprocessAndCompare($key, $outputValue, $fwsettingValue) {
+    if ($key -eq 'RemoteIP') {
+        if ($outputValue -eq $fwsettingValue) {
+            return $true
+        }
+
+        if ($outputValue -eq $fwsettingValue+'-'+$fwsettingValue) {
+            return $true
+        }
+
+        if (($outputValue -eq $fwsettingValue+'/32') -or ($outputValue -eq $fwsettingValue+'/255.255.255.255')) {
+            return $true
+        }
+
+        if ($outputValue -match '^([\d\.]+)\/(\d+)$') {
+            $netmask = convertToNetmask($Matches[2])
+            if ($fwsettingValue -eq $Matches[1]+"/"+$netmask) {
+                return $true
+            }
+        }
+
+        if ($fwsettingValue -match '^([\d\.]+)\/(\d+)$') {
+            $netmask = convertToNetmask($Matches[2])
+            if ($outputValue -eq $Matches[1]+"/"+$netmask) {
+                return $true
+            }
+        }
+    }
+    elseif ($key -eq 'Profiles') {
+        if (($fwsettingValue -eq "any") -and ($outputValue -eq "Domain,Private,Public")) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
 function getFirewallRule ($fwsettings) {
     try {
 
@@ -69,17 +112,15 @@ function getFirewallRule ($fwsettings) {
                 };
             } else {
                 ForEach($fwsetting in $fwsettings.GetEnumerator()) {
-                    if ( $output.$($fwsetting.Key) -ne $fwsettings.$($fwsetting.Key)) {
-
-                        if (($fwsetting.Key -eq 'RemoteIP') -and (($output.$($fwsetting.Key) -eq ($fwsettings.$($fwsetting.Key)+'-'+$fwsettings.$($fwsetting.Key))) -or ($output.$($fwsetting.Key) -eq ($fwsettings.$($fwsetting.Key)+'/32')))) {
+                    if ($output.$($fwsetting.Key) -ne $fwsettings.$($fwsetting.Key)) {
+                        if ((preprocessAndCompare -key $fwsetting.Key -outputValue $output.$($fwsetting.Key) -fwsettingValue $fwsettings.$($fwsetting.Key))) {
                             Continue
                         } elseif (($fwsetting.Key -eq 'DisplayName') -and ($output."Rule Name" -eq $fwsettings.$($fwsetting.Key))) {
-                            Continue
-                        } elseif (($fwsetting.Key -eq 'Profiles') -and ($fwsettings.$($fwsetting.Key) -eq "any") -and ($output.$($fwsetting.Key) -eq "Domain,Private,Public")) {
                             Continue
                         } else {
                             $diff=$true;
                             $difference+=@($fwsettings.$($fwsetting.Key));
+                            #$difference+=@("output:$rule.$fwsetting,fwsetting:$fwsettings.$fwsetting");
                         };
                     };
                 };

--- a/lib/ansible/modules/windows/win_firewall_rule.ps1
+++ b/lib/ansible/modules/windows/win_firewall_rule.ps1
@@ -71,7 +71,7 @@ function getFirewallRule ($fwsettings) {
                 ForEach($fwsetting in $fwsettings.GetEnumerator()) {
                     if ( $output.$($fwsetting.Key) -ne $fwsettings.$($fwsetting.Key)) {
 
-                        if (($fwsetting.Key -eq 'RemoteIP') -and ($output.$($fwsetting.Key) -eq ($fwsettings.$($fwsetting.Key)+'-'+$fwsettings.$($fwsetting.Key)))) {
+                        if (($fwsetting.Key -eq 'RemoteIP') -and (($output.$($fwsetting.Key) -eq ($fwsettings.$($fwsetting.Key)+'-'+$fwsettings.$($fwsetting.Key))) -or ($output.$($fwsetting.Key) -eq ($fwsettings.$($fwsetting.Key)+'/32')))) {
                             Continue
                         } elseif (($fwsetting.Key -eq 'DisplayName') -and ($output."Rule Name" -eq $fwsettings.$($fwsetting.Key))) {
                             Continue

--- a/lib/ansible/modules/windows/win_firewall_rule.ps1
+++ b/lib/ansible/modules/windows/win_firewall_rule.ps1
@@ -72,9 +72,11 @@ function getFirewallRule ($fwsettings) {
                     if ( $output.$($fwsetting.Key) -ne $fwsettings.$($fwsetting.Key)) {
 
                         if (($fwsetting.Key -eq 'RemoteIP') -and ($output.$($fwsetting.Key) -eq ($fwsettings.$($fwsetting.Key)+'-'+$fwsettings.$($fwsetting.Key)))) {
-                            $donothing=$false
+                            Continue
                         } elseif (($fwsetting.Key -eq 'DisplayName') -and ($output."Rule Name" -eq $fwsettings.$($fwsetting.Key))) {
-                            $donothing=$false
+                            Continue
+                        } elseif (($fwsetting.Key -eq 'Profiles') -and ($fwsettings.$($fwsetting.Key) -eq "any") -and ($output.$($fwsetting.Key) -eq "Domain,Private,Public")) {
+                            Continue
                         } else {
                             $diff=$true;
                             $difference+=@($fwsettings.$($fwsetting.Key));

--- a/lib/ansible/modules/windows/win_firewall_rule.ps1
+++ b/lib/ansible/modules/windows/win_firewall_rule.ps1
@@ -120,7 +120,6 @@ function getFirewallRule ($fwsettings) {
                         } else {
                             $diff=$true;
                             $difference+=@($fwsettings.$($fwsetting.Key));
-                            #$difference+=@("output:$rule.$fwsetting,fwsetting:$fwsettings.$fwsetting");
                         };
                     };
                 };

--- a/test/integration/targets/win_firewall_rule/aliases
+++ b/test/integration/targets/win_firewall_rule/aliases
@@ -1,0 +1,1 @@
+windows/ci/group3

--- a/test/integration/targets/win_firewall_rule/tasks/main.yml
+++ b/test/integration/targets/win_firewall_rule/tasks/main.yml
@@ -1,0 +1,215 @@
+- name: Remove potentially leftover firewall rule
+  win_firewall_rule:
+    name: http
+    state: absent
+    action: "{{ item }}"
+    direction: In
+  with_items:
+     - allow
+     - block
+
+- name: Add firewall rule
+  win_firewall_rule:
+    name: http
+    enable: yes
+    state: present
+    localport: 80
+    action: allow
+    direction: In
+    protocol: TCP
+  register: add_firewall_rule
+
+- name: Check that creating new firewall rule succeeds with a change
+  assert:
+    that:
+    - add_firewall_rule.failed == false
+    - add_firewall_rule.changed == true
+
+- name: Add same firewall rule (again)
+  win_firewall_rule:
+    name: http
+    enable: yes
+    state: present
+    localport: 80
+    action: allow
+    direction: In
+    protocol: TCP
+  register: add_firewall_rule_again
+
+- name: Check that creating same firewall rule succeeds without a change
+  assert:
+    that:
+    - add_firewall_rule_again.failed == false
+    - add_firewall_rule_again.changed == false
+
+- name: Remove firewall rule
+  win_firewall_rule:
+    name: http
+    enable: yes
+    state: absent
+    localport: 80
+    action: allow
+    direction: In
+    protocol: TCP
+  register: remove_firewall_rule
+
+- name: Check that removing existing firewall rule succeeds with a change
+  assert:
+    that:
+    - remove_firewall_rule.failed == false
+    - remove_firewall_rule.changed == true
+
+- name: Remove absent firewall rule
+  win_firewall_rule:
+    name: http
+    enable: yes
+    state: absent
+    localport: 80
+    action: allow
+    direction: In
+    protocol: TCP
+  register: remove_absent_firewall_rule
+
+- name: Check that removing non existing firewall rule succeeds without a change
+  assert:
+    that:
+    - remove_absent_firewall_rule.failed == false
+    - remove_absent_firewall_rule.changed == false
+
+- name: Add firewall rule
+  win_firewall_rule:
+    name: http
+    enable: yes
+    state: present
+    localport: 80
+    action: allow
+    direction: In
+    protocol: TCP
+
+- name: Add different firewall rule
+  win_firewall_rule:
+    name: http
+    enable: yes
+    state: present
+    localport: 80
+    action: block
+    direction: In
+    protocol: TCP
+  ignore_errors: yes
+  register: add_different_firewall_rule_without_force
+
+- name: Check that creating different firewall rule without enabling force setting fails
+  assert:
+    that:
+    - add_different_firewall_rule_without_force.failed == true
+    - add_different_firewall_rule_without_force.changed == false
+    - add_different_firewall_rule_without_force.difference == ["block"]
+
+- name: Add different firewall rule with force setting
+  win_firewall_rule:
+    name: http
+    enable: yes
+    state: present
+    localport: 80
+    action: block
+    direction: In
+    protocol: TCP
+    force: yes
+  register: add_different_firewall_rule_with_force
+
+- name: Check that creating different firewall rule with enabling force setting succeeds
+  assert:
+    that:
+    - add_different_firewall_rule_with_force.failed == false
+    - add_different_firewall_rule_with_force.changed == true
+    - add_different_firewall_rule_with_force.difference == ["block"]
+
+- name: Add firewall rule when remoteip is range
+  win_firewall_rule:
+    name: http
+    enable: yes
+    state: present
+    localport: 80
+    remoteip: '192.168.0.1-192.168.0.5'
+    action: allow
+    direction: In
+    protocol: TCP
+    force: yes
+
+- name: Add same firewall rule when remoteip is range (again)
+  win_firewall_rule:
+    name: http
+    enable: yes
+    state: present
+    localport: 80
+    remoteip: '192.168.0.1-192.168.0.5'
+    action: allow
+    direction: In
+    protocol: TCP
+  register: add_firewall_rule_with_range_remoteip_again
+
+- name: Check that creating same firewall rule when remoteip is range succeeds without a change
+  assert:
+    that:
+    - add_firewall_rule_with_range_remoteip_again.failed == false
+    - add_firewall_rule_with_range_remoteip_again.changed == false
+
+- name: Add firewall rule when remoteip is subnet
+  win_firewall_rule:
+    name: http
+    enable: yes
+    state: present
+    localport: 80
+    remoteip: '192.168.0.0/24'
+    action: allow
+    direction: In
+    protocol: TCP
+    force: yes
+
+- name: Add same firewall rule when remoteip is subnet (again)
+  win_firewall_rule:
+    name: http
+    enable: yes
+    state: present
+    localport: 80
+    remoteip: '192.168.0.0/24'
+    action: allow
+    direction: In
+    protocol: TCP
+  register: add_firewall_rule_with_subnet_remoteip_again
+
+- name: Check that creating same firewall rule when remoteip is subnet succeeds without a change
+  assert:
+    that:
+    - add_firewall_rule_with_subnet_remoteip_again.failed == false
+    - add_firewall_rule_with_subnet_remoteip_again.changed == false
+
+- name: Add firewall rule when remoteip is IPv4
+  win_firewall_rule:
+    name: http
+    enable: yes
+    state: present
+    localport: 80
+    remoteip: '192.168.0.1'
+    action: allow
+    direction: In
+    protocol: TCP
+    force: yes
+
+- name: Add same firewall rule when remoteip is IPv4 (again)
+  win_firewall_rule:
+    name: http
+    enable: yes
+    state: present
+    localport: 80
+    remoteip: '192.168.0.1'
+    action: allow
+    direction: In
+    protocol: TCP
+  register: add_firewall_rule_with_ipv4_remoteip_again
+
+- name: Check that creating same firewall rule when remoteip is IPv4 succeeds without a change
+  assert:
+    that:
+    - add_firewall_rule_with_ipv4_remoteip_again.failed == false
+    - add_firewall_rule_with_ipv4_remoteip_again.changed == false

--- a/test/integration/targets/win_firewall_rule/tasks/main.yml
+++ b/test/integration/targets/win_firewall_rule/tasks/main.yml
@@ -130,7 +130,7 @@
     enable: yes
     state: present
     localport: 80
-    remoteip: '192.168.0.1-192.168.0.5'
+    remoteip: 192.168.0.1-192.168.0.5
     action: allow
     direction: In
     protocol: TCP
@@ -142,7 +142,7 @@
     enable: yes
     state: present
     localport: 80
-    remoteip: '192.168.0.1-192.168.0.5'
+    remoteip: 192.168.0.1-192.168.0.5
     action: allow
     direction: In
     protocol: TCP
@@ -160,7 +160,7 @@
     enable: yes
     state: present
     localport: 80
-    remoteip: '192.168.0.0/24'
+    remoteip: 192.168.0.0/24
     action: allow
     direction: In
     protocol: TCP
@@ -172,7 +172,7 @@
     enable: yes
     state: present
     localport: 80
-    remoteip: '192.168.0.0/24'
+    remoteip: 192.168.0.0/24
     action: allow
     direction: In
     protocol: TCP
@@ -190,7 +190,7 @@
     enable: yes
     state: present
     localport: 80
-    remoteip: '192.168.0.1'
+    remoteip: 192.168.0.1
     action: allow
     direction: In
     protocol: TCP
@@ -202,7 +202,7 @@
     enable: yes
     state: present
     localport: 80
-    remoteip: '192.168.0.1'
+    remoteip: 192.168.0.1
     action: allow
     direction: In
     protocol: TCP

--- a/test/integration/targets/win_firewall_rule/tasks/main.yml
+++ b/test/integration/targets/win_firewall_rule/tasks/main.yml
@@ -154,7 +154,7 @@
     - add_firewall_rule_with_range_remoteip_again.failed == false
     - add_firewall_rule_with_range_remoteip_again.changed == false
 
-- name: Add firewall rule when remoteip is subnet
+- name: Add firewall rule when remoteip in CIDR notation
   win_firewall_rule:
     name: http
     enable: yes
@@ -166,7 +166,7 @@
     protocol: TCP
     force: yes
 
-- name: Add same firewall rule when remoteip is subnet (again)
+- name: Add same firewall rule when remoteip in CIDR notation (again)
   win_firewall_rule:
     name: http
     enable: yes
@@ -176,13 +176,43 @@
     action: allow
     direction: In
     protocol: TCP
-  register: add_firewall_rule_with_subnet_remoteip_again
+  register: add_firewall_rule_with_cidr_remoteip_again
 
-- name: Check that creating same firewall rule when remoteip is subnet succeeds without a change
+- name: Check that creating same firewall rule succeeds without a change when remoteip in CIDR notation
   assert:
     that:
-    - add_firewall_rule_with_subnet_remoteip_again.failed == false
-    - add_firewall_rule_with_subnet_remoteip_again.changed == false
+    - add_firewall_rule_with_cidr_remoteip_again.failed == false
+    - add_firewall_rule_with_cidr_remoteip_again.changed == false
+
+- name: Add firewall rule when remoteip contains a netmask
+  win_firewall_rule:
+    name: http
+    enable: yes
+    state: present
+    localport: 80
+    remoteip: 192.168.0.0/255.255.255.0
+    action: allow
+    direction: In
+    protocol: TCP
+    force: yes
+
+- name: Add same firewall rule when remoteip contains a netmask (again)
+  win_firewall_rule:
+    name: http
+    enable: yes
+    state: present
+    localport: 80
+    remoteip: 192.168.0.0/255.255.255.0
+    action: allow
+    direction: In
+    protocol: TCP
+  register: add_firewall_rule_remoteip_contains_netmask_again
+
+- name: Check that creating same firewall rule succeeds without a change when remoteip contains a netmask
+  assert:
+    that:
+    - add_firewall_rule_remoteip_contains_netmask_again.failed == false
+    - add_firewall_rule_remoteip_contains_netmask_again.changed == false
 
 - name: Add firewall rule when remoteip is IPv4
   win_firewall_rule:

--- a/test/integration/test_win_group3.yml
+++ b/test/integration/test_win_group3.yml
@@ -9,3 +9,4 @@
     - { role: win_command, tags: test_win_command }
     - { role: win_reg_stat, tags: test_win_reg_stat }
     - { role: win_region, tags: test_win-region }
+    - { role: win_firewall_rule, tags: test_win_firewall_rule }

--- a/test/integration/test_win_group3.yml
+++ b/test/integration/test_win_group3.yml
@@ -9,4 +9,3 @@
     - { role: win_command, tags: test_win_command }
     - { role: win_reg_stat, tags: test_win_reg_stat }
     - { role: win_region, tags: test_win-region }
-    - { role: win_firewall_rule, tags: test_win_firewall_rule }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
`win_firewall_rule` [uses](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/windows/win_firewall_rule.ps1#L27) command `netsh advfirewall firewall show rule name="RULE NAME" verbose` to get current firewall rules.

When `win_firewall_rule` `profile` task parameter is `"any"`, task actually fills `Profiles` by `"Domain,Private,Public"`:
```
PS C:\Windows\system32> netsh advfirewall firewall show rule name="http" verbose

Rule Name:                            http
----------------------------------------------------------------------
Enabled:                              Yes
Direction:                            In
Profiles:                             Domain,Private,Public
Grouping:
LocalIP:                              Any
RemoteIP:                             Any
Protocol:                             TCP
LocalPort:                            80
RemotePort:                           Any
Edge traversal:                       No
Service:                              Any
InterfaceTypes:                       Any
Security:                             NotRequired
Rule source:                          Local Setting
Action:                               Allow
```
But module doesn't convert `"Domain,Private,Public"` to `"any"` string.

When `win_firewall_rule` `remoteip` task parameter is `"192.168.0.1"`, task actually fills `RemoteIP` by `"192.168.0.1/32"`:
```
C:\Windows\system32>netsh advfirewall firewall show rule name=http

Rule Name:                            http
----------------------------------------------------------------------
Enabled:                              Yes
Direction:                            In
Profiles:                             Domain,Private,Public
Grouping:
LocalIP:                              Any
RemoteIP:                             192.168.0.1/32
Protocol:                             TCP
LocalPort:                            80
RemotePort:                           Any
Edge traversal:                       No
Action:                               Allow
Ok.
```
But module doesn't convert `"192.168.0.1/32"` to `"192.168.0.1"` string.

In this PR I fixed #22554 and #22786 and wrote tests for `win_firewall_rule` module.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
windows/win_firewall_rule

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel dc68503ef2) last updated 2017/03/20 09:48:55 (GMT +300)
  config file = /home/art/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
