### PR TITLE
cloud: ovirt: Fix disk image upload

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_disks.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disks.py
@@ -520,7 +520,7 @@ def main():
     try:
         disk = None
         state = module.params['state']
-        auth = module.params.pop('auth')
+        auth = module.params.get('auth')
         connection = create_connection(auth)
         disks_service = connection.system_service().disks_service()
         disks_module = DisksModule(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Patch:
  https://github.com/ansible/ansible/commit/9fe0ae082a1b0a6c18f8f1298d677c785b780f8c#diff-8c53caff442193400c36278509fb033f

Introduced a regression and broke a image upload flow. This PR fixes it.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt_disks

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
