### PR TITLE
Add ability to group hosts by AWS subnet ID

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -136,6 +136,7 @@ group_by_instance_type = True
 group_by_instance_state = False
 group_by_key_pair = True
 group_by_vpc_id = True
+group_by_vpc_subnet_id = True
 group_by_security_group = True
 group_by_tag_keys = True
 group_by_tag_none = True

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -431,6 +431,7 @@ class Ec2Inventory(object):
             'group_by_instance_state',
             'group_by_key_pair',
             'group_by_vpc_id',
+            'group_by_vpc_subnet_id',
             'group_by_security_group',
             'group_by_tag_keys',
             'group_by_tag_none',
@@ -904,6 +905,13 @@ class Ec2Inventory(object):
             self.push(self.inventory, vpc_id_name, hostname)
             if self.nested_groups:
                 self.push_group(self.inventory, 'vpcs', vpc_id_name)
+
+        # Inventory: Group bu Subnet
+        if self.group_by_vpc_subnet_id and instance.subnet_id:
+            subnet_id = self.to_safe(instance.subnet_id)
+            self.push(self.inventory, subnet_id, hostname)
+            if self.nested_groups:
+                self.push_group(self.inventory, 'subnets', subnet_id)
 
         # Inventory: Group by security group
         if self.group_by_security_group:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add another group alternative to ec2 inventory script. 
For our instance structure in AWS all our different types of server roles are grouped within (VPC) subnets. So public facing servers are in Public Subnet. These are mostly incoming or outgoing traffic gateways. All webservers / app serveres are hosted in Private Subnets where they are organised according to which install profile they have. The only group tag which made sense to us is by subnet ID.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
EC2 external inventory script ( contrib/inventory/ec2 )

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Included example of how this looks below.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
"subnet_1e1b6237": [
  "20.100.223.102"
], 
"subnet_44e14c2d": [
  "20.100.100.242", 
  "20.100.100.26"
], 
"subnet_21f87cfb": [
  "20.100.200.74", 
  "20.100.200.63", 
  "20.100.200.13", 
  "20.100.200.152", 
  "20.100.200.193", 
  "20.100.200.94", 
  "20.100.200.145", 
  "20.100.200.247", 
  "20.100.200.7", 
  "20.100.200.189", 
  "20.100.200.72", 
  "20.100.200.235", 
  "20.100.200.79", 
  "20.100.200.168", 
  "20.100.200.178", 
  "20.100.200.231", 
  "20.100.200.99", 
  "20.100.200.51", 
  "20.100.200.70", 
  "20.100.200.131", 
  "20.100.200.27", 
  "20.100.200.108"
],
```
