### PR TITLE
Mark keystore_pass as 'no_log', to avoid leaking it

### DIFF
--- a/lib/ansible/modules/system/java_cert.py
+++ b/lib/ansible/modules/system/java_cert.py
@@ -220,7 +220,7 @@ def main():
         cert_alias=dict(type='str'),
         cert_port=dict(default='443', type='int'),
         keystore_path=dict(type='str'),
-        keystore_pass=dict(required=True, type='str'),
+        keystore_pass=dict(required=True, type='str', no_log=True),
         keystore_create=dict(default=False, type='bool'),
         executable=dict(default='keytool', type='str'),
         state=dict(default='present',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Mark keystore_pass as 'no_log', to avoid leaking it
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
java_cert.py


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
security issue
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
