### PR TITLE
Add no_log to all network module_utils provider argument

### DIFF
--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -54,7 +54,7 @@ eos_argument_spec = {
     'validate_certs': dict(type='bool'),
     'timeout': dict(type='int'),
 
-    'provider': dict(type='dict'),
+    'provider': dict(type='dict', no_log=True),
     'transport': dict(choices=['cli', 'eapi'])
 }
 

--- a/lib/ansible/module_utils/ios.py
+++ b/lib/ansible/module_utils/ios.py
@@ -40,7 +40,7 @@ ios_argument_spec = {
     'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
     'auth_pass': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS']), no_log=True),
     'timeout': dict(type='int'),
-    'provider': dict(type='dict'),
+    'provider': dict(type='dict', no_log=True),
 }
 
 def check_args(module, warnings):

--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -38,7 +38,7 @@ junos_argument_spec = {
     'password': dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), no_log=True),
     'ssh_keyfile': dict(fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE']), type='path'),
     'timeout': dict(type='int', default=10),
-    'provider': dict(type='dict'),
+    'provider': dict(type='dict', no_log=True),
     'transport': dict()
 }
 

--- a/lib/ansible/module_utils/network.py
+++ b/lib/ansible/module_utils/network.py
@@ -42,7 +42,7 @@ NET_TRANSPORT_ARGS = dict(
     authorize=dict(default=False, fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
     auth_pass=dict(no_log=True, fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS'])),
 
-    provider=dict(type='dict'),
+    provider=dict(type='dict', no_log=True),
     transport=dict(choices=list()),
 
     timeout=dict(default=10, type='int')

--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -50,7 +50,7 @@ nxos_argument_spec = {
     'validate_certs': dict(type='bool'),
     'timeout': dict(type='int'),
 
-    'provider': dict(type='dict'),
+    'provider': dict(type='dict', no_log=True),
     'transport': dict(choices=['cli', 'nxapi'])
 }
 


### PR DESCRIPTION
##### SUMMARY

The provider argument on the network modules argspec can contain
credentials.
Make sure we don't log it.

Fixes #21892

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME

module_utils/ios
module_utils/eos
module_utils/network
module_utils/junos
module_utils/nxos

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (issue_21892 19450dc00a) last updated 2017/03/13 14:49:34 (GMT +200)

```
