### PR TITLE
yaml inventory: Support host-list (not a dictionary)

### DIFF
--- a/lib/ansible/plugins/inventory/yaml.py
+++ b/lib/ansible/plugins/inventory/yaml.py
@@ -137,7 +137,11 @@ class InventoryModule(BaseFileInventoryPlugin):
                 if 'hosts' in group_data:
                     for host_pattern in group_data['hosts']:
                         hosts, port = self._parse_host(host_pattern)
-                        self.populate_host_vars(hosts, group_data['hosts'][host_pattern], group, port)
+                        # If hosts-list is a dictionary, add variables to hostvars, otherwise skip
+                        if isinstance(group_data['hosts'], dict):
+                            self.populate_host_vars(hosts, group_data['hosts'][host_pattern], group, port)
+                        else:
+                            self.populate_host_vars(hosts, None, group, port)
         else:
             self.display.warning("Skipping '%s' as this is not a valid group name" % group)
 

--- a/lib/ansible/plugins/inventory/yaml.py
+++ b/lib/ansible/plugins/inventory/yaml.py
@@ -120,28 +120,30 @@ class InventoryModule(BaseFileInventoryPlugin):
             self.inventory.add_group(group)
 
             if isinstance(group_data, dict):
-                #make sure they are dicts
+                # make sure they are dicts
                 for section in ['vars', 'children', 'hosts']:
                     if section in group_data and isinstance(group_data[section], string_types):
                         group_data[section] = {group_data[section]: None}
 
-                if 'vars' in group_data:
+                if 'vars' in group_data and group_data['vars'] is not None:
                     for var in group_data['vars']:
                         self.inventory.set_variable(group, var, group_data['vars'][var])
 
-                if 'children' in group_data:
+                if 'children' in group_data and group_data['children'] is not None:
                     for subgroup in group_data['children']:
                         self._parse_group(subgroup, group_data['children'][subgroup])
                         self.inventory.add_child(group, subgroup)
 
-                if 'hosts' in group_data:
+                if 'hosts' in group_data and group_data['hosts'] is not None:
                     for host_pattern in group_data['hosts']:
                         hosts, port = self._parse_host(host_pattern)
+
                         # If hosts-list is a dictionary, add variables to hostvars, otherwise skip
                         if isinstance(group_data['hosts'], dict):
                             self.populate_host_vars(hosts, group_data['hosts'][host_pattern], group, port)
                         else:
                             self.populate_host_vars(hosts, None, group, port)
+
         else:
             self.display.warning("Skipping '%s' as this is not a valid group name" % group)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Currently the YAML parser expects that every hosts-entry comprises of a dictionary of hosts with variables. Unfortunately that's not the case, inventories can simply consist of a list of hosts (because variables are defined elsewhere) and this would result in:
```
ERROR! Attempted to read "hosts.yaml" as YAML: list indices must be integers, not AnsibleUnicode
```
This PR allows for listing hosts as one would expect in YAML, just as one can do in a JSON inventory.
And it also support empty values.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
yaml inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3