### PR TITLE
cloud: ovirt: Fix ovirt_tags documentation

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_tags.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_tags.py
@@ -51,6 +51,9 @@ options:
     vms:
         description:
             - "List of the VMs names, which should have assigned this tag."
+    hosts:
+        description:
+            - "List of the hosts names, which should have assigned this tag."
 extends_documentation_fragment: ovirt
 '''
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This patch fixes the ```ovirt_tags``` documentation, as it was missing the documentation for ```hosts``` attribute.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt_tags

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
