### PR TITLE
Divided test methods of TestExtendValue class

### DIFF
--- a/test/units/playbook/test_base.py
+++ b/test/units/playbook/test_base.py
@@ -248,49 +248,49 @@ class TestBase(unittest.TestCase):
 class TestExtendValue(unittest.TestCase):
     # _extend_value could be a module or staticmethod but since its
     # not, the test is here.
-    def test_extend_value_list_newlist(self):    
+    def test_extend_value_list_newlist(self):
         b = base.Base()
         value_list = ['first', 'second']
         new_value_list = ['new_first', 'new_second']
         ret = b._extend_value(value_list, new_value_list)
         self.assertEquals(value_list + new_value_list, ret)
 
-    def test_extend_value_list_newlist_prepend(self):    
+    def test_extend_value_list_newlist_prepend(self):
         b = base.Base()
         value_list = ['first', 'second']
-        new_value_list = ['new_first', 'new_second']        
+        new_value_list = ['new_first', 'new_second']
         ret_prepend = b._extend_value(value_list, new_value_list, prepend=True)
         self.assertEquals(new_value_list + value_list, ret_prepend)
 
-    def test_extend_value_newlist_list(self):    
+    def test_extend_value_newlist_list(self):
         b = base.Base()
         value_list = ['first', 'second']
-        new_value_list = ['new_first', 'new_second']        
+        new_value_list = ['new_first', 'new_second']
         ret = b._extend_value(new_value_list, value_list)
         self.assertEquals(new_value_list + value_list, ret)
-        
-    def test_extend_value_newlist_list_prepend(self):    
+
+    def test_extend_value_newlist_list_prepend(self):
         b = base.Base()
         value_list = ['first', 'second']
         new_value_list = ['new_first', 'new_second']
         ret = b._extend_value(new_value_list, value_list, prepend=True)
         self.assertEquals(value_list + new_value_list, ret)
-        
-    def test_extend_value_string_newlist(self):    
+
+    def test_extend_value_string_newlist(self):
         b = base.Base()
         some_string = 'some string'
         new_value_list = ['new_first', 'new_second']
         ret = b._extend_value(some_string, new_value_list)
         self.assertEquals([some_string] + new_value_list, ret)
-        
-    def test_extend_value_string_newstring(self):    
+
+    def test_extend_value_string_newstring(self):
         b = base.Base()
         some_string = 'some string'
         new_value_string = 'this is the new values'
         ret = b._extend_value(some_string, new_value_string)
         self.assertEquals([some_string, new_value_string], ret)
-        
-    def test_extend_value_list_newstring(self):    
+
+    def test_extend_value_list_newstring(self):
         b = base.Base()
         value_list = ['first', 'second']
         new_value_string = 'this is the new values'

--- a/test/units/playbook/test_base.py
+++ b/test/units/playbook/test_base.py
@@ -245,43 +245,66 @@ class TestBase(unittest.TestCase):
         self.assertEquals(variable_manager, self.b._variable_manager)
 
 
-# TODO/FIXME: test methods for each of the compares would be more precise
 class TestExtendValue(unittest.TestCase):
-    def test_extend_value(self):
-        # _extend_value could be a module or staticmethod but since its
-        # not, the test is here.
+    # _extend_value could be a module or staticmethod but since its
+    # not, the test is here.
+    def test_extend_value_list_newlist(self):    
         b = base.Base()
         value_list = ['first', 'second']
         new_value_list = ['new_first', 'new_second']
         ret = b._extend_value(value_list, new_value_list)
         self.assertEquals(value_list + new_value_list, ret)
 
+    def test_extend_value_list_newlist_prepend(self):    
+        b = base.Base()
+        value_list = ['first', 'second']
+        new_value_list = ['new_first', 'new_second']        
         ret_prepend = b._extend_value(value_list, new_value_list, prepend=True)
         self.assertEquals(new_value_list + value_list, ret_prepend)
 
+    def test_extend_value_newlist_list(self):    
+        b = base.Base()
+        value_list = ['first', 'second']
+        new_value_list = ['new_first', 'new_second']        
         ret = b._extend_value(new_value_list, value_list)
         self.assertEquals(new_value_list + value_list, ret)
-
+        
+    def test_extend_value_newlist_list_prepend(self):    
+        b = base.Base()
+        value_list = ['first', 'second']
+        new_value_list = ['new_first', 'new_second']
         ret = b._extend_value(new_value_list, value_list, prepend=True)
         self.assertEquals(value_list + new_value_list, ret)
-
+        
+    def test_extend_value_string_newlist(self):    
+        b = base.Base()
         some_string = 'some string'
+        new_value_list = ['new_first', 'new_second']
         ret = b._extend_value(some_string, new_value_list)
         self.assertEquals([some_string] + new_value_list, ret)
-
+        
+    def test_extend_value_string_newstring(self):    
+        b = base.Base()
+        some_string = 'some string'
         new_value_string = 'this is the new values'
         ret = b._extend_value(some_string, new_value_string)
         self.assertEquals([some_string, new_value_string], ret)
-
+        
+    def test_extend_value_list_newstring(self):    
+        b = base.Base()
+        value_list = ['first', 'second']
+        new_value_string = 'this is the new values'
         ret = b._extend_value(value_list, new_value_string)
         self.assertEquals(value_list + [new_value_string], ret)
 
-    def test_extend_value_none(self):
+    def test_extend_value_none_none(self):
         b = base.Base()
         ret = b._extend_value(None, None)
         self.assertEquals(len(ret), 0)
         self.assertFalse(ret)
 
+    def test_extend_value_none_list(self):
+        b = base.Base()
         ret = b._extend_value(None, ['foo'])
         self.assertEquals(ret, ['foo'])
 


### PR DESCRIPTION
I've divided the two test methods of the TestExtendValue class into multiple test methods so there is a test method for each compare.

##### SUMMARY
This fixes a TODO/FIXME in the code, namely: "# TODO/FIXME: test methods for each of the compares would be more precise". There is a test method for each of the compares now. Each method creates the same objects as before to test on.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
playbook unit tests

##### ANSIBLE VERSION
```
2.3.0
```