### PR TITLE
allow users to control group var merge order

### DIFF
--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -123,10 +123,7 @@ class Group:
     def set_variable(self, key, value):
 
         if key == 'ansible_group_priority':
-            try:
-                self.set_priority(int(value))
-            except:
-                pass
+            self.set_priority(int(value))
         else:
             self.vars[key] = value
 

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -122,7 +122,13 @@ class Group:
 
     def set_variable(self, key, value):
 
-        self.vars[key] = value
+        if key == 'ansible_group_priority':
+            try:
+                self.set_priority(int(value))
+            except:
+                pass
+        else:
+            self.vars[key] = value
 
     def clear_hosts_cache(self):
 

--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -140,6 +140,6 @@ class Host:
     def get_group_vars(self):
         results = {}
         groups = self.get_groups()
-        for group in sorted(groups, key=lambda g: (g.depth, g.name)):
+        for group in sorted(groups, key=lambda g: (g.depth, g.priority, g.name)):
             results = combine_vars(results, group.get_vars())
         return results

--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -160,10 +160,7 @@ class InventoryParser(object):
             # applied to the current group.
             elif state == 'vars':
                 (k, v) = self._parse_variable_definition(line)
-                if k != 'ansible_group_priority':
-                    self.groups[groupname].set_variable(k, v)
-                else:
-                    self.groups[groupname].set_priority(v)
+                self.groups[groupname].set_variable(k, v)
 
             # [groupname:children] contains subgroup names that must be
             # added as children of the current group. The subgroup names

--- a/lib/ansible/inventory/yaml.py
+++ b/lib/ansible/inventory/yaml.py
@@ -85,10 +85,7 @@ class InventoryParser(object):
 
             if 'vars' in group_data:
                 for var in group_data['vars']:
-                    if var != 'ansible_group_priority':
-                        self.groups[group].set_variable(var, group_data['vars'][var])
-                    else:
-                        self.groups[group].set_priority(group_data['vars'][var])
+                    self.groups[group].set_variable(var, group_data['vars'][var])
 
             if 'children' in group_data:
                 for subgroup in group_data['children']:

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -260,7 +260,7 @@ class VariableManager:
                 for item in data:
                     all_vars = combine_vars(all_vars, item)
 
-            for group in sorted(host.get_groups(), key=lambda g: (g.depth, g.name)):
+            for group in sorted(host.get_groups(), key=lambda g: (g.depth, g.priority, g.name)):
                 if group.name in self._group_vars_files and group.name != 'all':
                     for data in self._group_vars_files[group.name]:
                         data = preprocess_vars(data)

--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -252,6 +252,7 @@ class VariableManager:
             # first we merge in vars from groups specified in the inventory (INI or script)
             all_vars = combine_vars(all_vars, host.get_group_vars())
 
+            # these are PLAY host/group vars, inventory adjacent ones have already been processed
             # next, we load any vars from group_vars files and then any vars from host_vars
             # files which may apply to this host or the groups it belongs to. We merge in the
             # special 'all' group_vars first, if they exist


### PR DESCRIPTION
##### SUMMARY

With `ansible_group_priority` var at each group will determine merge order with siblings,
falling back to sorted names when priority is equal as it did before.

Parent/children relationships still work as they did and have higher precedence than priority

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
group_vars

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```

