### PR TITLE
S3: don't set OrdinaryCallingFormat for fakes3 or rgw since they use it b…

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3.py
+++ b/lib/ansible/modules/cloud/amazon/s3.py
@@ -527,7 +527,11 @@ def main():
     # otherwise the connection will fail. See https://github.com/boto/boto/issues/2836
     # for more details.
     if '.' in bucket:
-        aws_connect_kwargs['calling_format'] = OrdinaryCallingFormat()
+        # don't set OrdinaryCallingFormat for fakes3 or rgw since it is used by default
+        if s3_url and (rgw or is_fakes3(s3_url)):
+            pass
+        else:
+            aws_connect_kwargs['calling_format'] = OrdinaryCallingFormat()
 
     # Look at s3_url and tweak connection settings
     # if connecting to RGW, Walrus or fakes3


### PR DESCRIPTION
…y default - Fixes #22317

##### SUMMARY
Only set OrdinaryCallingFormat for buckets with "." in the names if they are not fakes3 or rgw (since they use it by default). Fixes #22317. Alternative to #22318.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/s3.py

##### ANSIBLE VERSION
```
ansible 2.3.0 (s3-fakes3-rgw-bugfix 8df427e2ba) last updated 2017/03/13 17:06:58 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```