### PR TITLE
Monit Module: FIx Pending Issue, Support Program Checks

### DIFF
--- a/test/units/modules/monitoring/test_monit.py
+++ b/test/units/modules/monitoring/test_monit.py
@@ -1,0 +1,810 @@
+# -*- coding: utf-8 -*-
+# (c) 2016 Toshio Kuratomi <tkuratomi@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the monit.py monitoring module"""
+
+# Stdlib
+from __future__ import (
+    absolute_import, division, print_function, unicode_literals
+)
+import sys
+try:
+    import mock
+except ImportError:
+    from unittest import mock
+
+# Third party
+import pytest
+
+# Local
+from ansible.modules.monitoring import monit
+
+
+# Keep tests from lasting forever
+monit.SLEEP_TIME = 0
+
+
+@pytest.fixture()
+def module(monkeypatch):
+    """Replace AnsibleModule with a mock object"""
+    mock_module = mock.MagicMock(name='AnsibleModuleMock')
+
+    mock_module.params = {
+        'name': 'monit_test',
+        'timeout': 5,
+    }
+    mock_module.check_mode = False
+
+    monkeypatch.setattr(
+        monit, 'AnsibleModule', mock.MagicMock(return_value=mock_module)
+    )
+
+    mock_module.exit_json.side_effect = lambda *x, **y: sys.exit()
+    mock_module.fail_json.side_effect = lambda *x, **y: sys.exit()
+
+    return mock_module
+
+
+class TestMonitModule:
+    """Tests for the monit module"""
+
+    @pytest.mark.parametrize('cmd_output, fail', [
+        (  # Reload, good status
+            [
+                (0, '', ''),
+                (0, "Program 'monit_test' Status ok", '')
+            ],
+            False
+        ),
+        (  # Reload, failed status (doesn't care)
+            [
+                (0, '', ''),
+                (0, "Program 'monit_test' Status failed", '')
+            ],
+            False
+        ),
+        (  # Reload, running status
+            [
+                (0, '', ''),
+                (0, "Process 'monit_test' Running", '')
+            ],
+            False
+        ),
+        (  # Reload, not monitored (doesn't care)
+            [
+                (0, '', ''),
+                (0, "Process 'monit_test' Not monitored", '')
+            ],
+            False
+        ),
+        (  # Reload, initializing; should call again in wait loop
+            [
+                (0, '', ''),
+                (0, "Process 'monit_test' Initializing", ''),
+                (0, "Process 'monit_test' Running", '')
+            ],
+            False
+        ),
+        (  # Reload, pending; should call again in wait loop
+            [
+                (0, '', ''),
+                (0, "Process 'monit_test' Pending", ''),
+                (0, "Process 'monit_test' Running", ''),
+            ],
+            False
+        ),
+        (  # Reload, bad RC
+                [(1, '', ''), ],
+                True
+        ),
+        (  # Reload, bad RC
+                [(2, '', ''), ],
+                True
+        ),
+    ])
+    def test_reloaded(self, module, cmd_output, fail):
+        # type: (mock.MagicMock, tuple, bool) -> None
+        """Test when state == reloaded
+
+        :param cmd_output: a list of return tuples that should be
+            returned, in order, from module.check_command
+        :param fail: whether module.fail_json() is expected to be called
+        """
+        module.params['state'] = 'reloaded'
+        module.run_command.side_effect = cmd_output
+
+        with pytest.raises(SystemExit):
+            monit.main()
+
+        # Assert we had all expected calls
+        assert len(module.run_command.mock_calls) == len(cmd_output)
+
+        if fail:
+            module.fail_json.assert_called_once_with(
+                msg='monit reload failed',
+                stdout=cmd_output[0][1],
+                stderr=cmd_output[0][2]
+            )
+        else:
+            module.exit_json.assert_called_once_with(
+                changed=True, name=module.params['name'], state='reloaded'
+            )
+
+    @pytest.mark.parametrize('cmd_output, fail, fail_msg', [
+        (  # Not present, immediately good after reload
+            [
+                (0, '', ''),
+                (0, '', ''),
+                (0, "Program 'monit_test' Status ok", ''),
+            ],
+            False,
+            None,
+        ),
+        (  # Not present, immediately good after reload
+            [
+                (0, '', ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Running", ''),
+            ],
+            False,
+            None,
+        ),
+        (  # Not present, not present after reload, good on second try
+            [
+                (0, '', ''),
+                (0, '', ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Running", ''),
+            ],
+            False,
+            None,
+        ),
+        (  # Not present, not present after reload, good on second try
+            [
+                (0, '', ''),
+                (0, '', ''),
+                (0, '', ''),
+                (0, "Program 'monit_test' Status ok", ''),
+            ],
+            False,
+            None,
+        ),
+        (  # Not present, not present after reload, then pending, then good
+            [
+                (0, '', ''),
+                (0, '', ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Pending", ''),
+                (0, "Process 'monit_test' Running", ''),
+            ],
+            False,
+            None,
+        ),
+        (  # Not present, not present after reload, then pending, then good
+            [
+                (0, '', ''),
+                (0, '', ''),
+                (0, '', ''),
+                (0, "Program 'monit_test' Initializing", ''),
+                (0, "Program 'monit_test' Status ok", ''),
+            ],
+            False,
+            None,
+        ),
+    ])
+    def test_present_reload(self, module, cmd_output, fail, fail_msg):
+        # type: (mock.MagicMock, tuple, bool, str) -> None
+        """Test when state == present and item is not already present
+
+        :param cmd_output: a list of return tuples that should be
+            returned, in order, from module.check_command
+        :param fail: whether module.fail_json() is expected to be called
+        :param fail_msg: expected value of the msg kwarg in the call to
+            module.fail_json()
+        """
+        module.params['state'] = 'present'
+        module.run_command.side_effect = cmd_output
+
+        with pytest.raises(SystemExit):
+            monit.main()
+
+        # Assert we had all expected calls
+        assert len(module.run_command.mock_calls) == len(cmd_output)
+
+        if fail:
+            module.fail_json.assert_called_once_with(msg=fail_msg)
+            assert not module.exit_json.mock_calls
+        else:
+            assert not module.fail_json.mock_calls
+            module.exit_json.assert_called_once_with(
+                changed=True, name=module.params['name'], state='present'
+            )
+
+    @pytest.mark.parametrize('cmd_output', [
+        [(0, "Process 'monit_test' Running", ''), ],
+        [(0, "Process 'monit_test' Running - restart pending", ''), ],
+        [(0, "Process 'monit_test' Not monitored", ''), ],
+        [(0, "Process 'monit_test' Initializing", ''), ],
+        [(0, "Process 'monit_test' Pending", ''), ],
+        [(0, "Program 'monit_test' Status ok", ''), ],
+        [(0, "Program 'monit_test' Status failed", ''), ],
+        [(0, "Program 'monit_test' Not monitored", ''), ],
+        [(0, "Program 'monit_test' Initializing", ''), ],
+        [(0, "Program 'monit_test' Pending", ''), ],
+    ])
+    def test_present_present(self, module, cmd_output):
+        # type: (mock.MagicMock, tuple) -> None
+        """Test when state == present and item is already present
+
+        :param cmd_output: a list of return tuples that should be
+            returned, in order, from module.check_command
+        """
+        module.params['state'] = 'present'
+        module.run_command.side_effect = cmd_output
+
+        with pytest.raises(SystemExit):
+            monit.main()
+
+        # Assert we had all expected calls
+        assert len(module.run_command.mock_calls) == len(cmd_output)
+
+        assert not module.fail_json.mock_calls
+
+        module.exit_json.assert_called_once_with(
+            changed=False, name=module.params['name'], state='present'
+        )
+
+    @pytest.mark.parametrize('state, cmd_output', [
+        ('started', [(0, "Process 'monit_test' Running", '')]),
+        ('started', [(0, "Program 'monit_test' Status ok", '')]),
+        ('running', [(0, "Process 'monit_test' Running", '')]),
+        ('running', [(0, "Program 'monit_test' Status ok", '')]),
+    ])
+    def test_started_monitored_running(self, module, state, cmd_output):
+        # type: (mock.MagicMock, str, tuple) -> None
+        """Test when state is monitored or started and item is already running
+
+        :param state: desired module state
+        :param cmd_output: a list of return tuples that should be
+            returned, in order, from module.check_command
+        """
+        module.params['state'] = state
+        module.run_command.side_effect = cmd_output
+
+        with pytest.raises(SystemExit):
+            monit.main()
+
+        # Assert we had all expected calls
+        assert len(module.run_command.mock_calls) == len(cmd_output)
+
+        assert not module.fail_json.mock_calls
+
+        module.exit_json.assert_called_once_with(
+            changed=False, name=module.params['name'], state=state
+        )
+
+    @pytest.mark.parametrize('cmd_output, fail, fail_status', [
+        (
+            [
+                (0, "Process 'monit_test' Running", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Not monitored", ''),
+            ],
+            False,
+            None
+        ),
+        (
+            [
+                (0, "Process 'monit_test' Running", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Running - stop pending", ''),
+            ],
+            False,
+            None
+        ),
+        (
+            [
+                (0, "Program 'monit_test' Status ok", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Not monitored", ''),
+            ],
+            False,
+            None
+        ),
+        (
+            [
+                (0, "Program 'monit_test' Status ok", ''),
+                (0, '', ''),
+                (0, "Program 'monit_test' Status ok - stop pending", ''),
+            ],
+            False,
+            None
+        ),
+        (
+            [
+                (0, "Process 'monit_test' Running", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Running", ''),
+            ],
+            True,
+            'running'
+        ),
+        (
+            [
+                (0, "Program 'monit_test' Status ok", ''),
+                (0, '', ''),
+                (0, "Program 'monit_test' Status ok", ''),
+            ],
+            True,
+            'status ok'
+        ),
+    ])
+    def test_stopped(self, module, cmd_output, fail, fail_status):
+        # type: (mock.MagicMock, tuple, bool, str) -> None
+        """Test when state == stopped
+
+        :param cmd_output: a list of return tuples that should be
+            returned, in order, from module.check_command
+        :param fail: whether ``module.fail_json()`` is expected to be
+            called
+        :param fail_status: expected kwarg for ``status`` in call to
+            ``module.fail_json()``
+        """
+        module.params['state'] = 'stopped'
+        module.run_command.side_effect = cmd_output
+
+        with pytest.raises(SystemExit):
+            monit.main()
+
+        # Assert we had all expected calls
+        assert len(module.run_command.mock_calls) == len(cmd_output)
+
+        if fail:
+            module.fail_json.assert_called_once_with(
+                msg='monit_test process not stopped',
+                status=fail_status
+            )
+        else:
+            module.exit_json.assert_called_once_with(
+                changed=True, name=module.params['name'], state='stopped'
+            )
+
+    @pytest.mark.parametrize('cmd_output, fail, fail_status', [
+        (
+                [
+                    (0, "Process 'monit_test' Running", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Not monitored", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Process 'monit_test' Running", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Running - unmonitor pending", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Program 'monit_test' Status ok", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Not monitored", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Program 'monit_test' Status ok", ''),
+                    (0, '', ''),
+                    (0, "Program 'monit_test' Status ok - unmonitor pending", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Process 'monit_test' Running", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Running", ''),
+                ],
+                True,
+                'running'
+        ),
+        (
+                [
+                    (0, "Program 'monit_test' Status ok", ''),
+                    (0, '', ''),
+                    (0, "Program 'monit_test' Status ok", ''),
+                ],
+                True,
+                'status ok'
+        ),
+    ])
+    def test_unmonitored(self, module, cmd_output, fail, fail_status):
+        # type: (mock.MagicMock, tuple, bool, str) -> None
+        """Test when state == unmonitored
+
+        :param cmd_output: a list of return tuples that should be
+            returned, in order, from module.check_command
+        :param fail: whether ``module.fail_json()`` is expected to be
+            called
+        :param fail_status: expected kwarg for ``status`` in call to
+            ``module.fail_json()``
+        """
+        module.params['state'] = 'unmonitored'
+        module.run_command.side_effect = cmd_output
+
+        with pytest.raises(SystemExit):
+            monit.main()
+
+        # Assert we had all expected calls
+        assert len(module.run_command.mock_calls) == len(cmd_output)
+
+        if fail:
+            module.fail_json.assert_called_once_with(
+                msg='monit_test process not unmonitored',
+                status=fail_status
+            )
+        else:
+            module.exit_json.assert_called_once_with(
+                changed=True, name=module.params['name'], state='unmonitored'
+            )
+
+    @pytest.mark.parametrize('cmd_output, fail, fail_status', [
+        (
+                [
+                    (0, "Process 'monit_test' Running", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Running", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Process 'monit_test' Running", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Initializing", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Process 'monit_test' Running", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Running - restart pending", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Program 'monit_test' Status ok", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Status ok", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Program 'monit_test' Status ok", ''),
+                    (0, '', ''),
+                    (0, "Program 'monit_test' Initializing", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Program 'monit_test' Status ok", ''),
+                    (0, '', ''),
+                    (0, "Program 'monit_test' Status ok - restart pending", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Process 'monit_test' Running", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Stopped", ''),
+                ],
+                True,
+                'stopped'
+        ),
+        (
+                [
+                    (0, "Program 'monit_test' Status ok", ''),
+                    (0, '', ''),
+                    (0, "Program 'monit_test' Status failed", ''),
+                ],
+                True,
+                'status failed'
+        ),
+    ])
+    def test_restarted(self, module, cmd_output, fail, fail_status):
+        # type: (mock.MagicMock, tuple, bool, str) -> None
+        """Test when state == restarted
+
+        :param cmd_output: a list of return tuples that should be
+            returned, in order, from module.check_command
+        :param fail: whether ``module.fail_json()`` is expected to be
+            called
+        :param fail_status: expected kwarg for ``status`` in call to
+            ``module.fail_json()``
+        """
+        module.params['state'] = 'restarted'
+        module.run_command.side_effect = cmd_output
+
+        with pytest.raises(SystemExit):
+            monit.main()
+
+        # Assert we had all expected calls
+        assert len(module.run_command.mock_calls) == len(cmd_output)
+
+        if fail:
+            module.fail_json.assert_called_once_with(
+                msg='monit_test process not restarted',
+                status=fail_status
+            )
+        else:
+            module.exit_json.assert_called_once_with(
+                changed=True, name=module.params['name'], state='restarted'
+            )
+
+    @pytest.mark.parametrize('cmd_output, fail, fail_status', [
+        (
+                [
+                    (0, "Process 'monit_test' Stopped", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Running", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Process 'monit_test' Not monitored", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Running", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Process 'monit_test' Stopped", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Initializing", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Process 'monit_test' Stopped", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Running - start pending", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Program 'monit_test' Status failed", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Status ok", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Program 'monit_test' Status failed", ''),
+                    (0, '', ''),
+                    (0, "Program 'monit_test' Initializing", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Process 'monit_test' Stopped", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Stopped", ''),
+                ],
+                True,
+                'stopped'
+        ),
+        (
+                [
+                    (0, "Program 'monit_test' Status failed", ''),
+                    (0, '', ''),
+                    (0, "Program 'monit_test' Status failed", ''),
+                ],
+                True,
+                'status failed'
+        ),
+    ])
+    def test_restarted(self, module, cmd_output, fail, fail_status):
+        # type: (mock.MagicMock, tuple, bool, str) -> None
+        """Test when state == started
+
+        :param cmd_output: a list of return tuples that should be
+            returned, in order, from module.check_command
+        :param fail: whether ``module.fail_json()`` is expected to be
+            called
+        :param fail_status: expected kwarg for ``status`` in call to
+            ``module.fail_json()``
+        """
+        module.params['state'] = 'started'
+        module.run_command.side_effect = cmd_output
+
+        with pytest.raises(SystemExit):
+            monit.main()
+
+        # Assert we had all expected calls
+        assert len(module.run_command.mock_calls) == len(cmd_output)
+
+        if fail:
+            module.fail_json.assert_called_once_with(
+                msg='monit_test process not started',
+                status=fail_status
+            )
+        else:
+            module.exit_json.assert_called_once_with(
+                changed=True, name=module.params['name'], state='started'
+            )
+
+    @pytest.mark.parametrize('cmd_output, fail, fail_status', [
+        (
+                [
+                    (0, "Process 'monit_test' Not monitored", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Running", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Process 'monit_test' Stopped", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Running", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Process 'monit_test' Stopped", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Stopped", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Process 'monit_test' Not monitored", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Initializing", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Process 'monit_test' Not monitored", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Running - start pending", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Program 'monit_test' Status failed", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Status ok", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Program 'monit_test' Status failed", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Status failed", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Program 'monit_test' Not monitored", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Status ok", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Program 'monit_test' Status failed", ''),
+                    (0, '', ''),
+                    (0, "Program 'monit_test' Initializing", ''),
+                ],
+                False,
+                None
+        ),
+        (
+                [
+                    (0, "Program 'monit_test' Not monitored", ''),
+                    (0, '', ''),
+                    (0, "Program 'monit_test' Not monitored", ''),
+                ],
+                True,
+                'not monitored'
+        ),
+        (
+                [
+                    (0, "Process 'monit_test' Not monitored", ''),
+                    (0, '', ''),
+                    (0, "Process 'monit_test' Not monitored", ''),
+                ],
+                True,
+                'not monitored'
+        ),
+    ])
+    def test_restarted(self, module, cmd_output, fail, fail_status):
+        # type: (mock.MagicMock, tuple, bool, str) -> None
+        """Test when state == started
+
+        :param cmd_output: a list of return tuples that should be
+            returned, in order, from module.check_command
+        :param fail: whether ``module.fail_json()`` is expected to be
+            called
+        :param fail_status: expected kwarg for ``status`` in call to
+            ``module.fail_json()``
+        """
+        module.params['state'] = 'monitored'
+        module.run_command.side_effect = cmd_output
+
+        with pytest.raises(SystemExit):
+            monit.main()
+
+        # Assert we had all expected calls
+        assert len(module.run_command.mock_calls) == len(cmd_output)
+
+        if fail:
+            module.fail_json.assert_called_once_with(
+                msg='monit_test process not monitored',
+                status=fail_status
+            )
+        else:
+            module.exit_json.assert_called_once_with(
+                changed=True, name=module.params['name'], state='monitored'
+            )

--- a/test/units/modules/monitoring/test_monit.py
+++ b/test/units/modules/monitoring/test_monit.py
@@ -109,12 +109,12 @@ class TestMonitModule:
             False
         ),
         (  # Reload, bad RC
-                [(1, '', ''), ],
-                True
+            [(1, '', ''), ],
+            True
         ),
         (  # Reload, bad RC
-                [(2, '', ''), ],
-                True
+            [(2, '', ''), ],
+            True
         ),
     ])
     def test_reloaded(self, module, cmd_output, fail):
@@ -386,58 +386,58 @@ class TestMonitModule:
 
     @pytest.mark.parametrize('cmd_output, fail, fail_status', [
         (
-                [
-                    (0, "Process 'monit_test' Running", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Not monitored", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Process 'monit_test' Running", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Not monitored", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Process 'monit_test' Running", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Running - unmonitor pending", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Process 'monit_test' Running", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Running - unmonitor pending", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Program 'monit_test' Status ok", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Not monitored", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Program 'monit_test' Status ok", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Not monitored", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Program 'monit_test' Status ok", ''),
-                    (0, '', ''),
-                    (0, "Program 'monit_test' Status ok - unmonitor pending", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Program 'monit_test' Status ok", ''),
+                (0, '', ''),
+                (0, "Program 'monit_test' Status ok - unmonitor pending", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Process 'monit_test' Running", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Running", ''),
-                ],
-                True,
-                'running'
+            [
+                (0, "Process 'monit_test' Running", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Running", ''),
+            ],
+            True,
+            'running'
         ),
         (
-                [
-                    (0, "Program 'monit_test' Status ok", ''),
-                    (0, '', ''),
-                    (0, "Program 'monit_test' Status ok", ''),
-                ],
-                True,
-                'status ok'
+            [
+                (0, "Program 'monit_test' Status ok", ''),
+                (0, '', ''),
+                (0, "Program 'monit_test' Status ok", ''),
+            ],
+            True,
+            'status ok'
         ),
     ])
     def test_unmonitored(self, module, cmd_output, fail, fail_status):
@@ -472,76 +472,76 @@ class TestMonitModule:
 
     @pytest.mark.parametrize('cmd_output, fail, fail_status', [
         (
-                [
-                    (0, "Process 'monit_test' Running", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Running", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Process 'monit_test' Running", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Running", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Process 'monit_test' Running", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Initializing", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Process 'monit_test' Running", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Initializing", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Process 'monit_test' Running", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Running - restart pending", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Process 'monit_test' Running", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Running - restart pending", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Program 'monit_test' Status ok", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Status ok", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Program 'monit_test' Status ok", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Status ok", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Program 'monit_test' Status ok", ''),
-                    (0, '', ''),
-                    (0, "Program 'monit_test' Initializing", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Program 'monit_test' Status ok", ''),
+                (0, '', ''),
+                (0, "Program 'monit_test' Initializing", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Program 'monit_test' Status ok", ''),
-                    (0, '', ''),
-                    (0, "Program 'monit_test' Status ok - restart pending", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Program 'monit_test' Status ok", ''),
+                (0, '', ''),
+                (0, "Program 'monit_test' Status ok - restart pending", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Process 'monit_test' Running", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Stopped", ''),
-                ],
-                True,
-                'stopped'
+            [
+                (0, "Process 'monit_test' Running", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Stopped", ''),
+            ],
+            True,
+            'stopped'
         ),
         (
-                [
-                    (0, "Program 'monit_test' Status ok", ''),
-                    (0, '', ''),
-                    (0, "Program 'monit_test' Status failed", ''),
-                ],
-                True,
-                'status failed'
+            [
+                (0, "Program 'monit_test' Status ok", ''),
+                (0, '', ''),
+                (0, "Program 'monit_test' Status failed", ''),
+            ],
+            True,
+            'status failed'
         ),
     ])
     def test_restarted(self, module, cmd_output, fail, fail_status):
@@ -576,76 +576,76 @@ class TestMonitModule:
 
     @pytest.mark.parametrize('cmd_output, fail, fail_status', [
         (
-                [
-                    (0, "Process 'monit_test' Stopped", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Running", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Process 'monit_test' Stopped", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Running", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Process 'monit_test' Not monitored", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Running", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Process 'monit_test' Not monitored", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Running", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Process 'monit_test' Stopped", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Initializing", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Process 'monit_test' Stopped", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Initializing", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Process 'monit_test' Stopped", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Running - start pending", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Process 'monit_test' Stopped", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Running - start pending", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Program 'monit_test' Status failed", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Status ok", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Program 'monit_test' Status failed", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Status ok", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Program 'monit_test' Status failed", ''),
-                    (0, '', ''),
-                    (0, "Program 'monit_test' Initializing", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Program 'monit_test' Status failed", ''),
+                (0, '', ''),
+                (0, "Program 'monit_test' Initializing", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Process 'monit_test' Stopped", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Stopped", ''),
-                ],
-                True,
-                'stopped'
+            [
+                (0, "Process 'monit_test' Stopped", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Stopped", ''),
+            ],
+            True,
+            'stopped'
         ),
         (
-                [
-                    (0, "Program 'monit_test' Status failed", ''),
-                    (0, '', ''),
-                    (0, "Program 'monit_test' Status failed", ''),
-                ],
-                True,
-                'status failed'
+            [
+                (0, "Program 'monit_test' Status failed", ''),
+                (0, '', ''),
+                (0, "Program 'monit_test' Status failed", ''),
+            ],
+            True,
+            'status failed'
         ),
     ])
     def test_restarted(self, module, cmd_output, fail, fail_status):
@@ -680,103 +680,103 @@ class TestMonitModule:
 
     @pytest.mark.parametrize('cmd_output, fail, fail_status', [
         (
-                [
-                    (0, "Process 'monit_test' Not monitored", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Running", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Process 'monit_test' Not monitored", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Running", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Process 'monit_test' Stopped", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Running", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Process 'monit_test' Stopped", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Running", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Process 'monit_test' Stopped", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Stopped", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Process 'monit_test' Stopped", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Stopped", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Process 'monit_test' Not monitored", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Initializing", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Process 'monit_test' Not monitored", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Initializing", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Process 'monit_test' Not monitored", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Running - start pending", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Process 'monit_test' Not monitored", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Running - start pending", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Program 'monit_test' Status failed", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Status ok", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Program 'monit_test' Status failed", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Status ok", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Program 'monit_test' Status failed", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Status failed", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Program 'monit_test' Status failed", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Status failed", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Program 'monit_test' Not monitored", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Status ok", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Program 'monit_test' Not monitored", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Status ok", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Program 'monit_test' Status failed", ''),
-                    (0, '', ''),
-                    (0, "Program 'monit_test' Initializing", ''),
-                ],
-                False,
-                None
+            [
+                (0, "Program 'monit_test' Status failed", ''),
+                (0, '', ''),
+                (0, "Program 'monit_test' Initializing", ''),
+            ],
+            False,
+            None
         ),
         (
-                [
-                    (0, "Program 'monit_test' Not monitored", ''),
-                    (0, '', ''),
-                    (0, "Program 'monit_test' Not monitored", ''),
-                ],
-                True,
-                'not monitored'
+            [
+                (0, "Program 'monit_test' Not monitored", ''),
+                (0, '', ''),
+                (0, "Program 'monit_test' Not monitored", ''),
+            ],
+            True,
+            'not monitored'
         ),
         (
-                [
-                    (0, "Process 'monit_test' Not monitored", ''),
-                    (0, '', ''),
-                    (0, "Process 'monit_test' Not monitored", ''),
-                ],
-                True,
-                'not monitored'
+            [
+                (0, "Process 'monit_test' Not monitored", ''),
+                (0, '', ''),
+                (0, "Process 'monit_test' Not monitored", ''),
+            ],
+            True,
+            'not monitored'
         ),
     ])
     def test_restarted(self, module, cmd_output, fail, fail_status):


### PR DESCRIPTION
##### SUMMARY
This update to `monit.py` fixes a bug in which the `status`
variable (which initially referenced a function) being overwritten
by a string on line 150, which led to `wait_for_monit_to_stop_pending()`
to throw a `TypeError` and return messages like this:

```
failed: [server-name] (item={u'name': u'check_rabbit_queue', u'template': u'check_rabbit_queue.jinja2'}) => {"failed": true, "item": {"name": "check_rabbit_queue", "template": "check_rabbit_queue.jinja2"}, "module_stderr": "Connection to 23.253.83.88 closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_VvIl3Q/ansible_module_monit.py\", line 185, in <module>\r\n    main()\r\n  File \"/tmp/ansible_VvIl3Q/ansible_module_monit.py\", line 130, in main\r\n    wait_for_monit_to_stop_pending()\r\n  File \"/tmp/ansible_VvIl3Q/ansible_module_monit.py\", line 97, in wait_for_monit_to_stop_pending\r\n    running_status = status()\r\nTypeError: 'str' object is not callable\r\n", "msg": "MODULE FAILURE"}
```

This also adds support for `check_program` style monit checks by looking for
their specific good/bad/pending statuses (`Status ok`, `Status failed`, and
`Initializing`, respectively).

Other small improvements:
* Added an `is_pending()` function to check whether a status return is "pending",
which allowed for fewer calls out to `monit status`
* Renamed `status` to `running_status` throughout, to ensure no more accidental
overwrites of the `status()` function.
* Added tests. They are not perfect, and a bit repetitive
* Pulled `sleep_time` out into a module-level `SLEEP_TIME` variable, which
allowed for easier overwriting in testing

**NOTE:** I am getting a few test failures when running `make tests` due to certain
modules (e.g. `test_helpers.py`) being unable to import `units.mock` and associated
modules/objects underneath. This seems to be due to `absolute_import` issues, but
I didn't touch anything related to that, so I left it as is.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
monit

##### ANSIBLE VERSION
```
ansible 2.3.0 (monit-status-fix 8cace628c8) last updated 2017/03/13 17:52:50 (GMT -500)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.10 (default, Dec  5 2016, 22:11:56) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION

For me, the bug described above was tangentially reproducible any time I added
a new monit config file to `/etc/monit/conf-available`, linked it to `conf-enabled`,
and then ran the monit module with `status=present`. 

It was also reproducible 100% of the time when trying to monitor a
program check style monit service.

Relevant Ansible Playbook Section:
```yml
- block:
  - name: place monitoring scripts (files)
    file:
      src: "{{ item.file }}"
      dest: "{{ item.path | default(monit_bin_dir + item.name) }}"
      owner: "{{ monit_user }}"
      group: "{{ monit_user }}"
      mode: 0774
    failed_when: '"file" in item and "template" in item'
    when: '"file" in item'
    with_items: "{{ monit_monitored_programs }}"

  - name: place monitoring scripts (templates)
    template:
      src: "{{ item.template }}"
      dest: "{{ item.path | default(monit_bin_dir + item.name) }}"
      owner: "{{ monit_user }}"
      group: "{{ monit_user }}"
      mode: 0774
    failed_when: '"file" in item and "template" in item'
    when: '"template" in item'
    with_items: "{{ monit_monitored_programs }}"

  become: yes


- block:
  - name: add/update monit configuration files
    template:
      dest: /etc/monit/conf-available/{{ item.name }}
      src: program_check.conf.jinja2
      mode: 0644
    with_items: "{{ monit_monitored_programs }}"
    notify: restart monit

  - name: link monit configuration files
    file:
      src: /etc/monit/conf-available/{{ item.name }}
      path: /etc/monit/conf-enabled/{{ item.name }}
      state: link
    with_items: "{{ monit_monitored_programs }}"
    notify: restart monit

  become: yes


- block:
  - name: add monit configuration files
    template:
      dest: /etc/monit/conf-available/{{ item.name }}
      src: process_check.conf.jinja2
      mode: 0644
    with_items: "{{ monit_monitored_processes }}"

  - name: link monit configuration files
    file:
      src: /etc/monit/conf-available/{{ item.name }}
      path: /etc/monit/conf-enabled/{{ item.name }}
      state: link
    with_items: "{{ monit_monitored_processes }}"
    notify: restart monit

  become: yes


- block:
    - name: enable monitored processes
      monit:
        name: "{{ item.name }}"
        state: present
      with_items: "{{ monit_monitored_programs + monit_monitored_processes}}"

    - name: monitor monitored processes
      monit:
        name: "{{ item.name }}"
        state: monitored
      with_items: "{{ monit_monitored_programs + monit_monitored_processes}}"

  become: yes
```

Previous output:
```
 ____________________________________________
< TASK [alerts : enable monitored processes] >
 --------------------------------------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

failed: [server-name] (item={u'name': u'check_rabbit_queue', u'template': u'check_rabbit_queue.jinja2'}) => {"failed": true, "item": {"name": "check_rabbit_queue", "template": "check_rabbit_queue.jinja2"}, "module_stderr": "Connection to 23.253.83.88 closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_VvIl3Q/ansible_module_monit.py\", line 185, in <module>\r\n    main()\r\n  File \"/tmp/ansible_VvIl3Q/ansible_module_monit.py\", line 130, in main\r\n    wait_for_monit_to_stop_pending()\r\n  File \"/tmp/ansible_VvIl3Q/ansible_module_monit.py\", line 97, in wait_for_monit_to_stop_pending\r\n    running_status = status()\r\nTypeError: 'str' object is not callable\r\n", "msg": "MODULE FAILURE"}
```

Output with change:
```
 ____________________________________________
< TASK [alerts : enable monitored processes] >
 --------------------------------------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

ok: [server-name] => (item={u'name': u'check_rabbit_queue', u'template': u'check_rabbit_queue.jinja2'})

 _____________________________________________
< TASK [alerts : monitor monitored processes] >
 ---------------------------------------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

changed: [server-name] => (item={u'name': u'check_rabbit_queue', u'template': u'check_rabbit_queue.jinja2'})
```

One side note is that previously, the monitored services were actually getting
added to monit and monitored just fine, but the Ansible playbook was failing
anyway. Because it did not recognize `Status ok` as a valid status, it was
also attempting to reload the program checks on every run.