### PR TITLE
update ec2_tag documentation example for ec2 volumes

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_tag.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_tag.py
@@ -100,9 +100,8 @@ EXAMPLES = '''
     tags:
       Name: dbserver
       Env: production
-  with_subelements:
-    - ec2_vol.results
-    - volumes
+  with_items:
+    - ec2_vol.volumes
 
 - name: Get EC2 facts
   action: ec2_facts


### PR DESCRIPTION
##### SUMMARY
Currently the documentation utilizes with_subelements, but does not parse the results correctly.  By changing to with_items: and specifying the proper list, we are able to tag the gathered volumes as expected.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ec2_tag

##### ANSIBLE VERSION
ansible 2.2.1.0
