### PR TITLE
Handle junos galaxy modules which can not be imported cleanly. Fixes #22589

### DIFF
--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -39,6 +39,30 @@ except ImportError:
 class ActionModule(_ActionModule):
 
     def run(self, tmp=None, task_vars=None):
+        # Override sys.exit() with a no-op
+        def _override_sys_exit(return_code):
+            pass
+
+        saved_sys_exit = sys.exit
+        sys.exit = _override_sys_exit
+
+        # Send stdout to /dev/null
+        saved_stdout = sys.stdout
+        null_stdout = open(os.devnull, 'w')
+        sys.stdout = null_stdout
+
+        module = None
+        try:
+            module = module_loader._load_module_source(self._task.action, module_loader.find_plugin(self._task.action))
+        except Exception:
+            pass
+
+        # Restore sys.exit and sys.stdout
+        sys.exit = saved_sys_exit
+        sys.stdout = saved_stdout
+
+        if module is None or not getattr(module, 'USE_PERSISTENT_CONNECTION', False):
+            return super(ActionModule, self).run(tmp, task_vars)
 
         if self._play_context.connection != 'local':
             return dict(
@@ -46,11 +70,6 @@ class ActionModule(_ActionModule):
                 msg='invalid connection specified, expected connection=local, '
                     'got %s' % self._play_context.connection
             )
-
-        module = module_loader._load_module_source(self._task.action, module_loader.find_plugin(self._task.action))
-
-        if not getattr(module, 'USE_PERSISTENT_CONNECTION', False):
-            return super(ActionModule, self).run(tmp, task_vars)
 
         provider = self.load_provider()
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Allows existing junos galaxy modules to execute on 2.3 by handling the fact that they can not be
imported cleanly from within the junos action handler.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/junos.py

##### ANSIBLE VERSION
```
user@h0:~/Automation/Projects/Ansible$ ansible --version
ansible 2.3.0 (execute_existing_junos_galaxy_modules c4f105fefe) last updated 2017/03/13 18:14:39 (GMT -600)
  config file = /media/sf_Automation/Projects/Ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.9 (default, Jun 29 2016, 13:08:31) [GCC 4.9.2]
```
based on
```
user@h0:~/Automation/Projects/Ansible$ ansible --version
ansible 2.3.0 (devel 07674a8446) last updated 2017/03/13 17:48:23 (GMT -600)
  config file = /media/sf_Automation/Projects/Ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.9 (default, Jun 29 2016, 13:08:31) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
See #22589 for output before change.

Output after this change:
```
user@h0:~/Automation/Projects/Ansible$ ansible-playbook -vvvv --limit r0 playbooks/galaxy/facts.pb.yaml 
Using /media/sf_Automation/Projects/Ansible/ansible.cfg as config file
Loading callback plugin default of type stdout, v2.0 from /media/sf_Automation/Projects/Ansible/Repos/stacywsmith/ansible/lib/ansible/plugins/callback/__init__.pyc
Loading callback plugin jsnapy of type aggregate, v2.0 from /media/sf_Automation/Projects/Ansible/Repos/stacywsmith/ansible/lib/ansible/plugins/callback/__init__.pyc

PLAYBOOK: facts.pb.yaml ********************************************************************************************************************
1 plays in playbooks/galaxy/facts.pb.yaml

PLAY [Get facts from Junos routers using the galaxy module] ********************************************************************************
META: ran handlers

TASK [Get Junos Facts] *********************************************************************************************************************
task path: /media/sf_Automation/Projects/Ansible/playbooks/galaxy/facts.pb.yaml:9
Using module file /media/sf_Automation/Projects/Ansible/Repos/stacywsmith/ansible-junos-stdlib/library/junos_get_facts
<r0> ESTABLISH LOCAL CONNECTION FOR USER: user
<r0> EXEC /bin/sh -c 'echo ~ && sleep 0'
<r0> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/user/.ansible/tmp/ansible-tmp-1489451567.23-70854537572393 `" && echo ansible-tmp-1489451567.23-70854537572393="` echo /home/user/.ansible/tmp/ansible-tmp-1489451567.23-70854537572393 `" ) && sleep 0'
<r0> PUT /tmp/tmp0_PSj0 TO /home/user/.ansible/tmp/ansible-tmp-1489451567.23-70854537572393/junos_get_facts
<r0> EXEC /bin/sh -c 'chmod u+x /home/user/.ansible/tmp/ansible-tmp-1489451567.23-70854537572393/ /home/user/.ansible/tmp/ansible-tmp-1489451567.23-70854537572393/junos_get_facts && sleep 0'
<r0> EXEC /bin/sh -c '/usr/bin/python /home/user/.ansible/tmp/ansible-tmp-1489451567.23-70854537572393/junos_get_facts; rm -rf "/home/user/.ansible/tmp/ansible-tmp-1489451567.23-70854537572393/" > /dev/null 2>&1 && sleep 0'
ok: [r0] => {
    "changed": false, 
    "facts": {
        "HOME": "/var/home/user", 
        "RE0": {
            "last_reboot_reason": "Router rebooted after a normal shutdown.", 
            "mastership_state": "master", 
            "model": "RE-VMX", 
            "status": "OK", 
            "up_time": "12 days, 4 hours, 49 minutes, 2 seconds"
        }, 
        "RE1": null, 
        "RE_hw_mi": false, 
        "current_re": [
            "re0", 
            "master", 
            "node", 
            "fwdd", 
            "member", 
            "pfem"
        ], 
        "domain": "englab.juniper.net", 
        "fqdn": "r0.englab.juniper.net", 
        "has_2RE": false, 
        "hostname": "r0", 
        "hostname_info": {
            "re0": "r0"
        }, 
        "ifd_style": "CLASSIC", 
        "junos_info": {
            "re0": {
                "object": {
                    "build": 7, 
                    "major": [
                        16, 
                        1
                    ], 
                    "minor": "4", 
                    "type": "R"
                }, 
                "text": "16.1R4.7"
            }
        }, 
        "master": "RE0", 
        "model": "MX960", 
        "model_info": {
            "re0": "MX960"
        }, 
        "personality": "MX", 
        "re_info": {
            "default": {
                "0": {
                    "last_reboot_reason": "Router rebooted after a normal shutdown.", 
                    "mastership_state": "master", 
                    "model": "RE-VMX", 
                    "status": "OK"
                }, 
                "default": {
                    "last_reboot_reason": "Router rebooted after a normal shutdown.", 
                    "mastership_state": "master", 
                    "model": "RE-VMX", 
                    "status": "OK"
                }
            }
        }, 
        "re_master": {
            "default": "0"
        }, 
        "serialnumber": "VMX5868", 
        "srx_cluster": null, 
        "switch_style": "BRIDGE_DOMAIN", 
        "vc_capable": false, 
        "vc_fabric": null, 
        "vc_master": null, 
        "vc_mode": null, 
        "version": "16.1R4.7", 
        "version_RE0": "16.1R4.7", 
        "version_RE1": null, 
        "version_info": {
            "build": 7, 
            "major": [
                16, 
                1
            ], 
            "minor": "4", 
            "type": "R"
        }, 
        "virtual": true
    }, 
    "invocation": {
        "module_args": {
            "console": null, 
            "host": "r0", 
            "logfile": null, 
            "mode": null, 
            "passwd": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": "830", 
            "savedir": null, 
            "ssh_private_key_file": null, 
            "user": "user"
        }
    }
}

TASK [Print Facts] *************************************************************************************************************************
task path: /media/sf_Automation/Projects/Ansible/playbooks/galaxy/facts.pb.yaml:15
ok: [r0] => {
    "changed": false, 
    "response.facts": {
        "HOME": "/var/home/user", 
        "RE0": {
            "last_reboot_reason": "Router rebooted after a normal shutdown.", 
            "mastership_state": "master", 
            "model": "RE-VMX", 
            "status": "OK", 
            "up_time": "12 days, 4 hours, 49 minutes, 2 seconds"
        }, 
        "RE1": null, 
        "RE_hw_mi": false, 
        "current_re": [
            "re0", 
            "master", 
            "node", 
            "fwdd", 
            "member", 
            "pfem"
        ], 
        "domain": "englab.juniper.net", 
        "fqdn": "r0.englab.juniper.net", 
        "has_2RE": false, 
        "hostname": "r0", 
        "hostname_info": {
            "re0": "r0"
        }, 
        "ifd_style": "CLASSIC", 
        "junos_info": {
            "re0": {
                "object": {
                    "build": 7, 
                    "major": [
                        16, 
                        1
                    ], 
                    "minor": "4", 
                    "type": "R"
                }, 
                "text": "16.1R4.7"
            }
        }, 
        "master": "RE0", 
        "model": "MX960", 
        "model_info": {
            "re0": "MX960"
        }, 
        "personality": "MX", 
        "re_info": {
            "default": {
                "0": {
                    "last_reboot_reason": "Router rebooted after a normal shutdown.", 
                    "mastership_state": "master", 
                    "model": "RE-VMX", 
                    "status": "OK"
                }, 
                "default": {
                    "last_reboot_reason": "Router rebooted after a normal shutdown.", 
                    "mastership_state": "master", 
                    "model": "RE-VMX", 
                    "status": "OK"
                }
            }
        }, 
        "re_master": {
            "default": "0"
        }, 
        "serialnumber": "VMX5868", 
        "srx_cluster": null, 
        "switch_style": "BRIDGE_DOMAIN", 
        "vc_capable": false, 
        "vc_fabric": null, 
        "vc_master": null, 
        "vc_mode": null, 
        "version": "16.1R4.7", 
        "version_RE0": "16.1R4.7", 
        "version_RE1": null, 
        "version_info": {
            "build": 7, 
            "major": [
                16, 
                1
            ], 
            "minor": "4", 
            "type": "R"
        }, 
        "virtual": true
    }
}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************************************************************************
r0                         : ok=2    changed=0    unreachable=0    failed=0   
```