### PR TITLE
win_service Added -Force option and minor cleanup

### DIFF
--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -68,13 +68,12 @@ options:
     description:
       - The display name to set for the service.
     version_added: "2.3"
-  ignore_dependencies:
+  force_dependent_services:
     description:
-    - When stopping or restarting a service this will Force the service to stop
-      if it has services that are dependent on this.
-    - If C(state) is stopped, restarted or absent and there are services that
-      are dependent on the service you wish to modify, this needs to be set to
-      True for it to succeed.
+    - If True, stopping or restarting a service with dependent services will
+      force the dependent services to stop or restart also.
+    - If False, stopping or restarting a service with dependent services may
+      fail.
     default: False
     version_added: "2.3"
   name:

--- a/lib/ansible/modules/windows/win_service.py
+++ b/lib/ansible/modules/windows/win_service.py
@@ -40,7 +40,6 @@ options:
       service.
     - This works by C(dependency_action) to either add/remove or set the
       services in this list.
-    required: False
     version_added: "2.3"
   dependency_action:
     description:
@@ -49,7 +48,6 @@ options:
     - Remove the dependencies to the existing dependencies.
     - Set the dependencies to only the values in the list replacing the
       existing dependencies.
-    required: False
     default: set
     choices:
     - set
@@ -60,18 +58,24 @@ options:
     description:
       - Whether to allow the service user to interact with the desktop.
       - This should only be set to true when using the LocalSystem username.
-    required: False
     default: False
     version_added: "2.3"
   description:
     description:
       - The description to set for the service.
-    required: False
     version_added: "2.3"
   display_name:
     description:
       - The display name to set for the service.
-    required: False
+    version_added: "2.3"
+  ignore_dependencies:
+    description:
+    - When stopping or restarting a service this will Force the service to stop
+      if it has services that are dependent on this.
+    - If C(state) is stopped, restarted or absent and there are services that
+      are dependent on the service you wish to modify, this needs to be set to
+      True for it to succeed.
+    default: False
     version_added: "2.3"
   name:
     description:
@@ -80,7 +84,6 @@ options:
   path:
     description:
       - The path to the executable to set for the service.
-    required: False
     version_added: "2.3"
   password:
     description:
@@ -88,13 +91,11 @@ options:
       - This and the C(username) argument must be supplied together.
       - If specifying LocalSystem, NetworkService or LocalService this field
         must be an empty string and not null.
-    required: False
     version_added: "2.3"
   start_mode:
     description:
       - Set the startup type for the service.
       - C(delayed) added in Ansible 2.3
-    required: false
     choices:
       - auto
       - manual
@@ -106,7 +107,6 @@ options:
         commands unless necessary.
       - C(restarted) will always bounce the service.
       - C(absent) added in Ansible 2.3
-    required: false
     choices:
       - started
       - stopped
@@ -116,7 +116,6 @@ options:
     description:
       - The username to set the service to start as.
       - This and the C(password) argument must be supplied together.
-    required: False
     version_added: "2.3"
 author: "Chris Hoffman (@chrishoffman)"
 '''

--- a/test/integration/targets/win_service/tasks/main.yml
+++ b/test/integration/targets/win_service/tasks/main.yml
@@ -19,6 +19,7 @@
 - name: remove the dummy test services if it is left over from previous tests
   win_service:
     name: "{{item}}"
+    ignore_dependencies: True
     state: absent
   with_items:
   - "{{test_win_service_name}}"
@@ -775,6 +776,7 @@
 - name: make sure all services are stopped, set to LocalSystem and set to auto start before next test
   win_service:
     name: "{{item}}"
+    ignore_dependencies: True
     state: stopped
     start_mode: auto
     username: LocalSystem
@@ -817,13 +819,21 @@
     - "win_service_parent1_stat.depended_by == ['TestServiceDependency']"
     - "win_service_parent2_stat.depended_by == ['TestServiceDependency']"
 
-- name: remove the service
+- name: fail to remove service with dependencies
   win_service:
     name: "{{test_win_service_name}}"
     state: absent
+  register: win_service_removed_failed
+  failed_when: win_service_removed_failed.msg != "Cannot stop service 'Test Service New (TestService)' because it has dependent services. It can only be stopped if the Force flag is set."
+
+- name: remove the service while ignoring dependencies
+  win_service:
+    name: "{{test_win_service_name}}"
+    ignore_dependencies: True
+    state: absent
   register: win_service_removed
 
-- name: check that removing the service succeeds with changes
+- name: check that removing the service while ignoring dependencies succeeds with changes
   assert:
     that:
     - "win_service_removed|changed"
@@ -839,6 +849,7 @@
 - name: make sure all services are removed in the end
   win_service:
     name: "{{item}}"
+    ignore_dependencies: True
     state: absent
   with_items:
   - "{{test_win_service_name}}"

--- a/test/integration/targets/win_service/tasks/main.yml
+++ b/test/integration/targets/win_service/tasks/main.yml
@@ -19,7 +19,7 @@
 - name: remove the dummy test services if it is left over from previous tests
   win_service:
     name: "{{item}}"
-    ignore_dependencies: True
+    force_dependent_services: True
     state: absent
   with_items:
   - "{{test_win_service_name}}"
@@ -776,7 +776,7 @@
 - name: make sure all services are stopped, set to LocalSystem and set to auto start before next test
   win_service:
     name: "{{item}}"
-    ignore_dependencies: True
+    force_dependent_services: True
     state: stopped
     start_mode: auto
     username: LocalSystem
@@ -829,7 +829,7 @@
 - name: remove the service while ignoring dependencies
   win_service:
     name: "{{test_win_service_name}}"
-    ignore_dependencies: True
+    force_dependent_services: True
     state: absent
   register: win_service_removed
 
@@ -849,7 +849,7 @@
 - name: make sure all services are removed in the end
   win_service:
     name: "{{item}}"
-    ignore_dependencies: True
+    force_dependent_services: True
     state: absent
   with_items:
   - "{{test_win_service_name}}"


### PR DESCRIPTION
##### SUMMARY
As per the discussion in the Windows user group this cleans up win_service so that it matches general standard and adds the optional parameter around whether to force a service to stop.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
win_service

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 771b14acb2) last updated 2017/03/14 17:33:12 (GMT +1000)
  config file = /mnt/c/dev/test/role/ansible.cfg
  configured module search path = [u'/mnc/c/dev/test/role/library']
  python version = 2.7.12 (default, Dec 14 2016, 21:05:07) [GCC 4.8.4]
```