### PR TITLE
cloudstack: fix wrong vpc found by name

### DIFF
--- a/lib/ansible/module_utils/cloudstack.py
+++ b/lib/ansible/module_utils/cloudstack.py
@@ -235,11 +235,15 @@ class AnsibleCloudStack(object):
             self.module.fail_json(msg="No VPCs available.")
 
         for v in vpcs['vpc']:
-            if vpc in [v['displaytext'], v['name'], v['id']]:
-                self.vpc = v
-                return self._get_by_key(key, self.vpc)
+            if vpc in [v['name'], v['displaytext'], v['id']]:
+                # Fail if the identifyer matches more than one VPC
+                if self.vpc:
+                    self.module.fail_json(msg="More than one VPC found with the provided identifyer '%s'" % vpc)
+                else:
+                    self.vpc = v
+        if self.vpc:
+            return self._get_by_key(key, self.vpc)
         self.module.fail_json(msg="VPC '%s' not found" % vpc)
-
 
     def is_vm_in_vpc(self, vm):
         for n in vm.get('nic'):

--- a/lib/ansible/modules/cloud/cloudstack/cs_vpc.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_vpc.py
@@ -260,9 +260,12 @@ class AnsibleCloudStackVpc(AnsibleCloudStack):
         if vpcs:
             vpc_name = self.module.params.get('name')
             for v in vpcs['vpc']:
-                if vpc_name.lower() in [v['name'].lower(), v['id']]:
-                    self.vpc = v
-                    break
+                if vpc_name in [v['name'], v['displaytext'], v['id']]:
+                    # Fail if the identifyer matches more than one VPC
+                    if self.vpc:
+                        self.module.fail_json(msg="More than one VPC found with the provided identifyer '%s'" % vpc_name)
+                    else:
+                        self.vpc = v
         return self.vpc
 
     def restart_vpc(self):


### PR DESCRIPTION
Fail fast if more than one VPC found with given identifier.

##### SUMMARY
vpc names are not unique.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cs_vpc

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
 $ ansible -m cs_vpc -a "name=test_vpc_1 state=absent api_region=test-cloud" --check localhost 
 [WARNING]: Host file not found: /etc/ansible/hosts

 [WARNING]: provided hosts list is empty, only localhost is available

localhost | FAILED! => {
    "changed": false, 
    "failed": true, 
    "msg": "More than one VPC found with the provided identifyer 'test_vpc_1'"
}

```
