### PR TITLE
Add filter arg for include_vars module

### DIFF
--- a/lib/ansible/modules/utilities/logic/include_vars.py
+++ b/lib/ansible/modules/utilities/logic/include_vars.py
@@ -63,6 +63,13 @@ options:
     description:
         - This module allows you to specify the 'file' option directly w/o any other options.
           There is no 'free-form' option, this is just an indicator, see example below.
+  filter:
+    version_added: "2.3"
+    description:
+        - Pick sub-dictionnary from a YAML/JSON, only variables in this sub-dictionnary part are interpolated
+        - When arg dir is defined, filter is skipped
+        - Character `.` is used for getting an element in a map
+    default: null
 '''
 
 EXAMPLES = """
@@ -114,4 +121,9 @@ EXAMPLES = """
     dir: 'vars'
     ignore_files: 'bastion.yml'
     extensions: ['yml']
+
+- name: Include only a sub-dictionnary
+  include_vars:
+    file: foo.yml
+    filter: bar
 """

--- a/lib/ansible/plugins/action/include_vars.py
+++ b/lib/ansible/plugins/action/include_vars.py
@@ -74,7 +74,7 @@ class ActionModule(ActionBase):
         """ Set instance variables based on the arguments that were passed
         """
         self.VALID_DIR_ARGUMENTS = [
-            'dir', 'depth', 'files_matching', 'ignore_files', 'extensions',
+            'dir', 'depth', 'files_matching', 'ignore_files', 'extensions', 'filter'
         ]
         self.VALID_FILE_ARGUMENTS = ['file', '_raw_params']
         self.GLOBAL_FILE_ARGUMENTS = ['name']
@@ -98,6 +98,7 @@ class ActionModule(ActionBase):
         self.files_matching = self._task.args.get('files_matching', None)
         self.ignore_files = self._task.args.get('ignore_files', None)
         self.valid_extensions = self._task.args.get('extensions', self.VALID_FILE_EXTENSIONS)
+        self.filter = self._task.args.get('filter', None)
         if isinstance(self.valid_extensions, string_types):
             self.valid_extensions = list(self.valid_extensions)
 
@@ -146,6 +147,19 @@ class ActionModule(ActionBase):
             except AnsibleError as e:
                 failed = True
                 err_msg = to_native(e)
+
+        if self.filter and not self.source_dir:
+            try:
+                key = self.filter
+                for item in self.filter.split("."):
+                    results = results[item]
+                    key = item
+                results = {key: results}
+            except TypeError as e:
+                err_msg = to_native(e)
+                raise AnsibleError(err_msg + "- The field `filter` must be a string")
+            except KeyError as e:
+                raise AnsibleError("The key `" + self.filter +"` doesn't exist")
 
         if self.return_results_as_name:
             scope = dict()


### PR DESCRIPTION
##### SUMMARY
Add a filter argument for include_vars module which enables to get a sub element of dictionnary, sometimes ansible needs to include some parts of file to have a lazy evaluation. 
```
#example.yml
tomcat:
   metadata:
      version: 8
      uri: foobar.com
   url: " http://{{ dynamic.metadata.uri }}/dl/tomcat/{{ dynamic.metadata.version }}"
```
```
#playbook
- hosts: localhost

  tasks:
    - include_vars:
        file: example.yml
        filter: "tomcat.metadata"
        name: dynamic

    - include_vars:
        file: example.yml
        name: test

    - debug: msg="{{ test }}"
```
```
TASK [debug] *******************************************************************
ok: [localhost] => {
    "msg": {
        "tomcat": {
            "metadata": {
                "uri": "foobar.com", 
                "version": 8
            }, 
            "url": " http://foobar.com/dl/tomcat/8"
        }
    }
}
```
It's better that a bloc `raw | endraw`

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

include_vars