### PR TITLE
Implement eos_banner for EAPI

### DIFF
--- a/lib/ansible/modules/network/eos/eos_banner.py
+++ b/lib/ansible/modules/network/eos/eos_banner.py
@@ -107,9 +107,15 @@ def map_obj_to_commands(updates, module):
 
     elif state == 'present':
         if want['text'] and (want['text'] != have.get('text')):
-            commands.append('banner %s' % module.params['banner'])
-            commands.extend(want['text'].strip().split('\n'))
-            commands.append('EOF')
+            if module.params['transport'] == 'cli':
+                commands.append('banner %s' % module.params['banner'])
+                commands.extend(want['text'].strip().split('\n'))
+                commands.append('EOF')
+            else:
+                # For EAPI we need to construct a dict with cmd/input
+                # key/values for the banner
+                commands.append({'cmd': 'banner %s' % module.params['banner'],
+                                 'input': want['text'].strip('\n')})
 
     return commands
 
@@ -117,7 +123,12 @@ def map_config_to_obj(module):
     output = run_commands(module, ['show banner %s' % module.params['banner']])
     obj = {'banner': module.params['banner'], 'state': 'absent'}
     if output:
-        obj['text'] = output[0]
+        if module.params['transport'] == 'cli':
+            obj['text'] = output[0]
+        else:
+            # On EAPI we need to extract the banner text from dict key
+            # 'loginBanner'
+            obj['text'] = output[0]['loginBanner'].strip('\n')
         obj['state'] = 'present'
     return obj
 

--- a/test/units/modules/network/eos/eos_module.py
+++ b/test/units/modules/network/eos/eos_module.py
@@ -62,9 +62,9 @@ class AnsibleFailJson(Exception):
 class TestEosModule(unittest.TestCase):
 
     def execute_module(self, failed=False, changed=False, commands=None,
-            sort=True, defaults=False):
+            sort=True, defaults=False, transport='cli'):
 
-        self.load_fixtures(commands)
+        self.load_fixtures(commands, transport=transport)
 
         if failed:
             result = self.failed()
@@ -108,6 +108,6 @@ class TestEosModule(unittest.TestCase):
         self.assertEqual(result['changed'], changed, result)
         return result
 
-    def load_fixtures(self, commands=None):
+    def load_fixtures(self, commands=None, transport='cli'):
         pass
 

--- a/test/units/modules/network/eos/test_eos_command.py
+++ b/test/units/modules/network/eos/test_eos_command.py
@@ -36,7 +36,7 @@ class TestEosCommandModule(TestEosModule):
     def tearDown(self):
         self.mock_run_commands.stop()
 
-    def load_fixtures(self, commands=None):
+    def load_fixtures(self, commands=None, transport='cli'):
         def load_from_file(*args, **kwargs):
             module, commands = args
             output = list()

--- a/test/units/modules/network/eos/test_eos_config.py
+++ b/test/units/modules/network/eos/test_eos_config.py
@@ -41,7 +41,7 @@ class TestEosConfigModule(TestEosModule):
         self.mock_get_config.stop()
         self.mock_load_config.stop()
 
-    def load_fixtures(self, commands=None):
+    def load_fixtures(self, commands=None, transport='cli'):
         self.get_config.return_value = load_fixture('eos_config_config.cfg')
         self.load_config.return_value = dict(diff=None, session='session')
 

--- a/test/units/modules/network/eos/test_eos_eapi.py
+++ b/test/units/modules/network/eos/test_eos_eapi.py
@@ -53,7 +53,7 @@ class TestEosEapiModule(TestEosModule):
         except RuntimeError:
             pass
 
-    def load_fixtures(self, commands=None):
+    def load_fixtures(self, commands=None, transport='eapi'):
         def run_commands(module, commands, **kwargs):
             output = list()
             for cmd in commands:

--- a/test/units/modules/network/eos/test_eos_system.py
+++ b/test/units/modules/network/eos/test_eos_system.py
@@ -40,7 +40,7 @@ class TestEosSystemModule(TestEosModule):
         self.mock_get_config.stop()
         self.mock_load_config.stop()
 
-    def load_fixtures(self, commands=None):
+    def load_fixtures(self, commands=None, transport='cli'):
         self.get_config.return_value = load_fixture('eos_system_config.cfg')
         self.load_config.return_value = dict(diff=None, session='session')
 

--- a/test/units/modules/network/eos/test_eos_user.py
+++ b/test/units/modules/network/eos/test_eos_user.py
@@ -39,7 +39,7 @@ class TestEosUserModule(TestEosModule):
         self.mock_get_config.stop()
         self.mock_load_config.stop()
 
-    def load_fixtures(self, commands=None):
+    def load_fixtures(self, commands=None, transport='cli'):
         self.get_config.return_value = load_fixture('eos_user_config.cfg')
         self.load_config.return_value = dict(diff=None, session='session')
 


### PR DESCRIPTION
##### SUMMARY

On EAPI, the multi-line commands are expected to be a dict,
with key/value pairs 'cmd'/'input' .
This change implements that behaviour and fixes the idempotency
on EAPI as well.

Fixes #22494

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 
##### COMPONENT NAME

eos_banner

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (issue_22494 df49f22fa6) last updated 2017/03/14 15:39:57 (GMT +200)
```
