### PR TITLE
adds soft-update logic if force is set to no in zabbix_host module in…

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix_host.py
@@ -520,7 +520,23 @@ def main():
                 module.fail_json(msg="Specify at least one group for updating host '%s'." % host_name)
 
             if not force:
-                module.fail_json(changed=False, result="Host present, Can't update configuration without force")
+                # get existing groups, interfaces and templates and merge them with ones provided as an argument
+                # we do not want to overwrite anything if force: no is explicitly used, we just want to add new ones
+                for group_id in host.get_group_ids_by_group_names(host.get_host_groups_by_host_id(host_id)):
+                    if group_id not in group_ids:
+                        group_ids.append(group_id)
+
+                for interface in host._zapi.hostinterface.get({'output': 'extend', 'hostids': host_id}):
+                    # remove values not used during hostinterface.add/update calls
+                    interface = {x:interface[x] for x in interface.keys() if x not in ['interfaceid', 'hostid', 'bulk']}
+                    for index in interface.keys():
+                        if index in ['useip', 'main', 'type', 'port']:
+                            interface[index] = int(interface[index])
+
+                    if interface not in interfaces:
+                        interfaces.append(interface)
+
+                template_ids = list(set(template_ids + host.get_host_templates_by_host_id(host_id)))
 
             # get exist host's interfaces
             exist_interfaces = host._zapi.hostinterface.get({'output': 'extend', 'hostids': host_id})

--- a/lib/ansible/modules/monitoring/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix_host.py
@@ -528,7 +528,10 @@ def main():
 
                 for interface in host._zapi.hostinterface.get({'output': 'extend', 'hostids': host_id}):
                     # remove values not used during hostinterface.add/update calls
-                    interface = {x:interface[x] for x in interface.keys() if x not in ['interfaceid', 'hostid', 'bulk']}
+                    for key in interface.keys():
+                        if key in ['interfaceid', 'hostid', 'bulk']:
+                            interface.pop(key, None)
+
                     for index in interface.keys():
                         if index in ['useip', 'main', 'type', 'port']:
                             interface[index] = int(interface[index])


### PR DESCRIPTION
…stead of failing

##### SUMMARY
This patch adds soft update logic to zabbix_host module when used with `force: no` argument. So far this module fails if such option is used. Error message is: 

> Host present, Can't update configuration without force

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/monitoring/zabbix_host

##### ANSIBLE VERSION
```
ansible 2.3.0 (zabbix_host_module_force_option 3eb93687ec) last updated 2017/03/14 16:15:55 (GMT +200)
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Oct 10 2016, 12:56:26) [GCC 5.4.0]
```


##### ADDITIONAL INFORMATION
Prior to this patch, module zabbix_host allowed to only use `force: yes` and resources such as interfaces, groups or templates assigned to zabbix host were all removed before any update took place. With this patch, there is possibility to overwrite only specified resources and left existing ones intact.

Previously, when you have specified something like this:
```
- name: Create host in zabbix
  zabbix_host:
    server_url: https://zabbix.instance
    login_user: '{{ zabbix_user }}'
    login_password: '{{ zabbix_password }}'
    host_name: '{{ inventory_hostname }}'
    host_groups:
      - group1
      - group2
    link_templates:
      - template1
      - template2
    state: present
    status: enabled
    force: no
```

You would obtain following error:
```
TASK [Create host in zabbix] ***************************************************
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_dwWe7T/ansible_module_zabbix_host.py", line 562, in <module>
    main()
  File "/tmp/ansible_dwWe7T/ansible_module_zabbix_host.py", line 506, in main
    module.fail_json(changed=False, result="Host present, Can't update configuration without force")
  File "/tmp/ansible_dwWe7T/ansible_modlib.zip/ansible/module_utils/basic.py", line 1808, in fail_json
AssertionError: implementation error -- msg to explain the error is required
```

Now it will ensure, that host is in groups _group1_ and _group2_ and linked to templates _template1_ and _template2_. 

Lets say, we have added our host to _group3_ manually. When used with `force: yes`, this group would be removed. Now you can use `force: no` and this group will stay as well.