### PR TITLE
Fix bug in iam_role

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam_role.py
+++ b/lib/ansible/modules/cloud/amazon/iam_role.py
@@ -182,7 +182,7 @@ def create_or_update_role(connection, module):
     changed = False
 
     # Get role
-    role = get_role(connection, params['RoleName'])
+    role = get_role(connection, params['RoleName'], module)
 
     # If role is None, create it
     if role is None:
@@ -250,7 +250,7 @@ def create_or_update_role(connection, module):
         connection.add_role_to_instance_profile(InstanceProfileName=params['RoleName'], RoleName=params['RoleName'])
 
     # Get the role again
-    role = get_role(connection, params['RoleName'])
+    role = get_role(connection, params['RoleName'], module)
 
     role['attached_policies'] = get_attached_policy_list(connection, params['RoleName'])
     module.exit_json(changed=changed, iam_role=camel_dict_to_snake_dict(role))
@@ -261,7 +261,7 @@ def destroy_role(connection, module):
     params = dict()
     params['RoleName'] = module.params.get('name')
 
-    if get_role(connection, params['RoleName']):
+    if get_role(connection, params['RoleName'], module):
 
         # We need to remove any instance profiles from the role before we delete it
         try:
@@ -293,7 +293,7 @@ def destroy_role(connection, module):
     module.exit_json(changed=True)
 
 
-def get_role(connection, name):
+def get_role(connection, name, module):
 
     params = dict()
     params['RoleName'] = name


### PR DESCRIPTION
##### SUMMARY
Currently, if the authenticating IAM permissions do not have permissions to do IAM operations it causes a traceback in this module

The error looks something like 

```
    "module_stderr": "Traceback (most recent call last):\n  File \"/var/folders/kq/q0k1cmdx1k5fg1ppzrbfdky80000gn/T/ansible_nqXgN1/ansible_module_iam_role.py\", line 353, in <module>\n    main()\n  File \"/var/folders/kq/q0k1cmdx1k5fg1ppzrbfdky80000gn/T/ansible_nqXgN1/ansible_module_iam_role.py\", line 345, in main\n    create_or_update_role(connection, module)\n  File \"/var/folders/kq/q0k1cmdx1k5fg1ppzrbfdky80000gn/T/ansible_nqXgN1/ansible_module_iam_role.py\", line 180, in create_or_update_role\n    role = get_role(connection, params['RoleName'])\n  File \"/var/folders/kq/q0k1cmdx1k5fg1ppzrbfdky80000gn/T/ansible_nqXgN1/ansible_module_iam_role.py\", line 302, in get_role\n    module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))\nNameError: global name 'module' is not defined\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE"
}
```

Upon further inspection it seems like the module object isn't being passed into the function and thus comes back as undefined. With my patch, the error is properly returned with error_json. It _seems_ this will be an issue with other functions but it's outside the scope of the problem I encountered.
cc @wimnat 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
iam_role.py

##### ANSIBLE VERSION
tested with upstream version of iam_role


##### ADDITIONAL INFORMATION
After my patch the output shows:
```
    "msg": "An error occurred (AccessDenied) when calling the GetRole operation: User: arn:aws-us-gov:iam::xxxxx:user/xxxxx is not authorized to perform: iam:GetRole on resource: role vmimport",
    "response_metadata": {
        "http_headers": {
            "content-length": "366",
            "content-type": "text/xml",
            "date": "Tue, 14 Mar 2017 18:35:05 GMT",
            "x-amzn-requestid": "f17854bd-08e4-11e7-97d1-5974d51572f1"
        },
        "http_status_code": 403,
        "request_id": "f17854bd-08e4-11e7-97d1-5974d51572f1",
        "retry_attempts": 0
    }
}
```
