### PR TITLE
Support for group metrics collection in ec2_asg module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -163,14 +163,13 @@ options:
     description:
       - Enable group metrics collection for the auto scaling group.
     required: False
-    default: False
-    version_added: "2.3"
+    version_added: "2.4"
   metrics_granularity:
     description:
       - The granularity to associate with the metrics to collect. The only valid value is 1Minute.
     required: False
     default: "1Minute"
-    version_added: "2.3"
+    version_added: "2.4"
   metrics_members:
     description:
       - Group metrics to collect when collection is enabled.
@@ -184,7 +183,7 @@ options:
       - GroupStandbyInstances
       - GroupTerminatingInstances
       - GroupTotalInstances
-    version_added: "2.3"
+    version_added: "2.4"
 extends_documentation_fragment:
     - aws
     - ec2

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -159,6 +159,32 @@ options:
     default: []
     choices: ['Launch', 'Terminate', 'HealthCheck', 'ReplaceUnhealthy', 'AZRebalance', 'AlarmNotification', 'ScheduledActions', 'AddToLoadBalancer']
     version_added: "2.3"
+  metrics_collection:
+    description:
+      - Enable group metrics collection for the auto scaling group.
+    required: False
+    default: False
+    version_added: "2.3"
+  metrics_granularity:
+    description:
+      - The granularity to associate with the metrics to collect. The only valid value is 1Minute.
+    required: False
+    default: "1Minute"
+    version_added: "2.3"
+  metrics_members:
+    description:
+      - Group metrics to collect when collection is enabled.
+    required: False
+    default:
+      - GroupMinSize
+      - GroupMaxSize
+      - GroupDesiredCapacity
+      - GroupInServiceInstances
+      - GroupPendingInstances
+      - GroupStandbyInstances
+      - GroupTerminatingInstances
+      - GroupTotalInstances
+    version_added: "2.3"
 extends_documentation_fragment:
     - aws
     - ec2
@@ -243,6 +269,7 @@ log.getLogger('boto').setLevel(log.CRITICAL)
 try:
     import boto.ec2.autoscale
     from boto.ec2.autoscale import AutoScaleConnection, AutoScalingGroup, Tag
+    from boto.ec2.autoscale.group import EnabledMetric
     from boto.exception import BotoServerError
     HAS_BOTO = True
 except ImportError:
@@ -448,6 +475,9 @@ def create_autoscaling_group(connection, module):
     termination_policies = module.params.get('termination_policies')
     notification_topic = module.params.get('notification_topic')
     notification_types = module.params.get('notification_types')
+    metrics_collection = module.params.get('metrics_collection')
+    metrics_granularity = module.params.get('metrics_granularity')
+    metrics_members = module.params.get('metrics_members')
 
     if not vpc_zone_identifier and not availability_zones:
         region, ec2_url, aws_connect_params = get_aws_connection_info(module)
@@ -494,6 +524,14 @@ def create_autoscaling_group(connection, module):
         try:
             connection.create_auto_scaling_group(ag)
             suspend_processes(ag, module)
+
+            if metrics_collection:
+                connection.enable_metrics_collection(
+                    group_name,
+                    metrics_granularity,
+                    metrics_members
+                )
+
             if wait_for_instances:
                 wait_for_new_inst(module, connection, group_name, wait_timeout, desired_capacity, 'viable_instances')
                 wait_for_elb(connection, module, group_name)
@@ -534,6 +572,31 @@ def create_autoscaling_group(connection, module):
                 if group_attr != module_attr:
                     changed = True
                     setattr(as_group, attr, module_attr)
+
+        if not metrics_collection:
+            metrics_members = []
+
+        enabled_metrics = getattr(as_group, 'enabled_metrics')
+        desired_metrics = [
+            EnabledMetric(m, metrics_granularity) for m in metrics_members
+        ]
+
+        if set(desired_metrics) != set(enabled_metrics):
+            changed = True
+
+            if metrics_collection:
+                connection.enable_metrics_collection(
+                    group_name,
+                    metrics_granularity,
+                    metrics_members
+                )
+
+            else:
+                connection.disable_metrics_collection(
+                    group_name,
+                    metrics_members
+                )
+
 
         if len(set_tags) > 0:
             have_tags = {}
@@ -893,7 +956,19 @@ def main():
                 'autoscaling:EC2_INSTANCE_TERMINATE',
                 'autoscaling:EC2_INSTANCE_TERMINATE_ERROR'
             ]),
-            suspend_processes=dict(type='list', default=[])
+            suspend_processes=dict(type='list', default=[]),
+            metrics_collection=dict(type='bool', default=False),
+            metrics_granularity=dict(type='str', default='1Minute'),
+            metrics_members=dict(type='list', default=[
+                'GroupMinSize',
+                'GroupMaxSize',
+                'GroupDesiredCapacity',
+                'GroupInServiceInstances',
+                'GroupPendingInstances',
+                'GroupStandbyInstances',
+                'GroupTerminatingInstances',
+                'GroupTotalInstances',
+            ]),
         ),
     )
 


### PR DESCRIPTION
##### SUMMARY
Currently the `ec2_asg` module does not support enabling group metrics collection for an auto scaling group.  This implements a backwards compatible default that is fully configurable for explicit use.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
ec2_asg

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (auto-scaling-group-metrics 5631d1555e) last updated 2017/03/14 14:20:08 (GMT -500)
  config file = /home/ssiefkas/projects/ms.ansible.playbooks/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Dec 21 2016, 07:16:46) [GCC 6.2.1 20160830
```

##### ADDITIONAL INFORMATION
I've tested this against `devel` as well as a patch against 2.2.0.
