### PR TITLE
Fixes #5480 Handle setup module returning AccountDomainSid if running as SYSTEM

### DIFF
--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -131,7 +131,7 @@ foreach ($item in Get-ChildItem Env:) {
 }
  
 Try {
-    $machine_id = $user.User.AccountDomainSid.Value -ErrorAction Stop
+    $machine_id = $user.User.AccountDomainSid.Value
 }
 Catch {
     $machine_id = ""

--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -129,6 +129,13 @@ foreach ($item in Get-ChildItem Env:) {
     $value = ($item | select -ExpandProperty Value).TrimEnd("\")
     $env_vars.Add($name, $value)
 }
+ 
+Try {
+    $machine_id = $user.User.AccountDomainSid.Value -ErrorAction Stop
+}
+Catch {
+    $machine_id = ""
+}
 
 $ansible_facts = @{
     ansible_architecture = $win32_os.OSArchitecture
@@ -146,7 +153,7 @@ $ansible_facts = @{
     ansible_ip_addresses = $ips
     ansible_kernel = $osversion.Version.ToString()
     ansible_lastboot = $win32_os.lastbootuptime.ToString("u")
-    ansible_machine_id = $user.User.AccountDomainSid.Value
+    ansible_machine_id = $machine_id
     ansible_nodename = ($ip_props.HostName + "." + $ip_props.DomainName)
     ansible_os_family = "Windows"
     ansible_os_name = ($win32_os.Name.Split('|')[0]).Trim()


### PR DESCRIPTION
##### SUMMARY
This wraps a Try/Catch block around `User.AccountDomainSid.Value` in the case that one is running ansible over a custom transport method as SYSTEM, as described in [#5480](https://github.com/ansible/ansible-modules-core/issues/5480) from `ansible-modules-core`.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
setup.ps1

##### ANSIBLE VERSION
```
ansible 2.2.1.0
```

##### ADDITIONAL INFORMATION
Fixes the following error with a blank string, as suggested by @trondhindenes in the aforementioned issue.
```
{"exception":"At C:\\Windows\\TEMP\\ansible-tmp-1478196574.65-49351933792000\\setup.ps1:363 char:1\r\n+ Set-Attr $result.ansible_facts \\"ansible_machine_id\\" $user.User.AccountDomainSid. ...\r\n+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~","msg":"The property \\u0027Value\\u0027 cannot be found on this object. Verify that the property exists.","failed":true}
```
