### PR TITLE
[WIP]make windows async ... async

### DIFF
--- a/test/integration/targets/win_async_wrapper/tasks/main.yml
+++ b/test/integration/targets/win_async_wrapper/tasks/main.yml
@@ -1,3 +1,7 @@
+- name: capture timestamp before fire and forget
+  set_fact:
+    start_timestamp: "{{ lookup('pipe', 'date +%s') }}"
+
 - name: async fire and forget
   async_test:
     sleep_delay_sec: 5
@@ -12,6 +16,8 @@
     - asyncresult.started == 1
     - asyncresult.finished == 0
     - asyncresult.results_file is search('\.ansible_async.+\d+\.\d+')
+     # ensure that async is actually async- this test will fail if # hosts > forks or if the target host is VERY slow
+    - (lookup('pipe', 'date +%s') | int) - (start_timestamp | int) < 5
 
 - name: async poll immediate success
   async_test:


### PR DESCRIPTION
##### SUMMARY
Fixes #22575 - issue under new exec wrapper where unconstrained handle inheritance (for stdin) caused WinRM to block on breakaway processes. Uses explicit handle inheritance to ensure that only stdin read handle gets inherited. Adds test to ensure that async is actually async.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
powershell.py

