### PR TITLE
ec2_ami_copy encrypted should default to False

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
@@ -196,7 +196,7 @@ def main():
         source_image_id=dict(required=True),
         name=dict(default='default'),
         description=dict(default=''),
-        encrypted=dict(type='bool', required=False),
+        encrypted=dict(type='bool', default=False, required=False),
         kms_key_id=dict(type='str', required=False),
         wait=dict(type='bool', default=False),
         wait_timeout=dict(default=1200),


### PR DESCRIPTION
##### SUMMARY

Set encrypted to default False, rather than None

Otherwise you get:

```
Invalid type for parameter Encrypted, value: None, type: <type 'NoneType'>, valid types: <type 'bool'>)
```

I'm not really sure why this stopped working though.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_ami_copy

##### ANSIBLE VERSION
```
ansible 2.3.0 (devel 9755d2dbbc) last updated 2017/03/15 14:40:06 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```

##### ADDITIONAL INFORMATION
