### PR TITLE
Update tests README file to include new pytest-xdist dependency and t…

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,6 +1,8 @@
 Ansible Test System
 ===================
 
+Before starting you probably want the setup in the `hacking' directory.
+
 Folders
 =======
 
@@ -12,7 +14,10 @@ mock interfaces rather than producing side effects.
 
 Playbook engine code is better suited for integration tests.
 
-Requirements: `sudo pip install paramiko PyYAML jinja2 httplib2 passlib nose pytest mock`
+Requirements: `sudo pip install paramiko PyYAML jinja2 httplib2 passlib nose pytest pytest-xdist mock`
+
+You can also install tox which will run the unit tests and other checks when run.  This includes
+python style checks (PEP8 etc) which will be required for contributions to ansible.
 
 integration
 -----------


### PR DESCRIPTION
…ell about tox

##### SUMMARY

When you try to run pytest according to the current instructions it fails due to an unrecognised --boxed option.   If you install pytest-xdist then everything works.  

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

tests/README.md

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel f72701ebc7) last updated 2017/03/15 11:19:50 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/mikedd/dev/ansible/ansible-ssh-module/library']
  python version = 2.7.12 (default, Jul  1 2016, 15:12:24) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
#no changes
```
