### PR TITLE
cloud: docker: Fixes #22638 load image to memory when archive_path pr…

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -394,9 +394,9 @@ class ImageManager(DockerBaseClass):
                 self.fail("Error getting image %s - %s" % (image_name, str(exc)))
 
             try:
-                image_tar = open(self.archive_path, 'w')
-                image_tar.write(image.data)
-                image_tar.close()
+                with open(self.archive_path, 'w') as fd:
+                    for chunk in image.stream(2048, decode_content=False):
+                        fd.write(chunk)
             except Exception as exc:
                 self.fail("Error writing image archive %s - %s" % (self.archive_path, str(exc)))
 


### PR DESCRIPTION
…ovided

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #22638 
Write response content by chunks instead of complete loading it to memory.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
docker_image
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
N/A
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Method data loads all bytes of request into memory. It could cause out-of-memory errors. Use chunked writing instead, to prevent increasing of memory usage.
