### PR TITLE
add tmpfs support to docker_container module

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -414,6 +414,12 @@ options:
       - Number of seconds to wait for the container to stop before sending SIGKILL.
     required: false
     default: null
+  tmpfs:
+    description:
+      - List of mounting points for a tmpfs folder. This can be used to create a temporary writable folder when having a
+        read-only container
+    required: false
+    default: null
   trust_image_content:
     description:
       - If true, skip image verification.
@@ -747,6 +753,7 @@ class TaskParameters(DockerBaseClass):
         self.state = None
         self.stop_signal = None
         self.stop_timeout = None
+        self.tmpfs = None
         self.trust_image_content = None
         self.tty = None
         self.user = None
@@ -929,6 +936,7 @@ class TaskParameters(DockerBaseClass):
             cap_add='capabilities',
             extra_hosts='etc_hosts',
             read_only='read_only',
+            tmpfs='tmpfs',
             ipc_mode='ipc_mode',
             security_opt='security_opts',
             ulimits='ulimits',
@@ -1171,6 +1179,7 @@ class Container(DockerBaseClass):
         self.parameters.expected_ulimits = None
         self.parameters.expected_etc_hosts = None
         self.parameters.expected_env = None
+        self.parameters.expected_tmpfs = None
 
     def fail(self, msg):
         self.parameters.client.module.fail_json(msg=msg)
@@ -1202,6 +1211,7 @@ class Container(DockerBaseClass):
         self.parameters.expected_env = self._get_expected_env(image)
         self.parameters.expected_cmd = self._get_expected_cmd()
         self.parameters.expected_devices = self._get_expected_devices()
+        self.parameters.expected_tmpfs = self._get_expected_tmpfs()
 
         if not self.container.get('HostConfig'):
             self.fail("has_config_diff: Error parsing container properties. HostConfig missing.")
@@ -1262,8 +1272,9 @@ class Container(DockerBaseClass):
             restart_retries=restart_policy.get('MaximumRetryCount'),
             # Cannot test shm_size, as shm_size is not included in container inspection results.
             # shm_size=host_config.get('ShmSize'),
-            security_opts=host_config.get("SecuriytOpt"),
+            security_opts=host_config.get("SecurityOpt"),
             stop_signal=config.get("StopSignal"),
+            expected_tmpfs=host_config.get('Tmpfs'),
             tty=config.get('Tty'),
             expected_ulimits=host_config.get('Ulimits'),
             uts=host_config.get('UTSMode'),
@@ -1645,6 +1656,18 @@ class Container(DockerBaseClass):
         if not self.parameters.command:
             return None
         return shlex.split(self.parameters.command)
+    
+    def _get_expected_tmpfs(self):
+        self.log('_get_expected_tmpfs')
+        result = dict()
+        for tmpfs_mnt in self.parameters.tmpfs:
+            loc_param = tmpfs_mnt.split(":")
+            if (len(loc_param) == 1):
+                result[loc_param[0]] = ""
+            else:
+                result[loc_param[0]] = loc_param[1]
+        return result
+
 
     def _convert_simple_dict_to_list(self, param_name, join_with=':'):
         if getattr(self.parameters, param_name, None) is None:
@@ -2006,6 +2029,7 @@ def main():
         state=dict(type='str', choices=['absent', 'present', 'started', 'stopped'], default='started'),
         stop_signal=dict(type='str'),
         stop_timeout=dict(type='int'),
+        tmpfs=dict(type='list'),
         trust_image_content=dict(type='bool', default=False),
         tty=dict(type='bool', default=False),
         ulimits=dict(type='list'),


### PR DESCRIPTION
##### SUMMARY
when running docker containers with read only root file systems, there is the need to have writable tmpfs (eg. nginx image). In this pull request the --tmpfs option was added to the docker_container module

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
```
ansible 2.2.1.0
```
##### ADDITIONAL INFORMATION

