### PR TITLE
Add workaround for evasive in apache2_module

### DIFF
--- a/lib/ansible/modules/web_infrastructure/apache2_module.py
+++ b/lib/ansible/modules/web_infrastructure/apache2_module.py
@@ -143,10 +143,10 @@ def _module_is_enabled(module):
         else:
             module.fail_json(msg=error_msg)
 
-    searchstring = ' ' + replace_name(name)
+    searchstring = ' ' + create_apache_identifier(name)
     return searchstring in stdout
 
-def replace_name(name):
+def create_apache_identifier(name):
     """
     By convention if a module is loaded via name, it appears in apache2ctl -M as
     name_module.

--- a/test/integration/targets/apache2_module/tasks/actualtest.yml
+++ b/test/integration/targets/apache2_module/tasks/actualtest.yml
@@ -15,9 +15,12 @@
 
 - name: install apache via apt
   apt:
-    name: apache2
+    name: "{{item}}"
     state: present
   when: "ansible_os_family == 'Debian'"
+  with_items:
+    - apache2
+    - libapache2-mod-evasive
 
 - name: install apache via zypper
   zypper:
@@ -84,4 +87,11 @@
     name: autoindex
     state: absent
     force: True
-  when: "ansible_os_family != 'Suse'"
+  when: "ansible_os_family == 'Debian'"
+
+
+- name: enable evasive module, test https://github.com/ansible/ansible/issues/22635
+  apache2_module:
+    name: evasive
+    state: present
+  when: "ansible_os_family == 'Debian'"

--- a/test/units/modules/web_infrastructure/test_apache2_module.py
+++ b/test/units/modules/web_infrastructure/test_apache2_module.py
@@ -1,0 +1,17 @@
+import pytest
+from ansible.compat.tests import unittest
+
+from ansible.modules.web_infrastructure.apache2_module import replace_name
+
+REPLACEMENTS = [
+    ('php7.1', 'php7_module'),
+    ('php5.6', 'php5_module'),
+    ('shib2', 'mod_shib'),
+    ('evasive', 'evasive20_module'),
+    ('thismoduledoesnotexist', 'thismoduledoesnotexist_module'),  # the default
+]
+
+@pytest.mark.parametrize("replacement", REPLACEMENTS, ids=lambda x: x[0])
+def test_replacement(replacement):
+    "test the correct replacement of an a2enmod name with an apache2ctl name"
+    assert replace_name(replacement[0]) == replacement[1]

--- a/test/units/modules/web_infrastructure/test_apache2_module.py
+++ b/test/units/modules/web_infrastructure/test_apache2_module.py
@@ -1,7 +1,6 @@
 import pytest
-from ansible.compat.tests import unittest
 
-from ansible.modules.web_infrastructure.apache2_module import replace_name
+from ansible.modules.web_infrastructure.apache2_module import create_apache_identifier
 
 REPLACEMENTS = [
     ('php7.1', 'php7_module'),
@@ -12,6 +11,6 @@ REPLACEMENTS = [
 ]
 
 @pytest.mark.parametrize("replacement", REPLACEMENTS, ids=lambda x: x[0])
-def test_replacement(replacement):
+def test_apache_identifier(replacement):
     "test the correct replacement of an a2enmod name with an apache2ctl name"
-    assert replace_name(replacement[0]) == replacement[1]
+    assert create_apache_identifier(replacement[0]) == replacement[1]


### PR DESCRIPTION
##### SUMMARY

* Fixes #22635, allow to load/unload evasive module
* Clean up workarounds for php/shib
* Add test for evasive workaround
* Remove use of re module, since all searches work with native python

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
apache2_module

##### ANSIBLE VERSION
* ansible 2.2
* devel