### PR TITLE
Cast syslogport value from getenv as int (Fixes #22659)

### DIFF
--- a/lib/ansible/plugins/callback/syslog_json.py
+++ b/lib/ansible/plugins/callback/syslog_json.py
@@ -38,7 +38,7 @@ class CallbackModule(CallbackBase):
 
         self.handler = logging.handlers.SysLogHandler(
             address = (os.getenv('SYSLOG_SERVER','localhost'),
-                       os.getenv('SYSLOG_PORT',514)),
+                       int(os.getenv('SYSLOG_PORT',514))),
             facility= os.getenv('SYSLOG_FACILITY',logging.handlers.SysLogHandler.LOG_USER)
         )
         self.logger.addHandler(self.handler)


### PR DESCRIPTION
##### SUMMARY

The syslog_json callback plugin allows configuration of its target port by specifying the SYSLOG_PORT environment variable; however, it doesn't cast the value it obtains from get_env as int, so specifying a port number this way results in errors on each task and no syslog output.

SysLogHandler requires an int for port, but getenv produces a string. Casting return from getenv as int overcomes this mismatch.

Fixes https://github.com/ansible/ansible/issues/22659

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
syslog_json

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
