### PR TITLE
Remove python2.4 package install from other test.

### DIFF
--- a/test/utils/shippable/other.sh
+++ b/test/utils/shippable/other.sh
@@ -9,7 +9,6 @@ retry.py add-apt-repository 'ppa:fkrull/deadsnakes'
 retry.py apt-get update -qq
 retry.py apt-get install -qq \
     shellcheck \
-    python2.4 \
     g++-4.9 \
     python3.6-dev \
 


### PR DESCRIPTION
##### SUMMARY

Remove python2.4 package install from other test.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

CI

##### ANSIBLE VERSION

```
ansible 2.4.0 (at-py24 e793807e11) last updated 2017/03/15 15:49:48 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
