### PR TITLE
Fix module validation without base branch.

### DIFF
--- a/test/sanity/validate-modules/validate-modules
+++ b/test/sanity/validate-modules/validate-modules
@@ -1002,12 +1002,16 @@ class GitCache(object):
     def __init__(self, base_branch):
         self.base_branch = base_branch
 
-        self.base_tree = self._git(['ls-tree', '-r', '--name-only', self.base_branch, 'lib/ansible/modules/'])
+        if self.base_branch:
+            self.base_tree = self._git(['ls-tree', '-r', '--name-only', self.base_branch, 'lib/ansible/modules/'])
+        else:
+            self.base_tree = []
+
         self.head_tree = self._git(['ls-tree', '-r', '--name-only', 'HEAD', 'lib/ansible/modules/'])
 
         self.base_module_paths = dict((os.path.basename(p), p) for p in self.base_tree if os.path.splitext(p)[1] in ('.py', '.ps1'))
 
-        del self.base_module_paths['__init__.py']
+        self.base_module_paths.pop('__init__.py', None)
 
         self.head_aliased_modules = set()
 


### PR DESCRIPTION
##### SUMMARY

Fix module validation without base branch.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

validate-modules

##### ANSIBLE VERSION

```
ansible 2.4.0 (validate-fix ed62c7f953) last updated 2017/03/15 19:43:33 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
