### PR TITLE
Change the example of playbook include.

### DIFF
--- a/docs/docsite/rst/playbooks_roles.rst
+++ b/docs/docsite/rst/playbooks_roles.rst
@@ -37,7 +37,7 @@ Task versus Play includes
 Tasks and plays both use the `include` keyword, but implement the keyword differently. The difference between them is determined by their positioning and content. If the include is inside a play it can only be a 'task' include and include a list of tasks; if it is at the top level, it can only include plays. For example::
 
     # this is a 'play' include
-    - include: listofplays
+    - include: intro_example.yml
 
     - name: another play
       hosts: all


### PR DESCRIPTION
This (taken from https://github.com/ansible/ansible-examples/blob/master/language_features/nested_playbooks.yml) is a better example. It makes it clear that the full file name is used, and a single filename, as opposed to a YAML list. The old version, it was not clear if 'list_of_plays' was an *example* or a *variable*.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
