### PR TITLE
Retry on Throttling

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -85,7 +85,8 @@ class AWSRetry(CloudRetry):
         # https://github.com/boto/boto3/issues/876 (and linked PRs etc)
         retry_on = [
             'RequestLimitExceeded', 'Unavailable', 'ServiceUnavailable',
-            'InternalFailure', 'InternalError', 'TooManyRequestsException'
+            'InternalFailure', 'InternalError', 'TooManyRequestsException',
+            'Throttling'
         ]
 
         not_found = re.compile(r'^\w+.NotFound')


### PR DESCRIPTION
##### SUMMARY
We use ansible+cloudformation pretty heavily in our CI environments and occasionally bump into throttling issues.  By adding this error code to the retry system we should be able to achieve better stability.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
[AWSRetry](https://github.com/ansible/ansible/blob/4554e8d7694f27b9611314bd67c2f0bc1749e6e3/lib/ansible/module_utils/ec2.py#L71)