### PR TITLE
iam.py: allow groups parameter to be noticed as an empty list - fixes #22388

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam.py
+++ b/lib/ansible/modules/cloud/amazon/iam.py
@@ -55,7 +55,8 @@ options:
     choices: [ "present", "absent", "update" ]
   path:
     description:
-      - When creating or updating, specify the desired path of the resource. If state is present, it will replace the current path to match what is passed in when they do not match.
+      - When creating or updating, specify the desired path of the resource. If state is present,
+        it will replace the current path to match what is passed in when they do not match.
     required: false
     default: "/"
   trust_policy:
@@ -101,7 +102,8 @@ options:
     description:
      - C(always) will update passwords if they differ.  C(on_create) will only set the password for newly created users.
 notes:
-  - 'Currently boto does not support the removal of Managed Policies, the module will error out if your user/group/role has managed policies when you try to do state=absent. They will need to be removed manually.'
+  - 'Currently boto does not support the removal of Managed Policies, the module will error out if your
+    user/group/role has managed policies when you try to do state=absent. They will need to be removed manually.'
 author:
     - "Jonathan I. Davila (@defionscode)"
     - "Paul Seiffert (@seiffert)"
@@ -701,7 +703,7 @@ def main():
             if name_change and new_name:
                 orig_name = name
                 name = new_name
-            if groups:
+            if isinstance(groups, list):
                 user_groups, groups_changed = set_users_groups(
                     module, iam, name, groups, been_updated, new_name)
                 if groups_changed == user_changed:

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -47,7 +47,6 @@ lib/ansible/modules/cloud/amazon/ecs_service.py
 lib/ansible/modules/cloud/amazon/ecs_service_facts.py
 lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
 lib/ansible/modules/cloud/amazon/elasticache.py
-lib/ansible/modules/cloud/amazon/iam.py
 lib/ansible/modules/cloud/amazon/iam_cert.py
 lib/ansible/modules/cloud/amazon/iam_policy.py
 lib/ansible/modules/cloud/amazon/iam_role.py


### PR DESCRIPTION
make iam.py pep8

remove iam.py from pep8 legacy files

##### SUMMARY
Checks if groups is a list instead of checking if groups. According to the documentation groups is a`list of groups the user should belong to. When update, will gracefully remove groups not listed.` When updating with an empty list all groups should be gracefully removed. Fixes #22388. Also made iam.py pep8 and removed from legacy files.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/iam.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (allow-iam-remove-all-groups 6b71ab01a5) last updated 2017/03/16 12:17:13 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```