### PR TITLE
[bugfix] validate-module error during sanity checks

### DIFF
--- a/test/sanity/validate-modules/validate-modules
+++ b/test/sanity/validate-modules/validate-modules
@@ -624,6 +624,7 @@ class ModuleValidator(Validator):
 
     def _validate_docs(self):
         doc_info = self._get_docs()
+        deprecated = False
         if not bool(doc_info['DOCUMENTATION']['value']):
             self.errors.append((301, 'No DOCUMENTATION provided'))
         else:
@@ -658,7 +659,6 @@ class ModuleValidator(Validator):
                          'with DOCUMENTATION.extends_documentation_fragment')
                     ))
 
-                deprecated = False
                 if self.object_name.startswith('_') and not os.path.islink(self.object_path):
                     deprecated = True
                     if 'deprecated' not in doc or not doc.get('deprecated'):


### PR DESCRIPTION

##### SUMMARY
Noted in tests [here](https://app.shippable.com/github/ansible/ansible/runs/16493/1/console), the module validator declares a variable in a conditional that doesn't always run. This causes the validator to bomb out some of the time.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
validate-modules
##### ANSIBLE VERSION
N/A


##### ADDITIONAL INFORMATION

Seems error was introduced in https://github.com/ansible/ansible/commit/04e816e13b4f3adda09a9a0f20266349bf89c870