### PR TITLE
Fix ansible-test PR diff handling.

### DIFF
--- a/test/runner/lib/changes.py
+++ b/test/runner/lib/changes.py
@@ -68,8 +68,8 @@ class ShippableChanges(object):
             raise ChangeDetectionNotSupported('Change detection is not supported for tags.')
 
         if self.is_pr:
-            self.paths = sorted(git.get_diff_names([self.branch]))
-            self.diff = git.get_diff([self.branch])
+            self.paths = sorted(git.get_diff_names(['origin/%s' % self.branch, '--']))
+            self.diff = git.get_diff(['origin/%s' % self.branch, '--'])
         else:
             merge_runs = self.get_merge_runs(self.project_id, self.branch)
             last_successful_commit = self.get_last_successful_commit(git, merge_runs)


### PR DESCRIPTION
##### SUMMARY

Permits use of PRs on branches other than devel.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.4.0 (at-pr-fix 33e3666610) last updated 2017/03/16 10:00:59 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
