### PR TITLE
Dont break on throttling

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -325,7 +325,11 @@ def stack_operation(cfn, stack_name, operation):
         try:
             stack = get_stack_facts(cfn, stack_name)
             existed.append('yes')
-        except:
+        except Exception as ex:
+            if is_throttling_exception(ex):
+                # If the api is throttling, wait and try again
+                time.sleep(5)
+                continue
             # If the stack previously existed, and now can't be found then it's
             # been deleted successfully.
             if 'yes' in existed or operation == 'DELETE': # stacks may delete fast, look in a few ways.
@@ -365,6 +369,17 @@ def stack_operation(cfn, stack_name, operation):
 @AWSRetry.backoff(tries=3, delay=5)
 def describe_stacks(cfn, stack_name):
     return cfn.describe_stacks(StackName=stack_name)
+
+def is_throttling_exception(ex):
+  if not isinstance(ex, botocore.exceptions.ClientError):
+    return False
+  if 'Error' not in ex.response:
+    return False
+  if 'Code' not in ex.response['Error']:
+    return False
+  if ex.response['Error']['Code'] == 'Throttling':
+    return True
+  return False
 
 def get_stack_facts(cfn, stack_name):
     try:


### PR DESCRIPTION
##### SUMMARY
We heavily use ansible+cloudformation in our CI environments and sometimes encounter throttling exceptions from AWS (even with the retries).  Currently the module does not handle these exceptions in any special way and will either return "Stack Deleted" if the module existed previously or "Stack not found" otherwise.  Those returns are not necessarily reflective of the actual state and we would like to simply wait and try again when these kind of errors are encountered.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
[cloudformation.py](https://github.com/colin-hanson-zocdoc/ansible/blob/cd97f5c0d61d3508b8bc9162f7e34f403ec87cdd/lib/ansible/modules/cloud/amazon/cloudformation.py)
