### PR TITLE
RabbitMQ 3.6.7 changed a couple of response codes

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq_exchange.py
+++ b/lib/ansible/modules/messaging/rabbitmq_exchange.py
@@ -204,7 +204,8 @@ def main():
         elif module.params['state'] == 'absent':
             r = requests.delete( url, auth = (module.params['login_user'],module.params['login_password']))
 
-        if r.status_code == 204:
+        # RabbitMQ 3.6.7 changed this response code from 204 to 201
+        if r.status_code == 204 or r.status_code == 201:
             module.exit_json(
                 changed = True,
                 name = module.params['name']

--- a/lib/ansible/modules/messaging/rabbitmq_queue.py
+++ b/lib/ansible/modules/messaging/rabbitmq_queue.py
@@ -250,7 +250,8 @@ def main():
         elif module.params['state'] == 'absent':
             r = requests.delete( url, auth = (module.params['login_user'],module.params['login_password']))
 
-        if r.status_code == 204:
+        # RabbitMQ 3.6.7 changed this response code from 204 to 201
+        if r.status_code == 204 or r.status_code == 201:
             module.exit_json(
                 changed = True,
                 name = module.params['name']


### PR DESCRIPTION
##### SUMMARY
RabbitMQ 3.6.7 (released 3/15/2017) embeds a new HTTP server, and changed the response code returned from several endpoints.  This updates the rabbitmq_queue and rabbitmq_exchange modules to allow for this.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- rabbitmq_exchange
- rabbitmq_queue

##### ANSIBLE VERSION
All

##### ADDITIONAL INFORMATION
See RabbitMQ release notes here: [https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v3_6_7](https://github.com/rabbitmq/rabbitmq-server/releases/tag/rabbitmq_v3_6_7)
