### PR TITLE
Allow creation of github release tags

### DIFF
--- a/lib/ansible/modules/source_control/github_release.py
+++ b/lib/ansible/modules/source_control/github_release.py
@@ -50,7 +50,7 @@ options:
   tag:
     required: false
     description:
-      - Tag name when creating a release
+      - Tag name when creating a release. Required when using create_release.
     version_added: 2.4
   target:
     required: false
@@ -177,6 +177,10 @@ def main():
             module.exit_json(tag=None)
 
     if action == 'create_release':
+        release_exists = repository.release_from_tag(tag)
+        if release_exists:
+            module.fail_json(msg="Release already exists.")
+
         release = repository.create_release(
             tag, target, name, body, draft, prerelease)
         if release:

--- a/lib/ansible/modules/source_control/github_release.py
+++ b/lib/ansible/modules/source_control/github_release.py
@@ -179,7 +179,7 @@ def main():
             module.exit_json(tag=None)
 
     if action == 'create_release':
-        if tag == None:
+        if tag is None:
             module.fail_json(msg="Specify tag in order to create a release.")
         release_exists = repository.release_from_tag(tag)
         if release_exists:

--- a/lib/ansible/modules/source_control/github_release.py
+++ b/lib/ansible/modules/source_control/github_release.py
@@ -51,28 +51,34 @@ options:
     required: false
     description:
       - Tag name when creating a release
+    version_added: 2.4
   target:
     required: false
     description:
       - Target of release when creating a release
+    version_added: 2.4
   name:
     required: false
     description:
       - Name of release when creating a release
+    version_added: 2.4
   body:
     required: false
     description:
       - Description of the release when creating a release
+    version_added: 2.4
   draft:
     required: false
     description:
       - Sets if the release is a draft or not. (boolean)
     default: false
+    version_added: 2.4
   prerelease:
     required: false
     description:
       - Sets if the release is a prerelease or not. (boolean)
-    default: false
+    default: falseA
+    version_added: 2.4
 
 author:
     - "Adrian Moisey (@adrianmoisey)"

--- a/lib/ansible/modules/source_control/github_release.py
+++ b/lib/ansible/modules/source_control/github_release.py
@@ -77,7 +77,7 @@ options:
     required: false
     description:
       - Sets if the release is a prerelease or not. (boolean)
-    default: falseA
+    default: false
     version_added: 2.4
 
 author:

--- a/lib/ansible/modules/source_control/github_release.py
+++ b/lib/ansible/modules/source_control/github_release.py
@@ -73,12 +73,14 @@ options:
       - Sets if the release is a draft or not. (boolean)
     default: false
     version_added: 2.4
+    choices: ['True', 'False']
   prerelease:
     required: false
     description:
       - Sets if the release is a prerelease or not. (boolean)
     default: false
     version_added: 2.4
+    choices: ['True', 'False']
 
 author:
     - "Adrian Moisey (@adrianmoisey)"

--- a/lib/ansible/modules/source_control/github_release.py
+++ b/lib/ansible/modules/source_control/github_release.py
@@ -30,23 +30,49 @@ description:
     - Fetch metadata about Github Releases
 version_added: 2.2
 options:
-    token:
-        required: true
-        description:
-            - Github Personal Access Token for authenticating
-    user:
-        required: true
-        description:
-            - The GitHub account that owns the repository
-    repo:
-        required: true
-        description:
-            - Repository name
-    action:
-        required: true
-        description:
-            - Action to perform
-        choices: [ 'latest_release' ]
+  token:
+    required: true
+    description:
+      - Github Personal Access Token for authenticating
+  user:
+    required: true
+    description:
+      - The GitHub account that owns the repository
+  repo:
+    required: true
+    description:
+      - Repository name
+  action:
+    required: true
+    description:
+      - Action to perform
+    choices: [ 'latest_release', 'create_release' ]
+  tag:
+    required: false
+    description:
+      - Tag name when creating a release
+  target:
+    required: false
+    description:
+      - Target of release when creating a release
+  name:
+    required: false
+    description:
+      - Name of release when creating a release
+  body:
+    required: false
+    description:
+      - Description of the release when creating a release
+  draft:
+    required: false
+    description:
+      - Sets if the release is a draft or not. (boolean)
+    default: false
+  prerelease:
+    required: false
+    description:
+      - Sets if the release is a prerelease or not. (boolean)
+    default: false
 
 author:
     - "Adrian Moisey (@adrianmoisey)"
@@ -55,12 +81,23 @@ requirements:
 '''
 
 EXAMPLES = '''
-- name: Get latest release of test/test
+- name: Get latest release of testuser/testrepo
   github:
     token: tokenabc1234567890
     user: testuser
     repo: testrepo
     action: latest_release
+
+- name: Create a new release
+  github:
+    token: tokenabc1234567890
+    user: testuser
+    repo: testrepo
+    action: create_release
+    tag: test
+    target: master
+    name: My Release
+    body: Some description
 '''
 
 RETURN = '''
@@ -85,7 +122,14 @@ def main():
             repo=dict(required=True),
             user=dict(required=True),
             token=dict(required=True, no_log=True),
-            action=dict(required=True, choices=['latest_release']),
+            action=dict(
+                required=True, choices=['latest_release', 'create_release']),
+            tag=dict(type='str'),
+            target=dict(type='str'),
+            name=dict(type='str'),
+            body=dict(type='str'),
+            draft=dict(type='bool', default=False),
+            prerelease=dict(type='bool', default=False),
         ),
         supports_check_mode=True
     )
@@ -98,6 +142,12 @@ def main():
     user = module.params['user']
     login_token = module.params['token']
     action = module.params['action']
+    tag = module.params.get('tag')
+    target = module.params.get('target')
+    name = module.params.get('name')
+    body = module.params.get('body')
+    draft = module.params.get('draft')
+    prerelease = module.params.get('prerelease')
 
     # login to github
     try:
@@ -120,6 +170,13 @@ def main():
         else:
             module.exit_json(tag=None)
 
+    if action == 'create_release':
+        release = repository.create_release(
+            tag, target, name, body, draft, prerelease)
+        if release:
+            module.exit_json(tag=release.tag_name)
+        else:
+            module.exit_json(tag=None)
 
 from ansible.module_utils.basic import *
 

--- a/lib/ansible/modules/source_control/github_release.py
+++ b/lib/ansible/modules/source_control/github_release.py
@@ -179,6 +179,8 @@ def main():
             module.exit_json(tag=None)
 
     if action == 'create_release':
+        if tag == None:
+            module.fail_json(msg="Specify tag in order to create a release.")
         release_exists = repository.release_from_tag(tag)
         if release_exists:
             module.exit_json(

--- a/lib/ansible/modules/source_control/github_release.py
+++ b/lib/ansible/modules/source_control/github_release.py
@@ -179,7 +179,8 @@ def main():
     if action == 'create_release':
         release_exists = repository.release_from_tag(tag)
         if release_exists:
-            module.fail_json(msg="Release already exists.")
+            module.exit_json(
+                skipped=True, msg="Release for tag %s already exists." % tag)
 
         release = repository.create_release(
             tag, target, name, body, draft, prerelease)


### PR DESCRIPTION
##### SUMMARY
Allows a user to create a github release from Ansible.
Useful for anyone doing code releases with Ansible and GitHub Releases.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
github_release

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```