### PR TITLE
ec2_group: remove vpc requirement for default outbound traffic - fixes #20120

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -438,8 +438,8 @@ def main():
                                 src_group_id=grantGroup,
                                 cidr_ip=thisip)
                         changed = True
-        elif vpc_id:
-            # when using a vpc, but no egress rules are specified,
+        else:
+            # when no egress rules are specified,
             # we add in a default allow all out rule, which was the
             # default behavior before egress rules were added
             default_egress_rule = 'out--1-None-None-None-0.0.0.0/0'


### PR DESCRIPTION
##### SUMMARY
Fixing the behavior of ec2_group to match the documentation. The documentation doesn't say anything about requiring a VPC to set default egress rules for a security group, just that if rules_egress is not provided the default all-out rule is assumed. Before this fix, default egress rules were set only if you specified a vpc_id. Fixes #20120.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_group.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (ec2-group-no-egress-rule 4b0a44bd2e) last updated 2017/03/17 11:26:21 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```