### PR TITLE
removing folded style formatting for synopsis

### DIFF
--- a/lib/ansible/modules/network/panos/panos_security_policy.py
+++ b/lib/ansible/modules/network/panos/panos_security_policy.py
@@ -28,10 +28,11 @@ DOCUMENTATION = '''
 ---
 module: panos_security_policy
 short_description: Create security rule policy on PanOS devices.
-description: >
-    Security policies allow you to enforce rules and take action, and can be as general or specific as needed.
-    The policy rules are compared against the incoming traffic in sequence, and because the first rule that matches
-    the traffic is applied, the more specific rules must precede the more general ones.
+description:
+    - Security policies allow you to enforce rules and take action, and can be as
+      general or specific as needed. The policy rules are compared against the
+      incoming traffic in sequence, and because the first rule that matches the
+      traffic is applied, the more specific rules must precede the more general ones.
 author: "Ivan Bojer (@ivanbojer)"
 version_added: "2.3"
 requirements:


### PR DESCRIPTION
##### SUMMARY

Formatting of the synopsis section for the panos_security_policy module is currently incorrect:

https://docs.ansible.com/ansible/panos_security_policy_module.html

Appears to be due to using the folded YAML syntax in the module documentation. Updated and validated with a local sphinx html doc build that the formatting is corrected with this change.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
modules/network/panos/panos_security_policy

