### PR TITLE
Fix deb builder docker image

### DIFF
--- a/packaging/debian/Dockerfile
+++ b/packaging/debian/Dockerfile
@@ -7,7 +7,10 @@ RUN apt-get update && apt-get install -y \
     devscripts \
     make \
     pbuilder \
+    python-pip \
     python-setuptools
+
+RUN pip install Sphinx
 
 VOLUME /ansible
 WORKDIR /ansible


### PR DESCRIPTION
##### SUMMARY
I needed to install Sphinx inside this image to get `make deb` working.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Debian Packaging

##### ANSIBLE VERSION
N/A