### PR TITLE
Flip setenforce boolean

### DIFF
--- a/docs/docsite/rst/playbooks_intro.rst
+++ b/docs/docsite/rst/playbooks_intro.rst
@@ -282,7 +282,7 @@ of arguments and don't use the ``key=value`` form.  This makes
 them work as simply as you would expect::
 
    tasks:
-     - name: disable selinux
+     - name: enable selinux
        command: /sbin/setenforce 1
 
 The **command** and **shell** module care about return codes, so if you have a command

--- a/docs/docsite/rst/playbooks_intro.rst
+++ b/docs/docsite/rst/playbooks_intro.rst
@@ -283,7 +283,7 @@ them work as simply as you would expect::
 
    tasks:
      - name: disable selinux
-       command: /sbin/setenforce 0
+       command: /sbin/setenforce 1
 
 The **command** and **shell** module care about return codes, so if you have a command
 whose successful exit code is not zero, you may wish to do this::


### PR DESCRIPTION
##### SUMMARY
Change command module example from `setenforce 0` to `setenforce 1`

There are already plenty of guides on the internet that start out with disabling SELinux. As a Red Hat product, I would hate to see Ansible's documentation spread this poor security practice even further.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Documentation

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```


##### ADDITIONAL INFORMATION

