### PR TITLE
Fix ansible-test base branch usage on Shippable.

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -1136,7 +1136,7 @@ class SanityConfig(TestConfig):
             self.base_branch = args.base_branch  # str
         elif is_shippable():
             try:
-                self.base_branch = os.environ['BASE_BRANCH']  # str
+                self.base_branch = 'origin/%s' % os.environ['BASE_BRANCH']  # str
             except KeyError as ex:
                 raise MissingEnvironmentVariable(name=ex.args[0])
         else:


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test base branch usage on Shippable.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.4.0 (at-base-branch-fix b8fca74995) last updated 2017/03/17 17:06:44 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
