### PR TITLE
Fix uri options test to work again.

### DIFF
--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -198,7 +198,7 @@
 - name: Assert we got an allow header
   assert:
     that:
-      - 'result.allow|default("") == "HEAD, OPTIONS, GET"'
+      - 'result.allow.split(", ")|sort == ["GET", "HEAD", "OPTIONS"]'
 
 # Ubuntu12.04 doesn't have python-urllib3, this makes handling required dependencies a pain across all variations
 # We'll use this to just skip 12.04 on those tests.  We should be sufficiently covered with other OSes and versions


### PR DESCRIPTION
##### SUMMARY

Fix uri options test to work again.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

uri integration test

##### ANSIBLE VERSION

```
ansible 2.4.0 (uri-test-fix 4998934af4) last updated 2017/03/17 21:58:26 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)] 
```
