### PR TITLE
[route53_health_check] Consider port in identity test

### DIFF
--- a/lib/ansible/modules/cloud/amazon/route53_health_check.py
+++ b/lib/ansible/modules/cloud/amazon/route53_health_check.py
@@ -156,7 +156,7 @@ def find_health_check(conn, wanted):
     """Searches for health checks that have the exact same set of immutable values"""
     for check in conn.get_list_health_checks().HealthChecks:
         config = check.HealthCheckConfig
-        if config.get('IPAddress') == wanted.ip_addr and config.get('FullyQualifiedDomainName') == wanted.fqdn and config.get('Type') == wanted.hc_type and config.get('RequestInterval') == str(wanted.request_interval):
+        if config.get('IPAddress') == wanted.ip_addr and config.get('FullyQualifiedDomainName') == wanted.fqdn and config.get('Type') == wanted.hc_type and config.get('RequestInterval') == str(wanted.request_interval) and config.get('Port') == str(wanted.port):
             return check
     return None
 

--- a/lib/ansible/modules/cloud/amazon/route53_health_check.py
+++ b/lib/ansible/modules/cloud/amazon/route53_health_check.py
@@ -156,7 +156,13 @@ def find_health_check(conn, wanted):
     """Searches for health checks that have the exact same set of immutable values"""
     for check in conn.get_list_health_checks().HealthChecks:
         config = check.HealthCheckConfig
-        if config.get('IPAddress') == wanted.ip_addr and config.get('FullyQualifiedDomainName') == wanted.fqdn and config.get('Type') == wanted.hc_type and config.get('RequestInterval') == str(wanted.request_interval) and config.get('Port') == str(wanted.port):
+        if (
+            config.get('IPAddress') == wanted.ip_addr and
+            config.get('FullyQualifiedDomainName') == wanted.fqdn and
+            config.get('Type') == wanted.hc_type and
+            config.get('RequestInterval') == str(wanted.request_interval) and
+            config.get('Port') == str(wanted.port)
+        ):
             return check
     return None
 

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -54,7 +54,6 @@ lib/ansible/modules/cloud/amazon/rds_param_group.py
 lib/ansible/modules/cloud/amazon/rds_subnet_group.py
 lib/ansible/modules/cloud/amazon/redshift.py
 lib/ansible/modules/cloud/amazon/route53.py
-lib/ansible/modules/cloud/amazon/route53_health_check.py
 lib/ansible/modules/cloud/amazon/s3.py
 lib/ansible/modules/cloud/amazon/s3_lifecycle.py
 lib/ansible/modules/cloud/amazon/s3_sync.py


### PR DESCRIPTION
##### SUMMARY
Consider port when testing whether a health check already exists.

Before, asking for 2 health checks being present for `http://myhost:8888` and `http://myhost:9999`  resulted in just a single health check, as the module saw the two specs as equal.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
route53_health_check

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Mar  4 2017, 14:56:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```