### PR TITLE
win_share: tweaks after the caching mode changes

### DIFF
--- a/lib/ansible/modules/windows/win_share.ps1
+++ b/lib/ansible/modules/windows/win_share.ps1
@@ -138,7 +138,7 @@ Try {
         $permissionFull = Get-AnsibleParam -obj $params -name "full" -type "str" -default "" | NormalizeAccounts
         $permissionDeny = Get-AnsibleParam -obj $params -name "deny" -type "str" -default "" | NormalizeAccounts
 
-        $cachingMode = Get-AnsibleParam -obj $params -name "caching_mode" -type "str" -default "Manual" -validateSet "BranchCache","Documents","Manual","None","Programs"
+        $cachingMode = Get-AnsibleParam -obj $params -name "caching_mode" -type "str" -default "Manual" -validateSet "BranchCache","Documents","Manual","None","Programs","Unknown"
 
         If (-Not (Test-Path -Path $path)) {
             Fail-Json $result "$path directory does not exist on the host"

--- a/lib/ansible/modules/windows/win_share.ps1
+++ b/lib/ansible/modules/windows/win_share.ps1
@@ -138,7 +138,7 @@ Try {
         $permissionFull = Get-AnsibleParam -obj $params -name "full" -type "str" -default "" | NormalizeAccounts
         $permissionDeny = Get-AnsibleParam -obj $params -name "deny" -type "str" -default "" | NormalizeAccounts
 
-        $cachingMode = Get-AnsibleParam -obj $params -name "caching_mode" -type "str" -default "None" -validateSet "BranchCache","Documents","Manual","None","Programs", "Unkown"
+        $cachingMode = Get-AnsibleParam -obj $params -name "caching_mode" -type "str" -default "Manual" -validateSet "BranchCache","Documents","Manual","None","Programs"
 
         If (-Not (Test-Path -Path $path)) {
             Fail-Json $result "$path directory does not exist on the host"
@@ -252,7 +252,7 @@ Try {
     }
 }
 Catch {
-    Fail-Json $result "an error occurred when attempting to create share $name"
+    Fail-Json $result "an error occurred when attempting to create share $($name): $($_.Exception.Message)"
 }
 
 Exit-Json $result

--- a/lib/ansible/modules/windows/win_share.py
+++ b/lib/ansible/modules/windows/win_share.py
@@ -81,6 +81,7 @@ options:
       - Manual
       - None
       - Programs
+      - Unknown
     default: "Manual"
     version_added: "2.3"
 author: Hans-Joachim Kliemeck (@h0nIg), David Baumann (@daBONDi)

--- a/lib/ansible/modules/windows/win_share.py
+++ b/lib/ansible/modules/windows/win_share.py
@@ -39,15 +39,14 @@ options:
   name:
     description:
       - Share name
-    required: yes
+    required: True
   path:
     description:
       - Share directory
-    required: yes
+    required: True
   state:
     description:
       - Specify whether to add C(present) or remove C(absent) the specified share
-    required: no
     choices:
       - present
       - absent
@@ -55,36 +54,24 @@ options:
   description:
     description:
       - Share description
-    required: no
-    default: none
   list:
     description:
       - Specify whether to allow or deny file listing, in case user got no permission on share
-    required: no
     choices:
       - yes
       - no
-    default: none
   read:
     description:
       - Specify user list that should get read access on share, separated by comma.
-    required: no
-    default: none
   change:
     description:
       - Specify user list that should get read and write access on share, separated by comma.
-    required: no
-    default: none
   full:
     description:
       - Specify user list that should get full access on share, separated by comma.
-    required: no
-    default: none
   deny:
     description:
       - Specify user list that should get no access, regardless of implied access on share, separated by comma.
-    required: no
-    default: none
   caching_mode:
     description:
       - Set the CachingMode for this share.
@@ -94,9 +81,8 @@ options:
       - Manual
       - None
       - Programs
-      - Unknown
-    required: no
-    default: "None"
+    default: "Manual"
+    version_added: "2.3"
 author: Hans-Joachim Kliemeck (@h0nIg), David Baumann (@daBONDi)
 '''
 


### PR DESCRIPTION
##### SUMMARY
Some minor tweaks around win_share after some changes before 2.3 release. These changes are
* Changed the default caching mode to Manual as that is what is set from the original module
* Removed the Unknown caching mode option as that isn't a valid parameter
* Added better error responses to return the error info
* Fixed up the module info file to specify when this parameter was added

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_share

##### ANSIBLE VERSION
```
ansible 2.3.0.0 (stable-2.3 923c9ef17c) last updated 2017/03/17 09:12:40 (GMT +1000)
  config file = /apps/dev/playbook/jordan/mr-ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Sep 23 2016, 14:23:49) [GCC 4.4.7 20120313 (Red Hat 4.4.7-17)]
```

##### ADDITIONAL INFORMATION
Hoping to get this through before 2.3 as I believe this is a bug as now using this module changes the caching mode of a new share when not setting the mode to None when in fact the previous module before the changes set it to Manual
