### PR TITLE
cloudstack: fix load balancer idempotency if no zone given

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_loadbalancer_rule.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_loadbalancer_rule.py
@@ -253,7 +253,7 @@ class AnsibleCloudStackLBRule(AnsibleCloudStack):
             'account': self.get_account(key='name'),
             'domainid': self.get_domain(key='id'),
             'projectid': self.get_project(key='id'),
-            'zoneid': self.get_zone(key='id'),
+            'zoneid': self.get_zone(key='id') if self.module.params.get('zone') else None,
             'publicipid': self.get_ip_address(key='id'),
             'name': self.module.params.get('name'),
         }

--- a/lib/ansible/modules/cloud/cloudstack/cs_loadbalancer_rule_member.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_loadbalancer_rule_member.py
@@ -227,7 +227,7 @@ class AnsibleCloudStackLBRuleMember(AnsibleCloudStack):
     def get_rule(self):
         args               = self._get_common_args()
         args['name']       = self.module.params.get('name')
-        args['zoneid']     = self.get_zone(key='id')
+        args['zoneid']     = self.get_zone(key='id') if self.module.params.get('zone') else None
         if self.module.params.get('ip_address'):
             args['publicipid'] = self.get_ip_address(key='id')
         rules = self.cs.listLoadBalancerRules(**args)


### PR DESCRIPTION
##### SUMMARY
get_zone() is special, as it always returns a zone (default zone) even
if no zone param is given. This makes sense for many use cases.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cs_loadbalancer_rule

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```


##### ADDITIONAL INFORMATION
Needs backport to 2.3, tests in #20552 (WIP) 
