### PR TITLE
Fixing nxos_vrf_interface when interface name is not full

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vrf_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrf_interface.py
@@ -173,6 +173,10 @@ def get_vrf_list(module):
 def get_interface_info(interface, module):
     if not interface.startswith('loopback'):
         interface = interface.capitalize()
+
+    interface_type = get_interface_type(interface)
+    intf_module = re.split('\d+', interface)[0]
+    intf_name = interface_type + interface.split(intf_module)[1]
     command = 'show run | section interface.{0}'.format(interface)
     vrf_regex = ".*vrf\s+member\s+(?P<vrf>\S+).*"
 


### PR DESCRIPTION
##### SUMMARY
Since this module uses regex and CLI output to parse interface configuration, it doesn't work well when using incomplete interface names like "eth2/1" instead of "ethernet2/1". This patch fixes it. 

This should also be backported to previous versions.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_vrf_interface

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```

