### PR TITLE
Why: Feature to deploy monit on target host and make the module work with newer versions of monit

### DIFF
--- a/lib/ansible/modules/monitoring/monit.py
+++ b/lib/ansible/modules/monitoring/monit.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python"
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Darryl Stoflet <stoflet@gmail.com>

--- a/lib/ansible/modules/monitoring/monit.py
+++ b/lib/ansible/modules/monitoring/monit.py
@@ -19,9 +19,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-ANSIBLE_METADATA = {'status': ['preview'],
-                    'supported_by': 'community',
-                    'version': '1.1'}
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
 
 DOCUMENTATION = '''
 ---
@@ -29,7 +29,7 @@ module: monit
 short_description: Manage the state of a program monitored via Monit
 description:
      - Manage the state of a program monitored via I(Monit)
-version_added: "1.2"
+version_added: "1.3"
 options:
   name:
     description:
@@ -99,68 +99,67 @@ EXAMPLES = '''
     name: httpd
     state: started
 
-  - Deploy a specific version (5.21.0) of monit.
-    monit:
-      version: 5.21.0
-      path: /opt
-      state: deployed
+- name: Deploy a specific version (5.21.0) of monit.
+  monit:
+    version: 5.21.0
+    path: /opt
+    state: deployed
 
-  - Deploy monit from specified URL
-    monit:
-      url: https://mmonit.com/monit/dist/binary/5.21.0/monit-5.21.0-linux-x86.tar.gz
-      path: /opt
-      state: deployed
+- name: Deploy monit from specified URL
+  monit:
+    url: https://mmonit.com/monit/dist/binary/5.21.0/monit-5.21.0-linux-x86.tar.gz
+    path: /opt
+    state: deployed
 
-  - name: Start monit if not started
-    monit:
-      path: "/opt/monit/bin/monit"
-      config: "/etc/monitrc"
-      state: started
+- name: Start monit if not started
+  monit:
+    path: "/opt/monit/bin/monit"
+    config: "/etc/monitrc"
+    state: started
 
-  - name: Check service {{ ohai_machinename }} present
-    monit:
-      path: "/opt/monit/bin/monit"
-      config: "/etc/monitrc"
-      service: "{{ ohai_machinename }}"
-      state: "present"
+- name: Check service {{ ohai_machinename }} present
+  monit:
+    path: "/opt/monit/bin/monit"
+    config: "/etc/monitrc"
+    service: "{{ ohai_machinename }}"
+    state: "present"
 
-  - name: Start service apache
-    monit:
-      path: "/opt/monit/bin/monit"
-      config: "/etc/monitrc"
-      name: "apache"
-      state: "started"
+- name: Start service apache
+  monit:
+    path: "/opt/monit/bin/monit"
+    config: "/etc/monitrc"
+    name: "apache"
+    state: "started"
 
-  - name: Reload monit configuration
-    monit:
-      path: "/opt/monit/bin/monit"
-      config: "/etc/monitrc"
-      state: "reloaded"
+- name: Reload monit configuration
+  monit:
+    path: "/opt/monit/bin/monit"
+    config: "/etc/monitrc"
+    state: "reloaded"
 
-  - name: Stop Service apache
-    monit:
-      service: "apache"
-      state: "stopped"
+- name: Stop Service apache
+  monit:
+    service: "apache"
+    state: "stopped"
 
-  - name: Restart apache
-    monit:
-      service: "apache"
-      state: "restarted"
+- name: Restart apache
+  monit:
+    service: "apache"
+    state: "restarted"
 
-  - name: Unmonitor Service apache
-    monit:
-      name: "apache"
-      state: "unmonitored"
+- name: Unmonitor Service apache
+  monit:
+    name: "apache"
+    state: "unmonitored"
 
-  - name: Monitor Service apache
-    monit:
-      service: "apache"
-      state: "monitored"
+- name: Monitor Service apache
+  monit:
+    service: "apache"
+    state: "monitored"
 
-  - name: Stop monit
-    monit:
-      state: "stopped"
-
+- name: Stop monit
+  monit:
+    state: "stopped"
 '''
 
 import time
@@ -218,7 +217,7 @@ def main():
         line = out.split('\n')[0]
         rc, out, err = module.run_command('test -s {}/monit'.format(path))
         if rc == 0:
-             rc, out, err = module.run_command('rm -f {}/monit'.format(path), check_rc=True)
+            rc, out, err = module.run_command('rm -f {}/monit'.format(path), check_rc=True)
         rc, out, err = module.run_command("ln -s {}/{} {}/monit".format(path, line, path), check_rc=True)
         rc, out, err = module.run_command("rm -f {}".format(fileName))
 
@@ -271,7 +270,7 @@ def main():
 
         status(service_name)
         while service_status == '' or service_status[service_name]['status'].lower() == 'pending' \
-        or service_status[service_name]['status'].lower() == 'initializing':
+                or service_status[service_name]['status'].lower() == 'initializing':
             if time.time() >= timeout_time:
                 module.fail_json(
                     msg='waited too long for "pending", or "initiating" status to go away ({})'.format(

--- a/lib/ansible/modules/monitoring/monit.py
+++ b/lib/ansible/modules/monitoring/monit.py
@@ -41,6 +41,7 @@ options:
       - The name of the I(monit) program/process to manage. This is an alias of B(name).
     required: false
     default: null
+    version_added: "2.4"
   state:
     description:
       - The state of service
@@ -63,11 +64,13 @@ options:
         other B(state), it should point to the I(monit) binary e.g. "/opt/monit/bin/monit".
     required: false
     default: null
+    version_added: "2.4"
   config:
     description:
       - This may be used to specify the location of the configuration file.
     required: false
     default: null
+    version_added: "2.4"
   version:
     description:
       - This field may be used to specify the version of I(monit) to be deployed. This should be used
@@ -76,17 +79,20 @@ options:
         for the host and installs it.
     required: false
     default: null
+    version_added: "2.4"
   url:
     description:
       - This may be used to specify the URL for the monit tar ball to be downloaded.
     required: false
     default: null
+    version_added: "2.4"
   insecure:
     description:
       - This may be used to download the monit tar ball over HTTPS insecurely i.e., do not verify the SSL
         certificate of the server.
     required: false
     default: false
+    version_added: "2.4"
 requirements: [ ]
 author:
   - "Darryl Stoflet (@dstoflet)"

--- a/lib/ansible/modules/monitoring/monit.py
+++ b/lib/ansible/modules/monitoring/monit.py
@@ -19,10 +19,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-ANSIBLE_METADATA = {'metadata_version': '1.0',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.1'}
 
 DOCUMENTATION = '''
 ---
@@ -35,14 +34,19 @@ options:
   name:
     description:
       - The name of the I(monit) program/process to manage
-    required: true
+    required: false
+    default: null
+  service:
+    description:
+      - The name of the I(monit) program/process to manage. This is an alias of B(name).
+    required: false
     default: null
   state:
     description:
       - The state of service
     required: true
     default: null
-    choices: [ "present", "started", "stopped", "restarted", "monitored", "unmonitored", "reloaded" ]
+    choices: [ "present", "started", "stopped", "restarted", "monitored", "unmonitored", "reloaded", "deployed" ]
   timeout:
     description:
       - If there are pending actions for the service monitored by monit, then Ansible will check
@@ -51,8 +55,42 @@ options:
     required: false
     default: 300
     version_added: "2.1"
+  path:
+    description:
+      - This may be used to specify the location of the I(monit) binary if it is not available in PATH
+        environment.
+        If B(state) is I(deployed), this would be a directory where I(monit) gets extracted. For all
+        other B(state), it should point to the I(monit) binary e.g. "/opt/monit/bin/monit".
+    required: false
+    default: null
+  config:
+    description:
+      - This may be used to specify the location of the configuration file.
+    required: false
+    default: null
+  version:
+    description:
+      - This field may be used to specify the version of I(monit) to be deployed. This should be used
+        in conjuction with B(state) I(deployed). On specifying the I(version), this module automatically
+        tries to identify the platform and architecture of the target host and downloads the proper build
+        for the host and installs it.
+    required: false
+    default: null
+  url:
+    description:
+      - This may be used to specify the URL for the monit tar ball to be downloaded.
+    required: false
+    default: null
+  insecure:
+    description:
+      - This may be used to download the monit tar ball over HTTPS insecurely i.e., do not verify the SSL
+        certificate of the server.
+    required: false
+    default: false
 requirements: [ ]
-author: "Darryl Stoflet (@dstoflet)"
+author:
+  - "Darryl Stoflet (@dstoflet)"
+  - "Prakritish Sen Eshore (@prakritish)"
 '''
 
 EXAMPLES = '''
@@ -60,131 +98,305 @@ EXAMPLES = '''
 - monit:
     name: httpd
     state: started
+
+  - Deploy a specific version (5.21.0) of monit.
+    monit:
+      version: 5.21.0
+      path: /opt
+      state: deployed
+
+  - Deploy monit from specified URL
+    monit:
+      url: https://mmonit.com/monit/dist/binary/5.21.0/monit-5.21.0-linux-x86.tar.gz
+      path: /opt
+      state: deployed
+
+  - name: Start monit if not started
+    monit:
+      path: "/opt/monit/bin/monit"
+      config: "/etc/monitrc"
+      state: started
+
+  - name: Check service {{ ohai_machinename }} present
+    monit:
+      path: "/opt/monit/bin/monit"
+      config: "/etc/monitrc"
+      service: "{{ ohai_machinename }}"
+      state: "present"
+
+  - name: Start service apache
+    monit:
+      path: "/opt/monit/bin/monit"
+      config: "/etc/monitrc"
+      name: "apache"
+      state: "started"
+
+  - name: Reload monit configuration
+    monit:
+      path: "/opt/monit/bin/monit"
+      config: "/etc/monitrc"
+      state: "reloaded"
+
+  - name: Stop Service apache
+    monit:
+      service: "apache"
+      state: "stopped"
+
+  - name: Restart apache
+    monit:
+      service: "apache"
+      state: "restarted"
+
+  - name: Unmonitor Service apache
+    monit:
+      name: "apache"
+      state: "unmonitored"
+
+  - name: Monitor Service apache
+    monit:
+      service: "apache"
+      state: "monitored"
+
+  - name: Stop monit
+    monit:
+      state: "stopped"
+
 '''
 
 import time
-
+import platform
+import os
+import re
+from ansible.module_utils.facts import *
 
 def main():
     arg_spec = dict(
-        name=dict(required=True),
+        service=dict(required=False),
+        name=dict(required=False),
+        path=dict(required=False),
+        config=dict(required=False),
         timeout=dict(default=300, type='int'),
-        state=dict(required=True, choices=['present', 'started', 'restarted', 'stopped', 'monitored', 'unmonitored', 'reloaded'])
+        insecure=dict(default=False, type='bool'),
+        version=dict(required=False),
+        url=dict(required=False),
+        state=dict(required=True, choices=['present', 'started', 'restarted', 'stopped', 'monitored', 'unmonitored', 'reloaded', 'deployed'])
     )
 
     module = AnsibleModule(argument_spec=arg_spec, supports_check_mode=True)
 
-    name = module.params['name']
     state = module.params['state']
     timeout = module.params['timeout']
 
-    MONIT = module.get_bin_path('monit', True)
+    module.params['platform'] = platform.system().lower()
+    module.params['architecture'] = platform.architecture()[0]
+    if module.params['architecture'] == "64bit":
+        module.params['arch'] = "x64"
+    else:
+        module.params['arch'] = "x86"
 
-    def status():
-        """Return the status of the process in monit, or the empty string if not present."""
-        rc, out, err = module.run_command('%s summary' % MONIT, check_rc=True)
-        for line in out.split('\n'):
-            # Sample output lines:
-            # Process 'name'    Running
-            # Process 'name'    Running - restart pending
-            parts = line.split()
-            if len(parts) > 2 and parts[0].lower() == 'process' and parts[1] == "'%s'" % name:
-                return ' '.join(parts[2:]).lower()
+    service_status = dict()
+
+    def fetch(url, insecure=False):
+        fileName = '/tmp/' + os.path.basename(url)
+        CURL = module.get_bin_path('curl')
+        if CURL is None:
+            CURL = module.get_bin_path('wget', True)
+            if insecure:
+                cmd = "{} --no-check-certificate -O {} {}".format(CURL, fileName, url)
+            else:
+                cmd = "{} -O {} {}".format(CURL, fileName, url)
         else:
-            return ''
+            if insecure:
+                cmd = "{} --insecure -o {} {}".format(CURL, fileName, url)
+            else:
+                cmd = "{} -o {} {}".format(CURL, fileName, url)
+        rc, out, err = module.run_command(cmd, check_rc=True)
 
-    def run_command(command):
+    def deploy(fileName, path):
+        TAR = module.get_bin_path('tar', True)
+        rc, out, err = module.run_command("{} zxvf {} -C {}".format(TAR, fileName, path), check_rc=True)
+        line = out.split('\n')[0]
+        rc, out, err = module.run_command('test -s {}/monit'.format(path))
+        if rc == 0:
+             rc, out, err = module.run_command('rm -f {}/monit'.format(path), check_rc=True)
+        rc, out, err = module.run_command("ln -s {}/{} {}/monit".format(path, line, path), check_rc=True)
+        rc, out, err = module.run_command("rm -f {}".format(fileName))
+
+    def summary():
+        """Return the status of the process in monit, or the empty string if not present."""
+        service_status = {}
+        flag = False
+        for i in range(3):
+            rc, out, err = module.run_command("{} -B summary".format(MONIT))
+            if rc == 0:
+                flag = True
+                break
+            else:
+                time.sleep(5)
+        if not flag:
+            module.fail_json(msg=err, name='monit')
+        for line in out.split('\n'):
+            if re.search(r"^\s*Monit\s+", line) or re.search(r"^\s*Service Name\s*Status\s*Type", line):
+                continue
+            match = re.search(r"^\s*(\S+)\s+(\w+)\s+(\w+)\s*", line)
+            if match:
+                service_status[match.group(1).lower()] = {
+                    'status': match.group(2).lower(),
+                    'type': match.group(3).lower()
+                }
+
+    def status(service_name):
+        rc, out, err = module.run_command("{} -B status {}".format(MONIT, service_name), check_rc=True)
+        for line in out.split('\n'):
+            prog = re.compile(r".*'{}'".format(service_name))
+            if re.search(r"^Monit\s+", line) or prog.match(line):
+                continue
+            match = re.search(r"^\s*(\S+ \S+|\S+)\s+(.*)\s*$", line)
+            if match:
+                if service_name not in service_status:
+                    service_status[service_name] = {}
+                service_status[service_name][match.group(1).lower()] = match.group(2).lower()
+
+    def run_command(command, service_name):
         """Runs a monit command, and returns the new status."""
-        module.run_command('%s %s %s' % (MONIT, command, name), check_rc=True)
-        return status()
+        module.run_command("{} {} {}".format(MONIT, command, service_name), check_rc=True)
+        time.sleep(5)
+        summary()
+        status(service_name)
 
-    def wait_for_monit_to_stop_pending():
+    def wait_for_monit_to_stop_pending(service_name):
         """Fails this run if there is no status or it's pending/initalizing for timeout"""
         timeout_time = time.time() + timeout
         sleep_time = 5
 
-        running_status = status()
-        while running_status == '' or 'pending' in running_status or 'initializing' in running_status:
+        status(service_name)
+        while service_status == '' or service_status[service_name]['status'].lower() == 'pending' \
+        or service_status[service_name]['status'].lower() == 'initializing':
             if time.time() >= timeout_time:
                 module.fail_json(
-                    msg='waited too long for "pending", or "initiating" status to go away ({0})'.format(
-                        running_status
+                    msg='waited too long for "pending", or "initiating" status to go away ({})'.format(
+                        service_name
                     ),
                     state=state
                 )
 
             time.sleep(sleep_time)
-            running_status = status()
+            status(service_name)
 
-    if state == 'reloaded':
+    if state == 'deployed':
         if module.check_mode:
             module.exit_json(changed=True)
-        rc, out, err = module.run_command('%s reload' % MONIT)
-        if rc != 0:
-            module.fail_json(msg='monit reload failed', stdout=out, stderr=err)
-        wait_for_monit_to_stop_pending()
-        module.exit_json(changed=True, name=name, state=state)
+        if module.params['url'] is None:
+            monit_dist = 'https://mmonit.com/monit/dist/binary/'
+            if module.params['version'] is None:
+                module.fail_json(msg='URL or Monit version to be deployed is needed')
+            fileName = 'monit-' + module.params['version'] + '-' + module.params['platform'] + '-' + module.params['arch'] + '.tar.gz'
+            url = monit_dist + '/' + module.params['version'] + '/' + fileName
+            module.params['url'] = url
+        else:
+            fileName = os.path.basename(module.params['url'])
+        fetch(module.params['url'], module.params['insecure'])
+        if module.params['path'] is None:
+            module.params['path'] = "/opt"
+        deploy('/tmp/' + fileName, module.params['path'])
+        module.exit_json(changed=True, name='monit', state=state)
 
-    present = status() != ''
+    MONIT = module.params['path'] if module.params['path'] else module.get_bin_path('monit', True)
+    if module.params['config']:
+        MONIT += ' -c ' + module.params['config']
+    name = module.params['service'] if module.params['service'] else module.params['name']
+    if not name:
+        if state == 'started':
+            rc, out, err = module.run_command('{} summary'.format(MONIT))
+            if rc > 0:
+                rc, out, err = module.run_command('{}'.format(MONIT), check_rc=True)
+                module.exit_json(changed=True, name='monit', state=state)
+            else:
+                module.exit_json(changed=False, name='monit', state=state)
+        elif state == 'stopped':
+            rc, out, err = module.run_command('{} summary'.format(MONIT))
+            if rc > 0:
+                module.exit_json(changed=False, name='monit', state=state)
+            else:
+                rc, out, err = module.run_command('{} quit'.format(MONIT), check_rc=True)
+                module.exit_json(changed=True, name='monit', state=state)
+        elif state == 'reloaded':
+            rc, out, err = module.run_command('{} reload'.format(MONIT), check_rc=True)
+            summary()
+            module.exit_json(changed=True, name='monit', state=state)
+        else:
+            module.fail_json(msg='Service name is required', state=state)
 
-    if not present and not state == 'present':
-        module.fail_json(msg='%s process not presently configured with monit' % name, name=name, state=state)
+    summary()
+    status(name)
+
+    if name not in service_status:
+        module.fail_json(msg="{} process not presently configured with monit".format(name), name=name, state=state)
 
     if state == 'present':
-        if not present:
+        if name not in service_status:
             if module.check_mode:
                 module.exit_json(changed=True)
-            status = run_command('reload')
-            if status == '':
-                wait_for_monit_to_stop_pending()
-            module.exit_json(changed=True, name=name, state=state)
+            rc, out, err = module.run_command('{} reload'.format(MONIT), check_rc=True)
+            status(name)
+            if name not in service_status:
+                module.fail_json(msg="{} process not presently configured with monit".format(name), name=name, state=state)
+            else:
+                module.exit_json(changed=True, name=name, state=state)
         module.exit_json(changed=False, name=name, state=state)
 
-    wait_for_monit_to_stop_pending()
-    running = 'running' in status()
+    wait_for_monit_to_stop_pending(name)
+    status(name)
 
-    if running and state in ['started', 'monitored']:
-        module.exit_json(changed=False, name=name, state=state)
-
-    if running and state == 'stopped':
+    if state == 'stopped':
         if module.check_mode:
             module.exit_json(changed=True)
-        status = run_command('stop')
-        if status in ['not monitored'] or 'stop pending' in status:
-            module.exit_json(changed=True, name=name, state=state)
-        module.fail_json(msg='%s process not stopped' % name, status=status)
+        status(name)
+        run_command('stop', name)
+        if service_status[name]['status'] == 'not monitored' or service_status[name]['status'] == 'stop pending':
+            module.exit_json(changed=True, name=name, state=state, status=service_status[name]['status'])
+        module.fail_json(msg='{} process not stopped'.format(name), state=state, status=service_status[name]['status'])
 
-    if running and state == 'unmonitored':
+    if state == 'unmonitored':
         if module.check_mode:
             module.exit_json(changed=True)
-        status = run_command('unmonitor')
-        if status in ['not monitored'] or 'unmonitor pending' in status:
-            module.exit_json(changed=True, name=name, state=state)
-        module.fail_json(msg='%s process not unmonitored' % name, status=status)
+        run_command('unmonitor', name)
+        if service_status[name]['monitoring status'] == 'not monitored' or service_status[name]['monitoring status'] == 'unmonitor pending':
+            module.exit_json(changed=True, name=name, state=state, status=service_status[name]['status'])
+        module.fail_json(msg='%s process not unmonitored'.format(name), state=state, status=service_status[name]['status'])
 
     elif state == 'restarted':
         if module.check_mode:
             module.exit_json(changed=True)
-        status = run_command('restart')
-        if status in ['initializing', 'running'] or 'restart pending' in status:
-            module.exit_json(changed=True, name=name, state=state)
-        module.fail_json(msg='%s process not restarted' % name, status=status)
+        run_command('restart', name)
+        if service_status[name]['status'] == 'initializing' or service_status[name]['status'] == 'restart pending' or service_status[name]['status'] == 'ok':
+            module.exit_json(changed=True, name=name, state=state, status=service_status[name]['status'])
+        module.fail_json(msg='{} process not restarted'.format(name), state=state, status=service_status[name]['status'])
 
-    elif not running and state == 'started':
+    elif state == 'started':
         if module.check_mode:
             module.exit_json(changed=True)
-        status = run_command('start')
-        if status in ['initializing', 'running'] or 'start pending' in status:
-            module.exit_json(changed=True, name=name, state=state)
-        module.fail_json(msg='%s process not started' % name, status=status)
+        if service_status[name]['status'] == 'ok' or service_status[name]['status'] == 'initializing' or service_status[name]['status'] == 'start pending':
+            module.exit_json(changed=False, name=name, state=state)
+        else:
+            run_command('start', name)
+            time.sleep(5)
+            status(name)
+        if service_status[name]['status'] == 'ok' or service_status[name]['status'] == 'initializing' or service_status[name]['status'] == 'start pending':
+            module.exit_json(changed=True, name=name, state=state, status=service_status[name]['status'])
+        else:
+            module.fail_json(msg='{} process not started'.format(name), state=state, status=service_status[name]['status'])
 
-    elif not running and state == 'monitored':
+    elif state == 'monitored':
         if module.check_mode:
             module.exit_json(changed=True)
-        status = run_command('monitor')
-        if status not in ['not monitored']:
-            module.exit_json(changed=True, name=name, state=state)
-        module.fail_json(msg='%s process not monitored' % name, status=status)
+        if service_status[name]['monitoring status'] == 'monitored':
+            module.exit_json(changed=False, name=name, state=state)
+        run_command('monitor', name)
+        if service_status[name]['monitoring status'] == 'monitored':
+            module.exit_json(changed=True, name=name, state=state, status=service_status[name]['monitoring status'])
+        else:
+            module.fail_json(msg='%s process not monitored'.format(name), state=state, status=service_status[name]['monitoring status'])
 
     module.exit_json(changed=False, name=name, state=state)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Feature to deploy monit on target host and fix functionalities broken due to changed output in newer versions of monit.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
monit
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
[root@prakritish1 ansible]# ansible --version
ansible 2.2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
[root@prakritish1 ansible]#
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
These changes adds new functionalities as well as solve a few bugs:
###### New Functionalities

1. Allows users to deploy/install **monit** on the target host by specifying either the _version_ or _URL_ for the **monit** binary. This does not use packaged distribution, but downloads directly from **monit** distribution website. The module identifies the platform and architecture of the target host and downloads the relevant binary and deploys them at the specified path.

1. Adds capabilities to specify the _**path**_ of the **monit** binary and it's _**config**_ file if they are not available in default path.

1. Added _service_ as an alias for _name_.

###### Bug Fix
With the last few versions of **monit**, the output of the binary was changed and this may have broken the module and none of the existing functionalities were working. So, made the changes to fix the broken functionalities.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
