### PR TITLE
module_utils: Make `backup_local` try to preserve owner/group/SELinux context

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2097,6 +2097,28 @@ class AnsibleModule(object):
                 e = get_exception()
                 self.fail_json(msg='Could not make backup of %s to %s: %s' % (fn, backupdest, e))
 
+            fn_st = os.lstat(fn)
+            fn_uid = fn_st.st_uid
+            fn_gid = fn_st.st_gid
+            if fn_uid != os.getuid():
+                try:
+                    os.lchown(backupdest, fn_uid, -1)
+                except OSError:
+                    pass
+            if fn_gid != os.getgid():
+                try:
+                    os.lchown(backupdest, -1, fn_gid)
+                except OSError:
+                    pass
+            if HAVE_SELINUX and self.selinux_enabled():
+                try:
+                    fn_ret = selinux.lgetfilecon_raw(fn)
+                    bk_ret = selinux.lgetfilecon_raw(backupdest)
+                    if fn_ret[0] != -1 and bk_ret[0] != -1 and fn_ret[1] != bk_ret[1]:
+                        selinux.lsetfilecon(backupdest, fn_ret[1])
+                except OSError:
+                    pass
+
         return backupdest
 
     def cleanup(self, tmpfile):


### PR DESCRIPTION
##### SUMMARY
The original `backup_local` implementation would use `shutil.copy2()`, which uses `shutil.copyfile()` to copy the data and `shutil.copystat()` to copy the metadata (permissions, access & modification times, flags and extended attributes where possible). This excludes the owner and group information, however, as well as SELinux context.

The revised version attempts to discover the owner, group, and SELinux context of the original file and attempts to apply them to the backup file if different. Changing the owner will generally fail if not invoked as the root user; changing the group will generally fail if the user is not a member of that group; changing the context could fail if the context can't be discovered or is invalid. Failure to change any of these values is not considered a fatal failure, so the module can still continue. Using the built-in methods `set_owner_if_different()`, `set_group_if_different()`, and `set_context_if_different()` would potentially cause the module to exit on failure.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ansible.module_utils.basic

##### ANSIBLE VERSION
```
ansible 2.4.0 (file-backup-owner-group d985ce6e97) last updated 2017/03/19 13:41:30 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```

##### ADDITIONAL INFORMATION
To test this, we can use the Ansible `copy` module.

```
$ touch /tmp/test
$ ls -lnZ /tmp/test
-rw-rw-r--. 1 1000 1000 unconfined_u:object_r:user_tmp_t:s0 0 Mar 19 14:01 test
$ ansible localhost -m copy -a 'src="/tmp/test" dest="/tmp/test-copy" owner="1000" group="10" mode="0444" setype="tmp_t" backup="yes"'
$ ls -lnZ /tmp/test /tmp/test-copy
-rw-rw-r--. 1 1000 1000 unconfined_u:object_r:user_tmp_t:s0 0 Mar 19 14:01 /tmp/test
-r--r--r--. 1 1000   10 unconfined_u:object_r:tmp_t:s0      0 Mar 19 14:08 /tmp/test-copy
$ echo "Test." >> /tmp/test
$ ansible localhost -m copy -a 'src="/tmp/test" dest="/tmp/test-copy" owner="1000" group="10" mode="0444" setype="tmp_t" backup="yes"'
$ ls -lnZ /tmp/test /tmp/test-copy*
-rw-rw-r--. 1 1000 1000 unconfined_u:object_r:user_tmp_t:s0 6 Mar 19 14:09 /tmp/test
-r--r--r--. 1 1000   10 unconfined_u:object_r:tmp_t:s0      6 Mar 19 14:10 /tmp/test-copy
-r--r--r--. 1 1000   10 unconfined_u:object_r:tmp_t:s0      0 Mar 19 14:08 /tmp/test-copy.7716.2017-03-19@14:10:12~
```

Note that after the second invokation of `ansible`, a backup file is created which has the same data (null), permissions (0444), owner (1000), group (10) and SELinux context (`unconfined_u:object_r:tmp_t:s0`) as the first `/tmp/test-copy` file.