### PR TITLE
win_secedit module: adds ability to mod local security policies

### DIFF
--- a/lib/ansible/modules/windows/win_secedit.ps1
+++ b/lib/ansible/modules/windows/win_secedit.ps1
@@ -1,0 +1,177 @@
+#!powershell
+# This file is part of Ansible
+#
+# Copyright 2016, Red Hat Inc
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# WANT_JSON
+# POWERSHELL_COMMON
+
+########
+
+
+Set-StrictMode -Version Latest
+
+function Get-IniFile {
+    param (
+        [parameter(mandatory=$true, position=0, valuefrompipelinebypropertyname=$true, valuefrompipeline=$true)][string]$FilePath
+    )
+
+        $ini = New-Object System.Collections.Specialized.OrderedDictionary
+        $currentSection = New-Object System.Collections.Specialized.OrderedDictionary
+        $curSectionName = "default"
+
+        switch -regex (gc $FilePath)
+        {
+            "^\[(?<Section>.*)\]"
+            {
+                        $ini.Add($curSectionName, $currentSection)
+                        
+                        $curSectionName = $Matches['Section'].trim()
+                        $currentSection = New-Object System.Collections.Specialized.OrderedDictionary   
+            }
+                "(?<Key>.*)\=(?<Value>.*)"
+                {
+                        # add to current section Hash Set
+                        $currentSection.Add($Matches['Key'].trim(), $Matches['Value'].trim())
+                }
+                "^$"
+                {
+                        # ignore blank line
+                }
+                default
+                {
+                        throw "Unidentified: $_"  # should not happen
+                }
+        }
+        if ($ini.Keys -notcontains $curSectionName) { $ini.Add($curSectionName, $currentSection) }
+        
+        return $ini
+}
+
+function Out-IniFile{
+    param (
+        [parameter(mandatory=$true, position=0, valuefrompipelinebypropertyname=$true, valuefrompipeline=$true)][System.Collections.Specialized.OrderedDictionary]$ini,
+                [parameter(mandatory=$false,position=1, valuefrompipelinebypropertyname=$true, valuefrompipeline=$false)][String]$FilePath
+    )
+        
+        $output = ""
+        ForEach ($section in $ini.GetEnumerator())
+        {
+                if ($section.Name -ne "default") 
+                { 
+                        # insert a blank line after a section
+                        $sep = @{$true="";$false="`r`n"}[[String]::IsNullOrWhiteSpace($output)]
+                        $output += "$sep[$($section.Name)]`r`n" 
+                }
+                ForEach ($entry in $section.Value.GetEnumerator())
+                {
+                        $sep = @{$true="";$false="="}[$entry.Name -eq ";"]
+                        $output += "$($entry.Name)$sep$($entry.Value)`r`n"
+                }
+                
+        }
+        
+        $output = $output.TrimEnd("`r`n")
+        if ([String]::IsNullOrEmpty($FilePath))
+        {
+                return $output
+        }
+        else
+        {
+                $output | Out-File -FilePath $FilePath -Encoding:ASCII
+        }
+}
+
+$params = Parse-Args $args;
+
+$result = New-Object psobject @{
+    changed = $false
+};
+
+$category = Get-Attr $params "category"-failifempty $true
+$key = Get-Attr $params "key"-failifempty $true
+$value = Get-Attr $params "value"-failifempty $true
+$sepath = "$home\sec_edit_dump.inf"
+
+Try {
+    Get-GPO -All
+    Fail-Json $result "This host is joined to a Domain Controller, you'll need to modify GPO directly instead of secedit"
+}
+Catch {
+    If (!$_.Exception.Message -like 'is not associated') {
+        Fail-Json $result $_.Exception.Message
+    }
+    Else {}
+}
+
+SecEdit.exe /export /cfg $sepath /quiet
+
+$ini = Get-IniFile -FilePath $sepath
+
+Try {
+    $current_value = $ini.$category.$key
+}
+Catch {
+    If ($_.Exception.Message -like "*$category cannot be found*"){
+        $valid_categories = $ini.GETENUMERATOR() | % { $_.key + ',' } 
+        Fail-Json $result "The category you specified, $category, is not valid. Valid categories for this system are $valid_categories."
+    }
+    ElseIf ($_.Exception.Message -like "*$key*"){
+        $valid_keys = $ini.$category.GETENUMERATOR() | % { $_.key + ',' } 
+        Fail-Json $result "The key you specified, $category, is not valid. Valid keys for the category '$category' are: $valid_keys."
+    }
+    Else {
+        Fail-Json $result $_.Exception.Message
+    }
+}
+
+If ($current_value -eq $value) {
+    $result.msg = "Key Already Set"
+    $result.category = $category
+    $result.key = $key
+    $result.value = $value
+}
+Else {
+    $ini.$category.$key = $value
+    $ini | Out-IniFile -FilePath "$home\updated_inf"
+    SecEdit.exe /configure /db "$home\temp_db.sdb" /cfg "$home\updated_inf" /quiet 
+    $result.changed = $true
+    $result.msg = "Key updated"
+    $result.category = $category
+    $result.key = $key
+    $result.value = $value
+}
+
+# Secedit doesnt error out when you try to configure it with bad values, even with /validate.
+# The secedit behavior is to simply ignore invalid values and proceed anyways
+# Here we are re exporting secedit to deterimine if the value 'stuck'
+# If it is updated, then we're good to go. If it wasn't updated then we know
+# that the supplied value was improper
+
+SecEdit.exe /export /cfg $sepath /quiet
+
+$updated_ini = Get-IniFile -FilePath $sepath
+$updated_value = $updated_ini.$category.$key
+
+If ($updated_value -ne $value){
+    Fail-Json $result "The value you supplied '$value' was not accepted by SecEdit. Ensure it is a valid value and try again. The original value of '$current_value' has been kept in tact" 
+}
+
+rm $home\updated_inf 
+rm $home\temp_db.sdb 
+rm $home\sec_edit_dump.inf
+
+Exit-Json $result

--- a/lib/ansible/modules/windows/win_secedit.ps1
+++ b/lib/ansible/modules/windows/win_secedit.ps1
@@ -38,9 +38,9 @@ function Get-IniFile {
             "^\[(?<Section>.*)\]"
             {
                         $ini.Add($curSectionName, $currentSection)
-                        
+
                         $curSectionName = $Matches['Section'].trim()
-                        $currentSection = New-Object System.Collections.Specialized.OrderedDictionary   
+                        $currentSection = New-Object System.Collections.Specialized.OrderedDictionary
             }
                 "(?<Key>.*)\=(?<Value>.*)"
                 {
@@ -57,7 +57,7 @@ function Get-IniFile {
                 }
         }
         if ($ini.Keys -notcontains $curSectionName) { $ini.Add($curSectionName, $currentSection) }
-        
+
         return $ini
 }
 
@@ -66,24 +66,24 @@ function Out-IniFile{
         [parameter(mandatory=$true, position=0, valuefrompipelinebypropertyname=$true, valuefrompipeline=$true)][System.Collections.Specialized.OrderedDictionary]$ini,
                 [parameter(mandatory=$false,position=1, valuefrompipelinebypropertyname=$true, valuefrompipeline=$false)][String]$FilePath
     )
-        
+
         $output = ""
         ForEach ($section in $ini.GetEnumerator())
         {
-                if ($section.Name -ne "default") 
-                { 
+                if ($section.Name -ne "default")
+                {
                         # insert a blank line after a section
                         $sep = @{$true="";$false="`r`n"}[[String]::IsNullOrWhiteSpace($output)]
-                        $output += "$sep[$($section.Name)]`r`n" 
+                        $output += "$sep[$($section.Name)]`r`n"
                 }
                 ForEach ($entry in $section.Value.GetEnumerator())
                 {
                         $sep = @{$true="";$false="="}[$entry.Name -eq ";"]
                         $output += "$($entry.Name)$sep$($entry.Value)`r`n"
                 }
-                
+
         }
-        
+
         $output = $output.TrimEnd("`r`n")
         if ([String]::IsNullOrEmpty($FilePath))
         {
@@ -119,11 +119,11 @@ Try {
 }
 Catch {
     If ($_.Exception.Message -like "*$category cannot be found*"){
-        $valid_categories = $ini.GETENUMERATOR() | % { $_.key + ',' } 
+        $valid_categories = $ini.GETENUMERATOR() | % { $_.key + ',' }
         Fail-Json $result "The category you specified, $category, is not valid. Valid categories for this system are $valid_categories."
     }
     ElseIf ($_.Exception.Message -like "*$key*"){
-        $valid_keys = $ini.$category.GETENUMERATOR() | % { $_.key + ',' } 
+        $valid_keys = $ini.$category.GETENUMERATOR() | % { $_.key + ',' }
         Fail-Json $result "The key you specified, $key, is not valid. Valid keys for the category '$category' are: $valid_keys."
     }
     Else {
@@ -140,7 +140,7 @@ If ($current_value -eq $value) {
 Else {
     $ini.$category.$key = $value
     $ini | Out-IniFile -FilePath "$home\updated_inf"
-    SecEdit.exe /configure /db "$home\temp_db.sdb" /cfg "$home\updated_inf" /quiet 
+    SecEdit.exe /configure /db "$home\temp_db.sdb" /cfg "$home\updated_inf" /quiet
     $result.changed = $true
     $result.msg = "Key updated"
     $result.category = $category
@@ -161,7 +161,7 @@ $updated_ini = Get-IniFile -FilePath $sepath
 Try {
     $updated_value = $updated_ini.$category.$key
     If ($updated_value -ne $value){
-        Fail-Json $result "The value you supplied '$value' was not accepted by SecEdit. Ensure it is a valid value and try again. The original value of '$current_value' has been kept in tact" 
+        Fail-Json $result "The value you supplied '$value' was not accepted by SecEdit. Ensure it is a valid value and try again. The original value of '$current_value' has been kept in tact"
     }
 }
 Catch [System.Management.Automation.PropertyNotFoundException] {
@@ -172,8 +172,8 @@ Catch [System.Management.Automation.PropertyNotFoundException] {
     }
 }
 
-rm $home\updated_inf 
-rm $home\temp_db.sdb 
+rm $home\updated_inf
+rm $home\temp_db.sdb
 rm $home\sec_edit_dump.inf
 
 Exit-Json $result

--- a/lib/ansible/modules/windows/win_secedit.ps1
+++ b/lib/ansible/modules/windows/win_secedit.ps1
@@ -19,9 +19,6 @@
 # WANT_JSON
 # POWERSHELL_COMMON
 
-########
-
-
 Set-StrictMode -Version Latest
 
 function Get-IniFile {

--- a/lib/ansible/modules/windows/win_secedit.py
+++ b/lib/ansible/modules/windows/win_secedit.py
@@ -1,0 +1,92 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2016, Red Hat Inc  
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+DOCUMENTATION = '''
+---
+module: win_secedit
+version_added: "2.3"
+notes:
+    - If the target server is joined to a DC then it will error as any secedit modifications would be overwritten by GPO.
+    - SecEdit does not error out when you try to modify a key/value with an improper value, such as passing in a string when a valid value would be an integer. 
+    - Therefore, this module will attempt to configure secedit with any value supplied, then it does a second dump of secedit to see if the requested change persisted, if it didn't then it errors out, otherwise it continues as normal.
+short_description: Manipulate local security policies via secedit
+description:
+    - Modifies key-values for local security policies via secedit 
+options:
+  category:
+    description:
+      - The category you wish to modify a value under. This can things like 'System Access', 'Event Audit', etc. If you supply an invalid category the module will error out and let you know what the valid categories are for that particular system. 
+    required: true
+  key:
+    description:
+        - The key under the category for which you wish to modify the value. For example: under the System Access category there is a key 'MinimumPasswordAge' that could be targeted. 
+        - Just like with category, if an invalid key is specified, the module will error out and show what the valid keys for the given category are.
+    required: true
+  value:
+    description:
+      - The value to assign to the key. 
+    required: true
+author: Jonathan Davila (@defionscode) 
+'''
+
+EXAMPLES = '''
+  # Set the local security policy so that the maximum password age is 30 
+  - name: Set max pwd age to 30 days 
+    win_secedit:
+      category: System Access
+      key: MaximumPasswordAge
+      value: 30 
+
+  # Configure local policy to audit system events 
+  - name: Ensure system events are audited 
+    win_secedit:
+      category: Event Audit 
+      key: AuditSystemEvents 
+      value: 1 
+'''
+
+RETURN = '''
+msg:
+    description: whether the key was set or updated 
+    returned: success or changed
+    type: string 
+    sample: Key updated 
+
+category:
+    description: the category targeted 
+    returned: success or changed
+    type: string
+    sample: Event Audit 
+
+key:
+    description: the key within the category targeted 
+    returned: success or changed
+    type: string
+    sample: AuditAccountLogon 
+
+value:
+    description: the value of the key 
+    returned: success or changed
+    type: string
+    sample: 1 
+'''

--- a/lib/ansible/modules/windows/win_secedit.py
+++ b/lib/ansible/modules/windows/win_secedit.py
@@ -24,7 +24,7 @@
 DOCUMENTATION = '''
 ---
 module: win_secedit
-version_added: 2.3
+version_added: '2.3'
 notes:
     - If the target server is joined to a DC then it will error as any secedit modifications would be overwritten by GPO.
     - SecEdit does not error out when you try to modify a key value with an improper value, such as passing in a string when a valid value would be an integer.
@@ -39,16 +39,20 @@ options:
         This can things like System Access, Event Audit, etc. 
         If you supply an invalid category the module will error out and let you know what the valid categories are for that particular system. 
     required: true
+    default: null
   key:
     description:
       - The key under the category for which you wish to modify the value. For example: under the System Access category there is a key MinimumPasswordAge that could be targeted. 
       - Just like with category, if an invalid key is specified, the module will error out and show what the valid keys for the given category are.
     required: true
+    default: null
   value:
     description:
       - The value to assign to the key. 
     required: true
-author: Jonathan Davila <@defionscode> 
+    default: null
+author:
+    - Jonathan Davila (@defionscode) 
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/windows/win_secedit.py
+++ b/lib/ansible/modules/windows/win_secedit.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright 2016, Red Hat Inc  
+# Copyright 2016, Red Hat Inc
 #
 # This file is part of Ansible
 #
@@ -21,72 +21,81 @@
 # this is a windows documentation stub.  actual code lives in the .ps1
 # file of the same name
 
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.0'}
+
 DOCUMENTATION = '''
 ---
 module: win_secedit
-version_added: '2.3'
+version_added: '2.4'
 short_description: Manipulate local security policies via secedit
 description:
     - Modifies key values for local security policies via secedit
 options:
   category:
     description:
-      - The category you wish to modify a value under. This can things like System Access, Event Audit, etc. If you supply an invalid category the module will error out and let you know what the valid categories are for that particular system. 
+      - The category you wish to modify a value under. This can things like System Access, Event Audit, etc.
+        If you supply an invalid category the module will error out and let you know what the valid categories are for that particular system.
     required: true
     default: null
   key:
     description:
-      - The key under the category for which you wish to modify the value. For example, under the System Access category there is a key MinimumPasswordAge that could be targeted. Just like with category, if an invalid key is specified, the module will error out and show what the valid keys for the given category are.
+      - The key under the category for which you wish to modify the value.
+        For example, under the System Access category there is a key MinimumPasswordAge that could be targeted.
+        Just like with category, if an invalid key is specified, the module will error out and show what the valid keys for the given category are.
     required: true
     default: null
   value:
     description:
-      - The value to assign to the key. 
+      - The value to assign to the key.
     required: true
     default: null
 author:
-    - Jonathan Davila (@defionscode) 
+    - Jonathan Davila (@defionscode)
 notes:
     - If the target server is joined to a DC then it will error as any secedit modifications would be overwritten by GPO.
-    - SecEdit does not error out when you try to modify a key value with an improper value, such as passing in a string when a valid value would be an integer.
-    - Therefore, this module will attempt to configure secedit with any value supplied, then it does a second dump of secedit to see if the requested change persisted, if it did not then it errors out, otherwise it continues as normal.
+    - SecEdit does not error out when you try to modify a key value with an improper value,
+      such as passing in a string when a valid value would be an integer.
+    - Therefore, this module will attempt to configure secedit with any value supplied, then it does a second dump of secedit
+      to see if the requested change persisted, if it did not then it errors out, otherwise it continues as normal.
 '''
 
 EXAMPLES = '''
-# Set the local security policy so that the maximum password age is 30 
-- name: Set max pwd age to 30 days 
-win_secedit:
-  category: System Access
-  key: MaximumPasswordAge
-  value: 30 
+# Set the local security policy so that the maximum password age is 30
+- name: Set max pwd age to 30 days
+  win_secedit:
+    category: System Access
+    key: MaximumPasswordAge
+    value: 30
 
-# Configure local policy to audit system events 
-- name: Ensure system events are audited 
-win_secedit:
-  category: Event Audit 
-  key: AuditSystemEvents 
-  value: 1 
+# Configure local policy to audit system events
+- name: Ensure system events are audited
+  win_secedit:
+    category: Event Audit
+    key: AuditSystemEvents
+    value: 1
 '''
 
 RETURN = '''
 msg:
-    description: whether the key was set or updated 
+    description: whether the key was set or updated
     returned: success or changed
-    type: string 
-    sample: Key updated 
+    type: string
+    sample: Key updated
 category:
-    description: the category targeted 
+    description: the category targeted
     returned: success or changed
     type: string
-    sample: Event Audit 
+    sample: Event Audit
 key:
-    description: the key within the category targeted 
+    description: the key within the category targeted
     returned: success or changed
     type: string
-    sample: AuditAccountLogon 
+    sample: AuditAccountLogon
 value:
-    description: the value of the key 
+    description: the value of the key
     returned: success or changed
     type: string
-    sample: 1 
+    sample: 1
 '''

--- a/lib/ansible/modules/windows/win_secedit.py
+++ b/lib/ansible/modules/windows/win_secedit.py
@@ -24,45 +24,47 @@
 DOCUMENTATION = '''
 ---
 module: win_secedit
-version_added: "2.3"
+version_added: 2.3
 notes:
     - If the target server is joined to a DC then it will error as any secedit modifications would be overwritten by GPO.
-    - SecEdit does not error out when you try to modify a key/value with an improper value, such as passing in a string when a valid value would be an integer. 
-    - Therefore, this module will attempt to configure secedit with any value supplied, then it does a second dump of secedit to see if the requested change persisted, if it didn't then it errors out, otherwise it continues as normal.
+    - SecEdit does not error out when you try to modify a key value with an improper value, such as passing in a string when a valid value would be an integer.
+    - Therefore, this module will attempt to configure secedit with any value supplied, then it does a second dump of secedit to see if the requested change persisted, if it did not then it errors out, otherwise it continues as normal.
 short_description: Manipulate local security policies via secedit
 description:
-    - Modifies key-values for local security policies via secedit 
+    - Modifies key values for local security policies via secedit
 options:
   category:
     description:
-      - The category you wish to modify a value under. This can things like 'System Access', 'Event Audit', etc. If you supply an invalid category the module will error out and let you know what the valid categories are for that particular system. 
+      - The category you wish to modify a value under. 
+        This can things like System Access, Event Audit, etc. 
+        If you supply an invalid category the module will error out and let you know what the valid categories are for that particular system. 
     required: true
   key:
     description:
-        - The key under the category for which you wish to modify the value. For example: under the System Access category there is a key 'MinimumPasswordAge' that could be targeted. 
-        - Just like with category, if an invalid key is specified, the module will error out and show what the valid keys for the given category are.
+      - The key under the category for which you wish to modify the value. For example: under the System Access category there is a key MinimumPasswordAge that could be targeted. 
+      - Just like with category, if an invalid key is specified, the module will error out and show what the valid keys for the given category are.
     required: true
   value:
     description:
       - The value to assign to the key. 
     required: true
-author: Jonathan Davila (@defionscode) 
+author: Jonathan Davila <@defionscode> 
 '''
 
 EXAMPLES = '''
-  # Set the local security policy so that the maximum password age is 30 
-  - name: Set max pwd age to 30 days 
-    win_secedit:
-      category: System Access
-      key: MaximumPasswordAge
-      value: 30 
+# Set the local security policy so that the maximum password age is 30 
+- name: Set max pwd age to 30 days 
+win_secedit:
+  category: System Access
+  key: MaximumPasswordAge
+  value: 30 
 
-  # Configure local policy to audit system events 
-  - name: Ensure system events are audited 
-    win_secedit:
-      category: Event Audit 
-      key: AuditSystemEvents 
-      value: 1 
+# Configure local policy to audit system events 
+- name: Ensure system events are audited 
+win_secedit:
+  category: Event Audit 
+  key: AuditSystemEvents 
+  value: 1 
 '''
 
 RETURN = '''
@@ -71,19 +73,16 @@ msg:
     returned: success or changed
     type: string 
     sample: Key updated 
-
 category:
     description: the category targeted 
     returned: success or changed
     type: string
     sample: Event Audit 
-
 key:
     description: the key within the category targeted 
     returned: success or changed
     type: string
     sample: AuditAccountLogon 
-
 value:
     description: the value of the key 
     returned: success or changed

--- a/lib/ansible/modules/windows/win_secedit.py
+++ b/lib/ansible/modules/windows/win_secedit.py
@@ -25,25 +25,18 @@ DOCUMENTATION = '''
 ---
 module: win_secedit
 version_added: '2.3'
-notes:
-    - If the target server is joined to a DC then it will error as any secedit modifications would be overwritten by GPO.
-    - SecEdit does not error out when you try to modify a key value with an improper value, such as passing in a string when a valid value would be an integer.
-    - Therefore, this module will attempt to configure secedit with any value supplied, then it does a second dump of secedit to see if the requested change persisted, if it did not then it errors out, otherwise it continues as normal.
 short_description: Manipulate local security policies via secedit
 description:
     - Modifies key values for local security policies via secedit
 options:
   category:
     description:
-      - The category you wish to modify a value under. 
-        This can things like System Access, Event Audit, etc. 
-        If you supply an invalid category the module will error out and let you know what the valid categories are for that particular system. 
+      - The category you wish to modify a value under. This can things like System Access, Event Audit, etc. If you supply an invalid category the module will error out and let you know what the valid categories are for that particular system. 
     required: true
     default: null
   key:
     description:
-      - The key under the category for which you wish to modify the value. For example: under the System Access category there is a key MinimumPasswordAge that could be targeted. 
-      - Just like with category, if an invalid key is specified, the module will error out and show what the valid keys for the given category are.
+      - The key under the category for which you wish to modify the value. For example, under the System Access category there is a key MinimumPasswordAge that could be targeted. Just like with category, if an invalid key is specified, the module will error out and show what the valid keys for the given category are.
     required: true
     default: null
   value:
@@ -53,6 +46,10 @@ options:
     default: null
 author:
     - Jonathan Davila (@defionscode) 
+notes:
+    - If the target server is joined to a DC then it will error as any secedit modifications would be overwritten by GPO.
+    - SecEdit does not error out when you try to modify a key value with an improper value, such as passing in a string when a valid value would be an integer.
+    - Therefore, this module will attempt to configure secedit with any value supplied, then it does a second dump of secedit to see if the requested change persisted, if it did not then it errors out, otherwise it continues as normal.
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### COMPONENT NAME

win_secedit
##### ANSIBLE VERSION

```
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Allows users to modify local security policies via the secedit utility for example:

``` yml
    - name: Set local password age policy to 14 days
      win_secedit:
        category: System Access
        key: MaximumPasswordAge
        value: 14
```
