### PR TITLE
vmware_guest: Don't force onto specific host

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1080,7 +1080,9 @@ class PyVmomiHelper(object):
             if self.should_deploy_from_template():
                 # create the relocation spec
                 relospec = vim.vm.RelocateSpec()
-                relospec.host = hostsystem
+                # Only provide specific host when using ESXi host directly
+                if self.params['esxi_hostname']:
+                    relospec.host = hostsystem
                 relospec.datastore = datastore
                 relospec.pool = resource_pool
 
@@ -1103,7 +1105,8 @@ class PyVmomiHelper(object):
                 self.change_detected = True
             self.wait_for_task(task)
         except TypeError:
-            self.module.fail_json(msg="TypeError was returned, please ensure to give correct inputs.")
+            e = get_exception()
+            self.module.fail_json(msg="TypeError was returned, please ensure to give correct inputs. %s" % e)
 
         if task.info.state == 'error':
             # https://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=2021361


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Unless we provided a specific esxi_hostname, don't force new VMs onto the first host in the cluster.

Since we are cloning multiple VMs in a single task, they all get created on the same host (not efficient) and some will be automatically relocated immediately after (again not efficient). This small change ensures the VMs are created where it is deemed best.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vmware_guest

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3