### PR TITLE
Docs are wrong about Boto version wrt instance_profile_name param

### DIFF
--- a/lib/ansible/modules/cloud/amazon/GUIDELINES.md
+++ b/lib/ansible/modules/cloud/amazon/GUIDELINES.md
@@ -38,7 +38,7 @@ if boto_supports_profile_name_arg(ec2):
     params['instance_profile_name'] = instance_profile_name
 else:
     if instance_profile_name is not None:
-        module.fail_json(msg="instance_profile_name parameter requires boto version 2.5.0 or higher")
+        module.fail_json(msg="instance_profile_name parameter requires boto version 2.13.2 or higher")
 ```
 
 ## Using boto and boto3

--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -199,7 +199,7 @@ options:
   instance_profile_name:
     version_added: "1.3"
     description:
-      - Name of the IAM instance profile to use. Boto library must be 2.5.0+
+      - Name of the IAM instance profile to use. Boto library must be 2.13.2+
     required: false
     default: null
     aliases: []


### PR DESCRIPTION
##### SUMMARY
Inaccuracy in regards to the version of Boto adding instance_profile_name. The parameter was added in version 2.13.2 of Boto, not 2.5 (2.5 doesn't even exist?).

Source: 
https://github.com/boto/boto/commit/7cf2cd77a55487d2ba0637c26918c7aa3ef60381

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Amazon

##### ANSIBLE VERSION
N/A