### PR TITLE
Deauthorize shell on open_shell if privileged account

### DIFF
--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -101,6 +101,8 @@ class Connection(_Connection):
         if getattr(self._play_context, 'become', None):
             auth_pass = self._play_context.become_pass
             self._terminal.on_authorize(passwd=auth_pass)
+        else:
+            self._terminal.on_deauthorize()
 
         display.vvvv('shell successfully opened', self._play_context.remote_addr)
         return (0, 'ok', '')


### PR DESCRIPTION
##### SUMMARY

If the account that connects to the device is privileged
and able to run privileged commands without doing 'enable',
not setting authorize explicitly can cause unexpected behaviour on plays.
An example showing this behaviour is a playbook with two tasks, first
authorize and second non-authorize, e.g.:

- ios_banner:
  ...
  authorize: no

- ios_banner:
  ...
  authorize: yes

In the above example, running the playbook twice the first play runs ok
but the second fails.
This is due to the authorize task on the first play leaving the shell
in non-privileged mode, causing the non-authorize task of second play
to fail.
This confuses users, as depending on the play flow tasks can succeed
and fail even when the connecting user is the same and privileged.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

plugins/connection/network_cli

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (deauthorize_on_open_shell_if_not_become d92ffd36b1) last updated 2017/03/20 10:00:45 (GMT +200)
```
