### PR TITLE
Allow creation of Mongo user via localhost exception

### DIFF
--- a/lib/ansible/modules/database/mongodb/mongodb_user.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_user.py
@@ -431,10 +431,10 @@ def main():
             module.fail_json(msg='password parameter required when adding a user unless update_password is set to on_create')
 
         try:
-            uinfo = user_find(client, user, db_name)
-            if update_password != 'always' and uinfo:
+            if update_password != 'always':
+                uinfo = user_find(client, user, db_name)
                 password = None
-                if not check_if_roles_changed(uinfo, roles, db_name):
+                if uinfo and not check_if_roles_changed(uinfo, roles, db_name):
                     module.exit_json(changed=False, user=user)
 
             if module.check_mode:

--- a/lib/ansible/modules/database/mongodb/mongodb_user.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_user.py
@@ -433,9 +433,10 @@ def main():
         try:
             if update_password != 'always':
                 uinfo = user_find(client, user, db_name)
-                password = None
-                if uinfo and not check_if_roles_changed(uinfo, roles, db_name):
-                    module.exit_json(changed=False, user=user)
+                if uinfo:
+                    password = None
+                    if not check_if_roles_changed(uinfo, roles, db_name):
+                        module.exit_json(changed=False, user=user)
 
             if module.check_mode:
                 module.exit_json(changed=True, user=user)


### PR DESCRIPTION
##### SUMMARY
When access control is enabled, Mongo allows a user to be created from localhost (called the [localhost exception](https://docs.mongodb.com/v3.2/core/security-users/#localhost-exception)). When the `update_password` parameter was added to this module in Ansible 2.1, this functionality was broken due to a query performed before `user_add()` is called. This fix only performs the query when when `update_password` is set to `on-create`, allowing a user to be created via the localhost exception.

Fixes #22791

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
`mongodb_user`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
```
