### PR TITLE
Fallback to show-run on ios_banner for devices where show banner fails

### DIFF
--- a/lib/ansible/modules/network/ios/ios_banner.py
+++ b/lib/ansible/modules/network/ios/ios_banner.py
@@ -82,8 +82,10 @@ commands:
     - string
 """
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.connection import exec_command
 from ansible.module_utils.ios import load_config, run_commands
 from ansible.module_utils.ios import ios_argument_spec, check_args
+import re
 
 def map_obj_to_commands(updates, module):
     commands = list()
@@ -104,10 +106,17 @@ def map_obj_to_commands(updates, module):
     return commands
 
 def map_config_to_obj(module):
-    output = run_commands(module, ['show banner %s' % module.params['banner']])
+    rc, out, err = exec_command(module, 'show banner %s' % module.params['banner'])
+    if rc == 0:
+        output = out
+    else:
+        rc, out, err = exec_command(module,
+                                    'show running-config | begin banner %s'
+                                    % module.params['banner'])
+        output = re.search('\^C(.*)\^C', out, re.S).group(1).strip()
     obj = {'banner': module.params['banner'], 'state': 'absent'}
     if output:
-        obj['text'] = output[0]
+        obj['text'] = output
         obj['state'] = 'present'
     return obj
 

--- a/test/units/modules/network/ios/test_ios_banner.py
+++ b/test/units/modules/network/ios/test_ios_banner.py
@@ -29,18 +29,19 @@ class TestIosBannerModule(TestIosModule):
     module = ios_banner
 
     def setUp(self):
-        self.mock_run_commands = patch('ansible.modules.network.ios.ios_banner.run_commands')
-        self.run_commands = self.mock_run_commands.start()
+        self.mock_exec_command = patch('ansible.modules.network.ios.ios_banner.exec_command')
+        self.exec_command = self.mock_exec_command.start()
 
         self.mock_load_config = patch('ansible.modules.network.ios.ios_banner.load_config')
         self.load_config = self.mock_load_config.start()
 
     def tearDown(self):
-        self.mock_run_commands.stop()
+        self.mock_exec_command.stop()
         self.mock_load_config.stop()
 
     def load_fixtures(self, commands=None):
-        self.run_commands.return_value = [load_fixture('ios_banner_show_banner.txt').strip()]
+        self.exec_command.return_value = (0,
+                load_fixture('ios_banner_show_banner.txt').strip(), None)
         self.load_config.return_value = dict(diff=None, session='session')
 
     def test_ios_banner_create(self):


### PR DESCRIPTION
##### SUMMARY

On switches 'show banner' command doesn't work, fallback to show run|begin banner
and extract the banner text in case that fails.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

ios_banner

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (fix_ios_banner_on_switches 16cb12f4a9) last updated 2017/03/20 15:56:16 (GMT +200)
```