### PR TITLE
Add integration tests for file attributes

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -707,7 +707,7 @@ class AnsibleModule(object):
         except Exception:
             e = get_exception()
             # Use exceptions here because it isn't safe to call fail_json until no_log is processed
-            print('\n{"failed": true, "msg": "Module alias error: %s"}' % str(e))
+            print('\n{"failed": true, "msg": "Module alias error: %s"}' % to_native(e))
             sys.exit(1)
 
         # Save parameter values that should never be logged
@@ -894,7 +894,7 @@ class AnsibleModule(object):
             if e.errno == errno.ENOENT:
                 self.fail_json(path=path, msg='path %s does not exist' % path)
             else:
-                self.fail_json(path=path, msg='failed to retrieve selinux context')
+                self.fail_json(path=path, msg='failed to retrieve selinux context: %s' % to_native(e))
         if ret[0] == -1:
             return context
         # Limit split to 4 because the selevel, the last in the list,
@@ -982,9 +982,9 @@ class AnsibleModule(object):
                                          str(':'.join(new_context)))
             except OSError:
                 e = get_exception()
-                self.fail_json(path=path, msg='invalid selinux context: %s' % str(e), new_context=new_context, cur_context=cur_context, input_was=context)
+                self.fail_json(path=path, msg='invalid selinux context: %s' % to_native(e), new_context=new_context, cur_context=cur_context, input_was=context)
             if rc != 0:
-                self.fail_json(path=path, msg='set selinux context failed')
+                self.fail_json(path=path, msg='set selinux context failed: rc=%d' % rc)
             changed = True
         return changed
 
@@ -1018,7 +1018,8 @@ class AnsibleModule(object):
             try:
                 os.lchown(b_path, uid, -1)
             except OSError:
-                self.fail_json(path=path, msg='chown failed')
+                e = get_exception()
+                self.fail_json(path=path, msg='chown failed: %s' % to_native(e))
             changed = True
         return changed
 
@@ -1052,7 +1053,8 @@ class AnsibleModule(object):
             try:
                 os.lchown(b_path, -1, gid)
             except OSError:
-                self.fail_json(path=path, msg='chgrp failed')
+                e = get_exception()
+                self.fail_json(path=path, msg='chgrp failed: %s' % to_native(e))
             changed = True
         return changed
 
@@ -1076,7 +1078,7 @@ class AnsibleModule(object):
                     e = get_exception()
                     self.fail_json(path=path,
                                    msg="mode must be in octal or symbolic form",
-                                   details=str(e))
+                                   details=to_native(e))
 
                 if mode != stat.S_IMODE(mode):
                     # prevent mode from having extra info orbeing invalid long number
@@ -1123,7 +1125,7 @@ class AnsibleModule(object):
                     raise e
             except Exception:
                 e = get_exception()
-                self.fail_json(path=path, msg='chmod failed', details=str(e))
+                self.fail_json(path=path, msg='chmod failed: %s' % to_native(e), details=to_native(e))
 
             path_stat = os.lstat(b_path)
             new_mode = stat.S_IMODE(path_stat.st_mode)
@@ -1165,7 +1167,7 @@ class AnsibleModule(object):
                             raise Exception("Error while setting attributes: %s" % (out + err))
                     except:
                         e = get_exception()
-                        self.fail_json(path=path, msg='chattr failed', details=str(e))
+                        self.fail_json(path=path, msg='chattr failed: %s' % to_native(e), details=to_native(e))
         return changed
 
     def get_file_attributes(self, path):
@@ -1369,7 +1371,7 @@ class AnsibleModule(object):
             os.environ['LC_MESSAGES'] = 'C'
         except Exception:
             e = get_exception()
-            self.fail_json(msg="An unknown error was encountered while attempting to validate the locale: %s" % e)
+            self.fail_json(msg="An unknown error was encountered while attempting to validate the locale: %s" % to_native(e))
 
     def _handle_aliases(self):
         # this uses exceptions as it happens before we can safely call fail_json
@@ -1723,7 +1725,7 @@ class AnsibleModule(object):
                 self.params[k] = type_checker(value)
             except (TypeError, ValueError):
                 e = get_exception()
-                self.fail_json(msg="argument %s is of type %s and we were unable to convert to %s: %s" % (k, type(value), wanted, e))
+                self.fail_json(msg="argument %s is of type %s and we were unable to convert to %s: %s" % (k, type(value), wanted, to_native(e)))
 
     def _set_defaults(self, pre=True):
         for (k,v) in self.argument_spec.items():
@@ -2068,7 +2070,7 @@ class AnsibleModule(object):
                 shutil.copy2(fn, backupdest)
             except (shutil.Error, IOError):
                 e = get_exception()
-                self.fail_json(msg='Could not make backup of %s to %s: %s' % (fn, backupdest, e))
+                self.fail_json(msg='Could not make backup of %s to %s: %s' % (fn, backupdest, to_native(e)))
 
         return backupdest
 
@@ -2078,7 +2080,7 @@ class AnsibleModule(object):
                 os.unlink(tmpfile)
             except OSError:
                 e = get_exception()
-                sys.stderr.write("could not cleanup %s: %s" % (tmpfile, e))
+                sys.stderr.write("could not cleanup %s: %s" % (tmpfile, to_native(e)))
 
     def atomic_move(self, src, dest, unsafe_writes=False):
         '''atomically move src to dest, copying attributes from dest, returns true on success
@@ -2127,7 +2129,7 @@ class AnsibleModule(object):
             if e.errno not in [errno.EPERM, errno.EXDEV, errno.EACCES, errno.ETXTBSY, errno.EBUSY]:
                 # only try workarounds for errno 18 (cross device), 1 (not permitted),  13 (permission denied)
                 # and 26 (text file busy) which happens on vagrant synced folders and other 'exotic' non posix file systems
-                self.fail_json(msg='Could not replace file: %s to %s: %s' % (src, dest, e), exception=traceback.format_exc())
+                self.fail_json(msg='Could not replace file: %s to %s: %s' % (src, dest, to_native(e)), exception=traceback.format_exc())
             else:
                 b_dest_dir = os.path.dirname(b_dest)
                 # Use bytes here.  In the shippable CI, this fails with
@@ -2140,7 +2142,7 @@ class AnsibleModule(object):
                     tmp_dest_fd, tmp_dest_name = tempfile.mkstemp( prefix=native_prefix, dir=native_dest_dir, suffix=native_suffix)
                 except (OSError, IOError):
                     e = get_exception()
-                    self.fail_json(msg='The destination directory (%s) is not writable by the current user. Error was: %s' % (os.path.dirname(dest), e))
+                    self.fail_json(msg='The destination directory (%s) is not writable by the current user. Error was: %s' % (os.path.dirname(dest), to_native(e)))
                 except TypeError:
                     # We expect that this is happening because python3.4.x and
                     # below can't handle byte strings in mkstemp().  Traceback
@@ -2181,10 +2183,10 @@ class AnsibleModule(object):
                             if unsafe_writes and e.errno == errno.EBUSY:
                                 self._unsafe_writes(b_tmp_dest_name, b_dest)
                             else:
-                                self.fail_json(msg='Unable to rename file: %s to %s: %s' % (src, dest, e), exception=traceback.format_exc())
+                                self.fail_json(msg='Unable to rename file: %s to %s: %s' % (src, dest, to_native(e)), exception=traceback.format_exc())
                     except (shutil.Error, OSError, IOError):
                         e = get_exception()
-                        self.fail_json(msg='Failed to replace file: %s to %s: %s' % (src, dest, e), exception=traceback.format_exc())
+                        self.fail_json(msg='Failed to replace file: %s to %s: %s' % (src, dest, to_native(e)), exception=traceback.format_exc())
                 finally:
                     self.cleanup(b_tmp_dest_name)
 
@@ -2220,7 +2222,7 @@ class AnsibleModule(object):
                     in_src.close()
         except (shutil.Error, OSError, IOError):
             e = get_exception()
-            self.fail_json(msg='Could not write data to file (%s) from (%s): %s' % (dest, src, e), exception=traceback.format_exc())
+            self.fail_json(msg='Could not write data to file (%s) from (%s): %s' % (dest, src, to_native(e)), exception=traceback.format_exc())
 
 
     def _read_from_pipes(self, rpipes, rfds, file_descriptor):
@@ -2399,7 +2401,7 @@ class AnsibleModule(object):
                 os.chdir(cwd)
             except (OSError, IOError):
                 e = get_exception()
-                self.fail_json(rc=e.errno, msg="Could not open %s, %s" % (cwd, str(e)))
+                self.fail_json(rc=e.errno, msg="Could not open %s, %s" % (cwd, to_native(e)))
 
         old_umask = None
         if umask:

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -16,134 +16,225 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-- set_fact: output_file={{output_dir}}/foo.txt
+- set_fact:
+    output_file: '{{ output_dir }}/foo.txt'
 
 - name: prep with a basic copy
-  copy: src=foo.txt dest={{output_file}}
+  copy:
+    src: foo.txt
+    dest: '{{ output_file }}'
 
 - name: verify that we are checking a file and it is present
-  file: path={{output_file}} state=file
+  file:
+    path: '{{ output_file }}'
+    state: file
   register: file_result
 
 - name: verify that the file was marked as changed
   assert:
     that:
-      - "file_result.changed == false"
-      - "file_result.state == 'file'"
+      - file_result.changed == false
+      - file_result.state == 'file'
 
 - name: verify that we are checking an absent file
-  file: path={{output_dir}}/bar.txt state=absent
+  file:
+    path: '{{ output_dir }}/bar.txt'
+    state: absent
   register: file2_result
 
 - name: verify that the file was marked as changed
   assert:
     that:
-      - "file2_result.changed == false"
-      - "file2_result.state == 'absent'"
+      - file2_result.changed == false
+      - file2_result.state == 'absent'
 
 - name: verify we can touch a file
-  file: path={{output_dir}}/baz.txt state=touch
+  file:
+    path: '{{ output_dir }}/baz.txt'
+    state: touch
   register: file3_result
 
 - name: verify that the file was marked as changed
   assert:
     that:
-      - "file3_result.changed == true"
-      - "file3_result.state == 'file'"
-      - "file3_result.mode == '0644'"
+      - file3_result.changed == true
+      - file3_result.state == 'file'
+      - file3_result.mode == '0644'
 
 - name: change file mode
-  file: path={{output_dir}}/baz.txt mode=0600
+  file:
+    path: '{{ output_dir }}/baz.txt'
+    mode: 0600
   register: file4_result
 
 - name: verify that the file was marked as changed
   assert:
     that:
-      - "file4_result.changed == true"
-      - "file4_result.mode == '0600'"
+      - file4_result.changed == true
+      - file4_result.mode == '0600'
 
 - name: change ownership and group
-  file: path={{output_dir}}/baz.txt owner=1234 group=1234
+  file:
+    path: '{{ output_dir }}/baz.txt'
+    owner: 1234
+    group: 1234
+
+# NOTE: We test whether setting attributes works first
+- name: attempt to change attributes
+  file:
+    path: '{{ output_dir }}/baz.txt'
+    attributes: ai
+  ignore_errors: yes
+  register: test_attributes
+
+# NOTE:File attributes only work on Linux outside docker (AuFS)
+- name: test attributes capabilities
+  when: >
+    ansible_system == 'Linux'
+    and
+    ansible_virtualization_type != 'docker'
+    and
+    not test_attributes|failed
+  block:
+
+  - name: register file changes
+    stat:
+      path: '{{ output_dir }}/baz.txt'
+    register: baz_txt
+
+  - name: test file properties
+    assert:
+      that:
+      - baz_txt.stat.uid == 1234
+      - baz_txt.stat.gid == 1234
+      - baz_txt.stat.mode == '0600'
+      - baz_txt.stat.attr_flags == 'ia'
+      - baz_txt.stat.attributes == [ 'immutable', 'append' ]
+
+  - name: remove attributes
+    file:
+      path: '{{ output_dir }}/baz.txt'
+      attributes: ''
+
+  - name: register file changes
+    stat:
+      path: '{{ output_dir }}/baz.txt'
+    register: baz_txt
+
+  - name: test file properties
+    assert:
+      that:
+      - baz_txt.stat.uid == 1234
+      - baz_txt.stat.gid == 1234
+      - baz_txt.stat.mode == '0600'
+      - baz_txt.stat.attr_flags == ''
+      - baz_txt.stat.attributes == [ ]
 
 - name: setup a tmp-like directory for ownership test
-  file: path=/tmp/worldwritable mode=1777 state=directory
+  file:
+    path: /tmp/worldwritable
+    mode: 1777
+    state: directory
 
 - name: Ask to create a file without enough perms to change ownership
-  file: path=/tmp/worldwritable/baz.txt state=touch owner=root
+  file:
+    path: /tmp/worldwritable/baz.txt
+    state: touch
+    owner: root
   become: yes
   become_user: nobody
   register: chown_result
-  ignore_errors: True
+  ignore_errors: yes
 
 - name: Ask whether the new file exists
-  stat: path=/tmp/worldwritable/baz.txt
+  stat:
+    path: /tmp/worldwritable/baz.txt
   register: file_exists_result
 
 - name: Verify that the file doesn't exist on failure
   assert:
     that:
-      - "chown_result.failed == True"
-      - "file_exists_result.stat.exists == False"
+      - chown_result.failed == true
+      - file_exists_result.stat.exists == false
 
 - name: clean up
-  file: path=/tmp/worldwritable state=absent
+  file:
+    path: /tmp/worldwritablexi
+    state: absent
 
 - name: create soft link to file
-  file: src={{output_file}} dest={{output_dir}}/soft.txt state=link
+  file:
+    src: '{{ output_file}}'
+    dest: '{{output_dir}}/soft.txt'
+    state: link
   register: file5_result
 
 - name: verify that the file was marked as changed
   assert:
     that:
-      - "file5_result.changed == true"
+      - file5_result.changed == true
 
 - name: change soft link to relative
-  file: src={{output_file|basename}} dest={{output_dir}}/soft.txt state=link
+  file:
+    src: '{{ output_file|basename }}'
+    dest: '{{ output_dir }}/soft.txt'
+    state: link
   register: file5a_result
 
 - name: verify that the file was marked as changed
   assert:
     that:
-      - "file5a_result.changed == true"
-      - "file5a_result.diff.before.src == output_file|expanduser"
-      - "file5a_result.diff.after.src == output_file|basename"
+      - file5a_result.changed == true
+      - file5a_result.diff.before.src == output_file|expanduser
+      - file5a_result.diff.after.src == output_file|basename
 
 - name: soft link idempotency check
-  file: src={{output_file|basename}} dest={{output_dir}}/soft.txt state=link
+  file:
+    src: '{{ output_file|basename }}'
+    dest: '{{ output_dir }}/soft.txt'
+    state: link
   register: file5b_result
 
 - name: verify that the file was not marked as changed
   assert:
     that:
-      - "file5b_result.changed == false"
+      - file5b_result.changed == false
 
 - name: create hard link to file
-  file: src={{output_file}} dest={{output_dir}}/hard.txt state=hard
+  file:
+    src: '{{ output_file }}'
+    dest: '{{ output_dir }}/hard.txt'
+    state: hard
   register: file6_result
 
 - name: verify that the file was marked as changed
   assert:
     that:
-      - "file6_result.changed == true"
+      - file6_result.changed == true
 
 - name: touch a hard link
-  file: src={{output_file}} dest={{output_dir}}/hard.txt state=touch
+  file:
+    src: '{{ output_file }}'
+    dest: '{{ output_dir }}/hard.txt'
+    state: touch
   register: file6_touch_result
 
 - name: verify that the hard link was touched
   assert:
     that:
-      - "file6_touch_result.changed == true"
+      - file6_touch_result.changed == true
 
 - name: create a directory
-  file: path={{output_dir}}/foobar state=directory
+  file:
+    path: '{{ output_dir }}/foobar'
+    state: directory
   register: file7_result
 
 - name: verify that the file was marked as changed
   assert:
     that:
-      - "file7_result.changed == true"
-      - "file7_result.state == 'directory'"
+      - file7_result.changed == true
+      - file7_result.state == 'directory'
 
 - name: determine if selinux is installed
   shell: which getenforce || exit 0
@@ -153,110 +244,147 @@
   shell: getenforce
   register: selinux_enabled
   when: selinux_installed.stdout != ""
-  ignore_errors: true
+  ignore_errors: yes
 
 - name: decide to include or not include selinux tests
   include: selinux_tests.yml
   when: selinux_installed is defined and selinux_installed.stdout != "" and selinux_enabled.stdout != "Disabled"
 
 - name: remote directory foobar
-  file: path={{output_dir}}/foobar state=absent
+  file:
+    path: '{{ output_dir }}/foobar'
+    state: absent
 
 - name: remove file foo.txt
-  file: path={{output_dir}}/foo.txt state=absent
+  file:
+    path: '{{ output_dir }}/foo.txt'
+    state: absent
 
 - name: remove file bar.txt
-  file: path={{output_dir}}/foo.txt state=absent
+  file:
+    path: '{{ output_dir }}/foo.txt'
+    state: absent
 
 - name: remove file baz.txt
-  file: path={{output_dir}}/foo.txt state=absent
+  file:
+    path: '{{ output_dir }}/foo.txt'
+    state: absent
 
 - name: copy directory structure over
-  copy: src=foobar dest={{output_dir}}
+  copy:
+    src: foobar
+    dest: '{{ output_dir }}'
 
 - name: Change ownership of a directory with recurse=no(default)
-  file: path={{output_dir}}/foobar owner=1234
+  file:
+    path: '{{ output_dir }}/foobar'
+    owner: 1234
 
 - name: verify that the permission of the directory was set
-  file: path={{output_dir}}/foobar state=directory
+  file:
+    path: '{{ output_dir }}/foobar'
+    state: directory
   register: file8_result
 
 - name: assert that the directory has changed to have owner 1234
   assert:
     that:
-      - "file8_result.uid == 1234"
+      - file8_result.uid == 1234
 
 - name: verify that the permission of a file under the directory was not set
-  file: path={{output_dir}}/foobar/fileA state=file
+  file:
+    path: '{{ output_dir }}/foobar/fileA'
+    state: file
   register: file9_result
 
 - name: assert the file owner has not changed to 1234
   assert:
     that:
-      - "file9_result.uid != 1234"
+      - file9_result.uid != 1234
 
 - name: change the ownership of a directory with recurse=yes
-  file: path={{output_dir}}/foobar owner=1235 recurse=yes
+  file:
+    path: '{{ output_dir }}/foobar'
+    owner: 1235
+    recurse: yes
 
 - name: verify that the permission of the directory was set
-  file: path={{output_dir}}/foobar state=directory
+  file:
+    path: '{{ output_dir }}/foobar'
+    state: directory
   register: file10_result
 
 - name: assert that the directory has changed to have owner 1235
   assert:
     that:
-      - "file10_result.uid == 1235"
+      - file10_result.uid == 1235
 
 - name: verify that the permission of a file under the directory was not set
-  file: path={{output_dir}}/foobar/fileA state=file
+  file:
+    path: '{{ output_dir }}/foobar/fileA'
+    state: file
   register: file11_result
 
 - name: assert that the file has changed to have owner 1235
   assert:
     that:
-      - "file11_result.uid == 1235"
+      - file11_result.uid == 1235
 
 - name: fail to create soft link to non existent file
-  file: src=/noneexistent dest={{output_dir}}/soft2.txt state=link force=no
+  file:
+    src: /noneexistent
+    dest: '{{ output_dir }}/soft2.txt'
+    state: link
+    force: no
   register: file12_result
-  ignore_errors: true
+  ignore_errors: yes
 
 - name: verify that link was not created
   assert:
     that:
-      - "file12_result.failed == true"
+      - file12_result.failed == true
 
 - name: force creation soft link to non existent
-  file: src=/noneexistent dest={{output_dir}}/soft2.txt state=link force=yes
+  file:
+    src: /noneexistent
+    dest: '{{ output_dir }}/soft2.txt'
+    state: link
+    force: yes
   register: file13_result
 
 - name: verify that link was created
   assert:
     that:
-      - "file13_result.changed == true"
+      - file13_result.changed == true
 
 - name: remove directory foobar
-  file: path={{output_dir}}/foobar state=absent
+  file:
+    path: '{{ output_dir }}/foobar'
+    state: absent
   register: file14_result
 
 - name: verify that the directory was removed
   assert:
     that:
-      - 'file14_result.changed == true'
-      - 'file14_result.state == "absent"'
+      - file14_result.changed == true
+      - file14_result.state == 'absent'
 
 - name: create a test sub-directory
-  file: dest={{output_dir}}/sub1 state=directory
+  file:
+    path: '{{ output_dir }}/sub1'
+    state: directory
   register: file15_result
 
 - name: verify that the new directory was created
   assert:
     that:
-      - 'file15_result.changed == true'
-      - 'file15_result.state == "directory"'
+      - file15_result.changed == true
+      - file15_result.state == 'directory'
 
 - name: create test files in the sub-directory
-  file: dest={{output_dir}}/sub1/{{item}} state=touch
+  file:
+    path: '{{ output_dir }}/sub1/{{ item }}'
+    state: touch
   with_items:
   - file1
   - file2
@@ -266,60 +394,78 @@
 - name: verify the files were created
   assert:
     that:
-      - 'item.changed == true'
-      - 'item.state == "file"'
-  with_items: "{{file16_result.results}}"
+      - item.changed == true
+      - item.state == 'file'
+  with_items: "{{ file16_result.results }}"
 
 - name: try to force the sub-directory to a link
-  file: src={{output_dir}}/testing dest={{output_dir}}/sub1 state=link force=yes
+  file:
+    src: '{{ output_dir }}/testing'
+    dest: '{{ output_dir }}/sub1'
+    state: link
+    force: yes
   register: file17_result
-  ignore_errors: true
+  ignore_errors: yes
 
 - name: verify the directory was not replaced with a link
   assert:
     that:
-      - 'file17_result.failed == true'
-      - 'file17_result.state == "directory"'
+      - file17_result.failed == true
+      - file17_result.state == 'directory'
 
 - name: create soft link to directory using absolute path
-  file: src=/ dest={{output_dir}}/root state=link
+  file:
+    src: /
+    dest: '{{ output_dir }}/root'
+    state: link
   register: file18_result
 
 - name: verify that the result was marked as changed
   assert:
     that:
-      - "file18_result.changed == true"
+      - file18_result.changed == true
 
 - name: create another test sub-directory
-  file: dest={{output_dir}}/sub2 state=directory
+  file:
+    path: '{{ output_dir }}/sub2'
+    state: directory
   register: file19_result
 
 - name: verify that the new directory was created
   assert:
     that:
-      - 'file19_result.changed == true'
-      - 'file19_result.state == "directory"'
+      - file19_result.changed == true
+      - file19_result.state == 'directory'
 
 - name: create soft link to relative file
-  file: src=../sub1/file1 dest={{output_dir}}/sub2/link1 state=link
+  file:
+    src: ../sub1/file1
+    dest: '{{ output_dir }}/sub2/link1'
+    state: link
   register: file20_result
 
 - name: verify that the result was marked as changed
   assert:
     that:
-      - "file20_result.changed == true"
+      - file20_result.changed == true
 
 - name: create soft link to relative directory
-  file: src=sub1 dest={{output_dir}}/sub1-link state=link
+  file:
+    src: sub1
+    dest: '{{ output_dir }}/sub1-link'
+    state: link
   register: file21_result
 
 - name: verify that the result was marked as changed
   assert:
     that:
-      - "file21_result.changed == true"
+      - file21_result.changed == true
 
 - name: test file creation with symbolic mode
-  file: dest={{output_dir}}/test_symbolic state=touch mode=u=rwx,g=rwx,o=rwx
+  file:
+    path: '{{ output_dir }}/test_symbolic'
+    state: touch
+    mode: u=rwx,g=rwx,o=rwx
   register: result
 
 - name: assert file mode
@@ -328,7 +474,10 @@
     - result.mode == '0777'
 
 - name: modify symbolic mode for all
-  file: dest={{output_dir}}/test_symbolic state=touch mode=a=r
+  file:
+    path: '{{ output_dir }}/test_symbolic'
+    state: touch
+    mode: a=r
   register: result
 
 - name: assert file mode
@@ -337,7 +486,10 @@
     - result.mode == '0444'
 
 - name: modify symbolic mode for owner
-  file: dest={{output_dir}}/test_symbolic state=touch mode=u+w
+  file:
+    path: '{{ output_dir }}/test_symbolic'
+    state: touch
+    mode: u+w
   register: result
 
 - name: assert file mode
@@ -346,7 +498,10 @@
     - result.mode == '0644'
 
 - name: modify symbolic mode for group
-  file: dest={{output_dir}}/test_symbolic state=touch mode=g+w
+  file:
+    path: '{{ output_dir }}/test_symbolic'
+    state: touch
+    mode: g+w
   register: result
 
 - name: assert file mode
@@ -355,7 +510,10 @@
     - result.mode == '0664'
 
 - name: modify symbolic mode for world
-  file: dest={{output_dir}}/test_symbolic state=touch mode=o+w
+  file:
+    path: '{{ output_dir }}/test_symbolic'
+    state: touch
+    mode: o+w
   register: result
 
 - name: assert file mode
@@ -364,7 +522,10 @@
     - result.mode == '0666'
 
 - name: modify symbolic mode for owner
-  file: dest={{output_dir}}/test_symbolic state=touch mode=u+x
+  file:
+    path: '{{ output_dir }}/test_symbolic'
+    state: touch
+    mode: u+x
   register: result
 
 - name: assert file mode
@@ -373,7 +534,10 @@
     - result.mode == '0766'
 
 - name: modify symbolic mode for group
-  file: dest={{output_dir}}/test_symbolic state=touch mode=g+x
+  file:
+    path: '{{ output_dir }}/test_symbolic'
+    state: touch
+    mode: g+x
   register: result
 
 - name: assert file mode
@@ -382,7 +546,10 @@
     - result.mode == '0776'
 
 - name: modify symbolic mode for world
-  file: dest={{output_dir}}/test_symbolic state=touch mode=o+x
+  file:
+    path: '{{ output_dir }}/test_symbolic'
+    state: touch
+    mode: o+x
   register: result
 
 - name: assert file mode
@@ -391,7 +558,10 @@
     - result.mode == '0777'
 
 - name: remove symbolic mode for world
-  file: dest={{output_dir}}/test_symbolic state=touch mode=o-wx
+  file:
+    path: '{{ output_dir }}/test_symbolic'
+    state: touch
+    mode: o-wx
   register: result
 
 - name: assert file mode
@@ -400,7 +570,10 @@
     - result.mode == '0774'
 
 - name: remove symbolic mode for group
-  file: dest={{output_dir}}/test_symbolic state=touch mode=g-wx
+  file:
+    path: '{{ output_dir }}/test_symbolic'
+    state: touch
+    mode: g-wx
   register: result
 
 - name: assert file mode
@@ -409,7 +582,10 @@
     - result.mode == '0744'
 
 - name: remove symbolic mode for owner
-  file: dest={{output_dir}}/test_symbolic state=touch mode=u-wx
+  file:
+    path: '{{ output_dir }}/test_symbolic'
+    state: touch
+    mode: u-wx
   register: result
 
 - name: assert file mode
@@ -418,7 +594,10 @@
     - result.mode == '0444'
 
 - name: set sticky bit with symbolic mode
-  file: dest={{output_dir}}/test_symbolic state=touch mode=o+t
+  file:
+    path: '{{ output_dir }}/test_symbolic'
+    state: touch
+    mode: o+t
   register: result
 
 - name: assert file mode
@@ -427,7 +606,10 @@
     - result.mode == '01444'
 
 - name: remove sticky bit with symbolic mode
-  file: dest={{output_dir}}/test_symbolic state=touch mode=o-t
+  file:
+    path: '{{ output_dir }}/test_symbolic'
+    state: touch
+    mode: o-t
   register: result
 
 - name: assert file mode
@@ -436,7 +618,10 @@
     - result.mode == '0444'
 
 - name: add setgid with symbolic mode
-  file: dest={{output_dir}}/test_symbolic state=touch mode=g+s
+  file:
+    path: '{{ output_dir }}/test_symbolic'
+    state: touch
+    mode: g+s
   register: result
 
 - name: assert file mode
@@ -445,7 +630,10 @@
     - result.mode == '02444'
 
 - name: remove setgid with symbolic mode
-  file: dest={{output_dir}}/test_symbolic state=touch mode=g-s
+  file:
+    path: '{{ output_dir }}/test_symbolic'
+    state: touch
+    mode: g-s
   register: result
 
 - name: assert file mode
@@ -454,7 +642,10 @@
     - result.mode == '0444'
 
 - name: add setuid with symbolic mode
-  file: dest={{output_dir}}/test_symbolic state=touch mode=u+s
+  file:
+    path: '{{ output_dir }}/test_symbolic'
+    state: touch
+    mode: u+s
   register: result
 
 - name: assert file mode
@@ -463,7 +654,10 @@
     - result.mode == '04444'
 
 - name: remove setuid with symbolic mode
-  file: dest={{output_dir}}/test_symbolic state=touch mode=u-s
+  file:
+    path: '{{ output_dir }}/test_symbolic'
+    state: touch
+    mode: u-s
   register: result
 
 - name: assert file mode
@@ -475,13 +669,22 @@
 # symlink is modified, rather than the link itself
 
 - name: create a test file
-  copy: dest={{output_dir}}/test_follow content="this is a test file\n" mode=0666
+  copy:
+    content: this is a test file\n
+    dest: '{{ output_dir }}/test_follow'
+    mode: 0666
 
 - name: create a symlink to the test file
-  file: path={{output_dir}}/test_follow_link src="./test_follow" state=link
+  file:
+    src: test_follow
+    dest: '{{ output_dir }}/test_follow_link'
+    state: link
 
 - name: modify the permissions on the link using follow=yes
-  file: path={{output_dir}}/test_follow_link mode=0644 follow=yes
+  file:
+    path: '{{ output_dir }}/test_follow_link'
+    mode: 0644
+    follow: yes
   register: result
 
 - name: assert that the chmod worked
@@ -490,7 +693,8 @@
     - result.changed
 
 - name: stat the link target
-  stat: path={{output_dir}}/test_follow
+  stat:
+    path: '{{ output_dir }}/test_follow'
   register: result
 
 - name: assert that the link target was modified correctly
@@ -499,58 +703,95 @@
     - result.stat.mode == '0644'
 
 - name: attempt to modify the permissions of the link itself
-  file: path={{output_dir}}/test_follow_link src="./test_follow" state=link mode=0600 follow=no
+  file:
+    src: test_follow
+    dest: '{{ output_dir }}/test_follow_link'
+    state: link
+    mode: '0600'
+    follow: no
   register: result
 
 # Whether the link itself changed is platform dependent! (BSD vs Linux?)
 # Just check that the underlying file was not changed
 - name: stat the link target
-  stat: path={{output_dir}}/test_follow
+  stat:
+    path: '{{ output_dir }}/test_follow'
   register: result
 
 - name: assert that the link target was unmodified
   assert:
     that:
     - result.stat.mode == '0644'
-  ignore_errors: True
+  ignore_errors: yes
 
 # Follow + recursive tests
 - name: create a toplevel directory
-  file: path={{output_dir}}/test_follow_rec state=directory mode=0755
+  file:
+    path: '{{ output_dir }}/test_follow_rec'
+    state: directory
+    mode: 0755
 
 - name: create a file outside of the toplevel
-  file: path={{output_dir}}/test_follow_rec_target_file state=touch mode=0700
+  file:
+    path: '{{ output_dir }}/test_follow_rec_target_file'
+    state: touch
+    mode: 0700
 
 - name: create a directory outside of the toplevel
-  file: path={{output_dir}}/test_follow_rec_target_dir state=directory mode=0700
+  file:
+    path: '{{ output_dir }}/test_follow_rec_target_dir'
+    state: directory
+    mode: 0700
 
 - name: create a file inside of the link target directory
-  file: path={{output_dir}}/test_follow_rec_target_dir/foo state=touch mode=0700
+  file:
+    path: '{{ output_dir }}/test_follow_rec_target_dir/foo'
+    state: touch
+    mode: 0700
 
 - name: create a symlink to the file
-  file: path={{output_dir}}/test_follow_rec/test_link state=link src="../test_follow_rec_target_file"
+  file:
+    src: ../test_follow_rec_target_file
+    dest: '{{ output_dir }}/test_follow_rec/test_link'
+    state: link
 
 - name: create a symlink to the directory
-  file: path={{output_dir}}/test_follow_rec/test_link_dir state=link src="../test_follow_rec_target_dir"
+  file:
+    src: ../test_follow_rec_target_dir
+    dest: '{{ output_dir }}/test_follow_rec/test_link_dir'
+    state: link
 
 - name: try to change permissions without following symlinks
-  file: path={{output_dir}}/test_follow_rec follow=False mode="a-x" recurse=True
+  file:
+    path: '{{ output_dir }}/test_follow_rec'
+    follow: no
+    mode: a-x
+    recurse: yes
 
 - name: stat the link file target
-  stat: path={{output_dir}}/test_follow_rec_target_file
+  stat:
+    path: '{{ output_dir }}/test_follow_rec_target_file'
   register: file_result
 
 - name: stat the link dir target
-  stat: path={{output_dir}}/test_follow_rec_target_dir
+  stat:
+    path: '{{ output_dir }}/test_follow_rec_target_dir'
   register: dir_result
 
 - name: stat the file inside the link dir target
-  stat: path={{output_dir}}/test_follow_rec_target_dir/foo
+  stat:
+    path: '{{ output_dir }}/test_follow_rec_target_dir/foo'
   register: file_in_dir_result
 
-- debug: var=file_result.stat.mode
-- debug: var=dir_result.stat.mode
-- debug: var=file_in_dir_result.stat.mode
+- debug:
+    var: file_result.stat.mode
+
+- debug:
+    var: dir_result.stat.mode
+
+- debug:
+    var: file_in_dir_result.stat.mode
+
 - name: assert that the link targets were unmodified
   assert:
     that:
@@ -559,23 +800,36 @@
     - file_in_dir_result.stat.mode == '0700'
 
 - name: try to change permissions with following symlinks
-  file: path={{output_dir}}/test_follow_rec follow=True mode="a-x" recurse=True
+  file:
+    path: '{{ output_dir }}/test_follow_rec'
+    follow: yes
+    mode: a-x
+    recurse: yes
 
 - name: stat the link file target
-  stat: path={{output_dir}}/test_follow_rec_target_file
+  stat:
+    path: '{{ output_dir }}/test_follow_rec_target_file'
   register: file_result
 
 - name: stat the link dir target
-  stat: path={{output_dir}}/test_follow_rec_target_dir
+  stat:
+    path: '{{ output_dir }}/test_follow_rec_target_dir'
   register: dir_result
 
 - name: stat the file inside the link dir target
-  stat: path={{output_dir}}/test_follow_rec_target_dir/foo
+  stat:
+    path: '{{ output_dir }}/test_follow_rec_target_dir/foo'
   register: file_in_dir_result
 
-- debug: var=file_result.stat.mode
-- debug: var=dir_result.stat.mode
-- debug: var=file_in_dir_result.stat.mode
+- debug:
+    var: file_result.stat.mode
+
+- debug:
+    var: dir_result.stat.mode
+
+- debug:
+    var: file_in_dir_result.stat.mode
+
 - name: assert that the link targets were modified
   assert:
     that:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This fixes #22785

It also implements the following changes:
- Add integration tests adding/removing attributes
- Improve the error output when chown/chgrp fails
- Improve readability of other file-related errors
- Reformatted all tests to use YAML syntax
- Ensure error strings are using to_native()

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/basic.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3