### PR TITLE
Disable failing MySQL tests on FreeBSD.

### DIFF
--- a/test/integration/targets/mysql_db/aliases
+++ b/test/integration/targets/mysql_db/aliases
@@ -1,3 +1,4 @@
 destructive
 posix/ci/group1
 skip/osx
+skip/freebsd

--- a/test/integration/targets/mysql_user/aliases
+++ b/test/integration/targets/mysql_user/aliases
@@ -1,3 +1,4 @@
 destructive
 posix/ci/group1
 skip/osx
+skip/freebsd

--- a/test/integration/targets/mysql_variables/aliases
+++ b/test/integration/targets/mysql_variables/aliases
@@ -1,3 +1,4 @@
 destructive
 posix/ci/group1
 skip/osx
+skip/freebsd


### PR DESCRIPTION
##### SUMMARY

Disable failing MySQL tests on FreeBSD.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Integration Tests

##### ANSIBLE VERSION

```
ansible 2.4.0 (skip-mysql-freebsd f7634b03d4) last updated 2017/03/20 09:05:54 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
