### PR TITLE
Add missing `needs/root` alias to `file` test.

### DIFF
--- a/test/integration/targets/file/aliases
+++ b/test/integration/targets/file/aliases
@@ -1,1 +1,2 @@
 posix/ci/group2
+needs/root


### PR DESCRIPTION
##### SUMMARY

Add missing `needs/root` alias to `file` test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.4.0 (file-needs-root b06ad6e329) last updated 2017/03/20 10:19:17 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
