### PR TITLE
fix --become_method=pbrun

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -535,7 +535,8 @@ class PlayContext(Base):
             elif self.become_method == 'pbrun':
 
                 prompt='Password:'
-                becomecmd = '%s %s -u %s %s' % (exe, flags, self.become_user, success_cmd)
+                becomecmd = '%s -b %s -u %s %s' % (exe, flags, self.become_user, '%s -c %s' % (executable, success_cmd))
+
 
             elif self.become_method == 'ksu':
                 def detect_ksu_prompt(b_data):

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -535,7 +535,7 @@ class PlayContext(Base):
             elif self.become_method == 'pbrun':
 
                 prompt='Password:'
-                becomecmd = '%s -b %s -u %s %s' % (exe, flags, self.become_user, '%s -c %s' % (executable, success_cmd))
+                becomecmd = '%s %s -u %s %s' % (exe, flags, self.become_user, '%s -c %s' % (executable, success_cmd))
 
 
             elif self.become_method == 'ksu':

--- a/test/units/playbook/test_play_context.py
+++ b/test/units/playbook/test_play_context.py
@@ -168,7 +168,8 @@ class TestPlayContext(unittest.TestCase):
         play_context.become_method = 'pbrun'
         exe="/bin/bash"
         cmd = play_context.make_become_cmd(cmd=default_cmd, executable=exe)
-        self.assertEqual(cmd, """%s %s -u %s %s -c 'echo %s; %s'""" % (pbrun_exe, pbrun_flags, play_context.become_user, exe, play_context.success_key, default_cmd))
+        self.assertEqual(cmd, """%s %s -u %s %s -c 'echo %s; %s'""" % (pbrun_exe, pbrun_flags, play_context.become_user, exe,
+                                                                       play_context.success_key, default_cmd))
 
         play_context.become_method = 'pfexec'
         cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")

--- a/test/units/playbook/test_play_context.py
+++ b/test/units/playbook/test_play_context.py
@@ -166,8 +166,9 @@ class TestPlayContext(unittest.TestCase):
         )
 
         play_context.become_method = 'pbrun'
-        cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")
-        self.assertEqual(cmd, """%s %s -u %s 'echo %s; %s'""" % (pbrun_exe, pbrun_flags, play_context.become_user, play_context.success_key, default_cmd))
+        exe="/bin/bash"
+        cmd = play_context.make_become_cmd(cmd=default_cmd, executable=exe)
+        self.assertEqual(cmd, """%s %s -u %s %s -c 'echo %s; %s'""" % (pbrun_exe, pbrun_flags, play_context.become_user, exe, play_context.success_key, default_cmd))
 
         play_context.become_method = 'pfexec'
         cmd = play_context.make_become_cmd(cmd=default_cmd, executable="/bin/bash")


### PR DESCRIPTION
##### SUMMARY
pbrun takes a command and command arguments. 
```
SYNOPSIS
       pbrun [<options>] <command> [<command arguments>]
```
It will not take a pipeline.  So, use /bin/sh -c \<quoted-pipeline> instead.

I'm more (less?) than a neophyte here.  This PR simply encodes the fix described in issue #14934.  I admit I could not even get the tests to run due to a setup error. However, the fix is very straightforward, fixing a code path which never could have worked, as far as I can tell.  There is quite a bit of discussion in the issue on the problem and the fix.

This PR was tested with pbrun 6.2.0-09.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/

##### ANSIBLE VERSION
```
$ ansible --version
ansible 2.4.0 (issue_14934 d56197fd54) last updated 2017/03/20 11:58:34 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
  python version = 3.6.0 (default, Dec 24 2016, 00:01:50) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION

Below are the verbose output before and after the fix.  

Note, I have the following in my ansible.cfg as in my powerbroker environment I can only use /bin/bash (not /bin/sh) 

```
[defaults]
executable=/bin/bash
```

Hosts names and usernames in the output have been anonymized.

<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
$ ansible app1 --become-method=pbrun --become -i inventory -a "tail /var/log/messages" -vvv
<g4t5698c.example.net> ESTABLISH CONNECTION FOR USER: doej
<g4t5698c.example.net> REMOTE_MODULE command tail /var/log/messages
<g4t5698c.example.net> EXEC ssh -C -tt -v -o ControlMaster=auto -o ControlPersist=60s -o ControlPath="/Users/doej/.ansible/cp/ansible-ssh-%h-%p-%r" -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 g4t5698c.example.net /bin/bash -c 'mkdir -p $HOME/.ansible/tmp/ansible-tmp-1490027053.04-86793734936940 && chmod a+rx $HOME/.ansible/tmp/ansible-tmp-1490027053.04-86793734936940 && echo $HOME/.ansible/tmp/ansible-tmp-1490027053.04-86793734936940'
<g4t5698c.example.net> PUT /var/folders/29/82w67lh55lzdgfxf9757c7q40000gn/T/tmpL2iEOn TO /home/doej/.ansible/tmp/ansible-tmp-1490027053.04-86793734936940/command
<g4t5698c.example.net> EXEC ssh -C -tt -v -o ControlMaster=auto -o ControlPersist=60s -o ControlPath="/Users/doej/.ansible/cp/ansible-ssh-%h-%p-%r" -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 g4t5698c.example.net /bin/bash -c 'pbrun -b -u root "'"'"'echo BECOME-SUCCESS-xznyebdgthuemeghdelqikqeyghsdnxp; LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /home/doej/.ansible/tmp/ansible-tmp-1490027053.04-86793734936940/command; rm -rf /home/doej/.ansible/tmp/ansible-tmp-1490027053.04-86793734936940/ >/dev/null 2>&1'"'"'"'
app1 | FAILED >> {
    "failed": true,
    "msg": "pbrun6.2.0-09[5621]: Request rejected by pbmasterd on g4u2087.example.net.\r\n\r\nOpenSSH_6.9p1, LibreSSL 2.1.8\r\ndebug1: Reading configuration data /etc/ssh/ssh_config\r\ndebug1: /etc/ssh/ssh_config line 21: Applying options for *\r\ndebug1: /etc/ssh/ssh_config line 56: Applying options for *\r\ndebug1: auto-mux: Trying existing master\r\ndebug1: mux_client_request_session: master session id: 2\r\nShared connection to g4t5698c.example.net closed.\r\n",
    "parsed": false
}
```
After
```
 ansible2 app1 --become-method=pbrun --become -i inventory -a "tail /var/log/messages" -vvv
Using /Users/doej/ansible.cfg as config file
Using module file /Users/doej/Virtualenvs/ansible2/lib/python3.6/site-packages/ansible/modules/core/commands/command.py
<g4t5698c.example.net> ESTABLISH SSH CONNECTION FOR USER: None
<g4t5698c.example.net> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/Users/doej/.ansible/cp/ansible-ssh-%h-%p-%r g4t5698c.example.net '/bin/bash -c '"'"'( umask 77 && mkdir -p "echo $HOME/.ansible/tmp/ansible-tmp-1490024530.638388-221852658825785" && echo ansible-tmp-1490024530.638388-221852658825785="echo $HOME/.ansible/tmp/ansible-tmp-1490024530.638388-221852658825785" ) && sleep 0'"'"''
<g4t5698c.example.net> PUT /var/folders/29/82w67lh55lzdgfxf9757c7q40000gn/T/tmpg8am11hr TO /home/doej/.ansible/tmp/ansible-tmp-1490024530.638388-221852658825785/command.py
<g4t5698c.example.net> SSH: EXEC sftp -b - -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/Users/doej/.ansible/cp/ansible-ssh-%h-%p-%r '[g4t5698c.example.net]'
<g4t5698c.example.net> ESTABLISH SSH CONNECTION FOR USER: None
<g4t5698c.example.net> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/Users/doej/.ansible/cp/ansible-ssh-%h-%p-%r g4t5698c.example.net '/bin/bash -c '"'"'chmod u+x /home/doej/.ansible/tmp/ansible-tmp-1490024530.638388-221852658825785/ /home/doej/.ansible/tmp/ansible-tmp-1490024530.638388-221852658825785/command.py && sleep 0'"'"''
<g4t5698c.example.net> ESTABLISH SSH CONNECTION FOR USER: None
<g4t5698c.example.net> SSH: EXEC ssh -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/Users/doej/.ansible/cp/ansible-ssh-%h-%p-%r -tt g4t5698c.example.net '/bin/bash -c '"'"'pbrun -b  -u root /bin/bash -c '"'"'"'"'"'"'"'"'echo BECOME-SUCCESS-hbfpcifmbizscqnycdiajglehwrkiako; /usr/bin/python /home/doej/.ansible/tmp/ansible-tmp-1490024530.638388-221852658825785/command.py; rm -rf "/home/doej/.ansible/tmp/ansible-tmp-1490024530.638388-221852658825785/" > /dev/null 2>&1'"'"'"'"'"'"'"'"' && sleep 0'"'"''
app1 | SUCCESS | rc=0 >>
Mar 20 15:17:27 g4t5698c pbrun6.2.0-09: [25233] Request rejected by pbmasterd on g4u2087.example.net.
Mar 20 15:18:50 g4t5698c pbrun6.2.0-09: [43901] Request rejected by pbmasterd on g4u2087.example.net.
Mar 20 15:19:17 g4t5698c ansible-command: Invoked with creates=None executable=None chdir=None args=tail /var/log/messages removes=None NO_LOG=None shell=False warn=True
Mar 20 15:19:29 g4t5698c pbrun6.2.0-09: [50641] Request rejected by pbmasterd on g4u2087.example.net.
Mar 20 15:19:55 g4t5698c pbrun6.2.0-09: [57499] Request rejected by pbmasterd on g4u2087.example.net.
Mar 20 15:24:45 g4t5698c ansible-command: Invoked with creates=None executable=None chdir=None args=tail /var/log/messages removes=None NO_LOG=None shell=False warn=True
Mar 20 15:41:50 g4t5698c pbrun6.2.0-09: [39986] Request rejected by pbmasterd on g4u2087.example.net.
Mar 20 15:42:12 g4t5698c xinetd[43024]: START: pblocald pid=45167 from=16.232.72.88
Mar 20 15:42:12 g4t5698c xinetd[43024]: EXIT: pblocald status=0 pid=45167 duration=0(sec)
Mar 20 15:42:12 g4t5698c ansible-command: Invoked with warn=True executable=None _uses_shell=False _raw_params=tail /var/log/messages removes=None creates=None chdir=None
```