### PR TITLE
rds.py - added more attributes to the returned output

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds.py
+++ b/lib/ansible/modules/cloud/amazon/rds.py
@@ -323,6 +323,199 @@ EXAMPLES = '''
     msg: "The new db endpoint is {{ rds.instance.endpoint }}"
 '''
 
+RETURN='''
+engine:
+    description: the name of the database engine
+    returned: when RDS instance exists
+    type: string
+    sample: "oracle-se"
+engine_version:
+    description: the version of the database engine
+    returned: when RDS instance exists
+    type: string
+    sample: "11.2.0.4.v6"
+license_model:
+    description: the license model information
+    returned: when RDS instance exists
+    type: string
+    sample: "bring-your-own-license"
+character_set_name:
+    description: the name of the character set that this instance is associated with
+    returned: when RDS instance exists
+    type: string
+    sample: "AL32UTF8"
+allocated_storage:
+    description: the allocated storage size in gigabytes (GB)
+    returned: when RDS instance exists
+    type: string
+    sample: "100"
+publicly_accessible:
+    description: the accessibility options for the DB instance
+    returned: when RDS instance exists
+    type: boolean
+    sample: "true"
+latest_restorable_time:
+    description: the latest time to which a database can be restored with point-in-time restore
+    returned: when RDS instance exists
+    type: datetime
+    sample: "1489707802.0"
+secondary_avaialbility_zone:
+    description: the name of the secondary AZ for a DB instance with multi-AZ support
+    returned: when RDS instance exists and is multy-AZ
+    type: string
+    sample: "eu-west-1b"
+backup_window:
+    description: the daily time range during which automated backups are created if automated backups are enabled
+    returned: when RDS instance exists and automated backups are enabled
+    type: string
+    sample: "03:00-03:30"
+auto_minor_version_upgrade:
+    description: indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window
+    returned: when RDS instance exists
+    type: boolean
+    sample: "true"
+read_replica_source_dbinstance_identifier:
+    description: the identifier of the source DB instance if this RDS instance is a read replica
+    returned: when read replica RDS instance exists
+    type: string
+    sample: "null"
+db_name:
+    description: the name of the database to create when the DB instance is created
+    returned: when RDS instance exists
+    type: string
+    sample: "ASERTG"
+parameter_groups:
+    description: the list of DB parameter groups applied to this RDS instance
+    returned: when RDS instance exists and parameter groups are defined
+    type: complex
+    contains:
+        parameter_apply_status:
+            description: the status of parameter updates
+            returned: when RDS instance exists
+            type: string
+            sample: "in-sync"
+        parameter_group_name:
+            description: the name of the DP parameter group
+            returned: when RDS instance exists
+            type: string
+            sample: "testawsrpprodb01spfile-1ujg7nrs7sgyz"
+option_groups:
+    description: the list of option group memberships for this RDS instance
+    returned: when RDS instance exists
+    type: complex
+    contains:
+        option_group_name:
+            description: the option group name for this RDS instance
+            returned: when RDS instance exists
+            type: string
+            sample: "default:oracle-se-11-2"
+        status:
+            description: the status of the RDS instance's option group membership
+            returned: when RDS instance exists
+            type: string
+            sample: "in-sync"
+pending_modified_values:
+    description: a dictionary of changes to the RDS instance that are pending
+    returned: when RDS instance exists
+    type: complex
+    contains:
+        db_instance_class:
+            description: the new DB instance class for this RDS instance that will be applied or is in progress
+            returned: when RDS instance exists
+            type: string
+            sample: "null"
+        db_instance_identifier:
+            description: the new DB instance identifier this RDS instance that will be applied or is in progress
+            returned: when RDS instance exists
+            type: string
+            sample: "null"
+        allocated_storage:
+            description: the new allocated storage size for this RDS instance that will be applied or is in progress
+            returned: when RDS instance exists
+            type: string
+            sample: "null"
+        backup_retention_period:
+            description: the pending number of days for which automated backups are retained
+            returned: when RDS instance exists
+            type: string
+            sample: "null"
+        engine_version:
+            description: indicates the database engine version
+            returned: when RDS instance exists
+            type: string
+            sample: "null"
+        iops:
+            description: the new provisioned IOPS value for this RDS instance that will be applied or is being applied
+            returned: when RDS instance exists
+            type: string
+            sample: "null"
+        master_user_password": null,
+            description: the pending or in-progress change of the master credentials for this RDS instance
+            returned: when RDS instance exists
+            type: string
+            sample: "null"
+        multi_az": null,
+            description: indicates that the single-AZ RDS instance is to change to a multi-AZ deployment
+            returned: when RDS instance exists
+            type: string
+            sample: "null"
+        port: null
+            description: specifies the pending port for this RDS instance
+            returned: when RDS instance exists
+            type: string
+            sample: "null"
+db_subnet_groups:
+    description: information on the subnet group associated with this RDS instance
+    returned: when RDS instance exists
+    type: complex
+    contains:
+        description:
+            description: the subnet group associated with the DB instance
+            returned: when RDS instance exists
+            type: string
+            sample: "Subnets for the UAT RDS SQL DB Instance"
+        name:
+            description: the name of the DB subnet group
+            returned: when RDS instance exists
+            type: string
+            sample: "samplesubnetgrouprds-j6paiqkxqp4z"
+        status:
+            description: the status of the DB subnet group
+            returned: when RDS instance exists
+            type: string
+            sample: "complete"
+        subnets:
+            description: the description of the DB subnet group
+            returned: when RDS instance exists
+            type: complex
+            contains:
+                availability_zone:
+                    description: subnet availability zone information
+                    returned: when RDS instance exists
+                    type: complex
+                    contains:
+                        name:
+                            description: avaialbility zone
+                            returned: when RDS instance exists
+                            type: string
+                            sample: "eu-west-1b"
+                        provisioned_iops_capable:
+                            description: whether provisioned iops are available in AZ subnet
+                            returned: when RDS instance exists
+                            type: boolean
+                            sample: "false"
+                identifier:
+                    description: the identifier of the subnet
+                    returned: when RDS instance exists
+                    type: string
+                    sample: "subnet-3fdba63e"
+                status:
+                    description: the status of the subnet
+                    returned: when RDS instance exists
+                    type: string
+                    sample: "active"
+'''
+
 import sys
 import time
 
@@ -608,16 +801,69 @@ class RDS2DBInstance:
         d = {
             'id': self.name,
             'create_time': self.instance['InstanceCreateTime'],
+            'engine': self.instance['Engine'],
+            'engine_version': self.instance['EngineVersion'],
+            'license_model': self.instance['LicenseModel'],
+            'character_set_name': self.instance['CharacterSetName'],
+            'allocated_storage': self.instance['AllocatedStorage'],
+            'publicly_accessible': self.instance['PubliclyAccessible'],
+            'latest_restorable_time': self.instance['LatestRestorableTime'],
             'status': self.status,
             'availability_zone': self.instance['AvailabilityZone'],
+            'secondary_avaialbility_zone': self.instance['SecondaryAvailabilityZone'],
             'backup_retention': self.instance['BackupRetentionPeriod'],
+            'backup_window': self.instance['PreferredBackupWindow'],
             'maintenance_window': self.instance['PreferredMaintenanceWindow'],
+            'auto_minor_version_upgrade': self.instance['AutoMinorVersionUpgrade'],
+            'read_replica_source_dbinstance_identifier': self.instance['ReadReplicaSourceDBInstanceIdentifier'],
             'multi_zone': self.instance['MultiAZ'],
             'instance_type': self.instance['DBInstanceClass'],
             'username': self.instance['MasterUsername'],
+            'db_name': self.instance['DBName'],
             'iops': self.instance['Iops'],
             'replication_source': self.instance['ReadReplicaSourceDBInstanceIdentifier']
         }
+        if self.instance['DBParameterGroups'] is not None:
+            parameter_groups = []
+            for x in self.instance['DBParameterGroups']:
+                parameter_groups.append({'parameter_group_name': x['DBParameterGroupName'], 'parameter_apply_status': x['ParameterApplyStatus']})
+            d['parameter_groups'] = parameter_groups
+        if self.instance['OptionGroupMemberships'] is not None:
+            option_groups = []
+            for x in self.instance['OptionGroupMemberships']:
+                option_groups.append({'status': x['Status'], 'option_group_name': x['OptionGroupName']})
+            d['option_groups'] = option_groups
+        if self.instance['PendingModifiedValues'] is not None:
+            pdv = self.instance['PendingModifiedValues']
+            d['pending_modified_values'] = {
+                'multi_az': pdv['MultiAZ'],
+                'master_user_password': pdv['MasterUserPassword'],
+                'port': pdv['Port'],
+                'iops': pdv['Iops'],
+                'allocated_storage': pdv['AllocatedStorage'],
+                'engine_version': pdv['EngineVersion'],
+                'backup_retention_period': pdv['BackupRetentionPeriod'],
+                'db_instance_class': pdv['DBInstanceClass'],
+                'db_instance_identifier': pdv['DBInstanceIdentifier']
+            }
+        if self.instance["DBSubnetGroup"] is not None:
+            dsg = self.instance["DBSubnetGroup"]
+            db_subnet_groups = {}
+            db_subnet_groups['vpc_id'] = dsg['VpcId']
+            db_subnet_groups['name'] = dsg['DBSubnetGroupName']
+            db_subnet_groups['status'] = dsg['SubnetGroupStatus'].lower()
+            db_subnet_groups['description'] = dsg['DBSubnetGroupDescription']
+            db_subnet_groups['subnets'] = []
+            for x in dsg["Subnets"]:
+                db_subnet_groups['subnets'].append({
+                    'status': x['SubnetStatus'].lower(),
+                    'identifier': x['SubnetIdentifier'],
+                    'availability_zone': {
+                        'name': x['SubnetAvailabilityZone']['Name'],
+                        'provisioned_iops_capable': x['SubnetAvailabilityZone']['ProvisionedIopsCapable']
+                    }
+                })
+            d['db_subnet_groups'] = db_subnet_groups
         if self.instance["VpcSecurityGroups"] is not None:
             d['vpc_security_groups'] = ','.join(x['VpcSecurityGroupId'] for x in self.instance['VpcSecurityGroups'])
         if "Endpoint" in self.instance and self.instance["Endpoint"] is not None:

--- a/lib/ansible/modules/cloud/amazon/rds.py
+++ b/lib/ansible/modules/cloud/amazon/rds.py
@@ -323,7 +323,7 @@ EXAMPLES = '''
     msg: "The new db endpoint is {{ rds.instance.endpoint }}"
 '''
 
-RETURN='''
+RETURN = '''
 engine:
     description: the name of the database engine
     returned: when RDS instance exists
@@ -357,7 +357,7 @@ publicly_accessible:
 latest_restorable_time:
     description: the latest time to which a database can be restored with point-in-time restore
     returned: when RDS instance exists
-    type: datetime
+    type: string
     sample: "1489707802.0"
 secondary_avaialbility_zone:
     description: the name of the secondary AZ for a DB instance with multi-AZ support
@@ -449,17 +449,17 @@ pending_modified_values:
             returned: when RDS instance exists
             type: string
             sample: "null"
-        master_user_password": null,
+        master_user_password:
             description: the pending or in-progress change of the master credentials for this RDS instance
             returned: when RDS instance exists
             type: string
             sample: "null"
-        multi_az": null,
+        multi_az:
             description: indicates that the single-AZ RDS instance is to change to a multi-AZ deployment
             returned: when RDS instance exists
             type: string
             sample: "null"
-        port: null
+        port:
             description: specifies the pending port for this RDS instance
             returned: when RDS instance exists
             type: string


### PR DESCRIPTION
##### SUMMARY
This PR enriches the output returned by module and adds more properties.
It doesn't change the structure of old returned values so is backwards compatible.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/rds.py

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION
None.

An example of new returned output:
```
TASK [rds_output : debug] *********************************************
ok: [localhost] => {
    "changed": false,
    "rds_res": {
        "changed": false,
        "instance": {
            "allocated_storage": 100,
            "auto_minor_version_upgrade": false,
            "availability_zone": "eu-west-1a",
            "backup_retention": 14,
            "backup_window": "03:00-03:30",
            "character_set_name": "AL32UTF8",
            "create_time": 1489079017.009,
            "db_name": "ASERTG",
            "db_subnet_groups": {
                "description": "Subnets for the RDS SQL DB Instance",
                "name": "samplesubnetgrouprds-j6paiqkxqp4z",
                "status": "complete",
                "subnets": [
                    {
                        "availability_zone": {
                            "name": "eu-west-1b",
                            "provisioned_iops_capable": false
                        },
                        "identifier": "subnet-3fdba63e",
                        "status": "active"
                    },
                    {
                        "availability_zone": {
                            "name": "eu-west-1a",
                            "provisioned_iops_capable": false
                        },
                        "identifier": "subnet-1ce85f4d",
                        "status": "active"
                    }
                ],
                "vpc_id": "vpc-11edfe4a"
            },
            "endpoint": "test.1fand5a7du9b.eu-west-1.rds.amazonaws.com",
            "engine": "oracle-se",
            "engine_version": "11.2.0.4.v6",
            "id": "test",
            "instance_type": "db.m4.xlarge",
            "iops": null,
            "latest_restorable_time": 1489707802.0,
            "license_model": "bring-your-own-license",
            "maintenance_window": "sat:01:00-sat:01:30",
            "multi_zone": true,
            "option_groups": [
                {
                    "option_group_name": "default:oracle-se-11-2",
                    "status": "in-sync"
                }
            ],
            "parameter_groups": [
                {
                    "parameter_apply_status": "in-sync",
                    "parameter_group_name": "testawsrpprodb01spfile-1ujg7nrs7sgyz"
                }
            ],
            "pending_modified_values": {
                "db_instance_class": null,
                "db_instance_identifier": null,
                "allocated_storage": null,
                "backup_retention_period": null,
                "engine_version": null,
                "iops": null,
                "master_user_password": null,
                "multi_az": null,
                "port": null
            },
            "port": 1530,
            "publicly_accessible": false,
            "read_replica_source_dbinstance_identifier": null,
            "replication_source": null,
            "secondary_avaialbility_zone": "eu-west-1b",
            "status": "available",
            "username": "ADMIN",
            "vpc_security_groups": "sg-daf9b5a3"
        }
    }
}
```
