### PR TITLE
Fix aws module errors

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway_facts.py
@@ -91,7 +91,7 @@ result:
 import json
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info, boto3_conn
+from ansible.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info, boto3_conn, camel_dict_to_snake_dict
 from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list, HAS_BOTO3
 
 try:

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
@@ -464,6 +464,7 @@ def ensure_route_table_absent(connection, module):
     route_table_id = module.params.get('route_table_id')
     tags = module.params.get('tags')
     vpc_id = module.params.get('vpc_id')
+    purge_subnets = module.params.get('purge_subnets')
 
     if lookup == 'tag':
         if tags is not None:
@@ -485,7 +486,7 @@ def ensure_route_table_absent(connection, module):
         return {'changed': False}
 
     # disassociate subnets before deleting route table
-    ensure_subnet_associations(connection, vpc_id, route_table, [], module.check_mode)
+    ensure_subnet_associations(connection, vpc_id, route_table, [], module.check_mode, purge_subnets)
     try:
         connection.delete_route_table(route_table.id, dry_run=module.check_mode)
     except EC2ResponseError as e:


### PR DESCRIPTION
##### SUMMARY
Fix a couple of errors I have found when executing the following EC2 modules:
ec2_vpc_nat_gateway_facts: Import camel_dict_to_snake_dict method to fix error when executing get_nat_gateways() method.

ec2_vpc_route_table: Add purge_subnets arg to satisfy arg requirements when calling ensure_subnet_associations() from ensure_route_table_absent().

See below for the stack trace errors encountered when executing these tasks in ansible.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway_facts.py
lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py

##### ANSIBLE VERSION
ansible 2.3.0.0


##### ADDITIONAL INFORMATION

Below are the ansible tasks I have executed in my playbook and the errors encountered.

name: Find NAT Gateways
  ec2_vpc_nat_gateway_facts:
    region: "{{ aws_region }}"
    filters:
      vpc-id: "{{ vpc_output.vpcs[0].id }}"
  register: nat_gateways_facts

The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_1TZ32n/ansible_module_ec2_vpc_nat_gateway_facts.py", line 151, in <module>
    main()
  File "/tmp/ansible_1TZ32n/ansible_module_ec2_vpc_nat_gateway_facts.py", line 145, in main
    results = get_nat_gateways(connection, module)
  File "/tmp/ansible_1TZ32n/ansible_module_ec2_vpc_nat_gateway_facts.py", line 118, in get_nat_gateways
    return [camel_dict_to_snake_dict(gateway) for gateway in result['NatGateways']]
NameError: global name 'camel_dict_to_snake_dict' is not defined


name: Delete route tables
  ec2_vpc_route_table:
    region: "{{ aws_region }}"
    state: absent
    route_table_id: "{{ item.id }}"
    lookup: id
    vpc_id: "{{ vpc_output.vpcs[0].id }}"
  with_items: "{{ route_tables_facts.route_tables }}"
  when: item.tags.Name is defined

The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_L_rUI_/ansible_module_ec2_vpc_route_table.py", line 669, in <module>
    main()
  File "/tmp/ansible_L_rUI_/ansible_module_ec2_vpc_route_table.py", line 661, in main
    result = ensure_route_table_absent(connection, module)
  File "/tmp/ansible_L_rUI_/ansible_module_ec2_vpc_route_table.py", line 488, in ensure_route_table_absent
    ensure_subnet_associations(connection, vpc_id, route_table, [], module.check_mode)
TypeError: ensure_subnet_associations() takes exactly 6 arguments (5 given)