### PR TITLE
Use flake8 for sanity testing

### DIFF
--- a/test/runner/lib/sanity.py
+++ b/test/runner/lib/sanity.py
@@ -316,7 +316,7 @@ def command_sanity_pep8(args, targets):
         return SanitySkipped(test)
 
     cmd = [
-        'pep8',
+        'flake8',
         '--max-line-length', '160',
         '--config', '/dev/null',
         '--ignore', ','.join(sorted(current_ignore)),
@@ -336,7 +336,7 @@ def command_sanity_pep8(args, targets):
     if args.explain:
         return SanitySkipped(test)
 
-    pattern = '^(?P<path>[^:]*):(?P<line>[0-9]+):(?P<column>[0-9]+): (?P<code>[WE][0-9]{3}) (?P<message>.*)$'
+    pattern = '^(?P<path>[^:]*):(?P<line>[0-9]+):(?P<column>[0-9]+): (?P<code>[WEF][0-9]{3}) (?P<message>.*)$'
 
     results = [re.search(pattern, line).groupdict() for line in stdout.splitlines()]
 

--- a/test/runner/requirements/sanity.txt
+++ b/test/runner/requirements/sanity.txt
@@ -1,5 +1,6 @@
 jinja2
 mock
+flake8
 pep8
 pylint
 pytest

--- a/tox.ini
+++ b/tox.ini
@@ -24,8 +24,39 @@ passenv =
 
 
 [flake8]
-# These are things that the devs don't agree make the code more readable
 # E402 module level import not at top of file
-ignore = E402
+
+# List below is from flake8 - currently just using F821
+# http://flake8.pycqa.org/en/latest/user/error-codes.html
+
+# F401	module imported but unused
+# F402	import module from line N shadowed by loop variable
+# F403	‘from module import *’ used; unable to detect undefined names
+# F404	future import(s) name after other statements
+# F405	name may be undefined, or defined from star imports: module
+# F406	‘from module import *’ only allowed at module level
+# F407	an undefined __future__ feature name was imported
+
+# F601	dictionary key name repeated with different values
+# F602	dictionary key variable name repeated with different values
+# F621	too many expressions in an assignment with star-unpacking
+# F622	two or more starred expressions in an assignment (a, *b, *c = d)
+# F631	assertion test is a tuple, which are always True
+
+# F701	a break statement outside of a while or for loop
+# F702	a continue statement outside of a while or for loop
+# F703	a continue statement in a finally block in a loop
+# F704	a yield or yield from statement outside of a function
+# F705	a return statement with arguments inside a generator
+# F706	a return statement outside of a function/method
+# F707	an except: block as not the last exception handler
+
+# F811	redefinition of unused name from line N
+# F812	list comprehension redefines name from line N
+# F822	undefined name name in __all__
+# F823	local variable name ... referenced before assignment
+# F831	duplicate argument name in function definition
+# F841	local variable name is assigned to but never used
+ignore = E402,F401,F402,F403,F404,F405,F406,F407,F601,F602,F621,F622,F631,F701,F702,F703,F704,F705,F706,F707,F811,F812,F822,F823,F831,F841
 # not all the devs believe in 80 column line length
 max-line-length = 160


### PR DESCRIPTION
##### SUMMARY
flake8 catches more errors than pep8, so will result in fewer bugs making the codebase

Would have caught the error introduced in #20214 addressed by #22818 

```
ERROR: Found 1 pep8 issue(s) which need to be resolved:
ERROR: lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway_facts.py:118:13: F821 undefined name 'camel_dict_to_snake_dict'
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
test/sanity

##### ANSIBLE VERSION
```
ansible 2.4.0 (flake8_tests e6e557cd76) last updated 2017/03/21 15:06:56 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
