### PR TITLE
fixes return data structure

### DIFF
--- a/lib/ansible/modules/network/ios/ios_command.py
+++ b/lib/ansible/modules/network/ios/ios_command.py
@@ -218,11 +218,11 @@ def main():
         module.fail_json(msg=msg, failed_conditions=failed_conditions)
 
 
-    result = {
+    result.update({
         'changed': False,
         'stdout': responses,
         'stdout_lines': list(to_lines(responses))
-    }
+    })
 
     module.exit_json(**result)
 


### PR DESCRIPTION
The return was being re-written instead of updated so warnings were
lost.  This patch now updates the result instead of replacing it.

