### PR TITLE
Fix get_s3_connection (fixes #22317) (#22318)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3.py
+++ b/lib/ansible/modules/cloud/amazon/s3.py
@@ -714,6 +714,13 @@ def main():
 def get_s3_connection(aws_connect_kwargs, location, rgw, s3_url):
     if s3_url and rgw:
         rgw = urlparse(s3_url)
+        # ensure none of the named arguments we will pass to boto.connect_s3
+        # are already present in aws_connect_kwargs
+        for kw in ['is_secure', 'host', 'port', 'calling_format']:
+            try:
+                del aws_connect_kwargs[kw]
+            except KeyError:
+                pass
         s3 = boto.connect_s3(
             is_secure=rgw.scheme == 'https',
             host=rgw.hostname,
@@ -723,6 +730,13 @@ def get_s3_connection(aws_connect_kwargs, location, rgw, s3_url):
         )
     elif is_fakes3(s3_url):
         fakes3 = urlparse(s3_url)
+        # ensure none of the named arguments we will pass to S3Connection
+        # are already present in aws_connect_kwargs
+        for kw in ['is_secure', 'host', 'port', 'calling_format']:
+            try:
+                del aws_connect_kwargs[kw]
+            except KeyError:
+                pass
         s3 = S3Connection(
             is_secure=fakes3.scheme == 'fakes3s',
             host=fakes3.hostname,


### PR DESCRIPTION
* Fix get_s3_connection (fixes #22317)

Override aws_connect_kwargs rather than prepending to them. Should fix an issue in which `calling_format` is set twice in the kwargs passed to `boto.connect_s3` or `S3Connection` if a bucket name contains a `.`

* Revert "Fix get_s3_connection (fixes #22317)"

This reverts commit 7f61b8bebd2929940495204f1a98d660a55985d8.

* implements alternative way of fixing issue with aws_connect_kwargs for rgw and fakes3 (fixes 22317)

* add comment to explain why the keys are being removed from aws_connect_kwargs

* remove trailing whitespace on comment line

##### SUMMARY
Override aws_connect_kwargs rather than prepending to them. Should fix an issue in which calling_format is set twice in the kwargs passed to boto.connect_s3 or S3Connection if a bucket name contains a .
fixes #22317  

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/s3.py

##### ANSIBLE VERSION
```
ansible 2.3.0.0 (S3-patch 89a2d1d6ad) last updated 2017/03/21 09:55:13 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```