### PR TITLE
win_scheduled_tasks: Improve example test framework

### DIFF
--- a/test/integration/targets/win_scheduled_task/tasks/main.yml
+++ b/test/integration/targets/win_scheduled_task/tasks/main.yml
@@ -1,46 +1,21 @@
 # NOTE: The win_scheduled_task module only works on Win2012+
 
 - name: Test Windows capabilities
-  raw: Get-Command New-ScheduledTask -ErrorAction SilentlyContinue; $?
+  raw: Get-Command New-ScheduledTask -ErrorAction SilentlyContinue; return $?
   failed_when: no
   register: new_scheduledtask
 
-- name: Set boolean for capability
-  set_fact:
-    has_new_scheduledtask: '{{ new_scheduledtask.rc == 0 }}'
-
-- name: Test in normal mode
-  when: has_new_scheduledtask
+- name: Only run tests when Windows is capable
+  when: new_scheduledtask.rc == 0
   block:
-  - include: tests.yml
 
-  - name: Check the various tasks in normal mode
-    assert:
-      that:
-      - add_scheduled_task.changed == true
-      - add_scheduled_task.exists == false
-      - add_scheduled_task_again.changed == false
-      - add_scheduled_task_again.exists == true
-      - remove_scheduled_task.changed == true
-      - remove_scheduled_task.exists == true
-      - remove_scheduled_task_again.changed == false
-      - remove_scheduled_task_again.exists == false
+  - name: Test in normal mode
+    include: tests.yml
+    vars:
+      in_check_mode: no
 
-
-- name: Test in check-mode
-  check_mode: yes
-  when: has_new_scheduledtask
-  block:
-  - include: tests.yml
-
-  - name: Check the various tests in check-mode
-    assert:
-      that:
-      - add_scheduled_task.changed == true
-      - add_scheduled_task.exists == false
-      - add_scheduled_task_again.changed == true
-      - add_scheduled_task_again.exists == false
-      - remove_scheduled_task.changed == false
-      - remove_scheduled_task.exists == false
-      - remove_scheduled_task_again.changed == false
-      - remove_scheduled_task_again.exists == false
+  - name: Test in check-mode
+    include: tests.yml
+    vars:
+      in_check_mode: yes
+    check_mode: yes

--- a/test/integration/targets/win_scheduled_task/tasks/tests.yml
+++ b/test/integration/targets/win_scheduled_task/tasks/tests.yml
@@ -1,11 +1,12 @@
 - name: Remove potentially leftover scheduled task
   win_scheduled_task: &wst_absent
-    name: Test
+    name: Ansible Test
     state: absent
+
 
 - name: Add scheduled task
   win_scheduled_task: &wst_present
-    name: Test
+    name: Ansible Test
     executable: dir.exe
     arguments: C:\Windows\Temp\
     frequency: once
@@ -13,14 +14,112 @@
     user: SYSTEM
   register: add_scheduled_task
 
+- name: Test add_scheduled_task
+  assert:
+    that:
+    - add_scheduled_task.changed == true
+    - add_scheduled_task.exists == false
+
+
 - name: Add scheduled task (again)
   win_scheduled_task: *wst_present
   register: add_scheduled_task_again
+
+- name: Test add_scheduled_task_again (normal mode)
+  assert:
+    that:
+    - add_scheduled_task_again.changed == false
+    - add_scheduled_task_again.exists == true
+  when: not in_check_mode
+
+- name: Test add_scheduled_task_again (check-mode)
+  assert:
+    that:
+    - add_scheduled_task_again.changed == true
+    - add_scheduled_task_again.exists == false
+  when: in_check_mode
+
+
+# FIXME: The below tasks should not require all options
+#        See: https://github.com/ansible/ansible/issues/19279
+- name: Run tests for normal mode only (expects scheduled task)
+  when: not in_check_mode
+  block:
+
+  - name: Disable scheduled task
+    win_scheduled_task:
+      <<: *wst_present
+      enabled: no
+    register: disable_scheduled_task
+
+  - name: Test disable_scheduled_task
+    assert:
+      that:
+      - disable_scheduled_task.changed == true
+      - disable_scheduled_task.exists == true
+
+
+  - name: Disable scheduled task (again)
+    win_scheduled_task:
+      <<: *wst_present
+      enabled: no
+    register: disable_scheduled_task_again
+
+  - name: Test disable_scheduled_task_again
+    assert:
+      that:
+      - disable_scheduled_task_again.changed == false
+      - disable_scheduled_task_again.exists == true
+
+
+  - name: Enable scheduled task
+    win_scheduled_task:
+      <<: *wst_present
+      enabled: yes
+    register: enable_scheduled_task
+
+  - assert:
+      that:
+      - enable_scheduled_task.changed == true
+      - enable_scheduled_task.exists == true
+
+  - name: Enable scheduled task (again)
+    win_scheduled_task:
+      <<: *wst_present
+      enabled: yes
+    register: enable_scheduled_task_again
+
+  - assert:
+      that:
+      - enable_scheduled_task_again.changed == false
+      - enable_scheduled_task_again.exists == true
+
 
 - name: Remove scheduled task
   win_scheduled_task: *wst_absent
   register: remove_scheduled_task
 
+- name: Test remove_scheduled_task (normal mode)
+  assert:
+    that:
+    - remove_scheduled_task.changed == true
+    - remove_scheduled_task.exists == true
+  when: not in_check_mode
+
+- name: Test remove_scheduled_task (check-mode)
+  assert:
+    that:
+    - remove_scheduled_task.changed == false
+    - remove_scheduled_task.exists == false
+  when: in_check_mode
+
+
 - name: Remove scheduled task (again)
   win_scheduled_task: *wst_absent
   register: remove_scheduled_task_again
+
+- name: Test remove_scheduled_task_again
+  assert:
+    that:
+    - remove_scheduled_task_again.changed == false
+    - remove_scheduled_task_again.exists == false


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Updated as discussed in previous Test Working Group.

Changes include:
- Moving the tests directly with the task
- Make the asserts depending on ansible_check_mode
- Add more tests for enabling/disabling scheduled tasks

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Integration Test Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_scheduled_task

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3