### PR TITLE
Remove ununsed Connection.log method

### DIFF
--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -61,10 +61,6 @@ class Connection(ConnectionBase):
         self._manager = None
         self._connected = False
 
-    def log(self, msg):
-        msg = 'h=%s u=%s %s' % (self._play_context.remote_addr, self._play_context.remote_user, msg)
-        logger.debug(msg)
-
     def _connect(self):
         super(Connection, self)._connect()
 


### PR DESCRIPTION

##### SUMMARY
method referenced 'logger' which no longer exists.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/plugins/connection/netconf.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (netconf_stylish 1bc8d971d0) last updated 2017/03/21 11:08:35 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```

