### PR TITLE
Fix bad ref to AnsibleConnectionError -> AnsibleConnectionFailure

### DIFF
--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -79,7 +79,7 @@ class Connection(ConnectionBase):
             key_filename = os.path.expanduser(self._play_context.private_key_file)
 
         if not self._network_os:
-            raise AnsibleConnectionError('network_os must be set for netconf connections')
+            raise AnsibleConnectionFailure('network_os must be set for netconf connections')
 
         try:
             self._manager = manager.connect(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix bad ref to AnsibleConnectionError -> AnsibleConnectionFailure

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/plugins/connection/netconf.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (netconf_stylish 1bc8d971d0) last updated 2017/03/21 11:08:35 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]


```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
