### PR TITLE
make netconf.py stylish

### DIFF
--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -19,16 +19,11 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
-import re
-import socket
-import json
-import signal
 import logging
 
 from ansible import constants as C
 from ansible.errors import AnsibleConnectionFailure, AnsibleError
 from ansible.plugins.connection import ConnectionBase, ensure_connect
-from ansible.module_utils.six.moves import StringIO
 
 try:
     from ncclient import manager
@@ -45,6 +40,7 @@ except ImportError:
     display = Display()
 
 logging.getLogger('ncclient').setLevel(logging.INFO)
+
 
 class Connection(ConnectionBase):
     ''' NetConf connections '''
@@ -136,4 +132,3 @@ class Connection(ConnectionBase):
     def fetch_file(self, in_path, out_path):
         """Fetch a file from remote to local"""
         pass
-


### PR DESCRIPTION

##### SUMMARY

(flake8 stuff)

netconf.py:22:1: F401 're' imported but unused
netconf.py:23:1: F401 'socket' imported but unused
netconf.py:24:1: F401 'json' imported but unused
netconf.py:25:1: F401 'signal' imported but unused
netconf.py:31:1: F401 'ansible.module_utils.six.moves.StringIO' imported but unused

In combo with bug fixes https://github.com/ansible/ansible/pull/22838 and https://github.com/ansible/ansible/pull/22837  gets netconf.py flake8 clean.
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/plugins/connection/netconf.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

ansible 2.4.0 (netconf_stylish 1bc8d971d0) last updated 2017/03/21 11:08:35 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
