### PR TITLE
keep ansible_local as top level var, always present

### DIFF
--- a/lib/ansible/vars/__init__.py
+++ b/lib/ansible/vars/__init__.py
@@ -287,6 +287,17 @@ class VariableManager:
                     all_vars = combine_vars(all_vars, host_facts)
                 # always return namespaced facts
                 all_vars = combine_vars(all_vars, {'ansible_facts': host_facts})
+
+                # push local to top namespace, ensure we always have, even if empty
+                if 'ansible_local' in all_vars['ansible_facts']:
+                    all_vars.update({'ansible_local': all_vars['ansible_facts']['ansible_local']})
+                else:
+                    all_vars.update({'ansible_local': {}})
+
+                # remove possible extra ansible_local from ansible_facts namespace
+                if 'ansible_local' in all_vars['ansible_facts']:
+                    del all_vars['ansible_facts']['ansible_local']
+
             except KeyError:
                 pass
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
restores ansible_local as 'top level var' which new fact namespacing was removing

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
facts
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```

