### PR TITLE
Fix stderr false return value

### DIFF
--- a/lib/ansible/modules/network/basics/uri.py
+++ b/lib/ansible/modules/network/basics/uri.py
@@ -425,15 +425,14 @@ def main():
         # and the filename already exists.  This allows idempotence
         # of uri executions.
         if os.path.exists(creates):
-            module.exit_json(stdout="skipped, since %s exists" % creates,
-                             changed=False, stderr=False, rc=0)
+            module.exit_json(stdout="skipped, since %s exists" % creates, changed=False, rc=0)
 
     if removes is not None:
         # do not run the command if the line contains removes=filename
         # and the filename do not exists.  This allows idempotence
         # of uri executions.
         if not os.path.exists(removes):
-            module.exit_json(stdout="skipped, since %s does not exist" % removes, changed=False, stderr=False, rc=0)
+            module.exit_json(stdout="skipped, since %s does not exist" % removes, changed=False, rc=0)
 
     # Make the request
     resp, content, dest = uri(module, url, dest, body, body_format, method,

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -514,7 +514,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         3 = its a directory, not a file
         4 = stat module failed, likely due to not finding python
         '''
-        x = "0"  # unknown error has occured
+        x = "0"  # unknown error has occurred
         try:
             remote_stat = self._execute_remote_stat(path, all_vars, follow=follow)
             if remote_stat['exists'] and remote_stat['isdir']:
@@ -754,9 +754,13 @@ class ActionBase(with_metaclass(ABCMeta, object)):
 
         # pre-split stdout/stderr into lines if needed
         if 'stdout' in data and 'stdout_lines' not in data:
-            data['stdout_lines'] = data.get('stdout', u'').splitlines()
+            # if the value is 'False', a default won't catch it.
+            txt = data.get('stdout', None) or u''
+            data['stdout_lines'] = txt.splitlines()
         if 'stderr' in data and 'stderr_lines' not in data:
-            data['stderr_lines'] = data.get('stderr', u'').splitlines()
+            # if the value is 'False', a default won't catch it.
+            txt = data.get('stderr', None) or u''
+            data['stderr_lines'] = txt.splitlines()
 
         display.debug("done with _execute_module (%s, %s)" % (module_name, module_args))
         return data

--- a/test/units/module_utils/basic/test_exit_json.py
+++ b/test/units/module_utils/basic/test_exit_json.py
@@ -89,6 +89,30 @@ class TestAnsibleModuleExitJson(unittest.TestCase):
         return_val = json.loads(self.fake_stream.getvalue())
         self.assertEquals(return_val, dict(changed=True, msg='success', invocation=empty_invocation))
 
+    def test_exit_json_stderr_lines(self):
+        with self.assertRaises(SystemExit) as ctx:
+            self.module.exit_json(msg='message', stderr="hello\nworld\n")
+        if isinstance(ctx.exception, int):
+            # Python2.6... why does sys.exit behave this way?
+            self.assertEquals(ctx.exception, 0)
+        else:
+            self.assertEquals(ctx.exception.code, 0)
+        return_val = json.loads(self.fake_stream.getvalue())
+        self.assertEquals(return_val, dict(msg="message", changed=False, stderr="hello\nworld\n",
+            stderr_lines=['hello','world'], invocation=empty_invocation))
+
+    def test_exit_json_stderr_false(self):
+        with self.assertRaises(SystemExit) as ctx:
+            self.module.exit_json(msg='message', stderr=False)
+        if isinstance(ctx.exception, int):
+            # Python2.6... why does sys.exit behave this way?
+            self.assertEquals(ctx.exception, 0)
+        else:
+            self.assertEquals(ctx.exception.code, 0)
+        return_val = json.loads(self.fake_stream.getvalue())
+        self.assertEquals(return_val, dict(msg="message", changed=False, invocation=empty_invocation,
+            stderr_lines=[], stderr=u''))
+
 class TestAnsibleModuleExitValuesRemoved(unittest.TestCase):
     OMIT = 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER'
     dataset = (

--- a/test/units/module_utils/basic/test_exit_json.py
+++ b/test/units/module_utils/basic/test_exit_json.py
@@ -89,30 +89,6 @@ class TestAnsibleModuleExitJson(unittest.TestCase):
         return_val = json.loads(self.fake_stream.getvalue())
         self.assertEquals(return_val, dict(changed=True, msg='success', invocation=empty_invocation))
 
-    def test_exit_json_stderr_lines(self):
-        with self.assertRaises(SystemExit) as ctx:
-            self.module.exit_json(msg='message', stderr="hello\nworld\n")
-        if isinstance(ctx.exception, int):
-            # Python2.6... why does sys.exit behave this way?
-            self.assertEquals(ctx.exception, 0)
-        else:
-            self.assertEquals(ctx.exception.code, 0)
-        return_val = json.loads(self.fake_stream.getvalue())
-        self.assertEquals(return_val, dict(msg="message", changed=False, stderr="hello\nworld\n",
-            stderr_lines=['hello','world'], invocation=empty_invocation))
-
-    def test_exit_json_stderr_false(self):
-        with self.assertRaises(SystemExit) as ctx:
-            self.module.exit_json(msg='message', stderr=False)
-        if isinstance(ctx.exception, int):
-            # Python2.6... why does sys.exit behave this way?
-            self.assertEquals(ctx.exception, 0)
-        else:
-            self.assertEquals(ctx.exception.code, 0)
-        return_val = json.loads(self.fake_stream.getvalue())
-        self.assertEquals(return_val, dict(msg="message", changed=False, invocation=empty_invocation,
-            stderr_lines=[], stderr=u''))
-
 class TestAnsibleModuleExitValuesRemoved(unittest.TestCase):
     OMIT = 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER'
     dataset = (


### PR DESCRIPTION
##### SUMMARY
exit_json(... stderr=False) has been used in `uri.py` forever. It isn't correct, but it is provoked by a regression introduced in [this commit](https://github.com/ansible/ansible/commit/c86a17b7a003ac22c173cfa832ed2368e15015e6#diff-69a29e19a76e98587550dab380483594R740) by @bcoca, probably inspired by #16294.

This is really sneaky. I fixed `uri.py`.

For a belt-and-suspenders fix, certainly a boolean shouldn't be passed, but some defensive coding will prevent this from being hit by any other modules.

I tried to unit test this (see commit+revert). But testing `_execute_module` is way too hairy for me.

This needs to be backported to 2.3.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/modules/network/basics/uri.py`
`lib/ansible/plugins/action/__init__.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
Provoking this requires using `creates` or `removes` and being skipped. That's why it wasn't caught more quickly.