### PR TITLE
Associate `systemd` module with `service` test.

### DIFF
--- a/test/integration/targets/service/aliases
+++ b/test/integration/targets/service/aliases
@@ -2,3 +2,4 @@ destructive
 posix/ci/group1
 skip/freebsd
 skip/osx
+systemd


### PR DESCRIPTION
##### SUMMARY

Associate `systemd` module with `service` test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Integration Tests

##### ANSIBLE VERSION

```
ansible 2.4.0 (test-aliases 82ad338c2f) last updated 2017/03/21 11:47:16 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
