### PR TITLE
Removing temporary files when not proxing inside urls utils

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -683,7 +683,6 @@ class SSLValidationHandler(urllib_request.BaseHandler):
 
         if not use_proxy:
             # ignore proxy settings for this host request
-            
             if tmp_ca_cert_path:
                 os.remove(tmp_ca_cert_path)
             if to_add_ca_cert_path:

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -634,6 +634,7 @@ class SSLValidationHandler(urllib_request.BaseHandler):
                             pass
 
         if not to_add:
+            os.remove(to_add_path)
             to_add_path = None
         return (tmp_path, to_add_path, paths_checked)
 
@@ -682,6 +683,11 @@ class SSLValidationHandler(urllib_request.BaseHandler):
 
         if not use_proxy:
             # ignore proxy settings for this host request
+            
+            if tmp_ca_cert_path:
+                os.remove(tmp_ca_cert_path)
+            if to_add_ca_cert_path:
+                os.remove(to_add_ca_cert_path)
             return req
 
         try:


### PR DESCRIPTION
##### SUMMARY
The unarchive module leaves behind files in /tmp. 

```
- name: "Download new version of the apps"
  unarchive: 
    src: "https://github.com/vccabral/ansible/archive/master.zip"
    dest: "/tmp/ansible/"
    remote_src: true
    validate_certs: true
```
After running a task like the one above, I noticed several files left behind including cert files and empty files. 

It is unknown is this is an outstanding issue. I found no documentation of ansible's unarchive module that suggests this behaviour and the mkstemp module explicitly states the user is responsible for clean up. 


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/urls/fetch_url

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 4a8f2dde20) last updated 2017/03/21 15:28:04 (GMT -400)
  config file = /Users/cabralv/Documents/code/ansible-consumer-finance/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.11 (default, Dec 16 2015, 13:23:46) [GCC 4.2.1 Compatible Apple LLVM 6.1.0 (clang-602.0.53)]
```


##### ADDITIONAL INFORMATION
You can recreate this bug with a simple playbook.

```
- name: "Download new version of the apps"
  unarchive: 
    src: "https://github.com/vccabral/ansible/archive/master.zip"
    dest: "/tmp/ansible/"
    remote_src: true
    validate_certs: true
```

To watch the /tmp directory fill up during the execution and never get cleaned up use this command:
```
$ watch "ls -la /tmp | grep tmp"
```
