### PR TITLE
Add HDD serial numbers. (rebase/fixes of #9454) 

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1463,16 +1463,18 @@ class LinuxHardware(Hardware):
                 d[key] = get_file_content(sysdir + "/device/" + key)
 
             sg_inq = module.get_bin_path('sg_inq') 
-            for key in ['serial']:
-                device = "/dev/%s" % (block)
-                try:
-                    rc, drivedata, err = module.run_command([sg_inq, device])
-                except:
-                    return
-                serial = re.search("Unit serial number:\s+(\w+)", drivedata)
-                if serial:
-                     d[key] = serial.group(1)
-		     
+            device = "/dev/%s" % (block)
+            try:
+                rc, drivedata, err = module.run_command([sg_inq, device])
+            except:
+                return
+            serial = re.search("Unit serial number:\s+(\w+)", drivedata)
+            if serial:
+                d[key] = serial.group(1)
+
+            for key in ['vendor', 'model']:
+                d[key] = get_file_content(sysdir + "/device/" + key)
+
             for key,test in [ ('removable','/removable'), \
                               ('support_discard','/queue/discard_granularity'),
                               ]:

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1462,10 +1462,10 @@ class LinuxHardware(Hardware):
             for key in ['vendor', 'model', 'sas_address', 'sas_device_handle']:
                 d[key] = get_file_content(sysdir + "/device/" + key)
 
-            sg_inq = module.get_bin_path('sg_inq') 
+            sg_inq = self.module.get_bin_path('sg_inq')
             device = "/dev/%s" % (block)
             try:
-                rc, drivedata, err = module.run_command([sg_inq, device])
+                rc, drivedata, err = self.module.run_command([sg_inq, device])
             except:
                 return
             serial = re.search("Unit serial number:\s+(\w+)", drivedata)

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1470,7 +1470,7 @@ class LinuxHardware(Hardware):
                 return
             serial = re.search("Unit serial number:\s+(\w+)", drivedata)
             if serial:
-                d[key] = serial.group(1)
+                d['serial'] = serial.group(1)
 
             for key in ['vendor', 'model']:
                 d[key] = get_file_content(sysdir + "/device/" + key)

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1463,14 +1463,14 @@ class LinuxHardware(Hardware):
                 d[key] = get_file_content(sysdir + "/device/" + key)
 
             sg_inq = self.module.get_bin_path('sg_inq')
-            device = "/dev/%s" % (block)
-            try:
+
+            if sg_inq:
+                device = "/dev/%s" % (block)
                 rc, drivedata, err = self.module.run_command([sg_inq, device])
-            except:
-                return
-            serial = re.search("Unit serial number:\s+(\w+)", drivedata)
-            if serial:
-                d['serial'] = serial.group(1)
+                if rc == 0:
+                    serial = re.search("Unit serial number:\s+(\w+)", drivedata)
+                    if serial:
+                        d['serial'] = serial.group(1)
 
             for key in ['vendor', 'model']:
                 d[key] = get_file_content(sysdir + "/device/" + key)

--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1462,6 +1462,17 @@ class LinuxHardware(Hardware):
             for key in ['vendor', 'model', 'sas_address', 'sas_device_handle']:
                 d[key] = get_file_content(sysdir + "/device/" + key)
 
+            sg_inq = module.get_bin_path('sg_inq') 
+            for key in ['serial']:
+                device = "/dev/%s" % (block)
+                try:
+                    rc, drivedata, err = module.run_command([sg_inq, device])
+                except:
+                    return
+                serial = re.search("Unit serial number:\s+(\w+)", drivedata)
+                if serial:
+                     d[key] = serial.group(1)
+		     
             for key,test in [ ('removable','/removable'), \
                               ('support_discard','/queue/discard_granularity'),
                               ]:


### PR DESCRIPTION
##### SUMMARY
This is a rebase and fixup of https://github.com/ansible/ansible/pull/9454 'Added HDD serial numbers'
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/module_utils/facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (pr_9454_rebase_hdd_serial_fact 21734b8aba) last updated 2017/03/21 17:19:02 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
