### PR TITLE
Ansible 2.3 feature support for dellos9 and dellos10

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -330,9 +330,8 @@ DEFAULT_STRATEGY_PLUGIN_PATH   = get_config(p, DEFAULTS, 'strategy_plugins', 'AN
                                             '~/.ansible/plugins/strategy:/usr/share/ansible/plugins/strategy', value_type='pathlist')
 
 NETWORK_GROUP_MODULES          = get_config(p, DEFAULTS, 'network_group_modules','NETWORK_GROUP_MODULES', ['eos', 'nxos', 'ios', 'iosxr', 'junos',
-                                                                                                           'vyos', 'sros'],
+                                                                                                           'vyos', 'sros', 'dellos9', 'dellos10'],
                                             value_type='list')
-
 DEFAULT_STRATEGY               = get_config(p, DEFAULTS, 'strategy',           'ANSIBLE_STRATEGY', 'linear')
 DEFAULT_STDOUT_CALLBACK        = get_config(p, DEFAULTS, 'stdout_callback',    'ANSIBLE_STDOUT_CALLBACK', 'default')
 # cache

--- a/lib/ansible/module_utils/dellos10.py
+++ b/lib/ansible/module_utils/dellos10.py
@@ -1,5 +1,6 @@
 #
 # (c) 2015 Peter Sprygada, <psprygada@ansible.com>
+# (c) 2017 Red Hat, Inc
 #
 # Copyright (c) 2016 Dell Inc.
 #
@@ -28,28 +29,98 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-
 import re
 
-from ansible.module_utils.network import register_transport, to_list
-from ansible.module_utils.shell import CliBase
-from ansible.module_utils.netcfg import NetworkConfig, ConfigLine
+from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.network_common import to_list, ComplexList
+from ansible.module_utils.connection import exec_command
+from ansible.module_utils.netcfg import NetworkConfig,ConfigLine
+
+_DEVICE_CONFIGS = {}
+
+WARNING_PROMPTS_RE = [
+    r"[\r\n]?\[confirm yes/no\]:\s?$",
+    r"[\r\n]?\[y/n\]:\s?$",
+    r"[\r\n]?\[yes/no\]:\s?$"
+]
+
+dellos10_argument_spec = {
+    'host': dict(),
+    'port': dict(type='int'),
+    'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
+    'password': dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), no_log=True),
+    'ssh_keyfile': dict(fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE']), type='path'),
+    'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
+    'auth_pass': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS']), no_log=True),
+    'timeout': dict(type='int'),
+    'provider': dict(type='dict'),
+}
+
+def check_args(module, warnings):
+    provider = module.params['provider'] or {}
+    for key in dellos10_argument_spec:
+        if key != 'provider' and module.params[key]:
+            warnings.append('argument %s has been deprecated and will be '
+                            'removed in a future version' % key)
 
 
-def get_config(module):
-    contents = module.params['config']
+def get_config(module, flags=[]):
+    cmd = 'show running-config '
+    cmd += ' '.join(flags)
+    cmd = cmd.strip()
 
-    if not contents:
-        contents = module.config.get_config()
-        module.params['config'] = contents
-        return NetworkConfig(indent=1, contents=contents[0])
-    else:
-        return NetworkConfig(indent=1, contents=contents)
+    try:
+        return _DEVICE_CONFIGS[cmd]
+    except KeyError:
+        rc, out, err = exec_command(module, cmd)
+        if rc != 0:
+            module.fail_json(msg='unable to retrieve current config', stderr=err)
+        cfg = str(out).strip()
+        _DEVICE_CONFIGS[cmd] = cfg
+        return cfg
 
+
+def to_commands(module, commands):
+    spec = {
+        'command': dict(key=True),
+        'prompt': dict(),
+        'answer': dict()
+    }
+    transform = ComplexList(spec, module)
+    return transform(commands)
+
+
+def run_commands(module, commands, check_rc=True):
+    responses = list()
+    commands = to_commands(module, to_list(commands))
+    for cmd in commands:
+        cmd = module.jsonify(cmd)
+        rc, out, err = exec_command(module, cmd)
+        if check_rc and rc != 0:
+            module.fail_json(msg=err, rc=rc)
+        responses.append(out)
+    return responses
+
+def load_config(module, commands):
+    rc, out, err = exec_command(module, 'configure terminal')
+    if rc != 0:
+        module.fail_json(msg='unable to enter configuration mode', err=err)
+
+    commands.append('commit')
+    for command in to_list(commands):
+        if command == 'end':
+            continue
+        cmd = {'command': command, 'prompt': WARNING_PROMPTS_RE, 'answer': 'yes'}
+        rc, out, err = exec_command(module, module.jsonify(cmd))
+        if rc != 0:
+            module.fail_json(msg=err, command=command, rc=rc)
+
+    exec_command(module, 'end')
 
 def get_sublevel_config(running_config, module):
     contents = list()
     current_config_contents = list()
+    running_config = NetworkConfig(contents=running_config, indent=1)
     obj = running_config.get_object(module.params['parents'])
     if obj:
         contents = obj.children
@@ -61,67 +132,8 @@ def get_sublevel_config(running_config, module):
             current_config_contents.append(c.rjust(len(c) + indent, ' '))
         if isinstance(c, ConfigLine):
             current_config_contents.append(c.raw)
-        indent = indent + 1
+        indent = 1
     sublevel_config = '\n'.join(current_config_contents)
 
     return sublevel_config
 
-
-class Cli(CliBase):
-
-    NET_PASSWD_RE = re.compile(r"[\r\n]?password:\s?$", re.I)
-
-    CLI_PROMPTS_RE = [
-        re.compile(r"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:#) ?$"),
-        re.compile(r"\[\w+\@[\w\-\.]+(?: [^\]])\] ?[>#\$] ?$")
-    ]
-
-    CLI_ERRORS_RE = [
-        re.compile(r"% ?Error"),
-        re.compile(r"% ?Bad secret"),
-        re.compile(r"Syntax error:"),
-        re.compile(r"invalid input", re.I),
-        re.compile(r"(?:incomplete|ambiguous) command", re.I),
-        re.compile(r"connection timed out", re.I),
-        re.compile(r"[^\r\n]+ not found", re.I),
-        re.compile(r"'[^']' +returned error code: ?\d+"),
-    ]
-
-
-    def connect(self, params, **kwargs):
-        super(Cli, self).connect(params, kickstart=False, **kwargs)
-        self.shell.send('terminal length 0')
-
-
-    def configure(self, commands, **kwargs):
-        cmds = ['configure terminal']
-        cmds.extend(to_list(commands))
-        cmds.append('end')
-        cmds.append('commit')
-
-        responses = self.execute(cmds)
-        responses.pop(0)
-        return responses
-
-
-    def get_config(self, **kwargs):
-        return self.execute(['show running-configuration'])
-
-
-    def load_config(self, commands, **kwargs):
-        return self.configure(commands)
-
-
-    def commit_config(self, **kwargs):
-        self.execute(['commit'])
-
-
-    def abort_config(self, **kwargs):
-        self.execute(['discard'])
-
-
-    def save_config(self):
-        self.execute(['copy running-config startup-config'])
-
-
-Cli = register_transport('cli', default=True)(Cli)

--- a/lib/ansible/modules/network/dellos10/dellos10_command.py
+++ b/lib/ansible/modules/network/dellos10/dellos10_command.py
@@ -2,7 +2,7 @@
 #
 # (c) 2015 Peter Sprygada, <psprygada@ansible.com>
 #
-# Copyright (c) 2016 Dell Inc.
+# Copyright (c) 2017 Dell Inc.
 #
 # This file is part of Ansible
 #
@@ -22,7 +22,7 @@
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
-                    'supported_by': 'community'}
+                    'supported_by': 'core'}
 
 
 DOCUMENTATION = """
@@ -140,14 +140,14 @@ warnings:
   type: list
   sample: ['...', '...']
 """
+import time
 
-from ansible.module_utils.basic import get_exception
-from ansible.module_utils.netcli import CommandRunner, FailedConditionsError
-from ansible.module_utils.network import NetworkModule, NetworkError
-from ansible.module_utils.six import string_types
-import ansible.module_utils.dellos10
+from ansible.module_utils.dellos10 import run_commands
+from ansible.module_utils.dellos10 import dellos10_argument_spec, check_args
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network_common import ComplexList
+from ansible.module_utils.netcli import Conditional
 
-VALID_KEYS = ['command', 'prompt', 'response']
 
 def to_lines(stdout):
     for item in stdout:
@@ -155,75 +155,87 @@ def to_lines(stdout):
             item = str(item).split('\n')
         yield item
 
-def parse_commands(module):
-    for cmd in module.params['commands']:
-        if isinstance(cmd, string_types):
-            cmd = dict(command=cmd, output=None)
-        elif 'command' not in cmd:
-            module.fail_json(msg='command keyword argument is required')
-        elif not set(cmd.keys()).issubset(VALID_KEYS):
-            module.fail_json(msg='unknown keyword specified')
-        yield cmd
+
+def parse_commands(module, warnings):
+    command = ComplexList(dict(
+        command=dict(key=True),
+        prompt=dict(),
+        answer=dict()
+    ), module)
+    commands = command(module.params['commands'])
+    for index, item in enumerate(commands):
+        if module.check_mode and not item['command'].startswith('show'):
+            warnings.append(
+                'only show commands are supported when using check mode, not '
+                'executing `%s`' % item['command']
+            )
+        elif item['command'].startswith('conf'):
+            module.fail_json(
+                msg='dellos10_command does not support running config mode '
+                    'commands.  Please use dellos10_config instead'
+            )
+    return commands
+
 
 def main():
-    spec = dict(
+    """main entry point for module execution
+    """
+    argument_spec = dict(
         # { command: <str>, prompt: <str>, response: <str> }
         commands=dict(type='list', required=True),
-        wait_for=dict(type='list'),
+
+        wait_for=dict(type='list', aliases=['waitfor']),
+        match=dict(default='all', choices=['all', 'any']),
+
         retries=dict(default=10, type='int'),
         interval=dict(default=1, type='int')
     )
 
-    module = NetworkModule(argument_spec=spec,
-                           connect_on_load=False,
+    argument_spec.update(dellos10_argument_spec)
+
+    module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
 
-    commands = list(parse_commands(module))
-    conditionals = module.params['wait_for'] or list()
+    result = {'changed': False}
 
     warnings = list()
-
-    runner = CommandRunner(module)
-
-    for cmd in commands:
-        if module.check_mode and not cmd['command'].startswith('show'):
-            warnings.append('only show commands are supported when using '
-                            'check mode, not executing `%s`' % cmd)
-        else:
-            if cmd['command'].startswith('conf'):
-                module.fail_json(msg='dellos10_command does not support running '
-                                     'config mode commands.  Please use '
-                                     'dellos10_config instead')
-            runner.add_command(**cmd)
-
-    for item in conditionals:
-        runner.add_conditional(item)
-
-    runner.retries = module.params['retries']
-    runner.interval = module.params['interval']
-
-    try:
-        runner.run()
-    except FailedConditionsError:
-        exc = get_exception()
-        module.fail_json(msg=str(exc), failed_conditions=exc.failed_conditions)
-    except NetworkError:
-        exc = get_exception()
-        module.fail_json(msg=str(exc))
-
-    result = dict(changed=False)
-
-    result['stdout'] = list()
-    for cmd in commands:
-        try:
-            output = runner.get_command(cmd['command'])
-        except ValueError:
-            output = 'command not executed due to check_mode, see warnings'
-        result['stdout'].append(output)
-
-
+    check_args(module, warnings)
+    commands = parse_commands(module, warnings)
     result['warnings'] = warnings
-    result['stdout_lines'] = list(to_lines(result['stdout']))
+
+    wait_for = module.params['wait_for'] or list()
+    conditionals = [Conditional(c) for c in wait_for]
+
+    retries = module.params['retries']
+    interval = module.params['interval']
+    match = module.params['match']
+
+    while retries > 0:
+        responses = run_commands(module, commands)
+
+        for item in list(conditionals):
+            if item(responses):
+                if match == 'any':
+                    conditionals = list()
+                    break
+                conditionals.remove(item)
+
+        if not conditionals:
+            break
+
+        time.sleep(interval)
+        retries -= 1
+
+    if conditionals:
+        failed_conditions = [item.raw for item in conditionals]
+        msg = 'One or more conditional statements have not be satisfied'
+        module.fail_json(msg=msg, failed_conditions=failed_conditions)
+
+    result = {
+        'changed': False,
+        'stdout': responses,
+        'stdout_lines': list(to_lines(responses))
+    }
 
     module.exit_json(**result)
 

--- a/lib/ansible/modules/network/dellos10/dellos10_command.py
+++ b/lib/ansible/modules/network/dellos10/dellos10_command.py
@@ -22,7 +22,7 @@
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
-                    'supported_by': 'core'}
+                    'supported_by': 'community'}
 
 
 DOCUMENTATION = """

--- a/lib/ansible/modules/network/dellos10/dellos10_config.py
+++ b/lib/ansible/modules/network/dellos10/dellos10_config.py
@@ -2,7 +2,7 @@
 #
 # (c) 2015 Peter Sprygada, <psprygada@ansible.com>
 #
-# Copyright (c) 2016 Dell Inc.
+# Copyright (c) 2017 Dell Inc.
 #
 # This file is part of Ansible
 #
@@ -22,7 +22,7 @@
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
-                    'supported_by': 'community'}
+                    'supported_by': 'core'}
 
 
 DOCUMENTATION = """
@@ -195,9 +195,13 @@ saved:
   sample: True
 
 """
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.netcfg import NetworkConfig, dumps
-from ansible.module_utils.network import NetworkModule
 from ansible.module_utils.dellos10 import get_config, get_sublevel_config
+from ansible.module_utils.dellos10 import dellos10_argument_spec, check_args
+from ansible.module_utils.dellos10 import load_config, run_commands
+from ansible.module_utils.dellos10 import WARNING_PROMPTS_RE
+
 
 def get_candidate(module):
     candidate = NetworkConfig(indent=1)
@@ -223,16 +227,18 @@ def main():
         match=dict(default='line',
                    choices=['line', 'strict', 'exact', 'none']),
         replace=dict(default='line', choices=['line', 'block']),
+
         update=dict(choices=['merge', 'check'], default='merge'),
         save=dict(type='bool', default=False),
         config=dict(),
         backup=dict(type='bool', default=False)
     )
 
+    argument_spec.update(dellos10_argument_spec)
+
     mutually_exclusive = [('lines', 'src')]
 
-    module = NetworkModule(argument_spec=argument_spec,
-                           connect_on_load=False,
+    module = AnsibleModule(argument_spec=argument_spec,
                            mutually_exclusive=mutually_exclusive,
                            supports_check_mode=True)
 
@@ -240,24 +246,30 @@ def main():
 
     match = module.params['match']
     replace = module.params['replace']
-    result = dict(changed=False, saved=False)
+
+    warnings = list()
+    check_args(module, warnings)
+
+    result = dict(changed=False, saved=False, warnings=warnings)
 
     candidate = get_candidate(module)
-
     if match != 'none':
         config = get_config(module)
         if parents:
             contents = get_sublevel_config(config, module)
             config = NetworkConfig(contents=contents, indent=1)
+        else:
+            config = NetworkConfig(contents=config, indent=1)
         configobjs = candidate.difference(config, match=match, replace=replace)
 
     else:
         configobjs = candidate.items
 
     if module.params['backup']:
-        result['__backup__'] = module.cli('show running-config')[0]
+        result['__backup__'] = get_config(module)
 
     commands = list()
+
     if configobjs:
         commands = dumps(configobjs, 'commands')
         commands = commands.split('\n')
@@ -269,11 +281,11 @@ def main():
             commands.extend(module.params['after'])
 
         if not module.check_mode and module.params['update'] == 'merge':
-            response = module.config.load_config(commands)
-            result['responses'] = response
+            load_config(module, commands)
 
             if module.params['save']:
-                module.config.save_config()
+                cmd = {'command': 'copy runing-config startup-config', 'prompt': WARNING_PROMPTS_RE, 'answer': 'yes'}
+                run_commands(module, [cmd])
                 result['saved'] = True
 
         result['changed'] = True

--- a/lib/ansible/modules/network/dellos10/dellos10_config.py
+++ b/lib/ansible/modules/network/dellos10/dellos10_config.py
@@ -22,7 +22,7 @@
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
-                    'supported_by': 'core'}
+                    'supported_by': 'community'}
 
 
 DOCUMENTATION = """

--- a/lib/ansible/modules/network/dellos10/dellos10_facts.py
+++ b/lib/ansible/modules/network/dellos10/dellos10_facts.py
@@ -2,7 +2,7 @@
 #
 # (c) 2015 Peter Sprygada, <psprygada@ansible.com>
 #
-# Copyright (c) 2016 Dell Inc.
+# Copyright (c) 2017 Dell Inc.
 #
 # This file is part of Ansible
 #
@@ -21,7 +21,7 @@
 #
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
-                    'supported_by': 'community'}
+                    'supported_by': 'core'}
 
 
 DOCUMENTATION = """
@@ -134,47 +134,57 @@ ansible_net_neighbors:
 
 import re
 
-from ansible.module_utils.basic import get_exception
-from ansible.module_utils.netcli import CommandRunner
-from ansible.module_utils.network import NetworkModule
-import ansible.module_utils.dellos10
+from ansible.module_utils.dellos10 import run_commands
+from ansible.module_utils.dellos10 import dellos10_argument_spec, check_args
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.six.moves import zip
 
 try:
     from lxml import etree as ET
 except ImportError:
     import xml.etree.ElementTree as ET
 
+
 class FactsBase(object):
 
-    def __init__(self, runner):
-        self.runner = runner
-        self.facts = dict()
+    COMMANDS = list()
 
-        self.commands()
+    def __init__(self, module):
+        self.module = module
+        self.facts = dict()
+        self.responses = None
+
+    def populate(self):
+        self.responses = run_commands(self.module, self.COMMANDS, check_rc=False)
+
+    def run(self, cmd):
+        return run_commands(self.module, cmd, check_rc=False)
 
 
 class Default(FactsBase):
 
-    def commands(self):
-        self.runner.add_command('show version | display-xml')
-        self.runner.add_command('show system | display-xml')
-        self.runner.add_command('show running-configuration | grep hostname')
+    COMMANDS = [
+        'show version | display-xml',
+        'show system | display-xml',
+        'show running-configuration | grep hostname'
+    ]
 
     def populate(self):
-
-        data = self.runner.get_command('show version | display-xml')
+        super(Default, self).populate()
+        data = self.responses[0]
         xml_data = ET.fromstring(data)
 
         self.facts['name'] = self.parse_name(xml_data)
         self.facts['version'] = self.parse_version(xml_data)
 
-        data = self.runner.get_command('show system | display-xml')
+        data = self.responses[1]
         xml_data = ET.fromstring(data)
 
         self.facts['servicetag'] = self.parse_serialnum(xml_data)
         self.facts['model'] = self.parse_model(xml_data)
 
-        data = self.runner.get_command('show running-configuration | grep hostname')
+        data = self.responses[2]
         self.facts['hostname'] = self.parse_hostname(data)
 
     def parse_name(self, data):
@@ -213,18 +223,21 @@ class Default(FactsBase):
 
 class Hardware(FactsBase):
 
-    def commands(self):
-        self.runner.add_command('show processes memory | grep Total')
+    COMMANDS = [
+        'show version | display-xml',
+        'show processes memory | grep Total'
+    ]
 
     def populate(self):
 
-        data = self.runner.get_command('show version | display-xml')
+        super(Hardware, self).populate()
+        data = self.responses[0]
+
         xml_data = ET.fromstring(data)
 
         self.facts['cpu_arch'] = self.parse_cpu_arch(xml_data)
 
-        data = self.runner.get_command('show processes memory | grep Total')
-
+        data = self.responses[1]
         match = self.parse_memory(data)
         if match:
             self.facts['memtotal_mb'] = int(match[0]) / 1024
@@ -243,24 +256,25 @@ class Hardware(FactsBase):
 
 class Config(FactsBase):
 
-    def commands(self):
-        self.runner.add_command('show running-config')
+    COMMANDS = ['show running-config']
 
     def populate(self):
-        config = self.runner.get_command('show running-config')
-        self.facts['config'] = config
+        super(Config, self).populate()
+        self.facts['config'] = self.responses[0]
 
 
 class Interfaces(FactsBase):
 
-    def commands(self):
-        self.runner.add_command('show interface | display-xml')
+    COMMANDS = [
+        'show interface | display-xml',
+    ]
 
     def populate(self):
+        super(Interfaces, self).populate()
         self.facts['all_ipv4_addresses'] = list()
         self.facts['all_ipv6_addresses'] = list()
 
-        data = self.runner.get_command('show interface | display-xml')
+        data = self.responses[0]
 
         xml_data = ET.fromstring(data)
 
@@ -294,21 +308,23 @@ class Interfaces(FactsBase):
 
         for interface in interfaces.findall('./data/ports/ports-state/port'):
             name = self.parse_item(interface, 'name')
-            fanout = self.parse_item(interface, 'fanout-state')
+            # media-type name interface name format phy-eth 1/1/1
             mediatype = self.parse_item(interface, 'media-type')
 
             typ, sname = name.split('-eth')
-
-            if fanout == "BREAKOUT_1x1":
-                name = "ethernet" + sname
+            name = "ethernet" + sname
+            try:
                 intf = int_facts[name]
                 intf['mediatype'] = mediatype
-            else:
-                # TODO: Loop for the exact subport
+            except:
+                # fanout
                 for subport in xrange(1, 5):
                     name = "ethernet" + sname + ":" + str(subport)
-                    intf = int_facts[name]
-                    intf['mediatype'] = mediatype
+                    try:
+                        intf = int_facts[name]
+                        intf['mediatype'] = mediatype
+                    except:
+                        pass
 
         return int_facts
 
@@ -329,7 +345,7 @@ class Interfaces(FactsBase):
         ipv4 = interface.find('ipv4')
         ip_address = ""
         if ipv4 is not None:
-            prim_ipaddr  = ipv4.find('./address/primary-addr')
+            prim_ipaddr = ipv4.find('./address/primary-addr')
             if prim_ipaddr is not None:
                 ip_address = prim_ipaddr.text
                 self.add_ip_address(ip_address, 'ipv4')
@@ -340,7 +356,7 @@ class Interfaces(FactsBase):
         ipv4 = interface.find('ipv4')
         ip_address = ""
         if ipv4 is not None:
-            sec_ipaddr  = ipv4.find('./address/secondary-addr')
+            sec_ipaddr = ipv4.find('./address/secondary-addr')
             if sec_ipaddr is not None:
                 ip_address = sec_ipaddr.text
                 self.add_ip_address(ip_address, 'ipv4')
@@ -351,7 +367,7 @@ class Interfaces(FactsBase):
         ipv6 = interface.find('ipv6')
         ip_address = ""
         if ipv6 is not None:
-            ipv6_addr  = ipv6.find('./address/ipv6-address')
+            ipv6_addr = ipv6.find('./address/ipv6-address')
             if ipv6_addr is not None:
                 ip_address = ipv6_addr.text
                 self.add_ip_address(ip_address, 'ipv6')
@@ -384,11 +400,16 @@ VALID_SUBSETS = frozenset(FACT_SUBSETS.keys())
 
 
 def main():
-    spec = dict(
+    """main entry point for module execution
+    """
+    argument_spec = dict(
         gather_subset=dict(default=['!config'], type='list')
     )
 
-    module = NetworkModule(argument_spec=spec, supports_check_mode=True)
+    argument_spec.update(dellos10_argument_spec)
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
 
     gather_subset = module.params['gather_subset']
 
@@ -426,28 +447,23 @@ def main():
     facts = dict()
     facts['gather_subset'] = list(runable_subsets)
 
-    runner = CommandRunner(module)
-
     instances = list()
     for key in runable_subsets:
-        runs = FACT_SUBSETS[key](runner)
-        instances.append(runs)
+        instances.append(FACT_SUBSETS[key](module))
 
-    runner.run()
-
-    try:
-        for inst in instances:
-            inst.populate()
-            facts.update(inst.facts)
-    except Exception:
-        module.exit_json(out=module.from_json(runner.items))
+    for inst in instances:
+        inst.populate()
+        facts.update(inst.facts)
 
     ansible_facts = dict()
-    for key, value in facts.items():
+    for key, value in iteritems(facts):
         key = 'ansible_net_%s' % key
         ansible_facts[key] = value
 
-    module.exit_json(ansible_facts=ansible_facts)
+    warnings = list()
+    check_args(module, warnings)
+
+    module.exit_json(ansible_facts=ansible_facts, warnings=warnings)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/dellos10/dellos10_facts.py
+++ b/lib/ansible/modules/network/dellos10/dellos10_facts.py
@@ -21,7 +21,7 @@
 #
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
-                    'supported_by': 'core'}
+                    'supported_by': 'community'}
 
 
 DOCUMENTATION = """

--- a/lib/ansible/modules/network/dellos9/dellos9_command.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_command.py
@@ -21,7 +21,7 @@
 #
 
 ANSIBLE_METADATA = {'status': ['preview'],
-                    'supported_by': 'core',
+                    'supported_by': 'community',
                     'metadata_version': '1.0'}
 
 DOCUMENTATION = """

--- a/lib/ansible/modules/network/dellos9/dellos9_command.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_command.py
@@ -20,10 +20,9 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-ANSIBLE_METADATA = {'metadata_version': '1.0',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'core',
+                    'metadata_version': '1.0'}
 
 DOCUMENTATION = """
 ---
@@ -149,14 +148,14 @@ warnings:
   type: list
   sample: ['...', '...']
 """
+import time
 
-from ansible.module_utils.basic import get_exception
-from ansible.module_utils.netcli import CommandRunner, FailedConditionsError
-from ansible.module_utils.network import NetworkModule, NetworkError
-from ansible.module_utils.six import string_types
-import ansible.module_utils.dellos9
+from ansible.module_utils.dellos9 import run_commands
+from ansible.module_utils.dellos9 import dellos9_argument_spec, check_args
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network_common import ComplexList
+from ansible.module_utils.netcli import Conditional
 
-VALID_KEYS = ['command', 'prompt', 'response']
 
 def to_lines(stdout):
     for item in stdout:
@@ -164,74 +163,87 @@ def to_lines(stdout):
             item = str(item).split('\n')
         yield item
 
-def parse_commands(module):
-    for cmd in module.params['commands']:
-        if isinstance(cmd, string_types):
-            cmd = dict(command=cmd, output=None)
-        elif 'command' not in cmd:
-            module.fail_json(msg='command keyword argument is required')
-        elif not set(cmd.keys()).issubset(VALID_KEYS):
-            module.fail_json(msg='unknown keyword specified')
-        yield cmd
+
+def parse_commands(module, warnings):
+    command = ComplexList(dict(
+        command=dict(key=True),
+        prompt=dict(),
+        answer=dict()
+    ), module)
+    commands = command(module.params['commands'])
+    for index, item in enumerate(commands):
+        if module.check_mode and not item['command'].startswith('show'):
+            warnings.append(
+                'only show commands are supported when using check mode, not '
+                'executing `%s`' % item['command']
+            )
+        elif item['command'].startswith('conf'):
+            module.fail_json(
+                msg='dellos9_command does not support running config mode '
+                    'commands.  Please use dellos9_config instead'
+            )
+    return commands
+
 
 def main():
-    spec = dict(
+    """main entry point for module execution
+    """
+    argument_spec = dict(
         # { command: <str>, prompt: <str>, response: <str> }
         commands=dict(type='list', required=True),
-        wait_for=dict(type='list'),
+
+        wait_for=dict(type='list', aliases=['waitfor']),
+        match=dict(default='all', choices=['all', 'any']),
+
         retries=dict(default=10, type='int'),
         interval=dict(default=1, type='int')
     )
 
-    module = NetworkModule(argument_spec=spec,
-                           connect_on_load=False,
+    argument_spec.update(dellos9_argument_spec)
+
+    module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
 
-    commands = list(parse_commands(module))
-    conditionals = module.params['wait_for'] or list()
+    result = {'changed': False}
 
     warnings = list()
-
-    runner = CommandRunner(module)
-
-    for cmd in commands:
-        if module.check_mode and not cmd['command'].startswith('show'):
-            warnings.append('only show commands are supported when using '
-                            'check mode, not executing `%s`' % cmd)
-        else:
-            if cmd['command'].startswith('conf'):
-                module.fail_json(msg='dellos9_command does not support running '
-                                     'config mode commands.  Please use '
-                                     'dellos9_config instead')
-            runner.add_command(**cmd)
-
-    for item in conditionals:
-        runner.add_conditional(item)
-
-    runner.retries = module.params['retries']
-    runner.interval = module.params['interval']
-
-    try:
-        runner.run()
-    except FailedConditionsError:
-        exc = get_exception()
-        module.fail_json(msg=str(exc), failed_conditions=exc.failed_conditions)
-    except NetworkError:
-        exc = get_exception()
-        module.fail_json(msg=str(exc))
-
-    result = dict(changed=False)
-
-    result['stdout'] = list()
-    for cmd in commands:
-        try:
-            output = runner.get_command(cmd['command'])
-        except ValueError:
-            output = 'command not executed due to check_mode, see warnings'
-        result['stdout'].append(output)
-
+    check_args(module, warnings)
+    commands = parse_commands(module, warnings)
     result['warnings'] = warnings
-    result['stdout_lines'] = list(to_lines(result['stdout']))
+
+    wait_for = module.params['wait_for'] or list()
+    conditionals = [Conditional(c) for c in wait_for]
+
+    retries = module.params['retries']
+    interval = module.params['interval']
+    match = module.params['match']
+
+    while retries > 0:
+        responses = run_commands(module, commands)
+
+        for item in list(conditionals):
+            if item(responses):
+                if match == 'any':
+                    conditionals = list()
+                    break
+                conditionals.remove(item)
+
+        if not conditionals:
+            break
+
+        time.sleep(interval)
+        retries -= 1
+
+    if conditionals:
+        failed_conditions = [item.raw for item in conditionals]
+        msg = 'One or more conditional statements have not be satisfied'
+        module.fail_json(msg=msg, failed_conditions=failed_conditions)
+
+    result = {
+        'changed': False,
+        'stdout': responses,
+        'stdout_lines': list(to_lines(responses))
+    }
 
     module.exit_json(**result)
 

--- a/lib/ansible/modules/network/dellos9/dellos9_config.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_config.py
@@ -20,21 +20,20 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-ANSIBLE_METADATA = {'metadata_version': '1.0',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'core',
+                    'version': '1.0'}
 
 DOCUMENTATION = """
 ---
 module: dellos9_config
 version_added: "2.2"
 author: "Dhivya P (@dhivyap)"
-short_description: Manage Dell EMC Networking OS9 configuration sections
+short_description: Manage Dell OS9 configuration sections
 description:
-  - OS9 configurations use a simple block indent file syntax
+  - Dell OS9 configurations use a simple block indent file syntax
     for segmenting configuration into sections.  This module provides
-    an implementation for working with OS9 configuration sections in
+    an implementation for working with Dell OS9 configuration sections in
     a deterministic way.
 extends_documentation_fragment: dellos9
 options:
@@ -42,15 +41,17 @@ options:
     description:
       - The ordered set of commands that should be configured in the
         section.  The commands must be the exact same commands as found
-        in the device running-config. Note the configuration
-        command syntax as the device config parser automatically modifies some commands. This argument is mutually exclusive with I(src).
+        in the device running-config.  Be sure to note the configuration
+        command syntax as some commands are automatically modified by the
+        device config parser. This argument is mutually exclusive with I(src).
     required: false
     default: null
     aliases: ['commands']
   parents:
     description:
       - The ordered set of parents that uniquely identify the section
-        the commands should be checked against.  If you omit the parents argument, the commands are checked against the set of top
+        the commands should be checked against.  If the parents argument
+        is omitted, the commands are checked against the set of top
         level or global commands.
     required: false
     default: null
@@ -66,7 +67,8 @@ options:
   before:
     description:
       - The ordered set of commands to push on to the command stack if
-        a change needs to be made.  The playbook designer can use this opportunity to perform configuration commands prior to pushing
+        a change needs to be made.  This allows the playbook designer
+        the opportunity to perform configuration commands prior to pushing
         any changes without affecting how the set of commands are matched
         against the system.
     required: false
@@ -74,19 +76,20 @@ options:
   after:
     description:
       - The ordered set of commands to append to the end of the command
-        stack if a change needs to be made. As with I(before), this
-        the playbook designer can append a set of commands to be
+        stack if a change needs to be made.  Just like with I(before) this
+        allows the playbook designer to append a set of commands to be
         executed after the command set.
     required: false
     default: null
   match:
     description:
       - Instructs the module on the way to perform the matching of
-        the set of commands against the current device config.  If you set
-        match to I(line), commands match line by line.  If you set
-        match to I(strict), command lines match by position.  If you set match to I(exact), command lines
-        must be an equal match.  Finally, if you set match to I(none), the
-        module does  not attempt to compare the source configuration with
+        the set of commands against the current device config.  If
+        match is set to I(line), commands are matched line by line.  If
+        match is set to I(strict), command lines are matched with respect
+        to position.  If match is set to I(exact), command lines
+        must be an equal match.  Finally, if match is set to I(none), the
+        module will not attempt to compare the source configuration with
         the running configuration on the remote device.
     required: false
     default: line
@@ -94,10 +97,10 @@ options:
   replace:
     description:
       - Instructs the module on the way to perform the configuration
-        on the device.  If you set the replace argument to I(line), then
-        the modified lines push to the device in configuration
-        mode.  If you set the replace argument to I(block), then the entire
-        command block pushes to the device in configuration mode if any
+        on the device.  If the replace argument is set to I(line) then
+        the modified lines are pushed to the device in configuration
+        mode.  If the replace argument is set to I(block) then the entire
+        command block is pushed to the device in configuration mode if any
         line is not correct.
     required: false
     default: line
@@ -106,9 +109,9 @@ options:
     description:
       - The I(update) argument controls how the configuration statements
         are processed on the remote device.  Valid choices for the I(update)
-        argument are I(merge) and I(check).  When you set this argument to
-        I(merge), the configuration changes merge with the current
-        device running configuration.  When you set this argument to I(check)
+        argument are I(merge) and I(check).  When the argument is set to
+        I(merge), the configuration changes are merged with the current
+        device running configuration.  When the argument is set to I(check)
         the configuration updates are determined but not actually configured
         on the remote device.
     required: false
@@ -124,15 +127,15 @@ options:
     choices: ['yes', 'no']
   config:
     description:
-      - The playbook designer can use the  C(config) argument to supply
-        the base configuration to be used to validate necessary configuration
-        changes.  If you provide this argument, the module
-        does not download the running-config from the remote node.
+      - The C(config) argument allows the playbook designer to supply
+        the base configuration to be used to validate configuration
+        changes necessary.  If this argument is provided, the module
+        will not download the running-config from the remote node.
     required: false
     default: null
   backup:
     description:
-      - This argument causes the module to create a full backup of
+      - This argument will cause the module to create a full backup of
         the current C(running-config) from the remote device before any
         changes are made.  The backup file is written to the C(backup)
         folder in the playbook root directory.  If the directory does not
@@ -146,7 +149,8 @@ notes:
 
   - This module requires to increase the ssh connection rate limit.
     Use the following command I(ip ssh connection-rate-limit 60)
-    to configure the same. This can also be done with the M(dellos9_config) module.
+    to configure the same. This can be done via C(dellos9_config) module
+    as well.
 """
 
 EXAMPLES = """
@@ -181,29 +185,31 @@ EXAMPLES = """
 
 RETURN = """
 updates:
-  description: The set of commands that will be pushed to the remote device.
-  returned: Always.
+  description: The set of commands that will be pushed to the remote device
+  returned: always
   type: list
   sample: ['...', '...']
 
 responses:
-  description: The set of responses from issuing the commands on the device.
-  returned: When not check_mode.
+  description: The set of responses from issuing the commands on the device
+  returned: when not check_mode
   type: list
   sample: ['...', '...']
 
 saved:
   description: Returns whether the configuration is saved to the startup
                configuration or not.
-  returned: When not check_mode.
-
+  returned: when not check_mode
   type: bool
   sample: True
 
 """
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.netcfg import NetworkConfig, dumps
-from ansible.module_utils.network import NetworkModule
 from ansible.module_utils.dellos9 import get_config, get_sublevel_config
+from ansible.module_utils.dellos9 import dellos9_argument_spec, check_args
+from ansible.module_utils.dellos9 import load_config, run_commands
+from ansible.module_utils.dellos9 import WARNING_PROMPTS_RE
 
 
 def get_candidate(module):
@@ -237,10 +243,11 @@ def main():
         backup=dict(type='bool', default=False)
     )
 
+    argument_spec.update(dellos9_argument_spec)
+
     mutually_exclusive = [('lines', 'src')]
 
-    module = NetworkModule(argument_spec=argument_spec,
-                           connect_on_load=False,
+    module = AnsibleModule(argument_spec=argument_spec,
                            mutually_exclusive=mutually_exclusive,
                            supports_check_mode=True)
 
@@ -248,7 +255,11 @@ def main():
 
     match = module.params['match']
     replace = module.params['replace']
-    result = dict(changed=False, saved=False)
+
+    warnings = list()
+    check_args(module, warnings)
+
+    result = dict(changed=False, saved=False, warnings=warnings)
 
     candidate = get_candidate(module)
 
@@ -257,15 +268,18 @@ def main():
         if parents:
             contents = get_sublevel_config(config, module)
             config = NetworkConfig(contents=contents, indent=1)
+        else:
+            config = NetworkConfig(contents=config, indent=1)
         configobjs = candidate.difference(config, match=match, replace=replace)
 
     else:
         configobjs = candidate.items
 
     if module.params['backup']:
-        result['__backup__'] = module.cli('show running-config')[0]
+        result['__backup__'] = get_config(module)
 
     commands = list()
+
     if configobjs:
         commands = dumps(configobjs, 'commands')
         commands = commands.split('\n')
@@ -277,11 +291,11 @@ def main():
             commands.extend(module.params['after'])
 
         if not module.check_mode and module.params['update'] == 'merge':
-            response = module.config.load_config(commands)
-            result['responses'] = response
+            load_config(module, commands)
 
             if module.params['save']:
-                module.config.save_config()
+                cmd = {'command': 'copy runing-config startup-config', 'prompt': WARNING_PROMPTS_RE, 'answer': 'yes'}
+                run_commands(module, [cmd])
                 result['saved'] = True
 
         result['changed'] = True

--- a/lib/ansible/modules/network/dellos9/dellos9_config.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_config.py
@@ -20,20 +20,21 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-ANSIBLE_METADATA = {'status': ['preview'],
-                    'supported_by': 'core',
-                    'version': '1.0'}
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'core'}
+
 
 DOCUMENTATION = """
 ---
 module: dellos9_config
 version_added: "2.2"
 author: "Dhivya P (@dhivyap)"
-short_description: Manage Dell OS9 configuration sections
+short_description: Manage Dell EMC Networking OS9 configuration sections
 description:
-  - Dell OS9 configurations use a simple block indent file syntax
+  - OS9 configurations use a simple block indent file syntax
     for segmenting configuration into sections.  This module provides
-    an implementation for working with Dell OS9 configuration sections in
+    an implementation for working with OS9 configuration sections in
     a deterministic way.
 extends_documentation_fragment: dellos9
 options:
@@ -41,17 +42,15 @@ options:
     description:
       - The ordered set of commands that should be configured in the
         section.  The commands must be the exact same commands as found
-        in the device running-config.  Be sure to note the configuration
-        command syntax as some commands are automatically modified by the
-        device config parser. This argument is mutually exclusive with I(src).
+        in the device running-config. Note the configuration
+        command syntax as the device config parser automatically modifies some commands. This argument is mutually exclusive with I(src).
     required: false
     default: null
     aliases: ['commands']
   parents:
     description:
       - The ordered set of parents that uniquely identify the section
-        the commands should be checked against.  If the parents argument
-        is omitted, the commands are checked against the set of top
+        the commands should be checked against.  If you omit the parents argument, the commands are checked against the set of top
         level or global commands.
     required: false
     default: null
@@ -67,8 +66,7 @@ options:
   before:
     description:
       - The ordered set of commands to push on to the command stack if
-        a change needs to be made.  This allows the playbook designer
-        the opportunity to perform configuration commands prior to pushing
+        a change needs to be made.  The playbook designer can use this opportunity to perform configuration commands prior to pushing
         any changes without affecting how the set of commands are matched
         against the system.
     required: false
@@ -76,20 +74,19 @@ options:
   after:
     description:
       - The ordered set of commands to append to the end of the command
-        stack if a change needs to be made.  Just like with I(before) this
-        allows the playbook designer to append a set of commands to be
+        stack if a change needs to be made. As with I(before), this
+        the playbook designer can append a set of commands to be
         executed after the command set.
     required: false
     default: null
   match:
     description:
       - Instructs the module on the way to perform the matching of
-        the set of commands against the current device config.  If
-        match is set to I(line), commands are matched line by line.  If
-        match is set to I(strict), command lines are matched with respect
-        to position.  If match is set to I(exact), command lines
-        must be an equal match.  Finally, if match is set to I(none), the
-        module will not attempt to compare the source configuration with
+        the set of commands against the current device config.  If you set
+        match to I(line), commands match line by line.  If you set
+        match to I(strict), command lines match by position.  If you set match to I(exact), command lines
+        must be an equal match.  Finally, if you set match to I(none), the
+        module does  not attempt to compare the source configuration with
         the running configuration on the remote device.
     required: false
     default: line
@@ -97,10 +94,10 @@ options:
   replace:
     description:
       - Instructs the module on the way to perform the configuration
-        on the device.  If the replace argument is set to I(line) then
-        the modified lines are pushed to the device in configuration
-        mode.  If the replace argument is set to I(block) then the entire
-        command block is pushed to the device in configuration mode if any
+        on the device.  If you set the replace argument to I(line), then
+        the modified lines push to the device in configuration
+        mode.  If you set the replace argument to I(block), then the entire
+        command block pushes to the device in configuration mode if any
         line is not correct.
     required: false
     default: line
@@ -109,9 +106,9 @@ options:
     description:
       - The I(update) argument controls how the configuration statements
         are processed on the remote device.  Valid choices for the I(update)
-        argument are I(merge) and I(check).  When the argument is set to
-        I(merge), the configuration changes are merged with the current
-        device running configuration.  When the argument is set to I(check)
+        argument are I(merge) and I(check).  When you set this argument to
+        I(merge), the configuration changes merge with the current
+        device running configuration.  When you set this argument to I(check)
         the configuration updates are determined but not actually configured
         on the remote device.
     required: false
@@ -127,15 +124,15 @@ options:
     choices: ['yes', 'no']
   config:
     description:
-      - The C(config) argument allows the playbook designer to supply
-        the base configuration to be used to validate configuration
-        changes necessary.  If this argument is provided, the module
-        will not download the running-config from the remote node.
+      - The playbook designer can use the  C(config) argument to supply
+        the base configuration to be used to validate necessary configuration
+        changes.  If you provide this argument, the module
+        does not download the running-config from the remote node.
     required: false
     default: null
   backup:
     description:
-      - This argument will cause the module to create a full backup of
+      - This argument causes the module to create a full backup of
         the current C(running-config) from the remote device before any
         changes are made.  The backup file is written to the C(backup)
         folder in the playbook root directory.  If the directory does not
@@ -149,8 +146,7 @@ notes:
 
   - This module requires to increase the ssh connection rate limit.
     Use the following command I(ip ssh connection-rate-limit 60)
-    to configure the same. This can be done via C(dellos9_config) module
-    as well.
+    to configure the same. This can also be done with the M(dellos9_config) module.
 """
 
 EXAMPLES = """
@@ -185,21 +181,22 @@ EXAMPLES = """
 
 RETURN = """
 updates:
-  description: The set of commands that will be pushed to the remote device
-  returned: always
+  description: The set of commands that will be pushed to the remote device.
+  returned: Always.
   type: list
   sample: ['...', '...']
 
 responses:
-  description: The set of responses from issuing the commands on the device
-  returned: when not check_mode
+  description: The set of responses from issuing the commands on the device.
+  returned: When not check_mode.
   type: list
   sample: ['...', '...']
 
 saved:
   description: Returns whether the configuration is saved to the startup
                configuration or not.
-  returned: when not check_mode
+  returned: When not check_mode.
+
   type: bool
   sample: True
 

--- a/lib/ansible/modules/network/dellos9/dellos9_config.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_config.py
@@ -22,7 +22,7 @@
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
-                    'supported_by': 'core'}
+                    'supported_by': 'community'}
 
 
 DOCUMENTATION = """

--- a/lib/ansible/modules/network/dellos9/dellos9_facts.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_facts.py
@@ -19,42 +19,41 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-
-ANSIBLE_METADATA = {'metadata_version': '1.0',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'core',
+                    'version': '1.0'}
 
 DOCUMENTATION = """
 ---
 module: dellos9_facts
 version_added: "2.2"
 author: "Dhivya P (@dhivyap)"
-short_description: Collect facts from remote devices running Dell EMC Networking OS9
+short_description: Collect facts from remote devices running Dell OS9
 description:
   - Collects a base set of device facts from a remote device that
-    is running OS9.  This module prepends all of the
+    is running Dell OS9.  This module prepends all of the
     base network fact keys with C(ansible_net_<fact>).  The facts
-    module always collects  a base set of facts from the device
+    module will always collect a base set of facts from the device
     and can enable or disable collection of additional facts.
 extends_documentation_fragment: dellos9
 options:
   gather_subset:
     description:
-      - When supplied, this argument restricts the facts collected
+      - When supplied, this argument will restrict the facts collected
         to a given subset.  Possible values for this argument include
-        all, hardware, config, and interfaces.  You can specify a list of
-        values to include a larger subset.  You can also use values
-        with an initial M(!) to specify that a specific subset should
+        all, hardware, config, and interfaces.  Can specify a list of
+        values to include a larger subset.  Values can also be used
+        with an initial C(M(!)) to specify that a specific subset should
         not be collected.
     required: false
     default: '!config'
 notes:
-  - This module requires OS9 version 9.10.0.1P13 or above.
+  - This module requires Dell OS9 version 9.10.0.1P13 or above.
 
-  - This module requires an increase of the SSH connection rate limit.
+  - This module requires to increase the ssh connection rate limit.
     Use the following command I(ip ssh connection-rate-limit 60)
-    to configure the same. This can be also be done with the M(dellos9_config) module.
+    to configure the same. This can be done via M(dellos9_config) module
+    as well.
 """
 
 EXAMPLES = """
@@ -75,104 +74,115 @@ EXAMPLES = """
 
 RETURN = """
 ansible_net_gather_subset:
-  description: The list of fact subsets collected from the device.
-  returned: Always.
+  description: The list of fact subsets collected from the device
+  returned: always
   type: list
 
 # default
 ansible_net_model:
-  description: The model name returned from the device.
-  returned: Always.
+  description: The model name returned from the device
+  returned: always
   type: str
 ansible_net_serialnum:
-  description: The serial number of the remote device.
-  returned: Always.
+  description: The serial number of the remote device
+  returned: always
   type: str
 ansible_net_version:
-  description: The operating system version running on the remote device.
-  returned: Always.
+  description: The operating system version running on the remote device
+  returned: always
   type: str
 ansible_net_hostname:
-  description: The configured hostname of the device.
-  returned: Always.
+  description: The configured hostname of the device
+  returned: always
   type: string
 ansible_net_image:
-  description: The image file the device is running.
-  returned: Always.
+  description: The image file the device is running
+  returned: always
   type: string
 
 # hardware
 ansible_net_filesystems:
-  description: All file system names available on the device.
-  returned: When hardware is configured.
+  description: All file system names available on the device
+  returned: when hardware is configured
   type: list
 ansible_net_memfree_mb:
-  description: The available free memory on the remote device in MB.
-  returned: When hardware is configured.
+  description: The available free memory on the remote device in Mb
+  returned: when hardware is configured
   type: int
 ansible_net_memtotal_mb:
-  description: The total memory on the remote device in MB.
-  returned: When hardware is configured.
+  description: The total memory on the remote device in Mb
+  returned: when hardware is configured
   type: int
 
 # config
 ansible_net_config:
-  description: The current active config from the device.
-  returned: When config is configured.
+  description: The current active config from the device
+  returned: when config is configured
   type: str
 
 # interfaces
 ansible_net_all_ipv4_addresses:
-  description: All IPv4 addresses configured on the device.
-  returned: When interfaces is configured.
+  description: All IPv4 addresses configured on the device
+  returned: when interfaces is configured
   type: list
 ansible_net_all_ipv6_addresses:
-  description: All IPv6 addresses configured on the device.
-  returned: When interfaces is configured.
+  description: All IPv6 addresses configured on the device
+  returned: when interfaces is configured
   type: list
 ansible_net_interfaces:
-  description: A hash of all interfaces running on the system.
-  returned: When interfaces is configured.
+  description: A hash of all interfaces running on the system
+  returned: when interfaces is configured
   type: dict
 ansible_net_neighbors:
   description: The list of LLDP neighbors from the remote device
-  returned: When interfaces is configured.
+  returned: when interfaces is configured
   type: dict
 """
 import re
 import itertools
 
-from ansible.module_utils.netcli import CommandRunner
-from ansible.module_utils.network import NetworkModule
-import ansible.module_utils.dellos9
+from ansible.module_utils.dellos9 import run_commands
+from ansible.module_utils.dellos9 import dellos9_argument_spec, check_args
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.six.moves import zip
 
 
 class FactsBase(object):
 
-    def __init__(self, runner):
-        self.runner = runner
-        self.facts = dict()
+    COMMANDS = list()
 
-        self.commands()
+    def __init__(self, module):
+        self.module = module
+        self.facts = dict()
+        self.responses = None
+
+    def populate(self):
+        self.responses = run_commands(self.module, self.COMMANDS, check_rc=False)
+
+    def run(self, cmd):
+        return run_commands(self.module, cmd, check_rc=False)
 
 
 class Default(FactsBase):
 
-    def commands(self):
-        self.runner.add_command('show version')
-        self.runner.add_command('show inventory')
-        self.runner.add_command('show running-config | grep hostname')
+    COMMANDS = [
+        'show version',
+        'show inventory',
+        'show running-config | grep hostname'
+    ]
 
     def populate(self):
-        data = self.runner.get_command('show version')
+        super(Default, self).populate()
+        data = self.responses[0]
         self.facts['version'] = self.parse_version(data)
         self.facts['model'] = self.parse_model(data)
         self.facts['image'] = self.parse_image(data)
 
-        data = self.runner.get_command('show inventory')
+        data = self.responses[1]
         self.facts['serialnum'] = self.parse_serialnum(data)
 
-        data = self.runner.get_command('show running-config | grep hostname')
+        data = self.responses[2]
         self.facts['hostname'] = self.parse_hostname(data)
 
     def parse_version(self, data):
@@ -206,15 +216,17 @@ class Default(FactsBase):
 
 class Hardware(FactsBase):
 
-    def commands(self):
-        self.runner.add_command('show file-systems')
-        self.runner.add_command('show memory | except Processor')
+    COMMANDS = [
+        'show file-systems',
+        'show memory | except Processor'
+    ]
 
     def populate(self):
-        data = self.runner.get_command('show file-systems')
+        super(Hardware, self).populate()
+        data = self.responses[0]
         self.facts['filesystems'] = self.parse_filesystems(data)
 
-        data = self.runner.get_command('show memory | except Processor')
+        data = self.responses[1]
         match = re.findall('\s(\d+)\s', data)
         if match:
             self.facts['memtotal_mb'] = int(match[0]) / 1024
@@ -226,25 +238,28 @@ class Hardware(FactsBase):
 
 class Config(FactsBase):
 
-    def commands(self):
-        self.runner.add_command('show running-config')
+    COMMANDS = ['show running-config']
 
     def populate(self):
-        self.facts['config'] = self.runner.get_command('show running-config')
+        super(Config, self).populate()
+        self.facts['config'] = self.responses[0]
 
 
 class Interfaces(FactsBase):
 
-    def commands(self):
-        self.runner.add_command('show interfaces')
-        self.runner.add_command('show ipv6 interface')
-        self.runner.add_command('show lldp neighbors detail')
+    COMMANDS = [
+        'show interfaces',
+        'show ipv6 interface',
+        'show lldp neighbors detail',
+        'show inventory'
+    ]
 
     def populate(self):
+        super(Interfaces, self).populate()
         self.facts['all_ipv4_addresses'] = list()
         self.facts['all_ipv6_addresses'] = list()
 
-        data = self.runner.get_command('show interfaces')
+        data = self.responses[0]
         interfaces = self.parse_interfaces(data)
 
         for key in interfaces.keys():
@@ -261,14 +276,14 @@ class Interfaces(FactsBase):
 
         self.facts['interfaces'] = self.populate_interfaces(interfaces)
 
-        data = self.runner.get_command('show ipv6 interface')
+        data = self.responses[1]
         if len(data) > 0:
             data = self.parse_ipv6_interfaces(data)
             self.populate_ipv6_interfaces(data)
 
-        data = self.runner.get_command('show inventory')
+        data = self.responses[3]
         if 'LLDP' in self.get_protocol_list(data):
-            neighbors = self.runner.get_command('show lldp neighbors detail')
+            neighbors = self.responses[2]
             self.facts['neighbors'] = self.parse_neighbors(neighbors)
 
     def get_protocol_list(self, data):
@@ -499,11 +514,16 @@ VALID_SUBSETS = frozenset(FACT_SUBSETS.keys())
 
 
 def main():
-    spec = dict(
+    """main entry point for module execution
+    """
+    argument_spec = dict(
         gather_subset=dict(default=['!config'], type='list')
     )
 
-    module = NetworkModule(argument_spec=spec, supports_check_mode=True)
+    argument_spec.update(dellos9_argument_spec)
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
 
     gather_subset = module.params['gather_subset']
 
@@ -541,28 +561,23 @@ def main():
     facts = dict()
     facts['gather_subset'] = list(runable_subsets)
 
-    runner = CommandRunner(module)
-
     instances = list()
     for key in runable_subsets:
-        runs = FACT_SUBSETS[key](runner)
-        instances.append(runs)
+        instances.append(FACT_SUBSETS[key](module))
 
-    runner.run()
-
-    try:
-        for inst in instances:
-            inst.populate()
-            facts.update(inst.facts)
-    except Exception:
-        module.exit_json(out=module.from_json(runner.items))
+    for inst in instances:
+        inst.populate()
+        facts.update(inst.facts)
 
     ansible_facts = dict()
-    for key, value in facts.items():
+    for key, value in iteritems(facts):
         key = 'ansible_net_%s' % key
         ansible_facts[key] = value
 
-    module.exit_json(ansible_facts=ansible_facts)
+    warnings = list()
+    check_args(module, warnings)
+
+    module.exit_json(ansible_facts=ansible_facts, warnings=warnings)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/dellos9/dellos9_facts.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_facts.py
@@ -19,41 +19,42 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
-ANSIBLE_METADATA = {'status': ['preview'],
-                    'supported_by': 'core',
-                    'version': '1.0'}
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'core'}
+
 
 DOCUMENTATION = """
 ---
 module: dellos9_facts
 version_added: "2.2"
 author: "Dhivya P (@dhivyap)"
-short_description: Collect facts from remote devices running Dell OS9
+short_description: Collect facts from remote devices running Dell EMC Networking OS9
 description:
   - Collects a base set of device facts from a remote device that
-    is running Dell OS9.  This module prepends all of the
+    is running OS9.  This module prepends all of the
     base network fact keys with C(ansible_net_<fact>).  The facts
-    module will always collect a base set of facts from the device
+    module always collects  a base set of facts from the device
     and can enable or disable collection of additional facts.
 extends_documentation_fragment: dellos9
 options:
   gather_subset:
     description:
-      - When supplied, this argument will restrict the facts collected
+      - When supplied, this argument restricts the facts collected
         to a given subset.  Possible values for this argument include
-        all, hardware, config, and interfaces.  Can specify a list of
-        values to include a larger subset.  Values can also be used
-        with an initial C(M(!)) to specify that a specific subset should
+        all, hardware, config, and interfaces.  You can specify a list of
+        values to include a larger subset.  You can also use values
+        with an initial M(!) to specify that a specific subset should
         not be collected.
     required: false
     default: '!config'
 notes:
-  - This module requires Dell OS9 version 9.10.0.1P13 or above.
+  - This module requires OS9 version 9.10.0.1P13 or above.
 
-  - This module requires to increase the ssh connection rate limit.
+  - This module requires an increase of the SSH connection rate limit.
     Use the following command I(ip ssh connection-rate-limit 60)
-    to configure the same. This can be done via M(dellos9_config) module
-    as well.
+    to configure the same. This can be also be done with the M(dellos9_config) module.
 """
 
 EXAMPLES = """
@@ -74,68 +75,68 @@ EXAMPLES = """
 
 RETURN = """
 ansible_net_gather_subset:
-  description: The list of fact subsets collected from the device
-  returned: always
+  description: The list of fact subsets collected from the device.
+  returned: Always.
   type: list
 
 # default
 ansible_net_model:
-  description: The model name returned from the device
-  returned: always
+  description: The model name returned from the device.
+  returned: Always.
   type: str
 ansible_net_serialnum:
-  description: The serial number of the remote device
-  returned: always
+  description: The serial number of the remote device.
+  returned: Always.
   type: str
 ansible_net_version:
-  description: The operating system version running on the remote device
-  returned: always
+  description: The operating system version running on the remote device.
+  returned: Always.
   type: str
 ansible_net_hostname:
-  description: The configured hostname of the device
-  returned: always
+  description: The configured hostname of the device.
+  returned: Always.
   type: string
 ansible_net_image:
-  description: The image file the device is running
-  returned: always
+  description: The image file the device is running.
+  returned: Always.
   type: string
 
 # hardware
 ansible_net_filesystems:
-  description: All file system names available on the device
-  returned: when hardware is configured
+  description: All file system names available on the device.
+  returned: When hardware is configured.
   type: list
 ansible_net_memfree_mb:
-  description: The available free memory on the remote device in Mb
-  returned: when hardware is configured
+  description: The available free memory on the remote device in MB.
+  returned: When hardware is configured.
   type: int
 ansible_net_memtotal_mb:
-  description: The total memory on the remote device in Mb
-  returned: when hardware is configured
+  description: The total memory on the remote device in MB.
+  returned: When hardware is configured.
   type: int
 
 # config
 ansible_net_config:
-  description: The current active config from the device
-  returned: when config is configured
+  description: The current active config from the device.
+  returned: When config is configured.
   type: str
 
 # interfaces
 ansible_net_all_ipv4_addresses:
-  description: All IPv4 addresses configured on the device
-  returned: when interfaces is configured
+  description: All IPv4 addresses configured on the device.
+  returned: When interfaces is configured.
   type: list
 ansible_net_all_ipv6_addresses:
-  description: All IPv6 addresses configured on the device
-  returned: when interfaces is configured
+  description: All IPv6 addresses configured on the device.
+  returned: When interfaces is configured.
   type: list
 ansible_net_interfaces:
-  description: A hash of all interfaces running on the system
-  returned: when interfaces is configured
+  description: A hash of all interfaces running on the system.
+  returned: When interfaces is configured.
   type: dict
 ansible_net_neighbors:
   description: The list of LLDP neighbors from the remote device
-  returned: when interfaces is configured
+  returned: When interfaces is configured.
   type: dict
 """
 import re

--- a/lib/ansible/modules/network/dellos9/dellos9_facts.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_facts.py
@@ -22,7 +22,7 @@
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
-                    'supported_by': 'core'}
+                    'supported_by': 'community'}
 
 
 DOCUMENTATION = """

--- a/lib/ansible/plugins/action/dellos10.py
+++ b/lib/ansible/plugins/action/dellos10.py
@@ -1,0 +1,125 @@
+#
+# (c) 2016 Red Hat Inc.
+#
+# Copyright (c) 2017 Dell Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import sys
+import copy
+
+from ansible.plugins.action.normal import ActionModule as _ActionModule
+from ansible.utils.path import unfrackpath
+from ansible.plugins import connection_loader
+from ansible.compat.six import iteritems
+from ansible.module_utils.dellos10 import dellos10_argument_spec
+from ansible.module_utils.basic import AnsibleFallbackNotFound
+from ansible.module_utils._text import to_bytes
+
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
+
+class ActionModule(_ActionModule):
+
+    def run(self, tmp=None, task_vars=None):
+
+        if self._play_context.connection != 'local':
+            return dict(
+                failed=True,
+                msg='invalid connection specified, expected connection=local, '
+                    'got %s' % self._play_context.connection
+            )
+
+        provider = self.load_provider()
+
+        pc = copy.deepcopy(self._play_context)
+        pc.connection = 'network_cli'
+        pc.network_os = 'dellos10'
+        pc.port = provider['port'] or self._play_context.port or 22
+        pc.remote_user = provider['username'] or self._play_context.connection_user
+        pc.password = provider['password'] or self._play_context.password
+        pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
+        pc.timeout = provider['timeout'] or self._play_context.timeout
+        pc.become = provider['authorize'] or False
+        pc.become_pass = provider['auth_pass']
+
+        connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+
+        socket_path = self._get_socket_path(pc)
+        display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)
+
+        if not os.path.exists(socket_path):
+            # start the connection if it isn't started
+            rc, out, err = connection.exec_command('open_shell()')
+            if not rc == 0:
+                return {'failed': True, 'msg': 'unable to open shell', 'rc': rc}
+        else:
+            # make sure we are in the right cli context which should be
+            # enable mode and not config module
+            rc, out, err = connection.exec_command('prompt()')
+            while str(out).strip().endswith(')#'):
+                display.debug('wrong context, sending exit to device')
+                connection.exec_command('exit')
+                rc, out, err = connection.exec_command('prompt()')
+
+        task_vars['ansible_socket'] = socket_path
+
+        if self._play_context.become_method == 'enable':
+            self._play_context.become = False
+            self._play_context.become_method = None
+
+        return super(ActionModule, self).run(tmp, task_vars)
+
+    def _get_socket_path(self, play_context):
+        ssh = connection_loader.get('ssh', class_only=True)
+        cp = ssh._create_control_path(play_context.remote_addr, play_context.port, play_context.remote_user)
+        path = unfrackpath("$HOME/.ansible/pc")
+        return cp % dict(directory=path)
+
+    def load_provider(self):
+        provider = self._task.args.get('provider', {})
+        for key, value in iteritems(dellos10_argument_spec):
+            if key != 'provider' and key not in provider:
+                if key in self._task.args:
+                    provider[key] = self._task.args[key]
+                elif 'fallback' in value:
+                    provider[key] = self._fallback(value['fallback'])
+                elif key not in provider:
+                    provider[key] = None
+        return provider
+
+    def _fallback(self, fallback):
+        strategy = fallback[0]
+        args = []
+        kwargs = {}
+
+        for item in fallback[1:]:
+            if isinstance(item, dict):
+                kwargs = item
+            else:
+                args = item
+        try:
+            return strategy(*args, **kwargs)
+        except AnsibleFallbackNotFound:
+            pass

--- a/lib/ansible/plugins/action/dellos10.py
+++ b/lib/ansible/plugins/action/dellos10.py
@@ -28,7 +28,7 @@ import copy
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.utils.path import unfrackpath
 from ansible.plugins import connection_loader
-from ansible.compat.six import iteritems
+from ansible.module_utils.six import iteritems
 from ansible.module_utils.dellos10 import dellos10_argument_spec
 from ansible.module_utils.basic import AnsibleFallbackNotFound
 from ansible.module_utils._text import to_bytes

--- a/lib/ansible/plugins/action/dellos10_config.py
+++ b/lib/ansible/plugins/action/dellos10_config.py
@@ -1,6 +1,8 @@
 #
 # Copyright 2015 Peter Sprygada <psprygada@ansible.com>
 #
+# Copyright (c) 2017 Dell Inc.
+#
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify
@@ -19,10 +21,94 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.plugins.action import ActionBase
-from ansible.plugins.action.net_config import ActionModule as NetActionModule
+import os
+import re
+import time
+import glob
 
-class ActionModule(NetActionModule, ActionBase):
-    pass
+from ansible.plugins.action.dellos10 import ActionModule as _ActionModule
+from ansible.module_utils._text import to_text
+from ansible.module_utils.six.moves.urllib.parse import urlsplit
+from ansible.utils.vars import merge_hash
+
+PRIVATE_KEYS_RE = re.compile('__.+__')
 
 
+class ActionModule(_ActionModule):
+
+    def run(self, tmp=None, task_vars=None):
+
+        if self._task.args.get('src'):
+            try:
+                self._handle_template()
+            except ValueError as exc:
+                return dict(failed=True, msg=exc.message)
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        if self._task.args.get('backup') and result.get('__backup__'):
+            # User requested backup and no error occurred in module.
+            # NOTE: If there is a parameter error, _backup key may not be in results.
+            filepath = self._write_backup(task_vars['inventory_hostname'],
+                                          result['__backup__'])
+
+            result['backup_path'] = filepath
+
+        # strip out any keys that have two leading and two trailing
+        # underscore characters
+        for key in result.keys():
+            if PRIVATE_KEYS_RE.match(key):
+                del result[key]
+
+        return result
+
+    def _get_working_path(self):
+        cwd = self._loader.get_basedir()
+        if self._task._role is not None:
+            cwd = self._task._role._role_path
+        return cwd
+
+    def _write_backup(self, host, contents):
+        backup_path = self._get_working_path() + '/backup'
+        if not os.path.exists(backup_path):
+            os.mkdir(backup_path)
+        for fn in glob.glob('%s/%s*' % (backup_path, host)):
+            os.remove(fn)
+        tstamp = time.strftime("%Y-%m-%d@%H:%M:%S", time.localtime(time.time()))
+        filename = '%s/%s_config.%s' % (backup_path, host, tstamp)
+        open(filename, 'w').write(contents)
+        return filename
+
+    def _handle_template(self):
+        src = self._task.args.get('src')
+        working_path = self._get_working_path()
+
+        if os.path.isabs(src) or urlsplit('src').scheme:
+            source = src
+        else:
+            source = self._loader.path_dwim_relative(working_path, 'templates', src)
+            if not source:
+                source = self._loader.path_dwim_relative(working_path, src)
+
+        if not os.path.exists(source):
+            raise ValueError('path specified in src not found')
+
+        try:
+            with open(source, 'r') as f:
+                template_data = to_text(f.read())
+        except IOError:
+            return dict(failed=True, msg='unable to load src file')
+
+        # Create a template search path in the following order:
+        # [working_path, self_role_path, dependent_role_paths, dirname(source)]
+        searchpath = [working_path]
+        if self._task._role is not None:
+            searchpath.append(self._task._role._role_path)
+            if hasattr(self._task, "_block:"):
+                dep_chain = self._task._block.get_dep_chain()
+                if dep_chain is not None:
+                    for role in dep_chain:
+                        searchpath.append(role._role_path)
+        searchpath.append(os.path.dirname(source))
+        self._templar.environment.loader.searchpath = searchpath
+        self._task.args['src'] = self._templar.template(template_data)

--- a/lib/ansible/plugins/action/dellos6_config.py
+++ b/lib/ansible/plugins/action/dellos6_config.py
@@ -1,6 +1,8 @@
 #
 # Copyright 2015 Peter Sprygada <psprygada@ansible.com>
 #
+# Copyright (c) 2017 Dell Inc.
+#
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify

--- a/lib/ansible/plugins/action/dellos9.py
+++ b/lib/ansible/plugins/action/dellos9.py
@@ -1,0 +1,125 @@
+#
+# (c) 2016 Red Hat Inc.
+#
+# Copyright (c) 2017 Dell Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import sys
+import copy
+
+from ansible.plugins.action.normal import ActionModule as _ActionModule
+from ansible.utils.path import unfrackpath
+from ansible.plugins import connection_loader
+from ansible.compat.six import iteritems
+from ansible.module_utils.dellos9 import dellos9_argument_spec
+from ansible.module_utils.basic import AnsibleFallbackNotFound
+from ansible.module_utils._text import to_bytes
+
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
+
+class ActionModule(_ActionModule):
+
+    def run(self, tmp=None, task_vars=None):
+
+        if self._play_context.connection != 'local':
+            return dict(
+                failed=True,
+                msg='invalid connection specified, expected connection=local, '
+                    'got %s' % self._play_context.connection
+            )
+
+        provider = self.load_provider()
+
+        pc = copy.deepcopy(self._play_context)
+        pc.connection = 'network_cli'
+        pc.network_os = 'dellos9'
+        pc.port = provider['port'] or self._play_context.port or 22
+        pc.remote_user = provider['username'] or self._play_context.connection_user
+        pc.password = provider['password'] or self._play_context.password
+        pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
+        pc.timeout = provider['timeout'] or self._play_context.timeout
+        pc.become = provider['authorize'] or False
+        pc.become_pass = provider['auth_pass']
+
+        connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+
+        socket_path = self._get_socket_path(pc)
+        display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)
+
+        if not os.path.exists(socket_path):
+            # start the connection if it isn't started
+            rc, out, err = connection.exec_command('open_shell()')
+            if not rc == 0:
+                return {'failed': True, 'msg': 'unable to open shell', 'rc': rc}
+        else:
+            # make sure we are in the right cli context which should be
+            # enable mode and not config module
+            rc, out, err = connection.exec_command('prompt()')
+            while str(out).strip().endswith(')#'):
+                display.debug('wrong context, sending exit to device')
+                connection.exec_command('exit')
+                rc, out, err = connection.exec_command('prompt()')
+
+        task_vars['ansible_socket'] = socket_path
+
+        if self._play_context.become_method == 'enable':
+            self._play_context.become = False
+            self._play_context.become_method = None
+
+        return super(ActionModule, self).run(tmp, task_vars)
+
+    def _get_socket_path(self, play_context):
+        ssh = connection_loader.get('ssh', class_only=True)
+        cp = ssh._create_control_path(play_context.remote_addr, play_context.port, play_context.remote_user)
+        path = unfrackpath("$HOME/.ansible/pc")
+        return cp % dict(directory=path)
+
+    def load_provider(self):
+        provider = self._task.args.get('provider', {})
+        for key, value in iteritems(dellos9_argument_spec):
+            if key != 'provider' and key not in provider:
+                if key in self._task.args:
+                    provider[key] = self._task.args[key]
+                elif 'fallback' in value:
+                    provider[key] = self._fallback(value['fallback'])
+                elif key not in provider:
+                    provider[key] = None
+        return provider
+
+    def _fallback(self, fallback):
+        strategy = fallback[0]
+        args = []
+        kwargs = {}
+
+        for item in fallback[1:]:
+            if isinstance(item, dict):
+                kwargs = item
+            else:
+                args = item
+        try:
+            return strategy(*args, **kwargs)
+        except AnsibleFallbackNotFound:
+            pass

--- a/lib/ansible/plugins/action/dellos9.py
+++ b/lib/ansible/plugins/action/dellos9.py
@@ -28,7 +28,7 @@ import copy
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.utils.path import unfrackpath
 from ansible.plugins import connection_loader
-from ansible.compat.six import iteritems
+from ansible.module_utils.six import iteritems
 from ansible.module_utils.dellos9 import dellos9_argument_spec
 from ansible.module_utils.basic import AnsibleFallbackNotFound
 from ansible.module_utils._text import to_bytes

--- a/lib/ansible/plugins/action/dellos9_config.py
+++ b/lib/ansible/plugins/action/dellos9_config.py
@@ -1,6 +1,8 @@
 #
 # Copyright 2015 Peter Sprygada <psprygada@ansible.com>
 #
+# Copyright (c) 2017 Dell Inc.
+#
 # This file is part of Ansible
 #
 # Ansible is free software: you can redistribute it and/or modify
@@ -19,10 +21,94 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.plugins.action import ActionBase
-from ansible.plugins.action.net_config import ActionModule as NetActionModule
+import os
+import re
+import time
+import glob
 
-class ActionModule(NetActionModule, ActionBase):
-    pass
+from ansible.plugins.action.dellos9 import ActionModule as _ActionModule
+from ansible.module_utils._text import to_text
+from ansible.module_utils.six.moves.urllib.parse import urlsplit
+from ansible.utils.vars import merge_hash
+
+PRIVATE_KEYS_RE = re.compile('__.+__')
 
 
+class ActionModule(_ActionModule):
+
+    def run(self, tmp=None, task_vars=None):
+
+        if self._task.args.get('src'):
+            try:
+                self._handle_template()
+            except ValueError as exc:
+                return dict(failed=True, msg=exc.message)
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        if self._task.args.get('backup') and result.get('__backup__'):
+            # User requested backup and no error occurred in module.
+            # NOTE: If there is a parameter error, _backup key may not be in results.
+            filepath = self._write_backup(task_vars['inventory_hostname'],
+                                          result['__backup__'])
+
+            result['backup_path'] = filepath
+
+        # strip out any keys that have two leading and two trailing
+        # underscore characters
+        for key in result.keys():
+            if PRIVATE_KEYS_RE.match(key):
+                del result[key]
+
+        return result
+
+    def _get_working_path(self):
+        cwd = self._loader.get_basedir()
+        if self._task._role is not None:
+            cwd = self._task._role._role_path
+        return cwd
+
+    def _write_backup(self, host, contents):
+        backup_path = self._get_working_path() + '/backup'
+        if not os.path.exists(backup_path):
+            os.mkdir(backup_path)
+        for fn in glob.glob('%s/%s*' % (backup_path, host)):
+            os.remove(fn)
+        tstamp = time.strftime("%Y-%m-%d@%H:%M:%S", time.localtime(time.time()))
+        filename = '%s/%s_config.%s' % (backup_path, host, tstamp)
+        open(filename, 'w').write(contents)
+        return filename
+
+    def _handle_template(self):
+        src = self._task.args.get('src')
+        working_path = self._get_working_path()
+
+        if os.path.isabs(src) or urlsplit('src').scheme:
+            source = src
+        else:
+            source = self._loader.path_dwim_relative(working_path, 'templates', src)
+            if not source:
+                source = self._loader.path_dwim_relative(working_path, src)
+
+        if not os.path.exists(source):
+            raise ValueError('path specified in src not found')
+
+        try:
+            with open(source, 'r') as f:
+                template_data = to_text(f.read())
+        except IOError:
+            return dict(failed=True, msg='unable to load src file')
+
+        # Create a template search path in the following order:
+        # [working_path, self_role_path, dependent_role_paths, dirname(source)]
+        searchpath = [working_path]
+        if self._task._role is not None:
+            searchpath.append(self._task._role._role_path)
+            if hasattr(self._task, "_block:"):
+                dep_chain = self._task._block.get_dep_chain()
+                if dep_chain is not None:
+                    for role in dep_chain:
+                        searchpath.append(role._role_path)
+        searchpath.append(os.path.dirname(source))
+        self._templar.environment.loader.searchpath = searchpath
+        self._task.args['src'] = self._templar.template(template_data)

--- a/lib/ansible/plugins/terminal/dellos10.py
+++ b/lib/ansible/plugins/terminal/dellos10.py
@@ -1,0 +1,78 @@
+#
+# (c) 2016 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Copyright (c) 2017 Dell Inc.
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import re
+import json
+
+from ansible.plugins.terminal import TerminalBase
+from ansible.errors import AnsibleConnectionFailure
+
+
+class TerminalModule(TerminalBase):
+
+    terminal_stdout_re = [
+        re.compile(r"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
+        re.compile(r"\[\w+\@[\w\-\.]+(?: [^\]])\] ?[>#\$] ?$")
+    ]
+
+    terminal_stderr_re = [
+        re.compile(r"% ?Error: (?:(?!\bdoes not exist\b)(?!\balready exists\b)(?!\bHost not found\b)(?!\bnot active\b).)*$"),
+        re.compile(r"% ?Bad secret"),
+        re.compile(r"invalid input", re.I),
+        re.compile(r"(?:incomplete|ambiguous) command", re.I),
+        re.compile(r"connection timed out", re.I),
+        re.compile(r"'[^']' +returned error code: ?\d+"),
+    ]
+
+    def on_open_shell(self):
+        try:
+            self._exec_cli_command('terminal length 0')
+        except AnsibleConnectionFailure:
+            raise AnsibleConnectionFailure('unable to set terminal parameters')
+
+    def on_authorize(self, passwd=None):
+        if self._get_prompt().endswith('#'):
+            return
+
+        cmd = {'command': 'enable'}
+        if passwd:
+            cmd['prompt'] = r"[\r\n]?password: $"
+            cmd['answer'] = passwd
+
+        try:
+            self._exec_cli_command(json.dumps(cmd))
+        except AnsibleConnectionFailure:
+            raise AnsibleConnectionFailure('unable to elevate privilege to enable mode')
+
+    def on_deauthorize(self):
+        prompt = self._get_prompt()
+        if prompt is None:
+            # if prompt is None most likely the terminal is hung up at a prompt
+            return
+
+        if prompt.strip().endswith(')#'):
+            self._exec_cli_command('end')
+            self._exec_cli_command('disable')
+
+        elif prompt.endswith('#'):
+            self._exec_cli_command('disable')

--- a/lib/ansible/plugins/terminal/dellos9.py
+++ b/lib/ansible/plugins/terminal/dellos9.py
@@ -1,0 +1,78 @@
+#
+# (c) 2016 Red Hat Inc.
+#
+# Copyright (c) 2017 Dell Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import re
+import json
+
+from ansible.plugins.terminal import TerminalBase
+from ansible.errors import AnsibleConnectionFailure
+
+
+class TerminalModule(TerminalBase):
+
+    terminal_stdout_re = [
+        re.compile(r"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
+        re.compile(r"\[\w+\@[\w\-\.]+(?: [^\]])\] ?[>#\$] ?$")
+    ]
+
+    terminal_stderr_re = [
+        re.compile(r"% ?Error: (?:(?!\bdoes not exist\b)(?!\balready exists\b)(?!\bHost not found\b)(?!\bnot active\b).)*$"),
+        re.compile(r"% ?Bad secret"),
+        re.compile(r"invalid input", re.I),
+        re.compile(r"(?:incomplete|ambiguous) command", re.I),
+        re.compile(r"connection timed out", re.I),
+        re.compile(r"'[^']' +returned error code: ?\d+"),
+    ]
+
+    def on_open_shell(self):
+        try:
+            self._exec_cli_command('terminal length 0')
+        except AnsibleConnectionFailure:
+            raise AnsibleConnectionFailure('unable to set terminal parameters')
+
+    def on_authorize(self, passwd=None):
+        if self._get_prompt().endswith('#'):
+            return
+
+        cmd = {'command': 'enable'}
+        if passwd:
+            cmd['prompt'] = r"[\r\n]?password: $"
+            cmd['answer'] = passwd
+
+        try:
+            self._exec_cli_command(json.dumps(cmd))
+        except AnsibleConnectionFailure:
+            raise AnsibleConnectionFailure('unable to elevate privilege to enable mode')
+
+    def on_deauthorize(self):
+        prompt = self._get_prompt()
+        if prompt is None:
+            # if prompt is None most likely the terminal is hung up at a prompt
+            return
+
+        if prompt.strip().endswith(')#'):
+            self._exec_cli_command('end')
+            self._exec_cli_command('disable')
+
+        elif prompt.endswith('#'):
+            self._exec_cli_command('disable')

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -512,12 +512,8 @@ lib/ansible/modules/network/cumulus/_cl_img_install.py
 lib/ansible/modules/network/cumulus/_cl_license.py
 lib/ansible/modules/network/cumulus/_cl_ports.py
 lib/ansible/modules/network/cumulus/nclu.py
-lib/ansible/modules/network/dellos10/dellos10_command.py
-lib/ansible/modules/network/dellos10/dellos10_config.py
-lib/ansible/modules/network/dellos10/dellos10_facts.py
 lib/ansible/modules/network/dellos6/dellos6_command.py
 lib/ansible/modules/network/dellos6/dellos6_facts.py
-lib/ansible/modules/network/dellos9/dellos9_command.py
 lib/ansible/modules/network/dnsimple.py
 lib/ansible/modules/network/dnsmadeeasy.py
 lib/ansible/modules/network/eos/_eos_template.py
@@ -882,9 +878,7 @@ lib/ansible/plugins/action/asa_config.py
 lib/ansible/plugins/action/asa_template.py
 lib/ansible/plugins/action/assemble.py
 lib/ansible/plugins/action/copy.py
-lib/ansible/plugins/action/dellos10_config.py
 lib/ansible/plugins/action/dellos6_config.py
-lib/ansible/plugins/action/dellos9_config.py
 lib/ansible/plugins/action/eos_template.py
 lib/ansible/plugins/action/fetch.py
 lib/ansible/plugins/action/group_by.py


### PR DESCRIPTION
##### SUMMARY
Ansible 2.3 feature support for dellos9 and dellos10

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
- ansible/modules/network/dellos9/*
- ansible/modules/network/dellos10/*
##### ANSIBLE VERSION
skg@SKG ~/ansible $ ansible --version
ansible 2.3.0.0 (detached HEAD e4494f85b6) last updated 2017/03/21 19:39:49 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
skg@SKG ~/ansible $ 
##### ADDITIONAL INFORMATION
addresses #22704 and #22705 
With the new Ansible 2.3 infra changes, the dellos modules doesn't work (the new infra changes are not backward compatible), so added the below changes support it.
- Added the new terminal plugin for DellOS9  and DellOS10
- Added the new action plugin for DellOS9 and DellOS10
- Modified the modules to work with the new infra.
with that it adds support for DellOS9 and DellOS10 Persistent Connection support.