### PR TITLE
Fix incorrect command-line parameters for Solaris

### DIFF
--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -327,7 +327,10 @@ def unset_mount(module, args):
 def _set_fstab_args(fstab_file):
     result = []
 
-    if fstab_file and fstab_file != '/etc/fstab' and get_platform().lower() != 'sunos':
+    if (
+            fstab_file and
+            fstab_file != '/etc/fstab' and
+            get_platform().lower() != 'sunos'):
         if get_platform().lower().endswith('bsd'):
             result.append('-F')
         else:

--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -327,7 +327,7 @@ def unset_mount(module, args):
 def _set_fstab_args(fstab_file):
     result = []
 
-    if fstab_file and fstab_file != '/etc/fstab':
+    if fstab_file and fstab_file != '/etc/fstab' and get_platform().lower() != 'sunos':
         if get_platform().lower().endswith('bsd'):
             result.append('-F')
         else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Solaris 'mount' command does not have flag to point to fstab file.
So no such flags should be passed to the command. 
Fixes #22135
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
mount module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0 and later 

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
