### PR TITLE
cloud: ovirt: Add support to specify multiple LUNs

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
@@ -76,7 +76,7 @@ options:
             - "C(address) - Address of the iSCSI storage server."
             - "C(port) - Port of the iSCSI storage server."
             - "C(target) - The target IQN for the storage device."
-            - "C(lun_id) - LUN id."
+            - "C(lun_id) - LUN id(s)."
             - "C(username) - A CHAP user name for logging into a target."
             - "C(password) - A CHAP password for logging into a target."
             - "C(override_luns) - If I(True) ISCSI storage domain luns will be overriden before adding."
@@ -133,7 +133,9 @@ EXAMPLES = '''
     data_center: mydatacenter
     iscsi:
       target: iqn.2016-08-09.domain-01:nickname
-      lun_id: 1IET_000d0002
+      lun_id:
+       - 1IET_000d0001
+       - 1IET_000d0002
       address: 10.34.63.204
 
 # Add data glusterfs storage domain
@@ -249,13 +251,17 @@ class StorageDomainModule(BaseModule):
                 type=otypes.StorageType(storage_type),
                 logical_units=[
                     otypes.LogicalUnit(
-                        id=storage.get('lun_id'),
+                        id=lun_id,
                         address=storage.get('address'),
                         port=storage.get('port', 3260),
                         target=storage.get('target'),
                         username=storage.get('username'),
                         password=storage.get('password'),
-                    ),
+                    ) for lun_id in (
+                        storage.get('lun_id')
+                        if isinstance(storage.get('lun_id'), list)
+                        else [storage.get('lun_id')]
+                    )
                 ] if storage_type in ['iscsi', 'fcp'] else None,
                 override_luns=storage.get('override_luns'),
                 mount_options=storage.get('mount_options'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR add support to specify multiple LUN ids for specific iSCSI target.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt_storage_domains

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
