### PR TITLE
Add an integration test step to win_regedit for the expandstring type.

### DIFF
--- a/test/integration/targets/win_regedit/tasks/main.yml
+++ b/test/integration/targets/win_regedit/tasks/main.yml
@@ -440,6 +440,32 @@
     that:
       - "check72_result.changed == false"
 
+# test expandstring
+
+- name: set an unexpanded reference to an environment variable
+  win_regedit:
+    key: HKCU:\Software\Cow Corp
+    value: envrionment_variable
+    data: "%PATH%"
+    datatype: expandstring
+  register: check81_result
+
+- assert:
+    that:
+      - "check81_result.changed == true"
+
+- name: check that setting the same unexpanded environment variable is not changed
+  win_regedit:
+    key: HKCU:\Software\Cow Corp
+    value: envrionment_variable
+    data: "%PATH%"
+    datatype: expandstring
+  register: check82_result
+
+- assert:
+    that:
+      - "check82_result.changed == false"
+
 # tear down
 
 - name: remove registry key used for testing


### PR DESCRIPTION
Reproduce the behavior of unexpanded references to environment variables described in #19213 as requested by @dagwieers.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Setting an unexpanded environment variable to the same value shouldn't result in a change.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_regedit

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```
