### PR TITLE
No need to specialcase comment characters

### DIFF
--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -327,17 +327,16 @@ class InventoryParser(object):
         Attempt to transform the string value from an ini file into a basic python object
         (int, dict, list, unicode string, etc).
         '''
-        if "#" not in v:
-            try:
-                v = ast.literal_eval(v)
-            # Using explicit exceptions.
-            # Likely a string that literal_eval does not like. We wil then just set it.
-            except ValueError:
-                # For some reason this was thought to be malformed.
-                pass
-            except SyntaxError:
-                # Is this a hash with an equals at the end?
-                pass
+        try:
+            v = ast.literal_eval(v)
+        # Using explicit exceptions.
+        # Likely a string that literal_eval does not like. We wil then just set it.
+        except ValueError:
+            # For some reason this was thought to be malformed.
+            pass
+        except SyntaxError:
+            # Is this a hash with an equals at the end?
+            pass
         return to_text(v, nonstring='passthru', errors='surrogate_or_strict')
 
     def get_host_variables(self, host):


### PR DESCRIPTION
If the # is inside of quotes, it's a string.  If it's outside of quotes
then an exception will be raised which we'll catch and then send to the
to_text() call at the end of the function anyhow.

Fixes #22868

(If a hash mark was present inside of a quoted string, the string would include quote marks.  If there was no hash mark, the quotes would be removed.)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
inventory/ini.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.3
```


##### ADDITIONAL INFORMATION
@jimi-c @bcoca could one of you take a look at this in case there's a reason that "#" was handled specially that I'm not aware of?
