### PR TITLE
Handle the case where HTTPError.info() returns a non-dict

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1009,8 +1009,16 @@ def fetch_url(module, url, data=None, headers=None, method=None,
             body = e.read()
         except AttributeError:
             body = ''
-        info.update(dict(msg=str(e), body=body, **e.info()))
-        info['status'] = e.code
+
+        # Try to add exception info to the output but don't fail if we can't
+        exc_info = e.info()
+        try:
+            info.update(dict(**e.info()))
+        except:
+            pass
+
+        info.update({'msg': str(e), 'body': body, 'status': e.code})
+
     except urllib_error.URLError:
         e = get_exception()
         code = int(getattr(e, 'code', -1))


### PR DESCRIPTION
This should give a better error message for #22872

##### SUMMARY

Sometimes (on python-2.4 only?) HTTPError.info() doesn't return a dict of headers.  This caused our exception handler to traceback.  anticipate this case so we can get the actual error message instead of the traceback from not getting a dict.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/urls.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.3
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
