### PR TITLE
Fall-back to show configuration on old IOSXR devices

### DIFF
--- a/lib/ansible/module_utils/iosxr.py
+++ b/lib/ansible/module_utils/iosxr.py
@@ -85,7 +85,7 @@ def run_commands(module, commands, check_rc=True):
         responses.append(out)
     return responses
 
-def load_config(module, commands, commit=False, replace=False, comment=None):
+def load_config(module, commands, warnings, commit=False, replace=False, comment=None):
 
     rc, out, err = exec_command(module, 'configure terminal')
     if rc != 0:
@@ -106,6 +106,13 @@ def load_config(module, commands, commit=False, replace=False, comment=None):
         module.fail_json(msg=err, commands=commands, rc=rc)
 
     rc, diff, err = exec_command(module, 'show commit changes diff')
+    if rc != 0:
+        # If we failed, maybe we are in an old version so
+        # we run show configuration instead
+        rc, diff, err = exec_command(module, 'show configuration')
+        if module._diff:
+            warnings.append('device platform does not support config diff')
+
     if commit:
         cmd = 'commit'
         if comment:

--- a/lib/ansible/modules/network/iosxr/_iosxr_template.py
+++ b/lib/ansible/modules/network/iosxr/_iosxr_template.py
@@ -146,7 +146,7 @@ def main():
         commands = [c.strip() for c in str(candidate).split('\n')]
 
     if commands:
-        load_config(module, commands, not module.check_mode)
+        load_config(module, commands, result['warnings'], not module.check_mode)
         result['changed'] = not module.check_mode
 
     result['updates'] = commands

--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -240,8 +240,8 @@ def run(module, result):
 
             result['commands'] = commands
 
-        diff = load_config(module, commands, not check_mode,
-                           replace_config, comment)
+        diff = load_config(module, commands, result['warnings'],
+                           not check_mode, replace_config, comment)
         if diff:
             result['diff'] = dict(prepared=diff)
             result['changed'] = True

--- a/lib/ansible/modules/network/iosxr/iosxr_system.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_system.py
@@ -243,7 +243,7 @@ def main():
 
     if commands:
         if not module.check_mode:
-            load_config(module, commands, commit=True)
+            load_config(module, commands, result['warnings'], commit=True)
         result['changed'] = True
 
     module.exit_json(**result)


### PR DESCRIPTION
##### SUMMARY

In old IOSXR versions, 'show commit changes diff' does not work.
Fall-back to 'show configuration' if that command fails so execution
can move forward.

Fixes #22235

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

module_utils/iosxr

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (issue_22235 26b2729597) last updated 2017/03/23 11:15:21 (GMT +200)
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
