### PR TITLE
Introspect flag to use on 'show run' when using defaults in ios_config

### DIFF
--- a/lib/ansible/module_utils/ios.py
+++ b/lib/ansible/module_utils/ios.py
@@ -50,6 +50,16 @@ def check_args(module, warnings):
             warnings.append('argument %s has been deprecated and will be '
                     'removed in a future version' % key)
 
+def get_defaults_flag(module):
+    rc, out, err = exec_command(module, 'show running-config ?')
+
+    commands = set()
+    for line in out.splitlines():
+        if line:
+            commands.add(line.strip().split()[0])
+
+    return 'all' if 'all' in commands else 'full'
+
 def get_config(module, flags=[]):
     cmd = 'show running-config '
     cmd += ' '.join(flags)

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -206,6 +206,7 @@ import re
 import time
 
 from ansible.module_utils.ios import run_commands, get_config, load_config
+from ansible.module_utils.ios import get_defaults_flag
 from ansible.module_utils.ios import ios_argument_spec
 from ansible.module_utils.ios import check_args as ios_check_args
 from ansible.module_utils.basic import AnsibleModule
@@ -266,7 +267,7 @@ def get_running_config(module):
     if not contents:
         flags = []
         if module.params['defaults']:
-            flags.append('all')
+            flags.append(get_defaults_flag(module))
         contents = get_config(module, flags=flags)
     contents, banners = extract_banners(contents)
     return NetworkConfig(indent=1, contents=contents), banners


### PR DESCRIPTION
##### SUMMARY

When the ios_config module has 'defaults' param it runs in the device the command
'show running-config all' but 'all' may not be available in older devices.
This change makes introspection by using the help command and run 'full' in case
'all' is not available.

Fixes #22747

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

ios_config
module_utils/ios

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (issue_22747 fde80fb297) last updated 2017/03/23 12:06:46 (GMT +200)
```
