### PR TITLE
Allow for CSRF protection in jenkins_script module

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_script.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_script.py
@@ -72,6 +72,7 @@ options:
         sent as an HTTP request header when executing the script.
         See U(https://wiki.jenkins-ci.org/display/JENKINS/CSRF+Protection) and
         U(https://wiki.jenkins-ci.org/display/JENKINS/Remote+access+API#RemoteaccessAPI-CSRFProtection)
+    version_added: 2.4
     required: false
     default: False
   args:


### PR DESCRIPTION
##### SUMMARY
When making a POST to against the Jenkins API while CSRF protection is
enabled, one must send a CSRF protection token as an HTTP header. This
commit performs a GET request against the Jenkins crumb issuer in order
to get a token to send along with the subsequent POST.

See:
  - https://wiki.jenkins-ci.org/display/JENKINS/CSRF+Protection
  - https://wiki.jenkins-ci.org/display/JENKINS/Remote+access+API#RemoteaccessAPI-CSRFProtection

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
`web_infrastructure/jenkins_script`

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = /Users/ptierno/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Dec 17 2016, 23:03:43) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
