### PR TITLE
Update playbooks_prompts.rst

### DIFF
--- a/docs/docsite/rst/playbooks_prompts.rst
+++ b/docs/docsite/rst/playbooks_prompts.rst
@@ -27,6 +27,9 @@ Here is a most basic example::
         - name: "favcolor"
           prompt: "what is your favorite color?"
 
+.. note::
+   Prompts for "vars_prompt" variables will be skipped for any variable that is already defined on the command line. See :ref:`_passing_variables_on_the_command_line` in the /Variables/ chapter.
+
 If you have a variable that changes infrequently, it might make sense to
 provide a default value that can be overridden.  This can be accomplished using
 the default argument::

--- a/docs/docsite/rst/playbooks_prompts.rst
+++ b/docs/docsite/rst/playbooks_prompts.rst
@@ -28,7 +28,7 @@ Here is a most basic example::
           prompt: "what is your favorite color?"
 
 .. note::
-   Prompts for individual "vars_prompt" variables will be skipped for any variable that is already defined on the command line. See :ref:`_passing_variables_on_the_command_line` in the /Variables/ chapter.
+   Prompts for individual "vars_prompt" variables will be skipped for any variable that is already defined on the command line, or when running from a non-interactive session (such as cron or Ansible Tower). See :ref:`_passing_variables_on_the_command_line` in the /Variables/ chapter.
    
    All "vars_prompt" variable prompts will also be skipped if Ansible is run without a TTY (eg via cron job or Ansible Tower).
 

--- a/docs/docsite/rst/playbooks_prompts.rst
+++ b/docs/docsite/rst/playbooks_prompts.rst
@@ -28,9 +28,7 @@ Here is a most basic example::
           prompt: "what is your favorite color?"
 
 .. note::
-   Prompts for individual "vars_prompt" variables will be skipped for any variable that is already defined on the command line, or when running from a non-interactive session (such as cron or Ansible Tower). See :ref:`_passing_variables_on_the_command_line` in the /Variables/ chapter.
-   
-   All "vars_prompt" variable prompts will also be skipped if Ansible is run without a TTY (eg via cron job or Ansible Tower).
+   Prompts for individual ``vars_prompt`` variables will be skipped for any variable that is already defined through the command line ``--extra-vars`` option, or when running from a non-interactive session (such as cron or Ansible Tower). See :ref:`_passing_variables_on_the_command_line` in the /Variables/ chapter.
 
 If you have a variable that changes infrequently, it might make sense to
 provide a default value that can be overridden.  This can be accomplished using

--- a/docs/docsite/rst/playbooks_prompts.rst
+++ b/docs/docsite/rst/playbooks_prompts.rst
@@ -28,7 +28,9 @@ Here is a most basic example::
           prompt: "what is your favorite color?"
 
 .. note::
-   Prompts for "vars_prompt" variables will be skipped for any variable that is already defined on the command line. See :ref:`_passing_variables_on_the_command_line` in the /Variables/ chapter.
+   Prompts for individual "vars_prompt" variables will be skipped for any variable that is already defined on the command line. See :ref:`_passing_variables_on_the_command_line` in the /Variables/ chapter.
+   
+   All "vars_prompt" variable prompts will also be skipped if Ansible is run without a TTY (eg via cron job or Ansible Tower).
 
 If you have a variable that changes infrequently, it might make sense to
 provide a default value that can be overridden.  This can be accomplished using


### PR DESCRIPTION
Clarify prompting only occurs when not in extra_vars

##### SUMMARY
Document omission of vars_prompt prompts when var in extra_vars.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
n/a

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
n/a


##### ADDITIONAL INFORMATION
The fact that vars_prompt doesn't actually prompt if the var was defined via CLI isn't documented. Nor is the fact that if you _want_ a conditional vars prompt, you can already do that with the built-in behavior (ie no need to resort to complicated conditional includes).
