### PR TITLE
Don't skip action/__init__.py

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -213,13 +213,13 @@ class ActionBase(with_metaclass(ABCMeta, object)):
 
         # any of these require a true
         for condition in [
-              self._connection.has_pipelining,
-              self._play_context.pipelining,
-              module_style == "new",                     # old style modules do not support pipelining
-              not C.DEFAULT_KEEP_REMOTE_FILES,           # user wants remote files
-              not wrap_async,                            # async does not support pipelining
-              self._play_context.become_method != 'su',  # su does not work with pipelining,
-              # FIXME: we might need to make become_method exclusion a configurable list
+            self._connection.has_pipelining,
+            self._play_context.pipelining,
+            module_style == "new",                     # old style modules do not support pipelining
+            not C.DEFAULT_KEEP_REMOTE_FILES,           # user wants remote files
+            not wrap_async,                            # async does not support pipelining
+            self._play_context.become_method != 'su',  # su does not work with pipelining,
+            # FIXME: we might need to make become_method exclusion a configurable list
         ]:
             if not condition:
                 return False

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -879,6 +879,7 @@ lib/ansible/playbook/taggable.py
 lib/ansible/playbook/task.py
 lib/ansible/playbook/task_include.py
 lib/ansible/plugins/__init__.py
+lib/ansible/plugins/action/__init__.py
 lib/ansible/plugins/action/asa_config.py
 lib/ansible/plugins/action/asa_template.py
 lib/ansible/plugins/action/assemble.py

--- a/test/sanity/pep8/skip.txt
+++ b/test/sanity/pep8/skip.txt
@@ -1,1 +1,0 @@
-lib/ansible/plugins/action/__init__.py


### PR DESCRIPTION
##### SUMMARY

Don't skip `action/__init__.py`.  I'm not sure why this was done initially, and I can't think of a good reason why we would want to skip it.  

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`ansible/plugins/action/__init__.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
N/A