### PR TITLE
Remove Ubuntu 12.04 from Shippable CI.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -30,7 +30,6 @@ matrix:
     - env: TEST=linux/fedora25/1
     - env: TEST=linux/opensuse42.1/1
     - env: TEST=linux/opensuse42.2/1
-    - env: TEST=linux/ubuntu1204/1
     - env: TEST=linux/ubuntu1404/1
     - env: TEST=linux/ubuntu1604/1
     - env: TEST=linux/ubuntu1604py3/1
@@ -41,7 +40,6 @@ matrix:
     - env: TEST=linux/fedora25/2
     - env: TEST=linux/opensuse42.1/2
     - env: TEST=linux/opensuse42.2/2
-    - env: TEST=linux/ubuntu1204/2
     - env: TEST=linux/ubuntu1404/2
     - env: TEST=linux/ubuntu1604/2
     - env: TEST=linux/ubuntu1604py3/2
@@ -52,7 +50,6 @@ matrix:
     - env: TEST=linux/fedora25/3
     - env: TEST=linux/opensuse42.1/3
     - env: TEST=linux/opensuse42.2/3
-    - env: TEST=linux/ubuntu1204/3
     - env: TEST=linux/ubuntu1404/3
     - env: TEST=linux/ubuntu1604/3
     - env: TEST=linux/ubuntu1604py3/3


### PR DESCRIPTION
##### SUMMARY

Ubuntu 12.04 will be end-of-life before stable-2.4 is released.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

CI

##### ANSIBLE VERSION

```
ansible 2.4.0 (no-ubuntu1204-ci 2d02386a1c) last updated 2017/03/23 10:59:06 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
