### PR TITLE
ec2_elb_lb: allow elb scheme to be updated by restarting the resource - fixes #19116

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
@@ -884,7 +884,7 @@ class ElbManager(object):
         if self.scheme:
             if self.elb.scheme != self.scheme:
                 if not self.wait:
-                    module.fail_json(msg="Unable to modify scheme without using the wait option")
+                    self.module.fail_json(msg="Unable to modify scheme without using the wait option")
                 return True
         return False
 

--- a/lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
@@ -107,7 +107,9 @@ options:
     version_added: "1.7"
   scheme:
     description:
-      - The scheme to use when creating the ELB. For a private VPC-visible ELB use 'internal'. If you choose to update your scheme with a different value the ELB will be destroyed and recreated. To update scheme you must use the option wait: yes.
+      - The scheme to use when creating the ELB. For a private VPC-visible ELB use 'internal'.
+        If you choose to update your scheme with a different value the ELB will be destroyed and
+        recreated. To update scheme you must use the option wait: yes.
     required: false
     default: 'internet-facing'
     version_added: "1.7"

--- a/lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
@@ -110,6 +110,7 @@ options:
       - The scheme to use when creating the ELB. For a private VPC-visible ELB use 'internal'.
         If you choose to update your scheme with a different value the ELB will be destroyed and
         recreated. To update scheme you must use the option wait.
+    choices: ["internal", "internet-facing"]
     required: false
     default: 'internet-facing'
     version_added: "1.7"
@@ -489,8 +490,7 @@ class ElbManager(object):
             # Zones and listeners will be added at creation
             self._create_elb()
         else:
-            new_scheme = self._get_scheme()
-            if new_scheme:
+            if self._get_scheme():
                 # the only way to change the scheme is by recreating the resource
                 self.ensure_gone()
                 self._create_elb()
@@ -881,7 +881,7 @@ class ElbManager(object):
 
     def _get_scheme(self):
         """Determine if the current scheme is different than the scheme of the ELB"""
-        if self.scheme and self.scheme != "":
+        if self.scheme:
             if self.elb.scheme != self.scheme:
                 if not self.wait:
                     module.fail_json(msg="Unable to modify scheme without using the wait option")
@@ -1261,7 +1261,7 @@ def main():
         health_check={'default': None, 'required': False, 'type': 'dict'},
         subnets={'default': None, 'required': False, 'type': 'list'},
         purge_subnets={'default': False, 'required': False, 'type': 'bool'},
-        scheme={'default': 'internet-facing', 'required': False},
+        scheme={'default': 'internet-facing', 'required': False, 'choices': ['internal', 'internet-facing']},
         connection_draining_timeout={'default': None, 'required': False, 'type': 'int'},
         idle_timeout={'default': None, 'type': 'int', 'required': False},
         cross_az_load_balancing={'default': None, 'type': 'bool', 'required': False},

--- a/lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
@@ -109,7 +109,7 @@ options:
     description:
       - The scheme to use when creating the ELB. For a private VPC-visible ELB use 'internal'.
         If you choose to update your scheme with a different value the ELB will be destroyed and
-        recreated. To update scheme you must use the option wait: yes.
+        recreated. To update scheme you must use the option wait.
     required: false
     default: 'internet-facing'
     version_added: "1.7"


### PR DESCRIPTION
use ensure_gone and require wait option

##### SUMMARY
Fixes #19116. Scheme is unable to be modified unless the resource is restarted. See lack of scheme in the AWS API Docs in [modifying attributes](http://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_ModifyLoadBalancerAttributes.html) as opposed to the docs on [creating a ELB](http://docs.aws.amazon.com/elasticloadbalancing/2012-06-01/APIReference/API_CreateLoadBalancer.html).

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_elb_lb.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (allow-scheme-update f45274c093) last updated 2017/03/23 14:08:34 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```
