### PR TITLE
fixes issue when host is defined in provider for junos

### DIFF
--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -57,6 +57,8 @@ class ActionModule(_ActionModule):
         pc = copy.deepcopy(self._play_context)
         pc.network_os = 'junos'
 
+        pc.remote_addr = provider['host'] or self._play_context.remote_addr
+
         if self._task.action == 'junos_netconf':
             pc.connection = 'network_cli'
             pc.port = provider['port'] or self._play_context.port or 22


### PR DESCRIPTION
The junos action handler was not honoring the host value in the provider
argument.  This patch will now use the provider host entry if it exists
and falls back to the inventory hostname

