### PR TITLE
ec2_eni: Only modify an ENI if the filters used to specify result in *exactly* one match

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_eni.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eni.py
@@ -483,9 +483,6 @@ def find_eni(connection, module):
     instance_id = module.params.get('instance_id')
     device_index = module.params.get('device_index')
 
-    if not eni_id:
-        return None
-
     try:
         filters = {}
         if subnet_id:
@@ -499,7 +496,7 @@ def find_eni(connection, module):
                 filters['attachment.device-index'] = device_index
 
         eni_result = connection.get_all_network_interfaces(eni_id, filters=filters)
-        if len(eni_result) > 0:
+        if len(eni_result) == 1:
             return eni_result[0]
         else:
             return None


### PR DESCRIPTION
##### SUMMARY
Let any of the filters lead to a unique match to modify. If there are more than one match or none, create a new eni. In response to comments in #22689. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_eni.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (modify_ec2_eni_correctly 92db05efaf) last updated 2017/03/23 14:47:29 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```
