### PR TITLE
[obsolete] RDS integration tests - see #25646

### DIFF
--- a/test/integration/amazon.yml
+++ b/test/integration/amazon.yml
@@ -14,6 +14,7 @@
     - { role: test_ec2_asg, tags: test_ec2_asg }
     - { role: test_ec2_vpc_nat_gateway, tags: test_ec2_vpc_nat_gateway }
     - { role: test_ecs_ecr, tags: test_ecs_ecr }
+    - { role: test_amazon_rds, tags: test_amazon_rds }
 
 # complex test for ec2_elb, split up over multiple plays
 # since there is a setup component as well as the test which

--- a/test/integration/roles/test_amazon_rds/tasks/main.yml
+++ b/test/integration/roles/test_amazon_rds/tasks/main.yml
@@ -92,6 +92,7 @@
       EC2_ACCESS_KEY: '{{ec2_access_key}}'
       EC2_SECRET_KEY: '{{ec2_secret_key}}'
     register: result
+    when: 'xfail is defined and xfail == True'
 
   - name: assert the test rds instance was modified correctly
     tags: test_amazon_rds
@@ -99,6 +100,7 @@
       that:
         - 'result.changed == False'
         - '"failed" not in result'
+    when: 'xfail is defined and xfail == True'
 
 # idempotency test 1 - try modify RDS but actually do nothing
 

--- a/test/integration/roles/test_amazon_rds/tasks/main.yml
+++ b/test/integration/roles/test_amazon_rds/tasks/main.yml
@@ -1,0 +1,153 @@
+# create and kill an RDS
+
+# Improvements expected in later versions of this test case
+
+# use present instead of create
+# use absent instead of delete
+# use SSD
+
+
+# Start with creation - N.B. if the RDS already exists from a previous run this
+# may not change anything so we don't insist on that
+
+  - name: create RDS
+    tags: test_amazon_rds
+    local_action:
+      module: rds
+      region: "{{ ec2_region }}"
+      command: create
+      instance_name: "{{ resource_prefix }}-rds"
+      db_engine: postgres
+      size: 10
+      instance_type: "db.t2.micro"
+      username: "{{ rds_master_db_user }}"
+      password: "{{ rds_db_master_password }}"
+      publicly_accessible: no
+      wait: yes
+      wait_timeout: 1200 # 600 doesn't cut it!!
+    environment:
+      EC2_REGION: '{{ec2_region}}'
+      EC2_ACCESS_KEY: '{{ec2_access_key}}'
+      EC2_SECRET_KEY: '{{ec2_secret_key}}'
+    register: result
+
+  - name: assert the test rds instance was created correctly
+    tags: test_amazon_rds
+    assert:
+      that:
+#        - 'result.changed'
+        - '"failed" not in result'
+
+
+# modify RDS
+
+  - name: modify RDS
+    tags: test_amazon_rds
+    local_action:
+      module: rds
+      region: "{{ ec2_region }}"
+      command: modify
+      instance_name: "{{ resource_prefix }}-rds"
+      db_engine: postgres
+      size: 18
+      instance_type: "db.t2.micro"
+      username: "{{ rds_master_db_user }}"
+      password: "{{ rds_db_master_password }}"
+#      publicly_accessible: no
+      wait: yes
+      wait_timeout: 600
+    environment:
+      EC2_REGION: '{{ec2_region}}'
+      EC2_ACCESS_KEY: '{{ec2_access_key}}'
+      EC2_SECRET_KEY: '{{ec2_secret_key}}'
+    register: result
+
+  - name: assert the test rds instance was modified correctly
+    tags: test_amazon_rds
+    assert:
+      that:
+        - 'result.changed'
+        - '"failed" not in result'
+
+
+# idempotency test 1 - try modify RDS but actually do nothing
+
+  - name: don't modify RDS if already there
+    tags: test_amazon_rds
+    local_action:
+      module: rds
+      region: "{{ ec2_region }}"
+      command: modify
+      instance_name: "{{ resource_prefix }}-rds"
+      db_engine: postgres
+      size: 18
+      instance_type: "db.t2.micro"
+      username: "{{ rds_master_db_user }}"
+      password: "{{ rds_db_master_password }}"
+#      publicly_accessible: no
+      wait: yes
+      wait_timeout: 600
+    environment:
+      EC2_REGION: '{{ec2_region}}'
+      EC2_ACCESS_KEY: '{{ec2_access_key}}'
+      EC2_SECRET_KEY: '{{ec2_secret_key}}'
+    register: result
+
+  - name: assert the test rds instance was modified correctly
+    tags: test_amazon_rds
+    assert:
+      that:
+        - 'result.changed == False'
+        - '"failed" not in result'
+
+# idempotency test 1 - try modify RDS but actually do nothing
+
+  - name: don't create RDS if already there
+    tags: test_amazon_rds
+    local_action:
+      module: rds
+      region: "{{ ec2_region }}"
+      command: create
+      instance_name: "{{ resource_prefix }}-rds"
+      db_engine: postgres
+      size: 18
+      instance_type: "db.t2.micro"
+      username: "{{ rds_master_db_user }}"
+      password: "{{ rds_db_master_password }}"
+#      publicly_accessible: no
+      wait: yes
+      wait_timeout: 600
+    environment:
+      EC2_REGION: '{{ec2_region}}'
+      EC2_ACCESS_KEY: '{{ec2_access_key}}'
+      EC2_SECRET_KEY: '{{ec2_secret_key}}'
+    register: result
+
+  - name: assert the test rds instance was modified correctly
+    tags: test_amazon_rds
+    assert:
+      that:
+        - 'result.changed == False'
+        - '"failed" not in result'
+
+
+  - name: delete RDS
+    tags: test_amazon_rds
+    local_action:
+      module: rds
+      region: "{{ ec2_region }}"
+      command: delete
+      instance_name: "{{ resource_prefix }}-rds"
+    environment:
+      EC2_REGION: '{{ec2_region}}'
+      EC2_ACCESS_KEY: '{{ec2_access_key}}'
+      EC2_SECRET_KEY: '{{ec2_secret_key}}'
+    register: result
+
+
+  - name: assert the test rds was deleted correctly
+    tags: test_amazon_rds
+    assert:
+      that:
+        - 'result.changed == True'
+        - '"failed" not in result'

--- a/test/integration/roles/test_amazon_rds/vars/main.yml
+++ b/test/integration/roles/test_amazon_rds/vars/main.yml
@@ -1,0 +1,2 @@
+rds_master_db_user: db_user
+rds_db_master_password: "{{ lookup('password', '/dev/null chars=ascii_letters,digits') }}"


### PR DESCRIPTION
…report

##### SUMMARY

This is the start if a set of integration test cases for the RDS module.  This allows demonstration of various bugs in the RDS module - lack of idempotency and falure to handle exceptions correctly.  

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

RDS module integration test cases

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel 955bb4991a) last updated 2017/03/23 23:24:30 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/mikedd/dev/ansible/ansible-add-modules/library']
  python version = 2.7.12 (default, Jul  1 2016, 15:12:24) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION

no changes to ansible/ansible-playbook code included in this pull request
