### PR TITLE
Streamline Arch Linux detection following systemd standard (rebase of pr 15675)

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -650,7 +650,7 @@ class Distribution(object):
         {'path': '/etc/openwrt_release', 'name': 'OpenWrt'},
         {'path': '/etc/system-release', 'name': 'Amazon'},
         {'path': '/etc/alpine-release', 'name': 'Alpine'},
-        {'path': '/etc/arch-release', 'name': 'Archlinux', 'allowempty': True},
+        {'path': '/etc/os-release', 'name': 'Archlinux'},
         {'path': '/etc/os-release', 'name': 'SuSE'},
         {'path': '/etc/SuSE-release', 'name': 'SuSE'},
         {'path': '/etc/gentoo-release', 'name': 'Gentoo'},
@@ -667,6 +667,7 @@ class Distribution(object):
         'OracleLinux': 'Oracle Linux',
         'RedHat': 'Red Hat',
         'Altlinux': 'ALT Linux',
+        'Archlinux': 'Arch Linux',
         'ClearLinux': 'Clear Linux Software for Intel Architecture',
         'SMGL': 'Source Mage GNU/Linux',
     }


### PR DESCRIPTION
This is a rebase of https://github.com/ansible/ansible/pull/15675

Original pr notes:

> Streamline Arch Linux detection following systemd standard os-release)
> 
> systemd is a first class citizen in Arch Linux variants and thus
> `/etc/os-release` will have the right info [1].
> 
> [1] https://www.freedesktop.org/software/systemd/man/os-release.html
> 
> ##### SUMMARY
> <!--- Describe the change, including rationale and design decisions -->
> 
> <!---
> If you are fixing an existing issue, please include "Fixes #nnn" in your
> commit message and your description; but you should still explain what
> the change does.
> -->
> 
> ##### ISSUE TYPE
> <!--- Pick one below and delete the rest: -->
>  - Feature Pull Request
>  - New Module Pull Request
>  - Bugfix Pull Request
>  - Docs Pull Request
> 
> ##### COMPONENT NAME
> <!--- Name of the module/plugin/module/task -->
> 
> ##### ANSIBLE VERSION
> <!--- Paste verbatim output from “ansible --version” between quotes below -->
> ```
> 
> ```
> 
> 
> ##### ADDITIONAL INFORMATION
> <!---
> Include additional information to help people understand the change here.
> For bugs that don't have a linked bug report, a step-by-step reproduction
> of the problem is helpful.
>   -->
> 
> <!--- Paste verbatim command output below, e.g. before and after your change -->
> ```
> 
> ```
> 