### PR TITLE
fixes ansible-connection working directory

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -63,7 +63,7 @@ def do_fork():
         if pid > 0:
             return pid
 
-        os.chdir("/")
+        #os.chdir("/")
         os.setsid()
         os.umask(0)
 
@@ -119,6 +119,7 @@ class Server():
         self.play_context = play_context
 
         display.display("starting new persistent socket with path %s" % path, log_only=True)
+        display.display('current working directory is %s' % os.getcwd(), log_only=True)
 
         self._start_time = datetime.datetime.now()
 


### PR DESCRIPTION
When ansible-connection forks the process, it changed the working
directory to /.  This patch will prevent ansible-connection from
changing the working directory in the forked process.

