### PR TITLE
fixes issue where nxos module will fail due to KeyError

### DIFF
--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -117,7 +117,11 @@ class ActionModule(_ActionModule):
         self._task.args['transport'] = transport
 
         result = super(ActionModule, self).run(tmp, task_vars)
-        del result['invocation']['module_args']['provider']
+
+        try:
+            del result['invocation']['module_args']['provider']
+        except KeyError:
+            pass
 
         return result
 


### PR DESCRIPTION
Updates nxos action handler to handle deleting provider key if exists or
silently continuing if a  KeyError is raised.

