### PR TITLE
Fix #22968 - Setting registry ACLs using win_acl is broken by ALL APPLICATION PACKAGES

### DIFF
--- a/lib/ansible/modules/windows/win_acl.ps1
+++ b/lib/ansible/modules/windows/win_acl.ps1
@@ -277,16 +277,7 @@ Try {
  
     # Check if the ACE exists already in the objects ACL list
     $match = $false
-    If ($path -match "^HK(CC|CR|CU|LM|U):\\") {
-        ForEach($rule in $objACL.Access){
-            $ruleIdentity = $rule.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier])
-            If (($rule.RegistryRights -eq $objACE.RegistryRights) -And ($rule.AccessControlType -eq $objACE.AccessControlType) -And ($ruleIdentity -eq $objACE.IdentityReference) -And ($rule.IsInherited -eq $objACE.IsInherited) -And ($rule.InheritanceFlags -eq $objACE.InheritanceFlags) -And ($rule.PropagationFlags -eq $objACE.PropagationFlags)) {
-                $match = $true
-                Break
-            }
-        }
-    }
-    Else {
+    ForEach($rule in $objACL.Access){
         # Workaround to handle special use case 'APPLICATION PACKAGE AUTHORITY\ALL APPLICATION PACKAGES' and
         # 'APPLICATION PACKAGE AUTHORITY\ALL RESTRICTED APPLICATION PACKAGES'- can't translate fully qualified name (win32 API bug/oddity)
         # 'ALL APPLICATION PACKAGES' exists only on Win2k12 and Win2k16 and 'ALL RESTRICTED APPLICATION PACKAGES' exists only in Win2k16
@@ -303,9 +294,17 @@ Try {
             else {
                 $ruleIdentity = $rule.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier])
             }
-            If (($rule.FileSystemRights -eq $objACE.FileSystemRights) -And ($rule.AccessControlType -eq $objACE.AccessControlType) -And ($ruleIdentity -eq $objACE.IdentityReference) -And ($rule.IsInherited -eq $objACE.IsInherited) -And ($rule.InheritanceFlags -eq $objACE.InheritanceFlags) -And ($rule.PropagationFlags -eq $objACE.PropagationFlags)) { 
-                $match = $true
-                Break
+
+            If ($path -match "^HK(CC|CR|CU|LM|U):\\") {
+                If (($rule.RegistryRights -eq $objACE.RegistryRights) -And ($rule.AccessControlType -eq $objACE.AccessControlType) -And ($ruleIdentity -eq $objACE.IdentityReference) -And ($rule.IsInherited -eq $objACE.IsInherited) -And ($rule.InheritanceFlags -eq $objACE.InheritanceFlags) -And ($rule.PropagationFlags -eq $objACE.PropagationFlags)) {
+                    $match = $true
+                    Break
+                }
+            } else {
+                If (($rule.FileSystemRights -eq $objACE.FileSystemRights) -And ($rule.AccessControlType -eq $objACE.AccessControlType) -And ($ruleIdentity -eq $objACE.IdentityReference) -And ($rule.IsInherited -eq $objACE.IsInherited) -And ($rule.InheritanceFlags -eq $objACE.InheritanceFlags) -And ($rule.PropagationFlags -eq $objACE.PropagationFlags)) { 
+                    $match = $true
+                    Break
+                }
             }
         }
     }


### PR DESCRIPTION
##### SUMMARY
Fixes #22968. The root cause is pretty much exactly the same problem which was resolved in #20555, but for registry ACLs instead.

The fix in #20555 only applied to filesystem ACLs. This PR applies the fix to both filesystem and registry ACLs.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_acl

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```

##### ADDITIONAL INFORMATION
Before:
```
[root@70daada2e2f6 /]# ansible windows -m win_acl -a 'path="HKLM:\SOFTWARE" user="Administrator" type="allow" rights="ReadKey"' -vvvv
No config file found; using defaults
Loading callback plugin minimal of type stdout, v2.0 from /opt/ansible/lib/ansible/plugins/callback/__init__.pyc
META: ran handlers
Using module file /opt/ansible/lib/ansible/modules/windows/win_acl.ps1
<iis-services> ESTABLISH WINRM CONNECTION FOR USER: Administrator on PORT 5986 TO iis-services
/usr/lib/python2.7/site-packages/urllib3/connectionpool.py:769: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)
EXEC (via pipeline wrapper)
iis-services | FAILED! => {
    "changed": false,
    "failed": true,
    "msg": "an error occurred when attempting to present ReadKey permission(s) on HKLM:\\SOFTWARE for Administrator - Exception calling \"Translate\" with \"1\" argument(s): \"Some or all identity references could not be translated.\""
```

After:
```
[root@70daada2e2f6 /]# ansible windows -m win_acl -a 'path="HKLM:\SOFTWARE" user="Administrator" type="allow" rights="ReadKey"' -vvvv
No config file found; using defaults
Loading callback plugin minimal of type stdout, v2.0 from /opt/ansible/lib/ansible/plugins/callback/__init__.pyc
META: ran handlers
Using module file /opt/ansible/lib/ansible/modules/windows/win_acl.ps1
<iis-services> ESTABLISH WINRM CONNECTION FOR USER: Administrator on PORT 5986 TO iis-services
/usr/lib/python2.7/site-packages/urllib3/connectionpool.py:769: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)
EXEC (via pipeline wrapper)
iis-services | SUCCESS => {
    "changed": true
}
META: ran handlers
META: ran handlers
```