### PR TITLE
Fix #22917 module fails to run if configured log file is not writeable

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -72,10 +72,10 @@ def do_fork():
             if pid > 0:
                 sys.exit(0)
 
-            if C.DEFAULT_LOG_PATH != '':
+            try:
                 out_file = file(C.DEFAULT_LOG_PATH, 'a+')
                 err_file = file(C.DEFAULT_LOG_PATH, 'a+', 0)
-            else:
+            except IOError:
                 out_file = file('/dev/null', 'a+')
                 err_file = file('/dev/null', 'a+', 0)
 


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
If log file is not accessible continue
to execute playbook.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bin/ansible-connection
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible --version
ansible 2.4.0 (9b2bdf2df6) last updated 2017/03/25 18:51:50 (GMT +550)
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
$ ansible-playbook ~/targets/junos_config_1.yml -i ~/targets/hosts 
[WARNING]: log file at /var/log/ansible.log is not writeable and we cannot create it, aborting


PLAY [load configure file into device] **************************************************************************************************

TASK [Gathering Facts] ******************************************************************************************************************
ok: [junos_mx]

TASK [Run junos_config] *****************************************************************************************************************

fatal: [junos_mx]: FAILED! => {"changed": false, "failed": true, "msg": "unable to connect to control socket"}
	to retry, use: --limit @/Users/gnalawad/targets/junos_config_1.retry

PLAY RECAP ******************************************************************************************************************************
junos_mx                   : ok=1    changed=0    unreachable=0    failed=1 
```
After:
```
$ ansible-playbook ~/targets/junos_config_1.yml -i ~/targets/hosts 
[WARNING]: log file at /var/log/ansible.log is not writeable and we cannot create it, aborting


PLAY [load configure file into device] ************************************************************************************************************************

TASK [Gathering Facts] ****************************************************************************************************************************************
ok: [junos_mx]

TASK [Run junos_config] ***************************************************************************************************************************************
changed: [junos_mx]

PLAY RECAP ****************************************************************************************************************************************************
junos_mx                   : ok=2    changed=1    unreachable=0    failed=0   
```