### PR TITLE
remove param vm_id in VirtualMachine initializer call

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -789,7 +789,6 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                     vhd = VirtualHardDisk(uri=vm_dict['properties']['storageProfile']['osDisk']['vhd']['uri'])
                     vm_resource = VirtualMachine(
                         vm_dict['location'],
-                        vm_id=vm_dict['properties']['vmId'],
                         os_profile=OSProfile(
                             admin_username=vm_dict['properties']['osProfile']['adminUsername'],
                             computer_name=vm_dict['properties']['osProfile']['computerName']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

There is a bug in the `azure_rm_virtualmachine` module. It references an outdated initializer in the Azure Python SDK. There was a [change in the Azure Python SDK that removed `vm_id` as a intializer parameter](https://github.com/Azure/azure-sdk-for-python/commit/8fcd762a07b6390c566e4aa34bd154e1a94e9469#diff-7d3b3e840bb59c6723d399467c315bfeR109). Because of this, it seems to have broken the `azure_rm_virtualmachine` module that is evident in issue #20444.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

azure_rm_virtualmachine module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

The usage after this bug fix is the same as it was prior to.

The repro of the original issue can be found in #20444.
