### PR TITLE
A couple more places where compat.six was used converted to module_utitls.six

### DIFF
--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -277,7 +277,7 @@ To test if something is a string, consider that it may be unicode.
     if type(x) == str:
 
     # yes
-    from ansible.compat.six import string_types
+    from ansible.module_utils.six import string_types
     if isinstance(x, string_types):
 
 Cleverness

--- a/docs/api/Makefile
+++ b/docs/api/Makefile
@@ -14,7 +14,7 @@ PAPER         =
 BUILDDIR      = _build
 RSTDIR        = rst
 MODULES_PATH  = ../../lib
-EXCLUDE_PATHS = ../../lib/ansible/modules ../../lib/ansible/utils/module_docs_fragments ../../lib/ansible/compat/six ../../lib/ansible/module_utils/six.py
+EXCLUDE_PATHS = ../../lib/ansible/modules ../../lib/ansible/utils/module_docs_fragments ../../lib/ansible/module_utils/six
 DOC_PROJECTS  = "Ansible API"
 
 # User-friendly check for sphinx-build


### PR DESCRIPTION
##### SUMMARY

Found that compat.six was used in one more piece of documentation and in a Makefile.  Replace those with the appropriate module_utils.six path.

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
documentation & build scripts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```