### PR TITLE
Add support for Elastic EBS Volumes. Fixes #21588

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vol.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vol.py
@@ -42,19 +42,20 @@ options:
     version_added: "1.6"
   id:
     description:
-      - volume id if you wish to attach an existing volume (requires instance) or remove an existing volume
+      - volume id if you wish to attach an existing volume (requires instance), modify or remove an existing volume
     required: false
     default: null
     version_added: "1.6"
   volume_size:
     description:
-      - size of volume (in GB) to create.
+      - size of volume (in GB) to create or extend existing volume (since 2.4)
     required: false
     default: null
   volume_type:
     description:
       - Type of EBS volume; standard (magnetic), gp2 (SSD), io1 (Provisioned IOPS), st1 (Throughput Optimized HDD), sc1 (Cold HDD).
         "Standard" is the old EBS default and continues to remain the Ansible default for backwards compatibility.
+        Note that it is not possible to modify the standard volumes or change their types.
     required: false
     default: standard
     version_added: "1.9"
@@ -119,9 +120,12 @@ options:
     default: {}
     version_added: "2.3"
 author: "Lester Wade (@lwade)"
+requirements:
+  - "boto >= 2.37.0"
+  - "boto3 >= 1.4.4 (for modifying existing volumes)"
 extends_documentation_fragment:
-    - aws
-    - ec2
+  - aws
+  - ec2
 '''
 
 EXAMPLES = '''
@@ -199,12 +203,34 @@ EXAMPLES = '''
     volume_type: gp2
     device_name: /dev/xvdf
 
-# Attach an existing volume to instance. The volume will be deleted upon instance termination.
+# Attach an existing volume to instance. The volume will be deleted upon instance termination
 - ec2_vol:
     instance: XXXXXX
     id: XXXXXX
     device_name: /dev/sdf
     delete_on_termination: yes
+
+# Update existing volume using volume id (since 2.4)
+- ec2_vol:
+    id: vol-xxxxxx
+    volume_size: 100
+    volume_type: io1
+    iops: 500
+
+# Extend existing volume using instance and device_name (since 2.4)
+- ec2_vol:
+    volume_size: 100
+    volume_type: gp2
+    instance: i-xxxxxx
+    device_name: /dev/sdf
+
+# Create new volume from snapshot, using extended size and attach to instance (since 2.4)
+- ec2_vol:
+    snapshot: snap-xxxxxx
+    volume_size: 100
+    volume_type: gp2
+    instance: i-xxxxxx
+    device_name: /dev/sda1
 '''
 
 RETURN = '''
@@ -261,6 +287,12 @@ try:
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
+try:
+    import botocore
+    import boto3
+    HAS_BOTO3 = True
+except ImportError:
+    HAS_BOTO3 = False
 
 
 def get_volume(module, ec2):
@@ -379,9 +411,62 @@ def create_volume(module, ec2, zone):
                 ec2.create_tags([volume.id], tags)
         except boto.exception.BotoServerError as e:
             module.fail_json(msg = "%s: %s" % (e.error_code, e.error_message))
+    else:
+        changed = modify_volume(module, ec2, volume)
 
     return volume, changed
 
+def get_boto3_ec2_connection(module):
+    try:
+        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+        if not region:
+            module.fail_json(msg="region must be specified")
+        return boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    except boto.exception.NoAuthHandlerFound as e:
+        module.fail_json(msg="Can't authorize connection - "+str(e))
+
+def modify_volume(module, ec2, volume):
+
+    if not HAS_BOTO3:
+        module.fail_json(msg='boto3 required for this module to modify volumes')
+
+    changed = False
+    volume_size = module.params.get('volume_size')
+    volume_type = module.params.get('volume_type')
+    volume_iops = module.params.get('iops')
+    change_attributes = dict(VolumeId=volume.id, VolumeType=volume.type)
+
+    # If custom iops is defined we use volume_type "io1" rather than the default of "standard"
+    if volume_iops:
+        volume_type = 'io1'
+
+    if volume_size and int(volume_size) > volume.size:
+        change_attributes['Size'] = int(volume_size)
+        changed = True
+
+    if volume_type and volume_type != volume.type:
+        change_attributes['VolumeType'] = volume_type
+        changed = True
+
+    if volume_iops and int(volume_iops) != volume.iops:
+        change_attributes['Iops'] = int(volume_iops)
+        changed = True
+
+    if changed:
+        try:
+            ec2_boto3 = get_boto3_ec2_connection(module)
+            modification_response = ec2_boto3.modify_volume(**change_attributes)
+            modification = modification_response['VolumeModification']
+
+            # Wait until the state is 'optimizing' | 'completed' | 'failed'
+            while modification['ModificationState'] == 'modifying':
+                time.sleep(5)
+                modifications = ec2_boto3.describe_volumes_modifications(VolumeIds=[volume.id])
+                modification = modifications['VolumesModifications'][0]
+        except botocore.exceptions.ClientError as e:
+            module.fail_json(msg=str(e))
+
+    return changed
 
 def attach_volume(module, ec2, volume, instance):
 
@@ -599,18 +684,21 @@ def main():
         # Check if there is a volume already mounted there.
         if device_name:
             if device_name in inst.block_device_mapping:
+                # Handle a case when instance and device_name is given instead of volume_id
+                volume = ec2.get_all_volumes(volume_ids=[inst.block_device_mapping[device_name].volume_id])[0]
+                changed = modify_volume(module, ec2, volume)
                 module.exit_json(msg="Volume mapping for %s already exists on instance %s" % (device_name, instance),
-                                 volume_id=inst.block_device_mapping[device_name].volume_id,
+                                 volume_id=volume.id,
                                  device=device_name,
-                                 changed=False)
+                                 changed=changed)
 
     # Delaying the checks until after the instance check allows us to get volume ids for existing volumes
     # without needing to pass an unused volume_size
     if not volume_size and not (id or name or snapshot):
         module.fail_json(msg="You must specify volume_size or identify an existing volume by id, name, or snapshot")
 
-    if volume_size and (id or snapshot):
-        module.fail_json(msg="Cannot specify volume_size together with id or snapshot")
+    if volume_size and id:
+        module.fail_json(msg="Cannot specify volume_size together with id")
 
     if state == 'present':
         volume, changed = create_volume(module, ec2, zone)


### PR DESCRIPTION
Fixes #21588

##### SUMMARY

Currently it is possible to create, detach, attach and remove EBS volumes.
This PR add support for modifying existing Elastic EBS Volumes either using volume's 'id' directly or by specifying both 'instance_id' with 'device_name'.
This is an important addition since it does not cause downtime on the instance if volume is already attached but it sends `modify_volume` request through boto3 instead.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_vol module

##### ANSIBLE VERSION

```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/etc/ansible/library']
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION

The traditional way of extending volumes was to stop ec2 instance, create new (updated) volume snapshot, create a new (extended) volume from the snapshot, detach old volume, attach the new volume back to the instance and start it. This traditional approach, however, is current not supported in Ansible since the ec2_vol module prevents specifying both `volume_size` and `snapshot_id` at the same time:

```python
if volume_size and (id or snapshot):
        module.fail_json(msg="Cannot specify volume_size together with id or snapshot")
```
This PR covers fixing the above limitation as well.

##### USE CASES AND EXAMPLES
```yaml
# Update existing volume using volume id
- ec2_vol:
    id: "{{ volume_id }}"
    volume_size: "{{ new_volume_size }}"
    volume_type: io1
    iops: "{{ new_iops }}

# Extend existing volume using instance and device_name
- ec2_vol:
    volume_size: "{{ new_volume_size }}"
    volume_type: gp2
    instance: "{{ an_instance_id }}"
    device_name: /dev/sdf

# Create new volume from snapshot using extended size and attach to existing instance
- ec2_vol:
    snapshot: "{{ a_snapshot_id }}"
    volume_size: "{{ new_volume_size }}"
    volume_type: gp2
    instance: "{{ an_instance_id }}"
    device_name: /dev/sda1
```

##### LIMITATIONS

There are some caveats to be noted upon modifying volumes:

* Most importantly, only one modification is allowed per volume within 6 hours
* Modification changes state of a volume to 'modifying' for a few seconds and IO is completely stopped during that time. Then it enters 'optimizing' state and IO resumes. I'm still waiting for an answer from the AWS team, whether it is safe to resize the filesystem while a volume is 'optimizing'
* Modifications of magnetic volumes, aka 'standard', are unsupported in either direction

The latter has impact on existing ansible configurations since it is not possible to modify 'standard' volumes, and this is the default in ec2_vol. The API will refuse any change to/from 'standard' volume.
