### PR TITLE
Migrate most uses of if type() to if isinstance()

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -1378,7 +1378,7 @@ class Ec2Inventory(object):
             elif key == 'ec2__previous_state':
                 instance_vars['ec2_previous_state'] = instance.previous_state or ''
                 instance_vars['ec2_previous_state_code'] = instance.previous_state_code
-            elif type(value) in [int, bool]:
+            elif isinstance(value, (int, bool)):
                 instance_vars[key] = value
             elif isinstance(value, six.string_types):
                 instance_vars[key] = value.strip()
@@ -1483,7 +1483,7 @@ class Ec2Inventory(object):
 
             # Target: Everything
             # Preserve booleans and integers
-            elif type(value) in [int, bool]:
+            elif isinstance(value, (int, bool)):
                 host_info[key] = value
 
             # Target: Everything

--- a/contrib/inventory/packet_net.py
+++ b/contrib/inventory/packet_net.py
@@ -385,7 +385,7 @@ class PacketInventory(object):
                 device_vars[key] = device.state or ''
             elif key == 'packet_hostname':
                 device_vars[key] = value
-            elif type(value) in [int, bool]:
+            elif isinstance(value, (int, bool)):
                 device_vars[key] = value
             elif isinstance(value, six.string_types):
                 device_vars[key] = value.strip()

--- a/contrib/inventory/ssh_config.py
+++ b/contrib/inventory/ssh_config.py
@@ -43,12 +43,15 @@
 import argparse
 import os.path
 import sys
-import paramiko
+from collections import MutableSequence
 
 try:
     import json
 except ImportError:
     import simplejson as json
+
+import paramiko
+
 
 SSH_CONF = '~/.ssh/config'
 
@@ -68,7 +71,7 @@ def get_config():
         cfg.parse(f)
         ret_dict = {}
         for d in cfg._config:
-            if type(d['host']) is list:
+            if isinstance(d['host'], MutableSequence):
                 alias = d['host'][0]
             else:
                 alias = d['host']
@@ -93,7 +96,7 @@ def print_list():
                 # If the attribute is a list, just take the first element.
                 # Private key is returned in a list for some reason.
                 attr = attributes[ssh_opt]
-                if type(attr) is list:
+                if isinstance(attr, MutableSequence):
                     attr = attr[0]
                 tmp_dict[ans_opt] = attr
         if tmp_dict:

--- a/lib/ansible/plugins/callback/dense.py
+++ b/lib/ansible/plugins/callback/dense.py
@@ -19,8 +19,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.plugins.callback.default import CallbackModule as CallbackModule_default
-from ansible.utils.color import colorize, hostcolor
+from collections import MutableMapping, MutableSequence
 
 HAS_OD = False
 try:
@@ -28,6 +27,10 @@ try:
     HAS_OD = True
 except ImportError:
     pass
+
+from ansible.module_utils.six import binary_type, text_type
+from ansible.plugins.callback.default import CallbackModule as CallbackModule_default
+from ansible.utils.color import colorize, hostcolor
 
 try:
     from __main__ import display
@@ -235,7 +238,7 @@ class CallbackModule_dense(CallbackModule_default):
 
         # Remove empty attributes (list, dict, str)
         for attr in result.copy():
-            if type(result[attr]) in (list, dict, basestring, unicode):
+            if isinstance(result[attr], (MutableSequence, MutableMapping, binary_type, text_type)):
                 if not result[attr]:
                     del(result[attr])
 

--- a/lib/ansible/plugins/callback/log_plays.py
+++ b/lib/ansible/plugins/callback/log_plays.py
@@ -22,6 +22,7 @@ __metaclass__ = type
 import os
 import time
 import json
+from collections import MutableMapping
 
 from ansible.module_utils._text import to_bytes
 from ansible.plugins.callback import CallbackBase
@@ -54,7 +55,7 @@ class CallbackModule(CallbackBase):
             os.makedirs("/var/log/ansible/hosts")
 
     def log(self, host, category, data):
-        if type(data) == dict:
+        if isinstance(data, MutableMapping):
             if '_ansible_verbose_override' in data:
                 # avoid logging extraneous data
                 data = 'omitted'

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -31,6 +31,7 @@ import re
 import string
 import sys
 import uuid
+from collections import MutableMapping, MutableSequence
 from datetime import datetime
 from functools import partial
 from random import Random, SystemRandom, shuffle
@@ -108,14 +109,13 @@ def to_nice_json(a, indent=4, *args, **kw):
 
 def to_bool(a):
     ''' return a bool for the arg '''
-    if a is None or type(a) == bool:
+    if a is None or isinstance(a, bool):
         return a
     if isinstance(a, string_types):
         a = a.lower()
-    if a in ['yes', 'on', '1', 'true', 1]:
+    if a in ('yes', 'on', '1', 'true', 1):
         return True
-    else:
-        return False
+    return False
 
 def to_datetime(string, format="%Y-%d-%m %H:%M:%S"):
     return datetime.strptime(string, format)
@@ -401,10 +401,10 @@ def extract(item, container, morekeys=None):
 def failed(*a, **kw):
     ''' Test if task result yields failed '''
     item = a[0]
-    if type(item) != dict:
+    if not isinstance(item, MutableMapping):
         raise errors.AnsibleFilterError("|failed expects a dictionary")
-    rc = item.get('rc',0)
-    failed = item.get('failed',False)
+    rc = item.get('rc', 0)
+    failed = item.get('failed', False)
     if rc != 0 or failed:
         return True
     else:
@@ -417,13 +417,13 @@ def success(*a, **kw):
 def changed(*a, **kw):
     ''' Test if task result yields changed '''
     item = a[0]
-    if type(item) != dict:
+    if not isinstance(item, MutableMapping):
         raise errors.AnsibleFilterError("|changed expects a dictionary")
     if not 'changed' in item:
         changed = False
         if ('results' in item    # some modules return a 'results' key
-                and type(item['results']) == list
-                and type(item['results'][0]) == dict):
+                and isinstance(item['results'], MutableSequence)
+                and isinstance(item['results'][0], MutableMapping)):
             for result in item['results']:
                 changed = changed or result.get('changed', False)
     else:
@@ -433,7 +433,7 @@ def changed(*a, **kw):
 def skipped(*a, **kw):
     ''' Test if task result yields skipped '''
     item = a[0]
-    if type(item) != dict:
+    if not isinstance(item, MutableMapping):
         raise errors.AnsibleFilterError("|skipped expects a dictionary")
     skipped = item.get('skipped', False)
     return skipped

--- a/lib/ansible/plugins/lookup/csvfile.py
+++ b/lib/ansible/plugins/lookup/csvfile.py
@@ -19,6 +19,7 @@ __metaclass__ = type
 
 import codecs
 import csv
+from collections import MutableSequence
 
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
@@ -102,7 +103,7 @@ class LookupModule(LookupBase):
             lookupfile = self.find_file_in_search_path(variables, 'files', paramvals['file'])
             var = self.read_csv(lookupfile, key, paramvals['delimiter'], paramvals['encoding'], paramvals['default'], paramvals['col'])
             if var is not None:
-                if type(var) is list:
+                if isinstance(var, MutableSequence):
                     for v in var:
                         ret.append(v)
                 else:

--- a/lib/ansible/plugins/lookup/dig.py
+++ b/lib/ansible/plugins/lookup/dig.py
@@ -22,11 +22,12 @@ from ansible.plugins.lookup import LookupBase
 import socket
 
 try:
+    import dns.exception
+    import dns.name
     import dns.resolver
     import dns.reversename
     from dns.rdatatype import (A, AAAA, CNAME, DLV, DNAME, DNSKEY, DS, HINFO, LOC,
             MX, NAPTR, NS, NSEC3PARAM, PTR, RP, SOA, SPF, SRV, SSHFP, TLSA, TXT)
-    import dns.exception
     HAVE_DNS = True
 except ImportError:
     HAVE_DNS = False
@@ -70,7 +71,7 @@ def make_rdata_dict(rdata):
         for f in fields:
             val     = rdata.__getattribute__(f)
 
-            if type(val) == dns.name.Name:
+            if isinstance(val, dns.name.Name):
                 val = dns.name.Name.to_text(val)
 
             if rdata.rdtype == DLV and f == 'digest':

--- a/lib/ansible/plugins/lookup/ini.py
+++ b/lib/ansible/plugins/lookup/ini.py
@@ -17,9 +17,10 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from io import StringIO
 import os
 import re
+from collections import MutableSequence
+from io import StringIO
 
 from ansible.errors import AnsibleError
 from ansible.module_utils.six.moves import configparser
@@ -110,7 +111,7 @@ class LookupModule(LookupBase):
             else:
                 var = self.read_ini(path, key, paramvals['section'], paramvals['default'], paramvals['re'])
             if var is not None:
-                if type(var) is list:
+                if isinstance(var, MutableSequence):
                     for v in var:
                         ret.append(v)
                 else:

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -53,6 +53,9 @@ except ImportError:
 
 __all__ = ['StrategyBase']
 
+class StrategySentinel:
+    pass
+
 # TODO: this should probably be in the plugins/__init__.py, with
 #       a smarter mechanism to set all of the attributes based on
 #       the loaders created there
@@ -70,12 +73,12 @@ class SharedPluginLoaderObj:
         self.module_loader = module_loader
 
 
-_sentinel = object()
+_sentinel = StrategySentinel()
 def results_thread_main(strategy):
     while True:
         try:
             result = strategy._final_q.get()
-            if type(result) == object:
+            if isinstance(result, StrategySentinel):
                 break
             else:
                 strategy._results_lock.acquire()

--- a/lib/ansible/plugins/test/core.py
+++ b/lib/ansible/plugins/test/core.py
@@ -21,6 +21,7 @@ __metaclass__ = type
 
 import re
 import operator as py_operator
+from collections import MutableMapping, MutableSequence
 from distutils.version import LooseVersion, StrictVersion
 
 from ansible import errors
@@ -28,7 +29,7 @@ from ansible import errors
 def failed(*a, **kw):
     ''' Test if task result yields failed '''
     item = a[0]
-    if type(item) != dict:
+    if not isinstance(item, MutableMapping):
         raise errors.AnsibleFilterError("|failed expects a dictionary")
     rc = item.get('rc',0)
     failed = item.get('failed',False)
@@ -44,13 +45,13 @@ def success(*a, **kw):
 def changed(*a, **kw):
     ''' Test if task result yields changed '''
     item = a[0]
-    if type(item) != dict:
+    if not isinstance(item, MutableMapping):
         raise errors.AnsibleFilterError("|changed expects a dictionary")
     if not 'changed' in item:
         changed = False
         if ('results' in item    # some modules return a 'results' key
-                and type(item['results']) == list
-                and type(item['results'][0]) == dict):
+                and isinstance(item['results'], MutableSequence)
+                and isinstance(item['results'][0],  MutableMapping)):
             for result in item['results']:
                 changed = changed or result.get('changed', False)
     else:
@@ -60,7 +61,7 @@ def changed(*a, **kw):
 def skipped(*a, **kw):
     ''' Test if task result yields skipped '''
     item = a[0]
-    if type(item) != dict:
+    if not isinstance(item, MutableMapping):
         raise errors.AnsibleFilterError("|skipped expects a dictionary")
     skipped = item.get('skipped', False)
     return skipped

--- a/test/units/modules/cloud/openstack/test_os_server.py
+++ b/test/units/modules/cloud/openstack/test_os_server.py
@@ -4,6 +4,7 @@ import yaml
 import inspect
 import collections
 
+from ansible.module_utils.six import string_types
 from ansible.modules.cloud.openstack import os_server
 
 
@@ -26,7 +27,7 @@ def params_from_doc(func):
     for task in cfg:
         for module, params in task.items():
             for k, v in params.items():
-                if k in ['nics'] and type(v) == str:
+                if k in ['nics'] and isinstance(v, string_types):
                     params[k] = [v]
         task[module] = collections.defaultdict(str,
                                                params)


### PR DESCRIPTION
Also convert those checks to use abcs instead of dict and list.

##### SUMMARY
This is just a cleanup to make code more pythonic.

Using isinstance means that subclasses will work, not just the specific type (for instance, if we ever started passing in a defaultdict instead of a dict, the old code would break but the new code will work).

Using abcs means that ducktyping will also work: ie, if we passed in a UserDict instead of a dict, the new code would work where the old code would not.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Various

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
There are a few instances of type() still in the code.  I was not as comfortable knowing whether changing those would have non-obvious impacts on the code so I decided not to touch them in this round of cleanups.