### PR TITLE
Add examples in os_server module showing userdata

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -373,7 +373,7 @@ EXAMPLES = '''
         volumes:
         - photos
         - music
-        
+
 # Creates a new instance with provisioning userdata using Cloud-Init
 - name: launch a compute instance
   hosts: localhost

--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -373,6 +373,46 @@ EXAMPLES = '''
         volumes:
         - photos
         - music
+        
+# Creates a new instance with provisioning userdata using Cloud-Init
+- name: launch a compute instance
+  hosts: localhost
+  tasks:
+    - name: launch an instance
+      os_server:
+        name: vm1
+        state: present
+        image: "Ubuntu Server 14.04"
+        flavor: "P-1"
+        network: "Production"
+        userdata: |
+          #cloud-config
+          chpasswd:
+            list: |
+              ubuntu:{{ default_password }}
+            expire: False
+          packages:
+            - ansible
+          package_upgrade: true
+
+# Creates a new instance with provisioning userdata using Bash Scripts
+- name: launch a compute instance
+  hosts: localhost
+  tasks:
+    - name: launch an instance
+      os_server:
+        name: vm1
+        state: present
+        image: "Ubuntu Server 14.04"
+        flavor: "P-1"
+        network: "Production"
+        userdata: |
+          {%- raw -%}#!/bin/bash
+          echo "  up ip route add 10.0.0.0/8 via {% endraw -%}{{ intra_router }}{%- raw -%}" >> /etc/network/interfaces.d/eth0.conf
+          echo "  down ip route del 10.0.0.0/8" >> /etc/network/interfaces.d/eth0.conf
+          ifdown eth0 && ifup eth0
+          {% endraw %}
+
 '''
 
 try:


### PR DESCRIPTION
##### SUMMARY
Added an example using Bash and also using Cloud-init. Also, showing using {% raw %} and {% endraw %} to provide a pointer to those hitting similar issues to the ones I had.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
os_server (cloud -> openstack -> os_server)

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### ADDITIONAL INFORMATION
This is just a documentation change to show how to embed cloud-init and bash based userdata config lines, with both easy templates and mildly more complicated ones to show how you might include unusual config items on your resultant builds.
