### PR TITLE
Show multi-line messages in debug documentation

### DIFF
--- a/lib/ansible/modules/utilities/logic/debug.py
+++ b/lib/ansible/modules/utilities/logic/debug.py
@@ -79,5 +79,5 @@ EXAMPLES = '''
 - debug:
     msg:
       - "Provisioning based on YOUR_KEY which is: '{{ lookup('env', 'YOUR_KEY') }}"
-      - "It appears you can't do filters though - this '{{ lookup('env', 'YOUR_KEY')|default('all') }}' renders as ''"
+      - "These servers were built using the password of '{{ password_used }}'. Please retain this for later use."
 '''

--- a/lib/ansible/modules/utilities/logic/debug.py
+++ b/lib/ansible/modules/utilities/logic/debug.py
@@ -74,4 +74,10 @@ EXAMPLES = '''
   debug:
     var: hostvars[inventory_hostname]
     verbosity: 4
+
+# Example that prints two lines of messages, but only if there's an environment value set
+- debug:
+    msg:
+      - "Provisioning based on YOUR_KEY which is: '{{ lookup('env', 'YOUR_KEY') }}"
+      - "It appears you can't do filters though - this '{{ lookup('env', 'YOUR_KEY')|default('all') }}' renders as ''"
 '''


### PR DESCRIPTION
##### SUMMARY
* Add two-line entry
* Indicate that jinja2 filters are not applied here

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
debug task

##### ANSIBLE VERSION
```
ansible 2.2.1.0
```

##### ADDITIONAL INFORMATION
```
TASK [debug] **************************************
ok: [localhost] => {
    "msg": [
      "Provisioning based on YOUR_KEY which is: abc123",
      "It appears you can't do filters though - this '' renders as ''"
    ]
}
```
