### PR TITLE
Add AWS profile support to credstash lookup plugin

### DIFF
--- a/docs/docsite/rst/playbooks_lookups.rst
+++ b/docs/docsite/rst/playbooks_lookups.rst
@@ -310,6 +310,12 @@ If you use the context feature when putting your secret, you can get it by passi
       - name: "Test credstash lookup plugin -- get the password with a context defined here"
         debug: msg="{{ lookup('credstash', 'some-password', context=dict(app='my_app', environment='production')) }}"
 
+AWS profiles may also be specified with a ``profile`` parameter::
+
+      ---
+      - name: "Test credstash lookup plugin -- use an AWS profile"
+        debug: msg="{{ lookup('credstash', 'some-password', profile='alternate_profile') }}"
+
 If you're not using 2.0 yet, you can do something similar with the credstash tool and the pipe lookup (see below)::
 
     debug: msg="Poor man's credstash lookup! {{ lookup('pipe', 'credstash -r us-west-1 get my-other-password') }}"

--- a/lib/ansible/plugins/lookup/credstash.py
+++ b/lib/ansible/plugins/lookup/credstash.py
@@ -41,8 +41,9 @@ class LookupModule(LookupBase):
                 version = kwargs.pop('version', '')
                 region = kwargs.pop('region', None)
                 table = kwargs.pop('table', 'credential-store')
+                profile = kwargs.pop('profile', None)
                 val = credstash.getSecret(term, version, region, table,
-                                          context=kwargs)
+                                          context=kwargs, profile_name=profile)
             except credstash.ItemNotFound:
                 raise AnsibleError('Key {0} not found'.format(term))
             except Exception as e:


### PR DESCRIPTION
##### SUMMARY
This change adds the ability to specify a profile parameter for the `credstash` lookup module. The functionality is already built-in to the credstash module, the change exposes this functionality to Ansible as a lookup parameter.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
credstash lookup plugin

##### ANSIBLE VERSION
```
$ansible --version
ansible 2.4.0 (credstash_profile 685e8b2d54) last updated 2017/03/27 16:21:29 (GMT +000)
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Sep 15 2016, 22:37:39) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]

```


##### ADDITIONAL INFORMATION
The below output demonstrates the new parameter, with sanitized profile names. In this case, the default profile output matches that of profile1.

```
$ cat test.yml
---

- name: test
  hosts: localhost
  tasks:
    - name: Lookup locally
      debug: msg="{{ lookup('credstash', 'indicator') }}"

    - name: Lookup in profile1
      debug: msg="{{ lookup('credstash', 'indicator', profile='profile1-admin') }}"

    - name: Lookup in profile2
      debug: msg="{{ lookup('credstash', 'indicator', profile='profile2-admin') }}"
$ ansible-playbook test.yml
 [WARNING]: Host file not found: /etc/ansible/hosts

 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [test] ****************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] *****************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [Lookup locally] ******************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "profile1-pass"
}

TASK [Lookup in profile1] ******************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "profile1-pass"
}

TASK [Lookup in profile2] ****************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "profile2-pass"
}

PLAY RECAP *****************************************************************************************************************************************************************************************************************************
localhost                  : ok=4    changed=0    unreachable=0    failed=0
```
