### PR TITLE
meta: add 'reset_connection' to choices and sort them matching to description

### DIFF
--- a/lib/ansible/modules/utilities/helper/meta.py
+++ b/lib/ansible/modules/utilities/helper/meta.py
@@ -39,7 +39,7 @@ options:
         - "C(clear_host_errors) (added in 2.1) clears the failed state (if any) from hosts specified in the play's list of hosts."
         - "C(end_play) (added in 2.2) causes the play to end without failing the host(s). Note that this affects all hosts."
         - "C(reset_connection) (added in 2.3) interrupts a persistent connection (i.e. ssh + control persist)"
-    choices: ['noop', 'flush_handlers', 'refresh_inventory', 'clear_facts', 'clear_host_errors', 'end_play', 'reset_connection']
+    choices: ['flush_handlers', 'refresh_inventory', 'noop', 'clear_facts', 'clear_host_errors', 'end_play', 'reset_connection']
     required: true
 notes:
     - C(meta) is not really a module nor action_plugin as such it cannot be overwritten.


### PR DESCRIPTION
##### SUMMARY
add 'reset_connection' to choices and sort them matching to description

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
meta

##### ANSIBLE VERSION
```ansible 2.2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```