### PR TITLE
pkg5 with `latest` shouldn't ignore absent packages

### DIFF
--- a/lib/ansible/modules/packaging/os/pkg5.py
+++ b/lib/ansible/modules/packaging/os/pkg5.py
@@ -127,7 +127,9 @@ def ensure(module, state, packages, params):
             'subcommand': 'install',
         },
         'latest': {
-            'filter': lambda p: not is_latest(module, p),
+            'filter': lambda p: (
+                not is_installed(module, p) or not is_latest(module, p)
+            ),
             'subcommand': 'install',
         },
         'absent': {


### PR DESCRIPTION
##### SUMMARY
When the state is set to `latest` we should install absent packages, not just upgrade already-installed packages.

Fixes #22823.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
pkg5

##### ANSIBLE VERSION
```
ansible 2.2.1.0
```
