### PR TITLE
pkg returns 4 for "nothing to do"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@ Ansible Changes By Release
 
 #### New Inventory scripts:
 - lxd
+* In the `pkg5` module, return variable `rc` was renamed to `pkg_rc`.
 
 #### New: Tests
 - any : true if any element is true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,7 +156,6 @@ Ansible Changes By Release
 
 #### New Inventory scripts:
 - lxd
-* In the `pkg5` module, return variable `rc` was renamed to `pkg_rc`.
 
 #### New: Tests
 - any : true if any element is true

--- a/lib/ansible/modules/packaging/os/pkg5.py
+++ b/lib/ansible/modules/packaging/os/pkg5.py
@@ -154,12 +154,13 @@ def ensure(module, state, packages, params):
                 '-q', '--'
             ] + to_modify
         )
-        response['pkg_rc'] = rc
+        response['rc'] = rc
         response['results'].append(out)
         response['msg'] += err
         response['changed'] = True
         if rc == 4:
             response['changed'] = False
+            response['failed'] = False
         elif rc != 0:
             module.fail_json(**response)
 

--- a/lib/ansible/modules/packaging/os/pkg5.py
+++ b/lib/ansible/modules/packaging/os/pkg5.py
@@ -154,11 +154,13 @@ def ensure(module, state, packages, params):
                 '-q', '--'
             ] + to_modify
         )
-        response['rc'] = rc
+        response['pkg_rc'] = rc
         response['results'].append(out)
         response['msg'] += err
         response['changed'] = True
-        if rc != 0:
+        if rc == 4:
+            response['changed'] = False
+        elif rc != 0:
             module.fail_json(**response)
 
     module.exit_json(**response)


### PR DESCRIPTION
##### SUMMARY
When the `pkg` command returns 4, set `changed` to false.

We need to handle this because our own checking for whether there's anything to do returns false negatives in certain circumstances.

We need to rename the response `rc`, because that name is reserved by Ansible to indicate a failure if it is non-zero.

Fixes ansible/ansible#22781 and ansible/ansible-modules-extras#932.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`pkg5`

##### ANSIBLE VERSION
```
ansible 2.2.1.0
```

