### PR TITLE
Support check mode in pkg5 module.

### DIFF
--- a/lib/ansible/modules/packaging/os/pkg5.py
+++ b/lib/ansible/modules/packaging/os/pkg5.py
@@ -90,7 +90,8 @@ def main():
                 default=False,
                 aliases=['accept_licences', 'accept'],
             ),
-        )
+        ),
+        supports_check_mode=True,
     )
 
     params = module.params
@@ -136,6 +137,11 @@ def ensure(module, state, packages, params):
         },
     }
 
+    if module.check_mode:
+        dry_run = ['-n']
+    else:
+        dry_run = []
+
     if params['accept_licenses']:
         accept_licenses = ['--accept']
     else:
@@ -147,6 +153,7 @@ def ensure(module, state, packages, params):
             [
                 'pkg', behaviour[state]['subcommand']
             ]
+            + dry_run
             + accept_licenses
             + [
                 '-q', '--'


### PR DESCRIPTION
##### SUMMARY
The Solairs 11 `pkg` command has a "dry-run" mode.  Use that to provide Ansible's check mode.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
`pkg5`

##### ANSIBLE VERSION
```
ansible 2.2.1.0
```