### PR TITLE
Add delay evaluation parameter in datadog module

### DIFF
--- a/lib/ansible/modules/monitoring/datadog_monitor.py
+++ b/lib/ansible/modules/monitoring/datadog_monitor.py
@@ -118,7 +118,7 @@ options:
         description: ["The delay evaluation in seconds before a monitor can change status."]
         required: false
         default: null
-        version_added: "2.3"
+        version_added: "2.4"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/monitoring/datadog_monitor.py
+++ b/lib/ansible/modules/monitoring/datadog_monitor.py
@@ -114,6 +114,11 @@ options:
         required: false
         default: null
         version_added: "2.3"
+    delay_evaluation:
+        description: ["The delay evaluation in seconds before a monitor can change status."]
+        required: false
+        default: null
+        version_added: "2.3"
 '''
 
 EXAMPLES = '''
@@ -182,7 +187,8 @@ def main():
             tags=dict(required=False, type='list', default=None),
             locked=dict(required=False, default=False, type='bool'),
             require_full_window=dict(required=False, default=None, type='bool'),
-            id=dict(required=False)
+            id=dict(required=False),
+            delay_evaluation=dict(required=False, default=None, type='int')
         )
     )
 
@@ -277,7 +283,8 @@ def install_monitor(module):
         "escalation_message": module.params['escalation_message'],
         "notify_audit": module.boolean(module.params['notify_audit']),
         "locked": module.boolean(module.params['locked']),
-        "require_full_window" : module.params['require_full_window']
+        "require_full_window" : module.params['require_full_window'],
+        "delay_evaluation" : module.params['delay_evaluation']
     }
 
     if module.params['type'] == "service check":

--- a/lib/ansible/modules/monitoring/datadog_monitor.py
+++ b/lib/ansible/modules/monitoring/datadog_monitor.py
@@ -114,8 +114,8 @@ options:
         required: false
         default: null
         version_added: "2.3"
-    delay_evaluation:
-        description: ["The delay evaluation in seconds before a monitor can change status."]
+    evaluation_delay:
+        description: ["The evaluation delay in seconds before a monitor can change status."]
         required: false
         default: null
         version_added: "2.4"
@@ -188,7 +188,7 @@ def main():
             locked=dict(required=False, default=False, type='bool'),
             require_full_window=dict(required=False, default=None, type='bool'),
             id=dict(required=False),
-            delay_evaluation=dict(required=False, default=None, type='int')
+            evaluation_delay=dict(required=False, default=None, type='int')
         )
     )
 
@@ -284,7 +284,7 @@ def install_monitor(module):
         "notify_audit": module.boolean(module.params['notify_audit']),
         "locked": module.boolean(module.params['locked']),
         "require_full_window" : module.params['require_full_window'],
-        "delay_evaluation" : module.params['delay_evaluation']
+        "evaluation_delay" : module.params['evaluation_delay']
     }
 
     if module.params['type'] == "service check":


### PR DESCRIPTION
**ISSUE TYPE**
Feature Pull Request

**COMPONENT NAME**
datadog_monitor

**ANSIBLE VERSION**
ansible 2.3.0.0

**SUMMARY**

The reason for this change is to be capable of specifying delay evaluation in datadog monitor. Delay evaluation represents the minimum amount of seconds before an alert can be triggered. We needed this parameter for our datadog service checks. After discussing with datadog, they applied this new feature to their API. That's why, we want to share it since that parameter represents an important need for some cases.

Having this parameter allows you to trigger alerts from datadog only after a minimum amount of time. It will reduce false positive, notably in dev environment for example, when you need not to consider an alert if a service is down less than 15, 20 minutes etc... 

I'm contributing this in the hopes that it will be useful to others in the same situation, please let me know what you think? Thanks!