### PR TITLE
Fix Librato Annotation response code check

### DIFF
--- a/lib/ansible/modules/monitoring/librato_annotation.py
+++ b/lib/ansible/modules/monitoring/librato_annotation.py
@@ -138,7 +138,7 @@ def post_annotation(module):
     module.params['url_username'] = user
     module.params['url_password'] = api_key
     response, info = fetch_url(module, url, data=json_body, headers=headers)
-    if info['status'] != 200:
+    if info['status'] != 201:
         module.fail_json(msg="Request Failed", reason=e.reason)
     response = response.read()
     module.exit_json(changed=True, annotation=response)


### PR DESCRIPTION
##### SUMMARY
Check's for the correct HTTP response code when creating an annotation via the Librato API.

A `201 Created` is expected instead of `200 OK` per [the docs](https://www.librato.com/docs/api/#create-an-annotation)

Fixes ansible/ansible-modules-extras#2256

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`modules/monitoring/librato_annotation.py`

##### ANSIBLE VERSION
```
ansible 2.2.1.0
```