### PR TITLE
Add Virtuozzo distribution support

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -675,7 +675,7 @@ class Distribution(object):
     OS_FAMILY = dict(
         RedHat = 'RedHat', Fedora = 'RedHat', CentOS = 'RedHat', Scientific = 'RedHat',
         SLC = 'RedHat', Ascendos = 'RedHat', CloudLinux = 'RedHat', PSBM = 'RedHat',
-        OracleLinux = 'RedHat', OVS = 'RedHat', OEL = 'RedHat', Amazon = 'RedHat',
+        OracleLinux = 'RedHat', OVS = 'RedHat', OEL = 'RedHat', Amazon = 'RedHat', Virtuozzo = 'RedHat',
         XenServer = 'RedHat', Ubuntu = 'Debian', Debian = 'Debian', Raspbian = 'Debian', Slackware = 'Slackware', SLES = 'Suse',
         SLED = 'Suse', openSUSE = 'Suse', openSUSE_Tumbleweed = 'Suse', SuSE = 'Suse', SLES_SAP = 'Suse', SUSE_LINUX = 'Suse', Gentoo = 'Gentoo',
         Funtoo = 'Gentoo', Archlinux = 'Archlinux', Manjaro = 'Archlinux', Mandriva = 'Mandrake', Mandrake = 'Mandrake', Altlinux = 'Altlinux', SMGL = 'SMGL',

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -127,6 +127,35 @@ TESTSETS = [
             }
         },
     {
+        "name": "Virtuozzo 7.3",
+        "platform.dist": [
+            "redhat",
+            "7.3",
+            ""
+            ],
+        "input": {
+            "/etc/redhat-release": "Virtuozzo Linux release 7.3\n",
+            "/etc/os-release": ("NAME=\"Virtuozzo\"\n"
+                                "VERSION=\"7.0.3\"\n"
+                                "ID=\"virtuozzo\"\n"
+                                "ID_LIKE=\"rhel fedora\"\n"
+                                "VERSION_ID=\"7\"\n"
+                                "PRETTY_NAME=\"Virtuozzo release 7.0.3\"\n"
+                                "ANSI_COLOR=\"0;31\"\n"
+                                "CPE_NAME=\"cpe:/o:virtuozzoproject:vz:7\"\n"
+                                "HOME_URL=\"http://www.virtuozzo.com\"\n"
+                                "BUG_REPORT_URL=\"https://bugs.openvz.org/\"\n"),
+            "/etc/system-release": "Virtuozzo release 7.0.3 (640)\n"
+            },
+        "result": {
+            "distribution_release": "NA",
+            "distribution": "Virtuozzo",
+            "distribution_major_version": "7",
+            "os_family": "RedHat",
+            "distribution_version": "7.3"
+            }
+        },
+    {
         "name" : "openSUSE Leap 42.1",
         "input": {
             "/etc/os-release":


### PR DESCRIPTION
##### SUMMARY
Add Virtuozzo distribution support.
Virtuozzo Linux is based on CentOS sources. Thus OS family
should be recognized as 'RedHat'.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module_utils/facts.py

##### ANSIBLE VERSION
ansible 2.2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

##### ADDITIONAL INFORMATION
Before change: ansible_os_family = 'Virtuozzo'
After change: ansible_os_family = 'RedHat'
