### PR TITLE
Fixes #23028, requirements for seboolean module

### DIFF
--- a/lib/ansible/modules/system/seboolean.py
+++ b/lib/ansible/modules/system/seboolean.py
@@ -49,7 +49,7 @@ options:
     choices: [ 'yes', 'no' ]
 notes:
    - Not tested on any debian based system
-requirements: [ ]
+requirements: [ libselinux-python, libsemanage-python ]
 author: "Stephen Fromm (@sfromm)"
 '''
 


### PR DESCRIPTION
##### SUMMARY

cf. [#23028](https://github.com/ansible/ansible/issues/23028); adds `libsemanage-python` as a requirement (in the documentation) for the `seboolean` module.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

`seboolean` module

##### ANSIBLE VERSION

```
ansible 2.2.1.0
```
##### ADDITIONAL INFORMATION

**N.B.:** No changes to actual executable code, only the commented that used for generating module documentation.