### PR TITLE
Replaced deprecated option autosubscribe with the new one called auto…

### DIFF
--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -124,7 +124,7 @@ options:
             -  Pull the latest subscription data from the server
         required: False
         default: False
-        version_added: "2.3"
+        version_added: "2.4"
 '''
 
 EXAMPLES = '''
@@ -454,6 +454,7 @@ class Rhsm(RegistrationBase):
     def refresh(self):
         args = [SUBMAN_CMD, 'refresh']
         rc, stderr, stdout = self.module.run_command(args, check_rc=True)
+
 
 class RhsmPool(object):
     '''

--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -119,6 +119,12 @@ options:
         required: False
         default: False
         version_added: "2.2"
+    refresh:
+        description:
+            -  Pull the latest subscription data from the server
+        required: False
+        default: False
+        version_added: "2.3"
 '''
 
 EXAMPLES = '''
@@ -313,7 +319,7 @@ class Rhsm(RegistrationBase):
             args.extend(['--org', org_id])
         else:
             if autosubscribe:
-                args.append('--autosubscribe')
+                args.append('--auto-attach')
             if username:
                 args.extend(['--username', username])
             if password:
@@ -445,6 +451,9 @@ class Rhsm(RegistrationBase):
         return {'changed': changed, 'subscribed_pool_ids': subscribed_pool_ids,
                 'unsubscribed_serials': serials}
 
+    def refresh(self):
+        args = [SUBMAN_CMD, 'refresh']
+        rc, stderr, stdout = self.module.run_command(args, check_rc=True)
 
 class RhsmPool(object):
     '''
@@ -577,6 +586,8 @@ def main():
                              required=False),
             force_register=dict(default=False,
                                 type='bool'),
+            refresh=dict(default=False,
+                         type='bool'),
         ),
         required_together=[['username', 'password'], ['activationkey', 'org_id']],
         mutually_exclusive=[['username', 'activationkey']],
@@ -599,6 +610,7 @@ def main():
     consumer_name = module.params["consumer_name"]
     consumer_id = module.params["consumer_id"]
     force_register = module.params["force_register"]
+    refresh = module.params["refresh"]
 
     global SUBMAN_CMD
     SUBMAN_CMD = module.get_bin_path('subscription-manager', True)
@@ -626,6 +638,8 @@ def main():
                               consumer_type, consumer_name, consumer_id, force_register,
                               environment, rhsm_baseurl, server_insecure)
                 subscribed_pool_ids = rhsm.subscribe(pool)
+                if refresh:
+                    rhsm.refresh()
             except Exception:
                 e = get_exception()
                 module.fail_json(msg="Failed to register with '%s': %s" % (server_hostname, e))


### PR DESCRIPTION
##### SUMMARY

Fixes #23014 by replacing deprecated option "--autosubscribe" with the new one called "--auto-attach". Pull requests also holds a refresh option for refreshing subscription after adding a new one.

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME
redhat_subscription

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
