### PR TITLE
module name incorrect

### DIFF
--- a/lib/ansible/modules/windows/win_domain.py
+++ b/lib/ansible/modules/windows/win_domain.py
@@ -54,7 +54,7 @@ reboot_required:
 
 EXAMPLES=r'''
 # ensure the named domain is reachable from the target host; if not, create the domain in a new forest residing on the target host
-- win_domain_controller:
+- win_domain:
     dns_domain_name: ansible.vagrant
     safe_mode_password: password123!
 


### PR DESCRIPTION
module name incorrect in example

##### SUMMARY
small docs issue

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
win_domain

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel e084e8809e) last updated 2017/03/24 11:58:45 (GMT +100)
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]

```


##### ADDITIONAL INFORMATION
Just a small docs issue
