### PR TITLE
win_chocolatey: Fix state=latest when absent

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -247,7 +247,7 @@ Function Choco-Install
         [int]$timeout
     )
 
-    if ((Choco-IsInstalled $package) -and -not $force)
+    if (Choco-IsInstalled $package)
     {
         if ($upgrade)
         {
@@ -258,8 +258,7 @@ Function Choco-Install
 
             return
         }
-
-        if (-not $force)
+        elseif (-not $force)
         {
             return
         }
@@ -385,16 +384,9 @@ Try
 {
     Chocolatey-Install-Upgrade
 
-    if ($state -eq "present")
+    if ($state -eq "present" -or $state -eq "latest")
     {
         Choco-Install -package $package -version $version -source $source -force $force `
-            -installargs $installargs -packageparams $packageparams `
-            -allowemptychecksums $allowemptychecksums -ignorechecksums $ignorechecksums `
-            -ignoredependencies $ignoredependencies -timeout $timeout
-    }
-    elseif ($state -eq "latest")
-    {
-        Choco-Upgrade -package $package -version $version -source $source -force $force `
             -installargs $installargs -packageparams $packageparams `
             -allowemptychecksums $allowemptychecksums -ignorechecksums $ignorechecksums `
             -ignoredependencies $ignoredependencies -timeout $timeout


### PR DESCRIPTION
##### SUMMARY
When using state=latest with the package not being installled, Ansible complains that the package is not installed and fails the task.
Whereas the expected behaviour is to install the package when it is missing.

This PR fixes this behaviour.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_chocolatey

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3