### PR TITLE
ec2_key: python3 bytes fix - fixes #23022

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_key.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_key.py
@@ -117,6 +117,7 @@ try:
 except ImportError:
     HAS_BOTO = False
 
+from ansible.module_utils._text import to_bytes
 import random
 import string
 
@@ -226,7 +227,7 @@ def main():
             if not module.check_mode:
                 if key_material:
                     '''We are providing the key, need to import'''
-                    key = ec2.import_key_pair(name, key_material)
+                    key = ec2.import_key_pair(name, to_bytes(key_material))
                 else:
                     '''
                     No material provided, let AWS handle the key creation and


### PR DESCRIPTION
##### SUMMARY
Fixes #23022. Imported to_bytes from module_utils and ensured key_material isn't a string. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_key.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (ec2-key-py3fix 77b2b2b2b4) last updated 2017/03/28 15:05:53 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```