### PR TITLE
ec2: fix instids and res_list being referenced before assigned - fixes #22692

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -1227,12 +1227,15 @@ def create_instances(module, ec2, vpc, override_count=None):
                 # Now we have to do the intermediate waiting
                 if wait:
                     instids = await_spot_requests(module, ec2, res, count)
+                else:
+                    instids = []
         except boto.exception.BotoServerError as e:
             module.fail_json(msg="Instance creation failed => %s: %s" % (e.error_code, e.error_message))
 
         # wait here until the instances are up
         num_running = 0
         wait_timeout = time.time() + wait_timeout
+        res_list = None
         while wait_timeout > time.time() and num_running < len(instids):
             try:
                 res_list = ec2.get_all_instances(instids)
@@ -1261,7 +1264,7 @@ def create_instances(module, ec2, vpc, override_count=None):
             module.fail_json(msg="wait for instances running timeout on %s" % time.asctime())
 
         # We do this after the loop ends so that we end up with one list
-        for res in res_list:
+        for res in res_list or ():
             running_instances.extend(res.instances)
 
         # Enabled by default by AWS

--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -1235,7 +1235,7 @@ def create_instances(module, ec2, vpc, override_count=None):
         # wait here until the instances are up
         num_running = 0
         wait_timeout = time.time() + wait_timeout
-        res_list = None
+        res_list = ()
         while wait_timeout > time.time() and num_running < len(instids):
             try:
                 res_list = ec2.get_all_instances(instids)
@@ -1264,7 +1264,7 @@ def create_instances(module, ec2, vpc, override_count=None):
             module.fail_json(msg="wait for instances running timeout on %s" % time.asctime())
 
         # We do this after the loop ends so that we end up with one list
-        for res in res_list or ():
+        for res in res_list:
             running_instances.extend(res.instances)
 
         # Enabled by default by AWS
@@ -1278,7 +1278,7 @@ def create_instances(module, ec2, vpc, override_count=None):
                 inst.modify_attribute('disableApiTermination', True)
 
         # Leave this as late as possible to try and avoid InvalidInstanceID.NotFound
-        if instance_tags:
+        if instance_tags and instids:
             try:
                 ec2.create_tags(instids, instance_tags)
             except boto.exception.EC2ResponseError as e:


### PR DESCRIPTION
##### SUMMARY
Fixes #22692.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (ec2-spot-instance-fix a099c6e310) last updated 2017/03/28 15:56:19 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```
