### PR TITLE
Fix synchronize tests for the updated quoting change between action and module

### DIFF
--- a/test/units/plugins/action/fixtures/synchronize/basic_become/meta.yaml
+++ b/test/units/plugins/action/fixtures/synchronize/basic_become/meta.yaml
@@ -25,7 +25,7 @@ asserts:
     - "self.execute_called"
     - "self.final_module_args['_local_rsync_path'] == 'rsync'"
     # this is a crucial aspect of this scenario ...
-    - "self.final_module_args['rsync_path'] == '\"sudo rsync\"'"
+    - "self.final_module_args['rsync_path'] == 'sudo rsync'"
     - "self.final_module_args['src'] == '/tmp/deleteme'"
     - "self.final_module_args['dest'] == 'root@el6host:/tmp/deleteme'"
     - "self.task.become == True"

--- a/test/units/plugins/action/fixtures/synchronize/basic_become/task_args_out.json
+++ b/test/units/plugins/action/fixtures/synchronize/basic_become/task_args_out.json
@@ -1,6 +1,6 @@
 {
   "dest": "root@el6host:/tmp/deleteme", 
   "src": "/tmp/deleteme", 
-  "rsync_path": "\"sudo rsync\"", 
+  "rsync_path": "sudo rsync", 
   "_local_rsync_path": "rsync"
 }

--- a/test/units/plugins/action/fixtures/synchronize/basic_become_cli/meta.yaml
+++ b/test/units/plugins/action/fixtures/synchronize/basic_become_cli/meta.yaml
@@ -25,7 +25,7 @@ asserts:
     - "self.execute_called"
     - "self.final_module_args['_local_rsync_path'] == 'rsync'"
     # this is a crucial aspect of this scenario ...
-    - "self.final_module_args['rsync_path'] == '\"sudo rsync\"'"
+    - "self.final_module_args['rsync_path'] == 'sudo rsync'"
     - "self.final_module_args['src'] == '/tmp/deleteme'"
     - "self.final_module_args['dest'] == 'root@el6host:/tmp/deleteme'"
     - "self.task.become == None"

--- a/test/units/plugins/action/fixtures/synchronize/basic_become_cli/task_args_out.json
+++ b/test/units/plugins/action/fixtures/synchronize/basic_become_cli/task_args_out.json
@@ -1,6 +1,6 @@
 {
   "dest": "root@el6host:/tmp/deleteme", 
   "src": "/tmp/deleteme", 
-  "rsync_path": "\"sudo rsync\"", 
+  "rsync_path": "sudo rsync", 
   "_local_rsync_path": "rsync"
 }

--- a/test/units/plugins/action/fixtures/synchronize/delegate_remote_su/task_args_out.json
+++ b/test/units/plugins/action/fixtures/synchronize/delegate_remote_su/task_args_out.json
@@ -1,6 +1,6 @@
 {
   "dest": "el6host:/tmp/deleteme", 
   "src": "/tmp/deleteme", 
-  "rsync_path": "\"sudo rsync\"", 
+  "rsync_path": "sudo rsync", 
   "_local_rsync_path": "rsync"
 }


### PR DESCRIPTION
##### SUMMARY
This commit: https://github.com/ansible/ansible/commit/d3a1aea7c5ee37b11f9798618d9ae83beb568d83  moved quoting from the action plugin to the module.  Need to update test expectations to match.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
synchronize unit tests

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.3
```
