### PR TITLE
Updates lldp module example to use ifname instead of ifalias

### DIFF
--- a/lib/ansible/modules/net_tools/lldp.py
+++ b/lib/ansible/modules/net_tools/lldp.py
@@ -40,7 +40,7 @@ EXAMPLES = '''
 
  - name: Print each switch/port
    debug:
-    msg: "{{ lldp[item]['chassis']['name'] }} / {{ lldp[item]['port']['ifalias'] }}"
+    msg: "{{ lldp[item]['chassis']['name'] }} / {{ lldp[item]['port']['ifname'] }}"
    with_items: "{{ lldp.keys() }}"
 
 # TASK: [Print each switch/port] ***********************************************************


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
LLDP example attempts to use ifalias which does not exist.  Uses ifname instead.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
network/lldp.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.2.0
  config file = /opt/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
fatal: [localhost]: FAILED! => {
    "failed": true,
    "msg": "the field 'args' has an invalid value, which appears to include a variable that is undefined. The error was: 'dict object' has no attribute 'ifalias'\n\nThe error appears to have been in '/opt/ansible/roles/discover/tasks/main.yml': line 6, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Print each switch and port\n  ^ here\n"
}
```
