### PR TITLE
win_domain_controller: doc fix. correct examples to match  _password module parameter names

### DIFF
--- a/lib/ansible/modules/windows/win_domain_controller.py
+++ b/lib/ansible/modules/windows/win_domain_controller.py
@@ -75,8 +75,8 @@ EXAMPLES=r'''
   - win_domain_controller:
       dns_domain_name: ansible.vagrant
       domain_admin_user: testguy@ansible.vagrant
-      domain_admin_pass: password123!
-      safe_mode_pass: password123!
+      domain_admin_password: password123!
+      safe_mode_password: password123!
       state: domain_controller
       log_path: c:\ansible_win_domain_controller.txt
 
@@ -91,8 +91,8 @@ EXAMPLES=r'''
   tasks:
   - win_domain_controller:
       domain_admin_user: testguy@ansible.vagrant
-      domain_admin_pass: password123!
-      local_admin_pass: password123!
+      domain_admin_password: password123!
+      local_admin_password: password123!
       state: member_server
       log_path: c:\ansible_win_domain_controller.txt
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Documentation fix
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #22871 Module wants '_password' parameter names, but examples were showing '_pass'.
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_domain_controller
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (win_domain_controller_docfix 7899d8f076) last updated 2017/03/29 08:12:19 (GMT +100)
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.6 (default, Jun 22 2015, 17:58:13) [GCC 4.8.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
