### PR TITLE
Add aliases file to nxos_interface integration target

### DIFF
--- a/test/integration/targets/nxos_interface/aliases
+++ b/test/integration/targets/nxos_interface/aliases
@@ -1,0 +1,1 @@
+network/ci


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add aliases file to nxos_interface integration target
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME

nxos_interface

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (add_aliases_file_to_nxos_interface f5449fdaa5) last updated 2017/03/29 12:40:09 (GMT +200)
```

