### PR TITLE
paramiko_ssh: fix crash upon pass prompt in py3

### DIFF
--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -302,7 +302,7 @@ class Connection(ConnectionBase):
                     chunk = chan.recv(bufsize)
                     display.debug("chunk is: %s" % chunk)
                     if not chunk:
-                        if 'unknown user' in become_output:
+                        if b'unknown user' in become_output:
                             raise AnsibleError( 'user %s does not exist' % self._play_context.become_user)
                         else:
                             break


### PR DESCRIPTION
##### SUMMARY
The pass prompt expects an answer and compares a `str` to a binary buffer, thus crashing.

It's an obvious fix to help transitioning towards Python3 and hopes it does not need a specific test.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
connections/paramiko_ssh

##### ANSIBLE VERSION
```
ansible 2.2.2.0
  config file = /home/vperron/dev/integration/ansible.cfg
  configured module search path = Default w/o overrides

```

##### ADDITIONAL INFORMATION
Crashed whenever I tried applying the simplest playbook with a become rule and the Paramiko transport.
