### PR TITLE
Fixes #21536: Allowing the ability to pass aws session paramters to credstash lookup

### DIFF
--- a/lib/ansible/plugins/lookup/credstash.py
+++ b/lib/ansible/plugins/lookup/credstash.py
@@ -43,10 +43,10 @@ class LookupModule(LookupBase):
                 version = kwargs.pop('version', '')
                 region = kwargs.pop('region', None)
                 table = kwargs.pop('table', 'credential-store')
-                profile_name = os.getenv('AWS_PROFILE', kwargs.pop('profile_name', None))
-                aws_access_key_id = os.getenv('AWS_ACCESS_KEY_ID', kwargs.pop('aws_access_key_id', None))
-                aws_secret_access_key = os.getenv('AWS_SECRET_ACCESS_KEY', kwargs.pop('aws_secret_access_key', None))
-                aws_session_token = os.getenv('AWS_SESSION_TOKEN', kwargs.pop('aws_session_token', None))
+                profile_name = kwargs.pop('profile_name', os.getenv('AWS_PROFILE', None))
+                aws_access_key_id = kwargs.pop('aws_access_key_id', os.getenv('AWS_ACCESS_KEY_ID', None))
+                aws_secret_access_key = kwargs.pop('aws_secret_access_key', os.getenv('AWS_SECRET_ACCESS_KEY', None))
+                aws_session_token = kwargs.pop('aws_session_token', os.getenv('AWS_SESSION_TOKEN', None))
                 kwargs_pass = {'profile_name': profile_name, 'aws_access_key_id': aws_access_key_id,
                                'aws_secret_access_key': aws_secret_access_key, 'aws_session_token': aws_session_token}
                 val = credstash.getSecret(term, version, region, table,

--- a/lib/ansible/plugins/lookup/credstash.py
+++ b/lib/ansible/plugins/lookup/credstash.py
@@ -17,6 +17,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import os
+
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 
@@ -41,10 +43,10 @@ class LookupModule(LookupBase):
                 version = kwargs.pop('version', '')
                 region = kwargs.pop('region', None)
                 table = kwargs.pop('table', 'credential-store')
-                profile_name = kwargs.pop('profile_name', None)
-                aws_access_key_id = kwargs.pop('aws_access_key_id', None)
-                aws_secret_access_key = kwargs.pop('aws_secret_access_key', None)
-                aws_session_token = kwargs.pop('aws_session_token', None)
+                profile_name = os.getenv('AWS_PROFILE', kwargs.pop('profile_name', None))
+                aws_access_key_id = os.getenv('AWS_ACCESS_KEY_ID', kwargs.pop('aws_access_key_id', None))
+                aws_secret_access_key = os.getenv('AWS_SECRET_ACCESS_KEY', kwargs.pop('aws_secret_access_key', None))
+                aws_session_token = os.getenv('AWS_SESSION_TOKEN', kwargs.pop('aws_session_token', None))
                 kwargs_pass = {'profile_name': profile_name, 'aws_access_key_id': aws_access_key_id,
                                'aws_secret_access_key': aws_secret_access_key, 'aws_session_token': aws_session_token}
                 val = credstash.getSecret(term, version, region, table,

--- a/lib/ansible/plugins/lookup/credstash.py
+++ b/lib/ansible/plugins/lookup/credstash.py
@@ -41,8 +41,14 @@ class LookupModule(LookupBase):
                 version = kwargs.pop('version', '')
                 region = kwargs.pop('region', None)
                 table = kwargs.pop('table', 'credential-store')
+                profile_name = kwargs.pop('profile_name', None)
+                aws_access_key_id = kwargs.pop('aws_access_key_id', None)
+                aws_secret_access_key = kwargs.pop('aws_secret_access_key', None)
+                aws_session_token = kwargs.pop('aws_session_token', None)
+                kwargs_pass = {'profile_name': profile_name, 'aws_access_key_id': aws_access_key_id,
+                               'aws_secret_access_key': aws_secret_access_key, 'aws_session_token': aws_session_token}
                 val = credstash.getSecret(term, version, region, table,
-                                          context=kwargs)
+                                          context=kwargs, **kwargs_pass)
             except credstash.ItemNotFound:
                 raise AnsibleError('Key {0} not found'.format(term))
             except Exception as e:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
#21536
in credstash.getSecret calls get_session(**kwargs) which is looking for 
```
def get_session(aws_access_key_id=None, aws_secret_access_key=None,
                aws_session_token=None, profile_name=None):
```
So I extracted the arguments out of the **kwargs if they exist, pass them into kwargs_pass and add it to credstash.getSecret
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
plugins/lookup/credstash

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.2.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
