### PR TITLE
Split on newlines when searching for become prompt

### DIFF
--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -253,10 +253,11 @@ class ConnectionBase(with_metaclass(ABCMeta, object)):
         if self._play_context.prompt is None:
             return False
         elif isinstance(self._play_context.prompt, string_types):
-            b_prompt = to_bytes(self._play_context.prompt)
-            return b_prompt in b_output
-        else:
-            return self._play_context.prompt(b_output)
+            b_prompt = to_bytes(self._play_context.prompt).strip()
+            b_lines = b_output.splitlines(True)
+            if not b_lines:
+                return False
+            return b_lines[-1].strip().endswith(b_prompt) or b_lines[0].strip().endswith(b_prompt)
 
     def check_incorrect_password(self, b_output):
         b_incorrect_password = to_bytes(gettext.dgettext(self._play_context.become_method, C.BECOME_ERROR_STRINGS[self._play_context.become_method]))


### PR DESCRIPTION
The fix for leading junk in sudo output: fee6e29 causes problems with
ssh + sudo.  On the initial connection using ControlPersist, the output
that we scan for the prompt contains both the command we're sending to
configure the prompt and the prompt itself.  The code in fee6e29 ends up
sending the password when it sees the line configuring the prompt which
is too early.

Switch to a version that splits on lines and then checks whether the
first or last line starts with the prompt to decide if it's time to send
the password.

Fixes #23054
References #20858

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
plugins/connection/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel, 2.3, 2.2.2
```