### PR TITLE
win_domain: fixes - changed parameter name from forest_root_dns_domain to dns_domain_name…

### DIFF
--- a/lib/ansible/modules/windows/win_domain.ps1
+++ b/lib/ansible/modules/windows/win_domain.ps1
@@ -37,7 +37,7 @@ Function Ensure-Prereqs {
 
 $parsed_args = Parse-Args $args -supports_check_mode $true
 $check_mode = Get-AnsibleParam $parsed_args "_ansible_check_mode" -default $false
-$forest_root_dns_domain = Get-AnsibleParam $parsed_args "forest_root_dns_domain" -failifempty $true
+$dns_domain_name = Get-AnsibleParam $parsed_args "dns_domain_name" -failifempty $true
 $safe_mode_admin_password = Get-AnsibleParam $parsed_args "safe_mode_password" -failifempty $true
 
 $forest = $null
@@ -54,7 +54,7 @@ $result = @{changed=$false; reboot_required=$false}
 Ensure-Prereqs
 
 Try {
-    $forest = Get-ADForest $forest_root_dns_domain -ErrorAction SilentlyContinue
+    $forest = Get-ADForest $dns_domain_name -ErrorAction SilentlyContinue
 }
 Catch { }
 
@@ -65,7 +65,7 @@ If(-not $forest) {
         $sm_cred = ConvertTo-SecureString $safe_mode_admin_password -AsPlainText -Force
 
         $install_forest_args = @{
-            DomainName=$forest_root_dns_domain;
+            DomainName=$dns_domain_name;
             SafeModeAdministratorPassword=$sm_cred;
             Confirm=$false;
             SkipPreChecks=$true;

--- a/lib/ansible/modules/windows/win_domain.py
+++ b/lib/ansible/modules/windows/win_domain.py
@@ -54,7 +54,7 @@ reboot_required:
 
 EXAMPLES=r'''
 # ensure the named domain is reachable from the target host; if not, create the domain in a new forest residing on the target host
-- win_domain_controller:
+- win_domain:
     dns_domain_name: ansible.vagrant
     safe_mode_password: password123!
 


### PR DESCRIPTION
… (to match documentation and other win_domain* modules) and fix example which has win_domain_controller instead of win_domain for module name.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixed parameter name to match the documentation (and other win_domain modules)
also fixed the example so that the correct module name was used).

In theory this could break any playbooks created in the short time since win_domain was merged, but since this was in 2.3 and the module is 'preview' module parameters aren't guaranteed to be stable.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
no actual bug report but I mentioned this in a comment on #22871
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_domain
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (win_domain_param_and_doc_fixes 51182e599b) last updated 2017/03/29 17:34:28 (GMT +100)
  config file =
  configured module search path = [u'/home/jon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  python version = 2.7.6 (default, Jun 22 2015, 17:58:13) [GCC 4.8.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
