### PR TITLE
restores pre 2.3 behavior with respects to keys

### DIFF
--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -26,6 +26,7 @@ import datetime
 import traceback
 import logging
 
+from ansible import constants as C
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils.six.moves import StringIO
 from ansible.plugins import terminal_loader
@@ -74,6 +75,10 @@ class Connection(_Connection):
 
     def _connect(self):
         """Connections to the device and sets the terminal type"""
+
+        if self._play_context.password and not self._play_context.private_key_file:
+            C.PARAMIKO_LOOK_FOR_KEYS = False
+
         super(Connection, self)._connect()
 
         display.display('ssh connection done, setting terminal', log_only=True)


### PR DESCRIPTION
This removes the requirement to configure look_for_keys=False and
restores the behavior to disable key lookup if no key was provided.
