### PR TITLE
Do not re.search show configuration stdout if empty

### DIFF
--- a/lib/ansible/modules/network/ios/ios_banner.py
+++ b/lib/ansible/modules/network/ios/ios_banner.py
@@ -113,7 +113,10 @@ def map_config_to_obj(module):
         rc, out, err = exec_command(module,
                                     'show running-config | begin banner %s'
                                     % module.params['banner'])
-        output = re.search('\^C(.*)\^C', out, re.S).group(1).strip()
+        if out:
+            output = re.search('\^C(.*)\^C', out, re.S).group(1).strip()
+        else:
+            output = None
     obj = {'banner': module.params['banner'], 'state': 'absent'}
     if output:
         obj['text'] = output


### PR DESCRIPTION
##### SUMMARY

If the banner is not set, the stdout of 'show configuration | begin banner <banner>'
returns empty string thus the re.search raises an exception.

Fixes #22216

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE Request

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ios_banner

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (fix_ios_banner_show_configuration_if_no_banner_set 285186c6d7) last updated 2017/03/29 22:13:40 (GMT +200)
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
