### PR TITLE
Fixes docker_container idempotency

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1288,10 +1288,19 @@ class Container(DockerBaseClass):
                         set_a = set(getattr(self.parameters, key))
                         set_b = set(value)
                         match = (set_a <= set_b)
+                elif isinstance(getattr(self.parameters, key), list) and not len(getattr(self.parameters, key)) \
+                        and value is None:
+                    # an empty list and None are ==
+                    continue
                 elif isinstance(getattr(self.parameters, key), dict) and isinstance(value, dict):
                     # compare two dicts
                     self.log("comparing two dicts: %s" % key)
                     match = self._compare_dicts(getattr(self.parameters, key), value)
+
+                elif isinstance(getattr(self.parameters, key), dict) and \
+                        not len(list(getattr(self.parameters, key).keys())) and value is None:
+                    # an empty dict and None are ==
+                    continue
                 else:
                     # primitive compare
                     self.log("primitive compare: %s" % key)
@@ -1689,7 +1698,7 @@ class ContainerManager(DockerBaseClass):
     def present(self, state):
         container = self._get_container(self.parameters.name)
         image = self._get_image()
-
+        self.log(image, pretty_print=True)
         if not container.exists:
             # New container
             self.log('No container found')


### PR DESCRIPTION
##### SUMMARY
Start a container: 

```
$ docker run -d --name hello centos:7 sleep 1d
```

Now run the following in a playbook:
```
docker_container:
  name: hello
  image: centos:7
  command:
    - sleep
    - 1d
```

The above should not change anything. However, it thinks it detects a difference between the module parameters and the running container's configuration, and so it removes the running container, and recreates it.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker_container.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel fe6f3017c2) last updated 2017/03/29 16:35:11 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/chouseknecht/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  python version = 2.7.12 (default, Oct 11 2016, 05:24:00) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```

##### ADDITIONAL INFORMATION
Test playbook:

```
- name: Prove Jag is crazies
  hosts: localhost
  connection: local
  gather_facts: no
  tasks:

     - name: Remove hello
       command: docker rm --force hello
       ignore_errors: yes

     - name: Create container hello
       command: docker run -d --name hello centos:7 sleep 1d

     - name: Show the running container
       command: docker ps
       register: output

     - name: Show it
       debug: var=output.stdout_lines

     - name: Should be idempotent
       docker_container:
         name: hello
         image: centos:7
         command:
         - sleep
         - 1d
         debug: yes
       register: output

     - name: show it
       debug: var=output

     - name: Assert no change
       assert:
        that:
          - not output.changed
```