### PR TITLE
elb_lb: import traceback before trying to use

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
@@ -404,7 +404,7 @@ except ImportError:
 
 import time
 import random
-
+import traceback
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import ec2_argument_spec, connect_to_aws, AnsibleAWSError
 from ansible.module_utils.ec2 import get_aws_connection_info


### PR DESCRIPTION
##### SUMMARY
elb_lb using exception=traceback.format_exc() in exception handling but never importing traceback.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_elb_lb.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (elb_lb_traceback b72604dfdc) last updated 2017/03/29 16:50:54 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
```