### PR TITLE
Fix ios_config return on python 2.4

### DIFF
--- a/lib/ansible/module_utils/ios.py
+++ b/lib/ansible/module_utils/ios.py
@@ -58,7 +58,10 @@ def get_defaults_flag(module):
         if line:
             commands.add(line.strip().split()[0])
 
-    return 'all' if 'all' in commands else 'full'
+    if 'all' in commands:
+        return 'all'
+    else:
+        return 'full'
 
 def get_config(module, flags=[]):
     cmd = 'show running-config '


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix ios_config return on python 2.4
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ios_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
