### PR TITLE
win_chocolatey: Perform exact presence check

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -100,7 +100,7 @@ Function Choco-IsInstalled
         [string]$package
     )
 
-    $cmd = "$executable list --local-only $package"
+    $cmd = "$executable list --local-only --exact $package"
     $output = invoke-expression $cmd
 
     $result.rc = $LastExitCode
@@ -249,7 +249,7 @@ Function Choco-Install
 
     if (Choco-IsInstalled $package)
     {
-        if ($upgrade)
+        if ($state -eq "latest")
         {
             Choco-Upgrade -package $package -version $version -source $source -force $force `
                 -installargs $installargs -packageparams $packageparams `


### PR DESCRIPTION
##### SUMMARY
The current implementation matches libreoffice-oldstable when testing for libreoffice.
So uninstalling libreoffice fails when libreoffice-oldstable is installed, because chocolatey thinks it is installed, but cannot uninstall it.

```
PS C:\WINDOWS\system32> choco list --local-only libreoffice
Chocolatey v0.10.3
libreoffice-oldstable 5.2.6
1 packages installed.
PS C:\WINDOWS\system32> choco list --local-only --exact libreoffice
Chocolatey v0.10.3
0 packages installed.
```

The solution is easy, just add `--exact`.

This fixes #22892.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_chocolatey

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3