### PR TITLE
Corrects typo in `inventory_ignore_extensions`

### DIFF
--- a/docs/docsite/rst/intro_configuration.rst
+++ b/docs/docsite/rst/intro_configuration.rst
@@ -507,7 +507,7 @@ It used to be called hostfile in Ansible before 1.9
 inventory_ignore_extensions
 ===========================
 
-Coma-separated list of file extension patterns to ignore when Ansible inventory
+Comma-separated list of file extension patterns to ignore when Ansible inventory
 is a directory with multiple sources (static and dynamic)::
 
     inventory_ignore_extensions = ~, .orig, .bak, .ini, .cfg, .retry, .pyc, .pyo


### PR DESCRIPTION
##### SUMMARY
Corrects a typo from 'Coma-separated' to 'Comma-separated' in `docs/docsite/rst/intro_configuration.rst#inventory_ignore_extensions`

##### ISSUE TYPE
Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/intro_configuration.rst

##### ANSIBLE VERSION
2.4.0

##### ADDITIONAL INFORMATION


