### PR TITLE
Fail when installing from Github-generated .zip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,13 @@ if not os.path.islink(os.path.join(os.getcwd(), 'bin', 'ansible-playbook')):
     # bin/ansible needs to be a symlink to bin/ansible - otherwise the CLI
     # script will simply believe it is running bin/ansible and fail, with an
     # unhelpful error message.
-    print("It appears that you are installing Ansible from an archive that "
-          "does not support symbolic links, usually a .zip file downloaded "
-          "from GitHub. This renders your copy of Ansible unusable.\n\n")
-    print("Please re-acquire Ansible from PyPI or from the git repository, "
-          "and try again.")
+    print("It appears that you are installing Ansible from a .zip file. "
+          "Because Python's zipfile library does not properly handle symbolic "
+          "links in a .zip file, pip and setuptools cannot install Ansible "
+          "like this.\n\n")
+    print("Please either unzip the .zip file yourself and try again with the "
+          "uncompressed version, or install Ansible with pip or setuptools "
+          "using the versions on PyPI or directly from the git repository.\n")
     sys.exit(3)
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,13 @@ with open('requirements.txt') as requirements_file:
                 "That indicates this copy of the source code is incomplete.")
         sys.exit(2)
 
-if not os.path.islink(os.path.join(os.getcwd(), 'bin', 'ansible-playbook')):
-    # GitHub creates .zip files automatically, but these .zip files do not
-    # support symlinks. For Ansible to work, everything in bin that's _not_
-    # bin/ansible needs to be a symlink to bin/ansible - otherwise the CLI
-    # script will simply believe it is running bin/ansible and fail, with an
-    # unhelpful error message.
+# Python's zipfile does not properly resolve symlinks in the zipfile. When
+# installing from zipfile, this can cause malformed versions of the CLI scripts.
+path_to_test = os.path.join(os.getcwd(), 'bin', 'ansible-playbook')
+# If pulling from VCS and not something run through sdist, it will be a symlink
+path_to_test = os.path.realpath(path_to_test)
+starts_with_shebang = open(path_to_test, 'r').read(2) == '#!'
+if not starts_with_shebang:
     print("It appears that you are installing Ansible from a .zip file. "
           "Because Python's zipfile library does not properly handle symbolic "
           "links in a .zip file, pip and setuptools cannot install Ansible "

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,19 @@ with open('requirements.txt') as requirements_file:
                 "That indicates this copy of the source code is incomplete.")
         sys.exit(2)
 
+if not os.path.islink(os.path.join(os.getcwd(), 'bin', 'ansible-playbook')):
+    # GitHub creates .zip files automatically, but these .zip files do not
+    # support symlinks. For Ansible to work, everything in bin that's _not_
+    # bin/ansible needs to be a symlink to bin/ansible - otherwise the CLI
+    # script will simply believe it is running bin/ansible and fail, with an
+    # unhelpful error message.
+    print("It appears that you are installing Ansible from an archive that "
+          "does not support symbolic links, usually a .zip file downloaded "
+          "from GitHub. This renders your copy of Ansible unusable.\n\n")
+    print("Please re-acquire Ansible from PyPI or from the git repository, "
+          "and try again.")
+    sys.exit(3)
+
 setup(
     name='ansible',
     version=__version__,


### PR DESCRIPTION
##### SUMMARY
The .zip files generated by GitHub for download do not support symbolic links, however the `bin` directory in the source tree depends on symlinks being there to work. When installing from a GitHub generated .zip-file, when the user runs any script except `ansible` (e.g. `ansible-playbook`), they are given an error as if they were trying to run `ansible`.

This patch makes `setup.py` bomb out with a helpful error message in the case that `ansible-playbook` is not a symlink.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
setup.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = 
  configured module search path = [u'/Users/jginsberg/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]

```


##### ADDITIONAL INFORMATION
New output when installing from .zip file:
```
(github-fix) Plucky-Badger:bin jginsberg$ pip install https://github.com/j00bar/ansible/archive/fail-on-github-zipfile.zip
Collecting https://github.com/j00bar/ansible/archive/fail-on-github-zipfile.zip
  Downloading https://github.com/j00bar/ansible/archive/fail-on-github-zipfile.zip
     - 7.5MB 3.3MB/s
    Complete output from command python setup.py egg_info:
    It appears that you are installing Ansible from an archive that does not support symbolic links, usually a .zip file downloaded from GitHub. This renders your copy of Ansible unusable.
    
    
    Please re-acquire Ansible from PyPI or from the git repository, and try again.
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 3 in /private/var/folders/wg/d5z1m_tn7d31p142wgc800tw0000gp/T/pip-edBgAD-build/
```

Output when installing from git repo or PyPi remains unchanged.