### PR TITLE
Support check_mode for add_host

### DIFF
--- a/lib/ansible/plugins/action/add_host.py
+++ b/lib/ansible/plugins/action/add_host.py
@@ -41,7 +41,7 @@ class ActionModule(ActionBase):
 
     def run(self, tmp=None, task_vars=None):
 
-        self._supports_check_mode = False
+        self._supports_check_mode = True
 
         result = super(ActionModule, self).run(tmp, task_vars)
 


### PR DESCRIPTION
##### SUMMARY

`add_host` doesn't really actually change anything - there's no
reason why it shouldn't work in `check_mode`.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
add_host

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel c1b3d6a51f) last updated 2017/03/30 09:17:50 (GMT +1000)
  config file = ./ansible.cfg
  configured module search path = [u'./library']
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```

##### ADDITIONAL INFORMATION
