### PR TITLE
Support check_mode for ec2_vpc_net_facts

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_net_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_net_facts.py
@@ -111,7 +111,8 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
 
     if not HAS_BOTO:
         module.fail_json(msg='boto required for this module')

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_net_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_net_facts.py
@@ -75,17 +75,17 @@ def get_vpc_info(vpc):
     except AttributeError:
         classic_link = False
 
-    vpc_info = { 'id': vpc.id,
-                 'instance_tenancy': vpc.instance_tenancy,
-                 'classic_link_enabled': classic_link,
-                 'dhcp_options_id': vpc.dhcp_options_id,
-                 'state': vpc.state,
-                 'is_default': vpc.is_default,
-                 'cidr_block': vpc.cidr_block,
-                 'tags': vpc.tags
-               }
+    vpc_info = {'id': vpc.id,
+                'instance_tenancy': vpc.instance_tenancy,
+                'classic_link_enabled': classic_link,
+                'dhcp_options_id': vpc.dhcp_options_id,
+                'state': vpc.state,
+                'is_default': vpc.is_default,
+                'cidr_block': vpc.cidr_block,
+                'tags': vpc.tags}
 
     return vpc_info
+
 
 def list_ec2_vpcs(connection, module):
 
@@ -107,7 +107,7 @@ def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(
         dict(
-            filters = dict(default=None, type='dict')
+            filters=dict(default=None, type='dict')
         )
     )
 

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -110,7 +110,6 @@ lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
-lib/ansible/modules/cloud/amazon/ec2_vpc_net_facts.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_vgw.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_vgw_facts.py


### PR DESCRIPTION
##### SUMMARY
As a facts module, ec2_vpc_net_facts supports check mode by default

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ec2_vpc_net_facts

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel c1b3d6a51f) last updated 2017/03/30 09:17:50 (GMT +1000)
  config file = ./ansible.cfg
  configured module search path = [u'./library']
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```