### PR TITLE
re-raise boto ClientError exception as expected

### DIFF
--- a/lib/ansible/modules/cloud/amazon/efs.py
+++ b/lib/ansible/modules/cloud/amazon/efs.py
@@ -518,8 +518,8 @@ def iterate_all(attr, map_method, **kwargs):
                 continue
             else:
                 raise
-                
-                
+
+
 def targets_equal(keys, a, b):
     """
      Method compare two mount targets by specified attributes

--- a/lib/ansible/modules/cloud/amazon/efs.py
+++ b/lib/ansible/modules/cloud/amazon/efs.py
@@ -516,7 +516,10 @@ def iterate_all(attr, map_method, **kwargs):
                 sleep(wait)
                 wait = wait * 2
                 continue
-
+            else:
+                raise
+                
+                
 def targets_equal(keys, a, b):
     """
      Method compare two mount targets by specified attributes


### PR DESCRIPTION
The current ThrottlingException handling code hides other actual exceptions from the user, and basically goes infinite loop instead. eg when the api caller doesn't have permission (example below) to use the api, ansible effectively hangs. adding the re-raise stops execution and shows the error to the command line as expected

can test by removing permission to the efs api, and calling the efs: module

The error was: botocore.exceptions.ClientError: An error occurred (AccessDeniedException) when calling the DescribeFileSystems operation: User: <x> is not authorized to perform: elasticfilesystem:DescribeFileSystems on the specified resource

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
