### PR TITLE
Remove DryRun parameter in ec2_vpc_igw_facts check_mode

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_igw_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_igw_facts.py
@@ -113,7 +113,7 @@ except ImportError:
 def get_internet_gateway_info(internet_gateway):
     internet_gateway_info = {'InternetGatewayId': internet_gateway['InternetGatewayId'],
                              'Attachments': internet_gateway['Attachments'],
-                             'Tags': internet_gateway['Tags'] }
+                             'Tags': internet_gateway['Tags']}
     return internet_gateway_info
 
 
@@ -140,8 +140,8 @@ def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(
         dict(
-            filters = dict(type='dict', default=dict()),
-            internet_gateway_ids = dict(type='list', default=None)
+            filters=dict(type='dict', default=dict()),
+            internet_gateway_ids=dict(type='list', default=None)
         )
     )
 

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_igw_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_igw_facts.py
@@ -121,7 +121,6 @@ def list_internet_gateways(client, module):
     params = dict()
 
     params['Filters'] = ansible_dict_to_boto3_filter_list(module.params.get('filters'))
-    params['DryRun'] = module.check_mode
 
     if module.params.get("internet_gateway_ids"):
         params['InternetGatewayIds'] = module.params.get("internet_gateway_ids")

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -177,7 +177,6 @@ lib/ansible/modules/cloud/amazon/ec2_vol_facts.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_options.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_options_facts.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py
-lib/ansible/modules/cloud/amazon/ec2_vpc_igw_facts.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway.py


### PR DESCRIPTION
##### SUMMARY

Using DryRun in check mode causes errors, and is not required
(as nothing changes when calling describe_internet_gateways)

Prevents the following error:
```
{"changed": false,
 "failed": true,
  "msg": "An error occurred (DryRunOperation) when calling
          the DescribeInternetGateways operation: Request
          would have succeeded, but DryRun flag is set."}
```



##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc_igw_facts

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel c1b3d6a51f) last updated 2017/03/30 09:17:50 (GMT +1000)
  config file = ./ansible.cfg
  configured module search path = [u'./library']
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
