### PR TITLE
Support check_mode for ec2_vpc_nat_gateway_facts

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway_facts.py
@@ -127,7 +127,8 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec,)
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
 
     # Validate Requirements
     if not HAS_BOTO3:


### PR DESCRIPTION
##### SUMMARY

As a facts module, just needs supports_check_mode switched on

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ec2_vpc_nat_gateway_facts

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel c1b3d6a51f) last updated 2017/03/30 09:17:50 (GMT +1000)
  config file = ./ansible.cfg
  configured module search path = [u'./library']
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```
