### PR TITLE
add extra_options, like extra_args in pip module.

### DIFF
--- a/lib/ansible/modules/packaging/language/npm.py
+++ b/lib/ansible/modules/packaging/language/npm.py
@@ -79,6 +79,11 @@ options:
     required: false
     default: present
     choices: [ "present", "absent", "latest" ]
+  extra_options:
+    description:
+      - Extra options passed to npm.
+    required: false
+    default: null
 '''
 
 EXAMPLES = '''
@@ -123,6 +128,11 @@ EXAMPLES = '''
     path: /app/location
     executable: /opt/nvm/v0.10.1/bin/npm
     state: present
+
+# execute with optional arguments
+- npm:
+    path: /app/location
+    extra_options: --no-optional
 '''
 
 import os
@@ -147,6 +157,7 @@ class Npm(object):
         self.registry = kwargs['registry']
         self.production = kwargs['production']
         self.ignore_scripts = kwargs['ignore_scripts']
+        self.extra_options = kwargs['extra_options']
 
         if kwargs['executable']:
             self.executable = kwargs['executable'].split(' ')
@@ -170,6 +181,8 @@ class Npm(object):
                 cmd.append('--ignore-scripts')
             if self.name:
                 cmd.append(self.name_version)
+            if self.extra_options:
+                cmd.append(self.extra_options)
             if self.registry:
                 cmd.append('--registry')
                 cmd.append(self.registry)
@@ -240,6 +253,7 @@ def main():
         executable=dict(default=None, type='path'),
         registry=dict(default=None),
         state=dict(default='present', choices=['present', 'absent', 'latest']),
+        extra_options=dict(),
         ignore_scripts=dict(default=False, type='bool'),
     )
     arg_spec['global'] = dict(default='no', type='bool')
@@ -257,14 +271,17 @@ def main():
     registry = module.params['registry']
     state = module.params['state']
     ignore_scripts = module.params['ignore_scripts']
+    extra_options = module.params['extra_options']
 
     if not path and not glbl:
         module.fail_json(msg='path must be specified when not using global')
     if state == 'absent' and not name:
         module.fail_json(msg='uninstalling a package is only available for named packages')
 
-    npm = Npm(module, name=name, path=path, version=version, glbl=glbl, production=production, \
-              executable=executable, registry=registry, ignore_scripts=ignore_scripts)
+    npm = Npm(module, name=name, path=path, version=version, glbl=glbl,
+              production=production, executable=executable,
+              registry=registry, ignore_scripts=ignore_scripts,
+              extra_options=extra_options)
 
     changed = False
     if state == 'present':

--- a/lib/ansible/modules/packaging/language/npm.py
+++ b/lib/ansible/modules/packaging/language/npm.py
@@ -84,6 +84,7 @@ options:
       - Extra options passed to npm.
     required: false
     default: null
+    version_added: "2.4"
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### SUMMARY

simple extra_options, so I can use some options like `--no-optional`, tested with a simple playbook:

```
- hosts: localhost
  tasks:
  - npm:
      name: pm2
      registry: https://registry.npm.taobao.org
      version: 2.0.19
      global: yes
      extra_options: '--no-optional'
      state: present
```

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME

modules/packaging/language/npm.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
$ ansible --version
ansible 2.4.0 (devel c32e1a5ea4) last updated 2017/03/28 10:14:19 (GMT +800)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible']
  python version = 2.7.9 (default, Jun 29 2016, 13:08:31) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
