### PR TITLE
Add prerelease state switch

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -91,9 +91,10 @@ options:
     description:
       - The state of module
       - The 'forcereinstall' option is only available in Ansible 2.1 and above.
+      - The 'prerelease' option is only available in Ansible 2.4 and above.
     required: false
     default: present
-    choices: [ "present", "absent", "latest", "forcereinstall" ]
+    choices: [ "present", "absent", "latest", "forcereinstall", "prerelease" ]
   extra_args:
     description:
       - Extra arguments passed to pip.

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -209,6 +209,11 @@ EXAMPLES = '''
     name: bottle
     state: forcereinstall
 
+# Install (Bottle), using the latest pre-release version
+- pip:
+    name: bottle
+    state: prerelease
+
 # Install (Bottle) while ensuring the umask is 0022 (to ensure other users can use it)
 - pip:
     name: bottle
@@ -386,6 +391,7 @@ def main():
         absent='uninstall -y',
         latest='install -U',
         forcereinstall='install -U --force-reinstall',
+        prerelease='install -U --pre'
     )
 
     module = AnsibleModule(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Adds the feature of installing pre-release version of pip packages.

Example usecase: deploying alpha packages of your own python packages using this instead of 'latest'.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
pip

##### ANSIBLE VERSION
```
ansible 2.2.2.0
```


##### ADDITIONAL INFORMATION
https://pip.pypa.io/en/stable/reference/pip_install/#pre-release-versions