### PR TITLE
Adds attached volumes to instance facts

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_instance_facts.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instance_facts.py
@@ -243,10 +243,7 @@ class AnsibleCloudStackInstanceFacts(AnsibleCloudStack):
             volumes = self.cs.listVolumes(**args)
             if volumes:
                 for vol in volumes['volume']:
-                   volume_details.append(dict(
-                        name=vol['name'],
-                        size=vol['size'],
-                        type=vol['type']))
+                    volume_details.append({'size': vol['size'], 'type': vol['type'], 'name': vol['name']})
         return volume_details
 
     def run(self):

--- a/lib/ansible/modules/cloud/cloudstack/cs_instance_facts.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instance_facts.py
@@ -208,7 +208,6 @@ class AnsibleCloudStackInstanceFacts(AnsibleCloudStack):
             'isoname':              'iso',
             'templatename':         'template',
             'keypair':              'ssh_key',
-            'volumes':              []
         }
         self.facts = {
             'cloudstack_instance': None,
@@ -237,7 +236,9 @@ class AnsibleCloudStackInstanceFacts(AnsibleCloudStack):
         volume_details = []
         if instance:
             args                = {}
-            args['projectid']   = instance['projectid']
+            args['account']     = instance['account'] if instance.has_key('account') else None
+            args['domainid']    = instance['domainid'] if instance.has_key('domainid') else None
+            args['projectid']   = instance['projectid'] if instance.has_key('projectid') else None
             args['virtualmachineid'] = instance['id']
 
             volumes = self.cs.listVolumes(**args)

--- a/lib/ansible/modules/cloud/cloudstack/cs_instance_facts.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instance_facts.py
@@ -236,9 +236,9 @@ class AnsibleCloudStackInstanceFacts(AnsibleCloudStack):
         volume_details = []
         if instance:
             args                = {}
-            args['account']     = instance['account'] if 'account' in instance.keys() else None
-            args['domainid']    = instance['domainid'] if 'domainid' in instance.keys() else None
-            args['projectid']   = instance['projectid'] if 'projectid' in instance.keys() else None
+            args['account']     = instance.get('account')
+            args['domainid']    = instance.get('domainid')
+            args['projectid']   = instance.get('projectid')
             args['virtualmachineid'] = instance['id']
 
             volumes = self.cs.listVolumes(**args)

--- a/lib/ansible/modules/cloud/cloudstack/cs_instance_facts.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instance_facts.py
@@ -236,9 +236,9 @@ class AnsibleCloudStackInstanceFacts(AnsibleCloudStack):
         volume_details = []
         if instance:
             args                = {}
-            args['account']     = instance['account'] if instance.has_key('account') else None
-            args['domainid']    = instance['domainid'] if instance.has_key('domainid') else None
-            args['projectid']   = instance['projectid'] if instance.has_key('projectid') else None
+            args['account']     = instance['account'] if 'account' in instance.keys() else None
+            args['domainid']    = instance['domainid'] if 'domainid' in instance.keys() else None
+            args['projectid']   = instance['projectid'] if 'projectid' in instance.keys() else None
             args['virtualmachineid'] = instance['id']
 
             volumes = self.cs.listVolumes(**args)

--- a/lib/ansible/modules/cloud/cloudstack/cs_instance_facts.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instance_facts.py
@@ -180,6 +180,11 @@ cloudstack_instance.instance_name:
   returned: success
   type: string
   sample: i-44-3992-VM
+cloudstack_instance.volumes:
+  description: List of dictionaries of the volumes attached to the instance.
+  returned: success
+  type: list
+  sample: '[ { name: "ROOT-1369", type: "ROOT", size: 10737418240 }, { name: "data01, type: "DATADISK", size: 10737418240 } ]'
 '''
 
 import base64
@@ -203,6 +208,7 @@ class AnsibleCloudStackInstanceFacts(AnsibleCloudStack):
             'isoname':              'iso',
             'templatename':         'template',
             'keypair':              'ssh_key',
+            'volumes':              []
         }
         self.facts = {
             'cloudstack_instance': None,
@@ -227,6 +233,21 @@ class AnsibleCloudStackInstanceFacts(AnsibleCloudStack):
                         break
         return self.instance
 
+    def get_volumes(self, instance):
+        volume_details = []
+        if instance:
+            args                = {}
+            args['projectid']   = instance['projectid']
+            args['virtualmachineid'] = instance['id']
+
+            volumes = self.cs.listVolumes(**args)
+            if volumes:
+                for vol in volumes['volume']:
+                   volume_details.append(dict(
+                        name=vol['name'],
+                        size=vol['size'],
+                        type=vol['type']))
+        return volume_details
 
     def run(self):
         instance = self.get_instance()
@@ -253,6 +274,9 @@ class AnsibleCloudStackInstanceFacts(AnsibleCloudStack):
                 for nic in instance['nic']:
                     if nic['isdefault'] and 'ipaddress' in nic:
                         self.result['default_ip'] = nic['ipaddress']
+            volumes = self.get_volumes(instance)
+            if volumes:
+                self.result['volumes'] = volumes
         return self.result
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR extends the functionality of cs_instance_facts by adding cloudstack volumes attached to the instance as a part of the output.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/cloud/cloudstack/cs_instance_facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Returns a list of dictionaries containing name, size and type of each attached volume.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
```
