### PR TITLE
ec2_vpc_route_table: update the local variable route_table with the latest tag changes - fixes #16899

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
@@ -590,6 +590,7 @@ def ensure_route_table_present(connection, module):
     if not tags_valid and tags is not None:
         result = ensure_tags(connection, route_table.id, tags,
                              add_only=True, check_mode=module.check_mode)
+        route_table.tags = result['tags']
         changed = changed or result['changed']
 
     if subnets:


### PR DESCRIPTION
##### SUMMARY
Fixes #16899. Tags were updated remotely but not reflected in the exit_json results. Only preexisting tags were in the results. This is the shortest fix, but a better one may be to repeat the process from [looking up the route table](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py#L548-L562) because I'm not sure if other attributes are perhaps not being visibly updated. Looking up the route table retrieves the latest attributes. If that is preferred, I'll move that chunk of code into its own function so it can be called easily at the beginning and end of [ensure_route_table_present()](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py#L530).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py

##### ANSIBLE VERSION
```
2.4.0
```