### PR TITLE
Added Tag functionality to Volume,Template,FWRule,PF Rule,ISO,Snapshot

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_firewall.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_firewall.py
@@ -348,7 +348,7 @@ class AnsibleCloudStackFirewall(AnsibleCloudStack):
 
         if firewall_rule:
             firewall_rule = self.ensure_tags(resource=firewall_rule, resource_type='Firewallrule')
-            self.firewall_rule=firewall_rule
+            self.firewall_rule = firewall_rule
 
         return firewall_rule
 

--- a/lib/ansible/modules/cloud/cloudstack/cs_firewall.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_firewall.py
@@ -115,6 +115,14 @@ options:
       - Poll async jobs until job has finished.
     required: false
     default: true
+  tags:
+    description:
+      - List of tags. Tags are a list of dictionaries having keys C(key) and C(value).
+      - "To delete all tags, set a empty list e.g. C(tags: [])."
+    required: false
+    default: null
+    aliases: [ 'tag' ]
+    version_added: "2.4"
 extends_documentation_fragment: cloudstack
 '''
 

--- a/lib/ansible/modules/cloud/cloudstack/cs_firewall.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_firewall.py
@@ -345,6 +345,11 @@ class AnsibleCloudStackFirewall(AnsibleCloudStack):
                 poll_async = self.module.params.get('poll_async')
                 if poll_async:
                     firewall_rule = self.poll_job(res, 'firewallrule')
+
+        if firewall_rule:
+            firewall_rule = self.ensure_tags(resource=firewall_rule, resource_type='Firewallrule')
+            self.firewall_rule=firewall_rule
+
         return firewall_rule
 
     def remove_firewall_rule(self):
@@ -398,6 +403,7 @@ def main():
         account=dict(),
         project=dict(),
         poll_async=dict(type='bool', default=True),
+        tags=dict(type='list', aliases=['tag'], default=None),
     ))
 
     required_together = cs_required_together()

--- a/lib/ansible/modules/cloud/cloudstack/cs_iso.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_iso.py
@@ -117,6 +117,14 @@ options:
     required: false
     default: true
     version_added: "2.3"
+  tags:
+    description:
+      - List of tags. Tags are a list of dictionaries having keys C(key) and C(value).
+      - "To delete all tags, set a empty list e.g. C(tags: [])."
+    required: false
+    default: null
+    aliases: [ 'tag' ]
+    version_added: "2.4"
 extends_documentation_fragment: cloudstack
 '''
 

--- a/lib/ansible/modules/cloud/cloudstack/cs_iso.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_iso.py
@@ -255,6 +255,11 @@ class AnsibleCloudStackIso(AnsibleCloudStack):
                 if 'errortext' in res:
                     self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
                 iso = res['iso'][0]
+
+        if iso:
+            iso = self.ensure_tags(resource=iso, resource_type='ISO')
+            self.iso=iso
+
         return iso
 
 
@@ -325,6 +330,7 @@ def main():
         is_dynamically_scalable = dict(type='bool', default=False),
         state = dict(choices=['present', 'absent'], default='present'),
         poll_async = dict(type='bool', default=True),
+        tags=dict(type='list', aliases=['tag'], default=None),
     ))
 
     module = AnsibleModule(

--- a/lib/ansible/modules/cloud/cloudstack/cs_portforward.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_portforward.py
@@ -288,6 +288,11 @@ class AnsibleCloudStackPortforwarding(AnsibleCloudStack):
             portforwarding_rule = self.update_portforwarding_rule(portforwarding_rule)
         else:
             portforwarding_rule = self.create_portforwarding_rule()
+
+        if portforwarding_rule:
+            portforwarding_rule = self.ensure_tags(resource=portforwarding_rule, resource_type='PortForwardingRule')
+            self.portforwarding_rule=portforwarding_rule
+
         return portforwarding_rule
 
 
@@ -395,6 +400,7 @@ def main():
         account = dict(default=None),
         project = dict(default=None),
         poll_async = dict(type='bool', default=True),
+        tags=dict(type='list', aliases=['tag'], default=None),
     ))
 
     module = AnsibleModule(

--- a/lib/ansible/modules/cloud/cloudstack/cs_portforward.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_portforward.py
@@ -123,6 +123,14 @@ options:
       - Poll async jobs until job has finished.
     required: false
     default: true
+  tags:
+    description:
+      - List of tags. Tags are a list of dictionaries having keys C(key) and C(value).
+      - "To delete all tags, set a empty list e.g. C(tags: [])."
+    required: false
+    default: null
+    aliases: [ 'tag' ]
+    version_added: "2.4"
 extends_documentation_fragment: cloudstack
 '''
 

--- a/lib/ansible/modules/cloud/cloudstack/cs_template.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_template.py
@@ -203,6 +203,14 @@ options:
       - Poll async jobs until job has finished.
     required: false
     default: true
+  tags:
+    description:
+      - List of tags. Tags are a list of dictionaries having keys C(key) and C(value).
+      - "To delete all tags, set a empty list e.g. C(tags: [])."
+    required: false
+    default: null
+    aliases: [ 'tag' ]
+    version_added: "2.4"
 extends_documentation_fragment: cloudstack
 '''
 

--- a/lib/ansible/modules/cloud/cloudstack/cs_template.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_template.py
@@ -482,6 +482,9 @@ class AnsibleCloudStackTemplate(AnsibleCloudStack):
                 poll_async = self.module.params.get('poll_async')
                 if poll_async:
                     template = self.poll_job(template, 'template')
+        if template:
+            template = self.ensure_tags(resource=template, resource_type='Template')
+
         return template
 
 
@@ -630,6 +633,7 @@ def main():
         account = dict(default=None),
         project = dict(default=None),
         poll_async = dict(type='bool', default=True),
+        tags=dict(type='list', aliases=['tag'], default=None),
     ))
 
     module = AnsibleModule(

--- a/lib/ansible/modules/cloud/cloudstack/cs_vmsnapshot.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_vmsnapshot.py
@@ -216,6 +216,9 @@ class AnsibleCloudStackVmSnapshot(AnsibleCloudStack):
                 if res and poll_async:
                     snapshot = self.poll_job(res, 'vmsnapshot')
 
+        if snapshot:
+            snapshot = self.ensure_tags(resource=snapshot, resource_type='Snapshot')
+
         return snapshot
 
 
@@ -268,6 +271,7 @@ def main():
         account = dict(default=None),
         project = dict(default=None),
         poll_async = dict(type='bool', default=True),
+        tags=dict(type='list', aliases=['tag'], default=None),
     ))
 
     required_together = cs_required_together()

--- a/lib/ansible/modules/cloud/cloudstack/cs_vmsnapshot.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_vmsnapshot.py
@@ -82,6 +82,14 @@ options:
       - Poll async jobs until job has finished.
     required: false
     default: true
+  tags:
+    description:
+      - List of tags. Tags are a list of dictionaries having keys C(key) and C(value).
+      - "To delete all tags, set a empty list e.g. C(tags: [])."
+    required: false
+    default: null
+    aliases: [ 'tag' ]
+    version_added: "2.4"
 extends_documentation_fragment: cloudstack
 '''
 

--- a/lib/ansible/modules/cloud/cloudstack/cs_volume.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_volume.py
@@ -127,6 +127,14 @@ options:
       - Poll async jobs until job has finished.
     required: false
     default: true
+  tags:
+    description:
+      - List of tags. Tags are a list of dictionaries having keys C(key) and C(value).
+      - "To delete all tags, set a empty list e.g. C(tags: [])."
+    required: false
+    default: null
+    aliases: [ 'tag' ]
+    version_added: "2.4"
 extends_documentation_fragment: cloudstack
 '''
 

--- a/lib/ansible/modules/cloud/cloudstack/cs_volume.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_volume.py
@@ -338,6 +338,10 @@ class AnsibleCloudStackVolume(AnsibleCloudStack):
                 poll_async = self.module.params.get('poll_async')
                 if poll_async:
                     volume = self.poll_job(res, 'volume')
+        if volume:
+            volume = self.ensure_tags(resource=volume, resource_type='Volume')
+            self.volume=volume
+
         return volume
 
 
@@ -458,6 +462,7 @@ def main():
         account = dict(default=None),
         project = dict(default=None),
         poll_async = dict(type='bool', default=True),
+        tags=dict(type='list', aliases=['tag'], default=None),
     ))
 
     module = AnsibleModule(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Modules for Volume,Template, FW Rule,PF Rule,ISO and Snapshot are now extended with the functionality to add tags to the objects in Cloudstack.
All changes are based on the function ensure_tags() from the superclass. 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

cs_volume,cs_iso,cs_template,cs_firewall,cs_portforward,cs_vmsnapshot

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
ansible 2.2.2.0

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
