### PR TITLE
Include '/' & '.' when password_hash generates a new salt

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -256,7 +256,8 @@ def get_encrypted_password(password, hashtype='sha512', salt=None):
                 saltsize = 8
             else:
                 saltsize = 16
-            salt = ''.join([r.choice(string.ascii_letters + string.digits) for _ in range(saltsize)])
+            saltcharset = string.ascii_letters + string.digits + '/.'
+            salt = ''.join([r.choice(saltcharset) for _ in range(saltsize)])
 
         if not HAS_PASSLIB:
             if sys.platform.startswith('darwin'):


### PR DESCRIPTION
##### SUMMARY
`password_hash` produces a crypt(3) style, salted hash of a string. If no salt is provided then Ansible generates one. The characters allowed in a crypt salt are `A-Z-a-z/.` However Ansible until now has not used '/.' when generating a random salt, this PR fixes that.

Fixes #23139

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
password_hash filter

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/willmerae/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```