### PR TITLE
When outputting text to a file, convert to bytes first.

### DIFF
--- a/docs/bin/generate_man.py
+++ b/docs/bin/generate_man.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 
 import os
-import io
 import sys
 
 from jinja2 import Environment, FileSystemLoader
+
+from ansible.module_utils._text import to_bytes
 
 
 def get_options(optlist):
@@ -124,6 +125,6 @@ if __name__ == '__main__':
 
         manpage = template.render(tvars)
         filename = '../man/man1/%s' % output[libname]
-        with io.open(filename, 'w') as f:
-            f.write(manpage)
+        with open(filename, 'wb') as f:
+            f.write(to_bytes(manpage))
             print("Wrote man docs to %s" % filename)


### PR DESCRIPTION
Fixes #23137

##### SUMMARY
Man page generation was tracing back when non-ascii was output to a man page.  Fix this by opening the file in binary mode and manually converting to a utf-8 encoded byte string.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docs/bin/generate_man.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```
