### PR TITLE
Ansible 2.3 feature support for dellos6. (#23084)

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -300,7 +300,7 @@ DEFAULT_TEST_PLUGIN_PATH       = get_config(p, DEFAULTS, 'test_plugins',       '
 DEFAULT_STRATEGY_PLUGIN_PATH   = get_config(p, DEFAULTS, 'strategy_plugins',   'ANSIBLE_STRATEGY_PLUGINS', '~/.ansible/plugins/strategy:/usr/share/ansible/plugins/strategy', value_type='pathlist')
 
 NETWORK_GROUP_MODULES          = get_config(p, DEFAULTS, 'network_group_modules','NETWORK_GROUP_MODULES', ['eos', 'nxos', 'ios', 'iosxr', 'junos',
-                                                                                                           'vyos', 'sros', 'dellos9', 'dellos10'],
+                                                                                                           'vyos', 'sros', 'dellos9', 'dellos10', 'dellos6'],
                                             value_type='list')
 
 DEFAULT_STRATEGY               = get_config(p, DEFAULTS, 'strategy',           'ANSIBLE_STRATEGY', 'linear')

--- a/lib/ansible/module_utils/dellos6.py
+++ b/lib/ansible/module_utils/dellos6.py
@@ -1,4 +1,3 @@
-
 #
 # (c) 2015 Peter Sprygada, <psprygada@ansible.com>
 #
@@ -29,22 +28,94 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-
 import re
 
-from ansible.module_utils.shell import CliBase
-from ansible.module_utils.network import Command, register_transport, to_list
+from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.network_common import to_list, ComplexList
+from ansible.module_utils.connection import exec_command
 from ansible.module_utils.netcfg import NetworkConfig, ConfigLine, ignore_line, DEFAULT_COMMENT_TOKENS
 
+_DEVICE_CONFIGS = {}
 
-def get_config(module):
-    contents = module.params['config']
-    if not contents:
-        contents = module.config.get_config()
-        module.params['config'] = contents
-        return Dellos6NetworkConfig(indent=0, contents=contents[0])
-    else:
-        return Dellos6NetworkConfig(indent=0, contents=contents)
+WARNING_PROMPTS_RE = [
+    r"[\r\n]?\[confirm yes/no\]:\s?$",
+    r"[\r\n]?\[y/n\]:\s?$",
+    r"[\r\n]?\[yes/no\]:\s?$"
+]
+
+dellos6_argument_spec = {
+    'host': dict(),
+    'port': dict(type='int'),
+    'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
+    'password': dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), no_log=True),
+    'ssh_keyfile': dict(fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE']), type='path'),
+    'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
+    'auth_pass': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS']), no_log=True),
+    'timeout': dict(type='int'),
+    'provider': dict(type='dict'),
+}
+
+
+def check_args(module, warnings):
+    provider = module.params['provider'] or {}
+    for key in dellos6_argument_spec:
+        if key != 'provider' and module.params[key]:
+            warnings.append('argument %s has been deprecated and will be '
+                            'removed in a future version' % key)
+
+
+def get_config(module, flags=[]):
+    cmd = 'show running-config '
+    cmd += ' '.join(flags)
+    cmd = cmd.strip()
+
+    try:
+        return _DEVICE_CONFIGS[cmd]
+    except KeyError:
+        rc, out, err = exec_command(module, cmd)
+        if rc != 0:
+            module.fail_json(msg='unable to retrieve current config', stderr=err)
+        cfg = str(out).strip()
+        _DEVICE_CONFIGS[cmd] = cfg
+        return cfg
+
+
+def to_commands(module, commands):
+    spec = {
+        'command': dict(key=True),
+        'prompt': dict(),
+        'answer': dict()
+    }
+    transform = ComplexList(spec, module)
+    return transform(commands)
+
+
+def run_commands(module, commands, check_rc=True):
+    responses = list()
+    commands = to_commands(module, to_list(commands))
+    for cmd in commands:
+        cmd = module.jsonify(cmd)
+        rc, out, err = exec_command(module, cmd)
+        if check_rc and rc != 0:
+            module.fail_json(msg=err, rc=rc)
+        responses.append(out)
+    return responses
+
+
+def load_config(module, commands):
+    rc, out, err = exec_command(module, 'configure terminal')
+    if rc != 0:
+        module.fail_json(msg='unable to enter configuration mode', err=err)
+
+    for command in to_list(commands):
+        if command == 'end':
+            continue
+        cmd = {'command': command, 'prompt': WARNING_PROMPTS_RE, 'answer': 'yes'}
+        rc, out, err = exec_command(module, module.jsonify(cmd))
+        if rc != 0:
+            module.fail_json(msg=err, command=command, rc=rc)
+    exec_command(module, 'end')
+
 
 def get_sublevel_config(running_config, module):
     contents = list()
@@ -52,7 +123,7 @@ def get_sublevel_config(running_config, module):
     sublevel_config = Dellos6NetworkConfig(indent=0)
     obj = running_config.get_object(module.params['parents'])
     if obj:
-        contents = obj.children
+        contents = obj._children
     for c in contents:
         if isinstance(c, ConfigLine):
             current_config_contents.append(c.raw)
@@ -104,42 +175,42 @@ def os6_parse(lines, indent=None, comment_tokens=None):
             continue
 
         else:
-            parent_match=False
+            parent_match = False
             # handle sublevel parent
             for pr in sublevel_cmds:
                 if pr.match(line):
                     if len(parent) != 0:
-                        cfg.parents.extend(parent)
+                        cfg._parents.extend(parent)
                     parent.append(cfg)
                     config.append(cfg)
                     if children:
-                        children.insert(len(parent) - 1,[])
+                        children.insert(len(parent) - 1, [])
                         children[len(parent) - 2].append(cfg)
-                    parent_match=True
+                    parent_match = True
                     continue
             # handle exit
             if childline.match(line):
                 if children:
-                    parent[len(children) - 1].children.extend(children[len(children) - 1])
-                    if len(children)>1:
-                        parent[len(children) - 2].children.extend(parent[len(children) - 1].children)
-                    cfg.parents.extend(parent)
+                    parent[len(children) - 1]._children.extend(children[len(children) - 1])
+                    if len(children) > 1:
+                        parent[len(children) - 2]._children.extend(parent[len(children) - 1]._children)
+                    cfg._parents.extend(parent)
                     children.pop()
                     parent.pop()
                 if not children:
                     children = list()
                     if parent:
-                        cfg.parents.extend(parent)
+                        cfg._parents.extend(parent)
                     parent = list()
                     config.append(cfg)
             # handle sublevel children
-            elif parent_match is False and len(parent)>0 :
+            elif parent_match is False and len(parent) > 0:
                 if not children:
-                    cfglist=[cfg]
+                    cfglist = [cfg]
                     children.append(cfglist)
                 else:
                     children[len(parent) - 1].append(cfg)
-                cfg.parents.extend(parent)
+                cfg._parents.extend(parent)
                 config.append(cfg)
             # handle global commands
             elif not parent:
@@ -150,71 +221,16 @@ def os6_parse(lines, indent=None, comment_tokens=None):
 class Dellos6NetworkConfig(NetworkConfig):
 
     def load(self, contents):
-        self._config = os6_parse(contents, self.indent, DEFAULT_COMMENT_TOKENS)
+        self._items = os6_parse(contents, self._indent, DEFAULT_COMMENT_TOKENS)
 
-    def diff_line(self, other, path=None):
+    def _diff_line(self, other, path=None):
         diff = list()
         for item in self.items:
             if str(item) == "exit":
                 for diff_item in diff:
-                    if item.parents == diff_item.parents:
+                    if item._parents == diff_item._parents:
                         diff.append(item)
                         break
             elif item not in other:
                 diff.append(item)
         return diff
-
-
-class Cli(CliBase):
-
-    NET_PASSWD_RE = re.compile(r"[\r\n]?password:\s?$", re.I)
-
-    CLI_PROMPTS_RE = [
-        re.compile(r"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
-        re.compile(r"\[\w+\@[\w\-\.]+(?: [^\]])\] ?[>#\$] ?$")
-    ]
-
-    CLI_ERRORS_RE = [
-        re.compile(r"% ?Error"),
-        re.compile(r"% ?Bad secret"),
-        re.compile(r"invalid input", re.I),
-        re.compile(r"(?:incomplete|ambiguous) command", re.I),
-        re.compile(r"connection timed out", re.I),
-        re.compile(r"[^\r\n]+ not found", re.I),
-        re.compile(r"'[^']' +returned error code: ?\d+")]
-
-
-    def connect(self, params, **kwargs):
-        super(Cli, self).connect(params, kickstart=False, **kwargs)
-
-
-    def authorize(self, params, **kwargs):
-        passwd = params['auth_pass']
-        self.run_commands(
-            Command('enable', prompt=self.NET_PASSWD_RE, response=passwd)
-        )
-        self.run_commands('terminal length 0')
-
-
-    def configure(self, commands, **kwargs):
-        cmds = ['configure terminal']
-        cmds.extend(to_list(commands))
-        cmds.append('end')
-        responses = self.execute(cmds)
-        responses.pop(0)
-        return responses
-
-
-    def get_config(self, **kwargs):
-        return self.execute(['show running-config'])
-
-
-    def load_config(self, commands, **kwargs):
-        return self.configure(commands)
-
-
-    def save_config(self):
-        self.execute(['copy running-config startup-config'])
-
-
-Cli = register_transport('cli', default=True)(Cli)

--- a/lib/ansible/modules/network/dellos6/dellos6_command.py
+++ b/lib/ansible/modules/network/dellos6/dellos6_command.py
@@ -141,13 +141,13 @@ warnings:
   sample: ['...', '...']
 """
 
-from ansible.module_utils.basic import get_exception
-from ansible.module_utils.netcli import CommandRunner, FailedConditionsError
-from ansible.module_utils.network import NetworkModule, NetworkError
-import ansible.module_utils.dellos6
-from ansible.module_utils.six import string_types
+import time
 
-VALID_KEYS = ['command', 'prompt', 'response']
+from ansible.module_utils.dellos6 import run_commands
+from ansible.module_utils.dellos6 import dellos6_argument_spec, check_args
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.network_common import ComplexList
+from ansible.module_utils.netcli import Conditional
 
 
 def to_lines(stdout):
@@ -156,76 +156,86 @@ def to_lines(stdout):
             item = str(item).split('\n')
         yield item
 
-def parse_commands(module):
-    for cmd in module.params['commands']:
-        if isinstance(cmd, string_types):
-            cmd = dict(command=cmd, output=None)
-        elif 'command' not in cmd:
-            module.fail_json(msg='command keyword argument is required')
-        elif not set(cmd.keys()).issubset(VALID_KEYS):
-            module.fail_json(msg='unknown keyword specified')
-        yield cmd
+
+def parse_commands(module, warnings):
+    command = ComplexList(dict(
+        command=dict(key=True),
+        prompt=dict(),
+        answer=dict()
+    ), module)
+    commands = command(module.params['commands'])
+    for index, item in enumerate(commands):
+        if module.check_mode and not item['command'].startswith('show'):
+            warnings.append(
+                'only show commands are supported when using check mode, not '
+                'executing `%s`' % item['command']
+            )
+        elif item['command'].startswith('conf'):
+            module.fail_json(
+                msg='dellos6_command does not support running config mode '
+                    'commands.  Please use dellos6_config instead'
+            )
+    return commands
+
 
 def main():
-    spec = dict(
+    """main entry point for module execution
+    """
+    argument_spec = dict(
+        # { command: <str>, prompt: <str>, response: <str> }
         commands=dict(type='list', required=True),
-        wait_for=dict(type='list'),
+
+        wait_for=dict(type='list', aliases=['waitfor']),
+        match=dict(default='all', choices=['all', 'any']),
+
         retries=dict(default=10, type='int'),
         interval=dict(default=1, type='int')
     )
 
-    module = NetworkModule(argument_spec=spec,
-                           connect_on_load=False,
+    argument_spec.update(dellos6_argument_spec)
+    module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
-    commands = list(parse_commands(module))
-    conditionals = module.params['wait_for'] or list()
+
+    result = {'changed': False}
 
     warnings = list()
-
-    runner = CommandRunner(module)
-
-    for cmd in commands:
-        if module.check_mode and not cmd['command'].startswith('show'):
-            warnings.append('only show commands are supported when using '
-                            'check mode, not executing `%s`' % cmd)
-        else:
-            if cmd['command'].startswith('conf'):
-                module.fail_json(msg='dellos6_command does not support running '
-                                     'config mode commands.  Please use '
-                                     'dellos6_config instead')
-            try:
-                runner.add_command(**cmd)
-            except AddCommandError:
-                exc = get_exception()
-                warnings.append('duplicate command detected: %s' % cmd)
-
-    for item in conditionals:
-        runner.add_conditional(item)
-
-    runner.retries = module.params['retries']
-    runner.interval = module.params['interval']
-
-    try:
-        runner.run()
-    except FailedConditionsError:
-        exc = get_exception()
-        module.fail_json(msg=str(exc), failed_conditions=exc.failed_conditions)
-    except NetworkError:
-        exc = get_exception()
-        module.fail_json(msg=str(exc))
-
-    result = dict(changed=False)
-
-    result['stdout'] = list()
-    for cmd in commands:
-        try:
-            output = runner.get_command(cmd['command'])
-        except ValueError:
-            output = 'command not executed due to check_mode, see warnings'
-        result['stdout'].append(output)
-
+    check_args(module, warnings)
+    commands = parse_commands(module, warnings)
     result['warnings'] = warnings
-    result['stdout_lines'] = list(to_lines(result['stdout']))
+
+    wait_for = module.params['wait_for'] or list()
+    conditionals = [Conditional(c) for c in wait_for]
+
+    retries = module.params['retries']
+    interval = module.params['interval']
+    match = module.params['match']
+
+    while retries > 0:
+        responses = run_commands(module, commands)
+
+        for item in list(conditionals):
+            if item(responses):
+                if match == 'any':
+                    conditionals = list()
+                    break
+                conditionals.remove(item)
+
+        if not conditionals:
+            break
+
+        time.sleep(interval)
+        retries -= 1
+
+    if conditionals:
+        failed_conditions = [item.raw for item in conditionals]
+        msg = 'One or more conditional statements have not be satisfied'
+        module.fail_json(msg=msg, failed_conditions=failed_conditions)
+
+    result = {
+        'changed': False,
+        'stdout': responses,
+        'stdout_lines': list(to_lines(responses))
+    }
 
     module.exit_json(**result)
 

--- a/lib/ansible/modules/network/dellos6/dellos6_facts.py
+++ b/lib/ansible/modules/network/dellos6/dellos6_facts.py
@@ -122,32 +122,46 @@ ansible_net_neighbors:
 
 """
 import re
+import itertools
 
-from ansible.module_utils.netcli import CommandRunner
-from ansible.module_utils.network import NetworkModule
-import ansible.module_utils.dellos6
+from ansible.module_utils.dellos6 import run_commands
+from ansible.module_utils.dellos6 import dellos6_argument_spec, check_args
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.six.moves import zip
+
 
 class FactsBase(object):
 
-    def __init__(self, runner):
-        self.runner = runner
-        self.facts = dict()
+    COMMANDS = list()
 
-        self.commands()
+    def __init__(self, module):
+        self.module = module
+        self.facts = dict()
+        self.responses = None
+
+    def populate(self):
+        self.responses = run_commands(self.module, self.COMMANDS, check_rc=False)
+
+    def run(self, cmd):
+        return run_commands(self.module, cmd, check_rc=False)
+
 
 class Default(FactsBase):
 
-    def commands(self):
-        self.runner.add_command('show version')
-        self.runner.add_command('show running-config | include hostname')
+    COMMANDS = [
+        'show version',
+        'show running-config | include hostname'
+    ]
 
     def populate(self):
-        data = self.runner.get_command('show version')
+        super(Default, self).populate()
+        data = self.responses[0]
         self.facts['version'] = self.parse_version(data)
         self.facts['serialnum'] = self.parse_serialnum(data)
         self.facts['model'] = self.parse_model(data)
         self.facts['image'] = self.parse_image(data)
-        hdata =self.runner.get_command('show running-config | include hostname')
+        hdata = self.responses[0]
         self.facts['hostname'] = self.parse_hostname(hdata)
 
     def parse_version(self, data):
@@ -178,12 +192,13 @@ class Default(FactsBase):
 
 class Hardware(FactsBase):
 
-    def commands(self):
-        self.runner.add_command('show memory cpu')
+    COMMANDS = [
+        'show memory cpu'
+    ]
 
     def populate(self):
-
-        data = self.runner.get_command('show memory cpu')
+        super(Hardware, self).populate()
+        data = self.responses[0]
         match = re.findall('\s(\d+)\s', data)
         if match:
             self.facts['memtotal_mb'] = int(match[0]) / 1024
@@ -192,38 +207,40 @@ class Hardware(FactsBase):
 
 class Config(FactsBase):
 
-    def commands(self):
-        self.runner.add_command('show running-config')
+    COMMANDS = ['show running-config']
 
     def populate(self):
-        self.facts['config'] = self.runner.get_command('show running-config')
+        super(Config, self).populate()
+        self.facts['config'] = self.responses[0]
 
 
 class Interfaces(FactsBase):
-    def commands(self):
-        self.runner.add_command('show interfaces')
-        self.runner.add_command('show interfaces status')
-        self.runner.add_command('show interfaces transceiver properties')
-        self.runner.add_command('show ip int')
-        self.runner.add_command('show lldp')
-        self.runner.add_command('show lldp remote-device all')
+    COMMANDS = [
+        'show interfaces',
+        'show interfaces status',
+        'show interfaces transceiver properties',
+        'show ip int',
+        'show lldp',
+        'show lldp remote-device all'
+    ]
 
     def populate(self):
         vlan_info = dict()
-        data = self.runner.get_command('show interfaces')
+        super(Interfaces, self).populate()
+        data = self.responses[0]
         interfaces = self.parse_interfaces(data)
-        desc = self.runner.get_command('show interfaces status')
-        properties = self.runner.get_command('show interfaces transceiver properties')
-        vlan = self.runner.get_command('show ip int')
+        desc = self.responses[1]
+        properties = self.responses[2]
+        vlan = self.responses[3]
         vlan_info = self.parse_vlan(vlan)
-        self.facts['interfaces'] = self.populate_interfaces(interfaces,desc,properties)
+        self.facts['interfaces'] = self.populate_interfaces(interfaces, desc, properties)
         self.facts['interfaces'].update(vlan_info)
-        if 'LLDP is not enabled' not in self.runner.get_command('show lldp'):
-            neighbors = self.runner.get_command('show lldp remote-device all')
+        if 'LLDP is not enabled' not in self.responses[4]:
+            neighbors = self.responses[5]
             self.facts['neighbors'] = self.parse_neighbors(neighbors)
 
-    def parse_vlan(self,vlan):
-        facts =dict()
+    def parse_vlan(self, vlan):
+        facts = dict()
         vlan_info, vlan_info_next = vlan.split('----------   -----   --------------- --------------- -------')
         for en in vlan_info_next.splitlines():
             if en == '':
@@ -233,7 +250,7 @@ class Interfaces(FactsBase):
             if intf not in facts:
                 facts[intf] = list()
             fact = dict()
-            matc=re.search('^([\w+\s\d]*)\s+(\S+)\s+(\S+)',en)
+            matc = re.search('^([\w+\s\d]*)\s+(\S+)\s+(\S+)', en)
             fact['address'] = matc.group(2)
             fact['masklen'] = matc.group(3)
             facts[intf].append(fact)
@@ -243,15 +260,15 @@ class Interfaces(FactsBase):
         facts = dict()
         for key, value in interfaces.items():
             intf = dict()
-            intf['description'] = self.parse_description(key,desc)
+            intf['description'] = self.parse_description(key, desc)
             intf['macaddress'] = self.parse_macaddress(value)
             intf['mtu'] = self.parse_mtu(value)
             intf['bandwidth'] = self.parse_bandwidth(value)
-            intf['mediatype'] = self.parse_mediatype(key,properties)
+            intf['mediatype'] = self.parse_mediatype(key, properties)
             intf['duplex'] = self.parse_duplex(value)
             intf['lineprotocol'] = self.parse_lineprotocol(value)
             intf['operstatus'] = self.parse_operstatus(value)
-            intf['type'] = self.parse_type(key,properties)
+            intf['type'] = self.parse_type(key, properties)
             facts[key] = intf
         return facts
 
@@ -265,8 +282,11 @@ class Interfaces(FactsBase):
             if intf not in facts:
                 facts[intf] = list()
             fact = dict()
-            fact['host'] = self.parse_lldp_host(en.split()[4])
             fact['port'] = self.parse_lldp_port(en.split()[3])
+            if (len(en.split()) > 4):
+                fact['host'] = self.parse_lldp_host(en.split()[4])
+            else:
+                fact['host'] = "Null"
             facts[intf].append(fact)
 
         return facts
@@ -287,11 +307,14 @@ class Interfaces(FactsBase):
 
     def parse_description(self, key, desc):
         desc, desc_next = desc.split('--------- --------------- ------ ------- ---- ------ ----- -- -------------------')
-        desc_val, desc_info = desc_next.split('Oob')
+        if desc_next.find('Oob') > 0:
+            desc_val, desc_info = desc_next.split('Oob')
+        elif desc_next.find('Port') > 0:
+            desc_val, desc_info = desc_next.split('Port')
         for en in desc_val.splitlines():
             if key in en:
                 match = re.search('^(\S+)\s+(\S+)', en)
-                if match.group(2) in ['Full','N/A']:
+                if match.group(2) in ['Full', 'N/A']:
                     return "Null"
                 else:
                     return match.group(2)
@@ -307,9 +330,9 @@ class Interfaces(FactsBase):
             return int(match.group(2))
 
     def parse_bandwidth(self, data):
-        match = re.search(r'Port Speed(.+)\s(\d+)\n', data)
+        match = re.search(r'Port Speed\s*[:\s\.]+\s(\d+)\n', data)
         if match:
-            return int(match.group(2))
+            return int(match.group(1))
 
     def parse_duplex(self, data):
         match = re.search(r'Port Mode\s([A-Za-z]*)(.+)\s([A-Za-z/]*)\n', data)
@@ -318,40 +341,43 @@ class Interfaces(FactsBase):
 
     def parse_mediatype(self, key, properties):
         mediatype, mediatype_next = properties.split('--------- ------- --------------------- --------------------- --------------')
-        flag=1
+        flag = 1
         for en in mediatype_next.splitlines():
             if key in en:
-                flag=0
-                match = re.search('^(\S+)\s+(\S+)\s+(\S+)',en)
+                flag = 0
+                match = re.search('^(\S+)\s+(\S+)\s+(\S+)', en)
                 if match:
                     strval = match.group(3)
                     return match.group(3)
-        if flag==1:
+        if flag == 1:
             return "null"
 
     def parse_type(self, key, properties):
         type_val, type_val_next = properties.split('--------- ------- --------------------- --------------------- --------------')
-        flag=1
+        flag = 1
         for en in type_val_next.splitlines():
             if key in en:
-                flag=0
-                match = re.search('^(\S+)\s+(\S+)\s+(\S+)',en)
+                flag = 0
+                match = re.search('^(\S+)\s+(\S+)\s+(\S+)', en)
                 if match:
                     strval = match.group(2)
                     return match.group(2)
-        if flag==1:
+        if flag == 1:
             return "null"
 
     def parse_lineprotocol(self, data):
-        match = re.search(r'Link Status.*\s(\S+)\s+(\S+)\n', data)
-        if match:
-            strval= match.group(2)
-            return strval.strip('/')
+        data = data.splitlines()
+        for d in data:
+            match = re.search(r'^Link Status\s*[:\s\.]+\s(\S+)', d)
+            if match:
+                return match.group(1)
 
     def parse_operstatus(self, data):
-        match = re.search(r'Link Status.*\s(\S+)\s+(\S+)\n', data)
-        if match:
-            return match.group(1)
+        data = data.splitlines()
+        for d in data:
+            match = re.search(r'^Link Status\s*[:\s\.]+\s(\S+)', d)
+            if match:
+                return match.group(1)
 
     def parse_lldp_intf(self, data):
         match = re.search(r'^([A-Za-z0-9/]*)', data)
@@ -359,7 +385,7 @@ class Interfaces(FactsBase):
             return match.group(1)
 
     def parse_lldp_host(self, data):
-        match = re.search(r'^([A-Za-z0-9]*)', data)
+        match = re.search(r'^([A-Za-z0-9-]*)', data)
         if match:
             return match.group(1)
 
@@ -378,11 +404,18 @@ FACT_SUBSETS = dict(
 
 VALID_SUBSETS = frozenset(FACT_SUBSETS.keys())
 
+
 def main():
-    spec = dict(
+    """main entry point for module execution
+    """
+    argument_spec = dict(
         gather_subset=dict(default=['!config'], type='list')
     )
-    module = NetworkModule(argument_spec=spec, supports_check_mode=True)
+
+    argument_spec.update(dellos6_argument_spec)
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
 
     gather_subset = module.params['gather_subset']
 
@@ -420,27 +453,23 @@ def main():
     facts = dict()
     facts['gather_subset'] = list(runable_subsets)
 
-    runner = CommandRunner(module)
     instances = list()
     for key in runable_subsets:
-        instances.append(FACT_SUBSETS[key](runner))
-    runner.run()
+        instances.append(FACT_SUBSETS[key](module))
 
-    try:
-        for inst in instances:
-            inst.populate()
-            facts.update(inst.facts)
-    except Exception:
-        module.exit_json(out=module.from_json(runner.items))
+    for inst in instances:
+        inst.populate()
+        facts.update(inst.facts)
 
     ansible_facts = dict()
-    for key, value in facts.items():
+    for key, value in iteritems(facts):
         key = 'ansible_net_%s' % key
         ansible_facts[key] = value
 
-    module.exit_json(ansible_facts=ansible_facts)
+    warnings = list()
+    check_args(module, warnings)
 
+    module.exit_json(ansible_facts=ansible_facts, warnings=warnings)
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/plugins/action/dellos6.py
+++ b/lib/ansible/plugins/action/dellos6.py
@@ -1,0 +1,120 @@
+# 2016 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import sys
+import copy
+
+from ansible.plugins.action.normal import ActionModule as _ActionModule
+from ansible.utils.path import unfrackpath
+from ansible.plugins import connection_loader
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.dellos6 import dellos6_argument_spec
+from ansible.module_utils.basic import AnsibleFallbackNotFound
+from ansible.module_utils._text import to_bytes
+
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
+
+class ActionModule(_ActionModule):
+
+    def run(self, tmp=None, task_vars=None):
+        if self._play_context.connection != 'local':
+            return dict(
+                failed=True,
+                msg='invalid connection specified, expected connection=local, '
+                    'got %s' % self._play_context.connection
+            )
+
+        provider = self.load_provider()
+
+        pc = copy.deepcopy(self._play_context)
+        pc.connection = 'network_cli'
+        pc.network_os = 'dellos6'
+        pc.port = provider['port'] or self._play_context.port or 22
+        pc.remote_user = provider['username'] or self._play_context.connection_user
+        pc.password = provider['password'] or self._play_context.password
+        pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
+        pc.timeout = provider['timeout'] or self._play_context.timeout
+        pc.become = provider['authorize'] or False
+        pc.become_pass = provider['auth_pass']
+
+        connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+
+        socket_path = self._get_socket_path(pc)
+        display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)
+
+        if not os.path.exists(socket_path):
+            # start the connection if it isn't started
+            rc, out, err = connection.exec_command('open_shell()')
+            if not rc == 0:
+                return {'failed': True, 'msg': 'unable to open shell', 'rc': rc}
+        else:
+            # make sure we are in the right cli context which should be
+            # enable mode and not config module
+            rc, out, err = connection.exec_command('prompt()')
+            while str(out).strip().endswith(')#'):
+                display.debug('wrong context, sending exit to device')
+                connection.exec_command('exit')
+                rc, out, err = connection.exec_command('prompt()')
+
+        task_vars['ansible_socket'] = socket_path
+
+        if self._play_context.become_method == 'enable':
+            self._play_context.become = False
+            self._play_context.become_method = None
+        return super(ActionModule, self).run(tmp, task_vars)
+
+    def _get_socket_path(self, play_context):
+        ssh = connection_loader.get('ssh', class_only=True)
+        cp = ssh._create_control_path(play_context.remote_addr, play_context.port, play_context.remote_user)
+        path = unfrackpath("$HOME/.ansible/pc")
+        return cp % dict(directory=path)
+
+    def load_provider(self):
+        provider = self._task.args.get('provider', {})
+        for key, value in iteritems(dellos6_argument_spec):
+            if key != 'provider' and key not in provider:
+                if key in self._task.args:
+                    provider[key] = self._task.args[key]
+                elif 'fallback' in value:
+                    provider[key] = self._fallback(value['fallback'])
+                elif key not in provider:
+                    provider[key] = None
+        return provider
+
+    def _fallback(self, fallback):
+        strategy = fallback[0]
+        args = []
+        kwargs = {}
+
+        for item in fallback[1:]:
+            if isinstance(item, dict):
+                kwargs = item
+            else:
+                args = item
+        try:
+            return strategy(*args, **kwargs)
+        except AnsibleFallbackNotFound:
+            pass

--- a/lib/ansible/plugins/action/dellos6_config.py
+++ b/lib/ansible/plugins/action/dellos6_config.py
@@ -1,7 +1,4 @@
-#
 # Copyright 2015 Peter Sprygada <psprygada@ansible.com>
-#
-# Copyright (c) 2017 Dell Inc.
 #
 # This file is part of Ansible
 #
@@ -21,10 +18,94 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.plugins.action import ActionBase
-from ansible.plugins.action.net_config import ActionModule as NetActionModule
+import os
+import re
+import time
+import glob
 
-class ActionModule(NetActionModule, ActionBase):
-    pass
+from ansible.plugins.action.dellos6 import ActionModule as _ActionModule
+from ansible.module_utils._text import to_text
+from ansible.module_utils.six.moves.urllib.parse import urlsplit
+from ansible.utils.vars import merge_hash
+
+PRIVATE_KEYS_RE = re.compile('__.+__')
 
 
+class ActionModule(_ActionModule):
+
+    def run(self, tmp=None, task_vars=None):
+
+        if self._task.args.get('src'):
+            try:
+                self._handle_template()
+            except ValueError as exc:
+                return dict(failed=True, msg=exc.message)
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        if self._task.args.get('backup') and result.get('__backup__'):
+            # User requested backup and no error occurred in module.
+            # NOTE: If there is a parameter error, _backup key may not be in results.
+            filepath = self._write_backup(task_vars['inventory_hostname'],
+                                          result['__backup__'])
+
+            result['backup_path'] = filepath
+
+        # strip out any keys that have two leading and two trailing
+        # underscore characters
+        for key in result.keys():
+            if PRIVATE_KEYS_RE.match(key):
+                del result[key]
+
+        return result
+
+    def _get_working_path(self):
+        cwd = self._loader.get_basedir()
+        if self._task._role is not None:
+            cwd = self._task._role._role_path
+        return cwd
+
+    def _write_backup(self, host, contents):
+        backup_path = self._get_working_path() + '/backup'
+        if not os.path.exists(backup_path):
+            os.mkdir(backup_path)
+        for fn in glob.glob('%s/%s*' % (backup_path, host)):
+            os.remove(fn)
+        tstamp = time.strftime("%Y-%m-%d@%H:%M:%S", time.localtime(time.time()))
+        filename = '%s/%s_config.%s' % (backup_path, host, tstamp)
+        open(filename, 'w').write(contents)
+        return filename
+
+    def _handle_template(self):
+        src = self._task.args.get('src')
+        working_path = self._get_working_path()
+
+        if os.path.isabs(src) or urlsplit('src').scheme:
+            source = src
+        else:
+            source = self._loader.path_dwim_relative(working_path, 'templates', src)
+            if not source:
+                source = self._loader.path_dwim_relative(working_path, src)
+
+        if not os.path.exists(source):
+            raise ValueError('path specified in src not found')
+
+        try:
+            with open(source, 'r') as f:
+                template_data = to_text(f.read())
+        except IOError:
+            return dict(failed=True, msg='unable to load src file')
+
+        # Create a template search path in the following order:
+        # [working_path, self_role_path, dependent_role_paths, dirname(source)]
+        searchpath = [working_path]
+        if self._task._role is not None:
+            searchpath.append(self._task._role._role_path)
+            if hasattr(self._task, "_block:"):
+                dep_chain = self._task._block.get_dep_chain()
+                if dep_chain is not None:
+                    for role in dep_chain:
+                        searchpath.append(role._role_path)
+        searchpath.append(os.path.dirname(source))
+        self._templar.environment.loader.searchpath = searchpath
+        self._task.args['src'] = self._templar.template(template_data)

--- a/lib/ansible/plugins/terminal/dellos6.py
+++ b/lib/ansible/plugins/terminal/dellos6.py
@@ -1,0 +1,73 @@
+#  2016 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import re
+import json
+
+from ansible.plugins.terminal import TerminalBase
+from ansible.errors import AnsibleConnectionFailure
+
+
+class TerminalModule(TerminalBase):
+
+    terminal_stdout_re = [
+        re.compile(r"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
+        re.compile(r"\[\w+\@[\w\-\.]+(?: [^\]])\] ?[>#\$] ?$")
+    ]
+
+    terminal_stderr_re = [
+        re.compile(r"% ?Error: (?:(?!\bdoes not exist\b)(?!\balready exists\b)(?!\bHost not found\b)(?!\bnot active\b).)*$"),
+        re.compile(r"% ?Bad secret"),
+        re.compile(r"invalid input", re.I),
+        re.compile(r"(?:incomplete|ambiguous) command", re.I),
+        re.compile(r"connection timed out", re.I),
+        re.compile(r"'[^']' +returned error code: ?\d+"),
+    ]
+
+    def on_authorize(self, passwd=None):
+        if self._get_prompt().endswith('#'):
+            return
+
+        cmd = {'command': 'enable'}
+        if passwd:
+            cmd['prompt'] = r"[\r\n]?password:$"
+            cmd['answer'] = passwd
+        try:
+            self._exec_cli_command(json.dumps(cmd))
+        except AnsibleConnectionFailure:
+            raise AnsibleConnectionFailure('unable to elevate privilege to enable mode')
+        # in dellos6 the terminal settings are accepted after the privilege mode
+        try:
+            self._exec_cli_command('terminal length 0')
+        except AnsibleConnectionFailure:
+            raise AnsibleConnectionFailure('unable to set terminal parameters')
+
+    def on_deauthorize(self):
+        prompt = self._get_prompt()
+        if prompt is None:
+            # if prompt is None most likely the terminal is hung up at a prompt
+            return
+
+        if prompt.strip().endswith(')#'):
+            self._exec_cli_command('end')
+            self._exec_cli_command('disable')
+
+        elif prompt.endswith('#'):
+            self._exec_cli_command('disable')


### PR DESCRIPTION
* Ansible 2.3 feature support for dellos6.

- With the new Ansible 2.3 infra changes, the dellos modules doesn't work
  (the new infra changes are not backward compatible), so added the below
  changes support it.
- Added the new terminal plugin for DellOS6
- Added the new action plugin for DellOS6
- Modified the modules to work with the new infra.
- with that it adds support for DellOS6 Persistent Connection support.

* Remove pep8 confirming files from dellos6.py and dellos6_config legacy-files

(cherry picked from commit a0344acd78c422457b5a018b9de59e213f39dc87)

See https://github.com/ansible/ansible/pull/23084