### PR TITLE
Add a DHCP option for vmware_guest network settings

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -732,35 +732,34 @@ class PyVmomiHelper(object):
         # Network settings
         adaptermaps = []
         for network in self.params['networks']:
-            guest_map = vim.vm.customization.AdapterMapping()
-            guest_map.adapter = vim.vm.customization.IPSettings()
+            if ('ip' in network and 'netmask' in network) or ('dhcp' in network):
+                guest_map = vim.vm.customization.AdapterMapping()
+                guest_map.adapter = vim.vm.customization.IPSettings()
 
-            if 'ip' in network:
-                guest_map.adapter.ip = vim.vm.customization.FixedIp()
-                guest_map.adapter.ip.ipAddress = str(network['ip'])
-            elif 'dhcp' in network:
-                guest_map.adapter.ip = vim.vm.customization.DhcpIpGenerator()
+                if 'ip' in network:
+                    guest_map.adapter.ip = vim.vm.customization.FixedIp()
+                    guest_map.adapter.ip.ipAddress = str(network['ip'])
+                elif 'dhcp' in network:
+                    guest_map.adapter.ip = vim.vm.customization.DhcpIpGenerator()
 
-            if 'netmask' in network:
-                guest_map.adapter.subnetMask = str(network['netmask'])
+                if 'netmask' in network:
+                    guest_map.adapter.subnetMask = str(network['netmask'])
 
-            if 'gateway' in network:
-                guest_map.adapter.gateway = network['gateway']
+                if 'gateway' in network:
+                    guest_map.adapter.gateway = network['gateway']
 
-            # On Windows, DNS domain and DNS servers can be set by network interface
-            # https://pubs.vmware.com/vi3/sdk/ReferenceGuide/vim.vm.customization.IPSettings.html
-            if 'domain' in network:
-                guest_map.adapter.dnsDomain = network['domain']
-            elif self.params['customization'].get('domain'):
-                guest_map.adapter.dnsDomain = self.params['customization']['domain']
+                # On Windows, DNS domain and DNS servers can be set by network interface
+                # https://pubs.vmware.com/vi3/sdk/ReferenceGuide/vim.vm.customization.IPSettings.html
+                if 'domain' in network:
+                    guest_map.adapter.dnsDomain = network['domain']
+                elif self.params['customization'].get('domain'):
+                    guest_map.adapter.dnsDomain = self.params['customization']['domain']
+                if 'dns_servers' in network:
+                    guest_map.adapter.dnsServerList = network['dns_servers']
+                elif self.params['customization'].get('dns_servers'):
+                    guest_map.adapter.dnsServerList = self.params['customization']['dns_servers']
 
-            if 'dns_servers' in network:
-                guest_map.adapter.dnsServerList = network['dns_servers']
-            elif self.params['customization'].get('dns_servers'):
-                guest_map.adapter.dnsServerList = self.params['customization']['dns_servers']
-
-            adaptermaps.append(guest_map)
-
+                adaptermaps.append(guest_map)
 
         # Global DNS settings
         globalip = vim.vm.customization.GlobalIPSettings()

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -732,7 +732,7 @@ class PyVmomiHelper(object):
         # Network settings
         adaptermaps = []
         for network in self.params['networks']:
-            if ('ip' in network and 'netmask' in network) or ('dhcp' in network):
+            if 'ip' in network and 'netmask' in network or 'dhcp' in network:
                 guest_map = vim.vm.customization.AdapterMapping()
                 guest_map.adapter = vim.vm.customization.IPSettings()
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -130,7 +130,9 @@ options:
    networks:
         description:
           - Network to use should include C(name) or C(vlan) entry
-          - Add an optional C(ip) and C(netmask) for network configuration
+          - Add an optional C(ip) for network configuration
+          - Add an optional C(dhcp) (bool) entry to get an IP via DHCP (to specify this option,do not specify thethe C(ip) option)
+          - Add an optional C(netmask) to specify a subnet mask
           - Add an optional C(gateway) entry to configure a gateway
           - Add an optional C(mac) entry to customize mac address
           - Add an optional C(dns_servers) or C(domain) entry per interface (Windows)
@@ -730,28 +732,35 @@ class PyVmomiHelper(object):
         # Network settings
         adaptermaps = []
         for network in self.params['networks']:
-            if 'ip' in network and 'netmask' in network:
-                guest_map = vim.vm.customization.AdapterMapping()
-                guest_map.adapter = vim.vm.customization.IPSettings()
+            guest_map = vim.vm.customization.AdapterMapping()
+            guest_map.adapter = vim.vm.customization.IPSettings()
+
+            if 'ip' in network:
                 guest_map.adapter.ip = vim.vm.customization.FixedIp()
                 guest_map.adapter.ip.ipAddress = str(network['ip'])
+            elif 'dhcp' in network:
+                guest_map.adapter.ip = vim.vm.customization.DhcpIpGenerator()
+
+            if 'netmask' in network:
                 guest_map.adapter.subnetMask = str(network['netmask'])
 
-                if 'gateway' in network:
-                    guest_map.adapter.gateway = network['gateway']
+            if 'gateway' in network:
+                guest_map.adapter.gateway = network['gateway']
 
-                # On Windows, DNS domain and DNS servers can be set by network interface
-                # https://pubs.vmware.com/vi3/sdk/ReferenceGuide/vim.vm.customization.IPSettings.html
-                if 'domain' in network:
-                    guest_map.adapter.dnsDomain = network['domain']
-                elif self.params['customization'].get('domain'):
-                    guest_map.adapter.dnsDomain = self.params['customization']['domain']
-                if 'dns_servers' in network:
-                    guest_map.adapter.dnsServerList = network['dns_servers']
-                elif self.params['customization'].get('dns_servers'):
-                    guest_map.adapter.dnsServerList = self.params['customization']['dns_servers']
+            # On Windows, DNS domain and DNS servers can be set by network interface
+            # https://pubs.vmware.com/vi3/sdk/ReferenceGuide/vim.vm.customization.IPSettings.html
+            if 'domain' in network:
+                guest_map.adapter.dnsDomain = network['domain']
+            elif self.params['customization'].get('domain'):
+                guest_map.adapter.dnsDomain = self.params['customization']['domain']
 
-                adaptermaps.append(guest_map)
+            if 'dns_servers' in network:
+                guest_map.adapter.dnsServerList = network['dns_servers']
+            elif self.params['customization'].get('dns_servers'):
+                guest_map.adapter.dnsServerList = self.params['customization']['dns_servers']
+
+            adaptermaps.append(guest_map)
+
 
         # Global DNS settings
         globalip = vim.vm.customization.GlobalIPSettings()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add a DHCP option for network settings that will allow DHCP rather than a static IP when creating a customized VM

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vmware_guest module
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (vmware-guest-allow-dhcp 4ee10eaaaa) last updated 2017/03/30 11:57:46 (GMT -500)
  config file = 
  configured module search path = ['/home/<user>/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  python version = 3.6.0 (default, Jan 16 2017, 12:12:55) [GCC 6.3.1 20170109]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
