### PR TITLE
allow plugins to override fragments

### DIFF
--- a/lib/ansible/utils/plugin_docs.py
+++ b/lib/ansible/utils/plugin_docs.py
@@ -77,17 +77,17 @@ def add_fragments(doc, filename):
             raise Exception("missing options in fragment (%s), possibly misformatted?: %s" % (fragment_name, filename))
 
         for key, value in fragment.items():
-            if key not in doc:
-                doc[key] = value
-            else:
+            if key in doc:
+                # assumes both structures have same type
                 if isinstance(doc[key], MutableMapping):
-                    doc[key].update(value)
+                    value.update(doc[key])
                 elif isinstance(doc[key], MutableSet):
-                    doc[key].add(value)
+                    value.add(doc[key])
                 elif isinstance(doc[key], MutableSequence):
-                    doc[key] = sorted(frozenset(doc[key] + value))
+                    value = sorted(frozenset(value + doc[key]))
                 else:
                     raise Exception("Attempt to extend a documentation fragement (%s) of unknown type: %s" % (fragment_name, filename))
+            doc[key] = value
 
 
 def get_docstring(filename, verbose=False):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Currently doc fragments override module specified options, this reverses the merge order.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
docs
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
