### PR TITLE
route53: Fixes #23152 and pep8 cleanup

### DIFF
--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -207,7 +207,6 @@ lib/ansible/modules/cloud/amazon/rds.py
 lib/ansible/modules/cloud/amazon/rds_param_group.py
 lib/ansible/modules/cloud/amazon/rds_subnet_group.py
 lib/ansible/modules/cloud/amazon/redshift.py
-lib/ansible/modules/cloud/amazon/route53.py
 lib/ansible/modules/cloud/amazon/route53_facts.py
 lib/ansible/modules/cloud/amazon/route53_health_check.py
 lib/ansible/modules/cloud/amazon/s3.py


### PR DESCRIPTION
##### SUMMARY
This sets the `value` parameter to default to `type='list'` instead of a string and removes no longer necessary code that tried to detect and parse a either a comma separated string or a native list. There is a function in the AnsibleModule class that now handles this by default. 

This fixes #23152 where any list (YAML notation/etc) passed in was parsed as a comma separated string and invalid data would end up being inserted into resource records. i.e. ', [, ], etc. This also removes the code that would sort the `value` list. This would cause the order of multi-valued resource records to not be honored as supplied.
 
Additionally several PEP8 formatting errors were cleaned up and the module was removed from `legacy-files.txt`
 
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
route53

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (route53_module_issue_23152_fix bcd1889154) last updated 2017/03/30 17:32:00 (GMT -400)
  config file = /Users/user/.ansible.cfg
  configured module search path = [u'/Users/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION

See issue #23152 for more information.
