### PR TITLE
Fix eos_banner cli basic_motd integration test

### DIFF
--- a/test/integration/targets/eos_banner/tests/cli/basic-motd.yaml
+++ b/test/integration/targets/eos_banner/tests/cli/basic-motd.yaml
@@ -5,6 +5,7 @@
     banner: motd
     state: absent
     authorize: yes
+    provider: "{{ cli }}"
 
 - name: Set motd
   eos_banner:


### PR DESCRIPTION
##### SUMMARY

A task was lacking the provider variable, causing the test to fail.

Fixes #23130

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

eos_banner

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (fix_eos_banner_cli_basic_motd_integration_test 4423b60948) last updated 2017/03/31 00:08:25 (GMT +200)

```
