### PR TITLE
Must use the count_tag option with exact_count

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -357,6 +357,8 @@ EXAMPLES = '''
         volume_size: 8
     vpc_subnet_id: subnet-29e63245
     assign_public_ip: yes
+    count_tag:
+      Name: dbserver
     exact_count: 1
 
 # Multiple groups example


### PR DESCRIPTION
##### SUMMARY
Fixed an example in ec2 module. The example, as is, prints out an error saying that count_tag option must be used with exact_count.

##### ISSUE TYPE
Docs Pull Request

##### COMPONENT NAME
ec2

##### ANSIBLE VERSION
2.4.0

##### ADDITIONAL INFORMATION


