### PR TITLE
Fix typo in AWS guidelines doc

### DIFF
--- a/lib/ansible/modules/cloud/amazon/GUIDELINES.md
+++ b/lib/ansible/modules/cloud/amazon/GUIDELINES.md
@@ -187,7 +187,7 @@ except ImportError:
 try:
     result = connection.aws_call()
 except ClientError, e:
-    module.fail_json(msg=e.message, exception=traceback.format_ex(),
+    module.fail_json(msg=e.message, exception=traceback.format_exc(),
                      **camel_dict_to_snake_dict(e.response))
 ```
 


### PR DESCRIPTION
##### SUMMARY
Change `format_ex` to `format_exc`

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
cloud/amazon/GUIDELINES.md

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 3efb11e225) last updated 2017/03/31 16:16:51 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'~/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```
