### PR TITLE
dellos10_facts failure: Updated the Regex for promt matching

### DIFF
--- a/lib/ansible/plugins/terminal/dellos10.py
+++ b/lib/ansible/plugins/terminal/dellos10.py
@@ -31,7 +31,7 @@ from ansible.errors import AnsibleConnectionFailure
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(r"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
+        re.compile(r"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:#) ?$"),
         re.compile(r"\[\w+\@[\w\-\.]+(?: [^\]])\] ?[>#\$] ?$")
     ]
 


### PR DESCRIPTION
##### SUMMARY
dellos10_facts failure: Updated the Regex for prompt matching.

##### ISSUE TYPE
 - Bugfix Pull Request #23185 

##### COMPONENT NAME
lib/ansible/modules/network/dellos10/dellos10_facts.py

##### ANSIBLE VERSION
(ansible) skg@SKG ~/dev/ansible_latest $ ansible --version
ansible 2.4.0 (bugfix_23185 e4206d8ef5) last updated 2017/03/31 09:51:44 (GMT -700)
  config file = 
  configured module search path = [u'/home/skg/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]

##### ADDITIONAL INFORMATION
The XML > and the enable prompt > are getting mixed up in the prompt comparison. Since OS10 currently doesn't support enable prompt >. Removed the same. Once > prompt is supported. We need to add addtional regexp to match both <> for xml and only > for prompt.