### PR TITLE
Fix logic in os_nova_host_aggregate module

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_nova_host_aggregate.py
+++ b/lib/ansible/modules/cloud/openstack/os_nova_host_aggregate.py
@@ -88,10 +88,12 @@ from distutils.version import StrictVersion
 
 def _needs_update(module, aggregate):
     new_metadata = (module.params['metadata'] or {})
-    new_metadata['availability_zone'] = module.params['availability_zone']
+    
+    if module.params['availability_zone'] is not None:
+      new_metadata['availability_zone'] = module.params['availability_zone']
 
     if ((module.params['name'] != aggregate.name) or
-            (module.params['hosts'] is not None and module.params['hosts'] != aggregate.hosts) or
+            (module.params['hosts'] is not None and set(module.params['hosts']) != set(aggregate.hosts)) or
             (module.params['availability_zone'] is not None and module.params['availability_zone'] != aggregate.availability_zone) or
             (module.params['metadata'] is not None and new_metadata != aggregate.metadata)):
         return True

--- a/lib/ansible/modules/cloud/openstack/os_nova_host_aggregate.py
+++ b/lib/ansible/modules/cloud/openstack/os_nova_host_aggregate.py
@@ -88,9 +88,9 @@ from distutils.version import StrictVersion
 
 def _needs_update(module, aggregate):
     new_metadata = (module.params['metadata'] or {})
-    
+
     if module.params['availability_zone'] is not None:
-      new_metadata['availability_zone'] = module.params['availability_zone']
+        new_metadata['availability_zone'] = module.params['availability_zone']
 
     if ((module.params['name'] != aggregate.name) or
             (module.params['hosts'] is not None and set(module.params['hosts']) != set(aggregate.hosts)) or


### PR DESCRIPTION
Fix logic around adding availability zone to metadata and comparing existing host list to parameter host list. 

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Previously, when no availability zone was defined, an empty availability zone was being appended to metadata. This was causing 'empty named availability zone' errors when running the module against an already existing host aggregate with no availability zone. This was fixed by only appending availability zone to metadata if it is not an empty parameter.

Also added set() casting when comparing existing and new host lists. Previously, if existing host list was not in the same order as the host list in the .yml parameter file the module would consider this a change even if the two lists had the same entries.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
os_nova_host_aggregate

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
