### PR TITLE
win_find fix up age parameter

### DIFF
--- a/lib/ansible/modules/windows/win_find.ps1
+++ b/lib/ansible/modules/windows/win_find.ps1
@@ -111,12 +111,12 @@ Function Assert-Age($info) {
 
             if ($specified_seconds -ge 0) {
                 $start_date = (Get-Date).AddSeconds($abs_seconds * -1)
-                if ($age_comparison -lt $start_date) {
+                if ($age_comparison -gt $start_date) {
                     $valid_match = $false
                 }
             } else {
                 $start_date = (Get-Date).AddSeconds($abs_seconds)
-                if ($age_comparison -gt $start_date) {
+                if ($age_comparison -lt $start_date) {
                     $valid_match = $false
                 }
             }
@@ -246,13 +246,13 @@ Function Get-FileStat($file) {
         filename = $file.Name
     }
 
-    $islink = $false
+    $islnk = $false
     $isdir = $false
     $isshared = $false
 
     if ($attributes -contains 'ReparsePoint') {
         # TODO: Find a way to differenciate between soft and junction links
-        $islink = $true
+        $islnk = $true
         $isdir = $true
 
         # Try and get the symlink source, can result in failure if link is broken
@@ -287,7 +287,7 @@ Function Get-FileStat($file) {
         }
     }
 
-    $file_stat.islink = $islink
+    $file_stat.islnk = $islnk
     $file_stat.isdir = $isdir
     $file_stat.isshared = $isshared
 
@@ -326,7 +326,7 @@ foreach ($path in $paths) {
         Fail-Json $result "Argument path $path does not exist cannot get information on"
     }
 }
-$paths_to_check = $paths_to_check | Select -Unique
+$paths_to_check = $paths_to_check | Select-Object -Unique
 
 foreach ($path in $paths_to_check) {
     $file = Get-Item -Force -Path $path

--- a/lib/ansible/modules/windows/win_find.py
+++ b/lib/ansible/modules/windows/win_find.py
@@ -23,7 +23,6 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
-
 DOCUMENTATION = r'''
 ---
 module: win_find
@@ -36,15 +35,15 @@ options:
     age:
         description:
             - Select files or folders whose age is equal to or greater than
-              the specified tim. Use a negative age to find files equal to or
-              less than the specified time. You can choose seconds, minues,
+              the specified time. Use a negative age to find files equal to or
+              less than the specified time. You can choose seconds, minutes,
               hours, days or weeks by specifying the first letter of an of
-              those words (e.g., "1w").
+              those words (e.g., "2s", "10d", 1w").
         required: false
     age_stamp:
         description:
             - Choose the file property against which we compare C(age). The
-              default attribute we compare with is last modification time.
+              default attribute we compare with is the last modification time.
         required: false
         default: mtime
         choices: ['atime', 'mtime', 'ctime']
@@ -271,7 +270,7 @@ files:
             returned: success, path exists
             type: boolean
             sample: True
-        islink:
+        islnk:
             description: if the path is a symbolic link or junction or not
             returned: success, path exists
             type: boolean

--- a/test/integration/targets/win_find/tasks/main.yml
+++ b/test/integration/targets/win_find/tasks/main.yml
@@ -1,13 +1,4 @@
 ---
-- name: remove links if they exist as win_file struggles
-  win_command: cmd.exe /c rmdir "{{item}}"
-  ignore_errors: True
-  with_items:
-  - "{{win_find_dir}}\\nested\\link"
-  - "{{win_find_dir}}\\broken-link"
-  - "{{win_find_dir}}\\hard-link-dest\\hard-link.log"
-  - "{{win_find_dir}}\\junction-link"
-
 - name: ensure the testing directory is cleared before setting up test
   win_file:
     path: "{{win_find_dir}}"
@@ -146,13 +137,13 @@
   win_find:
     paths: "{{win_output_dir}}\\win_find\\single\\large.ps1"
   register: actual
-  failed_when: "actual.msg != 'Argument path {{win_output_dir|regex_replace('\\\\', '\\\\\\\\')}}\\win_find\\single\\large.ps1 is a file not a directory'"
+  failed_when: actual.msg != 'Argument path ' + win_output_dir + '\\win_find\\single\\large.ps1 is a file not a directory'
 
 - name: expect failure whe path is set to a non existant folder
   win_find:
     paths: "{{win_output_dir}}\\win_find\\thisisafakefolder"
   register: actual
-  failed_when: "actual.msg != 'Argument path {{win_output_dir|regex_replace('\\\\', '\\\\\\\\')}}\\\\win_find\\\\thisisafakefolder does not exist cannot get information on'"
+  failed_when: actual.msg != 'Argument path ' + win_output_dir + '\\win_find\\thisisafakefolder does not exist cannot get information on'
 
 - name: get files in single directory
   win_find:
@@ -173,7 +164,7 @@
           filename: large.ps1,
           ishidden: False,
           isdir: False,
-          islink: False,
+          islnk: False,
           lastaccesstime: 1477984205,
           lastwritetime: 1477984205,
           owner: BUILTIN\Administrators,
@@ -189,7 +180,7 @@
           filename: out_20161101-091005.log,
           ishidden: False,
           isdir: False,
-          islink: False,
+          islnk: False,
           lastaccesstime: 1477984205,
           lastwritetime: 1477984205,
           owner: BUILTIN\Administrators,
@@ -205,7 +196,7 @@
           filename: small.ps1,
           ishidden: False,
           isdir: False,
-          islink: False,
+          islnk: False,
           lastaccesstime: 1477984205,
           lastwritetime: 1477984205,
           owner: BUILTIN\Administrators,
@@ -221,7 +212,7 @@
           filename: test.ps1,
           ishidden: False,
           isdir: False,
-          islink: False,
+          islnk: False,
           lastaccesstime: 1477984205,
           lastwritetime: 1477984205,
           owner: BUILTIN\Administrators,
@@ -233,7 +224,7 @@
 
 - name: assert actual == expected
   assert:
-    that: "actual == expected"
+    that: actual == expected
 
 - name: find hidden files
   win_find:
@@ -255,7 +246,7 @@
           filename: hidden.ps1,
           ishidden: True,
           isdir: False,
-          islink: False,
+          islnk: False,
           lastaccesstime: 1477984205,
           lastwritetime: 1477984205,
           owner: BUILTIN\Administrators,
@@ -267,7 +258,7 @@
 
 - name: assert actual == expected
   assert:
-    that: "actual == expected"
+    that: actual == expected
 
 - name: find file based on pattern
   win_find:
@@ -296,7 +287,7 @@
           filename: out_20161101-091005.log,
           ishidden: False,
           isdir: False,
-          islink: False,
+          islnk: False,
           lastaccesstime: 1477984205,
           lastwritetime: 1477984205,
           owner: BUILTIN\Administrators,
@@ -309,8 +300,8 @@
 - name: assert actual == expected
   assert:
     that: 
-    - "actual_pattern == expected"
-    - "actual_regex == expected"
+    - actual_pattern == expected
+    - actual_regex == expected
 
 - name: find files with recurse set
   win_find:
@@ -333,7 +324,7 @@
           filename: test.ps1,
           ishidden: False,
           isdir: False,
-          islink: False,
+          islnk: False,
           lastaccesstime: 1477984205,
           lastwritetime: 1477984205,
           owner: BUILTIN\Administrators,
@@ -349,7 +340,7 @@
           filename: file.ps1,
           ishidden: False,
           isdir: False,
-          islink: False,
+          islnk: False,
           lastaccesstime: 1477984205,
           lastwritetime: 1477984205,
           owner: BUILTIN\Administrators,
@@ -365,7 +356,7 @@
           filename: test.ps1,
           ishidden: False,
           isdir: False,
-          islink: False,
+          islnk: False,
           lastaccesstime: 1477984205,
           lastwritetime: 1477984205,
           owner: BUILTIN\Administrators,
@@ -377,7 +368,7 @@
 
 - name: assert actual == expected
   assert:
-    that: "actual == expected"
+    that: actual == expected
 
 - name: find files with recurse set and follow links
   win_find:
@@ -401,7 +392,7 @@
           filename: link.ps1,
           ishidden: False,
           isdir: False,
-          islink: False,
+          islnk: False,
           lastaccesstime: 1477984205,
           lastwritetime: 1477984205,
           owner: BUILTIN\Administrators,
@@ -417,7 +408,7 @@
           filename: test.ps1,
           ishidden: False,
           isdir: False,
-          islink: False,
+          islnk: False,
           lastaccesstime: 1477984205,
           lastwritetime: 1477984205,
           owner: BUILTIN\Administrators,
@@ -433,7 +424,7 @@
           filename: file.ps1,
           ishidden: False,
           isdir: False,
-          islink: False,
+          islnk: False,
           lastaccesstime: 1477984205,
           lastwritetime: 1477984205,
           owner: BUILTIN\Administrators,
@@ -449,7 +440,7 @@
           filename: test.ps1,
           ishidden: False,
           isdir: False,
-          islink: False,
+          islnk: False,
           lastaccesstime: 1477984205,
           lastwritetime: 1477984205,
           owner: BUILTIN\Administrators,
@@ -461,7 +452,7 @@
 
 - name: assert actual == expected
   assert:
-    that: "actual == expected"
+    that: actual == expected
 
 - name: find directories
   win_find:
@@ -481,7 +472,7 @@
           filename: sub-link,
           ishidden: False,
           isdir: True,
-          islink: False,
+          islnk: False,
           lastaccesstime: 1477984205,
           lastwritetime: 1477984205,
           owner: BUILTIN\Administrators,
@@ -493,7 +484,7 @@
 
 - name: assert actual == expected
   assert:
-    that: "actual == expected"
+    that: actual == expected
 
 - name: find directories recurse and follow with a broken link
   win_find:
@@ -506,20 +497,20 @@
 - name: check directory count with recurse and follow is correct
   assert:
     that:
-    - "actual.examined == 33"
-    - "actual.matched == 13"
-    - "actual.files[0].filename == 'broken-link'"
-    - "actual.files[0].islink == True"
-    - "actual.files[2].filename == 'junction-link'"
-    - "actual.files[2].islink == True"
-    - "actual.files[2].lnk_source == '{{win_find_dir|regex_replace('\\\\', '\\\\\\\\')}}\\\\junction-link-dest'"
-    - "actual.files[7].filename == 'link'"
-    - "actual.files[7].islink == True"
-    - "actual.files[7].lnk_source == '{{win_find_dir|regex_replace('\\\\', '\\\\\\\\')}}\\\\link-dest'"
-    - "actual.files[11].filename == 'folder'"
-    - "actual.files[11].islink == False"
-    - "actual.files[11].isshared == True"
-    - "actual.files[11].sharename == 'folder-share'"
+    - actual.examined == 33
+    - actual.matched == 13
+    - actual.files[0].filename == 'broken-link'
+    - actual.files[0].islnk == True
+    - actual.files[2].filename == 'junction-link'
+    - actual.files[2].islnk == True
+    - actual.files[2].lnk_source == win_find_dir + '\\junction-link-dest'
+    - actual.files[7].filename == 'link'
+    - actual.files[7].islnk == True
+    - actual.files[7].lnk_source == win_find_dir + '\\link-dest'
+    - actual.files[11].filename == 'folder'
+    - actual.files[11].islnk == False
+    - actual.files[11].isshared == True
+    - actual.files[11].sharename == 'folder-share'
 
 - name: filter files by size without byte specified
   win_find:
@@ -547,7 +538,7 @@
           filename: large.ps1,
           ishidden: False,
           isdir: False,
-          islink: False,
+          islnk: False,
           lastaccesstime: 1477984205,
           lastwritetime: 1477984205,
           owner: BUILTIN\Administrators,
@@ -560,8 +551,8 @@
 - name: assert actual == expected
   assert:
     that: 
-    - "actual_without_byte == expected"
-    - "actual_with_byte == expected"
+    - actual_without_byte == expected
+    - actual_with_byte == expected
 
 - name: filter files by size (less than) without byte specified
   win_find:
@@ -589,7 +580,7 @@
           filename: small.ps1,
           ishidden: False,
           isdir: False,
-          islink: False,
+          islnk: False,
           lastaccesstime: 1477984205,
           lastwritetime: 1477984205,
           owner: BUILTIN\Administrators,
@@ -602,8 +593,8 @@
 - name: assert actual == expected
   assert:
     that: 
-    - "actual_without_byte == expected"
-    - "actual_with_byte == expected"
+    - actual_without_byte == expected
+    - actual_with_byte == expected
 
 # For dates we cannot assert against expected as the times change, this is a poor mans attempt at testing
 - name: filter files by age without unit specified
@@ -621,32 +612,30 @@
 - name: assert dates match each other
   assert:
     that:
-    - "actual_without_unit == actual_with_unit"
-    - "actual_without_unit.matched == 1"
-    - "actual_without_unit.files[0].checksum == '7454f04e3ac587f711a416f4edf26507255e0a2e'"
-    - "actual_without_unit.files[0].path == '{{win_find_dir|regex_replace('\\\\', '\\\\\\\\')}}\\\\date\\\\new.ps1'"
+    - actual_without_unit == actual_with_unit
+    - actual_without_unit.matched == 1
+    - actual_without_unit.files[0].checksum == '031a04ecc76f794d7842651de732075dec6fef04'
+    - actual_without_unit.files[0].path == win_find_dir + '\\date\\old.ps1'
 
-- name: filter files by age (older than) without unit specified
+- name: filter files by age (newer than) without unit specified
   win_find:
     paths: "{{win_find_dir}}\\date"
-    age: -1
+    age: -3600
   register: actual_without_unit
 
-- name: filter files by age (older than) without unit specified
+- name: filter files by age (newer than) without unit specified
   win_find:
     paths: "{{win_find_dir}}\\date"
-    age: -1s
+    age: -1h
   register: actual_with_unit
 
 - name: assert dates match each other
   assert:
     that:
-    - "actual_without_unit == actual_with_unit"
-    - "actual_without_unit.matched == 2"
-    - "actual_without_unit.files[0].checksum == '7454f04e3ac587f711a416f4edf26507255e0a2e'"
-    - "actual_without_unit.files[0].path == '{{win_find_dir|regex_replace('\\\\', '\\\\\\\\')}}\\\\date\\\\new.ps1'"
-    - "actual_without_unit.files[1].checksum == '031a04ecc76f794d7842651de732075dec6fef04'"
-    - "actual_without_unit.files[1].path == '{{win_find_dir|regex_replace('\\\\', '\\\\\\\\')}}\\\\date\\\\old.ps1'"
+    - actual_without_unit == actual_with_unit
+    - actual_without_unit.matched == 1
+    - actual_without_unit.files[0].checksum == '7454f04e3ac587f711a416f4edf26507255e0a2e'
+    - actual_without_unit.files[0].path == win_find_dir + '\\date\\new.ps1'
 
 - name: get list of files with md5 checksum
   win_find:
@@ -658,7 +647,7 @@
 - name: assert md5 checksum value
   assert:
     that:
-    - "actual_md5_checksum.files[0].checksum == 'd1713d0f1d2e8fae230328d8fd59de01'"
+    - actual_md5_checksum.files[0].checksum == 'd1713d0f1d2e8fae230328d8fd59de01'
   
 - name: get list of files with sha1 checksum
   win_find:
@@ -670,7 +659,7 @@
 - name: assert sha1 checksum value
   assert:
     that:
-    - "actual_sha1_checksum.files[0].checksum == '8df33cee3325596517df5bb5aa980cf9c5c1fda3'"
+    - actual_sha1_checksum.files[0].checksum == '8df33cee3325596517df5bb5aa980cf9c5c1fda3'
 
 - name: get list of files with sha256 checksum
   win_find:
@@ -682,7 +671,7 @@
 - name: assert sha256 checksum value
   assert:
     that:
-    - "actual_sha256_checksum.files[0].checksum == 'c20d2eba7ffda0079812721b6f4e4e109e2f0c5e8cc3d1273a060df6f7d9f339'"
+    - actual_sha256_checksum.files[0].checksum == 'c20d2eba7ffda0079812721b6f4e4e109e2f0c5e8cc3d1273a060df6f7d9f339'
 
 - name: get list of files with sha384 checksum
   win_find:
@@ -694,7 +683,7 @@
 - name: assert sha384 checksum value
   assert:
     that:
-    - "actual_sha384_checksum.files[0].checksum == 'aed515eb216b9c7009ae8c4680f46c1e22004528b231aa0482a8587543bca47d3504e9f77e884eb2d11b2f9f5dc01651'"
+    - actual_sha384_checksum.files[0].checksum == 'aed515eb216b9c7009ae8c4680f46c1e22004528b231aa0482a8587543bca47d3504e9f77e884eb2d11b2f9f5dc01651'
 
 - name: get list of files with sha512 checksum
   win_find:
@@ -706,7 +695,7 @@
 - name: assert sha512 checksum value
   assert:
     that:
-    - "actual_sha512_checksum.files[0].checksum == '05abf64a68c4731699c23b4fc6894a36646fce525f3c96f9cf743b5d0c3bfd933dad0e95e449e3afe1f74d534d69a53b8f46cf835763dd42915813c897b02b87'"
+    - actual_sha512_checksum.files[0].checksum == '05abf64a68c4731699c23b4fc6894a36646fce525f3c96f9cf743b5d0c3bfd933dad0e95e449e3afe1f74d534d69a53b8f46cf835763dd42915813c897b02b87'
 
 - name: get list of files without checksum
   win_find:
@@ -718,35 +707,7 @@
 - name: assert no checksum is returned
   assert:
     that:
-    - "actual_no_checksum.files[0].checksum is undefined"
-
-- name: check if broken symbolic link exists
-  win_stat:
-    path: "{{win_find_dir}}\\broken-link"
-  register: broken_link_exists
-
-- name: delete broken symbolic link if it exists
-  win_command: cmd.exe /c rmdir {{win_find_dir}}\broken-link
-
-  when: broken_link_exists.stat.exists
-
-- name: check if junction symbolic link exists
-  win_stat:
-    path: "{{win_find_dir}}\\junction-link"
-  register: junction_link_exists
-
-- name: delete junction symbolic link if it exists
-  win_command: cmd.exe /c rmdir {{win_find_dir}}\junction-link
-  when: junction_link_exists.stat.exists
-
-- name: check if nested symbolic link exists
-  win_stat:
-    path: "{{win_find_dir}}\\nested\\link"
-  register: nested_link_exists
-
-- name: delete nested symbolic link if it exists
-  win_command: cmd.exe /c rmdir {{win_find_dir}}\nested\link
-  when: nested_link_exists.stat.exists
+    - actual_no_checksum.files[0].checksum is undefined
 
 - name: remove testing folder
   win_file:


### PR DESCRIPTION
##### SUMMARY
Fixed up the age parameter to use a positive value for search files older and negative for searching files newer like the find module.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_find

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 11138abc51) last updated 2017/04/01 12:25:17 (GMT +1000)
  config file = /mnt/c/dev/test/role/ansible.cfg
  configured module search path = [u'/mnc/c/dev/test/role/library']
  python version = 2.7.12 (default, Dec 14 2016, 21:05:07) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
This bugfix is for issue raised https://github.com/ansible/ansible/issues/23181#issuecomment-290732189. It also changes the return values for link from islink to islnk to match find and stat.
