### PR TITLE
win_stat change return islink to islnk to match stat

### DIFF
--- a/lib/ansible/modules/windows/win_stat.py
+++ b/lib/ansible/modules/windows/win_stat.py
@@ -150,7 +150,7 @@ stat:
             returned: success, path exists
             type: boolean
             sample: True
-        islink:
+        islnk:
             description: if the path is a symbolic link or junction or not
             returned: success, path exists
             type: boolean

--- a/test/integration/targets/win_stat/files/set_share.ps1
+++ b/test/integration/targets/win_stat/files/set_share.ps1
@@ -1,0 +1,7 @@
+$share_name = $args[1]
+$share_stat = Get-WmiObject -Class Win32_Share -Filter "name='$share_name'"
+If ($share_stat) {
+    $share_stat.Delete()
+}
+$wmi = [wmiClass] 'Win32_Share'
+$wmi.Create($args[0], $share_name, 0)

--- a/test/integration/targets/win_stat/files/setup_share.ps1
+++ b/test/integration/targets/win_stat/files/setup_share.ps1
@@ -1,6 +1,0 @@
-$share_stat = Get-WmiObject -Class Win32_Share -Filter "name='folder-share'"
-If ($share_stat) {
-    $share_stat.Delete()
-}
-$wmi = [wmiClass] 'Win32_Share'
-$wmi.Create($args[0], 'folder-share', 0)

--- a/test/integration/targets/win_stat/tasks/main.yml
+++ b/test/integration/targets/win_stat/tasks/main.yml
@@ -16,15 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-- name: remove links if they exist as win_file struggles
-  win_command: cmd.exe /c rmdir "{{item}}"
-  ignore_errors: True
-  with_items:
-  - "{{win_stat_dir}}\\link"
-  - "{{win_stat_dir}}\\nested\\hard-link.ps1"
-  - "{{win_stat_dir}}\\junction-link"
+# - name: ensure the testing directory is cleared before the run
+#   win_file:
+#     path: "{{win_stat_dir}}"
+#     state: absent
 
-- name: ensure the testing directory is cleared before the run
+- name: remove win_stat testing directories for clean slate
   win_file:
     path: "{{win_stat_dir}}"
     state: absent
@@ -68,7 +65,7 @@
   - "{{win_stat_dir}}\\folder space\\file.ps1"
 
 - name: create share
-  script: setup_share.ps1 {{win_stat_dir}}\shared
+  script: set_share.ps1 {{win_stat_dir}}\shared folder-share
 
 - name: create links
   win_command: cmd.exe /c mklink /{{item.type}} {{item.source}} {{item.target}}
@@ -107,488 +104,414 @@
 - name: test win_stat module on file
   win_stat:
     path: "{{win_output_dir}}\\win_stat\\nested\\file.ps1"
-  register: actual
-
-- name: set expected fact for file
-  set_fact:
-    expected:
-      changed: False
-      stat:
-        attributes: Archive
-        checksum: a9993e364706816aba3e25717850c26c9cd0d89d
-        creationtime: 1477984205
-        exists: True
-        extension: .ps1
-        filename: file.ps1
-        isarchive: True
-        isdir: False
-        ishidden: False
-        islink: False
-        isreadonly: False
-        isshared: False
-        lastaccesstime: 1477984205
-        lastwritetime: 1477984205
-        md5: 900150983cd24fb0d6963f7d28e17f72
-        owner: BUILTIN\Administrators
-        path: "{{win_output_dir}}\\win_stat\\nested\\file.ps1"
-        size: 3
+  register: stat_file
 
 - name: check actual for file
   assert:
     that:
-    - "actual == expected"
+    - stat_file.stat.attributes == 'Archive'
+    - stat_file.stat.checksum == 'a9993e364706816aba3e25717850c26c9cd0d89d'
+    - stat_file.stat.creationtime == 1477984205
+    - stat_file.stat.exists == True
+    - stat_file.stat.extension == '.ps1'
+    - stat_file.stat.filename == 'file.ps1'
+    - stat_file.stat.isarchive == True
+    - stat_file.stat.isdir == False
+    - stat_file.stat.ishidden == False
+    - stat_file.stat.islnk == False
+    - stat_file.stat.isreadonly == False
+    - stat_file.stat.isshared == False
+    - stat_file.stat.lastaccesstime == 1477984205
+    - stat_file.stat.lastwritetime == 1477984205
+    - stat_file.stat.md5 == '900150983cd24fb0d6963f7d28e17f72'
+    - stat_file.stat.owner == 'BUILTIN\Administrators'
+    - stat_file.stat.path == win_output_dir + '\\win_stat\\nested\\file.ps1'
+    - stat_file.stat.size == 3
 
 - name: test win_stat module on file without md5
   win_stat:
     path: "{{win_output_dir}}\\win_stat\\nested\\file.ps1"
     get_md5: False
-  register: actual
-
-- name: set expected fact for file without md5
-  set_fact:
-    expected:
-      changed: False
-      stat:
-        attributes: Archive
-        checksum: a9993e364706816aba3e25717850c26c9cd0d89d
-        creationtime: 1477984205
-        exists: True
-        extension: .ps1
-        filename: file.ps1
-        isarchive: True
-        isdir: False
-        ishidden: False
-        islink: False
-        isreadonly: False
-        isshared: False
-        lastaccesstime: 1477984205
-        lastwritetime: 1477984205
-        owner: BUILTIN\Administrators
-        path: "{{win_output_dir}}\\win_stat\\nested\\file.ps1"
-        size: 3
+  register: stat_file_md5
 
 - name: check actual for file without md5
   assert:
     that:
-    - "actual == expected"
+    - stat_file_md5.stat.attributes == 'Archive'
+    - stat_file_md5.stat.checksum == 'a9993e364706816aba3e25717850c26c9cd0d89d'
+    - stat_file_md5.stat.creationtime == 1477984205
+    - stat_file_md5.stat.exists == True
+    - stat_file_md5.stat.extension == '.ps1'
+    - stat_file_md5.stat.filename == 'file.ps1'
+    - stat_file_md5.stat.isarchive == True
+    - stat_file_md5.stat.isdir == False
+    - stat_file_md5.stat.ishidden == False
+    - stat_file_md5.stat.islnk == False
+    - stat_file_md5.stat.isreadonly == False
+    - stat_file_md5.stat.isshared == False
+    - stat_file_md5.stat.lastaccesstime == 1477984205
+    - stat_file_md5.stat.lastwritetime == 1477984205
+    - stat_file_md5.stat.md5 is not defined
+    - stat_file_md5.stat.owner == 'BUILTIN\Administrators'
+    - stat_file_md5.stat.path == win_output_dir + '\\win_stat\\nested\\file.ps1'
+    - stat_file_md5.stat.size == 3
 
 - name: test win_stat module on file with sha256
   win_stat:
     path: "{{win_output_dir}}\\win_stat\\nested\\file.ps1"
     checksum_algorithm: sha256
-  register: actual
-
-- name: set expected fact for file with sha256
-  set_fact:
-    expected:
-      changed: False
-      stat:
-        attributes: Archive
-        checksum: ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
-        creationtime: 1477984205
-        exists: True
-        extension: .ps1
-        filename: file.ps1
-        isarchive: True
-        isdir: False
-        ishidden: False
-        islink: False
-        isreadonly: False
-        isshared: False
-        lastaccesstime: 1477984205
-        lastwritetime: 1477984205
-        md5: 900150983cd24fb0d6963f7d28e17f72
-        owner: BUILTIN\Administrators
-        path: "{{win_output_dir}}\\win_stat\\nested\\file.ps1"
-        size: 3
+  register: stat_file_sha256
 
 - name: check actual for file with sha256
   assert:
     that:
-    - "actual == expected"
+    - stat_file_sha256.stat.attributes == 'Archive'
+    - stat_file_sha256.stat.checksum == 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
+    - stat_file_sha256.stat.creationtime == 1477984205
+    - stat_file_sha256.stat.exists == True
+    - stat_file_sha256.stat.extension == '.ps1'
+    - stat_file_sha256.stat.filename == 'file.ps1'
+    - stat_file_sha256.stat.isarchive == True
+    - stat_file_sha256.stat.isdir == False
+    - stat_file_sha256.stat.ishidden == False
+    - stat_file_sha256.stat.islnk == False
+    - stat_file_sha256.stat.isreadonly == False
+    - stat_file_sha256.stat.isshared == False
+    - stat_file_sha256.stat.lastaccesstime == 1477984205
+    - stat_file_sha256.stat.lastwritetime == 1477984205
+    - stat_file_sha256.stat.md5 == '900150983cd24fb0d6963f7d28e17f72'
+    - stat_file_sha256.stat.owner == 'BUILTIN\Administrators'
+    - stat_file_sha256.stat.path == win_output_dir + '\\win_stat\\nested\\file.ps1'
+    - stat_file_sha256.stat.size == 3
 
 - name: test win_stat module on file with sha384
   win_stat:
     path: "{{win_output_dir}}\\win_stat\\nested\\file.ps1"
     checksum_algorithm: sha384
-  register: actual
-
-- name: set expected fact for file with sha384
-  set_fact:
-    expected:
-      changed: False
-      stat:
-        attributes: Archive
-        checksum: cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7
-        creationtime: 1477984205
-        exists: True
-        extension: .ps1
-        filename: file.ps1
-        isarchive: True
-        isdir: False
-        ishidden: False
-        islink: False
-        isreadonly: False
-        isshared: False
-        lastaccesstime: 1477984205
-        lastwritetime: 1477984205
-        md5: 900150983cd24fb0d6963f7d28e17f72
-        owner: BUILTIN\Administrators
-        path: "{{win_output_dir}}\\win_stat\\nested\\file.ps1"
-        size: 3
+  register: stat_file_sha384
 
 - name: check actual for file with sha384
   assert:
     that:
-    - "actual == expected"
+    - stat_file_sha384.stat.attributes == 'Archive'
+    - stat_file_sha384.stat.checksum == 'cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7'
+    - stat_file_sha384.stat.creationtime == 1477984205
+    - stat_file_sha384.stat.exists == True
+    - stat_file_sha384.stat.extension == '.ps1'
+    - stat_file_sha384.stat.filename == 'file.ps1'
+    - stat_file_sha384.stat.isarchive == True
+    - stat_file_sha384.stat.isdir == False
+    - stat_file_sha384.stat.ishidden == False
+    - stat_file_sha384.stat.islnk == False
+    - stat_file_sha384.stat.isreadonly == False
+    - stat_file_sha384.stat.isshared == False
+    - stat_file_sha384.stat.lastaccesstime == 1477984205
+    - stat_file_sha384.stat.lastwritetime == 1477984205
+    - stat_file_sha384.stat.md5 == '900150983cd24fb0d6963f7d28e17f72'
+    - stat_file_sha384.stat.owner == 'BUILTIN\Administrators'
+    - stat_file_sha384.stat.path == win_output_dir + '\\win_stat\\nested\\file.ps1'
+    - stat_file_sha384.stat.size == 3
 
 - name: test win_stat module on file with sha512
   win_stat:
     path: "{{win_output_dir}}\\win_stat\\nested\\file.ps1"
     checksum_algorithm: sha512
-  register: actual
-
-- name: set expected fact for file with sha512
-  set_fact:
-    expected:
-      changed: False
-      stat:
-        attributes: Archive
-        checksum: ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f
-        creationtime: 1477984205
-        exists: True
-        extension: .ps1
-        filename: file.ps1
-        isarchive: True
-        isdir: False
-        ishidden: False
-        islink: False
-        isreadonly: False
-        isshared: False
-        lastaccesstime: 1477984205
-        lastwritetime: 1477984205
-        md5: 900150983cd24fb0d6963f7d28e17f72
-        owner: BUILTIN\Administrators
-        path: "{{win_output_dir}}\\win_stat\\nested\\file.ps1"
-        size: 3
+  register: stat_file_sha512
 
 - name: check actual for file with sha512
   assert:
     that:
-    - "actual == expected"
+    - stat_file_sha512.stat.attributes == 'Archive'
+    - stat_file_sha512.stat.checksum == 'ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f'
+    - stat_file_sha512.stat.creationtime == 1477984205
+    - stat_file_sha512.stat.exists == True
+    - stat_file_sha512.stat.extension == '.ps1'
+    - stat_file_sha512.stat.filename == 'file.ps1'
+    - stat_file_sha512.stat.isarchive == True
+    - stat_file_sha512.stat.isdir == False
+    - stat_file_sha512.stat.ishidden == False
+    - stat_file_sha512.stat.islnk == False
+    - stat_file_sha512.stat.isreadonly == False
+    - stat_file_sha512.stat.isshared == False
+    - stat_file_sha512.stat.lastaccesstime == 1477984205
+    - stat_file_sha512.stat.lastwritetime == 1477984205
+    - stat_file_sha512.stat.md5 == '900150983cd24fb0d6963f7d28e17f72'
+    - stat_file_sha512.stat.owner == 'BUILTIN\Administrators'
+    - stat_file_sha512.stat.path == win_output_dir + '\\win_stat\\nested\\file.ps1'
+    - stat_file_sha512.stat.size == 3
 
 - name: test win_stat on hidden file
   win_stat:
     path: "{{win_output_dir}}\\win_stat\\nested\\hidden.ps1"
-  register: actual
-
-- name: set expected fact for hidden file
-  set_fact:
-    expected:
-      changed: False
-      stat:
-        attributes: "Hidden, Archive"
-        checksum: a9993e364706816aba3e25717850c26c9cd0d89d
-        creationtime: 1477984205
-        exists: True
-        extension: .ps1
-        filename: hidden.ps1
-        isarchive: True
-        isdir: False
-        ishidden: True
-        islink: False
-        isreadonly: False
-        isshared: False
-        lastaccesstime: 1477984205
-        lastwritetime: 1477984205
-        md5: 900150983cd24fb0d6963f7d28e17f72
-        owner: BUILTIN\Administrators
-        path: "{{win_output_dir}}\\win_stat\\nested\\hidden.ps1"
-        size: 3
+  register: stat_file_hidden
 
 - name: check actual for hidden file
   assert:
     that:
-    - "actual == expected"
+    - stat_file_hidden.stat.attributes == 'Hidden, Archive'
+    - stat_file_hidden.stat.checksum == 'a9993e364706816aba3e25717850c26c9cd0d89d'
+    - stat_file_hidden.stat.creationtime == 1477984205
+    - stat_file_hidden.stat.exists == True
+    - stat_file_hidden.stat.extension == '.ps1'
+    - stat_file_hidden.stat.filename == 'hidden.ps1'
+    - stat_file_hidden.stat.isarchive == True
+    - stat_file_hidden.stat.isdir == False
+    - stat_file_hidden.stat.ishidden == True
+    - stat_file_hidden.stat.islnk == False
+    - stat_file_hidden.stat.isreadonly == False
+    - stat_file_hidden.stat.isshared == False
+    - stat_file_hidden.stat.lastaccesstime == 1477984205
+    - stat_file_hidden.stat.lastwritetime == 1477984205
+    - stat_file_hidden.stat.md5 == '900150983cd24fb0d6963f7d28e17f72'
+    - stat_file_hidden.stat.owner == 'BUILTIN\Administrators'
+    - stat_file_hidden.stat.path == win_output_dir + '\\win_stat\\nested\\hidden.ps1'
+    - stat_file_hidden.stat.size == 3
 
 - name: test win_stat on readonly file
   win_stat:
     path: "{{win_output_dir}}\\win_stat\\nested\\read-only.ps1"
-  register: actual
-
-- name: set expected fact for readonly file
-  set_fact:
-    expected:
-      changed: False
-      stat:
-        attributes: "ReadOnly, Archive"
-        checksum: a9993e364706816aba3e25717850c26c9cd0d89d
-        creationtime: 1477984205
-        exists: True
-        extension: .ps1
-        filename: read-only.ps1
-        isarchive: True
-        isdir: False
-        ishidden: False
-        islink: False
-        isreadonly: True
-        isshared: False
-        lastaccesstime: 1477984205
-        lastwritetime: 1477984205
-        md5: 900150983cd24fb0d6963f7d28e17f72
-        owner: BUILTIN\Administrators
-        path: "{{win_output_dir}}\\win_stat\\nested\\read-only.ps1"
-        size: 3
+  register: stat_readonly
 
 - name: check actual for readonly file
   assert:
     that:
-    - "actual == expected"
+    - stat_readonly.stat.attributes == 'ReadOnly, Archive'
+    - stat_readonly.stat.checksum == 'a9993e364706816aba3e25717850c26c9cd0d89d'
+    - stat_readonly.stat.creationtime == 1477984205
+    - stat_readonly.stat.exists == True
+    - stat_readonly.stat.extension == '.ps1'
+    - stat_readonly.stat.filename == 'read-only.ps1'
+    - stat_readonly.stat.isarchive == True
+    - stat_readonly.stat.isdir == False
+    - stat_readonly.stat.ishidden == False
+    - stat_readonly.stat.islnk == False
+    - stat_readonly.stat.isreadonly == True
+    - stat_readonly.stat.isshared == False
+    - stat_readonly.stat.lastaccesstime == 1477984205
+    - stat_readonly.stat.lastwritetime == 1477984205
+    - stat_readonly.stat.md5 == '900150983cd24fb0d6963f7d28e17f72'
+    - stat_readonly.stat.owner == 'BUILTIN\Administrators'
+    - stat_readonly.stat.path == win_output_dir + '\\win_stat\\nested\\read-only.ps1'
+    - stat_readonly.stat.size == 3
 
+# Requires more work once modular powershell utils are in
 - name: test win_stat on hard link file
   win_stat:
     path: "{{win_output_dir}}\\win_stat\\nested\\hard-link.ps1"
-  register: actual
-
-- name: set expected fact for hard link file
-  set_fact:
-    expected:
-      changed: False
-      stat:
-        attributes: Archive
-        checksum: a9993e364706816aba3e25717850c26c9cd0d89d
-        creationtime: 1477984205
-        exists: True
-        extension: .ps1
-        filename: hard-link.ps1
-        isarchive: True
-        isdir: False
-        ishidden: False
-        islink: False
-        isreadonly: False
-        isshared: False
-        lastaccesstime: 1477984205
-        lastwritetime: 1477984205
-        md5: 900150983cd24fb0d6963f7d28e17f72
-        owner: BUILTIN\Administrators
-        path: "{{win_output_dir}}\\win_stat\\nested\\hard-link.ps1"
-        size: 3
+  register: stat_hard_link
 
 - name: check actual for hard link file
   assert:
     that:
-    - "actual == expected"
+    - stat_hard_link.stat.attributes == 'Archive'
+    - stat_hard_link.stat.checksum == 'a9993e364706816aba3e25717850c26c9cd0d89d'
+    - stat_hard_link.stat.creationtime == 1477984205
+    - stat_hard_link.stat.exists == True
+    - stat_hard_link.stat.extension == '.ps1'
+    - stat_hard_link.stat.filename == 'hard-link.ps1'
+    - stat_hard_link.stat.isarchive == True
+    - stat_hard_link.stat.isdir == False
+    - stat_hard_link.stat.ishidden == False
+    - stat_hard_link.stat.islnk == False
+    - stat_hard_link.stat.isreadonly == False
+    - stat_hard_link.stat.isshared == False
+    - stat_hard_link.stat.lastaccesstime == 1477984205
+    - stat_hard_link.stat.lastwritetime == 1477984205
+    - stat_hard_link.stat.md5 == '900150983cd24fb0d6963f7d28e17f72'
+    - stat_hard_link.stat.owner == 'BUILTIN\Administrators'
+    - stat_hard_link.stat.path == win_output_dir + '\\win_stat\\nested\\hard-link.ps1'
+    - stat_hard_link.stat.size == 3
 
 - name: test win_stat on directory
   win_stat:
     path: "{{win_output_dir}}\\win_stat\\nested"
-  register: actual
-
-- name: set expected fact for directory
-  set_fact:
-    expected:
-      changed: False
-      stat:
-        attributes: Directory
-        creationtime: 1477984205
-        exists: True
-        filename: nested
-        isarchive: False
-        isdir: True
-        ishidden: False
-        islink: False
-        isreadonly: False
-        isshared: False
-        lastaccesstime: 1477984205
-        lastwritetime: 1477984205
-        owner: BUILTIN\Administrators
-        path: "{{win_output_dir}}\\win_stat\\nested"
-        size: 15
+  register: stat_directory
 
 - name: check actual for directory
   assert:
     that:
-    - "actual == expected"
+    - stat_directory.stat.attributes == 'Directory'
+    - stat_directory.stat.checksum is not defined
+    - stat_directory.stat.creationtime == 1477984205
+    - stat_directory.stat.exists == True
+    - stat_directory.stat.extension is not defined
+    - stat_directory.stat.filename == 'nested'
+    - stat_directory.stat.isarchive == False
+    - stat_directory.stat.isdir == True
+    - stat_directory.stat.ishidden == False
+    - stat_directory.stat.islnk == False
+    - stat_directory.stat.isreadonly == False
+    - stat_directory.stat.isshared == False
+    - stat_directory.stat.lastaccesstime == 1477984205
+    - stat_directory.stat.lastwritetime == 1477984205
+    - stat_directory.stat.md5 is not defined
+    - stat_directory.stat.owner == 'BUILTIN\Administrators'
+    - stat_directory.stat.path == win_output_dir + '\\win_stat\\nested'
+    - stat_directory.stat.size == 15
 
 - name: test win_stat on empty directory
   win_stat:
     path: "{{win_output_dir}}\\win_stat\\folder"
-  register: actual
-
-- name: set expected fact for empty directory
-  set_fact:
-    expected:
-      changed: False
-      stat:
-        attributes: Directory
-        creationtime: 1477984205
-        exists: True
-        filename: folder
-        isarchive: False
-        isdir: True
-        ishidden: False
-        islink: False
-        isreadonly: False
-        isshared: False
-        lastaccesstime: 1477984205
-        lastwritetime: 1477984205
-        owner: BUILTIN\Administrators
-        path: "{{win_output_dir}}\\win_stat\\folder"
-        size: 0
+  register: stat_directory_empty
 
 - name: check actual for empty directory
   assert:
     that:
-    - "actual == expected"
+    - stat_directory_empty.stat.attributes == 'Directory'
+    - stat_directory_empty.stat.checksum is not defined
+    - stat_directory_empty.stat.creationtime == 1477984205
+    - stat_directory_empty.stat.exists == True
+    - stat_directory_empty.stat.extension is not defined
+    - stat_directory_empty.stat.filename == 'folder'
+    - stat_directory_empty.stat.isarchive == False
+    - stat_directory_empty.stat.isdir == True
+    - stat_directory_empty.stat.ishidden == False
+    - stat_directory_empty.stat.islnk == False
+    - stat_directory_empty.stat.isreadonly == False
+    - stat_directory_empty.stat.isshared == False
+    - stat_directory_empty.stat.lastaccesstime == 1477984205
+    - stat_directory_empty.stat.lastwritetime == 1477984205
+    - stat_directory_empty.stat.md5 is not defined
+    - stat_directory_empty.stat.owner == 'BUILTIN\Administrators'
+    - stat_directory_empty.stat.path == win_output_dir + '\\win_stat\\folder'
+    - stat_directory_empty.stat.size == 0
 
 - name: test win_stat on directory with space in name
   win_stat:
     path: "{{win_output_dir}}\\win_stat\\folder space"
-  register: actual
-
-- name: set expected fact for directory with space in name
-  set_fact:
-    expected:
-      changed: False
-      stat:
-        attributes: Directory
-        creationtime: 1477984205
-        exists: True
-        filename: folder space
-        isarchive: False
-        isdir: True
-        ishidden: False
-        islink: False
-        isreadonly: False
-        isshared: False
-        lastaccesstime: 1477984205
-        lastwritetime: 1477984205
-        owner: BUILTIN\Administrators
-        path: "{{win_output_dir}}\\win_stat\\folder space"
-        size: 3
+  register: stat_directory_space
 
 - name: check actual for directory with space in name
   assert:
     that:
-    - "actual == expected"
+    - stat_directory_space.stat.attributes == 'Directory'
+    - stat_directory_space.stat.checksum is not defined
+    - stat_directory_space.stat.creationtime == 1477984205
+    - stat_directory_space.stat.exists == True
+    - stat_directory_space.stat.extension is not defined
+    - stat_directory_space.stat.filename == 'folder space'
+    - stat_directory_space.stat.isarchive == False
+    - stat_directory_space.stat.isdir == True
+    - stat_directory_space.stat.ishidden == False
+    - stat_directory_space.stat.islnk == False
+    - stat_directory_space.stat.isreadonly == False
+    - stat_directory_space.stat.isshared == False
+    - stat_directory_space.stat.lastaccesstime == 1477984205
+    - stat_directory_space.stat.lastwritetime == 1477984205
+    - stat_directory_space.stat.md5 is not defined
+    - stat_directory_space.stat.owner == 'BUILTIN\Administrators'
+    - stat_directory_space.stat.path == win_output_dir + '\\win_stat\\folder space'
+    - stat_directory_space.stat.size == 3
 
 - name: test win_stat on hidden directory
   win_stat:
     path: "{{win_output_dir}}\\win_stat\\hidden"
-  register: actual
-
-- name: set expected fact for hidden directory
-  set_fact:
-    expected:
-      changed: False
-      stat:
-        attributes: "Hidden, Directory"
-        creationtime: 1477984205
-        exists: True
-        filename: hidden
-        isarchive: False
-        isdir: True
-        ishidden: True
-        islink: False
-        isreadonly: False
-        isshared: False
-        lastaccesstime: 1477984205
-        lastwritetime: 1477984205
-        owner: BUILTIN\Administrators
-        path: "{{win_output_dir}}\\win_stat\\hidden"
-        size: 0
+  register: stat_hidden
 
 - name: check actual for hidden directory
   assert:
     that:
-    - "actual == expected"
+    - stat_hidden.stat.attributes == 'Hidden, Directory'
+    - stat_hidden.stat.checksum is not defined
+    - stat_hidden.stat.creationtime == 1477984205
+    - stat_hidden.stat.exists == True
+    - stat_hidden.stat.extension is not defined
+    - stat_hidden.stat.filename == 'hidden'
+    - stat_hidden.stat.isarchive == False
+    - stat_hidden.stat.isdir == True
+    - stat_hidden.stat.ishidden == True
+    - stat_hidden.stat.islnk == False
+    - stat_hidden.stat.isreadonly == False
+    - stat_hidden.stat.isshared == False
+    - stat_hidden.stat.lastaccesstime == 1477984205
+    - stat_hidden.stat.lastwritetime == 1477984205
+    - stat_hidden.stat.md5 is not defined
+    - stat_hidden.stat.owner == 'BUILTIN\Administrators'
+    - stat_hidden.stat.path == win_output_dir + '\\win_stat\\hidden'
+    - stat_hidden.stat.size == 0
 
 - name: test win_stat on shared directory
   win_stat:
     path: "{{win_output_dir}}\\win_stat\\shared"
-  register: actual
-
-- name: set expected fact for shared directory
-  set_fact:
-    expected:
-      changed: False
-      stat:
-        attributes: Directory
-        creationtime: 1477984205
-        exists: True
-        filename: shared
-        isarchive: False
-        isdir: True
-        ishidden: False
-        islink: False
-        isreadonly: False
-        isshared: True
-        lastaccesstime: 1477984205
-        lastwritetime: 1477984205
-        owner: BUILTIN\Administrators
-        path: "{{win_output_dir}}\\win_stat\\shared"
-        sharename: folder-share
-        size: 0
+  register: stat_shared
 
 - name: check actual for shared directory
   assert:
     that:
-    - "actual == expected"
+    - stat_shared.stat.attributes == 'Directory'
+    - stat_shared.stat.checksum is not defined
+    - stat_shared.stat.creationtime == 1477984205
+    - stat_shared.stat.exists == True
+    - stat_shared.stat.extension is not defined
+    - stat_shared.stat.filename == 'shared'
+    - stat_shared.stat.isarchive == False
+    - stat_shared.stat.isdir == True
+    - stat_shared.stat.ishidden == False
+    - stat_shared.stat.islnk == False
+    - stat_shared.stat.isreadonly == False
+    - stat_shared.stat.isshared == True
+    - stat_shared.stat.lastaccesstime == 1477984205
+    - stat_shared.stat.lastwritetime == 1477984205
+    - stat_shared.stat.md5 is not defined
+    - stat_shared.stat.owner == 'BUILTIN\Administrators'
+    - stat_shared.stat.path == win_output_dir + '\\win_stat\\shared'
+    - stat_shared.stat.sharename == 'folder-share'
+    - stat_shared.stat.size == 0
 
 - name: test win_stat on symlink
   win_stat:
     path: "{{win_output_dir}}\\win_stat\\link"
-  register: actual
+  register: stat_symlink
 
 # I cannot change modification time on links so we are resorting to checking the dict against known valuea
 - name: assert symlink actual
   assert:
     that:
-    - "actual.stat.attributes == 'Directory, ReparsePoint'"
-    - "actual.stat.creationtime is defined"
-    - "actual.stat.exists == True"
-    - "actual.stat.filename == 'link'"
-    - "actual.stat.isarchive == False"
-    - "actual.stat.isdir == True"
-    - "actual.stat.ishidden == False"
-    - "actual.stat.islink == True"
-    - "actual.stat.isreadonly == False"
-    - "actual.stat.isshared == False"
-    - "actual.stat.lastaccesstime is defined"
-    - "actual.stat.lastwritetime is defined"
-    - "actual.stat.lnk_source == '{{win_output_dir|regex_replace('\\\\', '\\\\\\\\')}}\\\\win_stat\\\\link-dest'"
-    - "actual.stat.owner == 'BUILTIN\\Administrators'"
-    - "actual.stat.path == '{{win_output_dir|regex_replace('\\\\', '\\\\\\\\')}}\\\\win_stat\\\\link'"
-    - "actual.stat.size is not defined"
-    - "actual.stat.checksum is not defined"
-    - "actual.stat.md5 is not defined"
+    - stat_symlink.stat.attributes == 'Directory, ReparsePoint'
+    - stat_symlink.stat.creationtime is defined
+    - stat_symlink.stat.exists == True
+    - stat_symlink.stat.filename == 'link'
+    - stat_symlink.stat.isarchive == False
+    - stat_symlink.stat.isdir == True
+    - stat_symlink.stat.ishidden == False
+    - stat_symlink.stat.islnk == True
+    - stat_symlink.stat.isreadonly == False
+    - stat_symlink.stat.isshared == False
+    - stat_symlink.stat.lastaccesstime is defined
+    - stat_symlink.stat.lastwritetime is defined
+    - stat_symlink.stat.lnk_source == win_output_dir + '\\win_stat\\link-dest'
+    - stat_symlink.stat.owner == 'BUILTIN\\Administrators'
+    - stat_symlink.stat.path == win_output_dir + '\\win_stat\\link'
+    - stat_symlink.stat.size is not defined
+    - stat_symlink.stat.checksum is not defined
+    - stat_symlink.stat.md5 is not defined
 
 - name: test win_stat on junction
   win_stat:
     path: "{{win_output_dir}}\\win_stat\\junction-link"
-  register: actual
+  register: stat_junction_point
 
 - name: assert symlink actual
   assert:
     that:
-    - "actual.stat.attributes == 'Directory, ReparsePoint'"
-    - "actual.stat.creationtime is defined"
-    - "actual.stat.exists == True"
-    - "actual.stat.filename == 'junction-link'"
-    - "actual.stat.isarchive == False"
-    - "actual.stat.isdir == True"
-    - "actual.stat.ishidden == False"
-    - "actual.stat.islink == True"
-    - "actual.stat.isreadonly == False"
-    - "actual.stat.isshared == False"
-    - "actual.stat.lastaccesstime is defined"
-    - "actual.stat.lastwritetime is defined"
-    - "actual.stat.lnk_source == '{{win_output_dir|regex_replace('\\\\', '\\\\\\\\')}}\\\\win_stat\\\\junction-dest'"
-    - "actual.stat.owner == 'BUILTIN\\Administrators'"
-    - "actual.stat.path == '{{win_output_dir|regex_replace('\\\\', '\\\\\\\\')}}\\\\win_stat\\\\junction-link'"
-    - "actual.stat.size is not defined"
-    - "actual.stat.checksum is not defined"
-    - "actual.stat.md5 is not defined"
+    - stat_junction_point.stat.attributes == 'Directory, ReparsePoint'
+    - stat_junction_point.stat.creationtime is defined
+    - stat_junction_point.stat.exists == True
+    - stat_junction_point.stat.filename == 'junction-link'
+    - stat_junction_point.stat.isarchive == False
+    - stat_junction_point.stat.isdir == True
+    - stat_junction_point.stat.ishidden == False
+    - stat_junction_point.stat.islnk == True
+    - stat_junction_point.stat.isreadonly == False
+    - stat_junction_point.stat.isshared == False
+    - stat_junction_point.stat.lastaccesstime is defined
+    - stat_junction_point.stat.lastwritetime is defined
+    - stat_junction_point.stat.lnk_source == win_output_dir + '\\win_stat\\junction-dest'
+    - stat_junction_point.stat.owner == 'BUILTIN\\Administrators'
+    - stat_junction_point.stat.path == win_output_dir + '\\win_stat\\junction-link'
+    - stat_junction_point.stat.size is not defined
+    - stat_junction_point.stat.checksum is not defined
+    - stat_junction_point.stat.md5 is not defined
 
 - name: test win_stat module non-existent path
   win_stat:
@@ -598,9 +521,9 @@
 - name: check win_stat missing result
   assert: 
     that:
-      - "not win_stat_missing.stat.exists"
-      - "not win_stat_missing|failed"
-      - "not win_stat_missing|changed"
+      - not win_stat_missing.stat.exists
+      - not win_stat_missing|failed
+      - not win_stat_missing|changed
 
 - name: test win_stat module without path argument
   action: win_stat
@@ -610,27 +533,9 @@
 - name: check win_stat result with no path argument
   assert:
     that:
-      - "win_stat_no_args|failed"
-      - "win_stat_no_args.msg"
-      - "not win_stat_no_args|changed"
-
-- name: check if junction symbolic link exists
-  win_stat:
-    path: "{{win_output_dir}}\\win_stat\\junction-link"
-  register: junction_link_exists
-
-- name: delete junction symbolic link if it exists
-  win_command: cmd.exe /c rmdir {{win_output_dir}}\win_stat\junction-link
-  when: junction_link_exists.stat.exists
-
-- name: check if symbolic link exists
-  win_stat:
-    path: "{{win_output_dir}}\\win_stat\\link"
-  register: nested_link_exists
-
-- name: delete nested symbolic link if it exists
-  win_shell: cmd.exe /c rmdir {{win_output_dir}}\win_stat\link
-  when: nested_link_exists.stat.exists
+      - win_stat_no_args|failed
+      - win_stat_no_args.msg
+      - not win_stat_no_args|changed
 
 - name: remove testing folder
   win_file:


### PR DESCRIPTION
##### SUMMARY
Changed win_stat to fix return value from islink to islnk to match the stat module.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_stat

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 11138abc51) last updated 2017/04/01 12:25:17 (GMT +1000)
  config file = /mnt/c/dev/test/role/ansible.cfg
  configured module search path = [u'/mnc/c/dev/test/role/library']
  python version = 2.7.12 (default, Dec 14 2016, 21:05:07) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
To keep the windows and unix modules as close as possible this is to change the return value from islink to islnk.
