### PR TITLE
Template parent include path before finding its dirname

### DIFF
--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -156,7 +156,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                         if not isinstance(parent_include, TaskInclude):
                             parent_include = parent_include._parent
                             continue
-                        parent_include_dir = templar.template(os.path.dirname(parent_include.args.get('_raw_params')))
+                        parent_include_dir = os.path.dirname(templar.template(parent_include.args.get('_raw_params')))
                         if cumulative_path is None:
                             cumulative_path = parent_include_dir
                         elif not os.path.isabs(cumulative_path):

--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -101,7 +101,7 @@ class IncludedFile:
                                 if not isinstance(parent_include, TaskInclude):
                                     parent_include = parent_include._parent
                                     continue
-                                parent_include_dir = templar.template(os.path.dirname(parent_include.args.get('_raw_params')))
+                                parent_include_dir = os.path.dirname(templar.template(parent_include.args.get('_raw_params')))
                                 if cumulative_path is None:
                                     cumulative_path = parent_include_dir
                                 elif not os.path.isabs(cumulative_path):


### PR DESCRIPTION
##### SUMMARY

PR prevents templating errors and playbook failure that are possible with some parent include paths.

Consider this parent include path:
```
- include: "{{ var | default('path/file.yml') }}"
```
If the included file also invokes an `include`, Ansible first evaluates
`os.path.dirname(parent include path)` which yields
`{{ var | default('path/`
which is incorrect in itself but also causes subsequent templating errors due to unbalanced quotes.

This PR fixes the incorrect dirname and templating errors by changing the order, templating the parent include path before finding its dirname.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- `playbook/included_file.py` -- `IncludedFile`
- `playbook/helpers.py` -- `load_list_of_tasks()`

##### ANSIBLE VERSION

```
ansible 2.4.0 (devel 11138abc51) last updated 2017/04/01 23:00:36 (GMT -600)
  config file =
  configured module search path = [u'/Users/philip/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  python version = 2.7.13 (default, Mar 13 2017, 12:42:50) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```

##### ADDITIONAL INFORMATION

To reproduce, create two include files:
```yml
# task-include.yml
- include: task-include-child.yml
```

```yml
# task-include-child.yml
- debug:
    msg: child include
```

Create a playbook:
```yml
# includes-test.yml
- gather_facts: false
  hosts: localhost
  vars:
    include_path: task-include.yml
  tasks:
    - include: "{{ include_path | default('some/default/file.yml') }}"
      static: yes
    - include: "{{ include_path | default('some/default/file.yml') }}"
    - debug: msg="remaining tasks"
```

**Output from current devel branch**

- error caused by `os.path.dirname()` mangling the Jinja before `templar.template()` can get to it

```
$ ansible-playbook -i hosts includes-test.yml
ERROR! template error while templating string: unexpected char u"'" at 26. String: {{ include_path | default('some/default
```

**Output after the change in `playbook/helpers.py` ONLY**

- play silently halts after _initiating_ child include, but doesn't run its tasks
- `debug: msg="remaining tasks"` never runs

```
$ ansible-playbook -i hosts includes-test.yml

PLAY [localhost] ******************************************************

TASK [debug] **********************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "child include"
}

TASK [include] *********************************************************
included: /Users/philip/projects/ansible/ansible/task-include.yml for localhost

TASK [include] *********************************************************

PLAY RECAP ************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0
```

**Output after both changes: `playbook/helpers.py` and `playbook/included_file.py`**

- Everything runs, and runs correctly

```
$ ansible-playbook -i hosts includes-test.yml

PLAY [localhost] ******************************************************

TASK [debug] **********************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "child include"
}

TASK [include] *********************************************************
included: /Users/philip/projects/ansible/ansible/task-include.yml for localhost

TASK [include] *********************************************************
included: /Users/philip/projects/ansible/ansible/task-include-child.yml for localhost

TASK [debug] **********************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "child include"
}

TASK [debug] **********************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "remaining tasks"
}

PLAY RECAP ************************************************************
localhost                  : ok=5    changed=0    unreachable=0    failed=0
```