### PR TITLE
Add valid return codes in rabitmq_exchange, rabbitmq_queue modules

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq_exchange.py
+++ b/lib/ansible/modules/messaging/rabbitmq_exchange.py
@@ -204,7 +204,7 @@ def main():
         elif module.params['state'] == 'absent':
             r = requests.delete( url, auth = (module.params['login_user'],module.params['login_password']))
 
-        if r.status_code == 204:
+        if r.status_code in [201, 204]:
             module.exit_json(
                 changed = True,
                 name = module.params['name']

--- a/lib/ansible/modules/messaging/rabbitmq_queue.py
+++ b/lib/ansible/modules/messaging/rabbitmq_queue.py
@@ -252,7 +252,7 @@ def main():
         elif module.params['state'] == 'absent':
             r = requests.delete( url, auth = (module.params['login_user'],module.params['login_password']))
 
-        if r.status_code == 204:
+        if r.status_code in [201, 204]:
             module.exit_json(
                 changed = True,
                 name = module.params['name']


### PR DESCRIPTION
##### SUMMARY
Add  `HTTP 201 Created` as valid return code in rabbitmq_exchange and rabbitmq_queue modules.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible/modules/messaging/rabbitmq_queue.py
ansible/modules/messaging/rabbitmq_exchange.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 11138abc51) last updated 2017/04/03 09:48:16 (GMT +300)
  config file = /home/e.slezhuk/.ansible.cfg
  configured module search path = [u'/home/e.slezhuk/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
My RabbitMQ version: 3.6.8-1, installed from standard Debian jessie package.

Before changes:
```
TASK [add exchange] ************************************************************
failed: [relk-rabbitmq-m1-01.qiwi.com] (item={u'password': u'***', u'name': u'slezhuktest'}) => {"details": "", "failed": true, "item": {"name": "slezhuktest", "password": "***"}, "msg": "Error creating exchange", "status": 201}
```

After changes:
```
TASK [add exchange] **************************************************************************************************************************************************************************
changed: [relk-rabbitmq-m1-01.qiwi.com] => (item={u'password': u'***', u'name': u'slezhuktest'})
```