### PR TITLE
Do not alter (lower) the TXT records, as it breaks lets encrypt DNS c…

### DIFF
--- a/lib/ansible/modules/network/exoscale/exo_dns_record.py
+++ b/lib/ansible/modules/network/exoscale/exo_dns_record.py
@@ -276,10 +276,6 @@ class ExoDnsRecord(ExoDns):
     def __init__(self, module):
         super(ExoDnsRecord, self).__init__(module)
 
-        self.content = self.module.params.get('content')
-        if self.content:
-            self.content = self.content.lower()
-
         self.domain = self.module.params.get('domain').lower()
         self.name = self.module.params.get('name').lower()
         if self.name == self.domain:
@@ -289,6 +285,13 @@ class ExoDnsRecord(ExoDns):
         self.record_type = self.module.params.get('record_type')
         if self.multiple and self.record_type != 'A':
             self.module.fail_json(msg="Multiple is only usable with record_type A")
+
+        self.content = self.module.params.get('content')
+        if self.content and self.record_type == 'TXT':
+            self.content = self.content
+        else:
+            self.content = self.content.lower()
+
 
     def _create_record(self, record):
         self.result['changed'] = True


### PR DESCRIPTION
…halenge

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Let's encrypt can be used with a DNS chalenge to verify domain ownership.  The challenge use a token that must be set on a specific TXT DNS record.  This token is case sensitive.

The exoscale DNS module does a content.lower() on the TXT record, breaking the Let's encrypt chalenge.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
exo_dns_record

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (letsencrypt-with-exoscale-dns 8f76872f97) last updated 2017/04/03 11:15:20 (GMT +200)
  config file = 
  configured module search path = [u'/Users/fabrice/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  python version = 2.7.13 (default, Mar 30 2017, 14:50:20) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
I'm  trying to use the exo_dns_record module to automate SSL certificate generation with let's encrypt, using the DNS validation method.

To do that, you need to create a TXT DNS entry with a chalenge string :

So for example if I want to create a certificate for the host toto.example.org
I need to create this TXT record on the domain example.org

_acme-challenge.toto IN TXT "BjMxdFFfRmvTkb49sNFnsj35xHpywmTQddSmwMbbvPA"

​The chalenge is case sensitive

In the exo_dns_record.py code, near line 279, you do a .lower()  on the content parameter passed to the module :

self.content = self.module.params.get('content')
if ​self.content:
self.content = self.content.lower()

So If I try to update my TXT record on the exoscale platform, the string is transformed to lowercase, and my let's encrypt challenge fails.

As a workaround, I directly update the record with a curl command.

But I think it will be better to leave the content parameter unchanged (at least for the TXT case).  