### PR TITLE
Added support for FUNCTION and PROCEDURE privileges to mysql_user

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -461,12 +461,20 @@ def privileges_unpack(priv, mode):
     for item in priv.strip().split('/'):
         pieces = item.strip().rsplit(':', 1)
         dbpriv = pieces[0].rsplit(".", 1)
+
+        # Check for FUNCTION or PROCEDURE object types
+        parts = dbpriv[0].split(" ", 1)
+        object_type = ''
+        if len(parts) > 1 and (parts[0] == 'FUNCTION' or parts[0] == 'PROCEDURE'):
+            object_type = parts[0] + ' '
+            dbpriv[0] = parts[1]
+
         # Do not escape if privilege is for database or table, i.e.
         # neither quote *. nor .*
         for i, side in enumerate(dbpriv):
             if side.strip('`') != '*':
                 dbpriv[i] = '%s%s%s' % (quote, side.strip('`'), quote)
-        pieces[0] = '.'.join(dbpriv)
+        pieces[0] = object_type + '.'.join(dbpriv)
 
         if '(' in pieces[1]:
             output[pieces[0]] = re.split(r',\s*(?=[^)]*(?:\(|$))', pieces[1].upper())


### PR DESCRIPTION
##### SUMMARY
Added support for FUNCTION and PROCEDURE in parsing the priv parameter of mysql_user

```
- mysql_user:
    user: db_user
    priv: FUNCTION dbname.function:EXECUTE/dbname.*:SELECT/PROCEDURE otherdb.procedure:EXECUTE
```
A privilege in priv can be prepended by `FUNCTION` or `PROCEDURE`. It should be separated from the db.table portion of the privilege by a space. This was chosen as it matches the format of the privilege as extracted in privileges_get function.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
mysql_user

##### ANSIBLE VERSION
```
ansible 2.2.2.0
```


##### ADDITIONAL INFORMATION

Currently only `TABLE` privileges can be manipulated with mysql_user

Granting execute privileges on a mysql `FUNCTION` requires an SQL statement of the form

```
GRANT EXECUTE ON FUNCTION dbname.function_name TO 'user';
```

Unfortunately if the `FUNCTION` keyword is included in `mysql_user` modules's priv parameter it is not recognized as a valid privilege level.

Object types of `FUNCTION` and `PROCEDURE` are supported by mysql (http://dev.mysql.com/doc/refman/5.7/en/grant.html) and it would be nice if the priv parameter supported specifying 'object_type', so that task like the following could be executed

```
- mysql_user:
    user: db_user
    priv: FUNCTION dbname.function_name:EXECUTE
    state: present
````