### PR TITLE
junos_config: Remove reliance on ability to output configuration in `set` format

### DIFF
--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -155,8 +155,8 @@ def load_config(module, candidate, warnings, action='merge', commit=False, forma
             candidate = '\n'.join(candidate)
 
         reply = load_configuration(module, candidate, action=action, format=format)
-        if isinstance(reply, tuple):
-            warnings.append(reply[1])
+        if isinstance(reply, list):
+            warnings.extend(reply)
 
         validate(module)
         diff = get_diff(module)

--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -96,7 +96,7 @@ def load_configuration(module, candidate=None, action='merge', rollback=None, fo
         else:
             cfg.append(candidate)
 
-    return send_request(module, obj, fail_rc=False)
+    return send_request(module, obj)
 
 def get_configuration(module, compare=False, format='xml', rollback='0'):
     if format not in CONFIG_FORMATS:
@@ -156,13 +156,7 @@ def load_config(module, candidate, warnings, action='merge', commit=False, forma
 
         reply = load_configuration(module, candidate, action=action, format=format)
         if isinstance(reply, tuple):
-            ns = {'nc': "urn:ietf:params:xml:ns:netconf:base:1.0"}
-            severity = reply[1].find('nc:error-severity', ns).text
-            message = reply[1].find('nc:error-message', ns).text
-            if severity == 'warning':
-                warnings.append(message)
-            else:
-                module.fail_json(msg=message)
+            warnings.append(reply[1])
 
         validate(module)
         diff = get_diff(module)

--- a/lib/ansible/module_utils/netconf.py
+++ b/lib/ansible/module_utils/netconf.py
@@ -31,22 +31,31 @@ from xml.etree.ElementTree import tostring, fromstring
 
 from ansible.module_utils.connection import exec_command
 
+
+NS_MAP = {'nc': "urn:ietf:params:xml:ns:netconf:base:1.0"}
+
 def send_request(module, obj, check_rc=True):
     request = tostring(obj)
     rc, out, err = exec_command(module, request)
     if rc != 0 and check_rc:
-        rpc_error = fromstring(err)
-        ns = {'nc': "urn:ietf:params:xml:ns:netconf:base:1.0"}
-        try:
-            severity  = rpc_error.find('nc:error-severity', ns).text
-            message = rpc_error.find('nc:error-message', ns).text
-        except AttributeError:
+        error_root = fromstring(err)
+        fake_parent = Element('root')
+        fake_parent.append(error_root)
+
+        error_list = fake_parent.findall('.//nc:rpc-error', NS_MAP)
+        if not error_list:
             module.fail_json(msg=str(err))
 
-        if severity == 'warning':
-            return rc, message
-        else:
-            module.fail_json(msg=message)
+        warnings = []
+        for rpc_error in error_list:
+            message = rpc_error.find('./nc:error-message', NS_MAP).text
+            severity = rpc_error.find('./nc:error-severity', NS_MAP).text
+
+            if severity == 'warning':
+                warnings.append(message)
+            else:
+                module.fail_json(msg=str(err))
+        return warnings
     return fromstring(out)
 
 def children(root, iterable):

--- a/lib/ansible/module_utils/netconf.py
+++ b/lib/ansible/module_utils/netconf.py
@@ -31,12 +31,15 @@ from xml.etree.ElementTree import tostring, fromstring
 
 from ansible.module_utils.connection import exec_command
 
-def send_request(module, obj, check_rc=True):
+def send_request(module, obj, check_rc=True, fail_rc=True):
     request = tostring(obj)
     rc, out, err = exec_command(module, request)
     if rc != 0:
         if check_rc:
-            module.fail_json(msg=str(err))
+            if fail_rc:
+                module.fail_json(msg=str(err))
+            else:
+                return rc, fromstring(err)
         return fromstring(out)
     return fromstring(out)
 

--- a/lib/ansible/modules/network/junos/_junos_template.py
+++ b/lib/ansible/modules/network/junos/_junos_template.py
@@ -157,7 +157,7 @@ def main():
             module.fail_json(msg='unable to retrieve device configuration')
         result['__backup__'] = str(match.text).strip()
 
-    diff = load_config(module, src, action=action, commit=commit, format=fmt)
+    diff = load_config(module, src, warnings, action=action, commit=commit, format=fmt)
     if diff:
         result['changed'] = True
         if module._diff:

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -232,7 +232,7 @@ def filter_delete_statements(module, candidate):
 
     return modified_candidate
 
-def configure_device(module):
+def configure_device(module, warnings):
     candidate = module.params['lines'] or module.params['src']
     if isinstance(candidate, string_types):
         candidate = candidate.split('\n')
@@ -264,7 +264,7 @@ def configure_device(module):
         kwargs['format'] = 'text'
         kwargs['action'] = 'set'
 
-    return load_config(module, candidate, **kwargs)
+    return load_config(module, candidate, warnings, **kwargs)
 
 def main():
     """ main entry point for module execution
@@ -328,7 +328,7 @@ def main():
         result['changed'] = True
 
     else:
-        diff = configure_device(module)
+        diff = configure_device(module, warnings)
         if diff:
             if module._diff:
                 result['diff'] = {'prepared': diff}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
This should remove any cases where junos_config relies on being able to retrieve configuration in `set` format, which is not available to devices version < 15.1

Fixes #22907

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
junos_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```
