### PR TITLE
expose credstash PROFILE and role ARN options to allow cross account calls

### DIFF
--- a/docs/docsite/rst/playbooks_lookups.rst
+++ b/docs/docsite/rst/playbooks_lookups.rst
@@ -292,6 +292,14 @@ You can specify regions or tables to fetch secrets from::
     - name: "Test credstash lookup plugin -- get the company's github password"
       debug: msg="Credstash lookup! {{ lookup('credstash', 'company-github-password', table='company-passwords') }}"
 
+You can access credentials kept in another aws account using an aws cli profile or sts assumed role
+    ---
+    - name: "Test credstash lookup plugin -- get credential from a different aws account named in ~/.aws/config"
+      debug: msg="Credstash lookup! {{ lookup('credstash', 'my-password', region='us-west-1', profile='production-account') }}"
+
+
+    - name: "Test credstash lookup plugin -- get credential from another account using STS assumed role"
+      debug: msg="Credstash lookup! {{ lookup('credstash', 'my-password', iam_arn_assume_role='sts-assume-other-account-role(specify arn)') }}"
 
 If you use the context feature when putting your secret, you can get it by passing a dictionary to the context option like this::
 

--- a/docs/docsite/rst/playbooks_lookups.rst
+++ b/docs/docsite/rst/playbooks_lookups.rst
@@ -292,7 +292,8 @@ You can specify regions or tables to fetch secrets from::
     - name: "Test credstash lookup plugin -- get the company's github password"
       debug: msg="Credstash lookup! {{ lookup('credstash', 'company-github-password', table='company-passwords') }}"
 
-You can access credentials kept in another aws account using an aws cli profile or sts assumed role
+You can access credentials kept in another aws account using an aws cli profile or sts assumed role.
+If both profile and iam_arn_assumed_role are set, iam_arn_assumed_role is ignored.
     ---
     - name: "Test credstash lookup plugin -- get credential from a different aws account named in ~/.aws/config"
       debug: msg="Credstash lookup! {{ lookup('credstash', 'my-password', region='us-west-1', profile='production-account') }}"

--- a/lib/ansible/plugins/lookup/credstash.py
+++ b/lib/ansible/plugins/lookup/credstash.py
@@ -1,3 +1,4 @@
+
 # (c) 2015, Ensighten <infra@ensighten.com>
 #
 # This file is part of Ansible
@@ -41,7 +42,8 @@ class LookupModule(LookupBase):
                 version = kwargs.pop('version', '')
                 region = kwargs.pop('region', None)
                 table = kwargs.pop('table', 'credential-store')
-                val = credstash.getSecret(term, version, region, table,
+                profile = kwargs.pop('profile', None)
+                val = credstash.getSecret(term, version, region, table, profile_name=profile,
                                           context=kwargs)
             except credstash.ItemNotFound:
                 raise AnsibleError('Key {0} not found'.format(term))

--- a/lib/ansible/plugins/lookup/credstash.py
+++ b/lib/ansible/plugins/lookup/credstash.py
@@ -57,7 +57,7 @@ class LookupModule(LookupBase):
                     except Exception as e:
                         raise AnsibleError('error assuming role {0} in profile {1}: {2}'.format(iam_arn_assume_role, profile, e))
                 try:
-                    val = credstash.getSecret(term, version, region, table, profile_name=profile, 
+                    val = credstash.getSecret(term, version, region, table, profile_name=profile,
                                               context=kwargs)
                 except Exception as e:
                     raise AnsibleError('credstash.getSecret failed with context {}'.format(kwargs))

--- a/lib/ansible/plugins/lookup/credstash.py
+++ b/lib/ansible/plugins/lookup/credstash.py
@@ -51,14 +51,14 @@ class LookupModule(LookupBase):
                 # As per docs, if profile is set we ignore arn.  Should probably log this.
                 # AWS_PROFILE set in environment WILL be respected.
                 if iam_arn_assume_role and not profile_was_set:
-                    try: 
-                        #creds = botocore.session.Session().get_credentials()
+                    try:
+                        # creds = botocore.session.Session().get_credentials()
                         session_params = credstash.get_session_params(None, iam_arn_assume_role)
                     except Exception as e:
                         raise AnsibleError('error assuming role {0} in profile {1}: {2}'.format(iam_arn_assume_role, profile, e))
                 try:
-                    val = credstash.getSecret(term, version, region, table, profile_name=profile,
-                                          context=kwargs)
+                    val = credstash.getSecret(term, version, region, table, profile_name=profile, 
+                                              context=kwargs)
                 except Exception as e:
                     raise AnsibleError('credstash.getSecret failed with context {}'.format(kwargs))
             except credstash.ItemNotFound:

--- a/lib/ansible/plugins/lookup/credstash.py
+++ b/lib/ansible/plugins/lookup/credstash.py
@@ -43,7 +43,7 @@ class LookupModule(LookupBase):
                 region = kwargs.pop('region', None)
                 table = kwargs.pop('table', 'credential-store')
                 profile = kwargs.pop('profile', None)
-                iam_arn_assume_role = kwargs.pop('iam_arn_credentials_store', None)
+                iam_arn_assume_role = kwargs.pop('iam_arn_assume_role', None)
                 val = credstash.getSecret(term, version, region, table, profile_name=profile,
                                           arn=iam_arn_assume_role, context=kwargs)
             except credstash.ItemNotFound:

--- a/lib/ansible/plugins/lookup/credstash.py
+++ b/lib/ansible/plugins/lookup/credstash.py
@@ -43,8 +43,9 @@ class LookupModule(LookupBase):
                 region = kwargs.pop('region', None)
                 table = kwargs.pop('table', 'credential-store')
                 profile = kwargs.pop('profile', None)
+                iam_arn_assume_role = kwargs.pop('iam_arn_credentials_store', None)
                 val = credstash.getSecret(term, version, region, table, profile_name=profile,
-                                          context=kwargs)
+                                          arn=iam_arn_assume_role, context=kwargs)
             except credstash.ItemNotFound:
                 raise AnsibleError('Key {0} not found'.format(term))
             except Exception as e:


### PR DESCRIPTION
##### SUMMARY

support a single aws account for credstash provisioning assets in other aws accounts
<!--- Describe the change, including rationale and design decisions -->

Credstash already supports -p PROFILE and -n ARN options but they are not exposed by the ansible lookup.
usage: credstash -h -r REGION -t TABLE -p PROFILE 
{delete,get,getall,list,put,setup}

but the ansible credstash lookup plugin does not expose them.

This will allow
`
vars:
my_secret_key: "{{ lookup('credstash', 'my_secret_key', region='us-west-2', iam_arn_assum_role=my_credstash_read_assume_role_arn) }}"

or 

vars:
my_secret_key: "{{ lookup('credstash', 'my_secret_key', region='us-west-2', profile=my_other_aws_account) }}"
`
We will prefer the iam_arn_assume_role method as it doesn't require a convention across devops and bots, just permission of the iam_role running the playbook to have permission to assume a credstash_read iam arn.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/plugins/lookup/credstash.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.

  -->
Here are the options in project credstash's credstash.py we are exposing
```
    role_parse = parsers['super'].add_mutually_exclusive_group()
    role_parse.add_argument("-p", "--profile", default=None,
                            help="Boto config profile to use when "
                            "connecting to AWS")
    role_parse.add_argument("-n", "--arn", default=None,
                            help="AWS IAM ARN for AssumeRole")
```
https://github.com/fugue/credstash/blob/master/credstash.py
It appears then ansible lookup should make "profile" and "iam_arn_assum_role" mutually exclusive.

Details of configuring ~/.aws/config and ~/.aws/credentials
https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before change, trying to access the creds in one aws account with AWS_SECRET_KEY and AWS_ACCESS_KEY from another gives

"msg": "An unhandled exception occurred while running the lookup plugin 'credstash'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Encountered exception while fetching my_secret: An error occurred (ResourceNotFoundException) when calling the Query operation: Requested resource not found"

After it works with no error.
```
