### PR TITLE
Fix vmware property filter

### DIFF
--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -560,7 +560,10 @@ class VMWareInventory(object):
 
                     # if the val wasn't set yet, get it from the parent
                     if not val:
-                        val = getattr(vm, x)
+                        try:
+                            val = getattr(vm, x)
+                        except AttributeError as e:
+                            self.debugl(e)
                     else:
                         # in a subkey, get the subprop from the previous attrib
                         try:


### PR DESCRIPTION
Me and my collegue @angystardust, using the property filters during a vm clone, have received an error from the dynamic inventory.
In that in that moment vmware doesn't have yet all the vm properties defined. 
With this try catch statement we can fix the problem.
It is important for us because during all the vm clones we can't use the dinamic inventory.
