### PR TITLE
Update fortios_config.py

### DIFF
--- a/lib/ansible/modules/network/fortios/fortios_config.py
+++ b/lib/ansible/modules/network/fortios/fortios_config.py
@@ -132,7 +132,7 @@ def main():
     f = FortiOS( module.params['host'],
         username=module.params['username'],
         password=module.params['password'],
-        timeout=module.params['username'],
+        timeout=module.params['timeout'],
         vdom=module.params['vdom'])
 
     #connect


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
timeout value should be pulled from "timeout" key...username is a string and causes login to error out.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
fortios_config
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/etc/ntc/ansible-modules/']
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
The FortiOS class instance was using the username value instead of the timeout value, which results in an invalid addition between float and str.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before:
fatal: [x.x.x.x]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "invocation": {
        "module_args": {
            "backup": false, 
            "backup_filename": null, 
            "backup_path": null, 
            "filter": "", 
            "host": "x.x.x.x", 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "src": "fortfwpol.conf", 
            "timeout": 60, 
            "username": "user", 
            "vdom": null
        }
    }, 
    "msg": "Error connecting device"
}

After:
A bunch of stuff
...
PLAY RECAP ******************************************************************************************************************************************************************************
10.1.100.123               : ok=1    changed=1    unreachable=0    failed=0 
```
