### PR TITLE
Stable 2.2. simple fix. PlaybookCLI does not honor configured callback

### DIFF
--- a/lib/ansible/cli/playbook.py
+++ b/lib/ansible/cli/playbook.py
@@ -154,7 +154,8 @@ class PlaybookCLI(CLI):
                 variable_manager.clear_facts(host)
 
         # create the playbook executor, which manages running the plays via a task queue manager
-        pbex = PlaybookExecutor(playbooks=self.args, inventory=inventory, variable_manager=variable_manager, loader=loader, options=self.options, passwords=passwords)
+        pbex = PlaybookExecutor(playbooks=self.args, inventory=inventory, variable_manager=variable_manager, loader=loader, options=self.options,
+                                passwords=passwords, callback=self.callback)
 
         results = pbex.run()
 

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -57,7 +57,8 @@ class PlaybookExecutor:
         if options.listhosts or options.listtasks or options.listtags or options.syntax:
             self._tqm = None
         else:
-            self._tqm = TaskQueueManager(inventory=inventory, variable_manager=variable_manager, loader=loader, options=options, passwords=self.passwords, stdout_callback=callback)
+            self._tqm = TaskQueueManager(inventory=inventory, variable_manager=variable_manager, loader=loader,
+                                         options=options, passwords=self.passwords, stdout_callback=callback)
 
         # Note: We run this here to cache whether the default ansible ssh
         # executable supports control persist.  Sometime in the future we may

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -44,7 +44,7 @@ class PlaybookExecutor:
     basis for bin/ansible-playbook operation.
     '''
 
-    def __init__(self, playbooks, inventory, variable_manager, loader, options, passwords):
+    def __init__(self, playbooks, inventory, variable_manager, loader, options, passwords, callback):
         self._playbooks        = playbooks
         self._inventory        = inventory
         self._variable_manager = variable_manager
@@ -52,11 +52,12 @@ class PlaybookExecutor:
         self._options          = options
         self.passwords         = passwords
         self._unreachable_hosts = dict()
+        self._callback         = callback
 
         if options.listhosts or options.listtasks or options.listtags or options.syntax:
             self._tqm = None
         else:
-            self._tqm = TaskQueueManager(inventory=inventory, variable_manager=variable_manager, loader=loader, options=options, passwords=self.passwords)
+            self._tqm = TaskQueueManager(inventory=inventory, variable_manager=variable_manager, loader=loader, options=options, passwords=self.passwords, stdout_callback=callback)
 
         # Note: We run this here to cache whether the default ansible ssh
         # executable supports control persist.  Sometime in the future we may

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -44,7 +44,7 @@ class PlaybookExecutor:
     basis for bin/ansible-playbook operation.
     '''
 
-    def __init__(self, playbooks, inventory, variable_manager, loader, options, passwords, callback):
+    def __init__(self, playbooks, inventory, variable_manager, loader, options, passwords, callback=None):
         self._playbooks        = playbooks
         self._inventory        = inventory
         self._variable_manager = variable_manager


### PR DESCRIPTION
##### SUMMARY
For some reason PlaybookCLI does not honor configured callback in base class, I fixed this to pass this callback to TaskQueueManager. It works for me and I was able to gather information from playbook execution from my callbacks at runtime.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/cli/playbook.py
lib/ansible/executor/playbook_executor.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
stable-2.2
```

