### PR TITLE
docker_container with pull: true will always report changed for Docker 1.12 on CentOS 7

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -430,13 +430,10 @@ class AnsibleDockerClient(Client):
         Pull an image
         '''
         self.log("Pulling image %s:%s" % (name, tag))
-        alreadyToLatest = False
+        old_tag = self.find_image(name, tag)
         try:
             for line in self.pull(name, tag=tag, stream=True, decode=True):
                 self.log(line, pretty_print=True)
-                if line.get('status'):
-                    if line.get('status').startswith('Status: Image is up to date for'):
-                        alreadyToLatest = True
                 if line.get('error'):
                     if line.get('errorDetail'):
                         error_detail = line.get('errorDetail')
@@ -448,6 +445,8 @@ class AnsibleDockerClient(Client):
         except Exception as exc:
             self.fail("Error pulling image %s:%s - %s" % (name, tag, str(exc)))
 
-        return self.find_image(name, tag), alreadyToLatest
+        new_tag = self.find_image(name, tag)
+
+        return new_tag, old_tag == new_tag
 
 


### PR DESCRIPTION
##### SUMMARY

- Docker 1.12 on CentOS 7 does not output `Status` line after pull
- Current implementation depends on the 'Status: Image is up to date for' to recognize when pull did not download newer image
- Related: #21508, #19549
- The patch changes the behavior to not rely on the Docker output when verifying if the image is the latest.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

module_utils docker_common

##### ANSIBLE VERSION

```
ansible 2.4.0 (fix_status_changed_for_docker_published_ports_without_defined_host_port b1e17c4b84) last updated 2017/04/03 22:01:10 (GMT +200)
  config file = 
  configured module search path = [u'/home/konrad/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/konrad/Build/ansible-graag/lib/ansible
  executable location = /home/konrad/Build/ansible-graag/bin/ansible
  python version = 2.7.9 (default, Jun 29 2016, 13:08:31) [GCC 4.9.2]
```
