### PR TITLE
docker_container will always report changed for published_ports: IP::PORT

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1513,7 +1513,10 @@ class Container(DockerBaseClass):
             if isinstance(container_port, int):
                 container_port = "%s/tcp" % container_port
             if len(config) == 1:
-                expected_bound_ports[container_port] = [{'HostIp': "0.0.0.0", 'HostPort': ""}]
+                if isinstance(config[0], int):
+                    expected_bound_ports[container_port] = [{'HostIp': "0.0.0.0", 'HostPort': config[0]}]
+                else:
+                    expected_bound_ports[container_port] = [{'HostIp': config[0], 'HostPort': ""}]
             elif isinstance(config[0], tuple):
                 expected_bound_ports[container_port] = []
                 for host_ip, host_port in config:


### PR DESCRIPTION
##### SUMMARY

- Published port defined as IP::PORT are parsed in docker_container._get_expected_ports as 0.0.0.0::PORT
- This causes the docker_container module to always return changed=True for such configs:
  - expected.container has correct IP
  - expected.parameters has 0.0.0.0 

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION

```
ansible 2.4.0 (fix_status_changed_for_docker_published_ports_without_defined_host_port b1e17c4b84) last updated 2017/04/03 22:01:10 (GMT +200)
  config file = 
  configured module search path = [u'/home/konrad/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/konrad/Build/ansible-graag/lib/ansible
  executable location = /home/konrad/Build/ansible-graag/bin/ansible
  python version = 2.7.9 (default, Jun 29 2016, 13:08:31) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION

Docker 1.12 on CentOS 7