### PR TITLE
Remove dupe supports_session method from eos module_utils

### DIFF
--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -111,10 +111,6 @@ class Cli:
             rc, out, err = self.exec_command(cmd)
         return out.endswith('#')
 
-    def supports_sessions(self):
-        rc, out, err = self.exec_command('show configuration sessions')
-        return rc == 0
-
     def get_config(self, flags=[]):
         """Retrieves the current config from the device or cache
         """


### PR DESCRIPTION
##### SUMMARY

Remove dupe supports_session method from eos module_utils

Fixes #23237

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/eos

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4
```
