### PR TITLE
Collect and display ssh config (-G) on '-vvvv'

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -975,6 +975,11 @@ class Connection(ConnectionBase):
             (returncode, stdout, stderr) = self._run(cmd, in_data, sudoable, checkrc=False)
         except AnsibleConnectionFailure:
             # -G failed, could be too old, not openssh, etc.
+            # The 'ssh -G' option will not attempt to connect (even versions without -G will
+            # exit with an invalid option error) so errors here should always indicate -G not being supported if
+            # we can assume the rest of the constructed cmd line is valid. ie, a user adding '--sdfadfasdfasd' to ssh_args
+            # will get this message in addition to normal ssh errors.
+            display.vvvv(u"SSH CONFIG DEBUG: {0}".format("Version of ssh doesn't support '-G'?"), host=self.host)
             return
 
         if returncode != 0:


### PR DESCRIPTION
##### SUMMARY
Collect and display ssh config (-G) on '-vvvv'

Via openssh's '-G' option. If we are at verbosity >=
4, then we run the ssh we would use for exec_command
but with the -G option, and capture and display the output.

The rationale is to make it easier to troubleshoot ssh config related problems

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request



##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/plugins/connection/ssh.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (ssh_G_V_in_vvvv 8469fae77b) last updated 2017/04/03 18:32:49 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]


```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Example output:

(The noisy output at '-vvv' is from the _ssh_retry decorator, that should probably get bumped to 'vvvvv', but thats preexisting...)

```
[fedora-25:ansible (ssh_G_in_vvvv %)]$ ansible -vvvv local_ssh -i hosts -m ping 
Using /etc/ansible/ansible.cfg as config file
Loading callback plugin minimal of type stdout, v2.0 from /home/adrian/src/ansible/lib/ansible/plugins/callback/__init__.pyc
META: ran handlers
Using module file /home/adrian/src/ansible/lib/ansible/modules/system/ping.py
<127.0.0.1> ESTABLISH SSH CONNECTION FOR USER: None
<127.0.0.1> SSH: EXEC ssh -vvv -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/home/adrian/.ansible/cp/ansible-ssh-%C 127.0.0.1 -G
<127.0.0.1> (0, 'user adrian\nhostname 127.0.0.1\nport 22\naddressfamily any\nbatchmode no\ncanonicalizefallbacklocal yes\ncanonicalizehostname false\nchallengeresponseauthentication yes\ncheckhostip yes\ncompression yes\ncontrolmaster auto\nenablesshkeysign no\nclearallforwardings no\nexitonforwardfailure no\nforwardagent no\nforwardx11 no\nforwardx11trusted yes\ngatewayports no\ngssapiauthentication yes\ngssapidelegatecredentials no\nhashknownhosts no\nhostbasedauthentication no\nidentitiesonly no\nkbdinteractiveauthentication no\nnohostauthenticationforlocalhost no\npasswordauthentication no\npermitlocalcommand no\nprotocol 2\nproxyusefdpass no\npubkeyauthentication yes\nrequesttty auto\nrhostsrsaauthentication no\nrsaauthentication yes\nstreamlocalbindunlink no\nstricthostkeychecking ask\ntcpkeepalive yes\ntunnel false\nuseprivilegedport no\nverifyhostkeydns false\nvisualhostkey no\nupdatehostkeys false\ncanonicalizemaxdots 1\ncompressionlevel 6\nconnectionattempts 1\nforwardx11timeout 1200\nnumberofpasswordprompts 3\nserveralivecountmax 3\nserveraliveinterval 0\nciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,aes128-cbc,aes192-cbc,aes256-cbc\ncontrolpath /home/adrian/.ansible/cp/ansible-ssh-ee9cf161400597b52cf9d4ecb22df3181058e1ba\nhostkeyalgorithms ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa\nhostbasedkeytypes ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa\nkexalgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha256,diffie-hellman-group14-sha1\nloglevel DEBUG3\nmacs umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1\npreferredauthentications gssapi-with-mic,gssapi-keyex,hostbased,publickey\npubkeyacceptedkeytypes ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa\nxauthlocation /usr/bin/xauth\nidentityfile ~/.ssh/id_rsa\nidentityfile ~/.ssh/id_dsa\nidentityfile ~/.ssh/id_ecdsa\nidentityfile ~/.ssh/id_ed25519\ncanonicaldomains\nglobalknownhostsfile /etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts2\nuserknownhostsfile ~/.ssh/known_hosts ~/.ssh/known_hosts2\nsendenv LANG\nsendenv LC_CTYPE\nsendenv LC_NUMERIC\nsendenv LC_TIME\nsendenv LC_COLLATE\nsendenv LC_MONETARY\nsendenv LC_MESSAGES\nsendenv LC_PAPER\nsendenv LC_NAME\nsendenv LC_ADDRESS\nsendenv LC_TELEPHONE\nsendenv LC_MEASUREMENT\nsendenv LC_IDENTIFICATION\nsendenv LC_ALL\nsendenv LANGUAGE\nsendenv XMODIFIERS\nfingerprinthash SHA256 MD5\nconnecttimeout 10\ntunneldevice any:any\ncontrolpersist 60\nescapechar ~\nipqos lowdelay throughput\nrekeylimit 0 0\nstreamlocalbindmask 0177\n', 'OpenSSH_7.4p1, OpenSSL 1.0.2k-fips  26 Jan 2017\r\ndebug1: Reading configuration data /home/adrian/.ssh/config\r\ndebug1: /home/adrian/.ssh/config line 79: Applying options for *\r\ndebug1: Reading configuration data /etc/ssh/ssh_config\r\ndebug3: /etc/ssh/ssh_config line 56: Including file /etc/ssh/ssh_config.d/05-redhat.conf depth 0\r\ndebug1: Reading configuration data /etc/ssh/ssh_config.d/05-redhat.conf\r\ndebug1: /etc/ssh/ssh_config.d/05-redhat.conf line 2: include /etc/crypto-policies/back-ends/openssh.config matched no files\r\ndebug1: /etc/ssh/ssh_config.d/05-redhat.conf line 8: Applying options for *\r\n')
<127.0.0.1> SSH CONFIG DEBUG: user adrian
hostname 127.0.0.1
port 22
addressfamily any
batchmode no
canonicalizefallbacklocal yes
canonicalizehostname false
challengeresponseauthentication yes
checkhostip yes
compression yes
controlmaster auto
enablesshkeysign no
clearallforwardings no
exitonforwardfailure no
forwardagent no
forwardx11 no
forwardx11trusted yes
gatewayports no
gssapiauthentication yes
gssapidelegatecredentials no
hashknownhosts no
hostbasedauthentication no
identitiesonly no
kbdinteractiveauthentication no
nohostauthenticationforlocalhost no
passwordauthentication no
permitlocalcommand no
protocol 2
proxyusefdpass no
pubkeyauthentication yes
requesttty auto
rhostsrsaauthentication no
rsaauthentication yes
streamlocalbindunlink no
stricthostkeychecking ask
tcpkeepalive yes
tunnel false
useprivilegedport no
verifyhostkeydns false
visualhostkey no
updatehostkeys false
canonicalizemaxdots 1
compressionlevel 6
connectionattempts 1
forwardx11timeout 1200
numberofpasswordprompts 3
serveralivecountmax 3
serveraliveinterval 0
ciphers chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,aes128-cbc,aes192-cbc,aes256-cbc
controlpath /home/adrian/.ansible/cp/ansible-ssh-ee9cf161400597b52cf9d4ecb22df3181058e1ba
hostkeyalgorithms ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
hostbasedkeytypes ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
kexalgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha256,diffie-hellman-group14-sha1
loglevel DEBUG3
macs umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1
preferredauthentications gssapi-with-mic,gssapi-keyex,hostbased,publickey
pubkeyacceptedkeytypes ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
xauthlocation /usr/bin/xauth
identityfile ~/.ssh/id_rsa
identityfile ~/.ssh/id_dsa
identityfile ~/.ssh/id_ecdsa
identityfile ~/.ssh/id_ed25519
canonicaldomains
globalknownhostsfile /etc/ssh/ssh_known_hosts /etc/ssh/ssh_known_hosts2
userknownhostsfile ~/.ssh/known_hosts ~/.ssh/known_hosts2
sendenv LANG
sendenv LC_CTYPE
sendenv LC_NUMERIC
sendenv LC_TIME
sendenv LC_COLLATE
sendenv LC_MONETARY
sendenv LC_MESSAGES
sendenv LC_PAPER
sendenv LC_NAME
sendenv LC_ADDRESS
sendenv LC_TELEPHONE
sendenv LC_MEASUREMENT
sendenv LC_IDENTIFICATION
sendenv LC_ALL
sendenv LANGUAGE
sendenv XMODIFIERS
fingerprinthash SHA256 MD5
connecttimeout 10
tunneldevice any:any
controlpersist 60
escapechar ~
ipqos lowdelay throughput
rekeylimit 0 0
streamlocalbindmask 0177

```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
