### PR TITLE
fortios_ipv4_policy.py state=absent Fix 23239

### DIFF
--- a/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
+++ b/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
@@ -37,7 +37,7 @@ options:
   id:
     description:
       - Policy ID
-        Warning: policy I(id)# is different than Policy sequence#
+        Warning, policy I(id) number is different than Policy sequence number
         Default web display show only policies sequence numbers,
         you need to add policy id column in display options.
     required: true

--- a/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
+++ b/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
@@ -36,9 +36,10 @@ extends_documentation_fragment: fortios
 options:
   id:
     description:
-      - Policy ID (/!\ warning: policy I(id) != Policy sequence! /!\ 
-        Default display show only policies sequence numbers, 
-        you need to add policy I(id) column in display options.
+      - Policy ID
+        /!\ Warning: policy I(id)# is different than Policy sequence# /!\
+        Default web display show only policies sequence numbers,
+        you need to add policy id column in display options.
     required: true
   state:
     description:

--- a/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
+++ b/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
@@ -37,7 +37,7 @@ options:
   id:
     description:
       - Policy ID
-        /!\ Warning: policy I(id)# is different than Policy sequence# /!\
+        Warning: policy I(id)# is different than Policy sequence#
         Default web display show only policies sequence numbers,
         you need to add policy id column in display options.
     required: true

--- a/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
+++ b/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
@@ -59,7 +59,7 @@ options:
     default: any
   src_addr:
     description:
-      - Specifies source address (or group) object name(s).
+      - Specifies source address (or group) object name(s). Required when I(state=present).
   src_addr_negate:
     description:
       - Negate source address param.
@@ -67,7 +67,7 @@ options:
     choices: ["true", "false"]
   dst_addr:
     description:
-      - Specifies destination address (or group) object name(s).
+      - Specifies destination address (or group) object name(s). Required when I(state=present).
   dst_addr_negate:
     description:
       - Negate destination address param.
@@ -75,12 +75,12 @@ options:
     choices: ["true", "false"]
   policy_action:
     description:
-      - Specifies accept or deny action policy.
+      - Specifies accept or deny action policy. Required when I(state=present).
     choices: ['accept', 'deny']
     aliases: ['action']
   service:
     description:
-      - "Specifies policy service(s), could be a list (ex: ['MAIL','DNS'])."
+      - "Specifies policy service(s), could be a list (ex: ['MAIL','DNS']). Required when I(state=present)."
     aliases:
       - services
   service_negate:

--- a/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
+++ b/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
@@ -36,13 +36,13 @@ extends_documentation_fragment: fortios
 options:
   id:
     description:
-      - "Policy ID\n
-        Warning: policy ID # is different than Policy sequence# \n
-        The policy ID is the number assigned at policy creation. \n
-        The sequence # represents the order in which the Fortigate will evaluate the rule for policy enforcement, \n
-        and also the order in which rules are listed in the GUI and CLI.\n
-        These two numbers do not necessarily correlate: this module is based off policy ID.\n
-        TIP: policy ID can be viewed in the GUI by adding "ID" to the display columns."
+      - "Policy ID.
+        Warning: policy ID number is different than Policy sequence number.
+        The policy ID is the number assigned at policy creation.
+        The sequence number represents the order in which the Fortigate will evaluate the rule for policy enforcement,
+        and also the order in which rules are listed in the GUI and CLI.
+        These two numbers do not necessarily correlate: this module is based off policy ID.
+        TIP: policy ID can be viewed in the GUI by adding 'ID' to the display columns"
     required: true
   state:
     description:

--- a/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
+++ b/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
@@ -36,10 +36,10 @@ extends_documentation_fragment: fortios
 options:
   id:
     description:
-      - Policy ID
+      - 'Policy ID
         Warning, policy I(id) number is different than Policy sequence number
         Default web display show only policies sequence numbers,
-        you need to add policy id column in display options.
+        you need to add policy id column in display options.'
     required: true
   state:
     description:

--- a/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
+++ b/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
@@ -60,7 +60,6 @@ options:
   src_addr:
     description:
       - Specifies source address (or group) object name(s).
-    required: true
   src_addr_negate:
     description:
       - Negate source address param.
@@ -69,7 +68,6 @@ options:
   dst_addr:
     description:
       - Specifies destination address (or group) object name(s).
-    required: true
   dst_addr_negate:
     description:
       - Negate destination address param.
@@ -79,12 +77,10 @@ options:
     description:
       - Specifies accept or deny action policy.
     choices: ['accept', 'deny']
-    required: true
     aliases: ['action']
   service:
     description:
       - "Specifies policy service(s), could be a list (ex: ['MAIL','DNS'])."
-    required: true
     aliases:
       - services
   service_negate:

--- a/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
+++ b/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
@@ -36,10 +36,13 @@ extends_documentation_fragment: fortios
 options:
   id:
     description:
-      - 'Policy ID
-        Warning, policy I(id) number is different than Policy sequence number
-        Default web display show only policies sequence numbers,
-        you need to add policy id column in display options.'
+      - "Policy ID\n
+        Warning: policy ID # is different than Policy sequence# \n
+        The policy ID is the number assigned at policy creation. \n
+        The sequence # represents the order in which the Fortigate will evaluate the rule for policy enforcement, \n
+        and also the order in which rules are listed in the GUI and CLI.\n
+        These two numbers do not necessarily correlate: this module is based off policy ID.\n
+        TIP: policy ID can be viewed in the GUI by adding "ID" to the display columns."
     required: true
   state:
     description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

path is missing when state=absent
update doc for unclear policy ID
required params based on state

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #23239

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
fortios_ipv4_policy

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (fix_23239 39ea712c27)
```