### PR TITLE
Fix deploy_helper join exception on no release.

### DIFF
--- a/lib/ansible/modules/web_infrastructure/deploy_helper.py
+++ b/lib/ansible/modules/web_infrastructure/deploy_helper.py
@@ -316,7 +316,10 @@ class DeployHelper(object):
         if not self.release and (self.state == 'query' or self.state == 'present'):
             self.release = time.strftime("%Y%m%d%H%M%S")
 
-        new_release_path = os.path.join(releases_path, self.release)
+        if self.release:
+            new_release_path = os.path.join(releases_path, self.release)
+        else:
+            new_release_path = None
 
         return {
             'project_path':             self.path,


### PR DESCRIPTION
##### SUMMARY

Fix an exception caused by `self.release` being `None`.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

deploy_helper

##### ANSIBLE VERSION

```
ansible 2.4.0 (deploy_helper_tests 824e14f99d) last updated 2017/04/03 16:23:31 (GMT -700)
  config file = 
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
