### PR TITLE
Pull filesystems from dict in case is not string on eos_facts

### DIFF
--- a/lib/ansible/modules/network/eos/eos_facts.py
+++ b/lib/ansible/modules/network/eos/eos_facts.py
@@ -201,6 +201,10 @@ class Hardware(FactsBase):
 
     def populate_filesystems(self):
         data = self.responses[0]
+
+        if isinstance(data, dict):
+            data = data['messages'][0]
+
         fs = re.findall(r'^Directory of (.+)/', data, re.M)
         return dict(filesystems=fs)
 


### PR DESCRIPTION
##### SUMMARY

Apparently in some devices the filesystems gathering command can return
a dict containing a 'messages' key with the filesystems, instead of a
plain string.

Fixes #23217

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
eos_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (issue_23217 8e4680f031) last updated 2017/04/04 11:33:16 (GMT +200)
```
