### PR TITLE
ec2_asg: check autoscaling group for tags before trying to use them - partially fixes #23234

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -551,11 +551,12 @@ def create_autoscaling_group(connection, module):
                 want_tags[tag.key] = [tag.value, tag.propagate_at_launch]
 
             dead_tags = []
-            for tag in as_group.tags:
-                have_tags[tag.key] = [tag.value, tag.propagate_at_launch]
-                if tag.key not in want_tags:
-                    changed = True
-                    dead_tags.append(tag)
+            if getattr(as_group, "tags", None):
+                for tag in as_group.tags:
+                    have_tags[tag.key] = [tag.value, tag.propagate_at_launch]
+                    if tag.key not in want_tags:
+                        changed = True
+                        dead_tags.append(tag)
 
             if dead_tags != []:
                 connection.delete_tags(dead_tags)

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -557,6 +557,8 @@ def create_autoscaling_group(connection, module):
                     if tag.key not in want_tags:
                         changed = True
                         dead_tags.append(tag)
+            elif getattr(as_group, "tags", None) is None and asg_tags:
+                module.warn("It appears your ASG is attached to a target group. This is a boto2 bug. Tags will be added but no tags are able to be removed.")
 
             if dead_tags != []:
                 connection.delete_tags(dead_tags)


### PR DESCRIPTION
##### SUMMARY
This is a [boto bug](https://github.com/boto/boto/issues/3613). For the time being (until ec2_asg works with boto3) Is it better to allow adding tags and ignore that dead tags are not being removed, or raise an exception?

The problem: as_group.tags may be None (incorrectly; when there is a target group attached it is None regardless of if there are tags, and it is expected to be an empty list anyway when there are no tags), but we were trying to iterate over it without checking that first. This PR allows tags to be added instead of failing, but doesn't allow tags to be removed since boto isn't retrieving those correctly. I have added a warning.
Partly fixes #23234

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_asg.py

##### ANSIBLE VERSION
```
2.4.0
```