### PR TITLE
'unable to open shell' -> direct to web help

### DIFF
--- a/lib/ansible/plugins/action/dellos10.py
+++ b/lib/ansible/plugins/action/dellos10.py
@@ -74,8 +74,8 @@ class ActionModule(_ActionModule):
             rc, out, err = connection.exec_command('open_shell()')
             if not rc == 0:
                 return {'failed': True,
-                        'msg': 'unable to open shell. Please see: '
-                               + 'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
+                        'msg': 'unable to open shell. Please see: ' +
+                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
                         'rc': rc}
         else:
             # make sure we are in the right cli context which should be

--- a/lib/ansible/plugins/action/dellos10.py
+++ b/lib/ansible/plugins/action/dellos10.py
@@ -73,7 +73,10 @@ class ActionModule(_ActionModule):
             # start the connection if it isn't started
             rc, out, err = connection.exec_command('open_shell()')
             if not rc == 0:
-                return {'failed': True, 'msg': 'unable to open shell', 'rc': rc}
+                return {'failed': True,
+                        'msg': 'unable to open shell. Please see: '
+                               + 'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
+                        'rc': rc}
         else:
             # make sure we are in the right cli context which should be
             # enable mode and not config module

--- a/lib/ansible/plugins/action/dellos6.py
+++ b/lib/ansible/plugins/action/dellos6.py
@@ -69,7 +69,10 @@ class ActionModule(_ActionModule):
             # start the connection if it isn't started
             rc, out, err = connection.exec_command('open_shell()')
             if not rc == 0:
-                return {'failed': True, 'msg': 'unable to open shell', 'rc': rc}
+                return {'failed': True,
+                        'msg': 'unable to open shell. Please see: '
+                               + 'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
+                        'rc': rc}
         else:
             # make sure we are in the right cli context which should be
             # enable mode and not config module

--- a/lib/ansible/plugins/action/dellos6.py
+++ b/lib/ansible/plugins/action/dellos6.py
@@ -70,8 +70,8 @@ class ActionModule(_ActionModule):
             rc, out, err = connection.exec_command('open_shell()')
             if not rc == 0:
                 return {'failed': True,
-                        'msg': 'unable to open shell. Please see: '
-                               + 'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
+                        'msg': 'unable to open shell. Please see: ' +
+                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
                         'rc': rc}
         else:
             # make sure we are in the right cli context which should be

--- a/lib/ansible/plugins/action/dellos9.py
+++ b/lib/ansible/plugins/action/dellos9.py
@@ -74,8 +74,8 @@ class ActionModule(_ActionModule):
             rc, out, err = connection.exec_command('open_shell()')
             if not rc == 0:
                 return {'failed': True,
-                        'msg': 'unable to open shell. Please see: '
-                               + 'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
+                        'msg': 'unable to open shell. Please see: ' +
+                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
                         'rc': rc}
         else:
             # make sure we are in the right cli context which should be

--- a/lib/ansible/plugins/action/dellos9.py
+++ b/lib/ansible/plugins/action/dellos9.py
@@ -73,7 +73,10 @@ class ActionModule(_ActionModule):
             # start the connection if it isn't started
             rc, out, err = connection.exec_command('open_shell()')
             if not rc == 0:
-                return {'failed': True, 'msg': 'unable to open shell', 'rc': rc}
+                return {'failed': True,
+                        'msg': 'unable to open shell. Please see: '
+                               + 'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
+                        'rc': rc}
         else:
             # make sure we are in the right cli context which should be
             # enable mode and not config module

--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -74,7 +74,9 @@ class ActionModule(_ActionModule):
                 display.vvvv('calling open_shell()', pc.remote_addr)
                 rc, out, err = connection.exec_command('open_shell()')
                 if not rc == 0:
-                    return {'failed': True, 'msg': 'unable to open shell'}
+                    return {'failed': True,
+                            'msg': 'unable to open shell. Please see: '
+                                   + 'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
             else:
                 # make sure we are in the right cli context which should be
                 # enable mode and not config module

--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -75,8 +75,8 @@ class ActionModule(_ActionModule):
                 rc, out, err = connection.exec_command('open_shell()')
                 if not rc == 0:
                     return {'failed': True,
-                            'msg': 'unable to open shell. Please see: '
-                                   + 'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
+                            'msg': 'unable to open shell. Please see: ' +
+                                   'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
             else:
                 # make sure we are in the right cli context which should be
                 # enable mode and not config module

--- a/lib/ansible/plugins/action/ios.py
+++ b/lib/ansible/plugins/action/ios.py
@@ -69,7 +69,10 @@ class ActionModule(_ActionModule):
             # start the connection if it isn't started
             rc, out, err = connection.exec_command('open_shell()')
             if not rc == 0:
-                return {'failed': True, 'msg': 'unable to open shell', 'rc': rc}
+                return {'failed': True,
+                        'msg': 'unable to open shell. Please see: '
+                               + 'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
+                        'rc': rc}
         else:
             # make sure we are in the right cli context which should be
             # enable mode and not config module

--- a/lib/ansible/plugins/action/ios.py
+++ b/lib/ansible/plugins/action/ios.py
@@ -70,8 +70,8 @@ class ActionModule(_ActionModule):
             rc, out, err = connection.exec_command('open_shell()')
             if not rc == 0:
                 return {'failed': True,
-                        'msg': 'unable to open shell. Please see: '
-                               + 'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
+                        'msg': 'unable to open shell. Please see: ' +
+                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
                         'rc': rc}
         else:
             # make sure we are in the right cli context which should be

--- a/lib/ansible/plugins/action/iosxr.py
+++ b/lib/ansible/plugins/action/iosxr.py
@@ -67,7 +67,10 @@ class ActionModule(_ActionModule):
             display.vvvv('calling open_shell()', pc.remote_addr)
             rc, out, err = connection.exec_command('open_shell()')
             if rc != 0:
-                return {'failed': True, 'msg': 'unable to open shell', 'rc': rc}
+                return {'failed': True,
+                        'msg': 'unable to open shell. Please see: '
+                               + 'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
+                        'rc': rc}
         else:
             # make sure we are in the right cli context which should be
             # enable mode and not config module

--- a/lib/ansible/plugins/action/iosxr.py
+++ b/lib/ansible/plugins/action/iosxr.py
@@ -68,8 +68,8 @@ class ActionModule(_ActionModule):
             rc, out, err = connection.exec_command('open_shell()')
             if rc != 0:
                 return {'failed': True,
-                        'msg': 'unable to open shell. Please see: '
-                               + 'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
+                        'msg': 'unable to open shell. Please see: ' +
+                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
                         'rc': rc}
         else:
             # make sure we are in the right cli context which should be

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -74,7 +74,10 @@ class ActionModule(_ActionModule):
                 rc, out, err = connection.exec_command('open_shell()')
                 display.vvvv('open_shell() returned %s %s %s' % (rc, out, err))
                 if rc != 0:
-                    return {'failed': True, 'msg': 'unable to open shell', 'rc': rc}
+                    return {'failed': True,
+                            'msg': 'unable to open shell. Please see: '
+                                   + 'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
+                            'rc': rc}
             else:
                 # make sure we are in the right cli context which should be
                 # enable mode and not config module


### PR DESCRIPTION
##### SUMMARY
The "unable to open shell" error is returned for a number of different,
direct people to online docs (we we can update out of band of releases)
to guide them though the various solutions.


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
networking

##### ANSIBLE VERSION
```
ansible 2.4.0 (unabletoopenshell 0e954dcd6e) last updated 2017/04/04 20:33:08 (GMT +100)

```


Example output
```yaml
TASK [Get facts] *********************************************************************************************************************************************************************************************************************************
fatal: [ios01]: FAILED! => {"changed": false, "failed": true, "msg": "unable to open shell. Please see: https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell", "rc": 255}
	to retry, use: --limit @/home/johnb/git/ansible-inc/ansible-workspace-2/test/integration/bug.retry

PLAY RECAP ***************************************************************************************************************************************************************************************************************************************
ios01                      : ok=0    changed=0    unreachable=0    failed=1 

```


For `stable-2.3` & `devel`