### PR TITLE
[WIP] Clearer error reporting for netconf

### DIFF
--- a/lib/ansible/module_utils/netconf.py
+++ b/lib/ansible/module_utils/netconf.py
@@ -47,6 +47,7 @@ def send_request(module, obj, check_rc=True):
             module.fail_json(msg=str(err))
 
         warnings = []
+        errors = []
         for rpc_error in error_list:
             message = rpc_error.find('./nc:error-message', NS_MAP).text
             severity = rpc_error.find('./nc:error-severity', NS_MAP).text
@@ -54,8 +55,27 @@ def send_request(module, obj, check_rc=True):
             if severity == 'warning':
                 warnings.append(message)
             else:
-                module.fail_json(msg=str(err))
-        return warnings
+                err_type = rpc_error.find('./nc:error-type', NS_MAP).text
+                err_tag = rpc_error.find('./nc:error-tag', NS_MAP).text
+                err_extras = []
+
+                for tag in ['error-app-tag', 'error-path']:
+                    node = rpc_error.find('./nc:%s' % tag, NS_MAP)
+                    if node:
+                        err_extras.append(node.text)
+
+                err_info = rpc_error.find('./nc:error-info', NS_MAP)
+                if err_info:
+                    for tag in err_info.findall('*'):
+                        err_extras.append('%s: %s' % (tag.tag.split('}', 1)[1], tag.text))
+
+                extra_info = ', '.join(err_extras)
+                err_message = '[%s] %s: %s (%s)' % (err_type, err_tag, message, extra_info)
+                errors.append(err_message)
+        if errors:
+            module.fail_json(msg=', '.join(errors))
+        else:
+            return warnings
     return fromstring(out)
 
 def children(root, iterable):


### PR DESCRIPTION
##### SUMMARY
Right now errors from netconf are just a pile of XML. No one wants that. This change tries to take the XML and pull out meaningful error messages.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/netconf.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```
