### PR TITLE
Fixes pylint errors

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_gtm_datacenter.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_datacenter.py
@@ -320,7 +320,7 @@ class BigIpGtmDatacenter(object):
         enabled = self.params['enabled']
 
         if state is None and enabled is None:
-            module.fail_json(msg="Neither 'state' nor 'enabled' set")
+            raise F5ModuleError("Neither 'state' nor 'enabled' set")
 
         try:
             if state == "present":

--- a/lib/ansible/modules/network/f5/bigip_routedomain.py
+++ b/lib/ansible/modules/network/f5/bigip_routedomain.py
@@ -476,18 +476,12 @@ class BigIpRouteDomain(object):
         result = dict()
         state = self.params['state']
 
-        if self.params['check_mode']:
-            if value == current:
-                changed = False
-            else:
-                changed = True
-        else:
-            if state == "present":
-                changed = self.present()
-                current = self.read()
-                result.update(current)
-            elif state == "absent":
-                changed = self.absent()
+        if state == "present":
+            changed = self.present()
+            current = self.read()
+            result.update(current)
+        elif state == "absent":
+            changed = self.absent()
 
         result.update(dict(changed=changed))
         return result

--- a/lib/ansible/modules/network/f5/bigip_ssl_certificate.py
+++ b/lib/ansible/modules/network/f5/bigip_ssl_certificate.py
@@ -444,6 +444,8 @@ class BigIpSslCertificate(object):
 
     def delete(self):
         changed = False
+        name = self.params['name']
+        partition = self.params['partition']
 
         check_mode = self.params['check_mode']
 


### PR DESCRIPTION
##### SUMMARY
Reported by gundalow, this fixes pylint errors in F5 modules

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
* lib/ansible/modules/network/f5/bigip_gtm_datacenter.py
* lib/ansible/modules/network/f5/bigip_routedomain.py
* lib/ansible/modules/network/f5/bigip_ssl_certificate.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.10 (default, Jul 30 2016, 18:31:42) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
