### PR TITLE
vmware_guest: Add support for Linked Clones

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1113,9 +1113,7 @@ class PyVmomiHelper(object):
                         self.module.fail_json(msg='virtual machine "{0}" does not contain snapshot named "{1}"'.format(
                             self.params['template'], self.params['snapshot_src']))
 
-                    if len(snapshot) == 1:
-                        snapshot = snapshot[0].snapshot
-                    clonespec.snapshot = snapshot
+                    clonespec.snapshot = snapshot[0].snapshot
 
                 clonespec.config = self.configspec
                 task = vm_obj.Clone(folder=destfolder, name=self.params['name'], spec=clonespec)

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -109,7 +109,7 @@ options:
             - Name of an existing snapshot to use to create a clone of a VM.
         default: None
         version_added: "2.4"
-   snapshot_linked:
+   linked_clone:
         description:
             - Whether to create a Linked Clone from the snapshot specified
         default: False
@@ -1099,7 +1099,7 @@ class PyVmomiHelper(object):
                 relospec.datastore = datastore
                 relospec.pool = resource_pool
 
-                if self.params['snapshot_src'] is not None and self.params['snapshot_linked']:
+                if self.params['snapshot_src'] is not None and self.params['linked_clone']:
                     relospec.diskMoveType = vim.vm.RelocateSpec.DiskMoveOptions.createNewChildDiskBacking
 
                 clonespec = vim.vm.CloneSpec(template=self.params['is_template'], location=relospec)
@@ -1310,7 +1310,7 @@ def main():
             cluster=dict(type='str'),
             wait_for_ip_address=dict(type='bool', default=False),
             snapshot_src=dict(type='str', default=None),
-            snapshot_linked=dict(type='bool', default=False),
+            linked_clone=dict(type='bool', default=False),
             networks=dict(type='list', default=[]),
             resource_pool=dict(type='str'),
             customization=dict(type='dict', no_log=True, default={}),

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -104,7 +104,7 @@ options:
             - Wait until vCenter detects an IP address for the VM
             - This requires vmware-tools (vmtoolsd) to properly work after creation
         default: False
-   snapshot_name:
+   snapshot_src:
         description:
             - A string that when specified, will create a linked clone copy of the VM. Snapshot must already be taken in vCenter.
         default: None
@@ -1094,19 +1094,19 @@ class PyVmomiHelper(object):
                 relospec.datastore = datastore
                 relospec.pool = resource_pool
 
-                if self.params['snapshot_name'] is not None:
+                if self.params['snapshot_src'] is not None:
                     relospec.diskMoveType = vim.vm.RelocateSpec.DiskMoveOptions.createNewChildDiskBacking
 
                 clonespec = vim.vm.CloneSpec(template=self.params['is_template'], location=relospec)
                 if self.customspec:
                     clonespec.customization = self.customspec
 
-                if self.params['snapshot_name'] is not None:
+                if self.params['snapshot_src'] is not None:
                     snapshot = self.get_snapshots_by_name_recursively(snapshots=vm_obj.snapshot.rootSnapshotList,
-                                                                      snapname=self.params['snapshot_name'])
+                                                                      snapname=self.params['snapshot_src'])
                     if len(snapshot) != 1:
                         self.module.fail_json(msg='virtual machine "{0}" does not contain snapshot named "{1}"'.format(
-                            self.params['template'], self.params['snapshot_name']))
+                            self.params['template'], self.params['snapshot_src']))
 
                     if len(snapshot) == 1:
                         snapshot = snapshot[0].snapshot
@@ -1304,7 +1304,7 @@ def main():
             esxi_hostname=dict(type='str'),
             cluster=dict(type='str'),
             wait_for_ip_address=dict(type='bool', default=False),
-            snapshot_name=dict(type='str', default=None),
+            snapshot_src=dict(type='str', default=None),
             networks=dict(type='list', default=[]),
             resource_pool=dict(type='str'),
             customization=dict(type='dict', no_log=True, default={}),

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -106,8 +106,13 @@ options:
         default: False
    snapshot_src:
         description:
-            - A string that when specified, will create a linked clone copy of the VM. Snapshot must already be taken in vCenter.
+            - Name of an existing snapshot to use to create a clone of a VM.
         default: None
+        version_added: "2.4"
+   snapshot_linked:
+        description:
+            - Whether to create a Linked Clone from the snapshot specified
+        default: False
         version_added: "2.4"
    force:
         description:
@@ -1094,7 +1099,7 @@ class PyVmomiHelper(object):
                 relospec.datastore = datastore
                 relospec.pool = resource_pool
 
-                if self.params['snapshot_src'] is not None:
+                if self.params['snapshot_src'] is not None and self.params['snapshot_linked']:
                     relospec.diskMoveType = vim.vm.RelocateSpec.DiskMoveOptions.createNewChildDiskBacking
 
                 clonespec = vim.vm.CloneSpec(template=self.params['is_template'], location=relospec)
@@ -1305,6 +1310,7 @@ def main():
             cluster=dict(type='str'),
             wait_for_ip_address=dict(type='bool', default=False),
             snapshot_src=dict(type='str', default=None),
+            snapshot_linked=dict(type='bool', default=False),
             networks=dict(type='list', default=[]),
             resource_pool=dict(type='str'),
             customization=dict(type='dict', no_log=True, default={}),

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -104,6 +104,11 @@ options:
             - Wait until vCenter detects an IP address for the VM
             - This requires vmware-tools (vmtoolsd) to properly work after creation
         default: False
+   snapshot_name:
+        description:
+            - A string that when specified, will create a linked clone copy of the VM. Snapshot must already be taken in vCenter.
+        default: None
+        version_added: "2.4"
    force:
         description:
             - Ignore warnings and complete the actions
@@ -1089,9 +1094,23 @@ class PyVmomiHelper(object):
                 relospec.datastore = datastore
                 relospec.pool = resource_pool
 
+                if self.params['snapshot_name'] is not None:
+                    relospec.diskMoveType = vim.vm.RelocateSpec.DiskMoveOptions.createNewChildDiskBacking
+
                 clonespec = vim.vm.CloneSpec(template=self.params['is_template'], location=relospec)
                 if self.customspec:
                     clonespec.customization = self.customspec
+
+                if self.params['snapshot_name'] is not None:
+                    snapshot = self.get_snapshots_by_name_recursively(snapshots=vm_obj.snapshot.rootSnapshotList,
+                                                                      snapname=self.params['snapshot_name'])
+                    if len(snapshot) != 1:
+                        self.module.fail_json(msg='virtual machine "{0}" does not contain snapshot named "{1}"'.format(
+                            self.params['template'], self.params['snapshot_name']))
+
+                    if len(snapshot) == 1:
+                       snapshot = snapshot[0].snapshot
+                    clonespec.snapshot = snapshot
 
                 clonespec.config = self.configspec
                 task = vm_obj.Clone(folder=destfolder, name=self.params['name'], spec=clonespec)
@@ -1133,6 +1152,15 @@ class PyVmomiHelper(object):
 
             vm_facts = self.gather_facts(vm)
             return {'changed': self.change_detected, 'failed': False, 'instance': vm_facts}
+
+    def get_snapshots_by_name_recursively(self, snapshots, snapname):
+        snap_obj = []
+        for snapshot in snapshots:
+            if snapshot.name == snapname:
+                snap_obj.append(snapshot)
+            else:
+                snap_obj = snap_obj + self.get_snapshots_by_name_recursively(snapshot.childSnapshotList, snapname)
+        return snap_obj
 
     def reconfigure_vm(self):
         self.configspec = vim.vm.ConfigSpec()
@@ -1276,6 +1304,7 @@ def main():
             esxi_hostname=dict(type='str'),
             cluster=dict(type='str'),
             wait_for_ip_address=dict(type='bool', default=False),
+            snapshot_name=dict(type='str', default=None),
             networks=dict(type='list', default=[]),
             resource_pool=dict(type='str'),
             customization=dict(type='dict', no_log=True, default={}),

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1109,7 +1109,7 @@ class PyVmomiHelper(object):
                             self.params['template'], self.params['snapshot_name']))
 
                     if len(snapshot) == 1:
-                       snapshot = snapshot[0].snapshot
+                        snapshot = snapshot[0].snapshot
                     clonespec.snapshot = snapshot
 
                 clonespec.config = self.configspec


### PR DESCRIPTION
##### SUMMARY
One thing I sorely miss from the vsphere_guest module is the ability to create linked clones.  I have implemented it into vmware_guest with minimal changes required.  I added one addition parameter
```
snapshot_name:
        description:
            - A string that when specified, will create a linked clone copy of the VM. Snapshot must already be taken in vCenter.
```
I had first thought to use the original parameter name from vsphere_guest but decided to instead keep the name in line with the vmware_guest_snapshot module.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
vmware_guest

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 1daa69d685) last updated 2017/04/05 01:07:34 (GMT -500)
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```

##### ADDITIONAL INFORMATION
I used this playbook to test (plus a few others to shutdown / remove).  If the VM/Template does not contain a snapshot with that name, it will error out.  The function "get_snapshots_by_name_recursively" was used from "vmware_guest_snapshot"
```
      vmware_guest:
        validate_certs: False
        hostname: "{{ vcenter_hostname }}"
        username: "{{ vcenter_user }}"
        password: "{{ vcenter_pass }}"
        name: "{{ vmname }}"
        template: "{{ vmtemplate }}"
        snapshot_name: "Snapshot1"
        wait_for_ip_address: True
        state: poweredon
        datacenter: "{{ vmdatacenter }}"
        cluster: "{{ vmcluster }}"
      register: newvm
```
