### PR TITLE
stat: better documentation

### DIFF
--- a/lib/ansible/modules/files/stat.py
+++ b/lib/ansible/modules/files/stat.py
@@ -39,7 +39,8 @@ options:
     default: no
   get_md5:
     description:
-      - Whether to return the md5 sum of the file.  Will return None if we're
+      - Whether to return the md5 sum of the file.
+      - Will return None if not a regular file or if we're
         unable to use md5 (Common for FIPS-140 compliant systems)
     required: false
     default: yes


### PR DESCRIPTION
  - md5 fails if the file is not a regular file ( symlink, dir,..)

##### SUMMARY
stat module fails silently when trying to retrieve md5 for files which are symlink

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
modules/files/stat.py

##### ANSIBLE VERSION
```
ansible 2.2.1.0
```


##### ADDITIONAL INFORMATION
stat module does not print md5 sum for non-regular files ( such as symlinks, dir,...)

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
$ ansible 127.0.0.1 -m stat  -a"get_md5=yes path=/etc/redhat-release"
SSH password: 
 [WARNING]: provided hosts list is empty, only localhost is available

127.0.0.1 | SUCCESS => {
    "changed": false, 
    "stat": {
        "atime": 1491313616.7554421, 
        "ctime": 1485348907.2048733, 
        "dev": 64768, 
        "executable": false, 
        "exists": true, 
        "gid": 0, 
        "gr_name": "root", 
        "inode": 524307, 
        "isblk": false, 
        "ischr": false, 
        "isdir": false, 
        "isfifo": false, 
        "isgid": false, 
        "islnk": true, 
        "isreg": false, 
        "issock": false, 
        "isuid": false, 
        "lnk_source": "/etc/fedora-release", 
        "mode": "0777", 
        "mtime": 1478189658.0, 
        "nlink": 1, 
        "path": "/etc/redhat-release", 
        "pw_name": "root", 
        "readable": true, 
        "rgrp": true, 
        "roth": true, 
        "rusr": true, 
        "size": 14, 
        "uid": 0, 
        "wgrp": true, 
        "woth": true, 
        "writeable": false, 
        "wusr": true, 
        "xgrp": true, 
        "xoth": true, 
        "xusr": true
    }
}


$ ansible 127.0.0.1 -m stat  -a"get_md5=yes path=/etc/fedora-release"
SSH password: 
 [WARNING]: provided hosts list is empty, only localhost is available

127.0.0.1 | SUCCESS => {
    "changed": false, 
    "stat": {
        "atime": 1491313616.7554421, 
        "checksum": "16e556d81e19c094d84e2e745a071d49000d7237", 
        "ctime": 1485348907.1618733, 
        "dev": 64768, 
        "executable": false, 
        "exists": true, 
        "gid": 0, 
        "gr_name": "root", 
        "inode": 524753, 
        "isblk": false, 
        "ischr": false, 
        "isdir": false, 
        "isfifo": false, 
        "isgid": false, 
        "islnk": false, 
        "isreg": true, 
        "issock": false, 
        "isuid": false, 
        "md5": "bc7778986f0571242b60cac59a4d9f53", 
        "mode": "0644", 
        "mtime": 1478189658.0, 
        "nlink": 1, 
        "path": "/etc/fedora-release", 
        "pw_name": "root", 
        "readable": true, 
        "rgrp": true, 
        "roth": true, 
        "rusr": true, 
        "size": 32, 
        "uid": 0, 
        "wgrp": false, 
        "woth": false, 
        "writeable": false, 
        "wusr": true, 
        "xgrp": false, 
        "xoth": false, 
        "xusr": false
    }
}


```
