### PR TITLE
ecs_taskdefinition module : Convert environment variables to string

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -352,6 +352,10 @@ def main():
             if not module.check_mode:
                 # Doesn't exist. create it.
                 volumes = module.params.get('volumes', []) or []
+                for container in module.params['containers']:
+                    if 'environment' in container:
+                        for environment in container['environment']:
+                            environment['value'] = str(environment['value'])
                 results['taskdefinition'] = task_mgr.register_task(module.params['family'],
                                                                    module.params['task_role_arn'],
                                                                    module.params['network_mode'],


### PR DESCRIPTION
##### SUMMARY

In this module, if the `containers` - `environment` variable is not a string type, it will result in an error.

This fix converts the value of the `containers` - `environment` variable to a string type.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

ecs_taskdefinition

##### ANSIBLE VERSION

2.2.2.0
