### PR TITLE
Fix nxos_facts for nxapi transport

### DIFF
--- a/test/integration/targets/nxos_facts/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_facts/tasks/nxapi.yaml
@@ -8,8 +8,21 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
+- name: enable nxapi
+  nxos_config:
+    lines:
+      - feature nxapi
+      - nxapi http port 80
+    provider: "{{ cli }}"
+
 - name: run test case
   include: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+
+- name: disable nxapi
+  nxos_config:
+    lines:
+      - no feature nxapi
+    provider: "{{ cli }}"


### PR DESCRIPTION
##### SUMMARY
2e476e6 broke handling of nxos_facts over nxapi. This restores that functionality while keeping the cli handling.

Fixes #23300

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
nxos_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```
