### PR TITLE
Fix basic-login eapi tests for eos_banner

### DIFF
--- a/test/integration/targets/eos_banner/tests/eapi/basic-login.yaml
+++ b/test/integration/targets/eos_banner/tests/eapi/basic-login.yaml
@@ -5,7 +5,7 @@
     banner: login
     state: absent
     authorize: yes
-    transport: "{{ eapi }}"
+    provider: "{{ eapi }}"
 
 - name: Set login
   eos_banner:
@@ -16,7 +16,7 @@
       string
     state: present
     authorize: yes
-    transport: "{{ eapi }}"
+    provider: "{{ eapi }}"
   register: result
 
 - debug:
@@ -39,7 +39,7 @@
       string
     state: present
     authorize: yes
-    transport: "{{ eapi }}"
+    provider: "{{ eapi }}"
   register: result
 
 - assert:


### PR DESCRIPTION
##### SUMMARY

We should be passing the provider dict, not the transport.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
eos_banner

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (fix_eos_banner_eapi_tests 5962193087) last updated 2017/04/05 17:12:30 (GMT +200)

```


