### PR TITLE
eapi & nxapi: Document validate_certs (#23305)

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/eos.py
+++ b/lib/ansible/utils/module_docs_fragments/eos.py
@@ -114,6 +114,12 @@ options:
             argument is not eapi, this value is ignored.
         default: yes
         choices: ['yes', 'no']
+      validate_certs:
+        description:
+          - If C(no), SSL certificates will not be validated. This should only be used
+            on personally controlled sites using self-signed certificates.  If the transport
+            argument is not eapi, this value is ignored.
+        choices: ['yes', 'no']
 
 
 """

--- a/lib/ansible/utils/module_docs_fragments/nxos.py
+++ b/lib/ansible/utils/module_docs_fragments/nxos.py
@@ -82,6 +82,12 @@ options:
     required: false
     default: no
     choices: ['yes', 'no']
+  validate_certs:
+    description:
+      - If C(no), SSL certificates will not be validated. This should only be used
+        on personally controlled sites using self-signed certificates.  If the transport
+        argument is not nxapi, this value is ignored.
+    choices: ['yes', 'no']
   provider:
     description:
       - Convenience method that allows all I(nxos) arguments to be passed as


### PR DESCRIPTION

##### SUMMARY
* Document validate_certs for eapi & nxapi

(cherry picked from commit 485affeb1243828320a01d8cf69055eeae3e7153)

Original PR https://github.com/ansible/ansible/pull/23305