### PR TITLE
Fix asserts on ios_banner tests

### DIFF
--- a/test/integration/targets/ios_banner/tests/cli/basic-login.yaml
+++ b/test/integration/targets/ios_banner/tests/cli/basic-login.yaml
@@ -25,8 +25,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'this is my login banner' in result.commands"
-      - "'that has a multiline' in result.commands"
+      - "'banner login @\nthis is my login banner\nthat has a multiline\nstring\n@' in result.commands"
 
 - name: Set login again (idempotent)
   ios_banner:

--- a/test/integration/targets/ios_banner/tests/cli/basic-motd.yaml
+++ b/test/integration/targets/ios_banner/tests/cli/basic-motd.yaml
@@ -24,8 +24,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'this is my motd banner' in result.commands"
-      - "'that has a multiline' in result.commands"
+      - "'banner motd @\nthis is my motd banner\nthat has a multiline\nstring\n@' in result.commands"
 
 - name: Set motd again (idempotent)
   ios_banner:


### PR DESCRIPTION
##### SUMMARY

The contain assert was broken.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
ios_banner

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (fix_ios_banner_tests e4c3fda176) last updated 2017/04/05 19:55:29 (GMT +200)

```
