### PR TITLE
Fix eapi basic-login asserts

### DIFF
--- a/test/integration/targets/eos_banner/tests/eapi/basic-login.yaml
+++ b/test/integration/targets/eos_banner/tests/eapi/basic-login.yaml
@@ -25,8 +25,8 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'this is my login banner' in result.commands"
-      - "'that has a multiline' in result.commands"
+      - "result.commands.0.cmd == 'banner login'"
+      - "result.commands.0.input == 'this is my login banner\nthat has a multiline\nstring'"
       # Ensure sessions contains epoc. Will fail after 18th May 2033
       - "'ansible_1' in result.session_name"
 


### PR DESCRIPTION
##### SUMMARY

The asserts where not checking the commands sent to the device

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
eos_banner

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (fix_eos_banner_eapi_asserts 5c1b311ab8) last updated 2017/04/05 20:35:48 (GMT +200)
```

