### PR TITLE
Check text key exists on eos_banner absent case

### DIFF
--- a/lib/ansible/modules/network/eos/eos_banner.py
+++ b/lib/ansible/modules/network/eos/eos_banner.py
@@ -95,7 +95,7 @@ def map_obj_to_commands(updates, module):
     want, have = updates
     state = module.params['state']
 
-    if state == 'absent' and have['text']:
+    if state == 'absent' and 'text' in have.keys() and have['text']:
         commands.append('no banner %s' % module.params['banner'])
 
     elif state == 'present':


### PR DESCRIPTION
##### SUMMARY

This can fail if we don't check the key exists.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
eos_banner

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (check_text_key_exist_eos_banner_absent 94cfca8cf9) last updated 2017/04/05 20:45:26 (GMT +200)
```
