### PR TITLE
[WIP] improve become_method: runas error handling

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -553,6 +553,13 @@ class PlayContext(Base):
             elif self.become_method == 'runas':
                 # become is handled inside the WinRM connection plugin
                 display.warning("The Windows 'runas' become method is experimental, and may change significantly in future Ansible releases.")
+
+                if not self.become_user:
+                    raise AnsibleError(("The 'runas' become method requires a username "
+                                        "(specify with the '--become-user' CLI arg, the 'become_user' keyword, or the 'ansible_become_user' variable)"))
+                if not self.become_pass:
+                    raise AnsibleError(("The 'runas' become method requires a password "
+                                       "(specify with the '-K' CLI arg or the 'ansible_become_password' variable)"))
                 becomecmd = cmd
 
             elif self.become_method == 'doas':

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -316,6 +316,15 @@ Write-Output $output
 
 } # end exec_wrapper
 
+Function Dump-Error ($excep) {
+    $eo = @{failed=$true}
+
+    $eo.msg = $excep.Exception.Message
+    $eo.exception = $excep | Out-String
+    $host.SetShouldExit(1)
+
+    $eo | ConvertTo-Json -Depth 10
+}
 
 Function Run($payload) {
     # NB: action popping handled inside subprocess wrapper
@@ -370,14 +379,25 @@ Function Run($payload) {
         $psi.Username = $username
         $psi.Password = $($password | ConvertTo-SecureString -AsPlainText -Force)
 
-        [Ansible.Shell.ProcessUtil]::GrantAccessToWindowStationAndDesktop($username)
+        Try {
+            [Ansible.Shell.ProcessUtil]::GrantAccessToWindowStationAndDesktop($username)
+        }
+        Catch {
+            $excep = $_
+            throw "Error granting windowstation/desktop access to '$username' (is the username valid?): $excep"
+        }
 
         Try {
             $proc.Start() | Out-Null # will always return $true for non shell-exec cases
         }
         Catch {
-            Write-Output $_.Exception.InnerException
-            return
+            $excep = $_
+            if ($excep.Exception.InnerException -and `
+                $excep.Exception.InnerException -is [System.ComponentModel.Win32Exception] -and `
+                $excep.Exception.InnerException.NativeErrorCode -eq 5) {
+              throw "Become method 'runas' become is not currently supported with the NTLM or Kerberos auth types"
+            }
+            throw "Error launching under identity '$username': $excep"
         }
 
         $payload_string = $payload | ConvertTo-Json -Depth 99 -Compress
@@ -403,6 +423,10 @@ Function Run($payload) {
         Else {
             Throw "failed, rc was $rc, stderr was $stderr, stdout was $stdout"
         }
+    }
+    Catch {
+        $excep = $_
+        Dump-Error $excep
     }
     Finally {
         Remove-Item $temp -ErrorAction SilentlyContinue


### PR DESCRIPTION
##### SUMMARY
Prescriptive errors for username/password issues and NTLM/Kerb auth failures, cleans up exception noise. Fixes #23299.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
powershell.py

##### ANSIBLE VERSION
2.4.0

