### PR TITLE
Fix #22880 junos_config update issue

### DIFF
--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -129,13 +129,13 @@ options:
         candidate configuration. If statements in the loaded configuration
         conflict with statements in the candidate configuration, the loaded
         statements replace the candidate ones.
-        C(overwrite) discards the entire candidate configuration and replaces
+        C(override) discards the entire candidate configuration and replaces
         it with the loaded configuration.
         C(replace) substitutes each hierarchy level in the loaded configuration
         for the corresponding level.
     required: false
     default: merge
-    choices: ['merge', 'overwrite', 'replace']
+    choices: ['merge', 'override', 'replace']
     version_added: "2.3"
 requirements:
   - junos-eznc
@@ -276,7 +276,7 @@ def main():
         src_format=dict(choices=['xml', 'text', 'set', 'json']),
 
         # update operations
-        update=dict(default='merge', choices=['merge', 'overwrite', 'replace', 'update']),
+        update=dict(default='merge', choices=['merge', 'override', 'replace', 'update']),
 
         # deprecated replace in Ansible 2.3
         replace=dict(type='bool'),


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
`load_configuration()` in `module_utils/junos.py` check for `override` value of `update` parameter, whereas `network/junos/junos_config.py` mentions `overwrite`. Hence for `update` parameter add `override` as an acceptable value. `override` name is in sync with junos naming convention.
<!--- 
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
junos_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
