### PR TITLE
Create DigitalOcean block storage from snapshot

### DIFF
--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_block_storage.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_block_storage.py
@@ -37,7 +37,7 @@ options:
     required: true
   block_size:
     description:
-    - The size of the Block Storage volume in gigabytes. Required when command=create and state=present.
+    - The size of the Block Storage volume in gigabytes. Required when command=create and state=present. If snapshot_id is included, this will be ignored.
   volume_name:
     description:
     - The name of the Block Storage volume.
@@ -47,8 +47,12 @@ options:
     - Description of the Block Storage volume.
   region:
     description:
-    - The slug of the region where your Block Storage volume should be located in.
+    - The slug of the region where your Block Storage volume should be located in. If snapshot_id is included, this will be ignored.
     required: true
+  snapshot_id:
+    version_added: "2.5"
+    description:
+    - The snapshot id you would like the Block Storage volume created with. If included, region and block_size will be ignored and changed to null.
   droplet_id:
     description:
     - The droplet id you want to operate on. Required when command=attach.
@@ -60,6 +64,7 @@ options:
 notes:
   - Two environment variables can be used, DO_API_KEY and DO_API_TOKEN.
     They both refer to the v2 token.
+  - If snapshot_id is used, region and block_size will be ignored and changed to null.
 
 author:
     - "Harnek Sidhu (github: @harneksidhu)"
@@ -179,15 +184,23 @@ class DOBlockStorage(object):
             raise DOBlockStorageException(json['message'])
 
     def create_block_storage(self):
-        block_size = self.get_key_or_fail('block_size')
         volume_name = self.get_key_or_fail('volume_name')
-        region = self.get_key_or_fail('region')
+        snapshot_id = self.module.params['snapshot_id']
+        if snapshot_id:
+            self.module.params['block_size'] = None
+            self.module.params['region'] = None
+            block_size = None
+            region = None
+        else:
+            block_size = self.get_key_or_fail('block_size')
+            region = self.get_key_or_fail('region')
         description = self.module.params['description']
         data = {
             'size_gigabytes': block_size,
             'name': volume_name,
             'description': description,
-            'region': region
+            'region': region,
+            'snapshot_id': snapshot_id,
         }
         response = self.rest.post("volumes", data=data)
         status = response.status_code
@@ -259,10 +272,11 @@ def main():
             state=dict(choices=['present', 'absent'], required=True),
             command=dict(choices=['create', 'attach'], required=True),
             api_token=dict(aliases=['API_TOKEN'], no_log=True),
-            block_size=dict(type='int'),
+            block_size=dict(type='int', required=False),
             volume_name=dict(type='str', required=True),
             description=dict(type='str'),
-            region=dict(type='str', required=True),
+            region=dict(type='str', required=False),
+            snapshot_id=dict(type='str', required=False),
             droplet_id=dict(type='int'),
             timeout=dict(type='int', default=10),
         ),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

In its current configuration, the digital_ocean_block_storage module does not allow for creating a DigitalOcean block storage volume from a saved "snapshot," a feature that exists in the DO API.

By updating the `create_block_storage()` method and adding a `snapshot_id` parameter, DO block storage volumes can now be created from a saved snapshot. If the `snapshot_id` parameter is included, the `region` and `block_size` parameters are ignored and set to null values. For all actions besides volume creation, the module acts as before, with the same requirements.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

lib/ansible/modules/cloud/digital_ocean/digital_ocean_block_storage.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel 1daa69d685) last updated 2017/04/05 08:34:24 (GMT +000)
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
An example of creating a block storage volume using a snapshot id:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
- digital_ocean_block_storage:
    state: present
    command: create
    api_token: <TOKEN>
    snapshot_id: <ID>
    volume_name: nyc1-block-storage
```
