### PR TITLE
ecs_taskdefinition module : Convert environment variables to string (…

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -342,6 +342,10 @@ def main():
             if not module.check_mode:
                 # Doesn't exist. create it.
                 volumes = module.params.get('volumes', []) or []
+                for container in module.params['containers']:
+                    if 'environment' in container:
+                        for environment in container['environment']:
+                            environment['value'] = str(environment['value'])
                 results['taskdefinition'] = task_mgr.register_task(module.params['family'],
                                                                    module.params['task_role_arn'],
                                                                    module.params['network_mode'],


### PR DESCRIPTION
…#23297)

Before modification, it fails unless it is a string type
(cherry picked from commit dff35bc205c176a2f9b187e9849b96d311e1e141)


Original PR https://github.com/ansible/ansible/pull/23297
