### PR TITLE
Fix hacking/test-module to allow running modules with pdb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,10 @@
 *.py[co]
 build
 AUTHORS.TXT
-# Emacs backup files...
+# Emacs backup and autosave files...
 *~
 .\#*
+\#*
 # RPM stuff...
 MANIFEST
 dist

--- a/hacking/test-module
+++ b/hacking/test-module
@@ -228,11 +228,11 @@ def runtest(modfile, argspath, modname, module_style, interpreters):
     print(jsonify(results,format=True))
 
 
-def rundebug(debugger, modfile, argspath, modname, module_style):
+def rundebug(debugger, modfile, argspath, modname, module_style, interpreters):
     """Run interactively with console debugger."""
 
     if module_style == 'ansiballz':
-        modfile, argspath = ansiballz_setup(modfile, modname)
+        modfile, argspath = ansiballz_setup(modfile, modname, interpreters)
 
     if argspath is not None:
         subprocess.call("%s %s %s" % (debugger, modfile, argspath), shell=True)
@@ -257,7 +257,7 @@ def main():
 
     if options.execute:
         if options.debugger:
-            rundebug(options.debugger, modfile, argspath, modname, module_style)
+            rundebug(options.debugger, modfile, argspath, modname, module_style, interpreters)
         else:
             runtest(modfile, argspath, modname, module_style, interpreters)
 


### PR DESCRIPTION
##### SUMMARY

hacking/test-module fails if given a debugger to run - this fixes that

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME

hacking/test-module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0 (ansible-d2r ff3dc4f1e7) last updated 2017/03/21 10:44:16 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/mikedd/dev/ansible/ansible-d2r/library']
  python version = 2.7.12 (default, Jul  1 2016, 15:12:24) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION

what I did:
run 
    hacking/test-module -m lib/ansible/modules/system/ping.py --debugger=(which pdb)

what I expected to happen:
module should be run under pdb

what actually happened:
hacking/test-module crashed. 

extra information:
at one point in debugging somewhere in the system I also had to patch an "import pdb.pdb" statement to be simply "import pdb" not sure where that was though. 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
PROMPT> hacking/test-module -m lib/ansible/modules/system/ping.py --debugger=(which pdb)
* including generated source, if any, saving to: /home/mikedd/.ansible_module_generated
Traceback (most recent call last):
  File "hacking/test-module", line 266, in <module>
    main()
  File "hacking/test-module", line 260, in main
    rundebug(options.debugger, modfile, argspath, modname, module_style)
  File "hacking/test-module", line 235, in rundebug
    modfile, argspath = ansiballz_setup(modfile, modname)
TypeError: ansiballz_setup() takes exactly 3 arguments (2 given)


PROMPT> git checkout mdd-fix-test-module-pdb
Switched to branch 'mdd-fix-test-module-pdb'
PROMPT> hacking/test-module -m lib/ansible/modules/system/ping.py --debugger=(which pdb)
* including generated source, if any, saving to: /home/mikedd/.ansible_module_generated
* ansiballz module detected; extracted module source to: /home/mikedd/debug_dir
> /home/mikedd/debug_dir/ansible_module_ping.py(23)<module>()
-> ANSIBLE_METADATA = {'metadata_version': '1.0',
(Pdb) 

```
