### PR TITLE
azure_rm_securitygroup: allow string priority

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
@@ -336,6 +336,7 @@ state:
     }
 '''  # NOQA
 
+from ansible.module_utils.six import string_types
 from ansible.module_utils.basic import *
 from ansible.module_utils.azure_rm_common import *
 
@@ -366,7 +367,13 @@ def validate_rule(rule, rule_type=None):
     priority = rule.get('priority', None)
     if not priority:
         raise Exception("Rule priority is required.")
-    if not isinstance(priority, (int, long)):
+    if isinstance(priority, string_types):
+        try:
+            priority = int(priority)
+            rule['priority'] = priority
+        except ValueError:
+            raise Exception("Can't parse rule priority integer.")
+    elif not isinstance(priority, (int, long)):
         raise Exception("Rule priority attribute must be an integer.")
     if rule_type != 'default' and (priority < 100 or priority > 4096):
         raise Exception("Rule priority must be between 100 and 4096")
@@ -416,10 +423,10 @@ def compare_rules(r, rule):
         if rule['protocol'] != r['protocol']:
             changed = True
             r['protocol'] = rule['protocol']
-        if rule['source_port_range'] != r['source_port_range']:
+        if str(rule['source_port_range']) != r['source_port_range']:
             changed = True
             r['source_port_range'] = rule['source_port_range']
-        if rule['destination_port_range'] != r['destination_port_range']:
+        if str(rule['destination_port_range']) != r['destination_port_range']:
             changed = True
             r['destination_port_range'] = rule['destination_port_range']
         if rule['access'] != r['access']:


### PR DESCRIPTION
##### SUMMARY
Due to https://github.com/ansible/ansible/issues/9362 Ansible jinja filters fails to convert strings to integers in complex objects scenario and `azure_rm_securitygroup` do not follow best practices for converting strings to integers in arguments where possible (descibed here https://github.com/ansible/ansible/issues/17992#issuecomment-253837999), so if pass string value like '123' to `priority` argument - I get an error:
```
... 'priority': '123' - Rule priority attribute must be an integer.
```

I fix that by parsing `priority` if it have type string.
Plus I fix false `changed: True` for scenario where `source_port_range` or `destination_port_range` just single ports, `compare_rules` function compared strings with integers, which always led to false changed.

Tested with Ansible 2.3.0rc3.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_securitygroup

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /vagrant/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```
