### PR TITLE
fix iosxr commands to encode json

### DIFF
--- a/lib/ansible/module_utils/iosxr.py
+++ b/lib/ansible/module_utils/iosxr.py
@@ -79,6 +79,7 @@ def run_commands(module, commands, check_rc=True):
     responses = list()
     commands = to_commands(module, to_list(commands))
     for cmd in to_list(commands):
+        cmd = module.jsonify(cmd)
         rc, out, err = exec_command(module, cmd)
         if check_rc and rc != 0:
             module.fail_json(msg=err, rc=rc)

--- a/lib/ansible/modules/network/iosxr/iosxr_command.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_command.py
@@ -163,7 +163,6 @@ def parse_commands(module, warnings):
                 msg='iosxr_command does not support running config mode '
                     'commands.  Please use iosxr_config instead'
             )
-        commands[index] = module.jsonify(item)
     return commands
 
 def main():

--- a/test/units/modules/network/iosxr/test_iosxr_command.py
+++ b/test/units/modules/network/iosxr/test_iosxr_command.py
@@ -45,8 +45,7 @@ class TestIosxrCommandModule(TestIosxrModule):
 
             for item in commands:
                 try:
-                    obj = json.loads(item)
-                    command = obj['command']
+                    command = item['command']
                 except ValueError:
                     command = item
                 filename = str(command).replace(' ', '_')


### PR DESCRIPTION
the command dict in the iosxr module_utils wasn't encoding the request
to json.  this patch will fix that problem

