### PR TITLE
fix for iam

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam.py
+++ b/lib/ansible/modules/cloud/amazon/iam.py
@@ -510,7 +510,7 @@ def create_role(module, iam, name, path, role_list, prof_list, trust_policy_doc)
                 instance_profile_result = iam.create_instance_profile(name,
                     path=path).create_instance_profile_response.create_instance_profile_result.instance_profile
                 iam.add_role_to_instance_profile(name, name)
-        else: 
+        else:
             instance_profile_result = iam.get_instance_profile(name).get_instance_profile_response.get_instance_profile_result.instance_profile
     except boto.exception.BotoServerError as err:
         module.fail_json(changed=changed, msg=str(err))

--- a/lib/ansible/modules/cloud/amazon/iam.py
+++ b/lib/ansible/modules/cloud/amazon/iam.py
@@ -510,6 +510,8 @@ def create_role(module, iam, name, path, role_list, prof_list, trust_policy_doc)
                 instance_profile_result = iam.create_instance_profile(name,
                     path=path).create_instance_profile_response.create_instance_profile_result.instance_profile
                 iam.add_role_to_instance_profile(name, name)
+        else: 
+            instance_profile_result = iam.get_instance_profile(name).get_instance_profile_response.get_instance_profile_result.instance_profile
     except boto.exception.BotoServerError as err:
         module.fail_json(changed=changed, msg=str(err))
     else:


### PR DESCRIPTION
SUMMARY

fix for IAM module to return exactly the same thing once you re-call iam with iam_type = role.
Right now it's a bug since calling iam twice results in different values returned.

ISSUE TYPE

Bugfix Pull Request
COMPONENT NAME

cloud/amazon/iam.py

ANSIBLE VERSION

ansible 2.2.1.0
config file = /etc/ansible/ansible.cfg
configured module search path = Default w/o overrides

ADDITIONAL INFORMATION

It's a very simple fix for iam module which ensures the possibility to get instance_profile arn in a same way as during creation of new iam role.