### PR TITLE
Unhardcode the port and protocol on eos EAPI

### DIFF
--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -40,8 +40,7 @@ _DEVICE_CONNECTION = None
 
 eos_argument_spec = {
     'host': dict(),
-    'port': dict(type='int'),
-
+    'port': dict(type='int', default=443),
     'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
     'password': dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), no_log=True),
     'ssh_keyfile': dict(fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE']), type='path'),
@@ -50,8 +49,8 @@ eos_argument_spec = {
     'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
     'auth_pass': dict(no_log=True, fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS'])),
 
-    'use_ssl': dict(type='bool'),
-    'validate_certs': dict(type='bool'),
+    'use_ssl': dict(type='bool', default=True),
+    'validate_certs': dict(type='bool', default=True),
     'timeout': dict(type='int'),
 
     'provider': dict(type='dict', no_log=True),
@@ -236,20 +235,18 @@ class Eapi:
         self._session_support = None
         self._device_configs =  {}
 
-        host = module.params['host']
-        port = module.params['port']
+        host = module.params['provider']['host']
+        port = module.params['provider']['port']
 
         self._module.params['url_username'] = self._module.params['username']
         self._module.params['url_password'] = self._module.params['password']
 
-        if module.params['use_ssl']:
+        if module.params['provider']['use_ssl']:
             proto = 'https'
-            if not port:
-                port = 443
         else:
             proto = 'http'
-            if not port:
-                port = 80
+
+        module.params['validate_certs'] = module.params['provider']['validate_certs']
 
         self._url = '%s://%s:%s/command-api' % (proto, host, port)
 

--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -95,7 +95,7 @@ class ActionModule(_ActionModule):
                 provider['host'] = self._play_context.remote_addr
 
             if provider.get('port') is None:
-                provider['port'] = 443
+                provider['port'] = eos_argument_spec['port']['default']
 
             if provider.get('timeout') is None:
                 provider['timeout'] = self._play_context.timeout
@@ -110,10 +110,10 @@ class ActionModule(_ActionModule):
                 provider['authorize'] = False
 
             if provider.get('use_ssl') is None:
-                provider['use_ssl'] = True
+                provider['use_ssl'] = eos_argument_spec['use_ssl']['default']
 
             if provider.get('validate_certs') is None:
-                provider['validate_certs'] = True
+                provider['validate_certs'] = eos_argument_spec['validate_certs']['default']
 
             self._task.args['provider'] = provider
 


### PR DESCRIPTION
##### SUMMARY

We were hard-coding the protocol, port and validate_certs on
eos EAPI via the action plugin.
Put defaults on the eos_argument_spec and pull those values from it.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME

plugins/action/eos
module_utils/eos

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (unhardcode_eapi_protocol_port 9f954fe47a) last updated 2017/04/06 15:50:39 (GMT +200)
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
