### PR TITLE
Change Facter to not use puppet argument 

### DIFF
--- a/lib/ansible/modules/system/facter.py
+++ b/lib/ansible/modules/system/facter.py
@@ -54,7 +54,7 @@ def main():
 
     facter_path = module.get_bin_path('facter', opt_dirs=['/opt/puppetlabs/bin'])
 
-    cmd = [facter_path, "--puppet", "--json"]
+    cmd = [facter_path, "--json"]
 
     rc, out, err = module.run_command(cmd, check_rc=True)
     module.exit_json(**json.loads(out))


### PR DESCRIPTION
##### SUMMARY
The usage of `--puppet` has been deprecated within facter, it also resulted in an undocumented requirement on Puppet (in testing this module) as such we should look to remove this.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
system/facter.py

##### ANSIBLE VERSION
```
ansible 2.2.2.0
  config file = /home/michael/.ansible.cfg
  configured module search path = Default w/o overrides
```


##### ADDITIONAL INFORMATION
As the `--puppet` argument has been deprecated, it may be removed in future versions, thus removing early is ideal.

No changes in the output