### PR TITLE
Proposed fix for issue #23357

### DIFF
--- a/lib/ansible/modules/cloud/amazon/route53_zone.py
+++ b/lib/ansible/modules/cloud/amazon/route53_zone.py
@@ -177,7 +177,7 @@ def main():
         if vpc_id and 'VPCs' in zone_details:
             # this is to deal with this boto bug: https://github.com/boto/boto/pull/2882
             if isinstance(zone_details['VPCs'], dict):
-                if zone_details['VPCs']['VPC']['VPCId'] == vpc_id:
+                if zone_details['VPCs'][0]['VPCId'] == vpc_id:
                     zones[r53zone['Name']] = zone_id
             else: # Forward compatibility for when boto fixes that bug
                 if vpc_id in [v['VPCId'] for v in zone_details['VPCs']]:
@@ -201,7 +201,7 @@ def main():
                     msg="Can't change VPC from public to private"
                 )
 
-            vpc_details = details['GetHostedZoneResponse']['VPCs']['VPC']
+            vpc_details = details['GetHostedZoneResponse'][0]['VPC']
             current_vpc_id = vpc_details['VPCId']
             current_vpc_region = vpc_details['VPCRegion']
 


### PR DESCRIPTION
##### SUMMARY
Fixes the issue where a list is accessed by name instead of index. This blocks idempotency in runs after the zone is established when the zone is private.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
route53_zone

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```
##### ADDITIONAL INFORMATION
```
TASK [ec2_spinup : Create VPC-specific zone for local cloud domain] ***********************************************************************************************************************************************
ok: [localhost]

```
