### PR TITLE
Disable zypper tests for CI due to timeouts.

### DIFF
--- a/test/integration/targets/zypper/aliases
+++ b/test/integration/targets/zypper/aliases
@@ -1,2 +1,1 @@
 destructive
-posix/ci/group1


### PR DESCRIPTION
##### SUMMARY

Disable zypper tests for CI due to timeouts on opensuse 42.1:

https://app.shippable.com/github/ansible/ansible/runs/18274/16/console

The test can be re-enabled once it's not causing timeouts.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Integration Tests

##### ANSIBLE VERSION

```
ansible 2.4.0 (no-zypper-test d272e8c92d) last updated 2017/04/06 08:38:36 (GMT -700)
  config file = 
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
