### PR TITLE
Fixes loginBanner plucking over eapi transport when absent loginBanner

### DIFF
--- a/lib/ansible/modules/network/eos/eos_banner.py
+++ b/lib/ansible/modules/network/eos/eos_banner.py
@@ -121,7 +121,8 @@ def map_config_to_obj(module):
         else:
             # On EAPI we need to extract the banner text from dict key
             # 'loginBanner'
-            obj['text'] = output[0]['loginBanner'].strip('\n')
+            if isinstance(output[0], dict) and 'loginBanner' in output[0].keys():
+                obj['text'] = output[0]['loginBanner'].strip('\n')
         obj['state'] = 'present'
     return obj
 

--- a/test/integration/group_vars/eos.yaml
+++ b/test/integration/group_vars/eos.yaml
@@ -12,4 +12,5 @@ eapi:
   password: "{{ eos_eapi_pass | default('admin') }}"
   transport: eapi
   use_ssl: no
+  port: 80
   authorize: yes


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This patch fixes the eos module reading the loginBanner when using the eapi and the loginBanner isn't set.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel d988256ae4) last updated 2017/04/06 09:44:49 (GMT -600)
  config file = 
  configured module search path = [u'/home/calfonso/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/calfonso/code/ansible/lib/ansible
  executable location = /home/calfonso/code/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
