### PR TITLE
BUGFIX : using yaml hosts inventory, hosts in groups weren't added to…

### DIFF
--- a/lib/ansible/inventory/yaml.py
+++ b/lib/ansible/inventory/yaml.py
@@ -71,7 +71,7 @@ class InventoryParser(object):
         # 'all' at the time it was created.
         for group in self.groups.values():
             if group.depth == 0 and group.name not in ('all', 'ungrouped'):
-                self.groups['all'].add_child_group(Group(group_name))
+                self.groups['all'].add_child_group(group)
 
     def _parse_groups(self, group, group_data):
 


### PR DESCRIPTION
… the group 'all'

##### SUMMARY
fix "auto adding" to group "all" of hosts in groups using YAML inventory. (not listed as issue)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
tested on 2.3 and devel


##### ADDITIONAL INFORMATION
The problem is present at least in branches stable-2.3 too (and should be backported).

```
You can test using an host.yml file like :

test:
  hosts:
    192.168.1.1:
    192.168.1.2:
```
