### PR TITLE
proposed fix for issue #23352

### DIFF
--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -101,10 +101,10 @@ def _get_fs_size(fssize_cmd, dev, module):
         rc, size, err = module.run_command("%s %s" % (cmd, dev))
         if rc == 0:
             for line in size.splitlines():
-                #if 'data' in line:
-                if 'data ' in line:
-                    block_size = int(line.split('=')[2].split()[0])
-                    block_count = int(line.split('=')[3].split(',')[0])
+                col = line.split('=')
+                if col[0].strip() == 'data':
+                    block_size = int(col[2].split()[0])
+                    block_count = int(col[3].split(',')[0])
                     break
         else:
             module.fail_json(msg="Failed to get block count and block size of %s with %s" % (dev, cmd), rc=rc, err=err )


### PR DESCRIPTION
when device name ends with 'data' line matches in :
-                if 'data ' in line:

closes #23352

##### SUMMARY
Check if first column is 'data' before extracting block_size and block_count

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/system/filesystem.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.2.0
  config file =
  configured module search path = Default w/o overrides
```

##### ADDITIONAL INFORMATION
idempotentency confirmed with the change.
```
before:
localhost                  : ok=2    changed=1    unreachable=0    failed=0
after
localhost                  : ok=2    changed=0    unreachable=0    failed=0
```
