### PR TITLE
Fix #23360 junos_config set format issue (#23365)

### DIFF
--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -234,8 +234,6 @@ def filter_delete_statements(module, candidate):
 
 def configure_device(module, warnings):
     candidate = module.params['lines'] or module.params['src']
-    if isinstance(candidate, string_types):
-        candidate = candidate.split('\n')
 
     kwargs = {
         'comment': module.params['comment'],
@@ -256,6 +254,9 @@ def configure_device(module, warnings):
             kwargs.update({'format': 'text', 'action': 'set'})
         else:
             kwargs.update({'format': config_format, 'action': module.params['update']})
+
+    if isinstance(candidate, string_types):
+        candidate = candidate.split('\n')
 
     # this is done to filter out `delete ...` statements which map to
     # nothing in the config as that will cause an exception to be raised


### PR DESCRIPTION
(cherry picked from commit 990ba90380c3ea28138d3942810c46a90f49194a)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
junos_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Merged in devel https://github.com/ansible/ansible/pull/23365
```
