### PR TITLE
Update fedora24 Dockerfile to resolve dnf issue.

### DIFF
--- a/test/utils/docker/fedora24/Dockerfile
+++ b/test/utils/docker/fedora24/Dockerfile
@@ -10,6 +10,10 @@ rm -f /lib/systemd/system/basic.target.wants/*; \
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 RUN dnf clean all && \
+    dnf -y update libsolv && \
+    dnf clean all
+
+RUN dnf clean all && \
     dnf -y --setopt=install_weak_deps=false install \
     acl \
     asciidoc \


### PR DESCRIPTION
##### SUMMARY

Update fedora24 Dockerfile to resolve dnf issue.

The latest version of `hawkey` requires a newer version of `libsolv` than its dependencies indicate. Without this fix, installing `python2-dnf` will update only `hawkey` and render `dnf` non-functional.

This is a temporary mitigation until package dependencies are corrected.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Fedora 24 Dockerfile

##### ANSIBLE VERSION

```
ansible 2.4.0 (f24-docker 9650fa6c53) last updated 2017/04/06 15:52:10 (GMT -700)
  config file = 
  configured module search path = [u'/home/matt/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/matt/code/mattclay/ansible/lib/ansible
  executable location = /home/matt/code/mattclay/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```
