### PR TITLE
correctly get all hosts in 'all'

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -161,6 +161,7 @@ class Inventory(object):
 
         ### POST PROCESS groups and hosts after specific parser was invoked
 
+        hosts = []
         group_names = set()
         # set group vars from group_vars/ files and vars plugins
         for g in self.groups:
@@ -168,10 +169,11 @@ class Inventory(object):
             group.vars = combine_vars(group.vars, self.get_group_variables(group.name))
             self.get_group_vars(group)
             group_names.add(group.name)
+            hosts.extend(group.get_hosts())
 
         host_names = set()
         # get host vars from host_vars/ files and vars plugins
-        for host in self.get_hosts(ignore_limits=True, ignore_restrictions=True):
+        for host in hosts:
             host.vars = combine_vars(host.vars, self.get_host_variables(host.name))
             self.get_host_vars(host)
             host_names.add(host.name)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes code that ensured all hosts in all group (previouslly relied on them being in 'all'

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.2/2.3
```



##### ADDITIONAL INFORMATION

complimentary fix to #23366
