### PR TITLE
Fixes #23385 - bad default for multi_zone in rds module.

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds.py
+++ b/lib/ansible/modules/cloud/amazon/rds.py
@@ -1055,7 +1055,7 @@ def main():
         engine_version    = dict(required=False),
         parameter_group   = dict(required=False),
         license_model     = dict(choices=['license-included', 'bring-your-own-license', 'general-public-license', 'postgresql-license'], required=False),
-        multi_zone        = dict(type='bool', default=False),
+        multi_zone        = dict(type='bool', required=False),
         iops              = dict(required=False),
         security_groups   = dict(required=False),
         vpc_security_groups = dict(type='list', required=False),


### PR DESCRIPTION
##### SUMMARY
It looks like way back when, the key `default` for the parameter `multi_zone` was written when `required` was what was actually intended.  It does not make sense to have this *optional* parameter default to 'False' (the in-line documentation also mentions that this parameter is optional, and it makes sense for it to be so). Until the recent change in 0ed1e6a1f3fb14cb8ded5587eae54665f02a10f0, this issue didn't manifest itself and went unnoticed, but it is now showing up in a bad way: Any 'modify' action against a multi-AZ RDS which does not explicitly specify a value for the `multi_zone` parameter (for example, simply changing a password, or storage size) also causes the RDS to be modified to single-AZ.

Removing the default of 'False' from this parameter allows the module to behave as intended - the `multi_zone` (multi-AZ) parameter is only passed to boto if the user has specified it, rather than being passed with a value of 'False' when the user has not specified it at all.


##### ISSUE TYPE
 - Bugfix Pull Request
 
##### COMPONENT NAME
rds.py

##### ANSIBLE VERSION
```
ansible 2.3.0.0 (stable-2.3 0fe53eda86) last updated 2017/04/06 22:20:16 (GMT -500)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```

##### ADDITIONAL INFORMATION
