### PR TITLE
Fix --force for unversionned requirements

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -389,8 +389,9 @@ class GalaxyCLI(CLI):
                                         (role.name, role.install_info['version'], role.version or "unspecified"))
                         continue
                 else:
-                    display.display('- %s is already installed, skipping.' % str(role))
-                    continue
+                    if not force:
+                        display.display('- %s is already installed, skipping.' % str(role))
+                        continue
 
             try:
                 installed = role.install()


### PR DESCRIPTION
##### SUMMARY

In current stable (2.2), ansible galaxy install --force do erase
a role, even if the version is not set. This commit should restore
that specific behavior, in accordance to people reports:
  https://github.com/ansible/ansible/issues/11266#issuecomment-273801480

It was also the behavior planned in the initial discussion:
"if you're not fixing versions in your roles file, then it's fine
to expect that the role will be reinstalled each time you run
ansible-galaxy install.", cf https://github.com/ansible/ansible/pull/12904


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
galaxy

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
# ansible --version
ansible 2.4.0 (devel 48eeab8a53) last updated 2017/04/06 20:00:06 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible']
  ansible python module location = /usr/local/src/ansible/lib/ansible
  executable location = /usr/local/src/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION

That is breaking automation on a few infra I am managing (including my own), and likely require a backport on 2.3