### PR TITLE
Add missing provider to eos_banner basic-motd eapi test

### DIFF
--- a/test/integration/targets/eos_banner/tests/eapi/basic-motd.yaml
+++ b/test/integration/targets/eos_banner/tests/eapi/basic-motd.yaml
@@ -5,6 +5,7 @@
     banner: motd
     state: absent
     authorize: yes
+    provider: "{{ eapi }}"
 
 - name: Set motd
   eos_banner:


### PR DESCRIPTION
##### SUMMARY

Otherwise this stalls and timeouts, it doesn't have creds to run.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
eos_banner

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (add_missing_provider_eos_banner_eapi_motd_test a641f9b933) last updated 2017/04/07 13:29:47 (GMT +200)
```

