### PR TITLE
Reference correct variable and key for role expiry

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -321,7 +321,7 @@ def user_alter(cursor, module, user, password, role_attr_flags, encrypted, expir
                 if current_role_attrs[PRIV_TO_AUTHID_COLUMN[role_attr_name]] != role_attr_value:
                     role_attr_flags_changing = True
 
-        expires_changing = (expires is not None and expires == current_roles_attrs['rol_valid_until'])
+        expires_changing = (expires is not None and expires == current_role_attrs['rolvaliduntil'])
 
         if not pwchanging and not role_attr_flags_changing and not expires_changing:
             return False


### PR DESCRIPTION
Previously, this module could throw the following error message:
    
    NameError: global name 'current_roles_attrs' is not defined

The referencing key should also match the name of the column, which is
rolvaliduntil, not rol_valid_until

##### SUMMARY
Creating users with expiry set for PostgreSQL causes  "MODULE FAILURE". This is caused due to  a typo(?) in a reference to a variable and using a non-existent key.

##### ISSUE TYPE
typo

##### COMPONENT NAME
postgresql_user

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```


##### ADDITIONAL INFORMATION
I tested these changes locally and it caused the playbook to succeed.

Before:
```
failed: [localhost] (item={'key': u'klaas', 'value': {u'expires': u'2018-01-01'}}) => {
    "failed": true,
    "invocation": {
        "module_name": "postgresql_user"
    },
    "item": {
        "key": "klaas",
        "value": {
            "expires": "2018-01-01"
        }
    },
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_GXsGXW/ansible_module_postgresql_user.py\", line 666, in <module>\n    main()\n  File \"/tmp/ansible_GXsGXW/ansible_module_postgresql_user.py\", line 621, in main\n    changed = user_alter(cursor, module, user, password, role_attr_flags, encrypted, expires, no_password_changes)\n  File \"/tmp/ansible_GXsGXW/ansible_module_postgresql_user.py\", line 277, in user_alter\n    expires_changing = (expires is not None and expires == current_roles_attrs['rol_valid_until'])\nNameError: global name 'current_roles_attrs' is not defined\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE"
}
```

After:
```
changed: [localhost] => (item={'key': u'klaas', 'value': {u'expires': u'2018-01-01'}}) => {
    "changed": true,
    "invocation": {
        "module_args": {
            "db": "",
            "encrypted": true,
            "expires": "2018-01-01",
            "fail_on_user": true,
            "login_host": "",
            "login_password": "",
            "login_unix_socket": "",
            "login_user": "postgres",
            "name": "klaas",
            "no_password_changes": false,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": "50950",
            "priv": null,
            "role_attr_flags": "",
            "state": "present",
            "user": "klaas"
        },
        "module_name": "postgresql_user"
    },
    "item": {
        "key": "klaas",
        "value": {
            "expires": "2018-01-01"
        }
    },
    "user": "klaas"
}
```