### PR TITLE
Fix eos_banner basic-motd eapi asserts

### DIFF
--- a/test/integration/targets/eos_banner/tests/eapi/basic-motd.yaml
+++ b/test/integration/targets/eos_banner/tests/eapi/basic-motd.yaml
@@ -25,8 +25,8 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'this is my motd banner' in result.commands"
-      - "'that has a multiline' in result.commands"
+      - "result.commands.0.cmd == 'banner motd'"
+      - "result.commands.0.input == 'this is my motd banner\nthat has a multiline\nstring'"
       # Ensure sessions contains epoc. Will fail after 18th May 2033
       - "'ansible_1' in result.session_name"
 


### PR DESCRIPTION
##### SUMMARY

The commands in EAPI does not contain the plain command sent to the
device as a one liner, but it is split in cmd/input keys.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
eos_banner

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (fix_eos_banner_eapi_basic_motd_assert c0d07ec8d2) last updated 2017/04/07 14:08:40 (GMT +200)

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
