### PR TITLE
Check for proper response key on eos_banner map_config_to_obj

### DIFF
--- a/lib/ansible/modules/network/eos/eos_banner.py
+++ b/lib/ansible/modules/network/eos/eos_banner.py
@@ -121,8 +121,12 @@ def map_config_to_obj(module):
         else:
             # On EAPI we need to extract the banner text from dict key
             # 'loginBanner'
-            if isinstance(output[0], dict) and 'loginBanner' in output[0].keys():
-                obj['text'] = output[0]['loginBanner'].strip('\n')
+            if module.params['banner'] == 'login':
+                banner_response_key = 'loginBanner'
+            else:
+                banner_response_key = 'motd'
+            if isinstance(output[0], dict) and banner_response_key in output[0].keys():
+                obj['text'] = output[0][banner_response_key].strip('\n')
         obj['state'] = 'present'
     return obj
 


### PR DESCRIPTION
##### SUMMARY

If we run the task with 'login' banner, the 'show banner' command
will return a dict containing key 'loginBanner'.
However for motd, it will just return 'motd'.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
eos_banner