### PR TITLE
Do not assert session name on idempotent eos banner

### DIFF
--- a/lib/ansible/modules/network/eos/eos_banner.py
+++ b/lib/ansible/modules/network/eos/eos_banner.py
@@ -121,8 +121,12 @@ def map_config_to_obj(module):
         else:
             # On EAPI we need to extract the banner text from dict key
             # 'loginBanner'
-            if isinstance(output[0], dict) and 'loginBanner' in output[0].keys():
-                obj['text'] = output[0]['loginBanner'].strip('\n')
+            if module.params['banner'] == 'login':
+                banner_response_key = 'loginBanner'
+            else:
+                banner_response_key = 'motd'
+            if isinstance(output[0], dict) and banner_response_key in output[0].keys():
+                obj['text'] = output[0][banner_response_key].strip('\n')
         obj['state'] = 'present'
     return obj
 

--- a/test/integration/targets/eos_banner/tests/eapi/basic-motd.yaml
+++ b/test/integration/targets/eos_banner/tests/eapi/basic-motd.yaml
@@ -47,7 +47,7 @@
       - "result.changed == false"
       - "result.commands | length == 0"
       # Ensure sessions contains epoc. Will fail after 18th May 2033
-      - "result.session_name contains 'ansible_1'"
+      - "result.session_name is not defined"
 
 # FIXME add in tests for everything defined in docs
 # FIXME Test state:absent + test:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Do not assert session name on idempotent eos banner
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
eos_banner

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (do_not_assert_session_name_on_idempotent_eos_banner abe7d5ded0) last updated 2017/04/07 15:35:52 (GMT +200)
```
