### PR TITLE
Rebase and fix PR #20039

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_eni.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eni.py
@@ -108,6 +108,9 @@ options:
 extends_documentation_fragment:
     - aws
     - ec2
+notes:
+    - This modules leverage the uniqueness of end_id, private_ip_address and subnet_id,
+      or instance_id and device_id to uniquely identify Elastic Network Interfaces (ENIs).
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/ec2_eni.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eni.py
@@ -109,8 +109,8 @@ extends_documentation_fragment:
     - aws
     - ec2
 notes:
-    - This modules leverage the uniqueness of end_id, private_ip_address and subnet_id,
-      or instance_id and device_id to uniquely identify Elastic Network Interfaces (ENIs).
+    - This module identifies and ENI based on either the eni_id, a combination of private_ip_address and subnet_id,
+      or a combination of instance_id and device_id. Any of these options will let you specify a particular ENI.
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/amazon/ec2_eni.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eni.py
@@ -552,6 +552,9 @@ def main():
                            mutually_exclusive=[
                                ['secondary_private_ip_addresses', 'secondary_private_ip_address_count']
                                ],
+                           required_together=[
+                               ['instance_id', 'device_index']
+                               ],
                            required_if=([
                                ('state', 'present', ['subnet_id']),
                                ('state', 'absent', ['eni_id']),

--- a/lib/ansible/modules/cloud/amazon/ec2_eni.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eni.py
@@ -494,7 +494,7 @@ def uniquely_find_eni(connection, module):
                 filters['attachment.instance-id'] = instance_id
                 filters['attachment.device-index'] = device_index
 
-        if eni_id == None or len(filters) == 0:
+        if eni_id == None and len(filters) == 0:
             return None
 
         eni_result = connection.get_all_network_interfaces(eni_id, filters=filters)

--- a/lib/ansible/modules/cloud/amazon/ec2_eni.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eni.py
@@ -162,6 +162,12 @@ EXAMPLES = '''
     description: "My new description"
     state: present
 
+# Update an ENI identifying it by private_ip_address and subnet_id
+- ec2_eni:
+    subnet_id: subnet-xxxxxxx
+    private_ip_address: 172.16.1.1
+    description: "My new description"
+
 # Detach an ENI from an instance
 - ec2_eni:
     eni_id: eni-xxxxxxx

--- a/lib/ansible/modules/cloud/amazon/ec2_eni.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eni.py
@@ -477,6 +477,7 @@ def uniquely_find_eni(connection, module):
 
     eni_id = module.params.get("eni_id")
     private_ip_address = module.params.get('private_ip_address')
+    subnet_id = module.params.get('subnet_id')
     instance_id = module.params.get('instance_id')
     device_index = module.params.get('device_index')
 
@@ -487,12 +488,13 @@ def uniquely_find_eni(connection, module):
         if eni_id is None and private_ip_address is None and (instance_id is None and device_index is None):
             return None
 
-        if private_ip_address:
+        if private_ip_address and subnet_id:
             filters['private-ip-address'] = private_ip_address
-        else:
-            if instance_id and device_index:
-                filters['attachment.instance-id'] = instance_id
-                filters['attachment.device-index'] = device_index
+            filters['subnet-id'] = subnet_id
+
+        if instance_id and device_index:
+            filters['attachment.instance-id'] = instance_id
+            filters['attachment.device-index'] = device_index
 
         if eni_id is None and len(filters) == 0:
             return None

--- a/lib/ansible/modules/cloud/amazon/ec2_eni.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eni.py
@@ -319,7 +319,7 @@ def create_eni(connection, vpc_id, module):
 
     try:
         eni = connection.create_network_interface(subnet_id, private_ip_address, description, security_groups)
-        if attached == True and instance_id is not None:
+        if attached and instance_id is not None:
             try:
                 eni.attach(instance_id, device_index)
             except BotoServerError:
@@ -494,7 +494,7 @@ def uniquely_find_eni(connection, module):
                 filters['attachment.instance-id'] = instance_id
                 filters['attachment.device-index'] = device_index
 
-        if eni_id == None and len(filters) == 0:
+        if eni_id is None and len(filters) == 0:
             return None
 
         eni_result = connection.get_all_network_interfaces(eni_id, filters=filters)

--- a/lib/ansible/modules/cloud/amazon/ec2_eni.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eni.py
@@ -318,34 +318,32 @@ def create_eni(connection, vpc_id, module):
     changed = False
 
     try:
-        eni = find_eni(connection, module)
-        if eni is None:
-            eni = connection.create_network_interface(subnet_id, private_ip_address, description, security_groups)
-            if attached is True and instance_id is not None:
-                try:
-                    eni.attach(instance_id, device_index)
-                except BotoServerError:
-                    eni.delete()
-                    raise
-                # Wait to allow creation / attachment to finish
-                wait_for_eni(eni, "attached")
-                eni.update()
+        eni = connection.create_network_interface(subnet_id, private_ip_address, description, security_groups)
+        if attached == True and instance_id is not None:
+            try:
+                eni.attach(instance_id, device_index)
+            except BotoServerError:
+                eni.delete()
+                raise
+            # Wait to allow creation / attachment to finish
+            wait_for_eni(eni, "attached")
+            eni.update()
 
-            if secondary_private_ip_address_count is not None:
-                try:
-                    connection.assign_private_ip_addresses(network_interface_id=eni.id, secondary_private_ip_address_count=secondary_private_ip_address_count)
-                except BotoServerError:
-                    eni.delete()
-                    raise
+        if secondary_private_ip_address_count is not None:
+            try:
+                connection.assign_private_ip_addresses(network_interface_id=eni.id, secondary_private_ip_address_count=secondary_private_ip_address_count)
+            except BotoServerError:
+                eni.delete()
+                raise
 
-            if secondary_private_ip_addresses is not None:
-                try:
-                    connection.assign_private_ip_addresses(network_interface_id=eni.id, private_ip_addresses=secondary_private_ip_addresses)
-                except BotoServerError:
-                    eni.delete()
-                    raise
+        if secondary_private_ip_addresses is not None:
+            try:
+                connection.assign_private_ip_addresses(network_interface_id=eni.id, private_ip_addresses=secondary_private_ip_addresses)
+            except BotoServerError:
+                eni.delete()
+                raise
 
-            changed = True
+        changed = True
 
     except BotoServerError as e:
         module.fail_json(msg=e.message)
@@ -475,25 +473,29 @@ def detach_eni(eni, module):
         module.exit_json(changed=False, interface=get_eni_info(eni))
 
 
-def find_eni(connection, module):
+def univocally_find_eni(connection, module):
 
     eni_id = module.params.get("eni_id")
-    subnet_id = module.params.get('subnet_id')
     private_ip_address = module.params.get('private_ip_address')
     instance_id = module.params.get('instance_id')
     device_index = module.params.get('device_index')
 
     try:
         filters = {}
-        if subnet_id:
-            filters['subnet-id'] = subnet_id
+
+        # proceed only if we're univocally specifying an ENI
+        if eni_id is None and private_ip_address is None and (instance_id is None and device_index is None):
+            return None
+
         if private_ip_address:
             filters['private-ip-address'] = private_ip_address
         else:
-            if instance_id:
+            if instance_id and device_index:
                 filters['attachment.instance-id'] = instance_id
-            if device_index:
                 filters['attachment.device-index'] = device_index
+
+        if eni_id == None or len(filters) == 0:
+            return None
 
         eni_result = connection.get_all_network_interfaces(eni_id, filters=filters)
         if len(eni_result) == 1:
@@ -577,7 +579,7 @@ def main():
         subnet_id = module.params.get("subnet_id")
         vpc_id = _get_vpc_id(vpc_connection, module, subnet_id)
 
-        eni = find_eni(connection, module)
+        eni = univocally_find_eni(connection, module)
         if eni is None:
             create_eni(connection, vpc_id, module)
         else:

--- a/lib/ansible/modules/cloud/amazon/ec2_eni.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eni.py
@@ -473,7 +473,7 @@ def detach_eni(eni, module):
         module.exit_json(changed=False, interface=get_eni_info(eni))
 
 
-def univocally_find_eni(connection, module):
+def uniquely_find_eni(connection, module):
 
     eni_id = module.params.get("eni_id")
     private_ip_address = module.params.get('private_ip_address')
@@ -579,7 +579,7 @@ def main():
         subnet_id = module.params.get("subnet_id")
         vpc_id = _get_vpc_id(vpc_connection, module, subnet_id)
 
-        eni = univocally_find_eni(connection, module)
+        eni = uniquely_find_eni(connection, module)
         if eni is None:
             create_eni(connection, vpc_id, module)
         else:


### PR DESCRIPTION
##### SUMMARY
This PR aims to rebase and fix PR #20039 addressing issue #19972.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
ec2_eni module

##### ANSIBLE VERSION
```
ansible --version                                                                                                                                                                                                                                                     !8598
ansible 2.2.1.0
  config file =
  configured module search path = Default w/o overrides
```


##### ADDITIONAL INFORMATION
This code has been tested with the following playbook in order to simulate different usage scenarios of the `ec2_eni` module.

```
- name: Debug the ec2_eni module
  hosts: all
  vars:
    subnet_id: "<subnet-id>"
  tasks:

    - name: Create a first ENI
      ec2_eni:
        subnet_id: "{{ subnet_id }}"
        private_ip_address: "10.0.1.10"
        description: "First ENI"
        security_groups:
          - a-group
        state: "present"
      register: first_eni

    - name: Create a second ENI
      ec2_eni:
        subnet_id: "{{ subnet_id }}"
        description: "Second ENI"
        security_groups:
          - a-group
        state: "present"

    - name: Modify the first ENI
      ec2_eni:
        eni_id: "{{ first_eni['interface']['id'] }}"
        subnet_id: "{{ subnet_id }}"
        delete_on_termination: yes
        source_dest_check: no

    - name: Create a new ENI with the same IP of the firstENI
      ec2_eni:
        subnet_id: "{{ subnet_id }}"
        private_ip_address: "10.0.1.10"
        security_groups:
          - a-group
```
