### PR TITLE
Convert ec2_metric_alarm.py to boto3 and add support for the treat_missing_data option

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -141,15 +141,31 @@ options:
     default: Default
     choices: ['OldestInstance', 'NewestInstance', 'OldestLaunchConfiguration', 'ClosestToNextInstanceHour', 'Default']
     version_added: "2.0"
+  notifications:
+    description:
+      - A list of notification objects. Each notification is a dictionary.
+    suboptions:
+      topic:
+        description:
+          - A SNS topic ARN to send auto scaling notification to.
+        required: true
+      types:
+        description:
+          - A list of auto scaling events to trigger notifications on.
+        required: false
+        default: ['autoscaling:EC2_INSTANCE_LAUNCH', 'autoscaling:EC2_INSTANCE_LAUNCH_ERROR', 'autoscaling:EC2_INSTANCE_TERMINATE', 'autoscaling:EC2_INSTANCE_TERMINATE_ERROR']
+    required: false
+    default: []
+    version_added: "2.3"
   notification_topic:
     description:
-      - A SNS topic ARN to send auto scaling notifications to.
+      - This option has been deprecated in favor of C(notifications). A SNS topic ARN to send auto scaling notifications to.
     default: None
     required: false
     version_added: "2.2"
   notification_types:
     description:
-      - A list of auto scaling events to trigger notifications on.
+      - This option has been deprecated in favor of C(notifications). A list of auto scaling events to trigger notifications on.
     default: ['autoscaling:EC2_INSTANCE_LAUNCH', 'autoscaling:EC2_INSTANCE_LAUNCH_ERROR', 'autoscaling:EC2_INSTANCE_TERMINATE', 'autoscaling:EC2_INSTANCE_TERMINATE_ERROR']
     required: false
     version_added: "2.2"
@@ -447,6 +463,7 @@ def create_autoscaling_group(connection, module):
     as_groups = connection.get_all_groups(names=[group_name])
     wait_timeout = module.params.get('wait_timeout')
     termination_policies = module.params.get('termination_policies')
+    notifications = module.params.get('notifications')
     notification_topic = module.params.get('notification_topic')
     notification_types = module.params.get('notification_types')
 
@@ -501,6 +518,15 @@ def create_autoscaling_group(connection, module):
 
             if notification_topic:
                 ag.put_notification_configuration(notification_topic, notification_types)
+            else:
+                for notification in notifications:
+                    if 'topic' not in notification:
+                        module.fail_json(msg="You must specify a topic for each object specified in notifications.")
+                    elif 'types' not in notification:
+                        notification['types'] = ['autoscaling:EC2_INSTANCE_LAUNCH', 'autoscaling:EC2_INSTANCE_LAUNCH_ERROR', 'autoscaling:EC2_INSTANCE_TERMINATE', 'autoscaling:EC2_INSTANCE_TERMINATE_ERROR']
+
+                    ag.put_notification_configuration(notification['topic'], notification['types'])
+
 
             as_group = connection.get_all_groups(names=[group_name])[0]
             asg_properties = get_properties(as_group)
@@ -574,6 +600,17 @@ def create_autoscaling_group(connection, module):
                 as_group.put_notification_configuration(notification_topic, notification_types)
             except BotoServerError as e:
                 module.fail_json(msg="Failed to update Autoscaling Group notifications: %s" % str(e), exception=traceback.format_exc())
+        else:
+            try:
+                for notification in notifications:
+                    if 'topic' not in notification:
+                        module.fail_json(msg="You must specify a topic for each object specified in notifications.")
+                    elif 'types' not in notification:
+                        notification['types'] = ['autoscaling:EC2_INSTANCE_LAUNCH', 'autoscaling:EC2_INSTANCE_LAUNCH_ERROR', 'autoscaling:EC2_INSTANCE_TERMINATE', 'autoscaling:EC2_INSTANCE_TERMINATE_ERROR']
+
+                    as_group.put_notification_configuration(notification['topic'], notification['types'])
+            except BotoServerError as e:
+                module.fail_json(msg="Failed to update Autoscaling Group notifications: %s" % str(e), exception=traceback.format_exc())
 
         if wait_for_instances:
             wait_for_new_inst(module, connection, group_name, wait_timeout, desired_capacity, 'viable_instances')
@@ -588,11 +625,20 @@ def create_autoscaling_group(connection, module):
 
 def delete_autoscaling_group(connection, module):
     group_name = module.params.get('name')
+    notifications = module.params.get('notifications')
     notification_topic = module.params.get('notification_topic')
     wait_for_instances = module.params.get('wait_for_instances')
 
     if notification_topic:
         ag.delete_notification_configuration(notification_topic)
+    else:
+        for notification in notifications:
+            if 'topic' not in notification:
+                module.fail_json(msg="You must specify a topic for each object specified in notifications.")
+            elif 'types' not in notification:
+                notification['types'] = ['autoscaling:EC2_INSTANCE_LAUNCH', 'autoscaling:EC2_INSTANCE_LAUNCH_ERROR', 'autoscaling:EC2_INSTANCE_TERMINATE', 'autoscaling:EC2_INSTANCE_TERMINATE_ERROR']
+
+            ag.delete_notification_configuration(notification['topic'], notification['types'])
 
     groups = connection.get_all_groups(names=[group_name])
     if groups:
@@ -887,6 +933,7 @@ def main():
             default_cooldown=dict(type='int', default=300),
             wait_for_instances=dict(type='bool', default=True),
             termination_policies=dict(type='list', default='Default'),
+            notifications=dict(type='list', default=[]),
             notification_topic=dict(type='str', default=None),
             notification_types=dict(type='list', default=[
                 'autoscaling:EC2_INSTANCE_LAUNCH',
@@ -900,7 +947,10 @@ def main():
 
     module = AnsibleModule(
         argument_spec=argument_spec,
-        mutually_exclusive = [['replace_all_instances', 'replace_instances']]
+        mutually_exclusive = [
+            ['replace_all_instances', 'replace_instances'],
+            ['notifications', 'notification_topic']
+        ]
     )
 
     if not HAS_BOTO:
@@ -917,6 +967,10 @@ def main():
     except boto.exception.NoAuthHandlerFound as e:
         module.fail_json(msg=str(e))
     changed = create_changed = replace_changed = False
+    warnings = []
+
+    if module.params.get('notification_topic') is not None:
+        warnings.append('The notification_topic and notification_types options have been deprecated in favor of notifications.')
 
     if state == 'present':
         create_changed, asg_properties=create_autoscaling_group(connection, module)
@@ -927,7 +981,7 @@ def main():
         replace_changed, asg_properties=replace(connection, module)
     if create_changed or replace_changed:
         changed = True
-    module.exit_json( changed = changed, **asg_properties )
+    module.exit_json( warnings = warnings, changed = changed, **asg_properties )
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/amazon/ec2_metric_alarm.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_metric_alarm.py
@@ -56,7 +56,7 @@ options:
         description:
           - Determines how the threshold value is compared
         required: false
-        choices: ['<=','<','>','>=']
+        choices: ['LessThanOrEqualToThreshold', 'LessThanThreshold', 'GreaterThanThreshold', 'GreaterThanOrEqualToThreshold']
     threshold:
         description:
           - Sets the min/max bound for triggering the alarm
@@ -94,6 +94,13 @@ options:
         description:
           - A list of the names of action(s) to take when the alarm is in the 'ok' status
         required: false
+    treat_missing_data:
+        description:
+          - Sets how the alarm handles missing data points.
+        required: false
+        choices: ['breaching','notBreaching','ignore','missing']
+        default: 'missing'
+        version_added: "2.4"
 extends_documentation_fragment:
     - aws
     - ec2
@@ -108,7 +115,7 @@ EXAMPLES = '''
       metric: "CPUUtilization"
       namespace: "AWS/EC2"
       statistic: Average
-      comparison: "<="
+      comparison: "LessThanOrEqualToThreshold"
       threshold: 5.0
       period: 300
       evaluation_periods: 3
@@ -121,13 +128,10 @@ EXAMPLES = '''
 '''
 
 try:
-    import boto.ec2.cloudwatch
-    from boto.ec2.cloudwatch import CloudWatchConnection, MetricAlarm
-    from boto.exception import BotoServerError
-    HAS_BOTO = True
+    import boto3
+    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO = False
-
+    HAS_BOTO3 = False
 
 def create_metric_alarm(connection, module):
 
@@ -145,103 +149,130 @@ def create_metric_alarm(connection, module):
     alarm_actions = module.params.get('alarm_actions')
     insufficient_data_actions = module.params.get('insufficient_data_actions')
     ok_actions = module.params.get('ok_actions')
+    treat_missing_data = module.params.get('treat_missing_data')
 
-    alarms = connection.describe_alarms(alarm_names=[name])
+    warnings = []
 
-    if not alarms:
+    alarms = connection.describe_alarms(AlarmNames=[name])
 
-        alm = MetricAlarm(
-            name=name,
-            metric=metric,
-            namespace=namespace,
-            statistic=statistic,
-            comparison=comparison,
-            threshold=threshold,
-            period=period,
-            evaluation_periods=evaluation_periods,
-            unit=unit,
-            description=description,
-            dimensions=dimensions,
-            alarm_actions=alarm_actions,
-            insufficient_data_actions=insufficient_data_actions,
-            ok_actions=ok_actions
-        )
+    comparisons = {'<=' : 'LessThanOrEqualToThreshold', '<' : 'LessThanThreshold', '>=' : 'GreaterThanOrEqualToThreshold', '>' : 'GreaterThanThreshold'}
+    if comparison in ('<=', '<', '>', '>='):
+        warnings.append('Using the <=, <, > and >= operators has been deprecated. Please use LessThanOrEqualToThreshold, LessThanThreshold, GreaterThanThreshold or GreaterThanOrEqualToThreshold instead.')
+        comparison = comparisons[comparison]
+
+    if not isinstance(dimensions, list):
+        fixed_dimensions = []
+        for key, value in dimensions.iteritems():
+            fixed_dimensions.append({'Name': key, 'Value': value})
+        dimensions = fixed_dimensions
+
+    if not alarms['MetricAlarms']:
         try:
-            connection.create_alarm(alm)
+            connection.put_metric_alarm(
+                    AlarmName=name,
+                    MetricName=metric,
+                    Namespace=namespace,
+                    Statistic=statistic,
+                    ComparisonOperator=comparison,
+                    Threshold=threshold,
+                    Period=period,
+                    EvaluationPeriods=evaluation_periods,
+                    Unit=unit,
+                    AlarmDescription=description,
+                    Dimensions=dimensions,
+                    AlarmActions=alarm_actions,
+                    InsufficientDataActions=insufficient_data_actions,
+                    OKActions=ok_actions,
+                    TreatMissingData=treat_missing_data
+                )
             changed = True
-            alarms = connection.describe_alarms(alarm_names=[name])
-        except BotoServerError as e:
+            alarms = connection.describe_alarms(AlarmNames=[name])
+        except botocore.exceptions.ClientError as e:
             module.fail_json(msg=str(e))
 
     else:
-        alarm = alarms[0]
         changed = False
+        alarm = alarms['MetricAlarms'][0]
 
-        for attr in ('comparison','metric','namespace','statistic','threshold','period','evaluation_periods','unit','description'):
-            if getattr(alarm, attr) != module.params.get(attr):
+        for key, value in { 'MetricName': metric,
+                            'Namespace': namespace,
+                            'Statistic': statistic,
+                            'ComparisonOperator': comparison,
+                            'Threshold': threshold,
+                            'Period': period,
+                            'EvaluationPeriods': evaluation_periods,
+                            'Unit': unit,
+                            'AlarmDescription': description,
+                            'Dimensions': dimensions,
+                            'TreatMissingData': treat_missing_data }.iteritems():
+            if alarm[key] != value:
                 changed = True
-                setattr(alarm, attr, module.params.get(attr))
-        #this is to deal with a current bug where you cannot assign '<=>' to the comparator when modifying an existing alarm
-        comparison = alarm.comparison
-        comparisons = {'<=' : 'LessThanOrEqualToThreshold', '<' : 'LessThanThreshold', '>=' : 'GreaterThanOrEqualToThreshold', '>' : 'GreaterThanThreshold'}
-        alarm.comparison = comparisons[comparison]
+                alarm[key] = value
 
-        dim1 = module.params.get('dimensions')
-        dim2 = alarm.dimensions
-
-        for keys in dim1:
-            if not isinstance(dim1[keys], list):
-                dim1[keys] = [dim1[keys]]
-            if keys not in dim2 or dim1[keys] != dim2[keys]:
-                changed=True
-                setattr(alarm, 'dimensions', dim1)
-
-        for attr in ('alarm_actions','insufficient_data_actions','ok_actions'):
-            action = module.params.get(attr) or []
-            if getattr(alarm, attr) != action:
+        for key, value in { 'AlarmActions': alarm_actions,
+                            'InsufficientDataActions': insufficient_data_actions,
+                            'OKActions': ok_actions }.iteritems():
+            action = value or []
+            if alarm[key] != action:
                 changed = True
-                setattr(alarm, attr, module.params.get(attr))
+                alarm[key] = value
 
         try:
             if changed:
-                connection.create_alarm(alarm)
-        except BotoServerError as e:
+                connection.put_metric_alarm(
+                        AlarmName=alarm['AlarmName'],
+                        MetricName=alarm['MetricName'],
+                        Namespace=alarm['Namespace'],
+                        Statistic=alarm['Statistic'],
+                        ComparisonOperator=alarm['ComparisonOperator'],
+                        Threshold=alarm['Threshold'],
+                        Period=alarm['Period'],
+                        EvaluationPeriods=alarm['EvaluationPeriods'],
+                        Unit=alarm['Unit'],
+                        AlarmDescription=alarm['AlarmDescription'],
+                        Dimensions=alarm['Dimensions'],
+                        AlarmActions=alarm['AlarmActions'],
+                        InsufficientDataActions=alarm['InsufficientDataActions'],
+                        OKActions=alarm['OKActions'],
+                        TreatMissingData=alarm['TreatMissingData']
+                    )
+        except botocore.exceptions.ClientError as e:
             module.fail_json(msg=str(e))
-    result = alarms[0]
-    module.exit_json(changed=changed, name=result.name,
-        actions_enabled=result.actions_enabled,
-        alarm_actions=result.alarm_actions,
-        alarm_arn=result.alarm_arn,
-        comparison=result.comparison,
-        description=result.description,
-        dimensions=result.dimensions,
-        evaluation_periods=result.evaluation_periods,
-        insufficient_data_actions=result.insufficient_data_actions,
-        last_updated=result.last_updated,
-        metric=result.metric,
-        namespace=result.namespace,
-        ok_actions=result.ok_actions,
-        period=result.period,
-        state_reason=result.state_reason,
-        state_value=result.state_value,
-        statistic=result.statistic,
-        threshold=result.threshold,
-        unit=result.unit)
+
+    result = alarms['MetricAlarms'][0]
+    module.exit_json(changed=changed, warnings=warnings,
+        name=result['AlarmName'],
+        actions_enabled=result['ActionsEnabled'],
+        alarm_actions=result['AlarmActions'],
+        alarm_arn=result['AlarmArn'],
+        comparison=result['ComparisonOperator'],
+        description=result['AlarmDescription'],
+        dimensions=result['Dimensions'],
+        evaluation_periods=result['EvaluationPeriods'],
+        insufficient_data_actions=result['InsufficientDataActions'],
+        last_updated=result['AlarmConfigurationUpdatedTimestamp'],
+        metric=result['MetricName'],
+        namespace=result['Namespace'],
+        ok_actions=result['OKActions'],
+        period=result['Period'],
+        state_reason=result['StateReason'],
+        state_value=result['StateValue'],
+        statistic=result['Statistic'],
+        threshold=result['Threshold'],
+        unit=result['Unit'])
 
 def delete_metric_alarm(connection, module):
     name = module.params.get('name')
+    alarms = connection.describe_alarms(AlarmNames=[name])
 
-    alarms = connection.describe_alarms(alarm_names=[name])
-
-    if alarms:
+    if alarms['MetricAlarms']:
         try:
-            connection.delete_alarms([name])
+            connection.delete_alarms(AlarmNames=[name])
             module.exit_json(changed=True)
-        except BotoServerError as e:
+        except botocore.exceptions.ClientError as e:
             module.fail_json(msg=str(e))
     else:
         module.exit_json(changed=False)
-
 
 def main():
     argument_spec = ec2_argument_spec()
@@ -251,7 +282,7 @@ def main():
             metric=dict(type='str'),
             namespace=dict(type='str'),
             statistic=dict(type='str', choices=['SampleCount', 'Average', 'Sum', 'Minimum', 'Maximum']),
-            comparison=dict(type='str', choices=['<=', '<', '>', '>=']),
+            comparison=dict(type='str', choices=['LessThanOrEqualToThreshold', 'LessThanThreshold', 'GreaterThanThreshold', 'GreaterThanOrEqualToThreshold', '<=', '<', '>', '>=']),
             threshold=dict(type='float'),
             period=dict(type='int'),
             unit=dict(type='str', choices=['Seconds', 'Microseconds', 'Milliseconds', 'Bytes', 'Kilobytes', 'Megabytes', 'Gigabytes', 'Terabytes', 'Bits', 'Kilobits', 'Megabits', 'Gigabits', 'Terabits', 'Percent', 'Count', 'Bytes/Second', 'Kilobytes/Second', 'Megabytes/Second', 'Gigabytes/Second', 'Terabytes/Second', 'Bits/Second', 'Kilobits/Second', 'Megabits/Second', 'Gigabits/Second', 'Terabits/Second', 'Count/Second', 'None']),
@@ -261,23 +292,25 @@ def main():
             alarm_actions=dict(type='list'),
             insufficient_data_actions=dict(type='list'),
             ok_actions=dict(type='list'),
+            treat_missing_data=dict(type='str', choices=['breaching', 'notBreaching', 'ignore', 'missing'], default='missing'),
             state=dict(default='present', choices=['present', 'absent']),
             )
     )
 
     module = AnsibleModule(argument_spec=argument_spec)
 
-    if not HAS_BOTO:
-        module.fail_json(msg='boto required for this module')
+    if not HAS_BOTO3:
+        module.fail_json(msg='boto3 required for this module')
 
     state = module.params.get('state')
 
-    region, ec2_url, aws_connect_params = get_aws_connection_info(module)
+    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
 
     if region:
         try:
-            connection = connect_to_aws(boto.ec2.cloudwatch, region, **aws_connect_params)
-        except (boto.exception.NoAuthHandlerFound, AnsibleAWSError) as e:
+            connection = boto3_conn(module, conn_type='client', resource='cloudwatch',
+                                    region=region, endpoint=ec2_url, **aws_connect_params)
+        except (botocore.exceptions.ClientError, botocore.exceptions.ValidationError) as e:
             module.fail_json(msg=str(e))
     else:
         module.fail_json(msg="region must be specified")


### PR DESCRIPTION
##### SUMMARY

Converted ec2_metric_alarm.py to boto3. Added the treat_missing_data option to take advantage of a new CloudWatch feature that allows you to handle the INSUFFICIENT_DATA state in different ways.

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

ec2_metric_alarm module

##### ANSIBLE VERSION

```
ansible 2.2.0.0 (meredith cdec853e37) last updated 2016/11/15 15:12:03 (GMT -500)
  lib/ansible/modules/core: (detached HEAD fe9c56a003) last updated 2016/11/15 15:12:10 (GMT -500)
  lib/ansible/modules/extras: (detached HEAD f564e77a08) last updated 2016/11/15 15:12:10 (GMT -500)
  config file = 
  configured module search path = Default w/o overrides
```

##### ADDITIONAL INFORMATION

A warning is displayed indicating that the boto3 named ComparisonOperators should be used in place of symbols for the comparison operator. To support backwards compatibility, the symbols will be converted to named operators by the module.

```
 [WARNING]: Using the <=, <, > and >= operators has been deprecated. Please use LessThanOrEqualToThreshold, LessThanThreshold,
GreaterThanThreshold or GreaterThanOrEqualToThreshold instead.
```