### PR TITLE
ios_banner: Example of configuring from file

### DIFF
--- a/lib/ansible/modules/network/ios/ios_banner.py
+++ b/lib/ansible/modules/network/ios/ios_banner.py
@@ -44,7 +44,7 @@ options:
     description:
       - The banner text that should be
         present in the remote device running configuration.  This argument
-        accepts a multiline string. Requires I(state=present).
+        accepts a multiline string, with no empty lines. Requires I(state=present).
     default: null
   state:
     description:
@@ -68,6 +68,13 @@ EXAMPLES = """
   ios_banner:
     banner: motd
     state: absent
+
+- name: Configure banner from file
+  ios_banner:
+    banner:  motd
+    text: "{{ lookup('file', './config_partial/raw_banner.cfg') }}"
+    state: present
+
 """
 
 RETURN = """


### PR DESCRIPTION
I think most people's banner will come from an external file. Show an example, and clarify there is no extra lines allowed.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ios_banner
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
