### PR TITLE
Fix a traceback with python3 and diff output

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -952,12 +952,12 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 else:
                     display.debug("Reading local copy of the file %s" % source)
                     try:
-                        src = open(source)
-                        src_contents = src.read()
+                        with open(source, 'rb') as src:
+                            src_contents = src.read()
                     except Exception as e:
                         raise AnsibleError("Unexpected error while reading source (%s) for diff: %s " % (source, str(e)))
 
-                    if "\x00" in src_contents:
+                    if b"\x00" in src_contents:
                         diff['src_binary'] = 1
                     else:
                         diff['after_header'] = source


### PR DESCRIPTION
When retrieving file contents for diffing we need to get the contents as
binary.  Otherwise python3 will try to convert the file to text and fail
with non-decodable contents.

Fixes #23171

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
Fixes copy by way of lib/ansible/plugins/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.3
```