### PR TITLE
Redo #23418

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -722,11 +722,6 @@ class AnsibleModule(object):
                 no_log_object = self.params.get(arg_name, None)
                 if no_log_object:
                     self.no_log_values.update(return_values(no_log_object))
-            elif arg_name == 'provider' and isinstance(self.params.get(arg_name), dict):
-                param = self.params[arg_name]
-                for sub_param in ['auth_pass', 'password']:
-                    if param.get(sub_param):
-                        self.no_log_values.update(return_values(param[sub_param]))
 
             if arg_opts.get('removed_in_version') is not None and arg_name in self.params:
                 self._deprecations.append({

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -722,6 +722,11 @@ class AnsibleModule(object):
                 no_log_object = self.params.get(arg_name, None)
                 if no_log_object:
                     self.no_log_values.update(return_values(no_log_object))
+            elif arg_name == 'provider' and isinstance(self.params.get(arg_name), dict):
+                param = self.params[arg_name]
+                for sub_param in ['auth_pass', 'password']:
+                    if param.get(sub_param):
+                        self.no_log_values.update(return_values(param[sub_param]))
 
             if arg_opts.get('removed_in_version') is not None and arg_name in self.params:
                 self._deprecations.append({

--- a/lib/ansible/module_utils/dellos10.py
+++ b/lib/ansible/module_utils/dellos10.py
@@ -31,7 +31,7 @@
 #
 import re
 
-from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.basic import env_fallback, return_values
 from ansible.module_utils.network_common import to_list, ComplexList
 from ansible.module_utils.connection import exec_command
 from ansible.module_utils.netcfg import NetworkConfig,ConfigLine
@@ -62,6 +62,11 @@ def check_args(module, warnings):
         if key != 'provider' and module.params[key]:
             warnings.append('argument %s has been deprecated and will be '
                             'removed in a future version' % key)
+
+    if provider:
+        for param in ('auth_pass', 'password'):
+            if provider.get(param):
+                module.no_log_values.update(return_values(provider[param]))
 
 
 def get_config(module, flags=[]):

--- a/lib/ansible/module_utils/dellos6.py
+++ b/lib/ansible/module_utils/dellos6.py
@@ -30,7 +30,7 @@
 #
 import re
 
-from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.basic import env_fallback, return_values
 from ansible.module_utils.network_common import to_list, ComplexList
 from ansible.module_utils.connection import exec_command
 from ansible.module_utils.netcfg import NetworkConfig, ConfigLine, ignore_line, DEFAULT_COMMENT_TOKENS
@@ -62,6 +62,11 @@ def check_args(module, warnings):
         if key != 'provider' and module.params[key]:
             warnings.append('argument %s has been deprecated and will be '
                             'removed in a future version' % key)
+
+    if provider:
+        for param in ('auth_pass', 'password'):
+            if provider.get(param):
+                module.no_log_values.update(return_values(provider[param]))
 
 
 def get_config(module, flags=[]):

--- a/lib/ansible/module_utils/dellos9.py
+++ b/lib/ansible/module_utils/dellos9.py
@@ -31,7 +31,7 @@
 #
 import re
 
-from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.basic import env_fallback, return_values
 from ansible.module_utils.network_common import to_list, ComplexList
 from ansible.module_utils.connection import exec_command
 from ansible.module_utils.netcfg import NetworkConfig,ConfigLine
@@ -62,6 +62,11 @@ def check_args(module, warnings):
         if key != 'provider' and module.params[key]:
             warnings.append('argument %s has been deprecated and will be '
                             'removed in a future version' % key)
+
+    if provider:
+        for param in ('auth_pass', 'password'):
+            if provider.get(param):
+                module.no_log_values.update(return_values(provider[param]))
 
 
 def get_config(module, flags=[]):

--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -30,7 +30,7 @@
 import os
 import time
 
-from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.basic import env_fallback, return_values
 from ansible.module_utils.connection import exec_command
 from ansible.module_utils.network_common import to_list, ComplexList
 from ansible.module_utils.six import iteritems
@@ -63,6 +63,11 @@ def check_args(module, warnings):
         if key not in ['provider', 'transport', 'authorize'] and module.params[key]:
             warnings.append('argument %s has been deprecated and will be '
                     'removed in a future version' % key)
+
+    if provider:
+        for param in ('auth_pass', 'password'):
+            if provider.get(param):
+                module.no_log_values.update(return_values(provider[param]))
 
 def load_params(module):
     provider = module.params.get('provider') or dict()

--- a/lib/ansible/module_utils/ios.py
+++ b/lib/ansible/module_utils/ios.py
@@ -25,7 +25,7 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.basic import env_fallback, return_values
 from ansible.module_utils.network_common import to_list, ComplexList
 from ansible.module_utils.connection import exec_command
 
@@ -49,6 +49,11 @@ def check_args(module, warnings):
         if key not in ['provider', 'authorize'] and module.params[key]:
             warnings.append('argument %s has been deprecated and will be '
                     'removed in a future version' % key)
+
+    if provider:
+        for param in ('auth_pass', 'password'):
+            if provider.get(param):
+                module.no_log_values.update(return_values(provider[param]))
 
 def get_defaults_flag(module):
     rc, out, err = exec_command(module, 'show running-config ?')

--- a/lib/ansible/module_utils/iosxr.py
+++ b/lib/ansible/module_utils/iosxr.py
@@ -26,7 +26,7 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.basic import env_fallback, return_values
 from ansible.module_utils.network_common import to_list, ComplexList
 from ansible.module_utils.connection import exec_command
 
@@ -48,6 +48,10 @@ def check_args(module, warnings):
         if key != 'provider' and module.params[key]:
             warnings.append('argument %s has been deprecated and will be '
                     'removed in a future version' % key)
+
+    if provider:
+        if provider.get('password'):
+            module.no_log_values.update(return_values(provider[param]))
 
 def get_config(module, flags=[]):
     cmd = 'show running-config '

--- a/lib/ansible/module_utils/iosxr.py
+++ b/lib/ansible/module_utils/iosxr.py
@@ -50,8 +50,9 @@ def check_args(module, warnings):
                     'removed in a future version' % key)
 
     if provider:
-        if provider.get('password'):
-            module.no_log_values.update(return_values(provider[param]))
+        for param in ('password',):
+            if provider.get(param):
+                module.no_log_values.update(return_values(provider[param]))
 
 def get_config(module, flags=[]):
     cmd = 'show running-config '

--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -49,8 +49,9 @@ def check_args(module, warnings):
                     'removed in a future version' % key)
 
     if provider:
-        if provider.get('password'):
-            module.no_log_values.update(return_values(provider[param]))
+        for param in ('password',):
+            if provider.get(param):
+                module.no_log_values.update(return_values(provider[param]))
 
 def _validate_rollback_id(module, value):
     try:

--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -20,7 +20,7 @@ from contextlib import contextmanager
 
 from xml.etree.ElementTree import Element, SubElement
 
-from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.basic import env_fallback, return_values
 from ansible.module_utils.netconf import send_request, children
 from ansible.module_utils.netconf import discard_changes, validate
 from ansible.module_utils.six import string_types
@@ -47,6 +47,10 @@ def check_args(module, warnings):
         if key in ('provider',) and module.params[key]:
             warnings.append('argument %s has been deprecated and will be '
                     'removed in a future version' % key)
+
+    if provider:
+        if provider.get('password'):
+            module.no_log_values.update(return_values(provider[param]))
 
 def _validate_rollback_id(module, value):
     try:

--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -62,8 +62,9 @@ def check_args(module, warnings):
                     'removed in a future version' % key)
 
     if provider:
-        if provider.get('password'):
-            module.no_log_values.update(return_values(provider[param]))
+        for param in ('password',):
+            if provider.get(param):
+                module.no_log_values.update(return_values(provider[param]))
 
 def load_params(module):
     provider = module.params.get('provider') or dict()

--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -30,7 +30,7 @@
 import re
 import collections
 
-from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.basic import env_fallback, return_values
 from ansible.module_utils.network_common import to_list, ComplexList
 from ansible.module_utils.connection import exec_command
 from ansible.module_utils.six import iteritems
@@ -60,6 +60,10 @@ def check_args(module, warnings):
         if key not in ['provider', 'transport'] and module.params[key]:
             warnings.append('argument %s has been deprecated and will be '
                     'removed in a future version' % key)
+
+    if provider:
+        if provider.get('password'):
+            module.no_log_values.update(return_values(provider[param]))
 
 def load_params(module):
     provider = module.params.get('provider') or dict()

--- a/lib/ansible/module_utils/sros.py
+++ b/lib/ansible/module_utils/sros.py
@@ -28,7 +28,7 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.basic import env_fallback, return_values
 from ansible.module_utils.network_common import to_list, ComplexList
 from ansible.module_utils.connection import exec_command
 
@@ -50,6 +50,10 @@ def check_args(module, warnings):
         if key != 'provider' and module.params[key]:
             warnings.append('argument %s has been deprecated and will be '
                     'removed in a future version' % key)
+
+    if provider:
+        if provider.get('password'):
+            module.no_log_values.update(return_values(provider[param]))
 
 def get_config(module, flags=[]):
     cmd = 'admin display-config '

--- a/lib/ansible/module_utils/sros.py
+++ b/lib/ansible/module_utils/sros.py
@@ -52,8 +52,9 @@ def check_args(module, warnings):
                     'removed in a future version' % key)
 
     if provider:
-        if provider.get('password'):
-            module.no_log_values.update(return_values(provider[param]))
+        for param in ('password',):
+            if provider.get(param):
+                module.no_log_values.update(return_values(provider[param]))
 
 def get_config(module, flags=[]):
     cmd = 'admin display-config '

--- a/lib/ansible/module_utils/vyos.py
+++ b/lib/ansible/module_utils/vyos.py
@@ -25,7 +25,7 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.basic import env_fallback, return_values
 from ansible.module_utils.network_common import to_list
 from ansible.module_utils.connection import exec_command
 
@@ -49,6 +49,10 @@ def check_args(module, warnings):
         if key != 'provider' and module.params[key]:
             warnings.append('argument %s has been deprecated and will be '
                     'removed in a future version' % key)
+
+    if provider:
+        if provider.get('password'):
+            module.no_log_values.update(return_values(provider[param]))
 
 def get_config(module, target='commands'):
     cmd = ' '.join(['show configuration', target])

--- a/lib/ansible/module_utils/vyos.py
+++ b/lib/ansible/module_utils/vyos.py
@@ -51,8 +51,9 @@ def check_args(module, warnings):
                     'removed in a future version' % key)
 
     if provider:
-        if provider.get('password'):
-            module.no_log_values.update(return_values(provider[param]))
+        for param in ('password',):
+            if provider.get(param):
+                module.no_log_values.update(return_values(provider[param]))
 
 def get_config(module, target='commands'):
     cmd = ' '.join(['show configuration', target])

--- a/lib/ansible/plugins/action/dellos10.py
+++ b/lib/ansible/plugins/action/dellos10.py
@@ -93,12 +93,6 @@ class ActionModule(_ActionModule):
             self._play_context.become_method = None
 
         result = super(ActionModule, self).run(tmp, task_vars)
-
-        try:
-            del result['invocation']['module_args']['provider']
-        except KeyError:
-            pass
-
         return result
 
     def _get_socket_path(self, play_context):

--- a/lib/ansible/plugins/action/dellos6.py
+++ b/lib/ansible/plugins/action/dellos6.py
@@ -89,12 +89,6 @@ class ActionModule(_ActionModule):
             self._play_context.become_method = None
 
         result = super(ActionModule, self).run(tmp, task_vars)
-
-        try:
-            del result['invocation']['module_args']['provider']
-        except KeyError:
-            pass
-
         return result
 
     def _get_socket_path(self, play_context):

--- a/lib/ansible/plugins/action/dellos9.py
+++ b/lib/ansible/plugins/action/dellos9.py
@@ -93,12 +93,6 @@ class ActionModule(_ActionModule):
             self._play_context.become_method = None
 
         result = super(ActionModule, self).run(tmp, task_vars)
-
-        try:
-            del result['invocation']['module_args']['provider']
-        except KeyError:
-            pass
-
         return result
 
     def _get_socket_path(self, play_context):

--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -118,12 +118,6 @@ class ActionModule(_ActionModule):
             self._task.args['provider'] = provider
 
         result = super(ActionModule, self).run(tmp, task_vars)
-
-        try:
-            del result['invocation']['module_args']['provider']
-        except KeyError:
-            pass
-
         return result
 
     def _get_socket_path(self, play_context):

--- a/lib/ansible/plugins/action/ios.py
+++ b/lib/ansible/plugins/action/ios.py
@@ -88,12 +88,6 @@ class ActionModule(_ActionModule):
             self._play_context.become_method = None
 
         result = super(ActionModule, self).run(tmp, task_vars)
-
-        try:
-            del result['invocation']['module_args']['provider']
-        except KeyError:
-            pass
-
         return result
 
     def _get_socket_path(self, play_context):

--- a/lib/ansible/plugins/action/iosxr.py
+++ b/lib/ansible/plugins/action/iosxr.py
@@ -83,12 +83,6 @@ class ActionModule(_ActionModule):
         task_vars['ansible_socket'] = socket_path
 
         result = super(ActionModule, self).run(tmp, task_vars)
-
-        try:
-            del result['invocation']['module_args']['provider']
-        except KeyError:
-            pass
-
         return result
 
     def _get_socket_path(self, play_context):

--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -103,12 +103,6 @@ class ActionModule(_ActionModule):
         task_vars['ansible_socket'] = socket_path
 
         result = super(ActionModule, self).run(tmp, task_vars)
-
-        try:
-            del result['invocation']['module_args']['provider']
-        except KeyError:
-            pass
-
         return result
 
     def _get_socket_path(self, play_context):

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -120,12 +120,6 @@ class ActionModule(_ActionModule):
         self._task.args['transport'] = transport
 
         result = super(ActionModule, self).run(tmp, task_vars)
-
-        try:
-            del result['invocation']['module_args']['provider']
-        except KeyError:
-            pass
-
         return result
 
     def _get_socket_path(self, play_context):
@@ -160,5 +154,3 @@ class ActionModule(_ActionModule):
             return strategy(*args, **kwargs)
         except AnsibleFallbackNotFound:
             pass
-
-

--- a/lib/ansible/plugins/action/sros.py
+++ b/lib/ansible/plugins/action/sros.py
@@ -79,12 +79,6 @@ class ActionModule(_ActionModule):
         task_vars['ansible_socket'] = socket_path
 
         result = super(ActionModule, self).run(tmp, task_vars)
-
-        try:
-            del result['invocation']['module_args']['provider']
-        except KeyError:
-            pass
-
         return result
 
     def _get_socket_path(self, play_context):

--- a/lib/ansible/plugins/action/vyos.py
+++ b/lib/ansible/plugins/action/vyos.py
@@ -81,12 +81,6 @@ class ActionModule(_ActionModule):
         task_vars['ansible_socket'] = socket_path
 
         result = super(ActionModule, self).run(tmp, task_vars)
-
-        try:
-            del result['invocation']['module_args']['provider']
-        except KeyError:
-            pass
-
         return result
 
     def _get_socket_path(self, play_context):


### PR DESCRIPTION
##### SUMMARY
Fixes #23388 a different way, hopefully with less pain.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [eos_config : configure sub level command] **************************************************************************************
task path: /home/nate/workspace/ansible/ansible/test/integration/targets/eos_config/tests/eapi/sublevel.yaml:10
<veos01> connection transport is eapi
Using module file /home/nate/workspace/ansible/ansible/lib/ansible/modules/network/eos/eos_config.py
<veos01> ESTABLISH LOCAL CONNECTION FOR USER: nate
<veos01> EXEC /bin/sh -c 'echo ~ && sleep 0'
<veos01> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/nate/.ansible/tmp/ansible-tmp-1491605219.54-197731496949173 `" && echo ansible-tmp-1491605219.54-197731496949173="` echo /home/nate/.ansible/tmp/ansible-tmp-1491605219.54-197731496949173 `" ) && sleep 0'
<veos01> PUT /tmp/tmpVzKzku TO /home/nate/.ansible/tmp/ansible-tmp-1491605219.54-197731496949173/eos_config.py
<veos01> EXEC /bin/sh -c 'chmod u+x /home/nate/.ansible/tmp/ansible-tmp-1491605219.54-197731496949173/ /home/nate/.ansible/tmp/ansible-tmp-1491605219.54-197731496949173/eos_config.py && sleep 0'
<veos01> EXEC /bin/sh -c 'python /home/nate/.ansible/tmp/ansible-tmp-1491605219.54-197731496949173/eos_config.py; rm -rf "/home/nate/.ansible/tmp/ansible-tmp-1491605219.54-197731496949173/" > /dev/null 2>&1 && sleep 0'
changed: [veos01] => {
    "changed": true, 
    "commands": [
        "ip access-list test", 
        "10 permit ip any any log", 
        "exit"
    ], 
    "diff": {
        "prepared": "--- system:/running-config\n+++ session:/ansible_1491605220-session-config\n@@ -80,6 +80,9 @@\n    10 permit tcp host 172.30.22.10 eq snmp imap any syn\n    20 permit udp 172.33.214.0/24 range 80 85 0.0.0.0/4 tracked\n !\n+ip access-list test\n+   10 permit ip any any log \n+!\n ip access-list standard ans\n    10 permit 0.0.0.0/4 log \n    20 permit 6.7.8.0/24 log \n\n"
    }, 
    "invocation": {
        "module_args": {
            "after": [
                "exit"
            ], 
            "auth_pass": null, 
            "authorize": true, 
            "backup": false, 
            "before": null, 
            "config": null, 
            "defaults": false, 
            "force": false, 
            "host": "veos01", 
            "lines": [
                "10 permit ip any any log"
            ], 
            "match": "line", 
            "parents": [
                "ip access-list test"
            ], 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 443, 
            "provider": {
                "auth_pass": null, 
                "authorize": true, 
                "host": "veos01", 
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "port": 80, 
                "ssh_keyfile": null, 
                "timeout": 10, 
                "transport": "eapi", 
                "use_ssl": false, 
                "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "validate_certs": true
            }, 
            "replace": "line", 
            "save": false, 
            "src": null, 
            "ssh_keyfile": null, 
            "timeout": 10, 
            "transport": "eapi", 
            "url_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "url_username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "use_ssl": true, 
            "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "validate_certs": true
        }
    }, 
    "session": "ansible_1491605220", 
    "updates": [
        "ip access-list test", 
        "10 permit ip any any log", 
        "exit"
    ]
}
```
