### PR TITLE
dellos10: Fixes regular expression for error string matching.

### DIFF
--- a/lib/ansible/plugins/terminal/dellos10.py
+++ b/lib/ansible/plugins/terminal/dellos10.py
@@ -36,11 +36,13 @@ class TerminalModule(TerminalBase):
     ]
 
     terminal_stderr_re = [
-        re.compile(r"% ?Error: (?:(?!\bdoes not exist\b)(?!\balready exists\b)(?!\bHost not found\b)(?!\bnot active\b).)*$"),
+        re.compile(r"% ?Error"),
         re.compile(r"% ?Bad secret"),
+        re.compile(r"Syntax error:"),
         re.compile(r"invalid input", re.I),
         re.compile(r"(?:incomplete|ambiguous) command", re.I),
         re.compile(r"connection timed out", re.I),
+        re.compile(r"[^\r\n]+ not found", re.I),
         re.compile(r"'[^']' +returned error code: ?\d+"),
     ]
 


### PR DESCRIPTION
##### SUMMARY
Fixes regular expression for error string matching.
##### ISSUE TYPE
 - Bugfix Pull Request
##### COMPONENT NAME
/lib/ansible/plugins/terminal/dellos10.py
##### ANSIBLE VERSION
(ansible) skg@SKG ~/dev/ansible_latest $ ansible --version
ansible 2.4.0 (devel 2fdb8e7f90) last updated 2017/04/07 14:45:09 (GMT -700)

##### ADDITIONAL INFORMATION
As part of the Ansible 2.3 migration, the regular expression from OS9 modules are used for OS10.
Reverting back to OS10 regular expressions.

Please port back to stable2.3