### PR TITLE
Update sleep documentation in service module

### DIFF
--- a/lib/ansible/modules/system/service.py
+++ b/lib/ansible/modules/system/service.py
@@ -56,7 +56,8 @@ options:
         - If the service is being C(restarted) then sleep this many seconds
           between the stop and start command. This helps to workaround badly
           behaving init scripts that exit immediately after signaling a process
-          to stop.
+          to stop. Note that sleep is not supported for operating systems
+          running systemd.
     pattern:
         required: false
         version_added: "0.7"


### PR DESCRIPTION
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### SUMMARY
Add fix for sleep documentation in service module as this
option is not supported by OS running with systemd.

Fixes #22430

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/system/service.py

##### ANSIBLE VERSION
```
2.4 devel
```