### PR TITLE
[WIP] Azure base url addition

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -149,7 +149,8 @@ class AzureRMModuleBase(object):
                                     required_one_of=required_one_of,
                                     add_file_common_args=add_file_common_args,
                                     supports_check_mode=supports_check_mode,
-                                    required_if=merged_required_if)
+                                    required_if=merged_required_if
+                                    )
 
         if not HAS_MSRESTAZURE:
             self.fail("Do you have msrestazure installed? Try `pip install msrestazure`"
@@ -165,6 +166,10 @@ class AzureRMModuleBase(object):
         self._compute_client = None
         self.check_mode = self.module.check_mode
         self.facts_module = facts_module
+        self.resource = self.module.params.get('resource')
+        if self.resource:
+            self.resource.rstrip('\/')
+            self.resource += '/'
         # self.debug = self.module.params.get('debug')
 
         # authenticate
@@ -181,11 +186,20 @@ class AzureRMModuleBase(object):
         if self.credentials.get('client_id') is not None and \
            self.credentials.get('secret') is not None and \
            self.credentials.get('tenant') is not None:
-            self.azure_credentials = ServicePrincipalCredentials(client_id=self.credentials['client_id'],
+            if self.resource:
+                self.azure_credentials = ServicePrincipalCredentials(client_id=self.credentials['client_id'],
                                                                  secret=self.credentials['secret'],
-                                                                 tenant=self.credentials['tenant'])
+                                                                 tenant=self.credentials['tenant'],
+                                                                 resource=self.resource)
+            else:
+                self.azure_credentials = ServicePrincipalCredentials(client_id=self.credentials['client_id'],
+                                                                     secret=self.credentials['secret'],
+                                                                     tenant=self.credentials['tenant'])
         elif self.credentials.get('ad_user') is not None and self.credentials.get('password') is not None:
-            self.azure_credentials = UserPassCredentials(self.credentials['ad_user'], self.credentials['password'])
+            if self.resource:
+                self.azure_credentials = UserPassCredentials(self.credentials['ad_user'], self.credentials['password'], resource=self.resource)
+            else:
+                self.azure_credentials = UserPassCredentials(self.credentials['ad_user'], self.credentials['password'])
         else:
             self.fail("Failed to authenticate with provided credentials. Some attributes were missing. "
                       "Credentials must include client_id, secret and tenant or ad_user and password.")
@@ -591,7 +605,7 @@ class AzureRMModuleBase(object):
         self.log('Getting storage client...')
         if not self._storage_client:
             self.check_client_version('storage', storage_client_version, AZURE_EXPECTED_VERSIONS['storage_client_version'])
-            self._storage_client = StorageManagementClient(self.azure_credentials, self.subscription_id)
+            self._storage_client = StorageManagementClient(self.azure_credentials, self.subscription_id, base_url=self.resource)
             self._register('Microsoft.Storage')
         return self._storage_client
 
@@ -600,7 +614,7 @@ class AzureRMModuleBase(object):
         self.log('Getting network client')
         if not self._network_client:
             self.check_client_version('network', network_client_version, AZURE_EXPECTED_VERSIONS['network_client_version'])
-            self._network_client = NetworkManagementClient(self.azure_credentials, self.subscription_id)
+            self._network_client = NetworkManagementClient(self.azure_credentials, self.subscription_id, base_url=self.resource)
             self._register('Microsoft.Network')
         return self._network_client
 
@@ -609,7 +623,7 @@ class AzureRMModuleBase(object):
         self.log('Getting resource manager client')
         if not self._resource_client:
             self.check_client_version('resource', resource_client_version, AZURE_EXPECTED_VERSIONS['resource_client_version'])
-            self._resource_client = ResourceManagementClient(self.azure_credentials, self.subscription_id)
+            self._resource_client = ResourceManagementClient(self.azure_credentials, self.subscription_id, base_url=self.resource)
         return self._resource_client
 
     @property
@@ -617,6 +631,6 @@ class AzureRMModuleBase(object):
         self.log('Getting compute client')
         if not self._compute_client:
             self.check_client_version('compute', compute_client_version, AZURE_EXPECTED_VERSIONS['compute_client_version'])
-            self._compute_client = ComputeManagementClient(self.azure_credentials, self.subscription_id)
+            self._compute_client = ComputeManagementClient(self.azure_credentials, self.subscription_id, base_url=self.resource)
             self._register('Microsoft.Compute')
         return self._compute_client

--- a/lib/ansible/modules/cloud/azure/azure_rm_deployment.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_deployment.py
@@ -37,6 +37,10 @@ options:
     description:
       - The resource group name to use or create to host the deployed template
     required: true
+  resource:
+    description:
+      - The base URL for the Resource Manager API endpoint (e.g. https://management.azure.com)
+    required: false
   location:
     description:
       - The geo-locations in which the resource group will be located.

--- a/lib/ansible/modules/cloud/azure/azure_rm_deployment.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_deployment.py
@@ -408,6 +408,7 @@ class AzureRMDeploymentManager(AzureRMModuleBase):
 
         self.module_arg_spec = dict(
             resource_group_name=dict(type='str', required=True, aliases=['resource_group']),
+            resource=dict(type='str', default=None),
             state=dict(type='str', default='present', choices=['present', 'absent']),
             template=dict(type='dict', default=None),
             parameters=dict(type='dict', default=None),

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -43,6 +43,10 @@ options:
         description:
             - Name of a resource group where the network interface exists or will be created.
         required: true
+    resource:
+        description:
+            - The base URL for the Resource Manager API endpoint (e.g. https://management.azure.com)
+        required: false
     name:
         description:
             - Name of the network interface.

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -307,6 +307,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
             os_type=dict(type='str', choices=['Windows', 'Linux'], default='Linux'),
             open_ports=dict(type='list'),
             public_ip_allocation_method=dict(type='str', choices=['Dynamic', 'Static'], default='Dynamic'),
+            resource=dict(type='str', default=None)
         )
 
         self.resource_group = None

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface_facts.py
@@ -46,6 +46,10 @@ options:
             - Name of the resource group containing the network interface(s). Required when searching by name.
         required: false
         default: null
+    resource:
+        description:
+            - The base URL for the Resource Manager API endpoint (e.g. https://management.azure.com)
+        required: false
     tags:
         description:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface_facts.py
@@ -143,6 +143,7 @@ class AzureRMNetworkInterfaceFacts(AzureRMModuleBase):
         self.module_arg_spec = dict(
             name=dict(type='str'),
             resource_group=dict(type='str'),
+            resource=dict(type='str', default=None),
             tags=dict(type='list')
         )
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_publicipaddress.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_publicipaddress.py
@@ -162,6 +162,7 @@ class AzureRMPublicIPAddress(AzureRMModuleBase):
             location=dict(type='str'),
             allocation_method=dict(type='str', default='Dynamic', choices=['Dynamic', 'Static']),
             domain_name=dict(type='str', aliases=['domain_name_label']),
+            resource=dict(type='str', default=None)
         )
 
         self.resource_group = None

--- a/lib/ansible/modules/cloud/azure/azure_rm_publicipaddress.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_publicipaddress.py
@@ -41,6 +41,10 @@ options:
         description:
             - Name of resource group with which the Public IP is associated.
         required: true
+    resource:
+        description:
+            - The base URL for the Resource Manager API endpoint (e.g. https://management.azure.com)
+        required: false
     allocation_method:
         description:
             - Control whether the assigned Public IP remains permanently assigned to the object. If not

--- a/lib/ansible/modules/cloud/azure/azure_rm_publicipaddress_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_publicipaddress_facts.py
@@ -113,6 +113,7 @@ class AzureRMPublicIPFacts(AzureRMModuleBase):
         self.module_arg_spec = dict(
             name=dict(type='str'),
             resource_group=dict(type='str'),
+            resource=dict(type='str', default=None),
             tags=dict(type='list')
         )
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_publicipaddress_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_publicipaddress_facts.py
@@ -47,6 +47,10 @@ options:
             - Limit results by resource group. Required when using name parameter.
         required: false
         default: null
+    resource:
+        description:
+            - The base URL for the Resource Manager API endpoint (e.g. https://management.azure.com)
+        required: false
     tags:
         description:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.

--- a/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup.py
@@ -32,6 +32,10 @@ short_description: Manage Azure resource groups.
 description:
     - Create, update and delete a resource group.
 options:
+    resource:
+        description:
+            - The base URL for the Resource Manager API endpoint (e.g. https://management.azure.com)
+        required: false
     force:
         description:
             - Remove a resource group and all associated resources. Use with state 'absent' to delete a resource

--- a/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup.py
@@ -131,7 +131,8 @@ class AzureRMResourceGroup(AzureRMModuleBase):
             name=dict(type='str', required=True),
             state=dict(type='str', default='present', choices=['present', 'absent']),
             location=dict(type='str'),
-            force=dict(type='bool', default=False)
+            force=dict(type='bool', default=False),
+            resource=dict(type='str', default=None)
         )
 
         self.name = None

--- a/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup_facts.py
@@ -109,6 +109,7 @@ class AzureRMResourceGroupFacts(AzureRMModuleBase):
 
         self.module_arg_spec = dict(
             name=dict(type='str'),
+            resource=dict(type='str', default=None),
             tags=dict(type='list')
         )
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup_facts.py
@@ -41,6 +41,10 @@ options:
             - Limit results to a specific resource group.
         required: false
         default: null
+    resource:
+        description:
+            - The base URL for the Resource Manager API endpoint (e.g. https://management.azure.com)
+        required: false
     tags:
         description:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.

--- a/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
@@ -67,6 +67,10 @@ options:
         description:
             - Name of the resource group the security group belongs to.
         required: true
+    resource:
+        description:
+            - The base URL for the Resource Manager API endpoint (e.g. https://management.azure.com)
+        required: false
     rules:
         description:
             - Set of rules shaping traffic flow to or from a subnet or NIC. Each rule is a dictionary.

--- a/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
@@ -524,8 +524,9 @@ class AzureRMSecurityGroup(AzureRMModuleBase):
             purge_default_rules=dict(type='bool', default=False),
             purge_rules=dict(type='bool', default=False),
             resource_group=dict(required=True, type='str'),
+            resource=dict(type='str', default=None),
             rules=dict(type='list'),
-            state=dict(type='str', default='present', choices=['present', 'absent']),
+            state=dict(type='str', default='present', choices=['present', 'absent'])
         )
 
         self.default_rules = None

--- a/lib/ansible/modules/cloud/azure/azure_rm_securitygroup_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_securitygroup_facts.py
@@ -224,6 +224,7 @@ class AzureRMSecurityGroupFacts(AzureRMModuleBase):
         self.module_arg_spec = dict(
             name=dict(type='str'),
             resource_group=dict(required=True, type='str'),
+            resource=dict(type='str', default=None),
             tags=dict(type='list'),
         )
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_securitygroup_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_securitygroup_facts.py
@@ -45,6 +45,10 @@ options:
         description:
             - Name of the resource group to use.
         required: true
+    resource:
+        description:
+            - The base URL for the Resource Manager API endpoint (e.g. https://management.azure.com)
+        required: false
     tags:
         description:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.

--- a/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
@@ -179,7 +179,9 @@ class AzureRMStorageAccount(AzureRMModuleBase):
             state=dict(default='present', choices=['present', 'absent']),
             force=dict(type='bool', default=False),
             tags=dict(type='dict'),
-            kind=dict(type='str', default='Storage', choices=['Storage', 'BlobStorage'])
+            kind=dict(type='str', default='Storage', choices=['Storage', 'BlobStorage']),
+            storage_endpoint_suffix=dict(type='str', default=None),
+            resource=dict(type='str', default=None)
         )
 
         for key in SkuName:

--- a/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
@@ -37,6 +37,10 @@ options:
         description:
             - Name of the resource group to use.
         required: true
+    resource:
+        description:
+            - The base URL for the Resource Manager API endpoint (e.g. https://management.azure.com)
+        required: false
     name:
         description:
             - Name of the storage account to update or create.

--- a/lib/ansible/modules/cloud/azure/azure_rm_storageaccount_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageaccount_facts.py
@@ -46,6 +46,10 @@ options:
             - Limit results to a resource group. Required when filtering by name.
         required: false
         default: null
+    resource:
+        description:
+            - The base URL for the Resource Manager API endpoint (e.g. https://management.azure.com)
+        required: false
     tags:
         description:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.

--- a/lib/ansible/modules/cloud/azure/azure_rm_storageaccount_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageaccount_facts.py
@@ -125,6 +125,8 @@ class AzureRMStorageAccountFacts(AzureRMModuleBase):
         self.module_arg_spec = dict(
             name=dict(type='str'),
             resource_group=dict(type='str'),
+            resource=dict(type='str', default=None),
+            storage_endpoint_suffix=dict(type='str', default=None),
             tags=dict(type='list'),
         )
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_storageblob.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageblob.py
@@ -221,11 +221,13 @@ class AzureRMStorageBlob(AzureRMModuleBase):
 
         self.module_arg_spec = dict(
             storage_account_name=dict(required=True, type='str', aliases=['account_name']),
+            storage_endpoint_suffix=dict(type='str', default=None),
             blob=dict(type='str', aliases=['blob_name']),
             container=dict(required=True, type='str', aliases=['container_name']),
             dest=dict(type='str'),
             force=dict(type='bool', default=False),
             resource_group=dict(required=True, type='str'),
+            resource=dict(type='str', default=None),
             src=dict(type='str'),
             state=dict(type='str', default='present', choices=['absent', 'present']),
             public_access=dict(type='str', choices=['container', 'blob']),
@@ -234,7 +236,7 @@ class AzureRMStorageBlob(AzureRMModuleBase):
             content_language=dict(type='str'),
             content_disposition=dict(type='str'),
             cache_control=dict(type='str'),
-            content_md5=dict(type='str'),
+            content_md5=dict(type='str')
         )
 
         mutually_exclusive = [('src', 'dest')]

--- a/lib/ansible/modules/cloud/azure/azure_rm_storageblob.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageblob.py
@@ -39,6 +39,10 @@ options:
         required: true
         aliases:
             - account_name
+    storage_endpoint_suffix:
+        description:
+            - The endpoint suffix for storage endpoing API (e.g. core.windows.net)
+        required: false
     blob:
         description:
             - Name of a blob object within the container.
@@ -99,6 +103,10 @@ options:
         description:
             - Name of the resource group to use.
         required: true
+    resource:
+        description:
+            - The base URL for the Resource Manager API endpoint (e.g. https://management.azure.com)
+        required: false
     src:
         description:
             - Source file path. Use with state 'present' to upload a blob.

--- a/lib/ansible/modules/cloud/azure/azure_rm_subnet.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_subnet.py
@@ -38,6 +38,10 @@ options:
         description:
             - Name of resource group.
         required: true
+    resource:
+        description:
+            - The base URL for the Resource Manager API endpoint (e.g. https://management.azure.com)
+        required: false
     name:
         description:
             - Name of the subnet.

--- a/lib/ansible/modules/cloud/azure/azure_rm_subnet.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_subnet.py
@@ -166,11 +166,12 @@ class AzureRMSubnet(AzureRMModuleBase):
 
         self.module_arg_spec = dict(
             resource_group=dict(type='str', required=True),
+            resource=dict(type='str', default=None),
             name=dict(type='str', required=True),
             state=dict(type='str', default='present', choices=['present', 'absent']),
             virtual_network_name=dict(type='str', required=True, aliases=['virtual_network']),
             address_prefix_cidr=dict(type='str', aliases=['address_prefix']),
-            security_group_name=dict(type='str', aliases=['security_group']),
+            security_group_name=dict(type='str', aliases=['security_group'])
         )
 
         required_if = [

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -19,6 +19,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'curated'}
@@ -458,6 +459,7 @@ try:
     from azure.mgmt.storage.models import StorageAccountCreateParameters, Sku
     from azure.mgmt.storage.models.storage_management_client_enums import Kind, SkuTier, SkuName
     from azure.mgmt.compute.models.compute_management_client_enums import VirtualMachineSizeTypes, DiskCreateOptionTypes
+    from azure.storage._constants import SERVICE_HOST_BASE
 except ImportError:
     # This is handled in azure_rm_common
     pass
@@ -483,6 +485,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
 
         self.module_arg_spec = dict(
             resource_group=dict(type='str', required=True),
+            resource=dict(type='str', default=None),
             name=dict(type='str', required=True),
             state=dict(choices=['present', 'absent'], default='present', type='str'),
             location=dict(type='str'),
@@ -494,6 +497,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
             ssh_public_keys=dict(type='list'),
             image=dict(type='dict'),
             storage_account_name=dict(type='str', aliases=['storage_account']),
+            storage_endpoint_suffix=dict(type='str', default=None),
             storage_container_name=dict(type='str', aliases=['storage_container'], default='vhds'),
             storage_blob_name=dict(type='str', aliases=['storage_blob']),
             os_disk_caching=dict(type='str', aliases=['disk_caching'], choices=['ReadOnly', 'ReadWrite'],
@@ -508,7 +512,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
             subnet_name=dict(type='str', aliases=['subnet']),
             allocated=dict(type='bool', default=True),
             restarted=dict(type='bool', default=False),
-            started=dict(type='bool', default=True),
+            started=dict(type='bool', default=True)
         )
 
         for key in VirtualMachineSizeTypes:
@@ -528,6 +532,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
         self.storage_account_name = None
         self.storage_container_name = None
         self.storage_blob_name = None
+        self.storage_endpoint_suffix = SERVICE_HOST_BASE
         self.os_type = None
         self.os_disk_caching = None
         self.network_interface_names = None
@@ -612,7 +617,8 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
             if self.storage_account_name:
                 self.get_storage_account(self.storage_account_name)
 
-                requested_vhd_uri = 'https://{0}.blob.core.windows.net/{1}/{2}'.format(self.storage_account_name,
+                requested_vhd_uri = 'https://{0}.blob.{1}/{2}/{3}'.format(self.storage_account_name,
+                                                                                       self.storage_endpoint_suffix,
                                                                                        self.storage_container_name,
                                                                                        self.storage_blob_name)
 
@@ -727,8 +733,9 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                         storage_account = self.create_default_storage_account()
                         self.log("storage account:")
                         self.log(self.serialize_obj(storage_account, 'StorageAccount'), pretty_print=True)
-                        requested_vhd_uri = 'https://{0}.blob.core.windows.net/{1}/{2}'.format(
+                        requested_vhd_uri = 'https://{0}.blob.{1}/{2}/{3}'.format(
                             storage_account.name,
+                            self.storage_endpoint_suffix,
                             self.storage_container_name,
                             self.storage_blob_name)
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -45,6 +45,10 @@ options:
         description:
             - Name of the resource group containing the virtual machine.
         required: true
+    resource:
+        description:
+            - The base URL for the Resource Manager API endpoint (e.g. https://management.azure.com)
+        required: false
     name:
         description:
             - Name of the virtual machine.
@@ -129,6 +133,10 @@ options:
             - Name of an existing storage account that supports creation of VHD blobs. If not specified for a new VM,
               a new storage account named <vm name>01 will be created using storage type 'Standard_LRS'.
         default: null
+        required: false
+    storage_endpoint_suffix:
+        description:
+            - The endpoint suffix for storage endpoing API (e.g. core.windows.net)
         required: false
     storage_container_name:
         description:

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachineimage_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachineimage_facts.py
@@ -42,6 +42,10 @@ options:
             - Only show results for a specific security group.
         default: null
         required: false
+    resource:
+        description:
+            - The base URL for the Resource Manager API endpoint (e.g. https://management.azure.com)
+        required: false
     location:
         description:
             - Azure location value (ie. westus, eastus, eastus2, northcentralus, etc.). Supplying only a

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachineimage_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachineimage_facts.py
@@ -133,7 +133,8 @@ class AzureRMVirtualMachineImageFacts(AzureRMModuleBase):
             publisher=dict(type='str'),
             offer=dict(type='str'),
             sku=dict(type='str'),
-            version=dict(type='str')
+            version=dict(type='str'),
+            resource=dict(type='str', default=None)
         )
 
         self.results = dict(

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualnetwork.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualnetwork.py
@@ -183,13 +183,14 @@ class AzureRMVirtualNetwork(AzureRMModuleBase):
 
         self.module_arg_spec = dict(
             resource_group=dict(type='str', required=True),
+            resource=dict(type='str', default=None),
             name=dict(type='str', required=True),
             state=dict(type='str', default='present', choices=['present', 'absent']),
             location=dict(type='str'),
             address_prefixes_cidr=dict(type='list', aliases=['address_prefixes']),
             dns_servers=dict(type='list',),
             purge_address_prefixes=dict(type='bool', default=False, aliases=['purge']),
-            purge_dns_servers=dict(type='bool', default=False),
+            purge_dns_servers=dict(type='bool', default=False)
         )
 
         mutually_exclusive = [

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualnetwork.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualnetwork.py
@@ -38,6 +38,10 @@ options:
         description:
             - name of resource group.
         required: true
+    resource:
+        description:
+            - The base URL for the Resource Manager API endpoint (e.g. https://management.azure.com)
+        required: false
     address_prefixes_cidr:
         description:
             - List of IPv4 address ranges where each is formatted using CIDR notation. Required when creating

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualnetwork_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualnetwork_facts.py
@@ -46,6 +46,10 @@ options:
             - Limit results by resource group. Required when filtering by name.
         default: null
         required: false
+    resource:
+        description:
+            - The base URL for the Resource Manager API endpoint (e.g. https://management.azure.com)
+        required: false
     tags:
         description:
             - Limit results by providing a list of tags. Format tags as 'key' or 'key:value'.

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualnetwork_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualnetwork_facts.py
@@ -121,7 +121,8 @@ class AzureRMNetworkInterfaceFacts(AzureRMModuleBase):
         self.module_arg_spec = dict(
             name=dict(type='str'),
             resource_group=dict(type='str'),
-            tags=dict(type='list'),
+            resource=dict(type='str', default=None),
+            tags=dict(type='list')
         )
 
         self.results = dict(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added plumbing to pass in both the resource manager URL and the storage endpoint suffix for the Azure Cloud module and the inventory script. This is to support non-commercial regions like Azure Government, DoD, etc. where the API endpoints are different. This is a WIP because I am still waiting from feedback from Microsoft on a few places where it does not seem possible to pass the endpoints into their API.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Azure Cloud Module
Azure inventory script

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel a075c56dbf) last updated 2017/04/08 09:35:15 (GMT -400)
  config file = /Users/scarter/.ansible.cfg
  configured module search path = [u'/Users/scarter/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/scarter/projects/ansible/lib/ansible
  executable location = ../../ansible/bin/ansible
  python version = 2.7.13 (default, Mar 21 2017, 17:11:11) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
