### PR TITLE
pacman: Fix package matching pattern in upgraded package list

### DIFF
--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -209,7 +209,7 @@ def upgrade(module, pacman_path):
     }
 
     if rc == 0:
-        regex = re.compile('(\w+) ((?:\S+)-(?:\S+)) -> ((?:\S+)-(?:\S+))')
+        regex = re.compile('([\w-]+) ((?:\S+)-(?:\S+)) -> ((?:\S+)-(?:\S+))')
         b = []
         a = []
         for p in data:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Small adjustment in regex pattern to to handle packages with `-` in their names.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

pacman

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0 (pacman-result-fix 5f61a7550a) last updated 2017/04/08 15:32:16 (GMT -500)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Feb 13 2017, 23:32:07) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

As part of #20713, we now have a way of listing the packages that were upgraded as part of `pacman` upgrade action. However, the regex extracting the package names from raw `pacman` output needs to be adjusted to honor packages with `-` in their names (e.g., `aws-cli`, `device-mapper` etc.)

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before:
```
task path: ~/roles/packaging/tasks/packaging-archlinux.yml:22
changed: [archlinux-test] => {"changed": true, "msg": "System upgraded", "packages": ["cli", "mapper", "database", "botocore"]
```

After:
```
task path: ~/roles/packaging/tasks/packaging-archlinux.yml:22
changed: [archlinux-test] => {"changed": true, "msg": "System upgraded", "packages": ["aws-cli", "device-mapper", "geoip-database", "python-botocore"]
```
