### PR TITLE
Fix ansible-test empty diff handling on Shippable.

### DIFF
--- a/test/runner/lib/changes.py
+++ b/test/runner/lib/changes.py
@@ -80,7 +80,7 @@ class ShippableChanges(object):
             else:
                 # tracked files (including unchanged)
                 self.paths = sorted(git.get_file_names(['--cached']))
-                self.diff = None
+                self.diff = []
 
     def get_merge_runs(self, project_id, branch):
         """


### PR DESCRIPTION
##### SUMMARY

This prevents an exception from being raised when trying to run tests on Shippable for a new branch.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.4.0 (at-diff-fix c56b845d87) last updated 2017/04/08 21:46:18 (GMT -700)
  config file = 
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
