### PR TITLE
Set IO encoding for ansible-test on Shippable.

### DIFF
--- a/test/utils/shippable/shippable.sh
+++ b/test/utils/shippable/shippable.sh
@@ -22,6 +22,7 @@ pip --version
 pip list --disable-pip-version-check
 
 export PATH="test/runner:${PATH}"
+export PYTHONIOENCODING='utf-8'
 
 # remove empty core/extras module directories from PRs created prior to the repo-merge
 find lib/ansible/modules -type d -empty -print -delete


### PR DESCRIPTION
##### SUMMARY

In ansible-test on python 2, writing unicode to the console works when the encoding is utf-8. Doing the same through a pipe will attempt to encode using ascii instead. Setting PYTHONIOENCODING to utf-8 resolves the issue.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Shippable

##### ANSIBLE VERSION

```
ansible 2.4.0 (at-unicode-fix 1f69fa2436) last updated 2017/04/08 22:34:57 (GMT -700)
  config file = 
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
