### PR TITLE
Changes in the django_admin module

### DIFF
--- a/lib/ansible/modules/web_infrastructure/django_manage.py
+++ b/lib/ansible/modules/web_infrastructure/django_manage.py
@@ -224,7 +224,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             command=dict(default=None, required=True),
-            app_path=dict(default=None, required=True, type='path'),
+            app_path=dict(default=None, required=False, type='path'),
             settings=dict(default=None, required=False),
             pythonpath=dict(default=None, required=False, aliases=['python_path']),
             virtualenv=dict(default=None, required=False, type='path', aliases=['virtual_env']),
@@ -260,7 +260,10 @@ def main():
 
     _ensure_virtualenv(module)
 
-    cmd = "./manage.py %s" % (command, )
+    if app_path is not None:
+        cmd = "./manage.py %s" % (command, )
+    else:
+        cmd = "django-admin %s" % (command, )
 
     if command in noinput_commands:
         cmd = '%s --noinput' % cmd


### PR DESCRIPTION
##### SUMMARY
- Made app_path parameter optional
- In case app_path is not set use django-admin instead of manage.py

I propose those changes so that the module can be executed against a Django project deployed without the manage.py script.

The manage.py script is not mandatory and just sets the DJANGO_SETTINGS_MODULE environment variable. It is possible to deploy a Django project without manage.py and use django-admin to launch a Django command provided that you set the DJANGO_SETTINGS_MODULE variable manually or using the --settings option.
  
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
django_manage
##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = /home/marco/.ansible.cfg
  configured module search path = [u'/home/marco/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Dec  1 2017, 09:21:53) [GCC 6.4.1 20170727 (Red Hat 6.4.1-1)]

```
