### PR TITLE
Add `state` parameter to Alternatives module

### DIFF
--- a/lib/ansible/modules/system/alternatives.py
+++ b/lib/ansible/modules/system/alternatives.py
@@ -178,6 +178,8 @@ def set_alternative(module, cmd, name, path, link, priority,
 def remove_alternative(module, cmd, name, path, all_alternatives):
     """Remove the requested path if necessary"""
     if path in all_alternatives:
+        if module.check_mode:
+            module.exit_json(changed=True)
         try:
             module.run_command([cmd, '--remove', name, path], check_rc=True)
             module.exit_json(changed=True)

--- a/lib/ansible/modules/system/alternatives.py
+++ b/lib/ansible/modules/system/alternatives.py
@@ -146,7 +146,7 @@ def set_alternative(module, cmd, name, path, link, priority,
 
             module.exit_json(changed=True)
         except subprocess.CalledProcessError:
-            e = get_exception()
+            cpe = get_exception()
             module.fail_json(msg=str(dir(cpe)))
     else:
         module.exit_json(changed=False)

--- a/lib/ansible/modules/system/alternatives.py
+++ b/lib/ansible/modules/system/alternatives.py
@@ -81,7 +81,7 @@ EXAMPLES = '''
 '''
 
 import re
-from ansible.module_utils.basic import *
+from ansible.module_utils.basic import AnsibleModule, subprocess
 from ansible.module_utils.pycompat24 import get_exception
 
 def get_current(module, cmd, name, link):

--- a/lib/ansible/modules/system/alternatives.py
+++ b/lib/ansible/modules/system/alternatives.py
@@ -141,7 +141,8 @@ def set_alternative(module, cmd, name, path, link, priority,
             # install the requested path if necessary
             if path not in all_alternatives:
                 if not link:
-                    module.fail_json(msg="Needed to install the alternative, but unable to do so as we are missing the link")
+                    module.fail_json(msg="Needed to install the alternative, "
+                        "but unable to do so as we are missing the link")
 
                 module.run_command(
                     [cmd, '--install', link, name, path, str(priority)],

--- a/lib/ansible/modules/system/alternatives.py
+++ b/lib/ansible/modules/system/alternatives.py
@@ -180,7 +180,7 @@ def main():
     link = params['link']
     priority = params['priority']
 
-    UPDATE_ALTERNATIVES = module.get_bin_path('update-alternatives',True)
+    UPDATE_ALTERNATIVES = module.get_bin_path('update-alternatives', True)
     (current_path, all_alternatives, link) = get_current(
         module, UPDATE_ALTERNATIVES, name, link)
 

--- a/lib/ansible/modules/system/alternatives.py
+++ b/lib/ansible/modules/system/alternatives.py
@@ -85,7 +85,12 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.pycompat24 import get_exception
 
 def get_current(module, cmd, name, link):
+    """Get the options and the currently set value for the named alternative.
 
+    If `link` is not specified, this value will be retrieved from the
+    alternatives database.
+
+    Returns a tuple of currently set value, possible options, and link path."""
     current_path = None
     all_alternatives = []
 
@@ -124,6 +129,11 @@ def get_current(module, cmd, name, link):
 
 def set_alternative(module, cmd, name, path, link, priority,
         current_path, all_alternatives):
+    """Set the current named alternative to the specified path.
+
+    If not present in the currently configured alternatives, the requested
+    alternative will be added with the specified priority.  The `link`
+    parameter must be provided in this instance."""
     if current_path != path:
         if module.check_mode:
             module.exit_json(changed=True, current_path=current_path)
@@ -152,7 +162,7 @@ def set_alternative(module, cmd, name, path, link, priority,
         module.exit_json(changed=False)
 
 def main():
-
+    """Main module entrypoint"""
     module = AnsibleModule(
         argument_spec = dict(
             name = dict(required=True),

--- a/lib/ansible/modules/system/alternatives.py
+++ b/lib/ansible/modules/system/alternatives.py
@@ -58,6 +58,13 @@ options:
     required: false
     default: 50
     version_added: "2.2"
+  state:
+    description:
+      - The state of the identified alternative.
+    required: false
+    default: present
+    choices: [ present, absent ]
+    version_added: "2.4"
 requirements: [ update-alternatives ]
 '''
 
@@ -78,6 +85,12 @@ EXAMPLES = '''
     name: java
     path: /usr/lib/jvm/java-7-openjdk-i386/jre/bin/java
     priority: -10
+
+- name: remove a java version from the alternatives
+  alternatives:
+    name: java
+    path: /usr/lib/jvm/java-7-openjdk-amd64/jre/bin/java
+    state: absent
 '''
 
 import re
@@ -162,6 +175,18 @@ def set_alternative(module, cmd, name, path, link, priority,
     else:
         module.exit_json(changed=False)
 
+def remove_alternative(module, cmd, name, path, all_alternatives):
+    """Remove the requested path if necessary"""
+    if path in all_alternatives:
+        try:
+            module.run_command([cmd, '--remove', name, path], check_rc=True)
+            module.exit_json(changed=True)
+        except subprocess.CalledProcessError:
+            cpe = get_exception()
+            module.fail_json(msg=str(dir(cpe)))
+    else:
+        module.exit_json(changed=False)
+
 def main():
     """Main module entrypoint"""
     module = AnsibleModule(
@@ -171,6 +196,7 @@ def main():
             link = dict(required=False, type='path'),
             priority = dict(required=False, type='int',
                             default=50),
+            state = dict(choices=['present', 'absent'], default='present'),
         ),
         supports_check_mode=True,
     )
@@ -180,13 +206,17 @@ def main():
     path = params['path']
     link = params['link']
     priority = params['priority']
+    state = params['state']
 
     UPDATE_ALTERNATIVES = module.get_bin_path('update-alternatives', True)
     (current_path, all_alternatives, link) = get_current(
         module, UPDATE_ALTERNATIVES, name, link)
 
-    set_alternative(module, UPDATE_ALTERNATIVES, name, path, link, priority,
-                    current_path, all_alternatives)
+    if state == 'present':
+        set_alternative(module, UPDATE_ALTERNATIVES, name, path, link, priority,
+                        current_path, all_alternatives)
+    elif state == 'absent':
+        remove_alternative(module, UPDATE_ALTERNATIVES, name, path, all_alternatives)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### SUMMARY
Added a `state` parameter to the alternatives module to allow the removal of an alternatives symlink by passing `state=absent`.

In the process of adding this parameter, I have extracted functions where applicable and performed minor tidy-ups to the module per recommendations from pylint.

This tidy-up will enable further improvements I hope to make to this module including the addition of support for dependent alternatives symlinks.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
alternatives

##### ANSIBLE VERSION
```
ansible) [leynos@gradius src]$ ansible --version
ansible 2.4.0
  config file = 
  configured module search path = [u'/home/leynos/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/leynos/Projects/ansible/src/lib/ansible
  executable location = /home/leynos/Projects/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 13 2017, 10:15:16) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION

In the example below, we will create an alternative `list-files` set to `/usr/bin/ls`, and then remove it.

```
# ./hacking/test-module -m lib/ansible/modules/system/alternatives.py -a "name=list-files path=/usr/bin/ls link=/usr/bin/list-files"
* including generated source, if any, saving to: /root/.ansible_module_generated
* ansiballz module detected; extracted module source to: /root/debug_dir
***********************************
RAW OUTPUT

{"invocation": {"module_args": {"priority": 50, "path": "/usr/bin/ls", "state": "present", "link": "/usr/bin/list-files", "name": "list-files"}}, "changed": true}


***********************************
PARSED OUTPUT
{
    "changed": true, 
    "invocation": {
        "module_args": {
            "link": "/usr/bin/list-files", 
            "name": "list-files", 
            "path": "/usr/bin/ls", 
            "priority": 50, 
            "state": "present"
        }
    }
}
# list-files 
CHANGELOG.md	      ROADMAP.rst		lib
CODING_GUIDELINES.md  VERSION			packaging
CONTRIBUTING.md       ansible-core-sitemap.xml	requirements.txt
COPYING		      bin			setup.py
MANIFEST.in	      contrib			shippable.yml
MODULE_GUIDELINES.md  docs			test
Makefile	      docsite_requirements.txt	ticket_stubs
README.md	      examples			tox.ini
RELEASES.txt	      hacking
# ./hacking/test-module -m lib/ansible/modules/system/alternatives.py -a "name=list-files path=/usr/bin/ls state=absent"
* including generated source, if any, saving to: /root/.ansible_module_generated
* ansiballz module detected; extracted module source to: /root/debug_dir
***********************************
RAW OUTPUT

{"invocation": {"module_args": {"priority": 50, "path": "/usr/bin/ls", "state": "absent", "link": null, "name": "list-files"}}, "changed": true}


***********************************
PARSED OUTPUT
{
    "changed": true, 
    "invocation": {
        "module_args": {
            "link": null, 
            "name": "list-files", 
            "path": "/usr/bin/ls", 
            "priority": 50, 
            "state": "absent"
        }
    }
}
# list-files
bash: /usr/bin/list-files: No such file or directory
```
