### PR TITLE
Fix #23338 - rabbitmq_queue message ttl can't be 0

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq_queue.py
+++ b/lib/ansible/modules/messaging/rabbitmq_queue.py
@@ -224,7 +224,7 @@ def main():
         'dead_letter_exchange': 'x-dead-letter-exchange',
         'dead_letter_routing_key': 'x-dead-letter-routing-key'
     }.items():
-        if module.params[k]:
+        if module.params[k] is not None:
             module.params['arguments'][v] = module.params[k]
 
     # Exit if check_mode


### PR DESCRIPTION
##### SUMMARY
Fixes #23338 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
rabbitmq_queue