### PR TITLE
When apt errors, include it's exit code

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -526,7 +526,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
         else:
             diff = {}
         if rc:
-            return (False, dict(msg="'%s' failed: %s" % (cmd, err), stdout=out, stderr=err))
+            return (False, dict(msg="'%s' failed: %s" % (cmd, err), stdout=out, stderr=err, rc=rc))
         else:
             return (True, dict(changed=True, stdout=out, stderr=err, diff=diff))
     else:
@@ -659,7 +659,7 @@ def remove(m, pkgspec, cache, purge=False, force=False,
         else:
             diff = {}
         if rc:
-            m.fail_json(msg="'apt-get remove %s' failed: %s" % (packages, err), stdout=out, stderr=err)
+            m.fail_json(msg="'apt-get remove %s' failed: %s" % (packages, err), stdout=out, stderr=err, rc=rc)
         m.exit_json(changed=True, stdout=out, stderr=err, diff=diff)
 
 
@@ -708,7 +708,7 @@ def upgrade(m, mode="yes", force=False, default_release=None,
     else:
         diff = {}
     if rc:
-        m.fail_json(msg="'%s %s' failed: %s" % (apt_cmd, upgrade_command, err), stdout=out)
+        m.fail_json(msg="'%s %s' failed: %s" % (apt_cmd, upgrade_command, err), stdout=out, rc=rc)
     if (apt_cmd == APT_GET_CMD and APT_GET_ZERO in out) or (apt_cmd == APTITUDE_CMD and APTITUDE_ZERO in out):
         m.exit_json(changed=False, msg=out, stdout=out, stderr=err)
     m.exit_json(changed=True, msg=out, stdout=out, stderr=err, diff=diff)
@@ -785,7 +785,7 @@ def get_cache(module):
                 if rc == 0:
                     break
             if rc != 0:
-                module.fail_json(msg='Updating the cache to correct corrupt package lists failed:\n%s\n%s' % (str(e), str(so) + str(se)))
+                module.fail_json(msg='Updating the cache to correct corrupt package lists failed:\n%s\n%s' % (str(e), str(so) + str(se)), rc=rc)
             # try again
             cache = apt.Cache()
         else:


### PR DESCRIPTION
We invoke /usr/bin/apt inside of the ansible module.  When that command
exits, it doesn't always include a helpful error message.  Include the
exit code so that user's have all the information we can gice them as to
why apt failed.

Addresses #19128

 - Bugfix Pull Request

##### COMPONENT NAME
apt

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.3
```


##### ADDITIONAL INFORMATION
the exit code might not add much help for the user attempting to debug (because it looks like apt always returns exit code 0 for success and 100 for failure) but at least the user will know that it was /usr/bin/apt returning 100 rather than some problem inside of our code.