### PR TITLE
add the ability to wait between ec2_asg batch replaces

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -80,6 +80,12 @@ options:
     required: false
     version_added: "1.8"
     default: 1
+  replace_batch_wait:
+    description:
+      - Number of seconds to wait between each batch. Used with replace_all_instances.
+    required: false
+    version_added: "2.3"
+    default: 0
   replace_instances:
     description:
       - List of instance_ids belonging to the named ASG that you would like to terminate and be replaced with instances matching the current launch
@@ -644,6 +650,7 @@ def update_size(group, max_size, min_size, dc):
 
 def replace(connection, module):
     batch_size = module.params.get('replace_batch_size')
+    batch_wait_time = module.params.get('replace_batch_wait')
     wait_timeout = module.params.get('wait_timeout')
     group_name = module.params.get('name')
     max_size =  module.params.get('max_size')
@@ -704,6 +711,8 @@ def replace(connection, module):
     log.debug("beginning main loop")
     for i in get_chunks(instances, batch_size):
         # break out of this loop if we have enough new instances
+        if i[0] != instances[0]:
+            time.sleep(batch_wait_time)
         break_early, desired_size, term_instances = terminate_batch(connection, module, i, instances, False)
         wait_for_term_inst(connection, module, term_instances)
         wait_for_new_inst(module, connection, group_name, wait_timeout, desired_size, 'viable_instances')
@@ -883,6 +892,7 @@ def main():
             desired_capacity=dict(type='int'),
             vpc_zone_identifier=dict(type='list'),
             replace_batch_size=dict(type='int', default=1),
+            replace_batch_wait=dict(type='int', default=0),
             replace_all_instances=dict(type='bool', default=False),
             replace_instances=dict(type='list', default=[]),
             lc_check=dict(type='bool', default=True),

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -84,7 +84,7 @@ options:
     description:
       - Number of seconds to wait between each batch. Used with replace_all_instances.
     required: false
-    version_added: "2.3"
+    version_added: "2.4"
     default: 0
   replace_instances:
     description:


### PR DESCRIPTION
##### SUMMARY
See https://github.com/ansible/ansible-modules-core/pull/1006

This allows for a wait time in between replacing batches of EC2 instances in an ASG. This is useful in the scenario where a new instance added to an ASG does not reach full capacity quickly, as it may have to warm up its internal cache.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ec2_asg

##### ANSIBLE VERSION
```
> ansible --version
ansible 2.2.0.0
  config file = 
  configured module search path = Default w/o overrides
```


##### ADDITIONAL INFORMATION
none