### PR TITLE
[ON HOLD for general fix] Handle boto.provider.ProfileNotFoundError when doing ec2_connect

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -255,7 +255,10 @@ def boto_fix_security_token_in_profile(conn, profile_name):
 
 
 def connect_to_aws(aws_module, region, **params):
-    conn = aws_module.connect_to_region(region, **params)
+    try:
+        conn = aws_module.connect_to_region(region, **params)
+    except(boto.provider.ProfileNotFoundError):
+        raise AnsibleAWSError("Profile given for AWS was not found.  Please fix and retry.")
     if not conn:
         if region not in [aws_module_region.name for aws_module_region in aws_module.regions()]:
             raise AnsibleAWSError("Region %s does not seem to be available for aws module %s. If the region definitely exists, you may need to upgrade "

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -277,13 +277,13 @@ def ec2_connect(module):
     if region:
         try:
             ec2 = connect_to_aws(boto.ec2, region, **boto_params)
-        except (boto.exception.NoAuthHandlerFound, AnsibleAWSError) as e:
+        except (boto.exception.NoAuthHandlerFound, AnsibleAWSError, boto.provider.ProfileNotFoundError) as e:
             module.fail_json(msg=str(e))
     # Otherwise, no region so we fallback to the old connection method
     elif ec2_url:
         try:
             ec2 = boto.connect_ec2_endpoint(ec2_url, **boto_params)
-        except (boto.exception.NoAuthHandlerFound, AnsibleAWSError) as e:
+        except (boto.exception.NoAuthHandlerFound, AnsibleAWSError, boto.provider.ProfileNotFoundError) as e:
             module.fail_json(msg=str(e))
     else:
         module.fail_json(msg="Either region or ec2_url must be specified")

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -257,8 +257,9 @@ def boto_fix_security_token_in_profile(conn, profile_name):
 def connect_to_aws(aws_module, region, **params):
     try:
         conn = aws_module.connect_to_region(region, **params)
-    except(boto.provider.ProfileNotFoundError):
-        raise AnsibleAWSError("Profile given for AWS was not found.  Please fix and retry.")
+    except boto.provider.ProfileNotFoundError:
+        raise AnsibleAWSError(
+             "AWS Profile {0} not found.  Please fix and retry.".format(params["profie_name]))
     if not conn:
         if region not in [aws_module_region.name for aws_module_region in aws_module.regions()]:
             raise AnsibleAWSError("Region %s does not seem to be available for aws module %s. If the region definitely exists, you may need to upgrade "


### PR DESCRIPTION
##### SUMMARY

fix handling of boto.provider.ProfileNotFoundError during connection 

if the profile is set to one which doesn't exist in ~/.aws/credentials then boto returns a  boto.provider.ProfileNotFoundError exception.  This patch catches that error and returns a fail json.

N.B. since the  [AWS module guidelines](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/amazon/GUIDELINES.md
) don't recommend wrapping the connect call in a try/except, error handling has to be done internally to the function

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

ec2 module utils 

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/mikedd/dev/ansible/ansible-add-modules-2/library']
  ansible python module location = /home/mikedd/dev/ansible/ansible-add-modules-2/lib/ansible
  executable location = /home/mikedd/dev/ansible/ansible-add-modules-2/bin/ansible
  python version = 2.7.12 (default, Jul  1 2016, 15:12:24) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION

before:
```
TASK [test_ec2_group : test valid region parameter] ********************************************************************************************************************************************************
task path: /home/xxxxx/ansible/test/integration/roles/test_ec2_group/tasks/main.yml:80
Using module file /home/xxxxx/ansible/lib/ansible/modules/cloud/amazon/ec2_group.py
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: mikedd
<127.0.0.1> EXEC /bin/sh -c 'echo ~ && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/mikedd/.ansible/tmp/ansible-tmp-1491840959.82-137479677118700 `" && echo ansible-tmp-1491840959.82-137479677118700="` echo /home/mikedd/.ansible/tmp/ansible-tmp-1491840959.82-137479677118700 `" ) && sleep 0'
<127.0.0.1> PUT /tmp/tmpqct7NP TO /home/mikedd/.ansible/tmp/ansible-tmp-1491840959.82-137479677118700/ec2_group.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/mikedd/.ansible/tmp/ansible-tmp-1491840959.82-137479677118700/ /home/mikedd/.ansible/tmp/ansible-tmp-1491840959.82-137479677118700/ec2_group.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /home/mikedd/.ansible/tmp/ansible-tmp-1491840959.82-137479677118700/ec2_group.py; rm -rf "/home/mikedd/.ansible/tmp/ansible-tmp-1491840959.82-137479677118700/" > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_waC8Kj/ansible_module_ec2_group.py", line 608, in <module>
    main()
  File "/tmp/ansible_waC8Kj/ansible_module_ec2_group.py", line 396, in main
    ec2 = ec2_connect(module)
  File "/tmp/ansible_waC8Kj/ansible_modlib.zip/ansible/module_utils/ec2.py", line 279, in ec2_connect
  File "/tmp/ansible_waC8Kj/ansible_modlib.zip/ansible/module_utils/ec2.py", line 258, in connect_to_aws
  File "/usr/lib/python2.7/dist-packages/boto/ec2/__init__.py", line 66, in connect_to_region
    return region.connect(**kw_params)
  File "/usr/lib/python2.7/dist-packages/boto/regioninfo.py", line 187, in connect
    return self.connection_cls(region=self, **kw_params)
  File "/usr/lib/python2.7/dist-packages/boto/ec2/connection.py", line 103, in __init__
    profile_name=profile_name)
  File "/usr/lib/python2.7/dist-packages/boto/connection.py", line 1100, in __init__
    provider=provider)
  File "/usr/lib/python2.7/dist-packages/boto/connection.py", line 555, in __init__
    profile_name)
  File "/usr/lib/python2.7/dist-packages/boto/provider.py", line 200, in __init__
    self.get_credentials(access_key, secret_key, security_token, profile_name)
  File "/usr/lib/python2.7/dist-packages/boto/provider.py", line 296, in get_credentials
    profile_name)
boto.provider.ProfileNotFoundError: Profile "ansbile-testing-bogus-do-not-create" not found!

fatal: [localhost]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_waC8Kj/ansible_module_ec2_group.py\", line 608, in <module>\n    main()\n  File \"/tmp/ansible_waC8Kj/ansible_module_ec2_group.py\", line 396, in main\n    ec2 = ec2_connect(module)\n  File \"/tmp/ansible_waC8Kj/ansible_modlib.zip/ansible/module_utils/ec2.py\", line 279, in ec2_connect\n  File \"/tmp/ansible_waC8Kj/ansible_modlib.zip/ansible/module_utils/ec2.py\", line 258, in connect_to_aws\n  File \"/usr/lib/python2.7/dist-packages/boto/ec2/__init__.py\", line 66, in connect_to_region\n    return region.connect(**kw_params)\n  File \"/usr/lib/python2.7/dist-packages/boto/regioninfo.py\", line 187, in connect\n    return self.connection_cls(region=self, **kw_params)\n  File \"/usr/lib/python2.7/dist-packages/boto/ec2/connection.py\", line 103, in __init__\n    profile_name=profile_name)\n  File \"/usr/lib/python2.7/dist-packages/boto/connection.py\", line 1100, in __init__\n    provider=provider)\n  File \"/usr/lib/python2.7/dist-packages/boto/connection.py\", line 555, in __init__\n    profile_name)\n  File \"/usr/lib/python2.7/dist-packages/boto/provider.py\", line 200, in __init__\n    self.get_credentials(access_key, secret_key, security_token, profile_name)\n  File \"/usr/lib/python2.7/dist-packages/boto/provider.py\", line 296, in get_credentials\n    profile_name)\nboto.provider.ProfileNotFoundError: Profile \"ansbile-testing-bogus-do-not-create\" not found!\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE", 
    "rc": 0
}
```

after
```
fatal: [localhost]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "invocation": {
        "module_args": {
            "aws_access_key": null, 
            "aws_secret_key": null, 
            "description": "Created by ansible integration tests", 
            "ec2_url": null, 
            "name": "ansible-testing-sZAw8IPs", 
            "profile": "ansbile-testing-bogus-do-not-create", 
            "purge_rules": true, 
            "purge_rules_egress": true, 
            "region": null, 
            "rules": null, 
            "rules_egress": null, 
            "security_token": null, 
            "state": "present", 
            "validate_certs": true, 
            "vpc_id": null
        }
    }, 
    "msg": "Profile \"ansbile-testing-bogus-do-not-create\" not found!"
}
```