### PR TITLE
Added product as a filter

### DIFF
--- a/docs/docsite/rst/playbooks_filters.rst
+++ b/docs/docsite/rst/playbooks_filters.rst
@@ -629,6 +629,10 @@ Combinations always require a set size::
     - name: give me combinations for sets of 2
       debug: msg="{{ [1,2,3,4,5]|combinations(2)|list }}"
 
+To get the product of multiple lists::
+    
+    - name: give me a list of every allowed combination
+      debug: msg="{{ [["www", ""],["ticket","zammad"],["test.com.", "test.de."]]|product|list }}
 
 To get a list combining the elements of other lists use ``zip``::
 

--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -140,6 +140,7 @@ class FilterModule(object):
             # combinatorial
             'permutations': itertools.permutations,
             'combinations': itertools.combinations,
+            'product':  itertools.product,
 
             # computer theory
             'human_readable' : human_readable,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added Product filter because creating lists that need to have specific components in each place is not possible right now
example:
["www", ""] ["ticket","zammad"] ["test.com.", "test.de."]

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
