### PR TITLE
ecs_taskdefinition module : proposal : add `force_create: true` parameter

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -50,7 +50,7 @@ options:
         description:
             - Always create new task definition
         required: False
-        version_added: 2.4
+        version_added: 2.5
     containers:
         description:
             - A list of containers definitions

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -351,7 +351,7 @@ def main():
                 if existing:
                     break
 
-        if existing and not ('force_create' in module.params and module.params['force_create']):
+        if existing and not module.params.get('force_create'):
             # Awesome. Have an existing one. Nothing to do.
             results['taskdefinition'] = existing
         else:

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -33,7 +33,7 @@ options:
         description:
             - State whether the task definition should exist or be deleted
         required: true
-        choices: ['present', 'absent']
+        choices: ['present', 'absent', 'create']
     arn:
         description:
             - The arn of the task description to delete
@@ -219,7 +219,7 @@ def main():
 
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
-        state=dict(required=True, choices=['present', 'absent']),
+        state=dict(required=True, choices=['present', 'absent', 'create']),
         arn=dict(required=False, type='str'),
         family=dict(required=False, type='str'),
         revision=dict(required=False, type='int'),
@@ -240,7 +240,7 @@ def main():
     task_mgr = EcsTaskManager(module)
     results = dict(changed=False)
 
-    if module.params['state'] == 'present':
+    if module.params['state'] in ['present', 'create']:
         if 'containers' not in module.params or not module.params['containers']:
             module.fail_json(msg="To use task definitions, a list of containers must be specified")
 
@@ -345,7 +345,7 @@ def main():
                 if existing:
                     break
 
-        if existing:
+        if existing and not module.params['state'] == 'create':
             # Awesome. Have an existing one. Nothing to do.
             results['taskdefinition'] = existing
         else:

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -228,7 +228,7 @@ def main():
         arn=dict(required=False, type='str'),
         family=dict(required=False, type='str'),
         revision=dict(required=False, type='int'),
-        force_create=dict(required=False, type='bool'),
+        force_create=dict(required=False, default=False, type='bool'),
         containers=dict(required=False, type='list'),
         network_mode=dict(required=False, default='bridge', choices=['bridge', 'host', 'none'], type='str'),
         task_role_arn=dict(required=False, default='', type='str'),


### PR DESCRIPTION
##### SUMMARY

ecs_taskdefinition module : add `force_create: true` parameter.

always create a new task definition when `force_create: true` parameter is set.

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

ecs_taskdefinition module

##### ANSIBLE VERSION

```
2.2.0
```
