### PR TITLE
Add oracle-se2 database support

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds.py
+++ b/lib/ansible/modules/cloud/amazon/rds.py
@@ -50,7 +50,8 @@ options:
       - mariadb was added in version 2.2
     required: false
     default: null
-    choices: ['mariadb', 'MySQL', 'oracle-se1', 'oracle-se', 'oracle-ee', 'sqlserver-ee', 'sqlserver-se', 'sqlserver-ex', 'sqlserver-web', 'postgres', 'aurora']
+    choices: ['mariadb', 'MySQL', 'oracle-se1', 'oracle-se2', 'oracle-se', 'oracle-ee',
+              'sqlserver-ee', 'sqlserver-se', 'sqlserver-ex', 'sqlserver-web', 'postgres', 'aurora']
   size:
     description:
       - Size in gigabytes of the initial storage for the DB instance. Used only when command=create or command=modify.
@@ -1316,7 +1317,7 @@ def main():
         command=dict(choices=['create', 'replicate', 'delete', 'facts', 'modify', 'promote', 'snapshot', 'reboot', 'restore'], required=True),
         instance_name=dict(required=False),
         source_instance=dict(required=False),
-        db_engine=dict(choices=['mariadb', 'MySQL', 'oracle-se1', 'oracle-se', 'oracle-ee', 'sqlserver-ee', 'sqlserver-se', 'sqlserver-ex',
+        db_engine=dict(choices=['mariadb', 'MySQL', 'oracle-se1', 'oracle-se2', 'oracle-se', 'oracle-ee', 'sqlserver-ee', 'sqlserver-se', 'sqlserver-ex',
                                 'sqlserver-web', 'postgres', 'aurora'], required=False),
         size=dict(required=False),
         instance_type=dict(aliases=['type'], required=False),


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
rds

##### ANSIBLE VERSION

```
ansible 2.3.0 (devel 8e4d95b125) last updated 2016/11/29 18:45:42 (GMT +1000)
  lib/ansible/modules/core: (rds_oracle_se2 749c77c2ad) last updated 2016/12/01 21:37:01 (GMT +1000)
  lib/ansible/modules/extras: (detached HEAD 43bb97bc37) last updated 2016/11/28 20:36:43 (GMT +1000)
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Adds oracle-se2 support to rds2 module. 

Fixes ansible/ansible-modules-core#4808