### PR TITLE
Check mode for cloudformation module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -250,7 +250,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_bytes
 
 
-
 def get_stack_events(cfn, stack_name):
     '''This event data was never correct, it worked as a side effect. So the v2.3 format is different.'''
     ret = {'events':[], 'log':[]}

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -415,16 +415,14 @@ def check_mode_changeset(module, stack_params, cfn):
     stack_params['ChangeSetName'] = build_changeset_name(stack_params)
     try:
         change_set = cfn.create_change_set(**stack_params)
-        success = False
         for i in range(60): # total time 5 min
             description = cfn.describe_change_set(ChangeSetName=change_set['Id'])
-            if description['Status'] in ['CREATE_COMPLETE', 'FAILED']:
-                success = True
+            if description['Status'] in ('CREATE_COMPLETE', 'FAILED'):
                 break
             time.sleep(5)
-
-        if not success:
-            module.fail_json(msg="Failed to create change set "+name)
+        else:
+            # if the changeset doesn't finish in 5 mins, this `else` will trigger and fail
+            module.fail_json(msg="Failed to create change set %s" % stack_params['ChangeSetName'])
 
         cfn.delete_change_set(ChangeSetName=change_set['Id'])
 

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -451,6 +451,7 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         mutually_exclusive=[['template_url', 'template']],
+        supports_check_mode=True
     )
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 and botocore are required for this module')
@@ -508,6 +509,9 @@ def main():
     cfn.delete_stack = backoff_wrapper(cfn.delete_stack)
 
     stack_info = get_stack_facts(cfn, stack_params['StackName'])
+
+    if module.check_mode:
+        module.exit_json(changed={"changed": True})
 
     if state == 'present':
         if not stack_info:

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -233,8 +233,6 @@ stack_outputs:
 
 import json
 import time
-import random
-import string
 import traceback
 from hashlib import sha1
 

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -431,25 +431,15 @@ def check_mode_changeset(module, stack_params, cfn):
 
         cfn.delete_change_set(ChangeSetName=change_set['Id'])
 
+        reason = description.get('StatusReason')
+
         if description['Status'] == 'FAILED' and "didn't contain changes" in description['StatusReason']:
-            return {'changed': False, 'meta': description['StatusReason']}
-        return {'changed': True, 'meta': description['Changes']}
+            return {'changed': False, 'msg': reason, 'meta': description['StatusReason']}
+        return {'changed': True, 'msg': reason, 'meta': description['Changes']}
 
     except (botocore.exceptions.ValidationError, botocore.exceptions.ClientError) as err:
         error_msg = boto_exception(err)
         module.fail_json(msg=error_msg, exception=traceback.format_exc())
-
-
-def process_changeset(changeset):
-    """Given the output of boto3 describe_change_set, return a dict
-    suitable for module.exit_json"""
-    # StatusReason can be null
-    reason = changeset.get('StatusReason')
-    if changeset['Status'] == 'FAILED' and "didn't contain changes" in reason:
-        return {'changed': False, 'msg': reason, 'meta': []}
-    else:
-        return {'changed': True, 'msg': reason or 'Would change stack',
-                'meta': changeset['Changes']}
 
 
 def get_stack_facts(cfn, stack_name):

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -541,7 +541,14 @@ def main():
     stack_info = get_stack_facts(cfn, stack_params['StackName'])
 
     if module.check_mode:
-        module.exit_json(**check_mode_changeset(module, stack_params, cfn))
+        if state == 'absent' and stack_info:
+            module.exit_json(changed=True, meta='Stack would be deleted')
+        elif state == 'absent' and not stack_info:
+            module.exit_json(changed=False, meta='Stack doesn\'t exist')
+        elif state == 'present' and not stack_info:
+            module.exit_json(changed=True, meta='New stack would be created')
+        else:
+            module.exit_json(**check_mode_changeset(module, stack_params, cfn))
 
     if state == 'present':
         if not stack_info:


### PR DESCRIPTION
##### SUMMARY

Check mode for cloudformatio module using CloudFormation change sets.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
cloudformation module

##### ANSIBLE VERSION

```
ansible 2.4.0 (cloudformation-check-mode 280c5e01ac) last updated 2017/04/11 10:19:45 (GMT +300)
```

##### ADDITIONAL INFORMATION

A change set is created, described, and deleted when running in check mode. Only minimal AWS output processing is done, so the output is a bit verbose, but describes everything.

Example output with no changes:

```
TASK [Create dev cloudformation stack] **************************************************************************************
ok: [localhost] => {"changed": false, "meta": "The submitted information didn't contain changes. Submit different information to create a change set."}
```

Example output with changes:

```
TASK [Create dev cloudformation stack] **************************************************************************************
changed: [localhost] => {"changed": true, "meta": [{"ResourceChange": {"Action": "Modify", "Details": [{"ChangeSource": "DirectModification", "Evaluation": "Static", "Target": {"Attribute": "Properties", "Name": "AllocatedStorage", "RequiresRecreation": "Never"}}], "LogicalResourceId": "devDb", "PhysicalResourceId": "db-dev", "Replacement": "False", "ResourceType": "AWS::RDS::DBInstance", "Scope": ["Properties"]}, "Type": "Resource"}, {"ResourceChange": {"Action": "Modify", "Details": [{"CausingEntity": "devDB.Endpoint.Address", "ChangeSource": "ResourceAttribute", "Evaluation": "Dynamic", "Target": {"Attribute": "Properties", "Name": "ResourceRecords", "RequiresRecreation": "Never"}}], "LogicalResourceId": "devDBDns", "PhysicalResourceId": "devdb.dev.example.com", "Replacement": "False", "ResourceType": "AWS::Route53::RecordSet", "Scope": ["Properties"]}, "Type": "Resource"}]}
```

or pretty-printed:

```
{
  "changed": true,
  "meta": [
    {
      "ResourceChange": {
        "Action": "Modify",
        "Details": [
          {
            "ChangeSource": "DirectModification",
            "Evaluation": "Static",
            "Target": {
              "Attribute": "Properties",
              "Name": "AllocatedStorage",
              "RequiresRecreation": "Never"
            }
          }
        ],
        "LogicalResourceId": "devDb",
        "PhysicalResourceId": "db-dev",
        "Replacement": "False",
        "ResourceType": "AWS::RDS::DBInstance",
        "Scope": [
          "Properties"
        ]
      },
      "Type": "Resource"
    },
    {
      "ResourceChange": {
        "Action": "Modify",
        "Details": [
          {
            "CausingEntity": "devDB.Endpoint.Address",
            "ChangeSource": "ResourceAttribute",
            "Evaluation": "Dynamic",
            "Target": {
              "Attribute": "Properties",
              "Name": "ResourceRecords",
              "RequiresRecreation": "Never"
            }
          }
        ],
        "LogicalResourceId": "devDBDns",
        "PhysicalResourceId": "devdb.dev.example.com",
        "Replacement": "False",
        "ResourceType": "AWS::Route53::RecordSet",
        "Scope": [
          "Properties"
        ]
      },
      "Type": "Resource"
    }
  ]
}
```
