### PR TITLE
Fix Postgres user module always reporting changes

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -292,7 +292,7 @@ def user_alter(cursor, module, user, password, role_attr_flags, encrypted, expir
         # Do we actually need to do anything?
         pwchanging = False
         if password is not None:
-            if encrypted:
+            if encrypted == 'ENCRYPTED':
                 if password.startswith('md5'):
                     if password != current_role_attrs['rolpassword']:
                         pwchanging = True


### PR DESCRIPTION
##### SUMMARY
When using the postgresql_user module with unencrypted passwords the module always reported a change even though there was none, resulting in useless `ALTER` statements being executed.

The problem is that in a piece of code of the module (https://github.com/ansible/ansible-modules-core/commit/b4515c8909594d22cdfb1b5903cf0cee0ec21a26) the `encrypted` variable was treated as a boolean when in fact it's a string with the values `ENCRYPTED` or `UNENCRYPTED`. That caused the boolean condition to always be true, hence executing the unnecessary `ALTER` statements and reporting changes made in the playbook.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
postgresql_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
```
(Affects all versions)
