### PR TITLE
Add Windows AD Domain facts for membership and server type

### DIFF
--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -139,7 +139,7 @@ $domain_roles = @{
     5 = "Primary domain controller"
 }
 
-$domain_role = $domain_roles.Get_Item([Int32](Get-CimInstance Win32_ComputerSystem).DomainRole)
+$domain_role = $domain_roles.Get_Item([Int32]$win32_cs.DomainRole)
 
 $ansible_facts = @{
     ansible_architecture = $win32_os.OSArchitecture

--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -130,6 +130,17 @@ foreach ($item in Get-ChildItem Env:) {
     $env_vars.Add($name, $value)
 }
 
+$domain_roles = @{
+    0 = "Stand-alone workstation"
+    1 = "Member workstation"
+    2 = "Stand-alone server"
+    3 = "Member server"
+    4 = "Backup domain controller"
+    5 = "Primary domain controller"
+}
+
+$domain_role = $domain_roles.Get_Item([Int32](Get-CimInstance Win32_ComputerSystem).DomainRole)
+
 $ansible_facts = @{
     ansible_architecture = $win32_os.OSArchitecture
     ansible_bios_date = $win32_bios.ReleaseDate.ToString("MM/dd/yyyy")
@@ -173,6 +184,8 @@ $ansible_facts = @{
     ansible_user_id = $env:username
     ansible_user_sid = $user.User.Value
     ansible_windows_domain = $win32_cs.Domain
+    ansible_windows_domain_member = $win32_cs.PartOfDomain
+    ansible_windows_domain_role = $domain_role
 
     # Win32_PhysicalMemory is empty on some virtual platforms
     ansible_memtotal_mb = ([math]::round($win32_cs.TotalPhysicalMemory / 1024 / 1024))


### PR DESCRIPTION
##### SUMMARY
Adds additional facts to setup.ps1 for Windows hosts to help identify if a machine is part of an Active Directory Domain and what role it plays in that domain.

This is useful for making decisions applying config depending on whether or not a machine is part of a domain or not, or if it is whether is a domain controller or not.

Facts added -

 * ansible_windows_domain_member - returns true if machine is domain
   joined
 * ansible_windows_domain_role - indicates role of machine in domain

Roles list is taken from
https://technet.microsoft.com/en-us/library/ee198796.aspx and will
return sensible values for non domain joined machines too.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/windows/setup.ps1

##### ANSIBLE VERSION
```
ansible 2.4.0 (windows-domain-facts 5c6edcf87e) last updated 2017/04/11 19:43:52 (GMT +100)
  config file = 
  configured module search path = [u'/home/barney/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/barney/git/ansible/lib/ansible
  executable location = /home/barney/git/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
New output -

```
        "ansible_windows_domain_member": true, 
        "ansible_windows_domain_role": "Backup domain controller", 
```
