### PR TITLE
Ryanpineo fix ipaddr netmask with 32 cidr

### DIFF
--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -13,3 +13,4 @@ python-memcached
 pyyaml
 redis
 unittest2 ; python_version < '2.7'
+netaddr

--- a/test/units/plugins/filter/test_ipaddr.py
+++ b/test/units/plugins/filter/test_ipaddr.py
@@ -1,0 +1,35 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.compat.tests import unittest
+from ansible.plugins.filter.ipaddr import ipaddr, _netmask_query
+
+
+class TestNetmask(unittest.TestCase):
+    def test_whole_octets(self):
+        address = '1.1.1.1/24'
+        self.assertEqual(ipaddr(address, 'netmask'), '255.255.255.0')
+
+    def test_partial_octet(self):
+        address = '1.1.1.1/25'
+        self.assertEqual(ipaddr(address, 'netmask'), '255.255.255.128')
+
+    def test_32_cidr(self):
+        address = '1.12.1.34/32'
+        self.assertEqual(ipaddr(address, 'netmask'), '255.255.255.255')


### PR DESCRIPTION
##### SUMMARY
Ryanpineo had a PR for ipaddr here https://github.com/ansible/ansible/pull/12601

A different bugfix was merged but the test cases from the PR are useful.  I've rebased to current devel and added the netaddr dependency to the proper file for ansible-test to pick up on.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

tests of ipaddr

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (ryanpineo-fix-ipaddr-netmask-with-32-cidr 105242dad6) last updated 2017/04/11 12:02:57 (GMT -700)
  config file = 
  configured module search path = [u'/home/badger/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /srv/ansible/abadger2/lib/ansible
  executable location = /srv/ansible/abadger2/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```
