### PR TITLE
Add checks to confirm that the output from `xfs_info` has the expected format

### DIFF
--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -103,6 +103,10 @@ def _get_fs_size(fssize_cmd, dev, module):
             for line in size.splitlines():
                 col = line.split('=')
                 if col[0].strip() == 'data':
+                    if col[1].strip() != 'bsize':
+                        module.fail_json(msg='Unexpected output format from xfs_info (could not locate "bsize")')
+                    if col[2].split()[1] != 'blocks':
+                        module.fail_json(msg='Unexpected output format from xfs_info (could not locate "blocks")')
                     block_size = int(col[2].split()[0])
                     block_count = int(col[3].split(',')[0])
                     break


### PR DESCRIPTION
##### SUMMARY
Adds checks to ensure the format of the output given by `xfs_info` is as expected and that, subsequently, the correct values are being selected.

Given that the way the values are selected here is very fragile, this will help prevent incorrect values of the block size and count being chosen if `xfs_info` makes a change to the way it outputs these values.

Additional fix on https://github.com/ansible/ansible/issues/23352.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/system/filesystem.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = 
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.5/dist-packages/ansible-2.4.0-py3.5.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
- Discussed in https://github.com/ansible/ansible/pull/23367.
