### PR TITLE
Add .coveragerc to the tarball so unittests will run from the tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ prune ticket_stubs
 prune hacking
 include README.md COPYING
 include requirements.txt
+include .coveragerc
 include examples/hosts
 include examples/ansible.cfg
 include lib/ansible/module_utils/powershell.ps1


### PR DESCRIPTION
##### SUMMARY
unittests need a .coveragerc in order to run but this was left out of the tarballs.  Add it to MANIFEST.in so that future tarballs include it.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
MANIFEST.in

##### ANSIBLE VERSION
```
devel 2.3
```