### PR TITLE
Fix alarm action comparison

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_metric_alarm.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_metric_alarm.py
@@ -197,7 +197,9 @@ def create_metric_alarm(connection, module):
 
         for attr in ('alarm_actions','insufficient_data_actions','ok_actions'):
             action = module.params.get(attr) or []
-            if getattr(alarm, attr) != action:
+            # Boto and/or ansible may provide same elements in lists but in different order.
+            # Compare on sets since they do not need any order.
+            if set(getattr(alarm, attr)) != set(action):
                 changed = True
                 setattr(alarm, attr, module.params.get(attr))
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ec2_metric_alarm
##### ANSIBLE VERSION

```
ansible 2.0.2.0
```
##### SUMMARY

This fixes issue when list from module contains more than one element.
Ansible and/or boto may put same elements in list in different order,
thus resulting task as changed.

Fixes #3310
