### PR TITLE
Windows: Get rid of Set-Attr in remaining modules

### DIFF
--- a/lib/ansible/modules/windows/win_acl.ps1
+++ b/lib/ansible/modules/windows/win_acl.ps1
@@ -214,8 +214,9 @@ Function SetPrivilegeTokens() {
 
 $params = Parse-Args $args;
 
-$result = New-Object PSObject;
-Set-Attr $result "changed" $false;
+$result = @{
+    changed = $false
+}
 
 $path = Get-Attr $params "path" -failifempty $true
 $user = Get-Attr $params "user" -failifempty $true
@@ -314,7 +315,7 @@ Try {
         Try {
             $objACL.AddAccessRule($objACE)
             Set-ACL $path $objACL
-            Set-Attr $result "changed" $true;
+            $result.changed = $true
         }
         Catch {
             Fail-Json $result "an exception occurred when adding the specified rule - $($_.Exception.Message)"
@@ -324,7 +325,7 @@ Try {
         Try {
             $objACL.RemoveAccessRule($objACE)
             Set-ACL $path $objACL
-            Set-Attr $result "changed" $true;
+            $result.changed = $true
         }
         Catch {
             Fail-Json $result "an exception occurred when removing the specified rule - $($_.Exception.Message)"

--- a/lib/ansible/modules/windows/win_acl_inheritance.ps1
+++ b/lib/ansible/modules/windows/win_acl_inheritance.ps1
@@ -22,8 +22,9 @@
 
 $params = Parse-Args $args;
 
-$result = New-Object PSObject;
-Set-Attr $result "changed" $false;
+$result = @{
+    changed = $false
+}
 
 $path = Get-Attr $params "path" -failifempty $true
 $state = Get-Attr $params "state" "absent" -validateSet "present","absent" -resultobj $result
@@ -66,7 +67,7 @@ Try {
         }
 
         Set-ACL $path $objACL
-        Set-Attr $result "changed" $true;
+        $result.changed = $true
     }
     Elseif (($state -eq "absent") -And $inheritanceEnabled) {
         If ($reorganize) {
@@ -76,7 +77,7 @@ Try {
         }
 
         Set-ACL $path $objACL
-        Set-Attr $result "changed" $true;
+        $result.changed = $true
     }
 }
 Catch {

--- a/lib/ansible/modules/windows/win_dotnet_ngen.ps1
+++ b/lib/ansible/modules/windows/win_dotnet_ngen.ps1
@@ -22,8 +22,10 @@ $ErrorActionPreference = "Stop"
 # POWERSHELL_COMMON
 
 $params = Parse-Args $args;
-$result = New-Object PSObject;
-Set-Attr $result "changed" $false;
+
+$result = @{
+    changed = $false
+}
 
 function Invoke-NGen
 {
@@ -42,11 +44,11 @@ function Invoke-NGen
     if (test-path $cmd)
     {
         $update = Invoke-Expression "$cmd update /force";
-        Set-Attr $result "dotnet_ngen$($arity)_update_exit_code" $lastexitcode
-        Set-Attr $result "dotnet_ngen$($arity)_update_output" $update
+        $(result.dotnet_ngen$($arity)_update_exit_code) = $lastexitcode
+        $(result.dotnet_ngen$($arity)_update_output) = $update
         $eqi = Invoke-Expression "$cmd executequeueditems";
-        Set-Attr $result "dotnet_ngen$($arity)_eqi_exit_code" $lastexitcode
-        Set-Attr $result "dotnet_ngen$($arity)_eqi_output" $eqi
+        $(result.dotnet_ngen$($arity)_eqi_exit_code) = $lastexitcode
+        $(result.dotnet_ngen$($arity)_eqi_output) = $eqi
 
         $result.changed = $true
     }

--- a/lib/ansible/modules/windows/win_package.ps1
+++ b/lib/ansible/modules/windows/win_package.ps1
@@ -850,7 +850,7 @@ function Set-TargetResource
                     if($process)
                     {
                         $exitCode = $process.ExitCode
-                        Set-Attr -obj $result -name "exit_code" -value $exitCode
+                        $result.exit_code = $exitCode
                     }
                 }
             }
@@ -1254,8 +1254,10 @@ namespace Source
 
 
 $params = Parse-Args $args;
-$result = New-Object psobject;
-Set-Attr $result "changed" $false;
+
+$result = @{
+    changed = $false
+}
 
 $path = Get-Attr -obj $params -name path -failifempty $true -resultobj $result
 $name = Get-Attr -obj $params -name name -default $path
@@ -1294,7 +1296,7 @@ if (($username -ne $null) -and ($password -ne $null))
 }
 
 #Always return the name
-set-attr -obj $result -name "name" -value $name
+$result.name = $name
 
 $testdscresult = Test-TargetResource @dscparams
 if ($testdscresult -eq $true)
@@ -1316,12 +1318,12 @@ Else
     #Check if DSC thinks the computer needs a reboot:
     if ((get-variable DSCMachinestatus -Scope Global -ea 0) -and ($global:DSCMachineStatus -eq 1))
     {
-        Set-Attr $result "restart_required" $true
+        $result.restart_required = $true
     }
 
     #Set-TargetResource did its job. We can assume a change has happened
-    Set-Attr $result "changed" $true
+    $result.changed = $true
     Exit-Json -obj $result
-    
+
 }
 

--- a/lib/ansible/modules/windows/win_share.ps1
+++ b/lib/ansible/modules/windows/win_share.ps1
@@ -174,7 +174,7 @@ Try {
         }
         if ($share.CachingMode -ne $cachingMode) {
             Set-SmbShare -Force -Name $name -CachingMode $cachingMode
-            Set-Attr $result "changed" $true;
+            $result.changed = $true
         }
 
         # clean permissions that imply others

--- a/lib/ansible/modules/windows/win_unzip.ps1
+++ b/lib/ansible/modules/windows/win_unzip.ps1
@@ -22,8 +22,8 @@
 
 $params = Parse-Args $args;
 
-$result = New-Object psobject @{
-    win_unzip = New-Object psobject
+$result = @{
+    win_unzip = @{}
     changed = $false
 }
 
@@ -81,7 +81,7 @@ Else {
         Fail-Json $result "PowerShellCommunityExtensions PowerShell Module (PSCX) is required for non-'.zip' compressed archive types."
     }
     Else {
-        Set-Attr $result.win_unzip "pscx_status" "present"
+        $result.win_unzip.pscx_status = "present"
     }
 
     # Import
@@ -126,7 +126,7 @@ Else {
 
 If ($rm -eq $true){
     Remove-Item $src -Recurse -Force
-    Set-Attr $result.win_unzip "rm" "true"
+    $result.win_unzip.rm = "true"
 }
 
 # Fixes a fail error message (when the task actually succeeds) for a "Convert-ToJson: The converted JSON string is in bad format"
@@ -138,8 +138,8 @@ If ($src[$src.length-1] -eq "\") {
 If ($dest[$dest.length-1] -eq "\") {
     $dest = $dest.Substring(0, $dest.length-1)
 }
-Set-Attr $result.win_unzip "src" $src.toString()
-Set-Attr $result.win_unzip "dest" $dest.toString()
-Set-Attr $result.win_unzip "recurse" $recurse.toString()
+$result.win_unzip.src = $src.toString()
+$result.win_unzip.dest = $dest.toString()
+$result.win_unzip.recurse = $recurse.toString()
 
 Exit-Json $result

--- a/lib/ansible/modules/windows/win_webpicmd.ps1
+++ b/lib/ansible/modules/windows/win_webpicmd.ps1
@@ -67,8 +67,8 @@ Function Test-IsInstalledFromWebPI
 
     if ($LastExitCode -ne 0)
     {
-        Set-Attr $result "webpicmd_error_cmd" $cmd
-        Set-Attr $result "webpicmd_error_log" "$results"
+        $result.webpicmd_error_cmd = $cmd
+        $result.webpicmd_error_log = "$results"
 
         Throw "Error checking installation status for $package"
     }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Only a few more modules were using Set-Attr on the $result object rather
than using a normal hashtable. This PR changes the PSObject to a
hashtable and gets rid of Set-Attr.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_acl win_acl_inheritance win_dotnet_ngen win_share win_package win_unzip win_webpicmd

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.4