### PR TITLE
Network support for /32

### DIFF
--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -166,8 +166,7 @@ def _netmask_query(v):
     return str(v.netmask)
 
 def _network_query(v):
-    if v.size > 1:
-        return str(v.network)
+    return str(v.network)
 
 def _prefix_query(v):
     return int(v.prefixlen)

--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -94,7 +94,7 @@ def _bool_ipaddr_query(v):
         return True
 
 def _broadcast_query(v):
-    if v.size > 1:
+    if v.size > 2:
         return str(v.broadcast)
 
 def _cidr_query(v):

--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -166,6 +166,7 @@ def _netmask_query(v):
     return str(v.netmask)
 
 def _network_query(v):
+    '''Return the network of a given IP or subnet'''
     return str(v.network)
 
 def _prefix_query(v):

--- a/test/units/plugins/filter/test_ipaddr.py
+++ b/test/units/plugins/filter/test_ipaddr.py
@@ -33,3 +33,24 @@ class TestNetmask(unittest.TestCase):
     def test_32_cidr(self):
         address = '1.12.1.34/32'
         self.assertEqual(ipaddr(address, 'netmask'), '255.255.255.255')
+
+    def test_network_32(self):
+        address = '1.12.1.34/32'
+        self.assertEqual(ipaddr(address, 'network'), '1.12.1.34')
+
+    def test_network_32_long(self):
+        address = '1.12.1.34/255.255.255.255'
+        self.assertEqual(ipaddr(address, 'network'), '1.12.1.34')
+
+    def test_network_32_no_mask(self):
+        address = '1.12.1.34'
+        self.assertEqual(ipaddr(address, 'network'), '1.12.1.34')
+
+    def test_network_31(self):
+        address = '1.12.1.35/31'
+        self.assertEqual(ipaddr(address, 'network'), '1.12.1.34')
+
+    def test_network_24(self):
+        address = '1.12.1.34/24'
+        self.assertEqual(ipaddr(address, 'network'), '1.12.1.0')
+

--- a/test/units/plugins/filter/test_ipaddr.py
+++ b/test/units/plugins/filter/test_ipaddr.py
@@ -54,3 +54,22 @@ class TestNetmask(unittest.TestCase):
         address = '1.12.1.34/24'
         self.assertEqual(ipaddr(address, 'network'), '1.12.1.0')
 
+    def test_broadcast_24(self):
+        address = '1.12.1.34/24'
+        self.assertEqual(ipaddr(address, 'broadcast'), '1.12.1.255')
+
+    def test_broadcast_16(self):
+        address = '1.12.1.34/16'
+        self.assertEqual(ipaddr(address, 'broadcast'), '1.12.255.255')
+
+    def test_broadcast_27(self):
+        address = '1.12.1.34/27'
+        self.assertEqual(ipaddr(address, 'broadcast'), '1.12.1.63')
+
+    def test_broadcast_32(self):
+        address = '1.12.1.34/32'
+        self.assertEqual(ipaddr(address, 'broadcast'), None)
+
+    def test_broadcast_31(self):
+        address = '1.12.1.35/31'
+        self.assertEqual(ipaddr(address, 'broadcast'), None)

--- a/test/units/plugins/filter/test_ipaddr.py
+++ b/test/units/plugins/filter/test_ipaddr.py
@@ -73,3 +73,4 @@ class TestNetmask(unittest.TestCase):
     def test_broadcast_31(self):
         address = '1.12.1.35/31'
         self.assertEqual(ipaddr(address, 'broadcast'), None)
+

--- a/test/units/plugins/filter/test_ipaddr.py
+++ b/test/units/plugins/filter/test_ipaddr.py
@@ -73,4 +73,3 @@ class TestNetmask(unittest.TestCase):
     def test_broadcast_31(self):
         address = '1.12.1.35/31'
         self.assertEqual(ipaddr(address, 'broadcast'), None)
-


### PR DESCRIPTION
Why override the default from netaddr for /32 networks? This seems to be inline with industry standard (netaddr, most if not all of the subnet calculator sites) and I can't find an RFC that says there is no network on a /32, though I could be missing.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ipaddr
netmask
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/etc/ntc/ansible-modules/']
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Jinja:
{% set ipv4_host = '192.168.0.10/32' %}
ipv4_host = '192.168.0.10/32'
    network         {{ ipv4_host | ipaddr('network') }}

Output:

Before:
ipv4_host = '192.168.0.10/32'
    network         

After:
ipv4_host = '192.168.0.10/32'
    network         192.168.0.10
```
