### PR TITLE
Add vfat support for the filesystem module

### DIFF
--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -75,8 +75,7 @@ import os
 import re
 import stat
 
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import viewkeys
+from ansible.module_utils.basic import AnsibleModule, get_platform
 
 
 class Filesystem(object):
@@ -214,7 +213,10 @@ class Btrfs(Filesystem):
 
 
 class VFAT(Filesystem):
-    MKFS = 'mkfs.vfat'
+    if get_platform() == 'FreeBSD':
+        MKFS = "newfs_msdos"
+    else:
+        MKFS = 'mkfs.vfat'
 
     def get_fs_size(self, dev):
         cmd = self.module.get_bin_path(self.GROW, required=True)

--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -42,8 +42,9 @@ options:
   resizefs:
     description:
     - If C(yes), if the block device and filesytem size differ, grow the filesystem into the space.
-    - Supported for C(ext2), C(ext3), C(ext4), C(ext4dev), C(lvm) and C(xfs) filesystems.
+    - Supported for C(ext2), C(ext3), C(ext4), C(ext4dev), C(lvm), C(xfs) and C(vfat) filesystems.
     - XFS Will only grow if mounted.
+    - vFAT will likely fail if fatresize < 1.04.
     type: bool
     default: 'no'
     version_added: "2.0"
@@ -229,6 +230,7 @@ class VFAT(Filesystem):
         MKFS = "newfs_msdos"
     else:
         MKFS = 'mkfs.vfat'
+    GROW = 'fatresize'
 
     def get_fs_size(self, dev):
         cmd = self.module.get_bin_path(self.GROW, required=True)

--- a/test/integration/targets/filesystem/defaults/main.yml
+++ b/test/integration/targets/filesystem/defaults/main.yml
@@ -11,5 +11,5 @@ tested_filesystems:
   ext2: {fssize: 10, grow: True}
   xfs: {fssize: 20, grow: False}  # grow requires a mounted filesystem
   btrfs: {fssize: 100, grow: False}  # grow not implemented
-  vfat: {fssize: 20, grow: False}  # fatresize not supported due to segfaults
+  vfat: {fssize: 20, grow: True}
   # untested: lvm, requires a block device

--- a/test/integration/targets/filesystem/defaults/main.yml
+++ b/test/integration/targets/filesystem/defaults/main.yml
@@ -11,4 +11,5 @@ tested_filesystems:
   ext2: {fssize: 10, grow: True}
   xfs: {fssize: 20, grow: False}  # grow requires a mounted filesystem
   btrfs: {fssize: 100, grow: False}  # grow not implemented
+  vfat: {fssize: 20, grow: False}  # fatresize not supported due to segfaults
   # untested: lvm, requires a block device

--- a/test/integration/targets/filesystem/tasks/create_fs.yml
+++ b/test/integration/targets/filesystem/tasks/create_fs.yml
@@ -50,7 +50,7 @@
   - name: increase fake device
     shell: 'dd if=/dev/zero bs=1M count=20 >> {{ dev }}'
 
-  - when: 'grow|bool'
+  - when: 'grow|bool and (fstype != "vfat" or resize_vfat)'
     block:
     - name: Expand filesystem
       filesystem:

--- a/test/integration/targets/filesystem/tasks/create_fs.yml
+++ b/test/integration/targets/filesystem/tasks/create_fs.yml
@@ -81,6 +81,7 @@
           - 'fs5_result is successful'
 
   - import_tasks: overwrite_another_fs.yml
+    when: ansible_system != 'FreeBSD'
 
   always:
     - file:

--- a/test/integration/targets/filesystem/tasks/overwrite_another_fs.yml
+++ b/test/integration/targets/filesystem/tasks/overwrite_another_fs.yml
@@ -3,11 +3,19 @@
 
 - name: 'Create a vfat filesystem'
   command: 'mkfs.vfat {{ dev }}'
-  when: ansible_system != 'FreeBSD'
+  when: ansible_system != 'FreeBSD' and fstype != 'vfat'
 
 - name: 'Create a vfat filesystem'
   command: 'newfs_msdos -F12 {{ dev }}'
-  when: ansible_system == 'FreeBSD'
+  when: ansible_system == 'FreeBSD' and fstype != 'vfat'
+
+- name: 'Create a ext2 filesystem'
+  command: 'mkfs.ext2 {{ dev }}'
+  when: ansible_system != 'FreeBSD' and fstype == 'vfat'
+
+- name: 'Create a UFS filesystem'
+  command: 'newfs {{ dev }}'
+  when: ansible_system == 'FreeBSD' and fstype == 'vfat'
 
 - command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
   register: uuid

--- a/test/integration/targets/filesystem/tasks/overwrite_another_fs.yml
+++ b/test/integration/targets/filesystem/tasks/overwrite_another_fs.yml
@@ -12,11 +12,7 @@
 - name: 'Create a ext2 filesystem'
   # -F flag may not be necessary on mke2fs >= 1.43.6
   command: 'mkfs.ext2 -F {{ dev }}'
-  when: ansible_system != 'FreeBSD' and fstype == 'vfat'
-
-- name: 'Create a UFS filesystem'
-  command: 'newfs {{ dev }}'
-  when: ansible_system == 'FreeBSD' and fstype == 'vfat'
+  when: fstype == 'vfat'
 
 - command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
   register: uuid

--- a/test/integration/targets/filesystem/tasks/overwrite_another_fs.yml
+++ b/test/integration/targets/filesystem/tasks/overwrite_another_fs.yml
@@ -10,7 +10,8 @@
   when: ansible_system == 'FreeBSD' and fstype != 'vfat'
 
 - name: 'Create a ext2 filesystem'
-  command: 'mkfs.ext2 {{ dev }}'
+  # -F flag may not be necessary on mke2fs >= 1.43.6
+  command: 'mkfs.ext2 -F {{ dev }}'
   when: ansible_system != 'FreeBSD' and fstype == 'vfat'
 
 - name: 'Create a UFS filesystem'

--- a/test/integration/targets/filesystem/tasks/overwrite_another_fs.yml
+++ b/test/integration/targets/filesystem/tasks/overwrite_another_fs.yml
@@ -1,18 +1,8 @@
 - name: 'Recreate "disk" file'
   command: 'dd if=/dev/zero of={{ dev }} bs=1M count={{ fssize }}'
 
-- name: 'Create a vfat filesystem'
-  command: 'mkfs.vfat {{ dev }}'
-  when: ansible_system != 'FreeBSD' and fstype != 'vfat'
-
-- name: 'Create a vfat filesystem'
-  command: 'newfs_msdos -F12 {{ dev }}'
-  when: ansible_system == 'FreeBSD' and fstype != 'vfat'
-
-- name: 'Create a ext2 filesystem'
-  # -F flag may not be necessary on mke2fs >= 1.43.6
-  command: 'mkfs.ext2 -F {{ dev }}'
-  when: fstype == 'vfat'
+- name: 'Create a swap filesystem'
+  command: 'mkswap {{ dev }}'
 
 - command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
   register: uuid

--- a/test/integration/targets/filesystem/tasks/setup.yml
+++ b/test/integration/targets/filesystem/tasks/setup.yml
@@ -7,7 +7,6 @@
     - e2fsprogs
     - xfsprogs
     - dosfstools
-    - fatresize
 
 - block:
   - name: install btrfs progs
@@ -32,16 +31,26 @@
       - btrfsprogs
   when: ansible_system == 'Linux'
 
+- block:
+  - name: install fatresize
+    package:
+      name: fatresize
+      state: present
+  - command: fatresize --help
+    register: fatresize
+  - set_fact:
+      fatresize_version: '{{ fatresize.stdout_lines[0] | regex_search("[0-9]+\.[0-9]+\.[0-9]+")  }}'
+  when:
+    - ansible_system == 'Linux'
+    - ansible_os_family != 'Suse'
+    - ansible_os_family != 'RedHat' or (ansible_distribution == 'CentOS' and ansible_distribution_version is version('7.0', '>='))
+
 - command: mke2fs -V
   register: mke2fs
-
-- command: fatresize --help
-  register: fatresize
 
 - set_fact:
     # mke2fs 1.43.6 (29-Aug-2017)
     e2fsprogs_version: '{{ mke2fs.stderr_lines[0] | regex_search("[0-9]{1,2}\.[0-9]{1,2}(\.[0-9]{1,2})?") }}'
-    fatresize_version: '{{ fatresize.stdout_lines[0] | regex_search("[0-9]+\.[0-9]+\.[0-9]+")  }}'
 
 - set_fact:
     # http://e2fsprogs.sourceforge.net/e2fsprogs-release.html#1.43
@@ -49,4 +58,4 @@
     # using the entire block device.
     force_creation: "{{ e2fsprogs_version is version('1.43', '<') }}"
     # Earlier versions have a segfault bug
-    resize_vfat: "{{ fatresize_version is version('1.0.4', '>=') }}"
+    resize_vfat: "{{ fatresize_version|default('0.0') is version('1.0.4', '>=') }}"

--- a/test/integration/targets/filesystem/tasks/setup.yml
+++ b/test/integration/targets/filesystem/tasks/setup.yml
@@ -7,6 +7,7 @@
     - e2fsprogs
     - xfsprogs
     - dosfstools
+    - fatresize
 
 - block:
   - name: install btrfs progs
@@ -34,12 +35,18 @@
 - command: mke2fs -V
   register: mke2fs
 
+- command: fatresize --help
+  register: fatresize
+
 - set_fact:
     # mke2fs 1.43.6 (29-Aug-2017)
     e2fsprogs_version: '{{ mke2fs.stderr_lines[0] | regex_search("[0-9]{1,2}\.[0-9]{1,2}(\.[0-9]{1,2})?") }}'
+    fatresize_version: '{{ fatresize.stdout_lines[0] | regex_search("[0-9]+\.[0-9]+\.[0-9]+")  }}'
 
 - set_fact:
     # http://e2fsprogs.sourceforge.net/e2fsprogs-release.html#1.43
     # Mke2fs no longer complains if the user tries to create a file system
     # using the entire block device.
     force_creation: "{{ e2fsprogs_version is version('1.43', '<') }}"
+    # Earlier versions have a segfault bug
+    resize_vfat: "{{ fatresize_version is version('1.0.4', '>=') }}"


### PR DESCRIPTION
##### SUMMARY
This adds vfat support to the filesystem module. In my case, I need this because EFI partitions must be FAT32 formatted.

I was also quite confused by the logic in the module, so I re-factored it to make it (IMHO) clearer. This is a separate commit so it can be dropped/split into another PR if it is controversial.


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
filesystem module

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/kjw53/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/kjw53/.pip/lib/python2.7/site-packages/ansible-2.4.0-py2.7.egg/ansible
  executable location = /home/kjw53/.pip/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```

##### Additional Information

I can't seem to run tests on Debian Stretch (pytest does not recognize the `--boxed` option). If I can somehow add tests to the filesystem module, I am happy to, just can't find any documentation on the subject.