### PR TITLE
nmcli: Param type should be mandatory

### DIFF
--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -59,8 +59,8 @@ options:
             - A special value of "*" can be used for interface-independent connections.
             - The ifname argument is mandatory for all connection types except bond, team, bridge and vlan.
     type:
-        required: False
-        choices: [ ethernet, team, team-slave, bond, bond-slave, bridge, vlan ]
+        required: True
+        choices: [ethernet, team, team-slave, bond, bond-slave, bridge, vlan]
         description:
             - This is the type of device or network connection that you wish to create or modify.
     mode:

--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -1102,7 +1102,7 @@ def main():
             conn_name=dict(required=True, type='str'),
             master=dict(required=False, default=None, type='str'),
             ifname=dict(required=False, default=None, type='str'),
-            type=dict(required=False, default=None, choices=['ethernet', 'team', 'team-slave', 'bond', 'bond-slave', 'bridge', 'vlan'], type='str'),
+            type=dict(required=True, default=None, choices=['ethernet', 'team', 'team-slave', 'bond', 'bond-slave', 'bridge', 'vlan'], type='str'),
             ip4=dict(required=False, default=None, type='str'),
             gw4=dict(required=False, default=None, type='str'),
             dns4=dict(required=False, default=None, type='str'),


### PR DESCRIPTION
##### SUMMARY
Parameter type should be mandatory. Currently if no connection type is defined and state is set to present, you get a list index out of range error when calling create_connection method as cmd is empty.
In fact, trying to run nmcli in a console without specifying type param you get an error

```
[root@host: ~]# nmcli connection add con-name con ifname name
Error: 'type' argument is required
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
nmcli module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
type `required=False`
```
ansible host -i hosts -m nmcli -a "state=present conn_name=con"
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: IndexError: list index out of range
host | FAILED! => {
    "changed": false, 
    "cmd": "", 
    "failed": true, 
    "msg": "list index out of range", 
    "rc": 257
}

```
type `required=True`
```
ansible host -i hosts -m nmcli -a "state=present conn_name=con"
host | FAILED! => {
    "changed": false, 
    "failed": true, 
    "msg": "missing required arguments: type"
}
```