### PR TITLE
Fix documented key_secret default in nsupdate module

### DIFF
--- a/lib/ansible/modules/network/nsupdate.py
+++ b/lib/ansible/modules/network/nsupdate.py
@@ -55,7 +55,6 @@ options:
     key_secret:
         description:
             - Use TSIG key secret, associated with C(key_name), to authenticate against C(server)
-        default: 7911
     key_algorithm:
         description:
             - Specify key algorithm used by C(key_secret).


### PR DESCRIPTION
The nsupdate module itself doesn't implement any default value for the
key_secret parameter. Neither does the value in question make much sense.