### PR TITLE
Include .yamllint in manifest so yamllint works.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ prune hacking
 include README.md COPYING
 include requirements.txt
 include .coveragerc
+include .yamllint
 include examples/hosts
 include examples/ansible.cfg
 include lib/ansible/module_utils/powershell.ps1


### PR DESCRIPTION
##### SUMMARY

Without this, running the yamllint test from the source tarball will fail.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

MANIFEST.in

##### ANSIBLE VERSION

```
ansible 2.4.0 (manifest-yamllint 468accdb40) last updated 2017/04/12 10:22:17 (GMT -700)
  config file = 
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
