### PR TITLE
Clean up import statements for nxos_rollback

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_rollback.py
+++ b/lib/ansible/modules/network/nxos/nxos_rollback.py
@@ -78,67 +78,18 @@ status:
 '''
 
 
-from ansible.module_utils.pycompat24 import get_exception
-from ansible.module_utils.nxos import nxos_argument_spec
+from ansible.module_utils.nxos import nxos_argument_spec, run_commands
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.shell import ShellError
-
-
-def execute_commands(cmds, module, command_type=None):
-    command_type_map = {
-        'cli_show': 'json',
-        'cli_show_ascii': 'text'
-    }
-
-    try:
-        if command_type:
-            response = module.execute(cmds, command_type=command_type)
-        else:
-            response = module.execute(cmds)
-    except ShellError:
-        clie = get_exception()
-        module.fail_json(msg='Error sending {0}'.format(cmds),
-                         error=str(clie))
-    except AttributeError:
-        try:
-            if command_type:
-                command_type = command_type_map.get(command_type)
-                module.cli.add_commands(cmds, output=command_type)
-                response = module.cli.run_commands()
-            else:
-                module.cli.add_commands(cmds, output=command_type)
-                response = module.cli.run_commands()
-        except ShellError:
-            clie = get_exception()
-            module.fail_json(msg='Error sending {0}'.format(cmds),
-                             error=str(clie))
-    return response
-
-
-def prepare_show_command(command, module):
-    if module.params['transport'] == 'cli':
-        execute_commands(command, module)
-    elif module.params['transport'] == 'nxapi':
-        execute_commands(command, module, command_type='cli_show_ascii')
 
 
 def checkpoint(filename, module):
     commands = ['terminal dont-ask', 'checkpoint file %s' % filename]
-    prepare_show_command(commands, module)
+    run_commands(module, commands)
 
 
 def rollback(filename, module):
     commands = ['rollback running-config file %s' % filename]
-    try:
-        module.configure(commands)
-    except AttributeError:
-        try:
-            module.cli.add_commands(commands, output='config')
-            module.cli.run_commands()
-        except ShellError:
-            clie = get_exception()
-            module.fail_json(msg='Error sending CLI commands',
-                             error=str(clie), commands=commands)
+    run_commands(module, commands)
 
 
 def main():
@@ -153,9 +104,9 @@ def main():
     argument_spec.update(nxos_argument_spec)
 
     module = AnsibleModule(argument_spec=argument_spec,
-                        mutually_exclusive=[['checkpoint_file',
-                                             'rollback_to']],
-                        supports_check_mode=False)
+                           mutually_exclusive=[['checkpoint_file',
+                                                'rollback_to']],
+                           supports_check_mode=False)
 
     checkpoint_file = module.params['checkpoint_file']
     rollback_to = module.params['rollback_to']
@@ -163,18 +114,15 @@ def main():
     status = None
     filename = None
     changed = False
-    try:
-        if checkpoint_file:
-            checkpoint(checkpoint_file, module)
-            status = 'checkpoint file created'
-        elif rollback_to:
-            rollback(rollback_to, module)
-            status = 'rollback executed'
-        changed = True
-        filename = rollback_to or checkpoint_file
-    except ShellError:
-        clie = get_exception()
-        module.fail_json(msg=str(clie))
+
+    if checkpoint_file:
+        checkpoint(checkpoint_file, module)
+        status = 'checkpoint file created'
+    elif rollback_to:
+        rollback(rollback_to, module)
+        status = 'rollback executed'
+    changed = True
+    filename = rollback_to or checkpoint_file
 
     module.exit_json(changed=changed, status=status, filename=filename)
 

--- a/lib/ansible/modules/network/nxos/nxos_rollback.py
+++ b/lib/ansible/modules/network/nxos/nxos_rollback.py
@@ -78,13 +78,10 @@ status:
 '''
 
 
-import re
-from ansible.module_utils.nxos import get_config, load_config, run_commands
-from ansible.module_utils.nxos import nxos_argument_spec, check_args
+from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils.nxos import nxos_argument_spec
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.netcfg import CustomNetworkConfig
-
-import re
+from ansible.module_utils.shell import ShellError
 
 
 def execute_commands(cmds, module, command_type=None):
@@ -184,4 +181,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -588,7 +588,6 @@ lib/ansible/modules/network/nxos/nxos_pim_rp_address.py
 lib/ansible/modules/network/nxos/nxos_ping.py
 lib/ansible/modules/network/nxos/nxos_portchannel.py
 lib/ansible/modules/network/nxos/nxos_reboot.py
-lib/ansible/modules/network/nxos/nxos_rollback.py
 lib/ansible/modules/network/nxos/nxos_smu.py
 lib/ansible/modules/network/nxos/nxos_snapshot.py
 lib/ansible/modules/network/nxos/nxos_snmp_community.py


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
nxos_rollback import statements are out of date. This removes unnecessary imports and adds missing ones

Fixes #23531

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
nxos_rollback

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0
```
