### PR TITLE
Improve Fortios IPv4 policy with logging capabilities and use the backup_filename param

### DIFF
--- a/lib/ansible/module_utils/fortios.py
+++ b/lib/ansible/module_utils/fortios.py
@@ -65,13 +65,17 @@ fortios_error_codes = {
 
 def backup(module,running_config):
     backup_path = module.params['backup_path']
+    backup_filename = module.params['backup_filename']
     if not os.path.exists(backup_path):
         try:
             os.mkdir(backup_path)
         except:
             module.fail_json(msg="Can't create directory {0} Permission denied ?".format(backup_path))
     tstamp = time.strftime("%Y-%m-%d@%H:%M:%S", time.localtime(time.time()))
-    filename = '%s/%s_config.%s' % (backup_path, module.params['host'], tstamp)
+    if 0 < len(backup_filename):
+        filename = '%s/%s' % (backup_path, backup_filename)
+    else:
+        filename = '%s/%s_config.%s' % (backup_path, module.params['host'], tstamp)
     try:
         open(filename, 'w').write(running_config)
     except:

--- a/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
+++ b/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
@@ -117,6 +117,15 @@ options:
   application_list:
     description:
       - Specifies Application Control name.
+  logtraffic:
+    description:
+      - Logs sessions that matched policy.
+    default: utm
+    choices: ["disable", "utm", "all"]
+  logtraffic_start:
+      - Logs begining of session as well.
+    default: false
+    choices: ["true", "false"]
   comment:
     description:
       - free text to describe policy.
@@ -131,12 +140,13 @@ EXAMPLES = """
     username: admin
     password: password
     id: 42
-    srcaddr: internal_network
-    dstaddr: all
+    src_addr: internal_network
+    dst_addr: all
     service: dns
     nat: True
     state: present
     policy_action: accept
+    logtraffic: disable
 
 - name: Public Web
   fortios_ipv4_policy:
@@ -144,8 +154,8 @@ EXAMPLES = """
     username: admin
     password: password
     id: 42
-    srcaddr: all
-    dstaddr: webservers
+    src_addr: all
+    dst_addr: webservers
     services:
       - http
       - https
@@ -197,13 +207,15 @@ def main():
         webfilter_profile         = dict(type='str'),
         ips_sensor                = dict(type='str'),
         application_list          = dict(type='str'),
+        logtraffic                = dict(choices=['disable','all','utm'], default='utm'),
+        logtraffic_start          = dict(type='bool', default=False),
     )
 
     #merge global required_if & argument_spec from module_utils/fortios.py
     argument_spec.update(fortios_argument_spec)
 
     ipv4_policy_required_if = [
-        ['state', 'present', ['src_addr', 'dst_addr', 'policy_action', 'service']],
+        ['state', 'present', ['src_addr', 'dst_addr', 'policy_action', 'service','logtraffic','logtraffic_start']],
     ]
 
     module = AnsibleModule(
@@ -225,6 +237,11 @@ def main():
             module.fail_json(msg='Poolname param requires NAT to be true.')
         if module.params['fixedport']:
             module.fail_json(msg='Fixedport param requires NAT to be true.')
+
+    #log options
+    if module.params['logtraffic_start']:
+        if not module.params['logtraffic'] == 'all':
+            module.fail_json(msg='Logtraffic_start param requires logtraffic to be set to "all".')
 
     #id must be str(int) for pyFG to work
     policy_id = str(module.params['id'])
@@ -259,6 +276,14 @@ def main():
 
         # action
         new_policy.set_param('action', '%s' % (module.params['policy_action']))
+
+        #logging
+        new_policy.set_param('logtraffic', '%s' % (module.params['logtraffic']))
+        if module.params['logtraffic'] == 'all':
+            if module.params['logtraffic_start']:
+                new_policy.set_param('logtraffic-start', 'enable')
+            else:
+                new_policy.set_param('logtraffic-start', 'disable')
 
         # Schedule
         new_policy.set_param('schedule', '%s' % (module.params['schedule']))

--- a/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
+++ b/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
@@ -121,8 +121,9 @@ options:
     description:
       - Logs sessions that matched policy.
     default: utm
-    choices: ["disable", "utm", "all"]
+    choices: ['disable', 'utm', 'all']
   logtraffic_start:
+    description:
       - Logs begining of session as well.
     default: false
     choices: ["true", "false"]
@@ -215,7 +216,7 @@ def main():
     argument_spec.update(fortios_argument_spec)
 
     ipv4_policy_required_if = [
-        ['state', 'present', ['src_addr', 'dst_addr', 'policy_action', 'service','logtraffic','logtraffic_start']],
+        ['state', 'present', ['src_addr', 'dst_addr', 'policy_action', 'service']],
     ]
 
     module = AnsibleModule(

--- a/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
+++ b/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
@@ -118,11 +118,13 @@ options:
     description:
       - Specifies Application Control name.
   logtraffic:
+    version_added: "2.4"
     description:
       - Logs sessions that matched policy.
     default: utm
     choices: ['disable', 'utm', 'all']
   logtraffic_start:
+    version_added: "2.4"
     description:
       - Logs begining of session as well.
     default: false


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
- Improve Fortios IPv4 policy with logging capabilities and fix typos in examples.

Add the logtraffic and logtraffic_start options to firewall rule.
Fix 2 small typos in examples.

- Forti_config: use the backup_filename param and don't enforce the the filename value.

The backup_filename parameter was defined but code never used it. Now, if backup_filename is present, it overrrides the default config name.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Affects modules/network/fortios

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
[claer@sebastian ansible-fg]$ ansible --version
ansible 2.3.0.0 (stable-2.3 9818ca366d) last updated 2017/04/12 13:55:20 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
[claer@sebastian ansible-fg]$ 

```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
