### PR TITLE
Fix module validator blacklist handling.

### DIFF
--- a/test/sanity/validate-modules/validate-modules
+++ b/test/sanity/validate-modules/validate-modules
@@ -834,19 +834,25 @@ class ModuleValidator(Validator):
                      (option, should_be, version_added))
                 ))
 
+    @staticmethod
+    def is_blacklisted(path):
+        base_name = os.path.basename(path)
+        file_name, _ = os.path.splitext(base_name)
+
+        if file_name.startswith('_') and os.path.islink(path):
+            return True
+
+        if not frozenset((base_name, file_name)).isdisjoint(ModuleValidator.BLACKLIST):
+            return True
+
+        for pat in ModuleValidator.BLACKLIST_PATTERNS:
+            if fnmatch(base_name, pat):
+                return True
+
+        return False
+
     def validate(self):
         super(ModuleValidator, self).validate()
-
-        if self.object_name.startswith('_') and os.path.islink(self.object_path):
-            return
-
-        # Blacklists -- these files are not checked
-        if not frozenset((self.basename,
-                          self.name)).isdisjoint(self.BLACKLIST):
-            return
-        for pat in self.BLACKLIST_PATTERNS:
-            if fnmatch(self.basename, pat):
-                return
 
 #        if self._powershell_module():
 #            self.warnings.append('Cannot check powershell modules at this '
@@ -974,6 +980,8 @@ def main():
             path = module
             if args.exclude and args.exclude.search(path):
                 sys.exit(0)
+            if ModuleValidator.is_blacklisted(path):
+                sys.exit(0)
             with ModuleValidator(path, analyze_arg_spec=args.arg_spec,
                                  base_branch=args.base_branch, git_cache=git_cache) as mv:
                 mv.validate()
@@ -996,6 +1004,8 @@ def main():
             for filename in files:
                 path = os.path.join(root, filename)
                 if args.exclude and args.exclude.search(path):
+                    continue
+                if ModuleValidator.is_blacklisted(path):
                     continue
                 with ModuleValidator(path, analyze_arg_spec=args.arg_spec,
                                      base_branch=args.base_branch, git_cache=git_cache) as mv:


### PR DESCRIPTION
##### SUMMARY

Process the blacklist before creating a validator instance.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

validate-modules

##### ANSIBLE VERSION

```
ansible 2.4.0 (validate-blacklist c025e186c3) last updated 2017/04/12 23:03:18 (GMT -700)
  config file = 
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]

```