### PR TITLE
gce_net: change default to match with b7e78656 for idempotency

### DIFF
--- a/lib/ansible/modules/cloud/google/gce_net.py
+++ b/lib/ansible/modules/cloud/google/gce_net.py
@@ -65,20 +65,20 @@ options:
     description:
       - the source IPv4 address range in CIDR notation
     required: false
-    default: null
+    default: []
     aliases: ['src_cidr']
   src_tags:
     description:
       - the source instance tags for creating a firewall rule
     required: false
-    default: null
+    default: []
     aliases: []
   target_tags:
     version_added: "1.9"
     description:
       - the target instance tags for creating a firewall rule
     required: false
-    default: null
+    default: []
     aliases: []
   state:
     description:
@@ -325,9 +325,9 @@ def main():
             ipv4_range = dict(),
             fwname = dict(),
             name = dict(),
-            src_range = dict(type='list'),
-            src_tags = dict(type='list'),
-            target_tags = dict(type='list'),
+            src_range = dict(default=[], type='list'),
+            src_tags = dict(default=[], type='list'),
+            target_tags = dict(default=[], type='list'),
             state = dict(default='present'),
             service_account_email = dict(),
             pem_file = dict(type='path'),


### PR DESCRIPTION
##### SUMMARY
Commit b7e78656 casts `fw.source_ranges`/`fw.source_tags`/`fw.target_tags` to empty list if it is null, but leaves the module default for `src_range`/`src_tags`/`target_tags` as null. If any of these module options is left as the default null (especially common for `src_range`), the idempotency check will fail, and the firewall rule will keep getting recreated.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
gce_net module

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Apr 12 2017, 12:57:24) [GCC 5.4.0]
```


##### ADDITIONAL INFORMATION
To reproduce, remove the 2 lines with `src_range` from the example in https://github.com/ansible/ansible/pull/20483#issuecomment-275537807

The 2nd assertion would fail.