### PR TITLE
Minor fix to example in ec2_group docs

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -92,7 +92,7 @@ EXAMPLES = '''
     name: example
     description: an example EC2 group
     vpc_id: 12345
-    region: eu-west-1a
+    region: eu-west-1
     aws_secret_key: SECRET
     aws_access_key: ACCESS
     rules:
@@ -141,7 +141,7 @@ EXAMPLES = '''
     name: example2
     description: an example2 EC2 group
     vpc_id: 12345
-    region: eu-west-1a
+    region: eu-west-1
     rules:
       # 'ports' rule keyword was introduced in version 2.4. It accepts a single port value or a list of values including ranges (from_port-to_port).
       - proto: tcp


### PR DESCRIPTION
##### SUMMARY
Example in docs for region option was actually stating an availability zone (eu-west-1 vs eu-west-1a).

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
modules/cloud/amazon/ec2_group

##### ANSIBLE VERSION
develop

##### ADDITIONAL INFORMATION
-    region: eu-west-1a
+    region: eu-west-1