### PR TITLE
Option to validate SSL cert

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix_maintenance.py
+++ b/lib/ansible/modules/monitoring/zabbix_maintenance.py
@@ -118,6 +118,7 @@ options:
         description:
             - Validate SSL certificate of the Zabbix server.
         default: true
+        version_added: "2.4"
         required: false
 notes:
     - Useful for setting hosts in maintenance mode before big update,

--- a/lib/ansible/modules/monitoring/zabbix_maintenance.py
+++ b/lib/ansible/modules/monitoring/zabbix_maintenance.py
@@ -114,6 +114,11 @@ options:
         default: 10
         version_added: "2.1"
         required: false
+    validate_certs:
+        description:
+            - Validate SSL certificate of the Zabbix server.
+        default: true
+        required: false
 notes:
     - Useful for setting hosts in maintenance mode before big update,
       and removing maintenance window after update.
@@ -294,6 +299,7 @@ def main():
             desc=dict(type='str', required=False, default="Created by Ansible"),
             collect_data=dict(type='bool', required=False, default=True),
             timeout=dict(type='int', default=10),
+            validate_certs=dict(type='bool', required=False, default=True),
         ),
         supports_check_mode=True,
     )
@@ -314,6 +320,7 @@ def main():
     server_url = module.params['server_url']
     collect_data = module.params['collect_data']
     timeout = module.params['timeout']
+    validate_certs = module.params['validate_certs']
 
     if collect_data:
         maintenance_type = 0
@@ -321,7 +328,7 @@ def main():
         maintenance_type = 1
 
     try:
-        zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password)
+        zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password, validate_certs=validate_certs)
         zbx.login(login_user, login_password)
     except BaseException as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)


### PR DESCRIPTION
Option to validate SSL certificate of the Zabbix server (default: true)

##### SUMMARY
Added validate_certs option already supported by zabbix-api 0.4 so you can disable certificate validation of https Zabbix server URLs.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
zabbix_maintenance module

##### ANSIBLE VERSION
```
ansible 2.3.0.0
```

