### PR TITLE
Make it easier to find network modules

### DIFF
--- a/lib/ansible/modules/network/asa/asa_command.py
+++ b/lib/ansible/modules/network/asa/asa_command.py
@@ -27,7 +27,7 @@ DOCUMENTATION = """
 module: asa_command
 version_added: "2.2"
 author: "Peter Sprygada (@privateip), Patrick Ogenstad (@ogenstad)"
-short_description: Run arbitrary commands on Cisco ASA devices.
+short_description: Run arbitrary commands on Cisco ASA devices
 description:
   - Sends arbitrary commands to an ASA node and returns the results
     read from the device. The C(asa_command) module includes an

--- a/lib/ansible/modules/network/asa/asa_config.py
+++ b/lib/ansible/modules/network/asa/asa_config.py
@@ -26,7 +26,7 @@ DOCUMENTATION = """
 module: asa_config
 version_added: "2.2"
 author: "Peter Sprygada (@privateip), Patrick Ogenstad (@ogenstad)"
-short_description: Manage Cisco ASA configuration sections
+short_description: Manage configuration sections on Cisco ASA devices
 description:
   - Cisco ASA configurations use a simple block indent file syntax
     for segmenting configuration into sections.  This module provides

--- a/lib/ansible/modules/network/cumulus/_cl_license.py
+++ b/lib/ansible/modules/network/cumulus/_cl_license.py
@@ -25,7 +25,7 @@ DOCUMENTATION = '''
 module: cl_license
 version_added: "2.1"
 author: "Cumulus Networks (@CumulusNetworks)"
-short_description: Install Cumulus Linux license
+short_description: Install licenses fo Cumulus Linux
 deprecated: Deprecated in 2.3.
 description:
     - Installs a Cumulus Linux license. The module reports no change of status

--- a/lib/ansible/modules/network/fortios/fortios_config.py
+++ b/lib/ansible/modules/network/fortios/fortios_config.py
@@ -29,7 +29,7 @@ DOCUMENTATION = """
 module: fortios_config
 version_added: "2.3"
 author: "Benjamin Jolivot (@bjolivot)"
-short_description: Manage fortios firewall config
+short_description: Manage config on Fortinet FortiOS firewall devices
 description:
   - This module provides management of FortiOS Devices configuration.
 extends_documentation_fragment: fortios

--- a/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
+++ b/lib/ansible/modules/network/fortios/fortios_ipv4_policy.py
@@ -29,7 +29,7 @@ DOCUMENTATION = """
 module: fortios_ipv4_policy
 version_added: "2.3"
 author: "Benjamin Jolivot (@bjolivot)"
-short_description: Manage fortios firewall IPv4 policy objects
+short_description: Manage IPv4 policy objects on Fortinet FortiOS firewall devices
 description:
   - This module provides management of firewall IPv4 policies on FortiOS devices.
 extends_documentation_fragment: fortios

--- a/lib/ansible/modules/network/illumos/flowadm.py
+++ b/lib/ansible/modules/network/illumos/flowadm.py
@@ -27,7 +27,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 DOCUMENTATION = '''
 ---
 module: flowadm
-short_description: Manage bandwidth resource control and priority for protocols, services and zones.
+short_description: Manage bandwidth resource control and priority for protocols, services and zones on Solaris/illumos systems
 description:
     - Create/modify/remove networking bandwidth and associated resources for a type of traffic on a particular link.
 version_added: "2.2"

--- a/lib/ansible/modules/network/illumos/ipadm_addr.py
+++ b/lib/ansible/modules/network/illumos/ipadm_addr.py
@@ -27,7 +27,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 DOCUMENTATION = '''
 ---
 module: ipadm_addr
-short_description: Manage IP addresses on an interface.
+short_description: Manage IP addresses on an interface on Solaris/illumos systems
 description:
     - Create/delete static/dynamic IP addresses on network interfaces on Solaris/illumos systems.
     - Up/down static/dynamic IP addresses on network interfaces on Solaris/illumos systems.

--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -25,7 +25,7 @@ DOCUMENTATION = """
 module: ios_facts
 version_added: "2.2"
 author: "Peter Sprygada (@privateip)"
-short_description: Collect facts from remote devices running IOS
+short_description: Collect facts from remote devices running Cisco IOS
 description:
   - Collects a base set of device facts from a remote device that
     is running IOS.  This module prepends all of the

--- a/lib/ansible/modules/network/ios/ios_vrf.py
+++ b/lib/ansible/modules/network/ios/ios_vrf.py
@@ -26,7 +26,7 @@ DOCUMENTATION = """
 module: ios_vrf
 version_added: "2.3"
 author: "Peter Sprygada (@privateip)"
-short_description: Manage the collection of VRF definitions on IOS devices
+short_description: Manage the collection of VRF definitions on Cisco IOS devices
 description:
   - This module provides declarative management of VRF definitions on
     Cisco IOS devices.  It allows playbooks to manage individual or

--- a/lib/ansible/modules/network/iosxr/_iosxr_template.py
+++ b/lib/ansible/modules/network/iosxr/_iosxr_template.py
@@ -26,7 +26,7 @@ DOCUMENTATION = """
 module: iosxr_template
 version_added: "2.1"
 author: "Ricardo Carrillo Cruz (@rcarrillocruz)"
-short_description: Manage Cisco IOSXR device configurations over SSH
+short_description: Manage Cisco IOS-XR device configurations over SSH
 description:
   - Manages network device configurations over SSH.  This module
     allows implementers to work with the device running-config.  It

--- a/lib/ansible/modules/network/iosxr/_iosxr_template.py
+++ b/lib/ansible/modules/network/iosxr/_iosxr_template.py
@@ -26,7 +26,7 @@ DOCUMENTATION = """
 module: iosxr_template
 version_added: "2.1"
 author: "Ricardo Carrillo Cruz (@rcarrillocruz)"
-short_description: Manage Cisco IOS-XR device configurations over SSH
+short_description: Manage Cisco IOS XR device configurations over SSH
 description:
   - Manages network device configurations over SSH.  This module
     allows implementers to work with the device running-config.  It

--- a/lib/ansible/modules/network/iosxr/iosxr_command.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_command.py
@@ -26,7 +26,7 @@ DOCUMENTATION = """
 module: iosxr_command
 version_added: "2.1"
 author: "Ricardo Carrillo Cruz (@rcarrillocruz)"
-short_description: Run commands on remote devices running Cisco iosxr
+short_description: Run commands on remote devices running Cisco IOS-XR
 description:
   - Sends arbitrary commands to an iosxr node and returns the results
     read from the device. This module includes an

--- a/lib/ansible/modules/network/iosxr/iosxr_command.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_command.py
@@ -26,9 +26,9 @@ DOCUMENTATION = """
 module: iosxr_command
 version_added: "2.1"
 author: "Ricardo Carrillo Cruz (@rcarrillocruz)"
-short_description: Run commands on remote devices running Cisco IOS-XR
+short_description: Run commands on remote devices running Cisco IOS XR
 description:
-  - Sends arbitrary commands to an iosxr node and returns the results
+  - Sends arbitrary commands to an IOS XR node and returns the results
     read from the device. This module includes an
     argument that will cause the module to wait for a specific condition
     before returning or timing out if the condition is not met.

--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -26,7 +26,7 @@ DOCUMENTATION = """
 module: iosxr_config
 version_added: "2.1"
 author: "Ricardo Carrillo Cruz (@rcarrillocruz)"
-short_description: Manage Cisco IOS-XR configuration sections
+short_description: Manage Cisco IOS XR configuration sections
 description:
   - Cisco IOS XR configurations use a simple block indent file syntax
     for segmenting configuration into sections.  This module provides

--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -26,7 +26,7 @@ DOCUMENTATION = """
 module: iosxr_config
 version_added: "2.1"
 author: "Ricardo Carrillo Cruz (@rcarrillocruz)"
-short_description: Manage Cisco IOS XR configuration sections
+short_description: Manage Cisco IOS-XR configuration sections
 description:
   - Cisco IOS XR configurations use a simple block indent file syntax
     for segmenting configuration into sections.  This module provides

--- a/lib/ansible/modules/network/iosxr/iosxr_facts.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_facts.py
@@ -25,10 +25,10 @@ DOCUMENTATION = """
 module: iosxr_facts
 version_added: "2.2"
 author: "Ricardo Carrillo Cruz (@rcarrillocruz)"
-short_description: Collect facts from remote devices running IOS-XR
+short_description: Collect facts from remote devices running IOS XR
 description:
   - Collects a base set of device facts from a remote device that
-    is running iosxr.  This module prepends all of the
+    is running IOS XR.  This module prepends all of the
     base network fact keys with C(ansible_net_<fact>).  The facts
     module will always collect a base set of facts from the device
     and can enable or disable collection of additional facts.

--- a/lib/ansible/modules/network/iosxr/iosxr_system.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_system.py
@@ -26,10 +26,10 @@ DOCUMENTATION = """
 module: iosxr_system
 version_added: "2.3"
 author: "Peter Sprygada (@privateip)"
-short_description: Manage the system attributes on Cisco IOS-XR devices
+short_description: Manage the system attributes on Cisco IOS XR devices
 description:
   - This module provides declarative management of node system attributes
-    on Cisco IOS-XR devices.  It provides an option to configure host system
+    on Cisco IOS XR devices.  It provides an option to configure host system
     parameters or remove those parameters from the device active
     configuration.
 extends_documentation_fragment: iosxr

--- a/lib/ansible/modules/network/junos/_junos_template.py
+++ b/lib/ansible/modules/network/junos/_junos_template.py
@@ -27,7 +27,7 @@ DOCUMENTATION = """
 module: junos_template
 version_added: "2.1"
 author: "Peter Sprygada (@privateip)"
-short_description: Manage configuration on remote devices running Junos
+short_description: Manage configuration on remote devices running Juniper JUNOS
 description:
   - This module will load a candidate configuration
     from a template file onto a remote device running Junos.  The

--- a/lib/ansible/modules/network/junos/junos_facts.py
+++ b/lib/ansible/modules/network/junos/junos_facts.py
@@ -26,7 +26,7 @@ DOCUMENTATION = """
 module: junos_facts
 version_added: "2.1"
 author: "Nathaniel Case (@qalthos)"
-short_description: Collect facts from remote devices running Junos
+short_description: Collect facts from remote devices running Juniper Junos
 description:
   - Collects fact information from a remote device running the Junos
     operating system.  By default, the module will collect basic fact

--- a/lib/ansible/modules/network/junos/junos_rpc.py
+++ b/lib/ansible/modules/network/junos/junos_rpc.py
@@ -26,7 +26,7 @@ DOCUMENTATION = """
 module: junos_rpc
 version_added: "2.3"
 author: "Peter Sprygada (@privateip)"
-short_description: Runs an arbitrary RPC on the remote device over NetConf
+short_description: Runs an arbitrary RPC over NetConf on an Juniper JUNOS device
 description:
   - Sends a request to the remote device running JUNOS to execute the
     specified RPC using the NetConf transport.  The reply is then

--- a/lib/ansible/modules/network/junos/junos_user.py
+++ b/lib/ansible/modules/network/junos/junos_user.py
@@ -26,7 +26,7 @@ DOCUMENTATION = """
 module: junos_user
 version_added: "2.3"
 author: "Peter Sprygada (@privateip)"
-short_description: Manage local user accounts on Juniper devices
+short_description: Manage local user accounts on Juniper JUNOS devices
 description:
   - This module manages locally configured user accounts on remote
     network devices running the JUNOS operating system.  It provides


### PR DESCRIPTION
##### SUMMARY
Feedback has been it's difficult (via Google or directly) to find
modules as some people search for the company name vs product name,
therefore specify both.


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
asa_command
fortios_config

##### ANSIBLE VERSION
```
2.4.0
```
