### PR TITLE
Fix nonexistent 'module_name' key in callbacks

### DIFF
--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -189,10 +189,8 @@ class CallbackModule(CallbackBase):
 
     def v2_runner_on_ok(self, result):
         res = result._result
-        try:
-            module = res['invocation']['module_name']
-        except KeyError:
-            module = None
+        module = result._task.action
+
         if module == 'setup':
             host = result._host.get_name()
             self.send_facts(host, res)

--- a/lib/ansible/plugins/callback/mail.py
+++ b/lib/ansible/plugins/callback/mail.py
@@ -87,7 +87,7 @@ class CallbackModule(CallbackBase):
         sender = '"Ansible: %s" <root>' % host
         attach = res._task.action
         if 'invocation' in res._result:
-            attach = "%s:  %s" % (res._result['invocation']['module_name'], json.dumps(res._result['invocation']['module_args']))
+            attach = "%s:  %s" % (res._task.action, json.dumps(res._result['invocation']['module_args']))
 
         subject = 'Failed: %s' % attach
         body = 'The following task failed for host ' + host + ':\n\n%s\n\n' % attach


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
`result._result['invocation']` does not have any `module_name` key.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - plugin/callback

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0 (detached HEAD 9818ca366d) last updated 2017/04/11 15:38:06 (GMT +200)
```
