### PR TITLE
fixes issue where network modules would ignore provider host value

### DIFF
--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -57,6 +57,7 @@ class ActionModule(_ActionModule):
             pc = copy.deepcopy(self._play_context)
             pc.connection = 'network_cli'
             pc.network_os = 'eos'
+            pc.remote_addr = provider['host'] or self._play_context.remote_addr
             pc.remote_user = provider['username'] or self._play_context.connection_user
             pc.password = provider['password'] or self._play_context.password
             pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file

--- a/lib/ansible/plugins/action/ios.py
+++ b/lib/ansible/plugins/action/ios.py
@@ -54,6 +54,7 @@ class ActionModule(_ActionModule):
         pc = copy.deepcopy(self._play_context)
         pc.connection = 'network_cli'
         pc.network_os = 'ios'
+        pc.remote_addr = provider['host'] or self._play_context.remote_addr
         pc.port = provider['port'] or self._play_context.port or 22
         pc.remote_user = provider['username'] or self._play_context.connection_user
         pc.password = provider['password'] or self._play_context.password

--- a/lib/ansible/plugins/action/iosxr.py
+++ b/lib/ansible/plugins/action/iosxr.py
@@ -54,6 +54,7 @@ class ActionModule(_ActionModule):
         pc = copy.deepcopy(self._play_context)
         pc.connection = 'network_cli'
         pc.network_os = 'iosxr'
+        pc.remote_addr = provider['host'] or self._play_context.remote_addr
         pc.port = provider['port'] or self._play_context.port or 22
         pc.remote_user = provider['username'] or self._play_context.connection_user
         pc.password = provider['password'] or self._play_context.password

--- a/lib/ansible/plugins/action/vyos.py
+++ b/lib/ansible/plugins/action/vyos.py
@@ -53,6 +53,7 @@ class ActionModule(_ActionModule):
         pc = copy.deepcopy(self._play_context)
         pc.connection = 'network_cli'
         pc.network_os = 'vyos'
+        pc.remote_addr = provider['host'] or self._play_context.remote_addr
         pc.port = provider['port'] or self._play_context.port or 22
         pc.remote_user = provider['username'] or self._play_context.connection_user
         pc.password = provider['password'] or self._play_context.password


### PR DESCRIPTION
This addresses a problem where the action plugin would ignore the
remote_addr value for the host.  In this case, only the inventory values
for the hostname would be considered and populate the remote host
remote_addr value for the connection plugin.

