### PR TITLE
Fix return code

### DIFF
--- a/lib/ansible/modules/monitoring/honeybadger_deployment.py
+++ b/lib/ansible/modules/monitoring/honeybadger_deployment.py
@@ -137,7 +137,7 @@ def main():
         e = get_exception()
         module.fail_json(msg='Unable to notify Honeybadger: %s' % e)
     else:
-        if info['status'] == 200:
+        if info['status'] == 201:
             module.exit_json(changed=True)
         else:
             module.fail_json(msg="HTTP result code: %d connecting to %s" % (info['status'], url))


### PR DESCRIPTION
##### SUMMARY
This module should exit successfully when it gets a 201 return code from the Honeybadger API.  Currently it's exiting with failure because it is expecting a 200 return code, even though the deployment was successfully recorded (as indicated by the 201 response code).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module/honeybadger_deployment

##### ANSIBLE VERSION
```
ansible 2.2.2.0
  config file =
  configured module search path = Default w/o overrides
```
