### PR TITLE
New module: Add module to install/remove/register/unregiser windows powershell modules (windows/win_psmodule)

### DIFF
--- a/lib/ansible/modules/windows/win_psmodule.ps1
+++ b/lib/ansible/modules/windows/win_psmodule.ps1
@@ -42,6 +42,7 @@ Function Install-NugetProvider {
   if (!($PackageProvider)){
       try{
         Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -ErrorAction Stop -WhatIf:$CheckMode | out-null
+        $result.changed = $true
       }
       catch{
         $ErrorMessage = "Problems adding package provider: $($_.Exception.Message)"
@@ -65,6 +66,7 @@ Function Install-Repository {
       try {
         if (!($CheckMode)){
           Register-PSRepository -Name $Name -SourceLocation $Url -InstallationPolicy Trusted -ErrorAction Stop
+          $result.changed = $true
         }
       }
       catch {
@@ -88,6 +90,7 @@ Function Remove-Repository{
         try{
           if (!($CheckMode)){
             Unregister-PSRepository -Name $Name -ErrorAction Stop
+            $result.changed = $true
           }
         }
         catch{
@@ -139,8 +142,8 @@ Function Remove-PsModule {
     if (Get-Module -Listavailable|?{$_.name -eq $Name}){
       try{
         Uninstall-Module -Name $Name -Confirm:$false -Force -ErrorAction Stop -WhatIf:$CheckMode | out-null
-        $result.changed = $true
         $result.output = "Module $($Name) removed"
+        $result.changed = $true
       }
       catch{
         $ErrorMessage = "Problems removing $($Name) module: $($_.Exception.Message)"

--- a/lib/ansible/modules/windows/win_psmodule.ps1
+++ b/lib/ansible/modules/windows/win_psmodule.ps1
@@ -1,0 +1,154 @@
+#!powershell
+# This file is part of Ansible
+#
+# Copyright 2016, Daniele Lazzari <lazzari@mailup.com>
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# WANT_JSON
+# POWERSHELL_COMMON
+
+# win_psmodule (Powershell modules Additions/Removal)
+
+$params = Parse-Args $args -supports_check_mode $false
+
+$name = Get-AnsibleParam -obj $params "name" -type "str" -failifempty $true
+$repo = Get-AnsibleParam -obj $params "repository" -type "str" 
+$url = Get-AnsibleParam -obj $params "url" -type "str"
+$state = Get-AnsibleParam -obj $params "state" -type "str" -default "present" -validateset "present", "absent"
+$result = @{"changed" = $false
+            "output" = ""}
+
+
+Function Install-NugetProvider {
+  $PackageProvider = Get-PackageProvider -ListAvailable|?{($_.name -eq 'Nuget') -and ($_.version -ge "2.8.5.201")}
+  if (!($PackageProvider)){
+      try{
+        Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force -ErrorAction Stop|out-null
+      }
+      catch{
+        $ErrorMessage = "Problems adding package provider: $($_.Exception.Message)"
+        Fail-Json $result $ErrorMessage
+      }
+    }
+}
+
+Function Install-Repository {
+    Param(
+    [Parameter(Mandatory=$true)]
+    [string]$Name,
+    [Parameter(Mandatory=$true)]
+    [string]$Url
+    )
+    $Repo = (Get-PSRepository).SourceLocation
+
+    if ($Repo -notcontains $Url){ 
+      try {
+        Register-PSRepository -Name $Name -SourceLocation $Url -InstallationPolicy Trusted -ErrorAction Stop
+      }
+      catch {
+        $ErrorMessage = "Problems adding $($Name) repository: $($_.Exception.Message)"
+        Fail-Json $result $ErrorMessage
+      }
+    }
+}
+
+Function Remove-Repository{
+    Param(
+    [Parameter(Mandatory=$true)]
+    [string]$Name
+    )
+
+    $Repo = (Get-PSRepository).SourceLocation
+
+    if ($Repo -contains $Name){
+        try{
+            Unregister-PSRepository -Name $Name -ErrorAction Stop
+        }
+        catch{
+            $ErrorMessage = "Problems removing $($Name)repository: $($_.Exception.Message)"
+            Fail-Json $result $ErrorMessage
+        }
+    }
+}
+
+Function Install-PsModule {
+    param(
+      [Parameter(Mandatory=$true)]
+      [string]$Name
+    )
+    if (Get-Module -Listavailable|?{$_.name -eq $Name}){
+        $result.output = "Module $($Name) already present"
+    }
+    else {      
+      try{
+        Install-NugetProvider
+        Install-Module -Name $Name -Force -ErrorAction Stop
+        $result.output = "Module $($Name) Installed"
+        $result.changed = $true
+      }
+      catch{
+        $ErrorMessage = "Problems installing $($Name) module: $($_.Exception.Message)"
+        Fail-Json $result $ErrorMessage
+      }
+    }
+}
+
+Function Remove-PsModule {
+    param(
+      [Parameter(Mandatory=$true)]
+      [string]$Name
+    )
+    if (Get-Module -Listavailable|?{$_.name -eq $Name}){
+      try{
+        Uninstall-Module -Name $Name -Confirm:$false -Force -ErrorAction Stop
+        $result.changed = $true
+        $result.output = "Module $($Name) removed"
+
+      }
+      catch{
+        $ErrorMessage = "Problems removing $($Name) module: $($_.Exception.Message)"
+        Fail-Json $result $ErrorMessage
+      }
+
+    }
+    else{
+      $result.output = "Module $($Name) not present"
+    }
+}
+
+
+if ($PSVersionTable.PSVersion.Major -lt 5){
+  $ErrorMessage = "Powershell 5.0 or higher is needed"
+  Fail-Json $result $ErrorMessage
+}
+
+if ($state -eq "present"){
+    if (($repo) -and ($url)){
+          Install-Repository -Name $repo -Url $url
+        }
+    else {
+      $ErrorMessage = "Repository Name and Url are mandatory if you want to add a new repository"
+    }
+  Install-PsModule -Name $Name
+}
+else{
+  if (($repo) -and ($url)){
+          Remove-Repository -Name $repo
+        }
+  Remove-PsModule -Name $Name
+}
+
+
+Exit-Json $result

--- a/lib/ansible/modules/windows/win_psmodule.py
+++ b/lib/ansible/modules/windows/win_psmodule.py
@@ -90,9 +90,10 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-output:
+--- 
+output: 
   description: A message describing the task result.
   returned: always
+  sample: "Module PowerShellCookbook installed"
   type: string
-  sample: "Module PowerShellCookbook installed", "Module PowerShellCookbook already present"
 '''

--- a/lib/ansible/modules/windows/win_psmodule.py
+++ b/lib/ansible/modules/windows/win_psmodule.py
@@ -90,8 +90,8 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
---- 
-output: 
+---
+output:
   description: A message describing the task result.
   returned: always
   sample: "Module PowerShellCookbook installed"

--- a/lib/ansible/modules/windows/win_psmodule.py
+++ b/lib/ansible/modules/windows/win_psmodule.py
@@ -92,8 +92,18 @@ EXAMPLES = '''
 RETURN = '''
 ---
 output:
-  description: A message describing the task result.
+  description: a message describing the task result.
   returned: always
   sample: "Module PowerShellCookbook installed"
   type: string
+nuget_changed:
+  description: true when Nuget package provider is installed
+  returned: always
+  type: boolean
+  sample: True
+repository_changed:
+  description: true when a custom repository is installed or removed
+  returned: always
+  type: boolean
+  sample: True
 '''

--- a/lib/ansible/modules/windows/win_psmodule.py
+++ b/lib/ansible/modules/windows/win_psmodule.py
@@ -31,7 +31,7 @@ module: win_psmodule
 version_added: "2.4"
 short_description: Adds or removes a Powershell Module.
 description:
-    - This module helps to install Powershell modules and register custom modules repository on Windows Server. Powershell 5.0 or higer is needed.
+    - This module helps to install Powershell modules and register custom modules repository on Windows Server.
 options:
   name:
     description:
@@ -57,13 +57,16 @@ options:
     choices:
       - present
       - absent
+notes:
+   -  Powershell 5.0 or higer is needed.
+
 author: Daniele Lazzari
 '''
 
 EXAMPLES = '''
 ---
 - name: Add a powershell module
-  win_route:
+  win_psmodule:
     name: PowershellModule
     state: present
 
@@ -87,4 +90,9 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
+output:
+  description: A message describing the task result.
+  returned: always
+  type: string
+  sample: "Module PowerShellCookbook installed", "Module PowerShellCookbook already present"
 '''

--- a/lib/ansible/modules/windows/win_psmodule.py
+++ b/lib/ansible/modules/windows/win_psmodule.py
@@ -1,0 +1,83 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Daniele Lazzari <lazzari@mailup.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: win_psmodule
+version_added: "2.4"
+short_description: Adds or removes a Powershell Module.
+description:
+    - This module helps to install Powershell modules and register custom modules repository on Windows Server. Powershell 5.0 is needed.
+options:
+  name:
+    description:
+      - Name of the powershell module that has to be installed.
+    required: true
+  repository:
+    description:
+      - Name of the custom repository to register.
+  url:
+    description:
+      - Url of the custom repository.
+  state:
+    description:
+      - If present a new module is installed. If absent a module is removed.
+    default: present
+    choices:
+      - present
+      - absent
+author: Daniele Lazzari
+'''
+
+EXAMPLES = '''
+---
+- name: Add a powershell module
+  win_route:
+    name: PowershellModule
+    state: present
+
+- name: Add a powershell module and register a repository
+  win_psmodule:
+    name: MyCustomModule
+    repository: MyRepository
+    url: https://myrepo.com
+    state: present
+
+- name: Remove a powershell module
+  win_psmodule:
+    name: PowershellModule
+    state: absent
+
+- name: Remove a powershell module and a repository
+  win_psmodule:
+    name: MyCustomModule
+    repository: MyRepository
+    state: absent
+'''
+
+RETURN = '''
+'''

--- a/lib/ansible/modules/windows/win_psmodule.py
+++ b/lib/ansible/modules/windows/win_psmodule.py
@@ -31,12 +31,19 @@ module: win_psmodule
 version_added: "2.4"
 short_description: Adds or removes a Powershell Module.
 description:
-    - This module helps to install Powershell modules and register custom modules repository on Windows Server. Powershell 5.0 is needed.
+    - This module helps to install Powershell modules and register custom modules repository on Windows Server. Powershell 5.0 or higer is needed.
 options:
   name:
     description:
       - Name of the powershell module that has to be installed.
     required: true
+  allow_clobber:
+    description:
+      - If yes imports all commands, even if they have the same names as commands that already exists. Available only in Powershell 5.1 or higher.
+    default: no
+    choices:
+      - no
+      - yes
   repository:
     description:
       - Name of the custom repository to register.

--- a/test/integration/targets/win_psmodule/aliases
+++ b/test/integration/targets/win_psmodule/aliases
@@ -1,0 +1,1 @@
+windows/ci/group1

--- a/test/integration/targets/win_psmodule/defaults/main.yml
+++ b/test/integration/targets/win_psmodule/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+powershell_module: powershell-yaml
+wrong_module: powershell_yaml
+allow_clobber_module: PowerShellCookbook

--- a/test/integration/targets/win_psmodule/tasks/main.yml
+++ b/test/integration/targets/win_psmodule/tasks/main.yml
@@ -16,112 +16,13 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-- name: get powershell version
-  win_shell: $PSVersionTable.PSVersion.Major
-  register: version
 
-- name: install module from Powershell Gallery
-  win_psmodule:
-    name: "{{ powershell_module }}"
-    state: present
-  register: module_setup
-  when: version.stdout_lines[0]|int >= 5
+- name: get facts
+  setup:
 
-- name: check idempotency reinstalling module
-  win_psmodule:
-    name: "{{ powershell_module }}"
-    state: present
-  register: module_reinstall
-  when: version.stdout_lines[0]|int >= 5
+- name: Perform integration tests for Powershell 5+
+  when: ansible_powershell_version >= 5
+  block:
 
-- name: check module install with allow_clobber not active
-  win_psmodule:
-    name: "{{ allow_clobber_module }}"
-  register: fail_allow_clobber
-  ignore_errors: yes
-  when: version.stdout_lines[0]|int >= 5
-
-- name: check module install with allow_clobber active
-  win_psmodule:
-    name: "{{ allow_clobber_module }}"
-    allow_clobber: yes
-  register: ok_allow_clobber
-  when: version.stdout_lines[0]|int >= 5
-
-- name: check wrong module install attempt
-  win_psmodule: 
-    name: "{{ wrong_module }}"
-    state: present
-  ignore_errors: yes
-  register: module_fail
-  when: version.stdout_lines[0]|int >= 5
-
-- name: check fake custom ps repository registration attempt
-  win_psmodule:
-    name: "{{ wrong_module }}"
-    repository: Fake repository
-    url: http://my_fake_repo.com/repo/
-  ignore_errors: yes
-  register: repo_fail
-  when: version.stdout_lines[0]|int >= 5
-
-- name: check module is installed
-  win_shell: (Get-Module -Name {{ powershell_module }} -ListAvailable).Name
-  register: module_check
-  when: version.stdout_lines[0]|int >= 5
-
-- name: check allow_clobber module is installed
-  win_shell: (Get-Module -Name {{ allow_clobber_module }} -ListAvailable).Name
-  register: allow_clobber_check
-  when: version.stdout_lines[0]|int >= 5
-
-- name: test win_psmodule module setup
-  assert:
-    that:
-      - "module_setup|changed"
-      - "module_setup.output == 'Module {{ powershell_module }} installed'"
-      - "not module_reinstall|changed"
-      - "fail_allow_clobber|failed"
-      - "ok_allow_clobber|changed"
-      - "module_fail|failed"
-      - "repo_fail|failed"
-      - "module_check.stdout_lines[0] == '{{ powershell_module }}'"
-      - "allow_clobber_check.stdout_lines[0] == '{{ allow_clobber_module }}'"
-  when: version.stdout_lines[0]|int >= 5
-
-- name: remove installed powershell module
-  win_psmodule:
-    name: powershell-yaml
-    state: absent
-  register: module_uninstall
-  when: version.stdout_lines[0]|int >= 5
-
-- name: check module is uninstalled
-  win_shell: (Get-Module -Name {{ powershell_module }} -ListAvailable).Name
-  register: module_check
-  when: version.stdout_lines[0]|int >= 5
-
-- name: check idempotency re-removing module
-  win_psmodule:
-    name: "{{ powershell_module }}"
-    state: absent
-  register: module_uninstall_2
-  when: version.stdout_lines[0]|int >= 5
-
-- name: check removing allow_clobber module
-  win_psmodule:
-    name: "{{ allow_clobber_module }}"
-    state: absent
-  register: module_uninstall_3
-  when: version.stdout_lines[0]|int >= 5
-
-- name: test win_psmodule module uninstall
-  assert:
-    that:
-      - "module_uninstall|changed"
-      - "module_uninstall.output == 'Module {{ powershell_module }} removed'"
-      - "module_check.stdout == ''"
-      - "not module_uninstall_2|changed"
-      - "module_uninstall_3|changed"
-  when: version.stdout_lines[0]|int >= 5
-      
+    - name: run all tasks
+      include: test.yml

--- a/test/integration/targets/win_psmodule/tasks/main.yml
+++ b/test/integration/targets/win_psmodule/tasks/main.yml
@@ -25,28 +25,28 @@
     name: "{{ powershell_module }}"
     state: present
   register: module_setup
-  when: version.stdout_lines[0] >= 5
+  when: version.stdout_lines[0]|int >= 5
 
 - name: check idempotency reinstalling module
   win_psmodule:
     name: "{{ powershell_module }}"
     state: present
   register: module_reinstall
-  when: version.stdout_lines[0] >= 5
+  when: version.stdout_lines[0]|int >= 5
 
 - name: check module install with allow_clobber not active
   win_psmodule:
     name: "{{ allow_clobber_module }}"
   register: fail_allow_clobber
   ignore_errors: yes
-  when: version.stdout_lines[0] >= 5
+  when: version.stdout_lines[0]|int >= 5
 
 - name: check module install with allow_clobber active
   win_psmodule:
     name: "{{ allow_clobber_module }}"
     allow_clobber: yes
   register: ok_allow_clobber
-  when: version.stdout_lines[0] >= 5
+  when: version.stdout_lines[0]|int >= 5
 
 - name: check wrong module install attempt
   win_psmodule: 
@@ -54,7 +54,7 @@
     state: present
   ignore_errors: yes
   register: module_fail
-  when: version.stdout_lines[0] >= 5
+  when: version.stdout_lines[0]|int >= 5
 
 - name: check fake custom ps repository registration attempt
   win_psmodule:
@@ -63,17 +63,17 @@
     url: http://my_fake_repo.com/repo/
   ignore_errors: yes
   register: repo_fail
-  when: version.stdout_lines[0] >= 5
+  when: version.stdout_lines[0]|int >= 5
 
 - name: check module is installed
   win_shell: (Get-Module -Name {{ powershell_module }} -ListAvailable).Name
   register: module_check
-  when: version.stdout_lines[0] >= 5
+  when: version.stdout_lines[0]|int >= 5
 
 - name: check allow_clobber module is installed
   win_shell: (Get-Module -Name {{ allow_clobber_module }} -ListAvailable).Name
   register: allow_clobber_check
-  when: version.stdout_lines[0] >= 5
+  when: version.stdout_lines[0]|int >= 5
 
 - name: test win_psmodule module setup
   assert:
@@ -93,26 +93,26 @@
     name: powershell-yaml
     state: absent
   register: module_uninstall
-  when: version.stdout_lines[0] >= 5
+  when: version.stdout_lines[0]|int >= 5
 
 - name: check module is uninstalled
   win_shell: (Get-Module -Name {{ powershell_module }} -ListAvailable).Name
   register: module_check
-  when: version.stdout_lines[0] >= 5
+  when: version.stdout_lines[0]|int >= 5
 
 - name: check idempotency re-removing module
   win_psmodule:
     name: "{{ powershell_module }}"
     state: absent
   register: module_uninstall_2
-  when: version.stdout_lines[0] >= 5
+  when: version.stdout_lines[0]|int >= 5
 
 - name: check removing allow_clobber module
   win_psmodule:
     name: "{{ allow_clobber_module }}"
     state: absent
   register: module_uninstall_3
-  when: version.stdout_lines[0] >= 5
+  when: version.stdout_lines[0]|int >= 5
 
 - name: test win_psmodule module uninstall
   assert:

--- a/test/integration/targets/win_psmodule/tasks/main.yml
+++ b/test/integration/targets/win_psmodule/tasks/main.yml
@@ -56,11 +56,11 @@
   register: repo_fail
 
 - name: check module is installed
-  raw: (Get-Module -Name {{ powershell_module }} -ListAvailable).Name
+  win_shell: (Get-Module -Name {{ powershell_module }} -ListAvailable).Name
   register: module_check
 
 - name: check allow_clobber module is installed
-  raw: (Get-Module -Name {{ allow_clobber_module }} -ListAvailable).Name
+  win_shell: (Get-Module -Name {{ allow_clobber_module }} -ListAvailable).Name
   register: allow_clobber_check
 
 - name: test win_psmodule module setup
@@ -83,7 +83,7 @@
   register: module_uninstall
 
 - name: check module is uninstalled
-  raw: (Get-Module -Name {{ powershell_module }} -ListAvailable).Name
+  win_shell: (Get-Module -Name {{ powershell_module }} -ListAvailable).Name
   register: module_check
 
 - name: check idempotency re-removing module

--- a/test/integration/targets/win_psmodule/tasks/main.yml
+++ b/test/integration/targets/win_psmodule/tasks/main.yml
@@ -1,0 +1,109 @@
+# test code for the win_psmodule module when using winrm connection
+# (c) 2017, Daniele Lazzari <lazzari@mailup.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- name: install module from Powershell Gallery
+  win_psmodule:
+    name: "{{ powershell_module }}"
+    state: present
+  register: module_setup
+
+- name: check idempotency reinstalling module
+  win_psmodule:
+    name: "{{ powershell_module }}"
+    state: present
+  register: module_reinstall
+
+- name: check module install with allow_clobber not active
+  win_psmodule:
+    name: "{{ allow_clobber_module }}"
+  register: fail_allow_clobber
+  ignore_errors: yes
+
+- name: check module install with allow_clobber active
+  win_psmodule:
+    name: "{{ allow_clobber_module }}"
+    allow_clobber: yes
+  register: ok_allow_clobber
+
+- name: check wrong module install attempt
+  win_psmodule: 
+    name: "{{ wrong_module }}"
+    state: present
+  ignore_errors: yes
+  register: module_fail
+
+- name: check fake custom ps repository registration attempt
+  win_psmodule:
+    name: "{{ wrong_module }}"
+    repository: Fake repository
+    url: http://my_fake_repo.com/repo/
+  ignore_errors: yes
+  register: repo_fail
+
+- name: check module is installed
+  raw: (Get-Module -Name {{ powershell_module }} -ListAvailable).Name
+  register: module_check
+
+- name: check allow_clobber module is installed
+  raw: (Get-Module -Name {{ allow_clobber_module }} -ListAvailable).Name
+  register: allow_clobber_check
+
+- name: test win_psmodule module setup
+  assert:
+    that:
+      - "module_setup|changed"
+      - "module_setup.output == 'Module {{ powershell_module }} installed'"
+      - "not module_reinstall|changed"
+      - "fail_allow_clobber|failed"
+      - "ok_allow_clobber|changed"
+      - "module_fail|failed"
+      - "repo_fail|failed"
+      - "module_check.stdout_lines[0] == '{{ powershell_module }}'"
+      - "allow_clobber_check.stdout_lines[0] == '{{ allow_clobber_module }}'"
+
+- name: remove installed powershell module
+  win_psmodule:
+    name: powershell-yaml
+    state: absent
+  register: module_uninstall
+
+- name: check module is uninstalled
+  raw: (Get-Module -Name {{ powershell_module }} -ListAvailable).Name
+  register: module_check
+
+- name: check idempotency re-removing module
+  win_psmodule:
+    name: "{{ powershell_module }}"
+    state: absent
+  register: module_uninstall_2
+
+- name: check removing allow_clobber module
+  win_psmodule:
+    name: "{{ allow_clobber_module }}"
+    state: absent
+  register: module_uninstall_3
+
+- name: test win_psmodule module uninstall
+  assert:
+    that:
+      - "module_uninstall|changed"
+      - "module_uninstall.output == 'Module {{ powershell_module }} removed'"
+      - "module_check.stdout == ''"
+      - "not module_uninstall_2|changed"
+      - "module_uninstall_3|changed"
+      

--- a/test/integration/targets/win_psmodule/tasks/main.yml
+++ b/test/integration/targets/win_psmodule/tasks/main.yml
@@ -87,6 +87,7 @@
       - "repo_fail|failed"
       - "module_check.stdout_lines[0] == '{{ powershell_module }}'"
       - "allow_clobber_check.stdout_lines[0] == '{{ allow_clobber_module }}'"
+  when: version.stdout_lines[0]|int >= 5
 
 - name: remove installed powershell module
   win_psmodule:
@@ -122,4 +123,5 @@
       - "module_check.stdout == ''"
       - "not module_uninstall_2|changed"
       - "module_uninstall_3|changed"
+  when: version.stdout_lines[0]|int >= 5
       

--- a/test/integration/targets/win_psmodule/tasks/main.yml
+++ b/test/integration/targets/win_psmodule/tasks/main.yml
@@ -16,29 +16,37 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+- name: get powershell version
+  win_shell: $PSVersionTable.PSVersion.Major
+  register: version
+
 - name: install module from Powershell Gallery
   win_psmodule:
     name: "{{ powershell_module }}"
     state: present
   register: module_setup
+  when: version.stdout_lines[0] >= 5
 
 - name: check idempotency reinstalling module
   win_psmodule:
     name: "{{ powershell_module }}"
     state: present
   register: module_reinstall
+  when: version.stdout_lines[0] >= 5
 
 - name: check module install with allow_clobber not active
   win_psmodule:
     name: "{{ allow_clobber_module }}"
   register: fail_allow_clobber
   ignore_errors: yes
+  when: version.stdout_lines[0] >= 5
 
 - name: check module install with allow_clobber active
   win_psmodule:
     name: "{{ allow_clobber_module }}"
     allow_clobber: yes
   register: ok_allow_clobber
+  when: version.stdout_lines[0] >= 5
 
 - name: check wrong module install attempt
   win_psmodule: 
@@ -46,6 +54,7 @@
     state: present
   ignore_errors: yes
   register: module_fail
+  when: version.stdout_lines[0] >= 5
 
 - name: check fake custom ps repository registration attempt
   win_psmodule:
@@ -54,14 +63,17 @@
     url: http://my_fake_repo.com/repo/
   ignore_errors: yes
   register: repo_fail
+  when: version.stdout_lines[0] >= 5
 
 - name: check module is installed
   win_shell: (Get-Module -Name {{ powershell_module }} -ListAvailable).Name
   register: module_check
+  when: version.stdout_lines[0] >= 5
 
 - name: check allow_clobber module is installed
   win_shell: (Get-Module -Name {{ allow_clobber_module }} -ListAvailable).Name
   register: allow_clobber_check
+  when: version.stdout_lines[0] >= 5
 
 - name: test win_psmodule module setup
   assert:
@@ -81,22 +93,26 @@
     name: powershell-yaml
     state: absent
   register: module_uninstall
+  when: version.stdout_lines[0] >= 5
 
 - name: check module is uninstalled
   win_shell: (Get-Module -Name {{ powershell_module }} -ListAvailable).Name
   register: module_check
+  when: version.stdout_lines[0] >= 5
 
 - name: check idempotency re-removing module
   win_psmodule:
     name: "{{ powershell_module }}"
     state: absent
   register: module_uninstall_2
+  when: version.stdout_lines[0] >= 5
 
 - name: check removing allow_clobber module
   win_psmodule:
     name: "{{ allow_clobber_module }}"
     state: absent
   register: module_uninstall_3
+  when: version.stdout_lines[0] >= 5
 
 - name: test win_psmodule module uninstall
   assert:

--- a/test/integration/targets/win_psmodule/tasks/test.yml
+++ b/test/integration/targets/win_psmodule/tasks/test.yml
@@ -6,11 +6,22 @@
     state: present
   register: module_setup
 
+- name: test Powershell Gallery module setup
+  assert:
+    that:
+      - "module_setup|changed"
+      - "module_setup.output == 'Module {{ powershell_module }} installed'"
+
 - name: check idempotency reinstalling module
   win_psmodule:
     name: "{{ powershell_module }}"
     state: present
   register: module_reinstall
+
+- name: test win_psmodule idempotency
+  assert:
+    that:
+      - "not module_reinstall|changed"
 
 - name: check module install with allow_clobber not active
   win_psmodule:
@@ -18,11 +29,21 @@
   register: fail_allow_clobber
   ignore_errors: yes
 
+- name: test allow_clobber has failed
+  assert:
+    that:
+      - "fail_allow_clobber|failed"
+
 - name: check module install with allow_clobber active
   win_psmodule:
     name: "{{ allow_clobber_module }}"
     allow_clobber: yes
   register: ok_allow_clobber
+
+- name: test module install with allow_clobber active
+  assert:
+    that:
+      - "ok_allow_clobber|changed"
 
 - name: check wrong module install attempt
   win_psmodule: 
@@ -30,6 +51,11 @@
     state: present
   ignore_errors: yes
   register: module_fail
+
+- name: test module setup fails
+  assert:
+    that:
+      - "module_fail|failed"
 
 - name: check fake custom ps repository registration attempt
   win_psmodule:
@@ -39,27 +65,28 @@
   ignore_errors: yes
   register: repo_fail
 
+- name: test fake custom ps repository registration attempt
+  assert:
+    that:
+      - "repo_fail|failed"
+
 - name: check module is installed
   win_shell: (Get-Module -Name {{ powershell_module }} -ListAvailable).Name
   register: module_check
+
+- name: test module is installed
+  assert:
+    that:
+      - "module_check.stdout_lines[0] == '{{ powershell_module }}'"
 
 - name: check allow_clobber module is installed
   win_shell: (Get-Module -Name {{ allow_clobber_module }} -ListAvailable).Name
   register: allow_clobber_check
 
-- name: test win_psmodule module setup
+- name: test allow_clobber module is installed
   assert:
     that:
-      - "module_setup|changed"
-      - "module_setup.output == 'Module {{ powershell_module }} installed'"
-      - "not module_reinstall|changed"
-      - "fail_allow_clobber|failed"
-      - "ok_allow_clobber|changed"
-      - "module_fail|failed"
-      - "repo_fail|failed"
-      - "module_check.stdout_lines[0] == '{{ powershell_module }}'"
       - "allow_clobber_check.stdout_lines[0] == '{{ allow_clobber_module }}'"
-
 
 - name: remove installed powershell module
   win_psmodule:
@@ -67,9 +94,20 @@
     state: absent
   register: module_uninstall
 
+- name: test powershell module removal
+  assert:
+    that:
+      - "module_uninstall|changed"
+      - "module_uninstall.output == 'Module {{ powershell_module }} removed'"
+
 - name: check module is uninstalled
   win_shell: (Get-Module -Name {{ powershell_module }} -ListAvailable).Name
   register: module_check
+
+- name: test module is no more present
+  assert:
+    that:
+      - "module_check.stdout == ''"
 
 - name: check idempotency re-removing module
   win_psmodule:
@@ -77,18 +115,22 @@
     state: absent
   register: module_uninstall_2
 
+- name: test idempotency
+  assert:
+    that:
+      - "not module_uninstall_2|changed"
+
 - name: check removing allow_clobber module
   win_psmodule:
     name: "{{ allow_clobber_module }}"
     state: absent
   register: module_uninstall_3
 
-- name: test win_psmodule module uninstall
+- name: test removing allow_clobber module
   assert:
     that:
-      - "module_uninstall|changed"
-      - "module_uninstall.output == 'Module {{ powershell_module }} removed'"
-      - "module_check.stdout == ''"
       - "not module_uninstall_2|changed"
       - "module_uninstall_3|changed"
+
+      
       

--- a/test/integration/targets/win_psmodule/tasks/test.yml
+++ b/test/integration/targets/win_psmodule/tasks/test.yml
@@ -1,0 +1,94 @@
+---
+
+- name: install module from Powershell Gallery
+  win_psmodule:
+    name: "{{ powershell_module }}"
+    state: present
+  register: module_setup
+
+- name: check idempotency reinstalling module
+  win_psmodule:
+    name: "{{ powershell_module }}"
+    state: present
+  register: module_reinstall
+
+- name: check module install with allow_clobber not active
+  win_psmodule:
+    name: "{{ allow_clobber_module }}"
+  register: fail_allow_clobber
+  ignore_errors: yes
+
+- name: check module install with allow_clobber active
+  win_psmodule:
+    name: "{{ allow_clobber_module }}"
+    allow_clobber: yes
+  register: ok_allow_clobber
+
+- name: check wrong module install attempt
+  win_psmodule: 
+    name: "{{ wrong_module }}"
+    state: present
+  ignore_errors: yes
+  register: module_fail
+
+- name: check fake custom ps repository registration attempt
+  win_psmodule:
+    name: "{{ wrong_module }}"
+    repository: Fake repository
+    url: http://my_fake_repo.com/repo/
+  ignore_errors: yes
+  register: repo_fail
+
+- name: check module is installed
+  win_shell: (Get-Module -Name {{ powershell_module }} -ListAvailable).Name
+  register: module_check
+
+- name: check allow_clobber module is installed
+  win_shell: (Get-Module -Name {{ allow_clobber_module }} -ListAvailable).Name
+  register: allow_clobber_check
+
+- name: test win_psmodule module setup
+  assert:
+    that:
+      - "module_setup|changed"
+      - "module_setup.output == 'Module {{ powershell_module }} installed'"
+      - "not module_reinstall|changed"
+      - "fail_allow_clobber|failed"
+      - "ok_allow_clobber|changed"
+      - "module_fail|failed"
+      - "repo_fail|failed"
+      - "module_check.stdout_lines[0] == '{{ powershell_module }}'"
+      - "allow_clobber_check.stdout_lines[0] == '{{ allow_clobber_module }}'"
+
+
+- name: remove installed powershell module
+  win_psmodule:
+    name: powershell-yaml
+    state: absent
+  register: module_uninstall
+
+- name: check module is uninstalled
+  win_shell: (Get-Module -Name {{ powershell_module }} -ListAvailable).Name
+  register: module_check
+
+- name: check idempotency re-removing module
+  win_psmodule:
+    name: "{{ powershell_module }}"
+    state: absent
+  register: module_uninstall_2
+
+- name: check removing allow_clobber module
+  win_psmodule:
+    name: "{{ allow_clobber_module }}"
+    state: absent
+  register: module_uninstall_3
+
+- name: test win_psmodule module uninstall
+  assert:
+    that:
+      - "module_uninstall|changed"
+      - "module_uninstall.output == 'Module {{ powershell_module }} removed'"
+      - "module_check.stdout == ''"
+      - "not module_uninstall_2|changed"
+      - "module_uninstall_3|changed"
+      

--- a/test/integration/test_win_group1.yml
+++ b/test/integration/test_win_group1.yml
@@ -9,4 +9,3 @@
     - { role: win_fetch, tags: test_win_fetch }
     - { role: win_regmerge, tags: test_win_regmerge }
     - { role: win_regedit, tags: test_win_regedit }
-    - { role: win_psmodule, tags: test_win_psmodule }

--- a/test/integration/test_win_group1.yml
+++ b/test/integration/test_win_group1.yml
@@ -9,3 +9,4 @@
     - { role: win_fetch, tags: test_win_fetch }
     - { role: win_regmerge, tags: test_win_regmerge }
     - { role: win_regedit, tags: test_win_regedit }
+    - { role: win_psmodule, tags: test_win_psmodule }


### PR DESCRIPTION
##### SUMMARY
New module win_psmodule adds the ability to add/remove windows powershell modules and register/unregister modules repository.
Powershell 5.0 is required.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
win_psmodule

##### ANSIBLE VERSION
```
2.2.2.0
```
