### PR TITLE
os_user: fix 'module' variable undefined

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_user.py
+++ b/lib/ansible/modules/cloud/openstack/os_user.py
@@ -177,7 +177,7 @@ def _get_domain_id(cloud, domain):
 
     return domain_id
 
-def _get_default_project_id(cloud, default_project):
+def _get_default_project_id(cloud, default_project, module):
     project = cloud.get_project(default_project)
     if not project:
         module.fail_json(msg='Default project %s is not valid' % default_project)
@@ -232,7 +232,7 @@ def main():
                     module.fail_json(msg=msg)
             default_project_id = None
             if default_project:
-                default_project_id = _get_default_project_id(cloud, default_project)
+                default_project_id = _get_default_project_id(cloud, default_project, module)
 
             if user is None:
                 user = cloud.create_user(


### PR DESCRIPTION
module variable in the function is undefined. Pass it.

fix "NameError: name 'module' is not defined"

##### SUMMARY
when enterering the if condition in :
```
    if not project:
        module.fail_json(msg='Default project %s is not valid' % default_project)
```

module is undefined.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/openstack/os_user.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/fridim/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible-2.4.0-py3.6.egg/ansible
  executable location = /usr/bin/ansible
  python version = 3.6.0 (default, Jan 16 2017, 12:12:55) [GCC 6.3.1 20170109]

```
