### PR TITLE
PostgreSQL integration test suite: really generate locales on Debian

### DIFF
--- a/test/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/test/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -95,12 +95,13 @@
     group: "{{ pg_group }}"
     mode: "0644"
 
-- name: Generate pt_BR locale (Debian)
-  command: locale-gen pt_BR
-  when: ansible_os_family == 'Debian'
-
-- name: Generate es_ES locale (Debian)
-  command: locale-gen es_ES
+- name: Generate locales (Debian)
+  locale_gen:
+    name: '{{ item }}'
+    state: present
+  with_items:
+    - pt_BR
+    - es_ES
   when: ansible_os_family == 'Debian'
 
 - name: install i18ndata


### PR DESCRIPTION
##### SUMMARY
With Debian, PostgreSQL integration test suite doesn't correctly setup test environment: required locales aren't generated. `/usr/sbin/locale-gen` behaves differently on Debian and Ubuntu. This pull-request propose to use the `locale-gen` ansible module instead of the `locale-gen` command.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
PostgreSQL integration test suite.

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel c2370f14dd)
```
##### ADDITIONAL INFORMATION
Tested using:
```
ANSIBLE_REMOTE_USER=root ANSIBLE_ROLES_PATH=test/integration/targets ansible-playbook -i 'testhost,' -e ansible_host=$HOST_IP --tags=test_postgresql,test_postgresql_db,test_postgresql_privs,test_postgresql_user,needs_privileged test/integration/destructive.yml
```