### PR TITLE
PostgreSQL Integration test suite: improvements

### DIFF
--- a/test/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/test/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -45,7 +45,7 @@
   when: ansible_os_family == "Debian"
 
 - name: install dependencies for postgresql test
-  package: name={{ postgresql_package_item }} state=latest
+  package: name={{ postgresql_package_item }} state=present
   with_items: "{{ postgresql_packages }}"
   loop_control:
     loop_var: postgresql_package_item
@@ -88,17 +88,37 @@
   command: locale-gen es_ES
   when: ansible_os_family == 'Debian'
 
-- name: install i18ndata
-  zypper: name=glibc-i18ndata state=present
-  when: ansible_os_family == 'Suse'
+# Suse: locales are installed by default (glibc-locale package).
+# Fedora 23: locales are installed by default (glibc-common package)
+# CentOS: all locales are installed by default (glibc-common package) but some
+# RPM macros could prevent their installation (for example when using anaconda
+# instLangs parameter).
 
-- name: Generate pt_BR locale (Red Hat)
-  command: localedef -f ISO-8859-1 -i pt_BR pt_BR
-  when: ansible_os_family == "RedHat" or ansible_os_family == "Suse"
+- block:
+  - name: Check if locales need to be generated (RedHat)
+    shell: "localedef --list-archive | grep -a -q '^{{ locale }}$'"
+    register: locale_present
+    ignore_errors: True
+    with_items:
+      - es_ES
+      - pt_BR
+    loop_control:
+      loop_var: locale
 
-- name: Generate es_ES locale (Red Hat)
-  command: localedef -f ISO-8859-1 -i es_ES es_ES
-  when: ansible_os_family == "RedHat" or ansible_os_family == "Suse"
+  - name: Generate locale (RedHat)
+    command: 'localedef -f ISO-8859-1 -i {{ item.locale }} {{ item.locale }}'
+    when: item|failed
+    with_items: '{{ locale_present.results }}'
+  when: ansible_os_family == 'RedHat' and ansible_distribution != 'Fedora'
+
+- name: Install glibc langpacks (Fedora >= 24)
+  package:
+    name: '{{ item }}'
+    state: 'latest'
+  with_items:
+    - glibc-langpack-es
+    - glibc-langpack-pt
+  when: ansible_distribution == 'Fedora' and ansible_distribution_major_version|int >= 24
 
 - name: enable postgresql service (FreeBSD)
   lineinfile:

--- a/test/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/test/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -62,7 +62,7 @@
   command: /sbin/service postgresql initdb
   when: ansible_os_family == "RedHat" and ansible_service_mgr != "systemd"
 
-- name: Iniitalize postgres (Debian)
+- name: Initialize postgres (Debian)
   command: /usr/bin/pg_createcluster {{ pg_ver }} main
   # Sometimes package install creates the db cluster, sometimes this step is needed
   ignore_errors: True

--- a/test/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/test/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -56,11 +56,11 @@
 
 - name: Initialize postgres (RedHat systemd)
   command: postgresql-setup initdb
-  when: ansible_distribution == "Fedora" or (ansible_os_family  == "RedHat" and ansible_distribution_major_version|int >= 7)
+  when: ansible_os_family == "RedHat" and ansible_service_mgr == "systemd"
 
 - name: Initialize postgres (RedHat sysv)
   command: /sbin/service postgresql initdb
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int <= 6
+  when: ansible_os_family == "RedHat" and ansible_service_mgr != "systemd"
 
 - name: Iniitalize postgres (Debian)
   command: /usr/bin/pg_createcluster {{ pg_ver }} main

--- a/test/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/test/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -44,26 +44,11 @@
   ignore_errors: True
   when: ansible_os_family == "Debian"
 
-- name: install rpm dependencies for postgresql test
+- name: install dependencies for postgresql test
   package: name={{ postgresql_package_item }} state=latest
-  with_items: "{{postgresql_packages}}"
+  with_items: "{{ postgresql_packages }}"
   loop_control:
     loop_var: postgresql_package_item
-  when: ansible_os_family == "RedHat" or ansible_os_family == "Suse"
-
-- name: install dpkg dependencies for postgresql test
-  apt: name={{ postgresql_package_item }} state=latest
-  with_items: "{{postgresql_packages}}"
-  loop_control:
-    loop_var: postgresql_package_item
-  when: ansible_pkg_mgr  ==  'apt'
-
-- name: install FreeBSD dependencies for postgresql test
-  pkgng: name={{ postgresql_package_item }} state=present
-  with_items: "{{postgresql_packages}}"
-  loop_control:
-    loop_var: postgresql_package_item
-  when: ansible_os_family == "FreeBSD"
 
 - name: initialize postgres (FreeBSD)
   command: /usr/local/etc/rc.d/postgresql oneinitdb

--- a/test/integration/targets/setup_postgresql_db/vars/Debian-8.yml
+++ b/test/integration/targets/setup_postgresql_db/vars/Debian-8.yml
@@ -1,5 +1,3 @@
-postgresql_service: "postgresql"
-
 postgresql_packages:
   - "postgresql"
   - "postgresql-common"

--- a/test/integration/targets/setup_postgresql_db/vars/FreeBSD.yml
+++ b/test/integration/targets/setup_postgresql_db/vars/FreeBSD.yml
@@ -1,5 +1,3 @@
-postgresql_service: "postgresql"
-
 postgresql_packages:
   - "postgresql93-server"
   - "py27-psycopg2"

--- a/test/integration/targets/setup_postgresql_db/vars/Ubuntu-12.yml
+++ b/test/integration/targets/setup_postgresql_db/vars/Ubuntu-12.yml
@@ -1,5 +1,3 @@
-postgresql_service: "postgresql"
-
 postgresql_packages:
   - "postgresql"
   - "postgresql-common"

--- a/test/integration/targets/setup_postgresql_db/vars/Ubuntu-14.yml
+++ b/test/integration/targets/setup_postgresql_db/vars/Ubuntu-14.yml
@@ -1,5 +1,3 @@
-postgresql_service: "postgresql"
-
 postgresql_packages:
   - "postgresql"
   - "postgresql-common"

--- a/test/integration/targets/setup_postgresql_db/vars/Ubuntu-16-py3.yml
+++ b/test/integration/targets/setup_postgresql_db/vars/Ubuntu-16-py3.yml
@@ -1,5 +1,3 @@
-postgresql_service: "postgresql"
-
 postgresql_packages:
   - "postgresql"
   - "postgresql-common"

--- a/test/integration/targets/setup_postgresql_db/vars/Ubuntu-16.yml
+++ b/test/integration/targets/setup_postgresql_db/vars/Ubuntu-16.yml
@@ -1,5 +1,3 @@
-postgresql_service: "postgresql"
-
 postgresql_packages:
   - "postgresql"
   - "postgresql-common"

--- a/test/integration/targets/setup_postgresql_db/vars/default.yml
+++ b/test/integration/targets/setup_postgresql_db/vars/default.yml
@@ -1,5 +1,3 @@
-postgresql_service: "postgresql"
-
 postgresql_packages:
   - "postgresql-server"
   - "python-psycopg2"


### PR DESCRIPTION
##### SUMMARY
* handles Fedora >= 24
* simplify

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
PostgreSQL integration test suite

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel c2370f14dd)
```

##### ADDITIONAL INFORMATION
Tested on Fedora 23, Fedora 24, OpenSuse 42.2, Debian Jessie, Ubuntu Xenial using:
```
ANSIBLE_REMOTE_USER=root ANSIBLE_ROLES_PATH=test/integration/targets ansible-playbook -i 'testhost,' -e ansible_host=$HOST_IP --tags=test_postgresql,test_postgresql_db,test_postgresql_privs,test_postgresql_user,needs_privileged test/integration/destructive.yml
```

Note that with OpenSuse, `python-xml` needs to be installed.

Related: #23613.