### PR TITLE
filesystem: introduce swap

### DIFF
--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -42,7 +42,6 @@ options:
   force:
     description:
     - If C(yes), allows to create new filesystem on devices that already has filesystem.
-      Warning, C(swap) always override existing filesystems, even without force.
     type: bool
     default: 'no'
   resizefs:

--- a/test/integration/targets/filesystem/defaults/main.yml
+++ b/test/integration/targets/filesystem/defaults/main.yml
@@ -20,3 +20,4 @@ tested_filesystems:
   ocfs2: {fssize: '{{ ocfs2_fssize }}', grow: False}  # grow not implemented
   f2fs: {fssize: '{{ f2fs_fssize|default(60) }}', grow: 'f2fs_version is version("1.10.0", ">=")'}
   lvm: {fssize: 20, grow: True}
+  swap: {fssize: 10, grow: False}

--- a/test/integration/targets/filesystem/tasks/main.yml
+++ b/test/integration/targets/filesystem/tasks/main.yml
@@ -36,4 +36,5 @@
     # https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.23/v2.23-ReleaseNotes
     - 'not (item.0.key == "f2fs" and ansible_distribution == "Ubuntu" and ansible_distribution_version is version("14.04", "<="))'
     - 'not (item.1 == "overwrite_another_fs" and ansible_system == "FreeBSD")'
+    - 'not (item.0.key == "swap" and ansible_system != "Linux")'
   loop: "{{ query('dict', tested_filesystems)|product(['create_fs', 'overwrite_another_fs'])|list }}"

--- a/test/integration/targets/filesystem/tasks/overwrite_another_fs.yml
+++ b/test/integration/targets/filesystem/tasks/overwrite_another_fs.yml
@@ -1,8 +1,13 @@
 - name: 'Recreate "disk" file'
   command: 'dd if=/dev/zero of={{ image_file }} bs=1M count={{ fssize }}'
 
-- name: 'Create a swap filesystem'
-  command: 'mkswap {{ dev }}'
+- name: 'Create an unsupported filesystem (minix)'
+  shell: 'base64 -d | gzip -d > {{ dev }}'
+  args:
+    stdin: |
+      H4sIAPGkAVwCA+3XsQ0CQQwEQBt0EiJCIiWgguuBPr6Xb+Y7+XoIaAC4SykBz1gONt3IjgCqus
+      c5ckyb4Xa6rNdUChRxHPv+ABXtKoCyno/5A0S8tlzi0BxEUEhG/81dKwAAAADwH774rXnxACg
+      AAA==
 
 - command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
   register: uuid


### PR DESCRIPTION
* aggregate failures
* introduce swap support

##### SUMMARY

Before the patch (`/dev/DATA/swap` is an empty, newly created LV):

``` yaml
- name: mkswap
  filesystem: fstype=swap dev=/dev/DATA/swap
```

Returned:

```
ok: [docker02] => (item={u'fs_vfstype': u'swap', u'fs_spec': u'/dev/DATA/swap', u'size': u'2G'})
```

But on the target, nothing much happened:

``` console
root@docker02:~# blkid /dev/DATA/swap
root@docker02:~# file -Ls /dev/DATA/swap
/dev/DATA/swap: data
```

After the patch, the playbook says:

```
changed: [docker02] => (item={u'fs_vfstype': u'swap', u'fs_spec': u'/dev/DATA/swap', u'size': u'2G'})
```

Now on the target:

``` console
root@docker02:~# blkid /dev/DATA/swap
/dev/DATA/swap: UUID="40fc8cb4-f18a-4693-85e4-189b52ff66b3" TYPE="swap"
root@docker02:~# file -Ls /dev/DATA/swap
/dev/DATA/swap: Linux/i386 swap file (new style), version 1 (4K pages), size 524287 pages, no label, UUID=40fc8cb4-f18a-4693-85e4-189b52ff66b3
```

Thanks to the existing code, the swap functionality is idempotent and when re-run will detect the FS is already a swap:

```
ok: [docker02] => (item={u'fs_vfstype': u'swap', u'fs_spec': u'/dev/DATA/swap', u'size': u'2G'})
```

The target is:

```
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 14.04.4 LTS
Release:        14.04
Codename:       trusty
```

##### ISSUE TYPE

 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
- module filesystem

##### ANSIBLE VERSION
```
ansible 2.1.2.0
```

##### ADDITIONAL INFORMATION
Originally presented in ansible/ansible-modules-extras#3345; more information there.
