### PR TITLE
#23623: Fix ansible-galaxy mangling filenames that include the role name

### DIFF
--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -316,7 +316,7 @@ class GalaxyRole(object):
                             # bits that might be in the file for security purposes
                             # and drop any containing directory, as mentioned above
                             if member.isreg() or member.issym():
-                                parts = member.name.replace(archive_parent_dir, "").split(os.sep)
+                                parts = member.name.split(os.sep)[1:]
                                 final_parts = []
                                 for part in parts:
                                     if part != '..' and '~' not in part and '$' not in part:


### PR DESCRIPTION
##### SUMMARY
This change reverts one line of code in lib/ansible/galaxy/roles.py. The line is supposed to remove the first directory in the path of a file being extracted, but it removes any part of the path that matches the name of the role. Fixes #23623.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
/f/g/a/bin (stable-2.3|…) $ ./ansible-galaxy --version
/usr/local/Cellar/pyenv/1.0.7/libexec/pyenv: line 43: cd: ansible: Not a directory
ansible-galaxy 2.3.0.0 (stable-2.3 8a2ca28f73) last updated 2017/04/15 09:40:54 (GMT -500)
  config file =
  configured module search path = [u'/Users/<snip>/fathom/git/ansible/library']
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```

##### ADDITIONAL INFORMATION
See #23623 for more details. But to summarize, if you have a role named `foo` and it contains a file with a path `foo/bar/foo.bar`, it will be extracted as `foo/bar/.bar` instead. This change fixes that.