### PR TITLE
filesystem: get device size for btrfs

### DIFF
--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -66,8 +66,11 @@ EXAMPLES = '''
     opts: -cc
 '''
 import os
+import sys
+import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import human_to_bytes
 
 
 def _get_dev_size(dev, module):
@@ -78,8 +81,17 @@ def _get_dev_size(dev, module):
 
 
 def _get_fs_size(fssize_cmd, dev, module):
-    """ Return size in bytes of filesystem on device. Returns int """
+    """
+    :param str fssize_cmd: program called to get the filesystem size
+    :param str dev: path of the device we want the size
+    :param :class:`AnsibleModule` module:
+    :return: size in bytes of filesystem on device
+    :rtype: int
+    """
     cmd = module.get_bin_path(fssize_cmd, required=True)
+    rc = 0
+    err = None
+    block_size = block_count = 1
     if 'tune2fs' == fssize_cmd:
         # Get Block count and Block size
         rc, size, err = module.run_command("%s %s %s" % (cmd, '-l', dev))
@@ -106,22 +118,84 @@ def _get_fs_size(fssize_cmd, dev, module):
                     block_size = int(col[2].split()[0])
                     block_count = int(col[3].split(',')[0])
                     break
-        else:
-            module.fail_json(msg="Failed to get block count and block size of %s with %s" % (dev, cmd), rc=rc, err=err )
     elif 'btrfs' == fssize_cmd:
-        #ToDo
-        # There is no way to get the blocksize and blockcount for btrfs filesystems
-        block_size = 1
-        block_count = 1
+        rc, size, err = module.run_command([cmd, 'filesystem', 'show', '-d'])
+        # The command will return the name of the real device,
+        # which could be "/dev/dm-0" when the given dev was
+        # "/dev/mapper/VG-LV" or "/dev/VG/LV"
+        if rc == 0:
+            dev_path = os.path.realpath(dev)
+            for line in size.splitlines():
+                row = line.split()
+                if row and row[-1] == dev_path:
+                    # Newer versions (>= 4?) of the tool know --raw,
+                    # but even Ubuntu Trusty use v3.X which only print in
+                    # human readable units.
+                    return human_to_bytes(row[3].replace('i', ''))
     elif 'pvs' == fssize_cmd:
         rc, size, err = module.run_command([cmd, '--noheadings', '-o', 'pv_size', '--units', 'b', dev])
         if rc == 0:
             block_count = int(size[:-1])
             block_size = 1
-        else:
-            module.fail_json(msg="Failed to get block count and block size of %s with %s" % (dev, cmd), rc=rc, err=err )
+
+    if rc:
+        module.fail_json(
+            msg="Failed to get block count and block size of %s with %s" % (dev, cmd),
+            rc=rc,
+            err=err,
+        )
 
     return block_size*block_count
+
+
+def _grow_mounted(grow_cmd, grow_flag, dev, module):
+    '''mount a device to a temporary location to grow it
+
+    :param str device: device path to be mounted
+    :param module:
+    :type module: instance of :class:`ansible.module_utils.basic.AnsibleModule`
+    :return: roughly the same as :meth:`ansible.module_utils.basic.AnsibleModule.run_command`
+    :rtype: tuple (rc, out, err)
+    '''
+    cmd_mount = module.get_bin_path('mount', required=True)
+    cmd_umount = module.get_bin_path('umount', required=True)
+    cmd_grow = module.get_bin_path(grow_cmd, required=True)
+    rc = 0
+    out = None
+    err = None
+
+    if grow_flag is None:
+        grow_flag = ''
+
+    try:
+        tempdir = tempfile.mkdtemp()
+
+        # mount the device somewhere
+        rc, out, err = module.run_command([cmd_mount, dev, tempdir])
+        if rc:
+            err = "unable to temporarily mount %r to %r (%s)" % (dev, tempdir, err)
+        else:
+            # grow mounted filesystem
+            rc, out, err = module.run_command(
+                '%s %s %s' % (cmd_grow, grow_flag, tempdir)
+            )
+            if rc:
+                err = "unable to grow %r (%s)" % (dev, err)
+    except:
+        if not rc:
+            rc = 1
+            err = 'something failed (%s)' % (
+                sys.exc_info()[1]
+            )
+
+    try:
+        # cleanup (PEP 341 is not available in Python 2.4)
+        module.run_command([cmd_umount, tempdir])
+        os.rmdir(tempdir)
+    except:
+        pass
+
+    return rc, out, err
 
 
 def main():
@@ -170,13 +244,15 @@ def main():
             'mkfs' : 'mkfs.xfs',
             'grow' : 'xfs_growfs',
             'grow_flag' : None,
+            'grow_mount': True,
             'force_flag' : '-f',
             'fsinfo': 'xfs_growfs',
         },
         'btrfs' : {
             'mkfs' : 'mkfs.btrfs',
             'grow' : 'btrfs',
-            'grow_flag' : 'filesystem resize',
+            'grow_flag' : 'filesystem resize max',
+            'grow_mount': True,
             'force_flag' : '-f',
             'fsinfo': 'btrfs',
         },
@@ -247,6 +323,25 @@ def main():
             module.exit_json(changed=True, msg="Resizing filesystem %s on device %s" % (fstype,dev))
         elif module.check_mode and not fs_smaller:
             module.exit_json(changed=False, msg="%s filesystem is using the whole device %s" % (fstype, dev))
+        elif fs_smaller and fs_cmd_map[fstype].get('grow_mount', False):
+            rc, out, err = _grow_mounted(
+                growcmd,
+                fs_cmd_map[fstype]['grow_flag'],
+                dev,
+                module,
+            )
+            fssize_new = _get_fs_size(fssize_cmd, dev, module)
+            if rc == 0:
+                module.exit_json(
+                    changed=fssize_in_bytes != fssize_new,
+                    msg=out,
+                )
+            else:
+                module.fail_json(
+                    msg="Resizing filesystem %s on device '%s' failed" % (fstype, dev),
+                    rc=rc,
+                    err=err,
+                )
         elif fs_smaller:
             cmd = module.get_bin_path(growcmd, required=True)
             rc,out,err = module.run_command("%s %s" % (cmd, dev))

--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -43,7 +43,7 @@ options:
     choices: [ "yes", "no" ]
     default: "no"
     description:
-    - If yes, if the block device and filessytem size differ, grow the filesystem into the space. Note, XFS Will only grow if mounted.
+    - If yes, if the block device and filessytem size differ, grow the filesystem into the space. Note, BTRFS and XFS will only grow if mounted.
     required: false
     version_added: "2.0"
   opts:


### PR DESCRIPTION
##### SUMMARY
Fix a TODO left by @alxgu in 011ea55: return size in bytes of BTRFS.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- module filesystem

##### ANSIBLE VERSION
```
ansible 2.1.2.0
```

##### ADDITIONAL INFORMATION
Can be found in original PR: ansible/ansible-modules-extras#3313