### PR TITLE
bug: lvol fail when LV already exists

### DIFF
--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -366,7 +366,7 @@ def main():
     else:
         check_lv = snapshot
     for test_lv in lvs:
-        if test_lv['name'] == check_lv:
+        if test_lv['name'] in (check_lv, check_lv.rsplit('/', 1)[-1]):
             this_lv = test_lv
             break
     else:


### PR DESCRIPTION
##### SUMMARY
When running on my test system, the LV tasks failed when the playbook was ran a second time (remotely the same symptoms but not the same reason as in ansible/ansible#5165).
This is caused because the `lvs` does not return the full path.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- module lvol

##### ANSIBLE VERSION

```
ansible 2.0.1.0
ansible 2.1.2.0
```

##### ADDITIONAL INFORMATION
Can be found in original PR: ansible/ansible-modules-extras#3288

System (`lsb_release -a`):

```
Distributor ID: Ubuntu
Description:    Ubuntu 14.04.4 LTS
Release:        14.04
Codename:       trusty
```

Return of the command as executed by [lvol.py](https://github.com/ansible/ansible-modules-extras/blob/8a625f/system/lvol.py#L288-L289):

``` shell
# lvs -a --noheadings --nosuffix -o lv_name,size,lv_attr --units B --separator ';' DATA
  docker;10737418240;-wi-a----
  foobar;2147483648;-wi-a----
  mongodb;6442450944;-wi-a----
  swap;2147483648;-wi-a----
```

**Note:** I tried the `lvs` command on different systems (Ubuntu, CentOS, ...) and the full path never appear, the patch might be simplified by something like:

``` python
check_lv = (lv if snapshot is None else snapshot).rsplit('/', 1)[-1]
for test_lv in lvs:
  if test_lv['name'] == check_lv:
    break
```

What do you think?

---

Playbook sample:

``` yaml

---
- hosts: test
  vars:
    partitions:
      - {size: 10G, fs_spec: /dev/DATA/docker, fs_file: /var/lib/docker, fs_vfstype: btrfs}
      - {size:  6G, fs_spec: /dev/DATA/mongodb, fs_file: /var/lib/mongodb, fs_vfstype: xfs, fs_mntops: relatime}
      - {size:  2G, fs_spec: /dev/DATA/swap, fs_file: none, fs_vfstype: swap}
  tasks:
    - name: 'setup LVM VG'
      lvg:
        pvs: /dev/xvdb
        vg: DATA

    - name: 'setup LVM LV'
      lvol:
        vg: DATA
        lv: "{{ item.fs_spec }}"
        size: '{{ item.size }}'
      with_items: '{{ partitions }}'
...
```

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
# before change
TASK [docker : setup LVM LV] ***************************************************
failed: [docker02] (item={u'fs_file': u'/var/lib/docker', u'fs_spec': u'/dev/DATA/docker', u'fs_vfstype': u'btrfs', u'size': u'10G'}) => {"err": "  Logical volume \"docker\" already exists in volume group \"DATA\"\n", "failed": true, "item": {"fs_file": "/var/lib/docker", "fs_spec": "/dev/DATA/docker", "fs_vfstype": "btrfs", "size": "10G"}, "msg": "Creating logical volume '/dev/DATA/docker' failed", "rc": 5}
failed: [docker02] (item={u'fs_file': u'/var/lib/mongodb', u'fs_spec': u'/dev/DATA/mongodb', u'fs_mntops': u'relatime', u'fs_vfstype': u'xfs', u'size': u'6G'}) => {"err": "  Logical volume \"mongodb\" already exists in volume group \"DATA\"\n", "failed": true, "item": {"fs_file": "/var/lib/mongodb", "fs_mntops": "relatime", "fs_spec": "/dev/DATA/mongodb", "fs_vfstype": "xfs", "size": "6G"}, "msg": "Creating logical volume '/dev/DATA/mongodb' failed", "rc": 5}
failed: [docker02] (item={u'fs_file': u'none', u'fs_spec': u'/dev/DATA/swap', u'fs_vfstype': u'swap', u'size': u'2G'}) => {"err": "  Logical volume \"swap\" already exists in volume group \"DATA\"\n", "failed": true, "item": {"fs_file": "none", "fs_spec": "/dev/DATA/swap", "fs_vfstype": "swap", "size": "2G"}, "msg": "Creating logical volume '/dev/DATA/swap' failed", "rc": 5}

# after change
TASK [docker : setup LVM LV] ***************************************************
ok: [docker02] => (item={u'fs_file': u'/var/lib/docker', u'fs_spec': u'/dev/DATA/docker', u'fs_vfstype': u'btrfs', u'size': u'10G'})
ok: [docker02] => (item={u'fs_file': u'/var/lib/mongodb', u'fs_spec': u'/dev/DATA/mongodb', u'fs_mntops': u'relatime', u'fs_vfstype': u'xfs', u'size': u'6G'})
ok: [docker02] => (item={u'fs_file': u'none', u'fs_spec': u'/dev/DATA/swap', u'fs_vfstype': u'swap', u'size': u'2G'})
```
