### PR TITLE
Add the Cisco Spark Module to the 2.3 New Modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,8 @@ Ansible Changes By Release
 - bigswitch:
   * bigmon_chain
   * bigmon_policy
+- cisco
+  * cisco_spark
 - cloudengine:
   * ce_command
 - cloudscale_server


### PR DESCRIPTION
##### SUMMARY
Update the change log Ansible 2.3 New Module list to include the cisco_spark notification module.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
cisco_spark

##### ANSIBLE VERSION
```
➜  ~ ansible --version
ansible 2.3.0.0
```


##### ADDITIONAL INFORMATION
[Link to Module](https://github.com/ansible/ansible/blob/v2.3.0.0-1/lib/ansible/modules/notification/cisco_spark.py)


