### PR TITLE
Allow os_server_facts to filter results based on provided filters dictionary

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_server_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_facts.py
@@ -41,6 +41,9 @@ options:
      description:
         - restrict results to servers matching a dictionary of
           filters
+     required: false
+     default: None
+     version_added: "2.4"
    availability_zone:
      description:
        - Ignored. Present for backwards compatibility

--- a/lib/ansible/modules/cloud/openstack/os_server_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_facts.py
@@ -37,6 +37,10 @@ options:
           of additional API calls.
      type: bool
      default: 'no'
+   filters:
+     description:
+        - restrict results to servers matching a dictionary of
+          filters (e.g., {vm_state: 'active'})
    availability_zone:
      description:
        - Ignored. Present for backwards compatibility
@@ -63,6 +67,7 @@ def main():
     argument_spec = openstack_full_argument_spec(
         server=dict(required=False),
         detailed=dict(required=False, type='bool'),
+        filters=dict(required=False, type='dict', default=None)
     )
     module_kwargs = openstack_module_kwargs()
     module = AnsibleModule(argument_spec, **module_kwargs)
@@ -71,6 +76,8 @@ def main():
     try:
         openstack_servers = cloud.list_servers(
             detailed=module.params['detailed'])
+        openstack_servers = cloud.search_servers(
+            detailed=module.params['detailed'], filters=module.params['filters'])
 
         if module.params['server']:
             # filter servers by name

--- a/lib/ansible/modules/cloud/openstack/os_server_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_facts.py
@@ -41,8 +41,6 @@ options:
      description:
         - restrict results to servers matching a dictionary of
           filters
-     required: false
-     default: None
      version_added: "2.8"
    availability_zone:
      description:

--- a/lib/ansible/modules/cloud/openstack/os_server_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_facts.py
@@ -43,7 +43,7 @@ options:
           filters
      required: false
      default: None
-     version_added: "2.4"
+     version_added: "2.8"
    availability_zone:
      description:
        - Ignored. Present for backwards compatibility

--- a/lib/ansible/modules/cloud/openstack/os_server_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_server_facts.py
@@ -40,7 +40,7 @@ options:
    filters:
      description:
         - restrict results to servers matching a dictionary of
-          filters (e.g., {vm_state: 'active'})
+          filters
    availability_zone:
      description:
        - Ignored. Present for backwards compatibility
@@ -48,10 +48,12 @@ extends_documentation_fragment: openstack
 '''
 
 EXAMPLES = '''
-# Gather facts about all servers named <web*>:
+# Gather facts about all servers named <web*> that are in an active state:
 - os_server_facts:
     cloud: rax-dfw
     server: web*
+    filters:
+      vm_state: active
 - debug:
     var: openstack_servers
 '''


### PR DESCRIPTION
##### SUMMARY
Module currently allows us to retrieve servers from nova based on their name or uuid. This PR extends this to allow us to filter the servers that are returned based on an arbitrary set of nova properties by providing a 'filters' dictionary. This makes direct use of the filters option provided by shade.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
os_server_facts.py module

##### ANSIBLE VERSION
ansible 2.3.0.0


My use case is retrieving all instances deployed on a particular hypervisor, so that I can power those VMs down to do maintenance on the underlying server:

```
  - name: Retrieve all VMs deployed on hypervisor
    os_server_facts:
      cloud: "{{ overcloud }}"
      filters:
        OS-EXT-SRV-ATTR:hypervisor_hostname: "{{ hypervisor }}"

  - name: Power down all VMs deployed on hypervisor
    os_server_actions:
      cloud: "{{ overcloud }}"
      action: stop
      server: "{{ item.name }}"
    with_items: "{{ openstack_servers }}"
```