### PR TITLE
[docker_image] when using force: true, only consider it changed if we actually pulled

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -341,6 +341,10 @@ class ImageManager(DockerBaseClass):
                 self.results['changed'] = True
                 if not self.check_mode:
                     self.results['image'] = self.client.pull_image(self.name, tag=self.tag)
+                    if image:
+                        # If we have a previous image (meaning we're using
+                        # force), we're only changed # if the image id changed.
+                        self.results['changed'] = image.id != self.results['image'].id
 
         if self.archive_path:
             self.archive_image(self.name, self.tag)


### PR DESCRIPTION
##### SUMMARY

Right now, if you have a task like:

```yml
    - name: pull the latest docker images
      docker_image:
          name: "{{ item }}"
          force: true
      with_items:
          - pyca/caddy
          - pyca/crypto-jenkins
      notify:
          - restart caddy
          - restart jenkins
```

Ansible will always run the notifies, because `changed` is always true. If you don't use `force` though, it won't pull after the first time.

This change makes it so that `changed` is only true if the image changed.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

docker_image

##### ANSIBLE VERSION

```
ansible 2.2.2.0
  config file =
  configured module search path = Default w/o overrides
```
