### PR TITLE
Update package installation warning

### DIFF
--- a/lib/ansible/modules/source_control/github_release.py
+++ b/lib/ansible/modules/source_control/github_release.py
@@ -91,7 +91,8 @@ def main():
     )
 
     if not HAS_GITHUB_API:
-        module.fail_json(msg='Missing requried github3 module (check docs or install with: pip install github3)')
+        module.fail_json(msg='Missing required github3 module (check docs or '
+                             'install with: pip install github3.py==1.0.0a4)')
 
     repo = module.params['repo']
     user = module.params['user']


### PR DESCRIPTION
##### SUMMARY
Github_release requires github3.py==1.0.0a4, update warning
for the same.

Fixes #23626

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/source_control/github_release.py

##### ANSIBLE VERSION
```
2.4.devel
```