### PR TITLE
executor stats and task_executor pep8 error

### DIFF
--- a/lib/ansible/executor/stats.py
+++ b/lib/ansible/executor/stats.py
@@ -54,7 +54,7 @@ class AggregateStats:
             failures=self.failures.get(host, 0),
             unreachable=self.dark.get(host, 0),
             changed=self.changed.get(host, 0),
-            skipped=self.skipped.get(host, 0),
+            skipped=self.skipped.get(host, 0)
         )
 
     def set_custom_stats(self, which, what, host=None):

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -148,7 +148,7 @@ class TaskExecutor:
                             else:
                                 raise
                 elif isinstance(res, list):
-                    for (idx, item) in enumerate(res):
+                    for idx, item in enumerate(res):
                         res[idx] = _clean_res(item, errors=errors)
                 return res
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
executor stats and task_executor pep8 error
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

`executor/stats.py`
`executor/task_executor.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
N/A
```
