### PR TITLE
NameError: name 'temp_path' is not defined

### DIFF
--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -130,10 +130,11 @@ except (AttributeError, OSError):
 if scriptdir is not None:
     sys.path = [p for p in sys.path if p != scriptdir]
 
+import imp
+import sys
 import base64
 import shutil
 import zipfile
-import tempfile
 import subprocess
 
 if sys.version_info < (3,):
@@ -150,6 +151,17 @@ except ImportError:
     from StringIO import StringIO as IOStream
 
 ZIPDATA = """%(zipdata)s"""
+
+def import_non_local(name):
+    # http://stackoverflow.com/questions/6031584/importing-from-builtin-library-when-module-with-same-name-exists
+
+    f, pathname, desc = imp.find_module(name, sys.path[1:])
+    module = imp.load_module(name, f, pathname, desc)
+    f.close()
+
+    return module
+
+tempfile = import_non_local('tempfile')
 
 def invoke_module(module, modlib_path, json_params):
     pythonpath = os.environ.get('PYTHONPATH')

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -155,7 +155,7 @@ ZIPDATA = """%(zipdata)s"""
 def import_non_local(name):
     # http://stackoverflow.com/questions/6031584/importing-from-builtin-library-when-module-with-same-name-exists
 
-    f, pathname, desc = imp.find_module(name, sys.path[1:])
+    f, pathname, desc = imp.find_module(name, [i for i in sys.path if i != ''])
     module = imp.load_module(name, f, pathname, desc)
     f.close()
 


### PR DESCRIPTION
##### SUMMARY
`tempfile` is defined in global module.

When python2.7, Calling `import tempfile` loads `tempfile.py` . 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/files/temppath.py

##### ANSIBLE VERSION
```
2.4 devel
```


##### ADDITIONAL INFORMATION

ansible task
```
- name: "create tempdir"
  tempfile:
    state: "directory"
  register: "tempdir"
```

error
```
The full traceback is:
Traceback (most recent call last):
  File "/Users/opapy/.ansible/tmp/ansible-tmp-1492423078.96-144161962966092/tempfile.py", line 136, in <module>
    shutil.rmtree(temp_path)
NameError: name 'temp_path' is not defined

fatal: [localhost]: FAILED! => {
    "changed": false,
    "failed": true,
    "module_stderr": "Traceback (most recent call last):\n  File \"/Users/opapy/.ansible/tmp/ansible-tmp-1492423078.96-144161962966092/tempfile.py\", line 136, in <module>\n    shutil.rmtree(temp_path)\nNameError: name 'temp_path' is not defined\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE",
    "rc": 0
}
	to re
```

I am english pro :)