### PR TITLE
added support for OUPath parameter for win_domain_membership

### DIFF
--- a/lib/ansible/modules/windows/win_domain_membership.ps1
+++ b/lib/ansible/modules/windows/win_domain_membership.ps1
@@ -99,12 +99,13 @@ Function Join-Domain {
         [string] $dns_domain_name,
         [string] $new_hostname,
         [string] $domain_admin_user,
-        [string] $domain_admin_password
+        [string] $domain_admin_password,
+        [string] $domain_ou_path
     )
 
     Write-DebugLog ("Creating credential for user {0}" -f $domain_admin_user)
     $domain_cred = Create-Credential $domain_admin_user $domain_admin_password
-    
+
     $add_args = @{
         ComputerName="."
         Credential=$domain_cred
@@ -115,6 +116,11 @@ Function Join-Domain {
     Write-DebugLog "adding hostname set arg to Add-Computer args"
     If($new_hostname) {
         $add_args["NewName"] = $new_hostname
+    }
+
+    Write-DebugLog "adding OU path set arg to Add-Computer args"
+    if ($domain_ou_path) {
+        $add_args["OUPath"] = $domain_ou_path
     }
 
     Write-DebugLog "calling Add-Computer"
@@ -172,6 +178,7 @@ $hostname = Get-AnsibleParam $params "hostname"
 $workgroup_name = Get-AnsibleParam $params "workgroup_name"
 $domain_admin_user = Get-AnsibleParam $params "domain_admin_user" -failifempty $result
 $domain_admin_password = Get-AnsibleParam $params "domain_admin_password" -failifempty $result
+$domain_ou_path = Get-AnsibleParam $params "domain_ou_path"
 
 $log_path = Get-AnsibleParam $params "log_path"
 $_ansible_check_mode = Get-AnsibleParam $params "_ansible_check_mode" -default $false
@@ -220,6 +227,11 @@ Try {
                     If(-not $hostname_match) {
                         Write-DebugLog "adding hostname change to domain-join args"
                         $join_args.new_hostname = $hostname
+                    }
+
+                    if ($domain_ou_path) {
+                        Write-DebugLog "adding OU path to domain-join args"
+                        $join_args.domain_ou_path = $domain_ou_path
                     }
 
                     $join_result = Join-Domain @join_args
@@ -276,4 +288,3 @@ Catch {
 
     Throw
 }
-

--- a/lib/ansible/modules/windows/win_domain_membership.py
+++ b/lib/ansible/modules/windows/win_domain_membership.py
@@ -48,6 +48,7 @@ options:
   domain_ou_path:
     description:
       - the desired OU path for the Windows host in the target domain
+    version_added: "2.4"
   state:
     description:
       - whether the target host should be a member of a domain or workgroup

--- a/lib/ansible/modules/windows/win_domain_membership.py
+++ b/lib/ansible/modules/windows/win_domain_membership.py
@@ -45,6 +45,9 @@ options:
   hostname:
     description:
       - the desired hostname for the Windows host
+  domain_ou_path:
+    description:
+      - the desired OU path for the Windows host in the target domain
   state:
     description:
       - whether the target host should be a member of a domain or workgroup
@@ -69,6 +72,7 @@ reboot_required:
 EXAMPLES='''
 
 # host should be a member of domain ansible.vagrant; module will ensure the hostname is mydomainclient
+# host domain object will be created/joined in 'CN=Computers,DC=ansible,DC=vagrant'
 # and will use the passed credentials to join domain if necessary.
 # Ansible connection should use local credentials if possible.
 # If a reboot is required, the second task will trigger one and wait until the host is available.
@@ -80,6 +84,7 @@ EXAMPLES='''
       hostname: mydomainclient
       domain_admin_user: testguy@ansible.vagrant
       domain_admin_password: password123!
+      domain_ou_path: 'CN=Computers,DC=ansible,DC=vagrant'
       state: domain
     register: domain_state
 


### PR DESCRIPTION
##### SUMMARY
Adds support for the OUPath parameter of Add-Computer (i.e. the underlying PowerShell) for invoking win_domain_membership when state = domain.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
lib/ansible/modules/windows/win_domain_membership.ps1

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
# host should be a member of domain ansible.vagrant; module will ensure the hostname is mydomainclient
# host domain object will be created/joined in 'CN=Computers,DC=ansible,DC=vagrant'
# and will use the passed credentials to join domain if necessary.
# Ansible connection should use local credentials if possible.
# If a reboot is required, the second task will trigger one and wait until the host is available.
- hosts: winclient
  gather_facts: no
  tasks:
  - win_domain_membership:
      dns_domain_name: ansible.vagrant
      hostname: mydomainclient
      domain_admin_user: testguy@ansible.vagrant
      domain_admin_password: password123!
      domain_ou_path: 'CN=Computers,DC=ansible,DC=vagrant'
      state: domain
    register: domain_state

  - win_reboot:
    when: domain_state.reboot_required
```
