### PR TITLE
Make fetch default to fail on errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ Ansible Changes By Release
 
   The new behaviour mirrors how the variables would appear if there was no hash
   mark in the string.
+- As of 2.4.0, the fetch module fails if there are errors reading the remote
+  file.  Use ignore_errors or failed_when in playbooks if you wish to ignore
+  errors.
 
 ####New Inventory scripts:
 - lxd

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -64,7 +64,6 @@ FILE_ATTRIBUTES = {
 import locale
 import os
 import re
-import pipes
 import shlex
 import subprocess
 import sys
@@ -164,7 +163,7 @@ except ImportError:
 from ansible.module_utils.pycompat24 import get_exception, literal_eval
 from ansible.module_utils.six import (PY2, PY3, b, binary_type, integer_types,
         iteritems, text_type, string_types)
-from ansible.module_utils.six.moves import map, reduce
+from ansible.module_utils.six.moves import map, reduce, shlex_quote
 from ansible.module_utils._text import to_native, to_bytes, to_text
 
 PASSWORD_MATCH = re.compile(r'^(?:.+[-_\s])?pass(?:[-_\s]?(?:word|phrase|wrd|wd)?)(?:[-_\s].+)?$', re.I)
@@ -2317,7 +2316,7 @@ class AnsibleModule(object):
         shell = False
         if isinstance(args, list):
             if use_unsafe_shell:
-                args = " ".join([pipes.quote(x) for x in args])
+                args = " ".join([shlex_quote(x) for x in args])
                 shell = True
         elif isinstance(args, (binary_type, text_type)) and use_unsafe_shell:
             shell = True
@@ -2411,7 +2410,7 @@ class AnsibleModule(object):
                     is_passwd = True
             arg = heuristic_log_sanitize(arg, self.no_log_values)
             clean_args.append(arg)
-        clean_args = ' '.join(pipes.quote(arg) for arg in clean_args)
+        clean_args = ' '.join(shlex_quote(arg) for arg in clean_args)
 
         if data:
             st_in = subprocess.PIPE

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -915,10 +915,18 @@ class AnsibleModule(object):
         return (uid, gid)
 
     def find_mount_point(self, path):
-        path = os.path.realpath(os.path.expanduser(os.path.expandvars(path)))
-        while not os.path.ismount(path):
-            path = os.path.dirname(path)
-        return path
+        path_is_bytes = False
+        if isinstance(path, binary_type):
+            path_is_bytes = True
+
+        b_path = os.path.realpath(to_bytes(os.path.expanduser(os.path.expandvars(path)), errors='surrogate_or_strict'))
+        while not os.path.ismount(b_path):
+            b_path = os.path.dirname(b_path)
+
+        if path_is_bytes:
+            return b_path
+
+        return to_text(b_path, errors='surrogate_or_strict')
 
     def is_special_selinux_path(self, path):
         """

--- a/lib/ansible/modules/files/fetch.py
+++ b/lib/ansible/modules/files/fetch.py
@@ -27,9 +27,7 @@ short_description: Fetches a file from remote nodes
 description:
      - This module works like M(copy), but in reverse. It is used for fetching
        files from remote machines and storing them locally in a file tree,
-       organized by hostname. Note that this module is written to transfer
-       log files that might not be present, so a missing remote file won't
-       be an error unless fail_on_missing is set to 'yes'.
+       organized by hostname.
 version_added: "0.2"
 options:
   src:
@@ -50,10 +48,13 @@ options:
   fail_on_missing:
     version_added: "1.1"
     description:
-      - When set to 'yes', the task will fail if the source file is missing.
+      - When set to 'yes', the task will fail if the remote file cannot be
+        read for any reason.  Prior to Ansible-2.4, setting this would only fail
+        if the source file was missing.
+      - The default was changed to "yes" in Ansible-2.4.
     required: false
     choices: [ "yes", "no" ]
-    default: "no"
+    default: "yes"
   validate_checksum:
     version_added: "1.4"
     description:
@@ -80,6 +81,11 @@ notes:
       depending on the file size can consume all available memory on the
       remote or local hosts causing a C(MemoryError). Due to this it is
       advisable to run this module without C(become) whenever possible.
+    - Prior to Ansible-2.4 this module would not fail if reading the remote
+      file was impossible unless fail_on_missing was set.  In Ansible-2.4+,
+      playbook authors are encouraged to use fail_when or ignore_errors to
+      get this ability.  They may also explicitly set fail_on_missing to False
+      to get the non-failing behaviour.
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/files/stat.py
+++ b/lib/ansible/modules/files/stat.py
@@ -477,11 +477,11 @@ def main():
 
     # resolved permissions
     for perm in [('readable', os.R_OK), ('writeable', os.W_OK), ('executable', os.X_OK)]:
-        output[perm[0]] = os.access(path, perm[1])
+        output[perm[0]] = os.access(b_path, perm[1])
 
     # symlink info
     if output.get('islnk'):
-        output['lnk_source'] = os.path.realpath(path)
+        output['lnk_source'] = os.path.realpath(b_path)
 
     try: # user data
         pw = pwd.getpwuid(st.st_uid)
@@ -500,19 +500,19 @@ def main():
         if get_md5:
             # Will fail on FIPS-140 compliant systems
             try:
-                output['md5'] = module.md5(path)
+                output['md5'] = module.md5(b_path)
             except ValueError:
                 output['md5'] = None
 
         if get_checksum:
-            output['checksum'] = module.digest_from_file(path, checksum_algorithm)
+            output['checksum'] = module.digest_from_file(b_path, checksum_algorithm)
 
     # try to get mime data if requested
     if get_mime:
         output['mimetype'] = output['charset'] = 'unknown'
         mimecmd = module.get_bin_path('file')
         if mimecmd:
-            mimecmd = [mimecmd, '-i', path]
+            mimecmd = [mimecmd, '-i', b_path]
             try:
                 rc, out, err = module.run_command(mimecmd)
                 if rc == 0:
@@ -527,7 +527,7 @@ def main():
         output['version'] = None
         output['attributes'] = []
         output['attr_flags'] = ''
-        out = module.get_file_attributes(path)
+        out = module.get_file_attributes(b_path)
         for x in ('version', 'attributes', 'attr_flags'):
             if x in out:
                 output[x] = out[x]

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -521,6 +521,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         2 = permissions issue
         3 = its a directory, not a file
         4 = stat module failed, likely due to not finding python
+        5 = appropriate json module not found
         '''
         x = "0"  # unknown error has occurred
         try:
@@ -535,6 +536,8 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 x = "2"  # cannot read file
             elif errormsg.endswith(u'MODULE FAILURE'):
                 x = "4"  # python not found or module uncaught exception
+            elif 'json' in errormsg or 'simplejson' in errormsg:
+                x = "5" # json or simplejson modules needed
         finally:
             return x
 

--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -118,26 +118,31 @@ class ActionModule(ActionBase):
 
         dest = dest.replace("//","/")
 
-        if remote_checksum in ('0', '1', '2', '3', '4'):
-            # these don't fail because you may want to transfer a log file that
-            # possibly MAY exist but keep going to fetch other log files
+        if remote_checksum in ('0', '1', '2', '3', '4', '5'):
             result['changed'] = False
             result['file'] = source
             if remote_checksum == '0':
                 result['msg'] = "unable to calculate the checksum of the remote file"
             elif remote_checksum == '1':
-                if fail_on_missing:
-                    result['failed'] = True
-                    del result['changed']
-                    result['msg'] = "the remote file does not exist"
-                else:
-                    result['msg'] = "the remote file does not exist, not transferring, ignored"
+                result['msg'] = "the remote file does not exist"
             elif remote_checksum == '2':
-                result['msg'] = "no read permission on remote file, not transferring, ignored"
+                result['msg'] = "no read permission on remote file"
             elif remote_checksum == '3':
                 result['msg'] = "remote file is a directory, fetch cannot work on directories"
             elif remote_checksum == '4':
                 result['msg'] = "python isn't present on the system.  Unable to compute checksum"
+            elif remote_checksum == '5':
+                result['msg'] = "stdlib json or simplejson was not found on the remote machine. Only the raw module can work without those installed"
+            # Historically, these don't fail because you may want to transfer
+            # a log file that possibly MAY exist but keep going to fetch other
+            # log files. Today, this is better achieved by adding
+            # ignore_errors or failed_when to the task.  Control the behaviour
+            # via fail_when_missing
+            if fail_on_missing:
+                result['failed'] = True
+                del result['changed']
+            else:
+                result['msg'] += ", not transferring, ignored"
             return result
 
         # calculate checksum for the local file
@@ -169,7 +174,9 @@ class ActionModule(ActionBase):
                     msg="checksum mismatch", file=source, dest=dest, remote_md5sum=None,
                     checksum=new_checksum, remote_checksum=remote_checksum))
             else:
-                result.update(dict(changed=True, md5sum=new_md5, dest=dest, remote_md5sum=None, checksum=new_checksum, remote_checksum=remote_checksum))
+                result.update({'changed': True, 'md5sum': new_md5, 'dest': dest,
+                               'remote_md5sum': None, 'checksum': new_checksum,
+                               'remote_checksum': remote_checksum})
         else:
             # For backwards compatibility. We'll return None on FIPS enabled systems
             try:

--- a/test/integration/targets/fetch/tasks/main.yml
+++ b/test/integration/targets/fetch/tasks/main.yml
@@ -39,7 +39,7 @@
       'diff.stdout == ""'
 
 - name: attempt to fetch a non-existent file - do not fail on missing
-  fetch: src={{ output_dir }}/doesnotexist dest={{ output_dir }}/fetched
+  fetch: src={{ output_dir }}/doesnotexist dest={{ output_dir }}/fetched fail_on_missing=False
   register: fetch_missing_nofail
 
 - name: check fetch missing no fail result
@@ -61,13 +61,24 @@
       - "not fetch_missing|changed"
 
 - name: attempt to fetch a directory - should not fail but return a message
-  fetch: src={{ output_dir }} dest={{ output_dir }}/somedir
+  fetch: src={{ output_dir }} dest={{ output_dir }}/somedir fail_on_missing=False
   register: fetch_dir
 
 - name: check fetch directory result
   assert:
     that:
       - "not fetch_dir|changed"
+      - "fetch_dir.msg"
+
+- name: attempt to fetch a directory - should fail
+  fetch: src={{ output_dir }} dest={{ output_dir }}/somedir fail_on_missing=True
+  register: failed_fetch_dir
+  ignore_errors: true
+
+- name: check fetch directory result
+  assert:
+    that:
+      - "failed_fetch_dir['failed']"
       - "fetch_dir.msg"
 
 - name: create symlink to a file that we can fetch

--- a/test/units/module_utils/test_basic.py
+++ b/test/units/module_utils/test_basic.py
@@ -647,7 +647,7 @@ class TestModuleUtilsBasic(ModuleTestCase):
         )
 
         def _mock_ismount(path):
-            if path == '/':
+            if path == b'/':
                 return True
             return False
 
@@ -655,7 +655,9 @@ class TestModuleUtilsBasic(ModuleTestCase):
             self.assertEqual(am.find_mount_point('/root/fs/../mounted/path/to/whatever'), '/')
 
         def _mock_ismount(path):
-            if path == '/subdir/mount':
+            if path == b'/subdir/mount':
+                return True
+            if path == b'/':
                 return True
             return False
 


### PR DESCRIPTION
##### SUMMARY

The fetch module was originally written to not fail on errors retrieving files before we had ignore_errors and fail_when features of core ansible.  Now that we have those, fetch's default of ignoring errors is anachronistic.  This change makes it so that fetch will fail on errors.

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
fetch.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```