### PR TITLE
Make warning logs consistent

### DIFF
--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -72,6 +72,8 @@ def check_args(module, warnings):
                     'removed in a future version' % key)
 
     # set argument's default value if not provided in input
+    # This is done to avoid unwanted argument deprecation warning
+    # in case argument is not given as input (outside provider).
     for key in ARGS_DEFAULT_VALUE:
         if not module.params.get(key, None):
             module.params[key] = ARGS_DEFAULT_VALUE[key]

--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -40,7 +40,7 @@ _DEVICE_CONNECTION = None
 
 eos_argument_spec = {
     'host': dict(),
-    'port': dict(type='int', default=443),
+    'port': dict(type='int'),
     'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
     'password': dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), no_log=True),
     'ssh_keyfile': dict(fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE']), type='path'),
@@ -49,12 +49,18 @@ eos_argument_spec = {
     'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
     'auth_pass': dict(no_log=True, fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS'])),
 
-    'use_ssl': dict(type='bool', default=True),
-    'validate_certs': dict(type='bool', default=True),
+    'use_ssl': dict(type='bool'),
+    'validate_certs': dict(type='bool'),
     'timeout': dict(type='int'),
 
     'provider': dict(type='dict'),
     'transport': dict(choices=['cli', 'eapi'])
+}
+
+ARGS_DEFAULT_VALUE = {
+    'port': 443,
+    'use_ssl': True,
+    'validate_certs': True
 }
 
 def check_args(module, warnings):
@@ -63,6 +69,10 @@ def check_args(module, warnings):
         if key not in ['provider', 'transport', 'authorize'] and module.params[key]:
             warnings.append('argument %s has been deprecated and will be '
                     'removed in a future version' % key)
+
+    for key in ARGS_DEFAULT_VALUE:
+        if not module.params.get(key, None):
+            module.params[key] = ARGS_DEFAULT_VALUE[key]
 
     if provider:
         for param in ('auth_pass', 'password'):

--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -57,6 +57,7 @@ eos_argument_spec = {
     'transport': dict(choices=['cli', 'eapi'])
 }
 
+# Add argument's default value here
 ARGS_DEFAULT_VALUE = {
     'port': 443,
     'use_ssl': True,
@@ -70,6 +71,7 @@ def check_args(module, warnings):
             warnings.append('argument %s has been deprecated and will be '
                     'removed in a future version' % key)
 
+    # set argument's default value if not provided in input
     for key in ARGS_DEFAULT_VALUE:
         if not module.params.get(key, None):
             module.params[key] = ARGS_DEFAULT_VALUE[key]

--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -54,6 +54,8 @@ def check_args(module, warnings):
                     'removed in a future version' % key)
 
     # set argument's default value if not provided in input
+    # This is done to avoid unwanted argument deprecation warning
+    # in case argument is not given as input (outside provider).
     for key in ARGS_DEFAULT_VALUE:
         if not module.params.get(key, None):
             module.params[key] = ARGS_DEFAULT_VALUE[key]

--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -41,6 +41,7 @@ junos_argument_spec = {
     'transport': dict()
 }
 
+# Add argument's default value here
 ARGS_DEFAULT_VALUE = {
     'timeout': 10
 }
@@ -52,6 +53,7 @@ def check_args(module, warnings):
             warnings.append('argument %s has been deprecated and will be '
                     'removed in a future version' % key)
 
+    # set argument's default value if not provided in input
     for key in ARGS_DEFAULT_VALUE:
         if not module.params.get(key, None):
             module.params[key] = ARGS_DEFAULT_VALUE[key]

--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -36,9 +36,13 @@ junos_argument_spec = {
     'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
     'password': dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), no_log=True),
     'ssh_keyfile': dict(fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE']), type='path'),
-    'timeout': dict(type='int', default=10),
+    'timeout': dict(type='int'),
     'provider': dict(type='dict'),
     'transport': dict()
+}
+
+ARGS_DEFAULT_VALUE = {
+    'timeout': 10
 }
 
 def check_args(module, warnings):
@@ -47,6 +51,10 @@ def check_args(module, warnings):
         if key not in ('provider',) and module.params[key]:
             warnings.append('argument %s has been deprecated and will be '
                     'removed in a future version' % key)
+
+    for key in ARGS_DEFAULT_VALUE:
+        if not module.params.get(key, None):
+            module.params[key] = ARGS_DEFAULT_VALUE[key]
 
     if provider:
         for param in ('password',):

--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -67,6 +67,8 @@ def check_args(module, warnings):
                     'removed in a future version' % key)
 
     # set argument's default value if not provided in input
+    # This is done to avoid unwanted argument deprecation warning
+    # in case argument is not given as input (outside provider).
     for key in ARGS_DEFAULT_VALUE:
         if not module.params.get(key, None):
             module.params[key] = ARGS_DEFAULT_VALUE[key]

--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -54,12 +54,22 @@ nxos_argument_spec = {
     'transport': dict(choices=['cli', 'nxapi'])
 }
 
+# Add argument's default value here
+ARGS_DEFAULT_VALUE = {
+    'timeout': 10
+}
+
 def check_args(module, warnings):
     provider = module.params['provider'] or {}
     for key in nxos_argument_spec:
         if key not in ['provider', 'transport'] and module.params[key]:
             warnings.append('argument %s has been deprecated and will be '
                     'removed in a future version' % key)
+
+    # set argument's default value if not provided in input
+    for key in ARGS_DEFAULT_VALUE:
+        if not module.params.get(key, None):
+            module.params[key] = ARGS_DEFAULT_VALUE[key]
 
     if provider:
         for param in ('password',):
@@ -240,7 +250,7 @@ class Nxapi:
 
         headers = {'Content-Type': 'application/json'}
         result = list()
-        timeout = self._module.params['timeout'] or 10
+        timeout = self._module.params['timeout']
 
         for req in requests:
             if self._nxapi_auth:

--- a/lib/ansible/modules/network/eos/eos_facts.py
+++ b/lib/ansible/modules/network/eos/eos_facts.py
@@ -375,7 +375,7 @@ def main():
         key = 'ansible_net_%s' % key
         ansible_facts[key] = value
 
-    module.exit_json(ansible_facts=ansible_facts)
+    module.exit_json(ansible_facts=ansible_facts, warnings=warnings)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Arguments outside provider with default value should not 
log as a warning in case it is not mentioned in play.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/eos.py
module_utils/junos.py
network/eos/eos_facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
