### PR TITLE
crypto/openssl_csr: Specify proper Ansible version

### DIFF
--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -25,7 +25,7 @@ DOCUMENTATION = '''
 ---
 module: openssl_csr
 author: "Yanis Guenane (@Spredzy)"
-version_added: "2.3"
+version_added: "2.4"
 short_description: Generate OpenSSL Certificate Signing Request (CSR)
 description:
     - "This module allows one to (re)generates OpenSSL certificate signing requests.


### PR DESCRIPTION
##### SUMMARY

The commit was started before 2.3 was branched, but was only merged once
2.3 was actually branched. This leads to documentation stating this
module is new in 2.3 when it will be actually new in 2.4

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

- crypto/openssl_csr