### PR TITLE
ecs_taskdefinition module:  Fixed a bug that failed to compare containers

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -240,6 +240,11 @@ def main():
     task_mgr = EcsTaskManager(module)
     results = dict(changed=False)
 
+    for container in module.params['containers']:
+        if 'environment' in container:
+            for environment in container['environment']:
+                environment['value'] = str(environment['value'])
+
     if module.params['state'] == 'present':
         if 'containers' not in module.params or not module.params['containers']:
             module.fail_json(msg="To use task definitions, a list of containers must be specified")
@@ -352,10 +357,6 @@ def main():
             if not module.check_mode:
                 # Doesn't exist. create it.
                 volumes = module.params.get('volumes', []) or []
-                for container in module.params['containers']:
-                    if 'environment' in container:
-                        for environment in container['environment']:
-                            environment['value'] = str(environment['value'])
                 results['taskdefinition'] = task_mgr.register_task(module.params['family'],
                                                                    module.params['task_role_arn'],
                                                                    module.params['network_mode'],


### PR DESCRIPTION
##### SUMMARY

fix #23297

It is to fix the failed comparison of containers.

A new task definition is always created when `environment` contains non-strings before modification.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

ecs_taskdefinition module

##### ANSIBLE VERSION

```
2.3.0
```

##### ADDITIONAL INFORMATION
