### PR TITLE
Fix UnboundLocalError in `cloudflare_dns` module in check mode

### DIFF
--- a/lib/ansible/modules/net_tools/cloudflare_dns.py
+++ b/lib/ansible/modules/net_tools/cloudflare_dns.py
@@ -596,13 +596,17 @@ class CloudflareAPI(object):
             if (type == 'CNAME') and (cur_record['content'] != new_record['content']):
                 do_update = True
             if do_update:
-                if not self.module.check_mode:
+                if self.module.check_mode:
+                    result = new_record
+                else:
                     result, info = self._cf_api_call('/zones/{0}/dns_records/{1}'.format(zone_id,records[0]['id']),'PUT',new_record)
                 self.changed = True
                 return result,self.changed
             else:
                 return records,self.changed
-        if not self.module.check_mode:
+        if self.module.check_mode:
+            result = new_record
+        else:
             result, info = self._cf_api_call('/zones/{0}/dns_records'.format(zone_id),'POST',new_record)
         self.changed = True
         return result,self.changed


### PR DESCRIPTION
Fixes #23682

##### SUMMARY

There are two code paths inside the `cluodflare_dns` module where the `result` variable (used internally) is not set before being returned, specifically in check mode (#23682)

```python
# Line 600
if not self.module.check_mode:
    result, info = self._cf_api_call('/zones/{0}/dns_records/{1}'.format(zone_id,records[0]['id']),'PUT',new_record)
self.changed = True
return result,self.changed
```

```python
# Line 606
if not self.module.check_mode:
    result, info = self._cf_api_call('/zones/{0}/dns_records'.format(zone_id),'POST',new_record)
self.changed = True
return result,self.changed
```

In both cases, this causes execution in check mode to throw an error due to `result` being referenced without being defined.

To preserve the documented return values of this module, I've altered the code to return the new record's data.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`cloudflare_dns`

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel a06014663c) last updated 2017/04/18 07:08:27 (GMT +100)
  config file = 
  configured module search path = [u'/Users/jack/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/jack/Projects/ansible/lib/ansible
  executable location = /Users/jack/Projects/ansible/bin/ansible
  python version = 2.7.10 (default, Jul 30 2016, 18:31:42) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before change:

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: UnboundLocalError: local variable 'result' referenced before assignment
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_ioQv52/ansible_module_cloudflare_dns.py\", line 648, in <module>\n    main()\n  File \"/tmp/ansible_ioQv52/ansible_module_cloudflare_dns.py\", line 636, in main\n    result,changed = cf_api.ensure_dns_record()\n  File \"/tmp/ansible_ioQv52/ansible_module_cloudflare_dns.py\", line 584, in ensure_dns_record\n    return result,self.changed\nUnboundLocalError: local variable 'result' referenced before assignment\n", "module_stdout": "", "msg": "MODULE FAILURE"}
```

After change:
```
changed: [localhost]
```

##### Testing

Im unsure how to best create a test case for this, as the current test suite doesn't catch it. Perhaps someone could advise?