### PR TITLE
Rebasing commit  17378 RSA 1024 to RSA 4096

### DIFF
--- a/examples/scripts/ConfigureRemotingForAnsible.ps1
+++ b/examples/scripts/ConfigureRemotingForAnsible.ps1
@@ -31,6 +31,7 @@
 # Updated by Chris Church <cchurch@ansible.com>
 # Updated by Michael Crilly <mike@autologic.cm>
 # Updated by Anton Ouzounov <Anton.Ouzounov@careerbuilder.com>
+# Updated by Nicolas Simond <contact@nicolas-simond.com>
 # Updated by Dag Wieërs <dag@wieers.com>
 # Updated by Jordan Borean <jborean93@gmail.com>
 #
@@ -40,13 +41,14 @@
 # Version 1.3 - 2016-04-04
 # Version 1.4 - 2017-01-05
 # Version 1.5 - 2017-02-09
+# Version 1.6 - 2017-04-18
 
 # Support -Verbose option
 [CmdletBinding()]
 
 Param (
     [string]$SubjectName = $env:COMPUTERNAME,
-    [int]$CertValidityDays = 365,
+    [int]$CertValidityDays = 1095,
     [switch]$SkipNetworkProfileCheck,
     $CreateSelfSignedCert = $true,
     [switch]$ForceNewSSLCert,
@@ -77,7 +79,7 @@ Function New-LegacySelfSignedCert
 {
     Param (
         [string]$SubjectName,
-        [int]$ValidDays = 365
+        [int]$ValidDays = 1095
     )
 
     $name = New-Object -COM "X509Enrollment.CX500DistinguishedName.1"
@@ -86,7 +88,7 @@ Function New-LegacySelfSignedCert
     $key = New-Object -COM "X509Enrollment.CX509PrivateKey.1"
     $key.ProviderName = "Microsoft RSA SChannel Cryptographic Provider"
     $key.KeySpec = 1
-    $key.Length = 1024
+    $key.Length = 4096
     $key.SecurityDescriptor = "D:PAI(A;;0xd01f01ff;;;SY)(A;;0xd01f01ff;;;BA)(A;;0x80120089;;;NS)"
     $key.MachineContext = 1
     $key.Create()


### PR DESCRIPTION
Rebase of https://github.com/ansible/ansible/pull/17378#issuecomment-294705997

##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME
- ConfigureRemotingForAnsible.ps1
##### ANSIBLE VERSION

```
ansible 2.1.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Small change to use 4096 bits RSA keys as default for this script (especially for win servers managed over the Internet).
- Debian's guide to key creation currently recommends 4096 bit keys.
- Fedora's archive keys are all 4096 bit keys.
- BSI recommends at least 3072 bits key for 2017 - 2021.
- RSA 4096 is fully supported by Ansible and Windows Servers and safer.

Also, I propose to use a 3-year certificate, so you don't have to renew all your certs every year. 
This is generally the lifetime of a server (we keep them for 3 to 5 years in my job).

Finally, I think that this is a good idea to use the new `Microsoft Enhanced Cryptographic Provider v1.0` with ECDSA keys for this script but, I'm a dick in PS and I don't know how to do this.
