### PR TITLE
postgresql_user: use standard module hashlib instead of passlib

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -52,8 +52,8 @@ options:
       - >
         When passing an encrypted password, the encrypted parameter must also be true, and it must be generated with the format
         C('str[\\"md5\\"] + md5[ password + username ]'), resulting in a total of 35 characters.  An easy way to do this is:
-        C(echo \\"md5`echo -n \\"verysecretpasswordJOE\\" | md5`\\"). Note that if encrypted is set, the stored password will be hashed whether or not
-        it is pre-encrypted.
+        C(echo \\"md5`echo -n \\"verysecretpasswordJOE\\" | md5`\\"). Note that if the provided password string is already in
+        MD5-hashed format, then it is used as-is, regardless of encrypted parameter.
     required: false
     default: null
   db:

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -186,87 +186,13 @@
 #
 # Create and destroy user
 #
-- name: Create a user
-  become_user: "{{ pg_user }}"
-  become: True
-  postgresql_user:
-    name: "{{ db_user1 }}"
-    encrypted: 'yes'
-    password: "md55c8ccfd9d6711fc69a7eae647fc54f51"
-    login_user: "{{ pg_user }}"
-    db: postgres
-  register: result
-
-- name: Check that ansible reports they were created
-  assert:
-    that:
-      - "result.changed == True"
-
-- name: Check that they were created
-  become_user: "{{ pg_user }}"
-  become: True
-  shell: echo "select * from pg_user where usename='{{ db_user1 }}';" | psql -d postgres
-  register: result
-
-- assert:
-    that:
-      - "result.stdout_lines[-1] == '(1 row)'"
-
-- name: Check that creating user a second time does nothing
-  become_user: "{{ pg_user }}"
-  become: True
-  postgresql_user:
-    name: "{{ db_user1 }}"
-    encrypted: 'yes'
-    password: "md55c8ccfd9d6711fc69a7eae647fc54f51"
-    login_user: "{{ pg_user }}"
-    db: postgres
-  register: result
-
-- name: Check that ansible reports no change
-  assert:
-    that:
-      - "result.changed == False"
-
-- name: Remove user
-  become_user: "{{ pg_user }}"
-  become: True
-  postgresql_user:
-    name: "{{ db_user1 }}"
-    state: 'absent'
-    login_user: "{{ pg_user }}"
-    db: postgres
-  register: result
-
-- name: Check that ansible reports they were removed
-  assert:
-    that:
-      - "result.changed == True"
-
-- name: Check that they were removed
-  become_user: "{{ pg_user }}"
-  become: True
-  shell: echo "select * from pg_user where usename='{{ db_user1 }}';" | psql -d postgres
-  register: result
-
-- assert:
-    that:
-      - "result.stdout_lines[-1] == '(0 rows)'"
-
-- name: Check that removing user a second time does nothing
-  become_user: "{{ pg_user }}"
-  become: True
-  postgresql_user:
-    name: "{{ db_user1 }}"
-    state: 'absent'
-    login_user: "{{ pg_user }}"
-    db: postgres
-  register: result
-
-- name: Check that ansible reports no change
-  assert:
-    that:
-      - "result.changed == False"
+- include: test_user.yml
+  vars:
+    encrypted: '{{ item.user_creation_encrypted_value }}'
+    db_password1: 'secretù' # use UTF-8
+  with_items:
+    - user_creation_encrypted_value: 'yes'
+    - user_creation_encrypted_value: 'no'
 
 # BYPASSRLS role attribute was introduced in Postgres 9.5, so 
 # we want to test atrribute management differently depending
@@ -875,7 +801,7 @@
     login_password: "password"
     login_host: "localhost"
 
-- name: Check that they were created
+- name: Check that it was created
   become: True
   become_user: "{{ pg_user }}"
   shell: echo "select * from pg_user where usename='{{ db_user2 }}';" | psql -d postgres

--- a/test/integration/targets/postgresql/tasks/test_user.yml
+++ b/test/integration/targets/postgresql/tasks/test_user.yml
@@ -3,12 +3,6 @@
       become_user: "{{ pg_user }}"
       become: True
       register: result
-    task_parameters_readonly: &task_parameters_readonly
-      become_user: "{{ pg_user }}"
-      become: True
-      register: result
-      environment:
-        PGOPTIONS: '-c default_transaction_read_only=on' # ensure 'alter user' query isn't executed
     postgresql_parameters: &parameters
       db: postgres
       name: "{{ db_user1 }}"
@@ -16,11 +10,14 @@
 
   block: # block is only used here in order to be able to define YAML anchors at the beginning in 'vars' section
   - name: 'Check that PGOPTIONS environment variable is effective (1/2)'
-    <<: *task_parameters_readonly
+    <<: *task_parameters
     postgresql_user:
       <<: *parameters
       password: '{{ db_password1 }}'
     ignore_errors: true
+    environment:
+      PGCLIENTENCODING: 'UTF8'
+      PGOPTIONS: '-c default_transaction_read_only=on' # ensure 'alter user' query isn't executed
 
   - name: 'Check that PGOPTIONS environment variable is effective (2/2)'
     assert:
@@ -33,6 +30,8 @@
       <<: *parameters
       password: '{{ db_password1 }}'
       encrypted: '{{ encrypted }}'
+    environment:
+      PGCLIENTENCODING: 'UTF8'
 
   - block: &changed # block is only used here in order to be able to define YAML anchor
     - name: Check that ansible reports it was created
@@ -49,11 +48,14 @@
         - "result.stdout_lines[-1] == '(1 row)'"
 
   - name: Check that creating user a second time does nothing
-    <<: *task_parameters_readonly
+    <<: *task_parameters
     postgresql_user:
       <<: *parameters
       password: '{{ db_password1 }}'
       encrypted: '{{ encrypted }}'
+    environment:
+      PGCLIENTENCODING: 'UTF8'
+      PGOPTIONS: '-c default_transaction_read_only=on' # ensure 'alter user' query isn't executed
 
   - block: &not_changed # block is only used here in order to be able to define YAML anchor
     - name: Check that ansible reports no change
@@ -64,29 +66,36 @@
   - block:
 
     - name: 'Using MD5-hashed password: check that password not changed when using cleartext password'
-      <<: *task_parameters_readonly
+      <<: *task_parameters
       postgresql_user:
         <<: *parameters
         password: '{{ db_password1 }}'
         encrypted: 'yes'
+      environment:
+#        PGCLIENTENCODING: 'UTF8'
+        PGOPTIONS: '-c default_transaction_read_only=on' # ensure 'alter user' query isn't executed
 
     - <<: *not_changed
 
     - name: "Using MD5-hashed password: check that password not changed when using md5 hash with 'ENCRYPTED'"
-      <<: *task_parameters_readonly
+      <<: *task_parameters
       postgresql_user:
         <<: *parameters
         password: "md5{{ (db_password1 ~ db_user1) | hash('md5')}}"
         encrypted: 'yes'
+      environment:
+        PGOPTIONS: '-c default_transaction_read_only=on' # ensure 'alter user' query isn't executed
 
     - <<: *not_changed
 
     - name: "Using MD5-hashed password: check that password not changed when using md5 hash with 'UNENCRYPTED'"
-      <<: *task_parameters_readonly
+      <<: *task_parameters
       postgresql_user:
         <<: *parameters
         password: "md5{{ (db_password1 ~ db_user1) | hash('md5')}}"
         encrypted: 'no'
+      environment:
+        PGOPTIONS: '-c default_transaction_read_only=on' # ensure 'alter user' query isn't executed
 
     - <<: *not_changed
 
@@ -96,6 +105,8 @@
         <<: *parameters
         password: 'prefix{{ db_password1 }}'
         encrypted: 'yes'
+      environment:
+        PGCLIENTENCODING: 'UTF8'
 
     - <<: *changed
 
@@ -122,11 +133,14 @@
   - block:
 
     - name: 'Using cleartext password: check that password not changed when using cleartext password'
-      <<: *task_parameters_readonly
+      <<: *task_parameters
       postgresql_user:
         <<: *parameters
         password: "{{ db_password1 }}"
         encrypted: 'no'
+      environment:
+        PGCLIENTENCODING: 'UTF8'
+        PGOPTIONS: '-c default_transaction_read_only=on' # ensure 'alter user' query isn't executed
 
     - <<: *not_changed
 
@@ -136,6 +150,8 @@
         <<: *parameters
         password: "changed{{ db_password1 }}"
         encrypted: 'no'
+      environment:
+        PGCLIENTENCODING: 'UTF8'
 
     - <<: *changed
 
@@ -150,17 +166,21 @@
   - <<: *changed
 
   - name: Check that they were removed
-    <<: *task_parameters_readonly
+    <<: *task_parameters
     shell: echo "select * from pg_user where usename='{{ db_user1 }}';" | psql -d postgres
+    environment:
+        PGOPTIONS: '-c default_transaction_read_only=on' # ensure 'alter user' query isn't executed
 
   - assert:
       that:
         - "result.stdout_lines[-1] == '(0 rows)'"
 
   - name: Check that removing user a second time does nothing
-    <<: *task_parameters_readonly
+    <<: *task_parameters
     postgresql_user:
       state: 'absent'
       <<: *parameters
+    environment:
+        PGOPTIONS: '-c default_transaction_read_only=on' # ensure 'alter user' query isn't executed
 
   - <<: *not_changed

--- a/test/integration/targets/postgresql/tasks/test_user.yml
+++ b/test/integration/targets/postgresql/tasks/test_user.yml
@@ -1,0 +1,166 @@
+- vars:
+    task_parameters: &task_parameters
+      become_user: "{{ pg_user }}"
+      become: True
+      register: result
+    task_parameters_readonly: &task_parameters_readonly
+      become_user: "{{ pg_user }}"
+      become: True
+      register: result
+      environment:
+        PGOPTIONS: '-c default_transaction_read_only=on' # ensure 'alter user' query isn't executed
+    postgresql_parameters: &parameters
+      db: postgres
+      name: "{{ db_user1 }}"
+      login_user: "{{ pg_user }}"
+
+  block: # block is only used here in order to be able to define YAML anchors at the beginning in 'vars' section
+  - name: 'Check that PGOPTIONS environment variable is effective (1/2)'
+    <<: *task_parameters_readonly
+    postgresql_user:
+      <<: *parameters
+      password: '{{ db_password1 }}'
+    ignore_errors: true
+
+  - name: 'Check that PGOPTIONS environment variable is effective (2/2)'
+    assert:
+      that:
+          - "{{ result|failed }}"
+
+  - name: 'Create a user (password encrypted: {{ encrypted }})'
+    <<: *task_parameters
+    postgresql_user:
+      <<: *parameters
+      password: '{{ db_password1 }}'
+      encrypted: '{{ encrypted }}'
+
+  - block: &changed # block is only used here in order to be able to define YAML anchor
+    - name: Check that ansible reports it was created
+      assert:
+        that:
+          - "{{ result|changed }}"
+
+  - name: Check that it was created
+    <<: *task_parameters
+    shell: echo "select * from pg_user where usename='{{ db_user1 }}';" | psql -d postgres
+
+  - assert:
+      that:
+        - "result.stdout_lines[-1] == '(1 row)'"
+
+  - name: Check that creating user a second time does nothing
+    <<: *task_parameters_readonly
+    postgresql_user:
+      <<: *parameters
+      password: '{{ db_password1 }}'
+      encrypted: '{{ encrypted }}'
+
+  - block: &not_changed # block is only used here in order to be able to define YAML anchor
+    - name: Check that ansible reports no change
+      assert:
+        that:
+          - "{{ not result|changed }}"
+
+  - block:
+
+    - name: 'Using MD5-hashed password: check that password not changed when using cleartext password'
+      <<: *task_parameters_readonly
+      postgresql_user:
+        <<: *parameters
+        password: '{{ db_password1 }}'
+        encrypted: 'yes'
+
+    - <<: *not_changed
+
+    - name: "Using MD5-hashed password: check that password not changed when using md5 hash with 'ENCRYPTED'"
+      <<: *task_parameters_readonly
+      postgresql_user:
+        <<: *parameters
+        password: "md5{{ (db_password1 ~ db_user1) | hash('md5')}}"
+        encrypted: 'yes'
+
+    - <<: *not_changed
+
+    - name: "Using MD5-hashed password: check that password not changed when using md5 hash with 'UNENCRYPTED'"
+      <<: *task_parameters_readonly
+      postgresql_user:
+        <<: *parameters
+        password: "md5{{ (db_password1 ~ db_user1) | hash('md5')}}"
+        encrypted: 'no'
+
+    - <<: *not_changed
+
+    - name: 'Using MD5-hashed password: check that password changed when using another cleartext password'
+      <<: *task_parameters
+      postgresql_user:
+        <<: *parameters
+        password: 'prefix{{ db_password1 }}'
+        encrypted: 'yes'
+
+    - <<: *changed
+
+    - name: "Using MD5-hashed password: check that password changed when using another md5 hash with 'ENCRYPTED'"
+      <<: *task_parameters
+      postgresql_user:
+        <<: *parameters
+        password: "md5{{ ('prefix1' ~ db_password1 ~ db_user1) | hash('md5')}}"
+        encrypted: 'yes'
+
+    - <<: *changed
+
+    - name: "Using MD5-hashed password: check that password changed when using md5 hash with 'UNENCRYPTED'"
+      <<: *task_parameters
+      postgresql_user:
+        <<: *parameters
+        password: "md5{{ ('prefix2' ~ db_password1 ~ db_user1) | hash('md5')}}"
+        encrypted: 'no'
+
+    - <<: *changed
+
+    when: encrypted == 'yes'
+
+  - block:
+
+    - name: 'Using cleartext password: check that password not changed when using cleartext password'
+      <<: *task_parameters_readonly
+      postgresql_user:
+        <<: *parameters
+        password: "{{ db_password1 }}"
+        encrypted: 'no'
+
+    - <<: *not_changed
+
+    - name: 'Using cleartext password: check that password changed when using another cleartext password'
+      <<: *task_parameters
+      postgresql_user:
+        <<: *parameters
+        password: "changed{{ db_password1 }}"
+        encrypted: 'no'
+
+    - <<: *changed
+
+    when: encrypted == 'no'
+
+  - name: Remove user
+    <<: *task_parameters
+    postgresql_user:
+      state: 'absent'
+      <<: *parameters
+
+  - <<: *changed
+
+  - name: Check that they were removed
+    <<: *task_parameters_readonly
+    shell: echo "select * from pg_user where usename='{{ db_user1 }}';" | psql -d postgres
+
+  - assert:
+      that:
+        - "result.stdout_lines[-1] == '(0 rows)'"
+
+  - name: Check that removing user a second time does nothing
+    <<: *task_parameters_readonly
+    postgresql_user:
+      state: 'absent'
+      <<: *parameters
+
+  - <<: *not_changed

--- a/test/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/test/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -63,9 +63,9 @@
   when: ansible_os_family == "RedHat" and ansible_service_mgr != "systemd"
 
 - name: Initialize postgres (Debian)
-  command: /usr/bin/pg_createcluster {{ pg_ver }} main
-  # Sometimes package install creates the db cluster, sometimes this step is needed
-  ignore_errors: True
+  shell: '. /usr/share/postgresql-common/maintscripts-functions && set_system_locale && /usr/bin/pg_createcluster -u postgres {{ pg_ver }} main'
+  args:
+    creates: "/etc/postgresql/{{ pg_ver }}/"
   when: ansible_os_family == 'Debian'
 
 - name: Initialize postgres (Suse)


### PR DESCRIPTION
##### SUMMARY
When `passlib` isn't available, an useless `alter role` query is executed.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
postgresql_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel 8b4f5ba064)
```