### PR TITLE
Fix 'Group does not exist' when adding groups

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -545,7 +545,7 @@ class User(object):
         if self.groups is None:
             return None
         info = self.user_info()
-        groups = set(filter(None, self.groups.split(',')))
+        groups = set([x.strip() for x in self.groups.split(',') if x])
         for g in set(groups):
             if not self.group_exists(g):
                 self.module.fail_json(msg="Group %s does not exist" % (g))


### PR DESCRIPTION
##### SUMMARY
Creating a user with `groups=sudo, adm` instead of `groups=sudo,adm` (space) results in an error because the group ' adm' (with space) doesn't exist. This seems to be a bug, Unix group names can never begin or start with a whitespace character.
Strip() group names to fix this.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
User module

##### ANSIBLE VERSION
```
ansible 2.0.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```