### PR TITLE
fix ansible galaxy file mangling

### DIFF
--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -319,7 +319,7 @@ class GalaxyRole(object):
                             # bits that might be in the file for security purposes
                             # and drop any containing directory, as mentioned above
                             if member.isreg() or member.issym():
-                                parts = member.name.replace(archive_parent_dir, "").split(os.sep)
+                                parts = member.name.replace(archive_parent_dir, "", 1).split(os.sep)
                                 final_parts = []
                                 for part in parts:
                                     if part != '..' and '~' not in part and '$' not in part:


### PR DESCRIPTION
##### SUMMARY

without this patch, ansible-galaxy will mangle files containing
the archive parent directory name, eg 'owncloud/files/owncloud.cron'
will become 'owncloud/files/.cron'.

this patch simply limits the replacement to the first occurence of the
archive parent directory name.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

ansible-galaxy
