### PR TITLE
make os_security_group_rule idempotent

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
@@ -206,9 +206,9 @@ def _ports_match(protocol, module_min, module_max, rule_min, rule_max):
             module_min = None
             module_max = None
 
-        if module_min is None and module_max is None:
-            if (rule_min and int(rule_min) == 1
-                and rule_max and int(rule_max) == 65535):
+        if ((module_min is None and module_max is None) and
+                (rule_min and int(rule_min) == 1 and
+                    rule_max and int(rule_max) == 65535)):
                     # (None, None) == (1, 65535)
                     return True
 

--- a/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
@@ -209,8 +209,8 @@ def _ports_match(protocol, module_min, module_max, rule_min, rule_max):
         if module_min is None and module_max is None:
             if (rule_min and int(rule_min) == 1
                 and rule_max and int(rule_max) == 65535):
-                # (None, None) == (1, 65535)
-                return True
+                	# (None, None) == (1, 65535)
+                	return True
 
     # Sanity check to make sure we don't have type comparison issues.
     if module_min:

--- a/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
@@ -200,12 +200,17 @@ def _ports_match(protocol, module_min, module_max, rule_min, rule_max):
         if module_max and int(module_max) == -1:
             module_max = None
 
-    # Check if user is supplying None values for full TCP/UDP port range.
-    if protocol in ['tcp', 'udp'] and module_min is None and module_max is None:
-        if (rule_min and int(rule_min) == 1
+    # Check if the user is supplying -1 or None values for full TPC/UDP port range.
+    if protocol in ['tcp', 'udp'] or protocol is None:
+        if module_min and module_max and int(module_min) == int(module_max) == -1:
+            module_min = None
+            module_max = None
+
+        if module_min is None and module_max is None:
+            if (rule_min and int(rule_min) == 1
                 and rule_max and int(rule_max) == 65535):
-            # (None, None) == (1, 65535)
-            return True
+                # (None, None) == (1, 65535)
+                return True
 
     # Sanity check to make sure we don't have type comparison issues.
     if module_min:

--- a/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
@@ -209,8 +209,8 @@ def _ports_match(protocol, module_min, module_max, rule_min, rule_max):
         if module_min is None and module_max is None:
             if (rule_min and int(rule_min) == 1
                 and rule_max and int(rule_max) == 65535):
-                	# (None, None) == (1, 65535)
-                	return True
+                    # (None, None) == (1, 65535)
+                    return True
 
     # Sanity check to make sure we don't have type comparison issues.
     if module_min:


### PR DESCRIPTION
##### SUMMARY

Allows to define security group rules using the following syntax

```
- os_security_group_rule:
    cloud: mordred
    security_group: foo
    protocol: icmp
    port_range_min: -1
    port_range_max: -1
    remote_ip_prefix: 0.0.0.0/0
```
when protocol is TCP or UDP.

Fixes #19610.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
os_security_group_rule

##### ANSIBLE VERSION
```
ansible --version
ansible 2.3.0.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```