### PR TITLE
When become_method is su, self._play_context.prompt is a function. Fixes #23689

### DIFF
--- a/lib/ansible/plugins/connection/__init__.py
+++ b/lib/ansible/plugins/connection/__init__.py
@@ -258,6 +258,8 @@ class ConnectionBase(with_metaclass(ABCMeta, object)):
             if not b_lines:
                 return False
             return b_lines[-1].strip().endswith(b_prompt) or b_lines[0].strip().endswith(b_prompt)
+        else:
+            return self._play_context.prompt(b_output)
 
     def check_incorrect_password(self, b_output):
         b_incorrect_password = to_bytes(gettext.dgettext(self._play_context.become_method, C.BECOME_ERROR_STRINGS[self._play_context.become_method]))


### PR DESCRIPTION
##### SUMMARY

In 6f77498 / 4a9c5d9574038b80d199daafc9d1273f8a659831 we lost the `else` that would call `self._play_context.prompt` as a function.  As a result, when `become_method=su` we would return `None` implicitly when trying to match the prompt in `check_password_prompt`

Fixes #23689

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`plugins/connection/__init__.py`

##### ANSIBLE VERSION

```
devel
```


##### ADDITIONAL INFORMATION

This should also be cherry picked into stable-2.3 for a 2.3.1 release.