### PR TITLE
Keep trying other methods when transfer_method = smart

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -167,9 +167,12 @@ def _ssh_retry(func):
                     break
                 else:
                     raise AnsibleConnectionFailure("Failed to connect to the host via ssh: %s" % to_native(return_tuple[2]))
-            except (AnsibleConnectionFailure, Exception) as e:
+            except Exception as e:
                 if attempt == remaining_tries - 1:
-                    raise
+                    if isinstance(e, AnsibleConnectionFailure):
+                        return return_tuple
+                    else:
+                        raise
                 else:
                     pause = 2 ** attempt - 1
                     if pause > 30:


### PR DESCRIPTION
##### SUMMARY
Commit 1fe67f9 introduced a change to keep retrying file
transfers where previously retry only applied to commands.

This change broke transfer_method = smart in a way that
when sftp transfer is tried, it raises an exception
interrupting the flow to continue trying other methods.

This change catches AnsibleConnectionFailure in
_file_transport_command to continue trying other
methods.

Fixes #23711

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
plugins/connection/ssh.py

##### ANSIBLE VERSION
```
$ ansible --version
ansible 2.4.0 (devel 698fa37a44) last updated 2017/04/18 11:06:11 (GMT -500)
  config file = /Users/albertom/Desktop/test/ansible.cfg
  configured module search path = [u'/Users/albertom/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/albertom/github/ansible/lib/ansible
  executable location = /Users/albertom/github/ansible/bin/ansible
  python version = 2.7.13 (v2.7.13:a06454b1afa1, Dec 17 2016, 12:39:47) [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
```

##### ADDITIONAL INFORMATION
before
```
# ansible-playbook -i hosts test.yml

PLAY [all] ***********************************************************************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************************************
fatal: [wolverine]: UNREACHABLE! => {"changed": false, "msg": "Failed to connect to the host via ssh: Connection closed\r\n", "unreachable": true}
	to retry, use: --limit @/Users/albertom/Desktop/test/test.retry

PLAY RECAP ***********************************************************************************************************************************************************************************************
wolverine                  : ok=0    changed=0    unreachable=1    failed=0

```

after
```
$ ansible-playbook -i hosts test.yml

PLAY [all] ***********************************************************************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************************************
 [WARNING]: sftp transfer mechanism failed on [wolverine]. Use ANSIBLE_DEBUG=1 to see detailed information

ok: [wolverine]

TASK [Test] **********************************************************************************************************************************************************************************************
ok: [wolverine] => {
    "msg": "This is a test"
}

PLAY RECAP ***********************************************************************************************************************************************************************************************
wolverine                  : ok=2    changed=0    unreachable=0    failed=0

```
