### PR TITLE
elasticache_parameter_group: fix documentation and exception handling - fixes #23709

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -132,7 +132,7 @@ def create(module, conn, name, group_family, description):
         response = conn.create_cache_parameter_group(CacheParameterGroupName=name, CacheParameterGroupFamily=group_family, Description=description)
         changed = True
     except botocore.exceptions.ClientError as e:
-        module.fail_json(msg="Unable to create cache parameter group.", exception=traceback.format_exc())
+        module.fail_json(msg="Unable to create cache parameter group.", exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
     return response, changed
 
 def delete(module, conn, name):
@@ -142,7 +142,7 @@ def delete(module, conn, name):
         response = {}
         changed = True
     except botocore.exceptions.ClientError as e:
-        module.fail_json(msg="Unable to delete cache parameter group.", exception=traceback.format_exc())
+        module.fail_json(msg="Unable to delete cache parameter group.", exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
     return response, changed
 
 def make_current_modifiable_param_dict(module, conn, name):
@@ -216,7 +216,7 @@ def modify(module, conn, name, values):
     try:
         response = conn.modify_cache_parameter_group(CacheParameterGroupName=name, ParameterNameValues=format_parameters)
     except botocore.exceptions.ClientError as e:
-        module.fail_json(msg="Unable to modify cache parameter group.", exception=traceback.format_exc())
+        module.fail_json(msg="Unable to modify cache parameter group.", exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
     return response
 
 def reset(module, conn, name, values):
@@ -239,7 +239,7 @@ def reset(module, conn, name, values):
     try:
         response = conn.reset_cache_parameter_group(CacheParameterGroupName=name, ParameterNameValues=format_parameters, ResetAllParameters=all_parameters)
     except botocore.exceptions.ClientError as e:
-        module.fail_json(msg="Unable to reset cache parameter group.", exception=traceback.format_exc())
+        module.fail_json(msg="Unable to reset cache parameter group.", exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
 
     # determine changed
     new_parameters_dict = make_current_modifiable_param_dict(module, conn, name)

--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -32,8 +32,9 @@ options:
   group_family:
     description:
       - The name of the cache parameter group family that the cache parameter group can be used with.
+        Required when creating a cache parameter group.
     choices: ['memcached1.4', 'redis2.6', 'redis2.8', 'redis3.2']
-    required: when creating a cache parameter group
+    required: no
   name:
     description:
      - A user-specified name for the cache parameter group.

--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -68,7 +68,6 @@ EXAMPLES = """
         state: 'present'
     - name: 'Modify a test parameter group'
       elasticache_parameter_group:
-        group_family: 'redis3.2'
         name: 'test-param-group'
         values:
           activerehashing: yes
@@ -76,12 +75,10 @@ EXAMPLES = """
         state: 'present'
     - name: 'Reset all modifiable parameters for the test parameter group'
       elasticache_parameter_group:
-        group_family: 'redis3.2'
         name: 'test-param-group'
         state: reset
     - name: 'Delete a test parameter group'
       elasticache_parameter_group:
-        group_family: 'redis3.2'
         name: 'test-param-group'
         state: 'absent'
 """

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -193,7 +193,6 @@ lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
 lib/ansible/modules/cloud/amazon/efs.py
 lib/ansible/modules/cloud/amazon/efs_facts.py
 lib/ansible/modules/cloud/amazon/elasticache.py
-lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
 lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
 lib/ansible/modules/cloud/amazon/elasticache_subnet_group.py
 lib/ansible/modules/cloud/amazon/execute_lambda.py


### PR DESCRIPTION
##### SUMMARY
Fixed documentation for option `values` - the expected type for values is a dict, not a list. Fixed documentation. Removed boto exception handling to use botocore instead. Fixes #23709

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py

##### ANSIBLE VERSION
```
2.4.0
```