### PR TITLE
filesystem: Support FAT

### DIFF
--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -184,6 +184,13 @@ def main():
             'grow_flag' : 'filesystem resize',
             'force_flag' : '-f',
             'fsinfo': 'btrfs',
+        },
+        'fat' : {
+            'mkfs' : 'mkfs.fat',
+            'grow' : 'resize2fs',
+            'grow_flag' : None,
+            'force_flag' : None,
+            'fsinfo' : 'tune2fs',
         }
     }
 


### PR DESCRIPTION
##### SUMMARY
This adds support for `mkfs.fat` to the `filesystem` module.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
`filesystem` module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Dec 21 2016, 07:16:46) [GCC 6.2.1 20160830]

```
