### PR TITLE
Retry on Route53 throttling

### DIFF
--- a/lib/ansible/modules/cloud/amazon/route53.py
+++ b/lib/ansible/modules/cloud/amazon/route53.py
@@ -520,7 +520,12 @@ def main():
 
     sets = invoke_with_throttling_retries(conn.get_all_rrsets, zone.id, name=record_in,
                                           type=type_in, identifier=identifier_in)
-    for rset in sets:
+    sets_iter = iter(sets)
+    while True:
+        try:
+            rset = invoke_with_throttling_retries(next, sets_iter)
+        except StopIteration:
+            break
         # Due to a bug in either AWS or Boto, "special" characters are returned as octals, preventing round
         # tripping of things like * and @.
         decoded_name = rset.name.replace(r'\052', '*')


### PR DESCRIPTION
##### SUMMARY
Retry on throttling errors from Route53 API.

On large number of Route53 records, the for loop may fail to get next page of results from Route53. It is possible to handle the error and continue iterating over the records.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
route53

##### ANSIBLE VERSION
```
ansible 1.9.6
  configured module search path = ./library
```


##### ADDITIONAL INFORMATION
Can't provide steps to reproduce, because throttling errors are hard to reproduce.
