### PR TITLE
Set terminal width for network *_command modules to avoid paging Fixes #23474

### DIFF
--- a/lib/ansible/plugins/terminal/eos.py
+++ b/lib/ansible/plugins/terminal/eos.py
@@ -48,7 +48,8 @@ class TerminalModule(TerminalBase):
 
     def on_open_shell(self):
         try:
-            self._exec_cli_command('terminal length 0')
+            for cmd in ['terminal length 0', 'terminal width 512']:
+                self._exec_cli_command(cmd)
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')
 

--- a/lib/ansible/plugins/terminal/ios.py
+++ b/lib/ansible/plugins/terminal/ios.py
@@ -46,7 +46,8 @@ class TerminalModule(TerminalBase):
 
     def on_open_shell(self):
         try:
-            self._exec_cli_command('terminal length 0')
+            for cmd in ['terminal length 0', 'terminal width 512']:
+                self._exec_cli_command(cmd)
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')
 

--- a/lib/ansible/plugins/terminal/iosxr.py
+++ b/lib/ansible/plugins/terminal/iosxr.py
@@ -45,7 +45,7 @@ class TerminalModule(TerminalBase):
 
     def on_open_shell(self):
         try:
-            for cmd in ['terminal length 0', 'terminal exec prompt no-timestamp']:
+            for cmd in ['terminal length 0', 'terminal width 512', 'terminal exec prompt no-timestamp']:
                 self._exec_cli_command(cmd)
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')

--- a/lib/ansible/plugins/terminal/junos.py
+++ b/lib/ansible/plugins/terminal/junos.py
@@ -49,7 +49,7 @@ class TerminalModule(TerminalBase):
             if prompt.strip().endswith('%'):
                 display.vvv('starting cli', self._connection._play_context.remote_addr)
                 self._exec_cli_command('cli')
-            for c in ['set cli timestamp disable', 'set cli screen-length 0']:
+            for c in ['set cli timestamp disable', 'set cli screen-length 0', 'set cli screen-width 1024']:
                 self._exec_cli_command(c)
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')

--- a/lib/ansible/plugins/terminal/nxos.py
+++ b/lib/ansible/plugins/terminal/nxos.py
@@ -48,7 +48,8 @@ class TerminalModule(TerminalBase):
 
     def on_open_shell(self):
         try:
-            self._exec_cli_command('terminal length 0')
+            for cmd in ['terminal length 0', 'terminal width 511']:
+                self._exec_cli_command(cmd)
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')
 

--- a/lib/ansible/plugins/terminal/vyos.py
+++ b/lib/ansible/plugins/terminal/vyos.py
@@ -43,7 +43,8 @@ class TerminalModule(TerminalBase):
 
     def on_open_shell(self):
         try:
-            self._exec_cli_command('set terminal length 0')
+            for cmd in ['set terminal length 0', 'set terminal width 512']:
+                self._exec_cli_command(cmd)
             self._exec_cli_command('set terminal length %s' % self.terminal_length)
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #23474 
The terminal width on network devices isn't being set to avoid paging. If a command goes over the default amount the output from a `*_command` module will include the paged output of the command first.
The PR adds Terminal width to some extent so that paging can be avoided in the output for network `*_command` modules.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- plugins/terminal/ios.py
- plugins/terminal/iosxr.py
- plugins/terminal/eos.py
- plugins/terminal/nxos.py
- plugins/terminal/vyos.py
- plugins/terminal/junos.py


##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
Devel
```