### PR TITLE
add missing checks for async and check_mode

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -537,7 +537,7 @@ class TaskExecutor:
                 vars_copy[self._task.register] = wrap_var(result.copy())
 
             if self._task.async > 0:
-                if self._task.poll > 0 and not result.get('skipped'):
+                if self._task.poll > 0 and not result.get('skipped') and not result.get('failed'):
                     result = self._poll_async_result(result=result, templar=templar, task_vars=vars_copy)
                     #FIXME callback 'v2_runner_on_async_poll' here
 

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -90,7 +90,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         * Module parameters.  These are stored in self._task.args
         """
 
-        result = {'skipped': True}
+        result = {'skipped': True, 'failed': True}
 
         if self._task.async and not self._supports_async:
             result['msg'] = 'async is not supported for this task.'
@@ -100,6 +100,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             result['msg'] = 'check mode and async cannot be used on same task.'
         else:
             # we run!
+            result['failed'] = False
             del result['skipped']
 
         return result

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -90,18 +90,17 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         * Module parameters.  These are stored in self._task.args
         """
 
-        result = {'skipped': True, 'failed': True}
+        result = {}
 
         if self._task.async and not self._supports_async:
             result['msg'] = 'async is not supported for this task.'
+            result['failed'] = True
         elif self._play_context.check_mode and not self._supports_check_mode:
             result['msg'] = 'check mode is not supported for this task.'
+            result['skipped'] = True
         elif self._task.async and self._play_context.check_mode:
             result['msg'] = 'check mode and async cannot be used on same task.'
-        else:
-            # we run!
-            del result['failed']
-            del result['skipped']
+            result['failed'] = True
 
         return result
 

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -100,7 +100,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             result['msg'] = 'check mode and async cannot be used on same task.'
         else:
             # we run!
-            result['failed'] = False
+            del result['failed']
             del result['skipped']
 
         return result

--- a/lib/ansible/plugins/action/add_host.py
+++ b/lib/ansible/plugins/action/add_host.py
@@ -45,7 +45,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         # Parse out any hostname:port patterns

--- a/lib/ansible/plugins/action/assemble.py
+++ b/lib/ansible/plugins/action/assemble.py
@@ -84,7 +84,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if task_vars is None:

--- a/lib/ansible/plugins/action/assert.py
+++ b/lib/ansible/plugins/action/assert.py
@@ -33,7 +33,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if 'that' not in self._task.args:

--- a/lib/ansible/plugins/action/assert.py
+++ b/lib/ansible/plugins/action/assert.py
@@ -33,6 +33,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if 'that' not in self._task.args:
             raise AnsibleError('conditional required in "that" string')
 

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -40,7 +40,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         source  = self._task.args.get('src', None)

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -40,7 +40,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped'):
+        if result.get('skipped', False):
             return result
 
         source  = self._task.args.get('src', None)

--- a/lib/ansible/plugins/action/debug.py
+++ b/lib/ansible/plugins/action/debug.py
@@ -43,7 +43,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         verbosity = 0

--- a/lib/ansible/plugins/action/debug.py
+++ b/lib/ansible/plugins/action/debug.py
@@ -43,6 +43,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         verbosity = 0
         # get task verbosity
         if 'verbosity' in self._task.args:

--- a/lib/ansible/plugins/action/dellos10_config.py
+++ b/lib/ansible/plugins/action/dellos10_config.py
@@ -46,6 +46,9 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if self._task.args.get('backup') and result.get('__backup__'):
             # User requested backup and no error occurred in module.
             # NOTE: If there is a parameter error, _backup key may not be in results.

--- a/lib/ansible/plugins/action/dellos10_config.py
+++ b/lib/ansible/plugins/action/dellos10_config.py
@@ -46,7 +46,7 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if self._task.args.get('backup') and result.get('__backup__'):

--- a/lib/ansible/plugins/action/dellos6_config.py
+++ b/lib/ansible/plugins/action/dellos6_config.py
@@ -43,6 +43,9 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if self._task.args.get('backup') and result.get('__backup__'):
             # User requested backup and no error occurred in module.
             # NOTE: If there is a parameter error, _backup key may not be in results.

--- a/lib/ansible/plugins/action/dellos6_config.py
+++ b/lib/ansible/plugins/action/dellos6_config.py
@@ -43,7 +43,7 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if self._task.args.get('backup') and result.get('__backup__'):

--- a/lib/ansible/plugins/action/dellos9_config.py
+++ b/lib/ansible/plugins/action/dellos9_config.py
@@ -46,6 +46,9 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if self._task.args.get('backup') and result.get('__backup__'):
             # User requested backup and no error occurred in module.
             # NOTE: If there is a parameter error, _backup key may not be in results.

--- a/lib/ansible/plugins/action/dellos9_config.py
+++ b/lib/ansible/plugins/action/dellos9_config.py
@@ -46,7 +46,7 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if self._task.args.get('backup') and result.get('__backup__'):

--- a/lib/ansible/plugins/action/eos_config.py
+++ b/lib/ansible/plugins/action/eos_config.py
@@ -45,6 +45,9 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if self._task.args.get('backup') and result.get('__backup__'):
             # User requested backup and no error occurred in module.
             # NOTE: If there is a parameter error, _backup key may not be in results.

--- a/lib/ansible/plugins/action/eos_config.py
+++ b/lib/ansible/plugins/action/eos_config.py
@@ -45,7 +45,7 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if self._task.args.get('backup') and result.get('__backup__'):

--- a/lib/ansible/plugins/action/eos_template.py
+++ b/lib/ansible/plugins/action/eos_template.py
@@ -38,7 +38,7 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if self._task.args.get('backup') and result.get('__backup__'):

--- a/lib/ansible/plugins/action/eos_template.py
+++ b/lib/ansible/plugins/action/eos_template.py
@@ -38,6 +38,9 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if self._task.args.get('backup') and result.get('__backup__'):
             # User requested backup and no error occurred in module.
             # NOTE: If there is a parameter error, __backup__ key may not be in results.

--- a/lib/ansible/plugins/action/fail.py
+++ b/lib/ansible/plugins/action/fail.py
@@ -32,6 +32,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         msg = 'Failed as requested from task'
         if self._task.args and 'msg' in self._task.args:
             msg = self._task.args.get('msg')

--- a/lib/ansible/plugins/action/fail.py
+++ b/lib/ansible/plugins/action/fail.py
@@ -32,7 +32,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         msg = 'Failed as requested from task'

--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -37,7 +37,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if self._play_context.check_mode:

--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -37,6 +37,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if self._play_context.check_mode:
             result['skipped'] = True
             result['msg'] = 'check mode not (yet) supported for this module'

--- a/lib/ansible/plugins/action/group_by.py
+++ b/lib/ansible/plugins/action/group_by.py
@@ -32,6 +32,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if 'key' not in self._task.args:
             result['failed'] = True
             result['msg'] = "the 'key' param is required when using group_by"

--- a/lib/ansible/plugins/action/group_by.py
+++ b/lib/ansible/plugins/action/group_by.py
@@ -32,7 +32,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if 'key' not in self._task.args:

--- a/lib/ansible/plugins/action/include_vars.py
+++ b/lib/ansible/plugins/action/include_vars.py
@@ -155,7 +155,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if failed:

--- a/lib/ansible/plugins/action/include_vars.py
+++ b/lib/ansible/plugins/action/include_vars.py
@@ -155,6 +155,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if failed:
             result['failed'] = failed
             result['message'] = err_msg

--- a/lib/ansible/plugins/action/ios_config.py
+++ b/lib/ansible/plugins/action/ios_config.py
@@ -44,6 +44,9 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if self._task.args.get('backup') and result.get('__backup__'):
             # User requested backup and no error occurred in module.
             # NOTE: If there is a parameter error, _backup key may not be in results.

--- a/lib/ansible/plugins/action/ios_config.py
+++ b/lib/ansible/plugins/action/ios_config.py
@@ -44,7 +44,7 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if self._task.args.get('backup') and result.get('__backup__'):

--- a/lib/ansible/plugins/action/ios_template.py
+++ b/lib/ansible/plugins/action/ios_template.py
@@ -38,7 +38,7 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if self._task.args.get('backup') and result.get('__backup__'):

--- a/lib/ansible/plugins/action/ios_template.py
+++ b/lib/ansible/plugins/action/ios_template.py
@@ -38,6 +38,9 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if self._task.args.get('backup') and result.get('__backup__'):
             # User requested backup and no error occurred in module.
             # NOTE: If there is a parameter error, __backup__ key may not be in results.

--- a/lib/ansible/plugins/action/iosxr_config.py
+++ b/lib/ansible/plugins/action/iosxr_config.py
@@ -44,6 +44,9 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if self._task.args.get('backup') and result.get('__backup__'):
             # User requested backup and no error occurred in module.
             # NOTE: If there is a parameter error, _backup key may not be in results.

--- a/lib/ansible/plugins/action/iosxr_config.py
+++ b/lib/ansible/plugins/action/iosxr_config.py
@@ -44,7 +44,7 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if self._task.args.get('backup') and result.get('__backup__'):

--- a/lib/ansible/plugins/action/iosxr_template.py
+++ b/lib/ansible/plugins/action/iosxr_template.py
@@ -38,7 +38,7 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if self._task.args.get('backup') and result.get('__backup__'):

--- a/lib/ansible/plugins/action/iosxr_template.py
+++ b/lib/ansible/plugins/action/iosxr_template.py
@@ -38,6 +38,9 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if self._task.args.get('backup') and result.get('__backup__'):
             # User requested backup and no error occurred in module.
             # NOTE: If there is a parameter error, __backup__ key may not be in results.

--- a/lib/ansible/plugins/action/junos_config.py
+++ b/lib/ansible/plugins/action/junos_config.py
@@ -44,6 +44,9 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if self._task.args.get('backup') and result.get('__backup__'):
             # User requested backup and no error occurred in module.
             # NOTE: If there is a parameter error, _backup key may not be in results.

--- a/lib/ansible/plugins/action/junos_config.py
+++ b/lib/ansible/plugins/action/junos_config.py
@@ -44,7 +44,7 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if self._task.args.get('backup') and result.get('__backup__'):

--- a/lib/ansible/plugins/action/junos_template.py
+++ b/lib/ansible/plugins/action/junos_template.py
@@ -53,6 +53,9 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if self._task.args.get('backup') and result.get('__backup__'):
             # User requested backup and no error occurred in module.
             # NOTE: If there is a parameter error, __backup__ key may not be in results.

--- a/lib/ansible/plugins/action/junos_template.py
+++ b/lib/ansible/plugins/action/junos_template.py
@@ -53,7 +53,7 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if self._task.args.get('backup') and result.get('__backup__'):

--- a/lib/ansible/plugins/action/net_config.py
+++ b/lib/ansible/plugins/action/net_config.py
@@ -45,6 +45,9 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if self._task.args.get('backup') and result.get('__backup__'):
             # User requested backup and no error occurred in module.
             # NOTE: If there is a parameter error, _backup key may not be in results.

--- a/lib/ansible/plugins/action/net_config.py
+++ b/lib/ansible/plugins/action/net_config.py
@@ -45,7 +45,7 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if self._task.args.get('backup') and result.get('__backup__'):

--- a/lib/ansible/plugins/action/net_template.py
+++ b/lib/ansible/plugins/action/net_template.py
@@ -39,7 +39,7 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if self._task.args.get('backup') and result.get('__backup__'):

--- a/lib/ansible/plugins/action/net_template.py
+++ b/lib/ansible/plugins/action/net_template.py
@@ -39,6 +39,9 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if self._task.args.get('backup') and result.get('__backup__'):
             # User requested backup and no error occurred in module.
             # NOTE: If there is a parameter error, __backup__ key may not be in results.

--- a/lib/ansible/plugins/action/nxos_config.py
+++ b/lib/ansible/plugins/action/nxos_config.py
@@ -45,6 +45,9 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if self._task.args.get('backup') and result.get('__backup__'):
             # User requested backup and no error occurred in module.
             # NOTE: If there is a parameter error, _backup key may not be in results.

--- a/lib/ansible/plugins/action/nxos_config.py
+++ b/lib/ansible/plugins/action/nxos_config.py
@@ -45,7 +45,7 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if self._task.args.get('backup') and result.get('__backup__'):

--- a/lib/ansible/plugins/action/nxos_template.py
+++ b/lib/ansible/plugins/action/nxos_template.py
@@ -38,7 +38,7 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if self._task.args.get('backup') and result.get('__backup__'):

--- a/lib/ansible/plugins/action/nxos_template.py
+++ b/lib/ansible/plugins/action/nxos_template.py
@@ -38,6 +38,9 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if self._task.args.get('backup') and result.get('__backup__'):
             # User requested backup and no error occurred in module.
             # NOTE: If there is a parameter error, __backup__ key may not be in results.

--- a/lib/ansible/plugins/action/package.py
+++ b/lib/ansible/plugins/action/package.py
@@ -38,7 +38,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         module = self._task.args.get('use', 'auto')

--- a/lib/ansible/plugins/action/patch.py
+++ b/lib/ansible/plugins/action/patch.py
@@ -34,6 +34,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         src        = self._task.args.get('src', None)
         remote_src = boolean(self._task.args.get('remote_src', 'no'))
 

--- a/lib/ansible/plugins/action/patch.py
+++ b/lib/ansible/plugins/action/patch.py
@@ -34,7 +34,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         src        = self._task.args.get('src', None)

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -55,6 +55,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         duration_unit = 'minutes'
         prompt = None
         seconds = None

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -55,7 +55,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         duration_unit = 'minutes'

--- a/lib/ansible/plugins/action/raw.py
+++ b/lib/ansible/plugins/action/raw.py
@@ -32,6 +32,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if self._play_context.check_mode:
             # in --check mode, always skip this module execution
             result['skipped'] = True

--- a/lib/ansible/plugins/action/raw.py
+++ b/lib/ansible/plugins/action/raw.py
@@ -32,7 +32,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if self._play_context.check_mode:

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -34,7 +34,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if self._play_context.check_mode:

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -34,6 +34,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if self._play_context.check_mode:
             result['skipped'] = True
             result['msg'] = 'check mode not supported for this module'

--- a/lib/ansible/plugins/action/service.py
+++ b/lib/ansible/plugins/action/service.py
@@ -37,7 +37,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         module = self._task.args.get('use', 'auto').lower()

--- a/lib/ansible/plugins/action/set_fact.py
+++ b/lib/ansible/plugins/action/set_fact.py
@@ -34,6 +34,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         facts = dict()
         if self._task.args:
             for (k, v) in iteritems(self._task.args):

--- a/lib/ansible/plugins/action/set_fact.py
+++ b/lib/ansible/plugins/action/set_fact.py
@@ -34,7 +34,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         facts = dict()

--- a/lib/ansible/plugins/action/set_stats.py
+++ b/lib/ansible/plugins/action/set_stats.py
@@ -35,7 +35,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         stats = {'data': {}, 'per_host': False, 'aggregate': True}

--- a/lib/ansible/plugins/action/set_stats.py
+++ b/lib/ansible/plugins/action/set_stats.py
@@ -35,6 +35,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         stats = {'data': {}, 'per_host': False, 'aggregate': True}
 
         if self._task.args:

--- a/lib/ansible/plugins/action/sros_config.py
+++ b/lib/ansible/plugins/action/sros_config.py
@@ -44,6 +44,9 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if self._task.args.get('backup') and result.get('__backup__'):
             # User requested backup and no error occurred in module.
             # NOTE: If there is a parameter error, _backup key may not be in results.

--- a/lib/ansible/plugins/action/sros_config.py
+++ b/lib/ansible/plugins/action/sros_config.py
@@ -44,7 +44,7 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if self._task.args.get('backup') and result.get('__backup__'):

--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -167,6 +167,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         # Store remote connection type
         self._remote_transport = self._connection.transport
 

--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -167,7 +167,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         # Store remote connection type

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -55,7 +55,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         source = self._task.args.get('src', None)

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -55,6 +55,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         source = self._task.args.get('src', None)
         dest   = self._task.args.get('dest', None)
         force  = boolean(self._task.args.get('force', True))

--- a/lib/ansible/plugins/action/unarchive.py
+++ b/lib/ansible/plugins/action/unarchive.py
@@ -38,6 +38,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         source  = self._task.args.get('src', None)
         dest    = self._task.args.get('dest', None)
         remote_src = boolean(self._task.args.get('remote_src', False))

--- a/lib/ansible/plugins/action/unarchive.py
+++ b/lib/ansible/plugins/action/unarchive.py
@@ -38,7 +38,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         source  = self._task.args.get('src', None)

--- a/lib/ansible/plugins/action/vyos_config.py
+++ b/lib/ansible/plugins/action/vyos_config.py
@@ -45,6 +45,9 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         if self._task.args.get('backup') and result.get('__backup__'):
             # User requested backup and no error occurred in module.
             # NOTE: If there is a parameter error, _backup key may not be in results.

--- a/lib/ansible/plugins/action/vyos_config.py
+++ b/lib/ansible/plugins/action/vyos_config.py
@@ -45,7 +45,7 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         if self._task.args.get('backup') and result.get('__backup__'):

--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -76,6 +76,9 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
+        if result.get('skipped', False):
+            return result
+
         def ping_module_test(connect_timeout):
             ''' Test ping module, if available '''
             display.vvv("wait_for_connection: attempting ping module test")

--- a/lib/ansible/plugins/action/wait_for_connection.py
+++ b/lib/ansible/plugins/action/wait_for_connection.py
@@ -76,7 +76,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         def ping_module_test(connect_timeout):

--- a/lib/ansible/plugins/action/win_reboot.py
+++ b/lib/ansible/plugins/action/win_reboot.py
@@ -82,6 +82,10 @@ class ActionModule(ActionBase):
         winrm_port = self._connection._winrm_port
 
         result = super(ActionModule, self).run(tmp, task_vars)
+
+        if result.get('skipped', False):
+            return result
+
         result['warnings'] = []
 
         # Initiate reboot

--- a/lib/ansible/plugins/action/win_reboot.py
+++ b/lib/ansible/plugins/action/win_reboot.py
@@ -83,7 +83,7 @@ class ActionModule(ActionBase):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        if result.get('skipped', False):
+        if result.get('skipped', False) or result.get('failed', False):
             return result
 
         result['warnings'] = []

--- a/test/integration/targets/add_host/tasks/main.yml
+++ b/test/integration/targets/add_host/tasks/main.yml
@@ -37,3 +37,19 @@
     - groups['bogusgroup'] is not defined # same check as above to ensure that bogus groups are undefined...
     - groups['newdynamicgroup'] is defined
     - "'newdynamichost' in groups['newdynamicgroup']"
+
+# async
+- name: test failure with async
+  add_host:
+    name: newdynamichost
+    groups: newdynamicgroup
+    a_var: from add_host
+  async: 2
+  ignore_errors: true
+  register: result1
+
+- name: assert task failed with async
+  assert:
+    that:
+      - 'result1.failed'
+      - 'result1.msg == "async is not supported for this task."'

--- a/test/integration/targets/add_host/tasks/main.yml
+++ b/test/integration/targets/add_host/tasks/main.yml
@@ -41,9 +41,7 @@
 # async
 - name: test failure with async
   add_host:
-    name: newdynamichost
-    groups: newdynamicgroup
-    a_var: from add_host
+    name: newdynamichost2
   async: 2
   ignore_errors: true
   register: result1

--- a/test/integration/targets/script/tasks/main.yml
+++ b/test/integration/targets/script/tasks/main.yml
@@ -83,4 +83,3 @@
     that:
       - 'script_result3.failed'
       - 'script_result3.msg == "async is not supported for this task."'
-

--- a/test/integration/targets/script/tasks/main.yml
+++ b/test/integration/targets/script/tasks/main.yml
@@ -69,3 +69,18 @@
     that:
       - "script_result1|changed"
       - "script_result2.state == 'absent'"
+
+# async
+
+- name: test task failure with async param
+  script: /some/script.sh
+  async: 2
+  ignore_errors: true
+  register: script_result3
+
+- name: assert task with async param failed
+  assert:
+    that:
+      - 'script_result3.failed'
+      - 'script_result3.msg == "async is not supported for this task."'
+

--- a/test/units/plugins/action/test_raw.py
+++ b/test/units/plugins/action/test_raw.py
@@ -60,7 +60,7 @@ class TestCopyResultExclude(unittest.TestCase):
 
         play_context = Mock()
         task = MagicMock(Task)
-        task.async = MagicMock()
+        task.async = None
         connection = Mock()
 
         task.args = {'_raw_params': 'Args1'}

--- a/test/units/plugins/action/test_raw.py
+++ b/test/units/plugins/action/test_raw.py
@@ -43,7 +43,7 @@ class TestCopyResultExclude(unittest.TestCase):
 
         play_context = Mock()
         task = MagicMock(Task)
-        task.async = MagicMock()
+        task.async = None
         connection = Mock()
 
         task.args = {'_raw_params': 'Args1'}


### PR DESCRIPTION
fixes #23729

following refactoring of async : c86a17b7a003ac22c173cfa832ed2368e15015e6

when call to ActionBase.run returns a skipped result,
return directly in ActionModule.run

Restore previous behavior when misuse of async in modules not
supporting async: fail with msg


##### SUMMARY
Add fail in ActionBase.run so previous behavior before refactoring is kept.

Add check in every ActionModule.run so it returns if ActionBase.run fails.

Add tests.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (issue-23729 a1483ea2d2) last updated 2017/04/19 12:20:00 (GMT +200)
  config file =
  configured module search path = ['/home/fridim/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/fridim/sync/dev/ansible/lib/ansible
  executable location = /home/fridim/sync/dev/ansible/bin/ansible
  python version = 3.6.0 (default, Jan 16 2017, 12:12:55) [GCC 6.3.1 20170109]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
