### PR TITLE
Fix example fact(ansible_default_ipv4.address) for delegated_facts

### DIFF
--- a/docs/docsite/rst/playbooks_delegation.rst
+++ b/docs/docsite/rst/playbooks_delegation.rst
@@ -182,7 +182,7 @@ In 2.0, the directive `delegate_facts` may be set to `True` to assign the task's
           with_items: "{{groups['dbservers']}}"
 
 The above will gather facts for the machines in the dbservers group and assign the facts to those machines and not to app_servers.
-This way you can lookup `hostvars['dbhost1']['default_ipv4_addresses'][0]` even though dbservers were not part of the play, or left out by using `--limit`.
+This way you can lookup `hostvars['dbhost1']['default_ipv4']['address']` even though dbservers were not part of the play, or left out by using `--limit`.
 
 
 .. _run_once:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Ansible fact default_ipv4_addresses doesn't exist -> ['default_ipv4']['address']

##### ISSUE TYPE

 - Docs Pull Request
