### PR TITLE
Gen dynamic inventory base on host patterns

### DIFF
--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -126,7 +126,8 @@ class AdHocCLI(CLI):
 
         variable_manager.options_vars = load_options_vars(self.options)
 
-        inventory = Inventory(loader=loader, variable_manager=variable_manager, host_list=self.options.inventory)
+        # Generate dynamic inventory base on the provided patterns
+        inventory = Inventory(loader=loader, variable_manager=variable_manager, host_list=self.options.inventory, play_hosts=pattern)
         variable_manager.set_inventory(inventory)
 
         no_hosts = False

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -77,8 +77,8 @@ class PlaybookExecutor:
         entrylist = []
         entry = {}
         try:
-            for playbook_path in self._playbooks:
-                pb = Playbook.load(playbook_path, variable_manager=self._variable_manager, loader=self._loader)
+            for pb in self._playbooks:
+                playbook_path = pb._file_name
                 self._inventory.set_playbook_basedir(os.path.realpath(os.path.dirname(playbook_path)))
 
                 if self._tqm is None:  # we are doing a listing

--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -54,7 +54,7 @@ class Inventory(object):
     Host inventory for ansible.
     """
 
-    def __init__(self, loader, variable_manager, host_list=C.DEFAULT_HOST_LIST):
+    def __init__(self, loader, variable_manager, host_list=C.DEFAULT_HOST_LIST, play_hosts=None):
 
         # the host file file, or script path, or list of hosts
         # if a list, inventory data will NOT be loaded
@@ -62,6 +62,7 @@ class Inventory(object):
         self._loader = loader
         self._variable_manager = variable_manager
         self.localhost = None
+        self.play_hosts = play_hosts
 
         # caching to avoid repeated calculations, particularly with
         # external inventory scripts.
@@ -146,9 +147,9 @@ class Inventory(object):
             if self.is_directory(host_list):
                 # Ensure basedir is inside the directory
                 host_list = os.path.join(self.host_list, "")
-                self.parser = InventoryDirectory(loader=self._loader, groups=self.groups, filename=host_list)
+                self.parser = InventoryDirectory(loader=self._loader, groups=self.groups, filename=host_list, play_hosts=self.play_hosts)
             else:
-                self.parser = get_file_parser(host_list, self.groups, self._loader)
+                self.parser = get_file_parser(host_list, self.groups, self._loader, self.play_hosts)
                 vars_loader.add_directory(self._basedir, with_subdir=True)
 
             if not self.parser:

--- a/lib/ansible/inventory/dir.py
+++ b/lib/ansible/inventory/dir.py
@@ -34,7 +34,7 @@ from ansible.inventory.script import InventoryScript
 
 __all__ = ['get_file_parser']
 
-def get_file_parser(hostsfile, groups, loader):
+def get_file_parser(hostsfile, groups, loader, play_hosts=None):
     # check to see if the specified file starts with a
     # shebang (#!/), so if an error is raised by the parser
     # class we can show a more apropos error
@@ -56,7 +56,7 @@ def get_file_parser(hostsfile, groups, loader):
     # script
     if loader.is_executable(hostsfile):
         try:
-            parser = InventoryScript(loader=loader, groups=groups, filename=hostsfile)
+            parser = InventoryScript(loader=loader, groups=groups, filename=hostsfile, play_hosts=play_hosts)
             processed = True
         except Exception as e:
             myerr.append('Attempted to execute "%s" as inventory script: %s' % (hostsfile, to_native(e)))
@@ -89,7 +89,7 @@ def get_file_parser(hostsfile, groups, loader):
 class InventoryDirectory(object):
     ''' Host inventory parser for ansible using a directory of inventories. '''
 
-    def __init__(self, loader, groups=None, filename=C.DEFAULT_HOST_LIST):
+    def __init__(self, loader, groups=None, filename=C.DEFAULT_HOST_LIST, play_hosts=None):
         if groups is None:
             groups = dict()
 
@@ -117,7 +117,7 @@ class InventoryDirectory(object):
             if os.path.isdir(fullpath):
                 parser = InventoryDirectory(loader=loader, groups=groups, filename=fullpath)
             else:
-                parser = get_file_parser(fullpath, self.groups, loader)
+                parser = get_file_parser(fullpath, self.groups, loader, play_hosts)
                 if parser is None:
                     #FIXME: needs to use display
                     import warnings

--- a/lib/ansible/inventory/script.py
+++ b/lib/ansible/inventory/script.py
@@ -36,7 +36,7 @@ from ansible.module_utils._text import to_native, to_text
 class InventoryScript:
     ''' Host inventory parser for ansible using external inventory scripts. '''
 
-    def __init__(self, loader, groups=None, filename=C.DEFAULT_HOST_LIST):
+    def __init__(self, loader, groups=None, filename=C.DEFAULT_HOST_LIST, play_hosts=None):
         if groups is None:
             groups = dict()
 
@@ -48,6 +48,10 @@ class InventoryScript:
         # directory when '.' is not in PATH.
         self.filename = os.path.abspath(filename)
         cmd = [ self.filename, "--list" ]
+
+        if isinstance(play_hosts, list):
+            cmd += play_hosts
+
         try:
             sp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except OSError as e:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
After learning dynamic inventory and read EC2 example, it seems that dynamic modules need to go through and search whole external system, eventually output the formatted JSON.

However playbook only play on partial of the hosts, for dynamic inventory, it doesn't need to search whole external system (e.g. CMDB).

This PR make changes on dynamic inventory, get host patterns from command line (ansible-adhoc) or playbook (parse playbook before inventory be initialized). Give dynamic inventory a chance and allow it process the host patterns itself, output formatted JSON with only necessary hosts.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Dynamic inventory script output keep the same as before.
```
