### PR TITLE
Use sys.stdout.buffer to write vault bytes to stdout on py3

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -543,9 +543,13 @@ class VaultEditor:
         # FIXME: do we need this now? data_bytes should always be a utf-8 byte string
         b_file_data = to_bytes(data, errors='strict')
 
+        # get a ref to either sys.stdout.buffer for py3 or plain old sys.stdout for py2
+        # We need sys.stdout.buffer on py3 so we can write bytes to it since the plaintext
+        # of the vaulted object could be anything/binary/etc
+        output = getattr(sys.stdout, 'buffer', sys.stdout)
+
         if filename == '-':
-            file_data = to_text(b_file_data, encoding='utf-8', errors='strict', nonstring='strict')
-            sys.stdout.write(file_data)
+            output.write(b_file_data)
         else:
             if os.path.isfile(filename):
                 if shred:

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -533,12 +533,25 @@ class VaultEditor:
 
     # TODO: add docstrings for arg types since this code is picky about that
     def write_data(self, data, filename, shred=True):
-        """write data to given path
+        """Write the data bytes to given path
 
-        :arg data: the encrypted and hexlified data as a utf-8 byte string
+        This is used to write a byte string to a file or stdout. It is used for
+        writing the results of vault encryption or decryption. It is used for
+        saving the ciphertext after encryption and it is also used for saving the
+        plaintext after decrypting a vault. The type of the 'data' arg should be bytes,
+        since in the plaintext case, the original contents can be of any text encoding
+        or arbitrary binary data.
+
+        When used to write the result of vault encryption, the val of the 'data' arg
+        should be a utf-8 encoded byte string and not a text typ and not a text type..
+
+        When used to write the result of vault decryption, the val of the 'data' arg
+        should be a byte string and not a text type.
+
+        :arg data: the byte string (bytes) data
         :arg filename: filename to save 'data' to.
-        :arg shred: if shred==True, make sure that the original data is first shredded so
-        that is cannot be recovered.
+        :arg shred: if shred==True, make sure that the original data is first shredded so that is cannot be recovered.
+        :returns: None
         """
         # FIXME: do we need this now? data_bytes should always be a utf-8 byte string
         b_file_data = to_bytes(data, errors='strict')


### PR DESCRIPTION

##### SUMMARY
We need sys.stdout.buffer on py3 so we can write bytes to it since the plaintext
of the vaulted object could be anything/binary/etc

Before, attempting to write bytes to stdout on py3 would cause:

  TypeError: write() argument must be str, not bytes

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/parsing/vault/

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (vault_stdout_py3 9e0e9def08) last updated 2017/04/19 14:38:02 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
