### PR TITLE
Use isfile check on package manager paths

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -330,7 +330,7 @@ class Facts(object):
         else:
             self.facts['pkg_mgr'] = 'unknown'
             for pkg in Facts.PKG_MGRS:
-                if os.path.exists(pkg['path']):
+                if os.path.isfile(pkg['path']):
                     self.facts['pkg_mgr'] = pkg['name']
 
     def get_service_mgr_facts(self):


### PR DESCRIPTION
##### SUMMARY
Only detect a given package manager if the path is a file. We have a directory /usr/bin/pkg/ and on Ubuntu it causes the use of the package module to break.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
facts.py