### PR TITLE
Fix value parsing for Python3

### DIFF
--- a/lib/ansible/modules/system/sysctl.py
+++ b/lib/ansible/modules/system/sysctl.py
@@ -118,7 +118,10 @@ EXAMPLES = '''
 
 import os
 import tempfile
+
 from ansible.module_utils.basic import get_platform, get_exception, AnsibleModule, BOOLEANS_TRUE, BOOLEANS_FALSE
+from ansible.module_utils.six import binary_type, text_type
+from ansible.module_utils._text import to_native
 
 
 class SysctlModule(object):
@@ -211,20 +214,16 @@ class SysctlModule(object):
     def _parse_value(self, value):
         if value is None:
             return ''
-        if isinstance(value, bool):
+        elif isinstance(value, bool):
             if value:
                 return '1'
             else:
                 return '0'
-        # Check for python 2.x basestring which unifies (unicode, str) support
-        try:
-            basestring
-        except NameError:
-            basestring = str
-        if isinstance(value, basestring):
-            if value.lower() in BOOLEANS_TRUE:
+        elif isinstance(value, (binary_type, text_type)):
+            canonicalized_value = to_native(value).lower()
+            if canonicalized_value in BOOLEANS_TRUE:
                 return '1'
-            elif value.lower() in BOOLEANS_FALSE:
+            elif canonicalized_value in BOOLEANS_FALSE:
                 return '0'
             else:
                 return value.strip()

--- a/lib/ansible/modules/system/sysctl.py
+++ b/lib/ansible/modules/system/sysctl.py
@@ -211,12 +211,17 @@ class SysctlModule(object):
     def _parse_value(self, value):
         if value is None:
             return ''
-        elif isinstance(value, bool):
+        if isinstance(value, bool):
             if value:
                 return '1'
             else:
                 return '0'
-        elif isinstance(value, basestring):
+        # Check for python 2.x basestring which unifies (unicode, str) support
+        try:
+            basestring
+        except NameError:
+            basestring = str
+        if isinstance(value, basestring):
             if value.lower() in BOOLEANS_TRUE:
                 return '1'
             elif value.lower() in BOOLEANS_FALSE:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Python 2 unifies `str` and `unicode` using `basestring` as a base class.
Python 3 does not support `basestring` as unicode is supported by `str`.

To support Python 3, `basestring` is defined as `str`.

Fixes https://github.com/ansible/ansible/issues/23731
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
sysctl