### PR TITLE
Add 'uuid' to the attributes returned from the vmware_vm_facts module.

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_vm_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_facts.py
@@ -33,6 +33,7 @@ version_added: 2.0
 author: "Joseph Callen (@jcpowermac)"
 notes:
     - Tested on vSphere 5.5
+    - Tested on vSphere 6.5
 requirements:
     - "python >= 2.6"
     - PyVmomi
@@ -72,7 +73,8 @@ def get_all_virtual_machines(content):
             summary.config.name: {
                 "guest_fullname": summary.config.guestFullName,
                 "power_state": summary.runtime.powerState,
-                "ip_address": _ip_address
+                "ip_address": _ip_address,
+                "uuid": summary.config.uuid
             }
         }
 


### PR DESCRIPTION
##### SUMMARY

Add 'uuid' to the attributes returned from the vmware_vm_facts module.
uuid is required for certain operations with other modules, renaming a
vm for example.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
vmware_vm_facts module

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = /home/patrick/.ansible.cfg
  configured module search path = [u'/home/patrick/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION

Output:
```

localhost | SUCCESS => {
    "changed": false,
    "virtual_machines": {
        "vcenter": {
            "guest_fullname": "Other 3.x or later Linux (64-bit)",
            "ip_address": "10.2.0.18",
            "power_state": "poweredOn"
        }
    }
}

localhost | SUCCESS => {
    "changed": false,
    "virtual_machines": {
        "vcenter": {
            "guest_fullname": "Other 3.x or later Linux (64-bit)",
            "ip_address": "10.2.0.18",
            "power_state": "poweredOn",
            "uuid": "564d45d3-cae0-6cfc-c3de-d75c53f02330"
        }
    }
}

```
