### PR TITLE
Fix issue #23774 Make transport_test use exec

### DIFF
--- a/lib/ansible/plugins/connection/accelerate.py
+++ b/lib/ansible/plugins/connection/accelerate.py
@@ -101,10 +101,9 @@ class Connection(ConnectionBase):
     def transport_test(self, connect_timeout):
         ''' Test the transport mechanism, if available '''
         host = self._play_context.remote_addr
-        port = int(self._play_context.accelerate_port or 5099)
-        display.vvv("attempting transport test to %s:%s" % (host, port))
-        sock = socket.create_connection((host, port), connect_timeout)
-        sock.close()
+        display.vvv("attempting transport test to %s" % host)
+        self.reset()
+        self.exec_command("exit")
 
     def send_data(self, data):
         packed_len = struct.pack('!Q',len(data))

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -135,10 +135,9 @@ class Connection(ConnectionBase):
     def transport_test(self, connect_timeout):
         ''' Test the transport mechanism, if available '''
         host = self._play_context.remote_addr
-        port = int(self._play_context.port or 22)
-        display.vvv("attempting transport test to %s:%s" % (host, port))
-        sock = socket.create_connection((host, port), connect_timeout)
-        sock.close()
+        display.vvv("attempting transport test to %s" % host)
+        self.reset()
+        self.exec_command("exit")
 
     def _cache_key(self):
         return "%s__%s__" % (self._play_context.remote_addr, self._play_context.remote_user)

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -214,10 +214,9 @@ class Connection(ConnectionBase):
 
     def transport_test(self, connect_timeout):
         ''' Test the transport mechanism, if available '''
-        port = int(self.port or 22)
-        display.vvv("attempting transport test to %s:%s" % (self.host, port))
-        sock = socket.create_connection((self.host, port), connect_timeout)
-        sock.close()
+        display.vvv("attempting transport test to %s" % self.host)
+        self.reset()
+        self.exec_command("exit")
 
     @staticmethod
     def _create_control_path(host, port, user):

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -90,10 +90,9 @@ class Connection(ConnectionBase):
     def transport_test(self, connect_timeout):
         ''' Test the transport mechanism, if available '''
         host = self._winrm_host
-        port = int(self._winrm_port)
-        display.vvv("attempting transport test to %s:%s" % (host, port))
-        sock = socket.create_connection((host, port), connect_timeout)
-        sock.close()
+        display.vvv("attempting transport test to %s" % host)
+        self.reset()
+        self.exec_command("Exit")
 
     def set_host_overrides(self, host, hostvars=None):
         '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Since ssh may re-route traffic to any number of places before it 
reaches a host by the ssh config files and proxy hosts, we cannot use
sockets to test our transport.

It would make sense to use the same mechanism that we use to
perform actions on a host as we would to verify connectivity.

This change performs a dummy exec_command on the host to verify
that its transport works instead of using a single socket.

In particular, this fixes https://github.com/ansible/ansible/issues/23774

By using the ssh configuration built into exec_command, we are able to
handle proxy jumps specified in ssh config files.  This allows us to handle
bastion hosts when using wait_for_connection

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
wait_for_connection
ansible.plugins.connection.accelerate
ansible.plugins.connection.ssh
ansible.plugins.connection.paramiko_ssh
ansible.plugins.connection.winrm

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = 
  configured module search path = [u'/Users/smikulc/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/smikulc/virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.4.0-py2.7.egg/ansible
  executable location = /Users/smikulc/virtualenvs/ansible/bin/ansible
  python version = 2.7.10 (default, Jul 30 2016, 19:40:32) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION

For testing purposes, here is a demo that illustrates the bug fixed in this change https://github.com/smikulcik/ansible-waitforconnection-bug-demo