### PR TITLE
Refactor homebrew family of modules

### DIFF
--- a/lib/ansible/module_utils/homebrew.py
+++ b/lib/ansible/module_utils/homebrew.py
@@ -1,0 +1,245 @@
+# (c) 2013, Andrew Dunham <andrew@du.nham.ca>
+# (c) 2013, Daniel Jaouen <dcj24@cornell.edu>
+# (c) 2015-2017, Indrajit Raychaudhuri <irc+code@indrajit.com>
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+"""
+This module adds shared support for homebrew modules.
+
+In order to use this module, include it as part of a homebrew
+module as shown below.
+
+from ansible.module_utils.homebrew import *
+
+The 'homebrew' module provides the following utils and classes:
+
+    * negate_regex_group:
+        - Helper method to extract a negative regex group for valid characters.
+
+    * HomebrewBase
+        - The common base class to be used by other homebrew modules that are
+          subcommand of I(brew). For example, I(brew), I(brew cask),
+          I(brew tap), I(brew bundle) etc.
+"""
+import os.path
+import re
+
+from ansible.module_utils.six import iteritems, string_types
+
+
+def negate_regex_group(s):
+    lines = (line.strip() for line in s.split('\n') if line.strip())
+    chars = filter(None, (line.split('#')[0].strip() for line in lines))
+    group = r'[^' + r''.join(chars) + r']'
+    return re.compile(group)
+
+
+class HomebrewException(Exception):
+    pass
+
+
+class HomebrewBase(object):
+
+    # class regexes ------------------------------------------------ {{{
+    VALID_PATH_CHARS = r'''
+        \w                  # alphanumeric characters (i.e., [a-zA-Z0-9_])
+        \s                  # spaces
+        :                   # colons
+        {sep}               # the OS-specific path separator
+        .                   # dots
+        -                   # dashes
+    '''.format(sep=os.path.sep)
+
+    VALID_BREW_PATH_CHARS = r'''
+        \w                  # alphanumeric characters (i.e., [a-zA-Z0-9_])
+        \s                  # spaces
+        {sep}               # the OS-specific path separator
+        .                   # dots
+        -                   # dashes
+    '''.format(sep=os.path.sep)
+
+    INVALID_PATH_REGEX = negate_regex_group(VALID_PATH_CHARS)
+    INVALID_BREW_PATH_REGEX = negate_regex_group(VALID_BREW_PATH_CHARS)
+    # /class regexes ----------------------------------------------- }}}
+
+    # class validations -------------------------------------------- {{{
+    @classmethod
+    def valid_path(cls, path):
+        '''
+        `path` must be one of:
+         - list of paths
+         - a string containing only:
+             - alphanumeric characters
+             - dashes
+             - dots
+             - spaces
+             - colons
+             - os.path.sep
+        '''
+
+        if isinstance(path, string_types):
+            return not cls.INVALID_PATH_REGEX.search(path)
+
+        try:
+            iter(path)
+        except TypeError:
+            return False
+        else:
+            paths = path
+            return all(cls.valid_brew_path(path_) for path_ in paths)
+
+    @classmethod
+    def valid_brew_path(cls, brew_path):
+        '''
+        `brew_path` must be one of:
+         - None
+         - a string containing only:
+             - alphanumeric characters
+             - dashes
+             - dots
+             - spaces
+             - os.path.sep
+        '''
+
+        if brew_path is None:
+            return True
+
+        return (
+            isinstance(brew_path, string_types) and
+            not cls.INVALID_BREW_PATH_REGEX.search(brew_path)
+        )
+
+    @classmethod
+    def valid_state(cls, state):
+        pass
+
+    # /class validations ------------------------------------------- }}}
+
+    # class properties --------------------------------------------- {{{
+    @property
+    def module(self):
+        return self._module
+
+    @module.setter
+    def module(self, module):
+        if not self.valid_module(module):
+            self._module = None
+            self.failed = True
+            self.message = 'Invalid module: {0}.'.format(module)
+            raise HomebrewException(self.message)
+
+        else:
+            self._module = module
+            return module
+
+    @property
+    def path(self):
+        return self._path
+
+    @path.setter
+    def path(self, path):
+        if not self.valid_path(path):
+            self._path = []
+            self.failed = True
+            self.message = 'Invalid path: {0}.'.format(path)
+            raise HomebrewException(self.message)
+
+        else:
+            if isinstance(path, string_types):
+                self._path = path.split(':')
+            else:
+                self._path = path
+
+            return path
+
+    @property
+    def brew_path(self):
+        return self._brew_path
+
+    @brew_path.setter
+    def brew_path(self, brew_path):
+        if not self.valid_brew_path(brew_path):
+            self._brew_path = None
+            self.failed = True
+            self.message = 'Invalid brew_path: {0}.'.format(brew_path)
+            raise HomebrewException(self.message)
+
+        else:
+            self._brew_path = brew_path
+            return brew_path
+
+    @property
+    def params(self):
+        return self._params
+
+    @params.setter
+    def params(self, params):
+        self._params = self.module.params
+        return self._params
+
+    # /class properties -------------------------------------------- }}}
+
+    # prep --------------------------------------------------------- {{{
+    def _setup_status_vars(self):
+        self.failed = False
+        self.changed = False
+        self.changed_count = 0
+        self.unchanged_count = 0
+        self.message = ''
+
+    def _setup_instance_vars(self, **kwargs):
+        for key, val in iteritems(kwargs):
+            setattr(self, key, val)
+
+    def _prep(self):
+        self._prep_brew_path()
+
+    def _prep_brew_path(self):
+        if not self.module:
+            self.brew_path = None
+            self.failed = True
+            self.message = 'AnsibleModule not set.'
+            raise HomebrewException(self.message)
+
+        self.brew_path = self.module.get_bin_path(
+            'brew',
+            required=True,
+            opt_dirs=self.path,
+        )
+        if not self.brew_path:
+            self.brew_path = None
+            self.failed = True
+            self.message = 'Unable to locate homebrew executable.'
+            raise HomebrewException('Unable to locate homebrew executable.')
+
+        return self.brew_path
+
+    def _status(self):
+        return (self.failed, self.changed, self.message)
+    # /prep -------------------------------------------------------- }}}
+
+    def run(self):
+        try:
+            self._run()
+        except HomebrewException:
+            pass
+
+        if not self.failed and (self.changed_count + self.unchanged_count > 1):
+            self.message = "Changed: %d, Unchanged: %d" % (
+                self.changed_count,
+                self.unchanged_count,
+            )
+        (failed, changed, message) = self._status()
+
+        return (failed, changed, message)

--- a/lib/ansible/modules/packaging/os/homebrew_cask.py
+++ b/lib/ansible/modules/packaging/os/homebrew_cask.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Daniel Jaouen <dcj24@cornell.edu>
-# (c) 2016, Indrajit Raychaudhuri <irc+code@indrajit.com>
+# (c) 2016-2017, Indrajit Raychaudhuri <irc+code@indrajit.com>
 #
 # This module is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -43,7 +43,10 @@ options:
         aliases: ['pkg', 'package', 'cask']
     path:
         description:
-            - "':' separated list of paths to search for 'brew' executable."
+            - >
+              ':' separated list of paths to search for 'brew' executable. Since A package (I(formula) in homebrew parlance) location is prefixed
+              relative to the actual path of I(brew) command, providing an alternative I(brew) path enables managing different set of packages in an
+              alternative location in the system.
         required: false
         default: '/usr/local/bin'
     state:
@@ -94,48 +97,17 @@ EXAMPLES = '''
     install_options: force
 '''
 
-import os.path
-import re
-
-from ansible.module_utils.six import iteritems
-
+from ansible.module_utils.homebrew import *
 
 # exceptions -------------------------------------------------------------- {{{
 class HomebrewCaskException(Exception):
     pass
 # /exceptions ------------------------------------------------------------- }}}
 
-
-# utils ------------------------------------------------------------------- {{{
-def _create_regex_group(s):
-    lines = (line.strip() for line in s.split('\n') if line.strip())
-    chars = filter(None, (line.split('#')[0].strip() for line in lines))
-    group = r'[^' + r''.join(chars) + r']'
-    return re.compile(group)
-# /utils ------------------------------------------------------------------ }}}
-
-
-class HomebrewCask(object):
+class HomebrewCask(HomebrewBase):
     '''A class to manage Homebrew casks.'''
 
     # class regexes ------------------------------------------------ {{{
-    VALID_PATH_CHARS = r'''
-        \w                  # alphanumeric characters (i.e., [a-zA-Z0-9_])
-        \s                  # spaces
-        :                   # colons
-        {sep}               # the OS-specific path separator
-        .                   # dots
-        -                   # dashes
-    '''.format(sep=os.path.sep)
-
-    VALID_BREW_PATH_CHARS = r'''
-        \w                  # alphanumeric characters (i.e., [a-zA-Z0-9_])
-        \s                  # spaces
-        {sep}               # the OS-specific path separator
-        .                   # dots
-        -                   # dashes
-    '''.format(sep=os.path.sep)
-
     VALID_CASK_CHARS = r'''
         \w                  # alphanumeric characters (i.e., [a-zA-Z0-9_])
         .                   # dots
@@ -143,58 +115,10 @@ class HomebrewCask(object):
         -                   # dashes
     '''
 
-    INVALID_PATH_REGEX        = _create_regex_group(VALID_PATH_CHARS)
-    INVALID_BREW_PATH_REGEX   = _create_regex_group(VALID_BREW_PATH_CHARS)
-    INVALID_CASK_REGEX        = _create_regex_group(VALID_CASK_CHARS)
+    INVALID_CASK_REGEX = negate_regex_group(VALID_CASK_CHARS)
     # /class regexes ----------------------------------------------- }}}
 
     # class validations -------------------------------------------- {{{
-    @classmethod
-    def valid_path(cls, path):
-        '''
-        `path` must be one of:
-         - list of paths
-         - a string containing only:
-             - alphanumeric characters
-             - dashes
-             - dots
-             - spaces
-             - colons
-             - os.path.sep
-        '''
-
-        if isinstance(path, basestring):
-            return not cls.INVALID_PATH_REGEX.search(path)
-
-        try:
-            iter(path)
-        except TypeError:
-            return False
-        else:
-            paths = path
-            return all(cls.valid_brew_path(path_) for path_ in paths)
-
-    @classmethod
-    def valid_brew_path(cls, brew_path):
-        '''
-        `brew_path` must be one of:
-         - None
-         - a string containing only:
-             - alphanumeric characters
-             - dashes
-             - dots
-             - spaces
-             - os.path.sep
-        '''
-
-        if brew_path is None:
-            return True
-
-        return (
-            isinstance(brew_path, basestring)
-            and not cls.INVALID_BREW_PATH_REGEX.search(brew_path)
-        )
-
     @classmethod
     def valid_cask(cls, cask):
         '''A valid cask is either None or alphanumeric + backslashes.'''
@@ -236,67 +160,6 @@ class HomebrewCask(object):
 
     # class properties --------------------------------------------- {{{
     @property
-    def module(self):
-        return self._module
-
-    @module.setter
-    def module(self, module):
-        if not self.valid_module(module):
-            self._module = None
-            self.failed = True
-            self.message = 'Invalid module: {0}.'.format(module)
-            raise HomebrewCaskException(self.message)
-
-        else:
-            self._module = module
-            return module
-
-    @property
-    def path(self):
-        return self._path
-
-    @path.setter
-    def path(self, path):
-        if not self.valid_path(path):
-            self._path = []
-            self.failed = True
-            self.message = 'Invalid path: {0}.'.format(path)
-            raise HomebrewCaskException(self.message)
-
-        else:
-            if isinstance(path, basestring):
-                self._path = path.split(':')
-            else:
-                self._path = path
-
-            return path
-
-    @property
-    def brew_path(self):
-        return self._brew_path
-
-    @brew_path.setter
-    def brew_path(self, brew_path):
-        if not self.valid_brew_path(brew_path):
-            self._brew_path = None
-            self.failed = True
-            self.message = 'Invalid brew_path: {0}.'.format(brew_path)
-            raise HomebrewCaskException(self.message)
-
-        else:
-            self._brew_path = brew_path
-            return brew_path
-
-    @property
-    def params(self):
-        return self._params
-
-    @params.setter
-    def params(self, params):
-        self._params = self.module.params
-        return self._params
-
-    @property
     def current_cask(self):
         return self._current_cask
 
@@ -313,8 +176,9 @@ class HomebrewCask(object):
             return cask
     # /class properties -------------------------------------------- }}}
 
-    def __init__(self, module, path=path, casks=None, state=None,
+    def __init__(self, module, path, casks=None, state=None,
                  update_homebrew=False, install_options=None):
+        super(HomebrewCask, self).__init__()
         if not install_options:
             install_options = list()
         self._setup_status_vars()
@@ -323,60 +187,6 @@ class HomebrewCask(object):
                                   install_options=install_options,)
 
         self._prep()
-
-    # prep --------------------------------------------------------- {{{
-    def _setup_status_vars(self):
-        self.failed = False
-        self.changed = False
-        self.changed_count = 0
-        self.unchanged_count = 0
-        self.message = ''
-
-    def _setup_instance_vars(self, **kwargs):
-        for key, val in iteritems(kwargs):
-            setattr(self, key, val)
-
-    def _prep(self):
-        self._prep_brew_path()
-
-    def _prep_brew_path(self):
-        if not self.module:
-            self.brew_path = None
-            self.failed = True
-            self.message = 'AnsibleModule not set.'
-            raise HomebrewCaskException(self.message)
-
-        self.brew_path = self.module.get_bin_path(
-            'brew',
-            required=True,
-            opt_dirs=self.path,
-        )
-        if not self.brew_path:
-            self.brew_path = None
-            self.failed = True
-            self.message = 'Unable to locate homebrew executable.'
-            raise HomebrewCaskException('Unable to locate homebrew executable.')
-
-        return self.brew_path
-
-    def _status(self):
-        return (self.failed, self.changed, self.message)
-    # /prep -------------------------------------------------------- }}}
-
-    def run(self):
-        try:
-            self._run()
-        except HomebrewCaskException:
-            pass
-
-        if not self.failed and (self.changed_count + self.unchanged_count > 1):
-            self.message = "Changed: %d, Unchanged: %d" % (
-                self.changed_count,
-                self.unchanged_count,
-            )
-        (failed, changed, message) = self._status()
-
-        return (failed, changed, message)
 
     # checks ------------------------------------------------------- {{{
     def _current_cask_is_installed(self):
@@ -595,7 +405,7 @@ def main():
                        for install_option in p['install_options']]
 
     brew_cask = HomebrewCask(module=module, path=path, casks=casks,
-                             state=state,  update_homebrew=update_homebrew,
+                             state=state, update_homebrew=update_homebrew,
                              install_options=install_options)
     (failed, changed, message) = brew_cask.run()
     if failed:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Changes to reduce duplication of common `homebrew` operations:

- Extract common code to `module_utils`
- homebrew, homebrew_cask depend on base class `HomebrewCommon`


<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- homebrew
- homebres_cask

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (homebrew-refactor 0f092b59fe) last updated 2017/04/19 23:46:57 (GMT -500)
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

This refactoring is along the lines of cloud modules. Once this PR is vetted and accepted, there would be more cleanups including streamlining `homebrew_taps` module and creating a new `homebrew_bundle` module all relying on `HomebrewCommon`.