### PR TITLE
Ignore main route table association when determining which associations to remove.

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
@@ -401,6 +401,8 @@ def ensure_subnet_association(vpc_conn, vpc_id, route_table_id, subnet_id,
         if route_table.id is None:
             continue
         for a in route_table.associations:
+            if a.main:
+                continue
             if a.subnet_id == subnet_id:
                 if route_table.id == route_table_id:
                     return {'changed': False, 'association_id': a.id}
@@ -415,7 +417,7 @@ def ensure_subnet_association(vpc_conn, vpc_id, route_table_id, subnet_id,
 
 def ensure_subnet_associations(vpc_conn, vpc_id, route_table, subnets,
                                check_mode, purge_subnets):
-    current_association_ids = [a.id for a in route_table.associations]
+    current_association_ids = [a.id for a in route_table.associations if not a.main]
     new_association_ids = []
     changed = False
     for subnet in subnets:


### PR DESCRIPTION
##### SUMMARY
When you create a VPC, it automatically has a main route table. The main route table controls the routing for all subnets that are not explicitly associated with any other route table. You can add, remove, and modify routes in the main route table.

You can explicitly associate a subnet with the main route table, even if it's already implicitly associated.  You cannot, however, remove a subnet that is implicitly associated with the main route table (has the MAIN attribute set). You must explicitly associate it with a different route table.

##### ISSUE TYPE
 - Bugfix Pull Request

##### EXPECTED BEHAVIOR
Ansible does not try to remove implicit main route table associations. When managing the main route table, implicit associations can only be removed by explicitly associating the subnet with a different route table.

##### ACTUAL BEHAVIOR
Ansible tries to remove implicit associations, which is not supported. 

##### COMPONENT NAME
cloud/amazon/ec2_vpc_route_table

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = /home/ec2-user/repos/cmb-infosec-ansible/ansible.cfg
  configured module search path = [u'/home/ec2-user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ec2-user/ansible-env/lib/python2.7/site-packages/ansible
  executable location = /home/ec2-user/ansible-env/bin/ansible
  python version = 2.7.13+ (default, Feb 24 2017, 13:51:49) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```