### PR TITLE
amazon/ec2_vpc_igw: Allow EC2 VPC internet gateways to be tagged

### DIFF
--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -90,7 +90,6 @@ lib/ansible/modules/cloud/amazon/ec2_tag.py
 lib/ansible/modules/cloud/amazon/ec2_vol.py
 lib/ansible/modules/cloud/amazon/ec2_vol_facts.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_options.py
-lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_net.py


### PR DESCRIPTION
##### SUMMARY
Add tags support to ec2_vpc_igw module

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
cloud/amazon/ec2_vpc_igw

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = /home/ec2-user/repos/cmb-infosec-ansible/ansible.cfg
  configured module search path = [u'/home/ec2-user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ec2-user/ansible-env/lib/python2.7/site-packages/ansible
  executable location = /home/ec2-user/ansible-env/bin/ansible
  python version = 2.7.13+ (default, Feb 24 2017, 13:51:49) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```