### PR TITLE
Add eos_banner as module to banner param

### DIFF
--- a/lib/ansible/modules/network/eos/eos_banner.py
+++ b/lib/ansible/modules/network/eos/eos_banner.py
@@ -65,8 +65,9 @@ EXAMPLES = """
     state: present
 
 - name: remove the motd banner
-  banner: motd
-  state: absent
+  eos_banner:
+    banner: motd
+    state: absent
 """
 
 RETURN = """


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add `eos_banner` module to parameter `banner`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4.0 devel (latest)
```