### PR TITLE
Mdd s3 integration tests fix

### DIFF
--- a/test/integration/amazon.yml
+++ b/test/integration/amazon.yml
@@ -1,6 +1,7 @@
 - hosts: amazon
   gather_facts: true
   roles:
+    - { role: test_s3, tags: test_s3 }
     - { role: test_ec2_key, tags: test_ec2_key }
     - { role: test_ec2_group, tags: test_ec2_group }
     #- { role: test_ec2_vpc, tags: test_ec2_vpc }

--- a/test/integration/roles/test_s3/tasks/main.yml
+++ b/test/integration/roles/test_s3/tasks/main.yml
@@ -32,13 +32,19 @@
       - "result['changed'] == False"
 # ============================================================
 - name: create temporary file object to put in a bucket
-  command: mktemp /tmp/XXXXXXXX
+  tempfile:
   register: tmp1
+- name: make random contents
+  set_fact:
+      content: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits,punctuation') }}"
+
 - name: give temporary file data
-  shell: echo foo > "{{ tmp1.stdout }}"
+  copy:
+    content: "{{ content }}"
+    dest: "{{ tmp1.path }}"
 - name: get the stat of the file
   stat:
-    path: "{{ tmp1.stdout }}"
+    path: "{{ tmp1.path }}"
     get_checksum: yes
   register: file1stat
 # ============================================================
@@ -46,7 +52,7 @@
   s3:
     bucket: "{{ bucket.stdout }}"
     mode: put
-    src: "{{ tmp1.stdout }}"
+    src: "{{ tmp1.path }}"
     object: delete.txt
     aws_access_key: "{{ ec2_access_key }}"
     aws_secret_key: "{{ ec2_secret_key }}"
@@ -63,13 +69,13 @@
     seconds: 3
 # ============================================================
 - name: create a second temp file to download the object from the bucket
-  command: mktemp /tmp/XXXXXXXX
+  tempfile:
   register: tmp2
 - name: test get object
   s3:
     bucket: "{{ bucket.stdout }}"
     mode: get
-    dest: "{{ tmp2.stdout }}"
+    dest: "{{ tmp2.path }}"
     object: delete.txt
     aws_access_key: "{{ ec2_access_key }}"
     aws_secret_key: "{{ ec2_secret_key }}"
@@ -78,7 +84,7 @@
   register: result
 - name: get the stat of the file so we can compare the checksums
   stat:
-    path: "{{ tmp2.stdout }}"
+    path: "{{ tmp2.path }}"
     get_checksum: yes
   register: file2stat
 - name: assert checksums are the same
@@ -118,7 +124,7 @@
 - name: assert that we have the object's contents
   assert:
     that:
-      - "result['contents'] == 'foo\n'"
+      - "result['contents'] == content"
 # ============================================================
 - name: test list to get all objects in the bucket
   s3:
@@ -164,8 +170,8 @@
 - name: delete temporary file 1
   file:
     state: absent
-    path: "{{ tmp1.stdout }}"
+    path: "{{ tmp1.path }}"
 - name: delete temporary file 2
   file:
     state: absent
-    path: "{{ tmp2.stdout }}"
+    path: "{{ tmp2.path }}"

--- a/test/integration/roles/test_s3/tasks/main.yml
+++ b/test/integration/roles/test_s3/tasks/main.yml
@@ -2,7 +2,7 @@
 # tasks file for test_s3
 # ============================================================
 - name: generate random name for the bucket name
-  shell: bash -c 'echo ansible_test_$RANDOM'
+  command: bash -c 'echo ansible_test_$RANDOM'
   register: bucket
 # ============================================================
 - include_vars: "credentials.yml"
@@ -32,7 +32,7 @@
       - "result['changed'] == False"
 # ============================================================
 - name: create temporary file object to put in a bucket
-  shell: mktemp /tmp/XXXXXXXX
+  command: mktemp /tmp/XXXXXXXX
   register: tmp1
 - name: give temporary file data
   shell: echo foo > "{{ tmp1.stdout }}"
@@ -63,7 +63,7 @@
     seconds: 3
 # ============================================================
 - name: create a second temp file to download the object from the bucket
-  shell: mktemp /tmp/XXXXXXXX
+  command: mktemp /tmp/XXXXXXXX
   register: tmp2
 - name: test get object
   s3:

--- a/test/integration/roles/test_s3/tasks/main.yml
+++ b/test/integration/roles/test_s3/tasks/main.yml
@@ -2,10 +2,10 @@
 # tasks file for test_s3
 # ============================================================
 - name: generate random name for the bucket name
-  shell: echo ansible_test_$RANDOM
+  shell: bash -c 'echo ansible_test_$RANDOM'
   register: bucket
 # ============================================================
-- include_vars: "~/credentials.yml"
+- include_vars: "credentials.yml"
 # ============================================================
 - name: test create bucket
   s3:

--- a/test/integration/roles/test_s3/tasks/main.yml
+++ b/test/integration/roles/test_s3/tasks/main.yml
@@ -1,0 +1,171 @@
+---
+# tasks file for test_s3
+# ============================================================
+- name: generate random name for the bucket name
+  shell: echo ansible_test_$RANDOM
+  register: bucket
+# ============================================================
+- include_vars: "~/credentials.yml"
+# ============================================================
+- name: test create bucket
+  s3:
+    bucket: "{{ bucket.stdout }}"
+    mode: create
+    aws_access_key: "{{ ec2_access_key }}"
+    aws_secret_key: "{{ ec2_secret_key }}"
+  register: result
+- name: assert changed is True
+  assert:
+    that:
+      - "result['changed'] == True"
+# ============================================================
+- name: trying to create a bucket name that already exists
+  s3:
+    bucket: "{{ bucket.stdout }}"
+    mode: create
+    aws_access_key: "{{ ec2_access_key }}"
+    aws_secret_key: "{{ ec2_secret_key }}"
+  register: result
+- name: assert changed is False since the bucket already exists
+  assert:
+    that:
+      - "result['changed'] == False"
+# ============================================================
+- name: create temporary file object to put in a bucket
+  shell: mktemp /tmp/XXXXXXXX
+  register: tmp1
+- name: give temporary file data
+  shell: echo foo > "{{ tmp1.stdout }}"
+- name: get the stat of the file
+  stat:
+    path: "{{ tmp1.stdout }}"
+    get_checksum: yes
+  register: file1stat
+# ============================================================
+- name: test putting an object in the bucket
+  s3:
+    bucket: "{{ bucket.stdout }}"
+    mode: put
+    src: "{{ tmp1.stdout }}"
+    object: delete.txt
+    aws_access_key: "{{ ec2_access_key }}"
+    aws_secret_key: "{{ ec2_secret_key }}"
+  retries: 3
+  delay: 3
+  register: result
+- name: assert object exists
+  assert:
+    that:
+       "result['changed'] == True"
+# ============================================================
+- name: wait a few seconds before continuing
+  pause:
+    seconds: 3
+# ============================================================
+- name: create a second temp file to download the object from the bucket
+  shell: mktemp /tmp/XXXXXXXX
+  register: tmp2
+- name: test get object
+  s3:
+    bucket: "{{ bucket.stdout }}"
+    mode: get
+    dest: "{{ tmp2.stdout }}"
+    object: delete.txt
+    aws_access_key: "{{ ec2_access_key }}"
+    aws_secret_key: "{{ ec2_secret_key }}"
+  retries: 3
+  delay: 3
+  register: result
+- name: get the stat of the file so we can compare the checksums
+  stat:
+    path: "{{ tmp2.stdout }}"
+    get_checksum: yes
+  register: file2stat
+- name: assert checksums are the same
+  assert:
+    that:
+      - "file1stat['stat']['checksum'] == file2stat['stat']['checksum']"
+# ============================================================
+- name: wait a few seconds before continuing
+  pause:
+      seconds: 3
+# ============================================================
+- name: test geturl of the object
+  s3:
+    bucket: "{{ bucket.stdout }}"
+    mode: geturl
+    object: delete.txt
+    aws_access_key: "{{ ec2_access_key }}"
+    aws_secret_key: "{{ ec2_secret_key }}"
+  retries: 3
+  delay: 3
+  register: result
+- name: assert we have the object's url
+  assert:
+    that:
+      - "result['changed'] == True"
+# ============================================================
+- name: test getstr of the object
+  s3:
+    bucket: "{{ bucket.stdout }}"
+    mode: getstr
+    object: delete.txt
+    aws_access_key: "{{ ec2_access_key }}"
+    aws_secret_key: "{{ ec2_secret_key }}"
+  retries: 3
+  delay: 3
+  register: result
+- name: assert that we have the object's contents
+  assert:
+    that:
+      - "result['contents'] == 'foo\n'"
+# ============================================================
+- name: test list to get all objects in the bucket
+  s3:
+    bucket: "{{ bucket.stdout }}"
+    mode: list
+    aws_access_key: "{{ ec2_access_key }}"
+    aws_secret_key: "{{ ec2_secret_key }}"
+  retries: 3
+  delay: 3
+  register: result
+- name: assert that the keys are correct
+  assert:
+    that:
+      - "result['s3_keys'] == ['delete.txt']"
+# ============================================================
+- name: test delobj to just delete an object in the bucket
+  s3:
+    bucket: "{{ bucket.stdout }}"
+    mode: delobj
+    object: delete.txt
+    aws_access_key: "{{ ec2_access_key }}"
+    aws_secret_key: "{{ ec2_secret_key }}"
+  retries: 3
+  delay: 3
+  register: result
+- name: assert that delete.txt is no longer an object in the bucket deleteme
+  assert:
+    that:
+      - "result['changed'] == True"
+# ============================================================
+- name: test delete bucket
+  s3:
+    bucket: "{{ bucket.stdout }}"
+    mode: delete
+    aws_access_key: "{{ ec2_access_key }}"
+    aws_secret_key: "{{ ec2_secret_key }}"
+  register: result
+- name: assert that changed is True
+  assert:
+    that:
+      - "result['changed'] == True"
+# ============================================================
+- name: delete temporary file 1
+  file:
+    state: absent
+    path: "{{ tmp1.stdout }}"
+- name: delete temporary file 2
+  file:
+    state: absent
+    path: "{{ tmp2.stdout }}"


### PR DESCRIPTION
##### SUMMARY

make S3 integration tests run more generally 

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

s3 integration tests
##### ANSIBLE VERSION

```
ansible 2.4.0 (mdd-s3-integration-tests-fix 7cf4051817) last updated 2017/04/20 10:31:56 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/mikedd/dev/ansible/ansible-add-modules/library']
  python version = 2.7.12 (default, Jul  1 2016, 15:12:24) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION

I am using fish as an interactive shell so  it doesn't recognise $RANDOM - this ensures bash will be used even if a shell without $RANDOM is the default.
