### PR TITLE
Added Support for creating a Zabbix Inventory. It is possible to tag the

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix_host.py
@@ -167,6 +167,14 @@ EXAMPLES = '''
     status: enabled
     state: present
     inventory_mode: automatic
+    inventory_zabbix:
+      tag: "{{ your_tag }}"
+      alias: "{{ your_alias }}"
+      notes: "Special Informations: {{ your_informations | default('None') }}"
+      location: "{{ your_location }}"
+      site_rack: "{{ your_site_rack }}"
+      os: "{{ your_os }}"
+      hardware: "{{ your_hardware }}"
     interfaces:
       - type: 1
         main: 1

--- a/lib/ansible/modules/monitoring/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix_host.py
@@ -63,6 +63,8 @@ options:
     inventory_zabbix:
         description:
             - Add Facts for a zabbix inventory (e.g. Tag) (see example below).
+            - Please review the interface documentation for more information on the supported properties
+            - 'https://www.zabbix.com/documentation/3.2/manual/api/reference/host/object#host_inventory'
         required: false
         default: None
         version_added: '2.4'
@@ -166,7 +168,7 @@ EXAMPLES = '''
       - Example template2
     status: enabled
     state: present
-    inventory_mode: automatic
+    inventory_mode: manual
     inventory_zabbix:
       tag: "{{ your_tag }}"
       alias: "{{ your_alias }}"

--- a/lib/ansible/modules/monitoring/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix_host.py
@@ -62,7 +62,7 @@ options:
         version_added: '2.1'
     inventory_zabbix:
         description:
-            - Add Facts for a zabbix inventory (e.g.: Tag) (see example below).
+            - Add Facts for a zabbix inventory (e.g. Tag) (see example below).
         required: false
         default: None
         version_added: '2.4'

--- a/lib/ansible/modules/monitoring/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix_host.py
@@ -62,7 +62,7 @@ options:
         version_added: '2.1'
     inventory_zabbix:
         description:
-            - Add Facts for a zabbix inventory (e.g.: Tag)
+            - Add Facts for a zabbix inventory (e.g.: Tag) (see example below).
         required: false
         default: None
         version_added: '2.4'

--- a/lib/ansible/modules/monitoring/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix_host.py
@@ -60,6 +60,12 @@ options:
         required: false
         default: None
         version_added: '2.1'
+    inventory_zabbix:
+        description:
+            - Add Facts for a zabbix inventory (e.g.: Tag)
+        required: false
+        default: None
+        version_added: '2.4'
     status:
         description:
             - Monitoring status of the host.
@@ -500,6 +506,18 @@ class Host(object):
         except Exception as e:
             self._module.fail_json(msg="Failed to set inventory_mode to host: %s" % e)
 
+    def update_inventory_zabbix(self, host_id, inventory):
+
+        if not inventory:
+            return
+
+        request_str = {'hostid': host_id, 'inventory': inventory}
+        try:
+            if self._module.check_mode:
+                self._module.exit_json(changed=True)
+            self._zapi.host.update(request_str)
+        except Exception as e:
+            self._module.fail_json(msg="Failed to set inventory to host: %s" % e)
 
 def main():
     module = AnsibleModule(
@@ -522,6 +540,7 @@ def main():
             tls_psk=dict(type='str', required=False),
             tls_issuer=dict(type='str', required=False),
             tls_subject=dict(type='str', required=False),
+            inventory_zabbix=dict(required=False, type='dict'),
             timeout=dict(type='int', default=10),
             interfaces=dict(type='list', required=False),
             force=dict(type='bool', default=True),
@@ -553,6 +572,7 @@ def main():
     tls_psk = module.params['tls_psk']
     tls_issuer = module.params['tls_issuer']
     tls_subject = module.params['tls_subject']
+    inventory_zabbix = module.params['inventory_zabbix']
     status = module.params['status']
     state = module.params['state']
     timeout = module.params['timeout']
@@ -662,6 +682,7 @@ def main():
                     host.link_or_clear_template(host_id, template_ids, tls_connect, tls_accept, tls_psk_identity,
                                                 tls_psk, tls_issuer, tls_subject)
                     host.update_inventory_mode(host_id, inventory_mode)
+                    host.update_inventory_zabbix(host_id, inventory_zabbix)
                     module.exit_json(changed=True,
                                      result="Successfully update host %s (%s) and linked with template '%s'"
                                             % (host_name, ip, link_templates))
@@ -690,6 +711,7 @@ def main():
         host.link_or_clear_template(host_id, template_ids, tls_connect, tls_accept, tls_psk_identity,
                                     tls_psk, tls_issuer, tls_subject)
         host.update_inventory_mode(host_id, inventory_mode)
+        host.update_inventory_zabbix(host_id, inventory_zabbix)
         module.exit_json(changed=True, result="Successfully added host %s (%s) and linked with template '%s'" % (
             host_name, ip, link_templates))
 

--- a/lib/ansible/modules/monitoring/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix_host.py
@@ -67,7 +67,7 @@ options:
             - 'https://www.zabbix.com/documentation/3.2/manual/api/reference/host/object#host_inventory'
         required: false
         default: None
-        version_added: '2.4'
+        version_added: '2.5'
     status:
         description:
             - Monitoring status of the host.
@@ -528,6 +528,7 @@ class Host(object):
             self._zapi.host.update(request_str)
         except Exception as e:
             self._module.fail_json(msg="Failed to set inventory to host: %s" % e)
+
 
 def main():
     module = AnsibleModule(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added Support for creating a Zabbix Inventory. It is possible to tag the hosts and add Locations etc.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Module: zabbix_host

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
> ansible --version
ansible 2.3.0.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Mar 24 2017, 09:43:28) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Usage Example in task:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
- name: "Create a new host or update an existing host's info"
  local_action:
    module: zabbix_host
    server_url: "{{ zabbix_url }}"
    login_user: "{{ zabbix_api_user }}"
    login_password: "{{ zabbix_api_pass }}"
    host_name: "{{ zabbix_hostname }}"
    host_groups: "{{ zabbbix_hostgroup }}"
    link_templates: "{{ zabbix_link_templates }}"
    inventory_mode: automatic
    inventory_zabbix:
      tag: "{{ your_tag }}"
      alias: "{{ your_alias }}"
      notes: "Special Informations: {{ your_informations | default('None') }}"
      location: "{{ your_location }}"
      site_rack: "{{ your_site_rack }}"
      os: "{{ your_os }}"
      hardware: "{{ your_hardware }}"
      vendor: "{{ your_vendor }}"
    status: "{{ zabbix_host_status }}"
    state: "{{ zabbix_create_host }}"
    proxy: "{{ zabbix_proxy }}"
    interfaces: "{{ zabbix_interfaces }}"
  tags:
    - api
```
