### PR TITLE
route53_facts: add example for how to use next_marker option - fixes #23625

### DIFF
--- a/lib/ansible/modules/cloud/amazon/route53_facts.py
+++ b/lib/ansible/modules/cloud/amazon/route53_facts.py
@@ -56,9 +56,10 @@ options:
   next_marker:
     description:
       - "Some requests such as list_command: hosted_zones will return a maximum
-        number of entries - EG 100. If the number of entries exceeds this maximum
-        another request can be sent using the NextMarker entry from the first response
-        to get the next page of results"
+        number of entries - EG 100 or the number specified by max_items.
+        If the number of entries exceeds this maximum another request can be sent
+        using the NextMarker entry from the first response to get the next page
+        of results"
     required: false
   delegation_set_id:
     description:
@@ -163,6 +164,17 @@ EXAMPLES = '''
     delegation_set_id: delegation id
   register: delegation_sets
 
+- name: setup of example for using next_marker
+  route53_facts:
+    query: hosted_zone
+    max_items: 1
+  register: first_facts
+- name: example for using next_marker
+  route53_facts:
+    query: hosted_zone
+    next_marker: "{{ first_facts.NextMarker }}"
+    max_items: 1
+  when: "{{ 'NextMarker' in first_facts }}"
 '''
 try:
     import boto

--- a/lib/ansible/modules/cloud/amazon/route53_facts.py
+++ b/lib/ansible/modules/cloud/amazon/route53_facts.py
@@ -416,7 +416,7 @@ def main():
             'count',
             'tags',
         ], default='list'),
-        )
+    )
     )
 
     module = AnsibleModule(

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -207,7 +207,6 @@ lib/ansible/modules/cloud/amazon/rds.py
 lib/ansible/modules/cloud/amazon/rds_param_group.py
 lib/ansible/modules/cloud/amazon/rds_subnet_group.py
 lib/ansible/modules/cloud/amazon/redshift.py
-lib/ansible/modules/cloud/amazon/route53_facts.py
 lib/ansible/modules/cloud/amazon/route53_health_check.py
 lib/ansible/modules/cloud/amazon/s3.py
 lib/ansible/modules/cloud/amazon/s3_bucket.py


### PR DESCRIPTION
##### SUMMARY
It isn't clear how next_marker can be used so I added an example. Fixes #23625
Also made pep8 and removed from legacy files.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/route53_facts.py

##### ANSIBLE VERSION
```
2.4.0
```