### PR TITLE
async+script: add tests and pass it

### DIFF
--- a/test/integration/targets/script/tasks/main.yml
+++ b/test/integration/targets/script/tasks/main.yml
@@ -69,3 +69,17 @@
     that:
       - "script_result1|changed"
       - "script_result2.state == 'absent'"
+
+# async
+- name: test task failure with async param
+
+  script: /some/script.sh
+  async: 2
+  ignore_errors: true
+  register: script_result3
+
+- name: assert task with async param failed
+  assert:
+    that:
+      - 'script_result3.failed'
+      - 'script_result3.msg == "async is not supported for this task."'


### PR DESCRIPTION
Fixes #23729

adding a test to assert async+script  fails   and pass it.

revealing that when skipped is not present with failed on a task, the error is in task poll in task_executor.