### PR TITLE
ec2: Allow EC2-VPC instances to modify security groups - fixes #18928

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -617,7 +617,7 @@ EXAMPLES = '''
 
 import time
 from ast import literal_eval
-from ansible.module_utils.six import get_function_code, text_type
+from ansible.module_utils.six import get_function_code, string_types
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import get_aws_connection_info, ec2_argument_spec, ec2_connect, connect_to_aws
@@ -1444,14 +1444,14 @@ def startstop_instances(module, ec2, instance_ids, state, instance_tags):
             # Check security groups and if we're using ec2-vpc; ec2-classic security groups may not be modified
             if inst.vpc_id and group_name:
                 grp_details = ec2.get_all_security_groups(filters={'vpc_id': inst.vpc_id})
-                if isinstance(group_name, text_type):
+                if isinstance(group_name, string_types):
                     group_name = [group_name]
                 unmatched = set(group_name) - set(to_text(grp.name) for grp in grp_details)
                 if len(unmatched) > 0:
                     module.fail_json(msg="The following group names are not valid: %s" % ', '.join(unmatched))
                 group_ids = [to_text(grp.id) for grp in grp_details if to_text(grp.name) in group_name]
             elif inst.vpc_id and group_id:
-                if isinstance(group_id, text_type):
+                if isinstance(group_id, string_types):
                     group_id = [group_id]
                 grp_details = ec2.get_all_security_groups(group_ids=group_id)
                 group_ids = [grp_item.id for grp_item in grp_details]

--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -1441,20 +1441,20 @@ def startstop_instances(module, ec2, instance_ids, state, instance_tags):
                 changed = True
 
             # Check security groups and if we're using ec2-vpc; ec2-classic security groups may not be modified
-            if inst.vpc_id and (group_id or group_name):
-                if group_name:
-                    grp_details = ec2.get_all_security_groups(filters={'vpc_id': inst.vpc_id})
-                    if isinstance(group_name, basestring):
-                        group_name = [group_name]
-                    unmatched = set(group_name).difference(str(grp.name) for grp in grp_details)
-                    if len(unmatched) > 0:
-                        module.fail_json(msg="The following group names are not valid: %s" % ', '.join(unmatched))
-                    group_ids = [str(grp.id) for grp in grp_details if str(grp.name) in group_name]
-                elif group_id:
-                    if isinstance(group_id, basestring):
-                        group_id = [group_id]
-                    grp_details = ec2.get_all_security_groups(group_ids=group_id)
-                    group_ids = [grp_item.id for grp_item in grp_details]
+            if inst.vpc_id and group_name:
+                grp_details = ec2.get_all_security_groups(filters={'vpc_id': inst.vpc_id})
+                if isinstance(group_name, basestring):
+                    group_name = [group_name]
+                unmatched = set(group_name).difference(str(grp.name) for grp in grp_details)
+                if len(unmatched) > 0:
+                    module.fail_json(msg="The following group names are not valid: %s" % ', '.join(unmatched))
+                group_ids = [str(grp.id) for grp in grp_details if str(grp.name) in group_name]
+            elif inst.vpc_id and group_id:
+                if isinstance(group_id, basestring):
+                    group_id = [group_id]
+                grp_details = ec2.get_all_security_groups(group_ids=group_id)
+                group_ids = [grp_item.id for grp_item in grp_details]
+            if inst.vpc_id and (group_name or group_id):
                 if set([sg.id for sg in inst.groups]) != set(group_ids):
                     changed = inst.modify_attribute('groupSet', group_ids)
 

--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -1447,7 +1447,7 @@ def startstop_instances(module, ec2, instance_ids, state, instance_tags):
                 if isinstance(group_name, string_types):
                     group_name = [group_name]
                 unmatched = set(group_name) - set(to_text(grp.name) for grp in grp_details)
-                if len(unmatched) > 0:
+                if unmatched:
                     module.fail_json(msg="The following group names are not valid: %s" % ', '.join(unmatched))
                 group_ids = [to_text(grp.id) for grp in grp_details if to_text(grp.name) in group_name]
             elif inst.vpc_id and group_id:

--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -1455,10 +1455,8 @@ def startstop_instances(module, ec2, instance_ids, state, instance_tags):
                         group_id = [group_id]
                     grp_details = ec2.get_all_security_groups(group_ids=group_id)
                     group_ids = [grp_item.id for grp_item in grp_details]
-                for each in group_ids:
-                    if each not in [sg.id for sg in inst.groups] or len(group_ids) != len(inst.groups):
-                        changed = inst.modify_attribute('groupSet', group_ids)
-                        break
+                if set([sg.id for sg in inst.groups]) != set(group_ids):
+                    changed = inst.modify_attribute('groupSet', group_ids)
 
             # Check instance state
             if inst.state != state:

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -149,7 +149,6 @@ lib/ansible/modules/cloud/amazon/cloudfront_facts.py
 lib/ansible/modules/cloud/amazon/cloudtrail.py
 lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
 lib/ansible/modules/cloud/amazon/dynamodb_table.py
-lib/ansible/modules/cloud/amazon/ec2.py
 lib/ansible/modules/cloud/amazon/ec2_ami.py
 lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
 lib/ansible/modules/cloud/amazon/ec2_ami_find.py


### PR DESCRIPTION
make ec2 pep8

##### SUMMARY
EC2-VPC instances can modify security groups. Added that feature to the ec2 module. Made ec2 pep8 and removed from legacy file. Fixes #18928

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2.py

##### ANSIBLE VERSION
```
2.4.0
```
