### PR TITLE
Add wait_for_reboot option to win_reboot module

### DIFF
--- a/lib/ansible/modules/windows/win_reboot.py
+++ b/lib/ansible/modules/windows/win_reboot.py
@@ -58,6 +58,11 @@ options:
     description:
     - Message to display to users
     default: Reboot initiated by Ansible
+  wait_for_reboot:
+    description:
+    - Whether to wait for the machine to re-appear on the network
+    default: true
+    version_added: "2.4"
 notes:
 - If a shutdown was already scheduled on the system, C(win_reboot) will abort the scheduled shutdown and enforce its own shutdown.
 author:


### PR DESCRIPTION
##### SUMMARY
Adds support for issuing a reboot on a Windows machine without waiting for the system to re-appear on the network.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/win_reboot.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
```


##### ADDITIONAL INFORMATION
Set to a default value of True for backward compatibility.
```
- name: Issue reboot without waiting for system to re-appear
  win_reboot:
    wait_for_reboot: no
```
