### PR TITLE
Add eos_user module to users parameter

### DIFF
--- a/lib/ansible/modules/network/eos/eos_user.py
+++ b/lib/ansible/modules/network/eos/eos_user.py
@@ -107,11 +107,12 @@ EXAMPLES = """
     purge: yes
 
 - name: set multiple users to privilege level 15
-  users:
-    - username: netop
-    - username: netend
-  privilege: 15
-  state: present
+  eos_user:
+    users:
+      - username: netop
+      - username: netend
+    privilege: 15
+    state: present
 """
 
 RETURN = """


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add `eos_user` module to `users` parameter.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
`modules/network/eos/eos_user.py`
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4.0 devel
```