### PR TITLE
Fix the iosxr_facts mem gathering

### DIFF
--- a/lib/ansible/modules/network/iosxr/iosxr_facts.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_facts.py
@@ -174,11 +174,11 @@ class Hardware(FactsBase):
         self.facts['filesystems'] = self.parse_filesystems(
             results['dir /all'])
 
-        match = re.search(r'Physical Memory (\d+)M total \((\d+)',
+        match = re.search(r'Physical Memory: (\d+)M total \((\d+)',
             results['show memory summary'])
         if match:
-            self.facts['memtotal_mb'] = int(match[0])
-            self.facts['memfree_mb'] = int(match[1])
+            self.facts['memtotal_mb'] = match.group(1)
+            self.facts['memfree_mb'] = match.group(2)
 
     def parse_filesystems(self, data):
         return re.findall(r'^Directory of (\S+)', data, re.M)


### PR DESCRIPTION
##### SUMMARY

We were not calling match.group, plus we were lacking a ':' from
the expected output of 'show memory summary'.

Fixes #23737

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
iosxr_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (fix_iosxr_facts_show_mem de2b35aea7) last updated 2017/04/21 10:32:03 (GMT +200)
```
