### PR TITLE
Add assertion on test_iosxr_facts

### DIFF
--- a/test/units/modules/network/iosxr/test_iosxr_facts.py
+++ b/test/units/modules/network/iosxr/test_iosxr_facts.py
@@ -68,6 +68,8 @@ class TestIosxrFacts(TestIosxrModule):
         self.assertEquals(['disk0:', 'flash0:'], ansible_facts['ansible_net_filesystems'])
         self.assertIn('GigabitEthernet0/0/0/0',
             ansible_facts['ansible_net_interfaces'].keys())
+        self.assertEquals('3095', ansible_facts['ansible_net_memtotal_mb'])
+        self.assertEquals('1499', ansible_facts['ansible_net_memfree_mb'])
 
     def test_iosxr_facts_gather_subset_config(self):
         set_module_args({'gather_subset': 'config'})


### PR DESCRIPTION
##### SUMMARY

We hit bug #23737 due to bad coverage on test_iosxr_facts, we
were not checking memory facts at all.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
iosxr_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel d0fd8cefaa) last updated 2017/04/21 10:42:11 (GMT +200)
```
