### PR TITLE
Remove catch-all regex on IOS terminal plugin

### DIFF
--- a/lib/ansible/plugins/terminal/ios.py
+++ b/lib/ansible/plugins/terminal/ios.py
@@ -35,7 +35,7 @@ class TerminalModule(TerminalBase):
 
     terminal_stderr_re = [
         re.compile(r"% ?Error"),
-        re.compile(r"^% \w+", re.M),
+        #re.compile(r"^% \w+", re.M),
         re.compile(r"% ?Bad secret"),
         re.compile(r"invalid input", re.I),
         re.compile(r"(?:incomplete|ambiguous) command", re.I),


### PR DESCRIPTION
##### SUMMARY

We have a list of specific messages that we screen-scrape and flag
them as legit errors.
However, we also have a catch-all regex that matches everything
starting with %.
That can cause issues on commands that return lines with that
character, like for example the 'crypto key generate'.

Fixes #23770

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
plugins/terminal/ios

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (remove_catch_all_regex_on_terminal_stderr 27b3c63019) last updated 2017/04/21 15:14:03 (GMT +200)
```
