### PR TITLE
Fix file crash when using recurse=yes (#23861).

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -995,7 +995,6 @@ class AnsibleModule(object):
         b_path = to_bytes(path, errors='surrogate_then_strict')
         if expand:
             b_path = os.path.expanduser(os.path.expandvars(b_path))
-        path = to_text(b_path, errors='surrogate_then_strict')
         if owner is None:
             return changed
         orig_uid, orig_gid = self.user_and_group(path, expand)
@@ -1029,7 +1028,6 @@ class AnsibleModule(object):
         b_path = to_bytes(path, errors='surrogate_then_strict')
         if expand:
             b_path = os.path.expanduser(os.path.expandvars(b_path))
-        path = to_text(b_path, errors='surrogate_then_strict')
         if group is None:
             return changed
         orig_uid, orig_gid = self.user_and_group(b_path, expand)
@@ -1063,7 +1061,6 @@ class AnsibleModule(object):
         b_path = to_bytes(path, errors='surrogate_then_strict')
         if expand:
             b_path = os.path.expanduser(os.path.expandvars(b_path))
-        path = to_text(b_path, errors='surrogate_then_strict')
         path_stat = os.lstat(b_path)
 
         if mode is None:
@@ -1143,7 +1140,6 @@ class AnsibleModule(object):
         b_path = to_bytes(path, errors='surrogate_then_strict')
         if expand:
             b_path = os.path.expanduser(os.path.expandvars(b_path))
-        path = to_text(b_path, errors='surrogate_then_strict')
 
         existing = self.get_file_attributes(b_path)
 


### PR DESCRIPTION
Do not convert path in set_*_if_different.

##### SUMMARY

Fixes for #23861

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

file

##### ANSIBLE VERSION

```
ansible 2.4.0 (recursive-crash-non-utf8 7aab695887) last updated 2017/04/21 16:19:46 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION

You can retrieve an example at the following location: https://github.com/Yannig/yannig-ansible-playbooks/tree/master/file-encoding

```yaml
- name: "Recursive change with non utf-8 filename"
  hosts: localhost
  gather_facts: no
  tasks:
    - name: "Recursive change (crash)"
      file: path=dir mode=0755 recurse=yes
```

before:
```
LookupError: unknown error handler name 'surrogate_then_strict'
```

after: everything is fine!