### PR TITLE
conditional.py integration tests

### DIFF
--- a/test/integration/targets/conditionals/tasks/main.yml
+++ b/test/integration/targets/conditionals/tasks/main.yml
@@ -307,3 +307,55 @@
 - name: test complex templated condition
   debug: msg="it works"
   when: vars_file_var in things1|union([vars_file_var])
+
+- name: test dict with invalid key is undefined
+  vars:
+    mydict:
+     a: foo
+     b: bar
+  debug: var=mydict['c']
+  register: result
+  when: mydict['c'] is undefined
+
+- name: assert the task did not fail
+  assert:
+    that:
+      - "result.failed == false"
+
+- name: test dict with invalid key does not run with conditional is defined
+  vars:
+    mydict:
+      a: foo
+      b: bar
+  debug: var=mydict['c']
+  when: mydict['c'] is defined
+  register: result
+
+- name: assert the task was skipped
+  assert:
+    that:
+    - "result.skipped == true"
+
+- name: test list with invalid element does not run with conditional is defined
+  vars:
+    mylist: []
+  debug: var=mylist[0]
+  when: mylist[0] is defined
+  register: result
+
+- name: assert the task was skipped
+  assert:
+    that:
+    - "result.skipped == true"
+
+- name: test list with invalid element is undefined
+  vars:
+    mylist: []
+  debug: var=mylist[0]
+  when: mylist[0] is undefined
+  register: result
+
+- name: assert the task did not fail
+  assert:
+    that:
+      - "result.failed == false"


### PR DESCRIPTION
##### SUMMARY
~See #23871 for a reproducer. Using `when: something is defined`, but when `something` is a dict called with a key that doesn't exist, the task fails. Fixes #23871~

~Added another fix for a list being called with an index that doesn't exist. Fixes #24945~

#23871 and #24945 have been fixed by #25092
This PR is now just tests for those cases

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/conditionals/tasks/main.yml

##### ANSIBLE VERSION
```
2.4.0
```
