### PR TITLE
netconfig module updated to pay attention to .ssh/config

### DIFF
--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -85,6 +85,10 @@ class Connection(Rpc, ConnectionBase):
         if not network_os:
             raise AnsibleConnectionFailure('Unable to automatically determine host network os. Please ansible_network_os value')
 
+        ssh_config = os.getenv('ANSIBLE_NETCONF_SSH_CONFIG', False)
+        if ssh_config == 'True':
+            ssh_config = True
+
         try:
             self._manager = manager.connect(
                 host=self._play_context.remote_addr,
@@ -96,7 +100,8 @@ class Connection(Rpc, ConnectionBase):
                 look_for_keys=C.PARAMIKO_LOOK_FOR_KEYS,
                 allow_agent=self.allow_agent,
                 timeout=self._play_context.timeout,
-                device_params={'name': network_os}
+                device_params={'name': network_os},
+                ssh_config=ssh_config
             )
         except SSHUnknownHostError as exc:
             raise AnsibleConnectionFailure(str(exc))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The netconfig connection module was modified to pay attention to ssh config file.  Although other modules in the system have control over ssh using ssh config, but default to using system ssh including its default system files, ncclient used by the netconfig module defaults to not using the system ssh config.  As such, a bastion host cannot be used to access netconf with the module as it was.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
plugins/connection/netconf

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jan 30 2017, 14:01:14) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]

```


##### ADDITIONAL INFORMATION

Prior to this change access through ProxyCommand was not possible when using the netconf protocol.  This was discovered in an environment which required bastion host access to juniper routers for configuration.  Using the default configuration resulted in no configuration file being read, and thus the proxy configuration being ignored.  Further, since there was no way to pass individual ssh parameters to paramiko through ncclient, the ssh parameters in the `ansible_ssh_common_args` and similar can't just be passed along.

