### PR TITLE
[Old - don't merge] Cloud / Amazon error handling improvement

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2036,10 +2036,16 @@ class AnsibleModule(object):
         botocore, boto3 and boto, into nice error messages.
         """
         last_traceback=traceback.format_exc()
+
+        try:
+            except_msg = exception.message
+        except AttributeError:
+            except_msg = str(exception)
+
         if msg is not None:
-            message = '{}: {}'.format(msg, str(exception))
+            message = '{}: {}'.format(msg, except_msg)
         else:
-            message = str(exception)
+            message = except_msg
 
         try:
             response=exception.response

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2043,7 +2043,7 @@ class AnsibleModule(object):
             except_msg = str(exception)
 
         if msg is not None:
-            message = '{}: {}'.format(msg, except_msg)
+            message = '{0}: {1}'.format(msg, except_msg)
         else:
             message = except_msg
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2028,14 +2028,13 @@ class AnsibleModule(object):
         self._return_formatted(kwargs)
         sys.exit(1)
 
-
     def fail_json_aws(self, exception, msg=None):
         """call fail_json with processed exception
 
         function for converting exceptions thrown by AWS SDK modules,
         botocore, boto3 and boto, into nice error messages.
         """
-        last_traceback=traceback.format_exc()
+        last_traceback = traceback.format_exc()
 
         try:
             except_msg = exception.message
@@ -2048,16 +2047,15 @@ class AnsibleModule(object):
             message = except_msg
 
         try:
-            response=exception.response
+            response = exception.response
         except AttributeError:
-            response=None
+            response = None
 
         if response is None:
             self.fail_json(msg=message, exception=last_traceback)
         else:
             self.fail_json(msg=message, exception=last_traceback,
-                       **camel_dict_to_snake_dict(response))
-
+                           **camel_dict_to_snake_dict(response))
 
     def fail_on_missing_params(self, required_params=None):
         ''' This is for checking for required params when we can not check via argspec because we

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2037,9 +2037,9 @@ class AnsibleModule(object):
         """
         last_traceback=traceback.format_exc()
         if msg is not None:
-            message = '{}: {}'.format(msg, exception.message)
+            message = '{}: {}'.format(msg, str(exception))
         else:
-            message = exception.message
+            message = str(exception)
 
         try:
             response=exception.response

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2053,9 +2053,9 @@ class AnsibleModule(object):
             response=None
 
         if response is None:
-            self.fail_json(msg=message, traceback=last_traceback)
+            self.fail_json(msg=message, exception=last_traceback)
         else:
-            self.fail_json(msg=message, traceback=last_traceback,
+            self.fail_json(msg=message, exception=last_traceback,
                        **camel_dict_to_snake_dict(response))
 
 

--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -296,7 +296,7 @@ def main():
         client = boto3_conn(module, conn_type='client', resource='lambda',
                             region=region, endpoint=ec2_url, **aws_connect_kwargs)
     except (botocore.exceptions.ClientError, botocore.exceptions.ValidationError) as e:
-        module.fail_json(msg=str(e))
+        module.fail_json_aws(e, msg="Trying to connect to AWS")
 
     if role.startswith('arn:aws:iam'):
         role_arn = role
@@ -308,7 +308,7 @@ def main():
             account_id = iam_client.get_user()['User']['Arn'].split(':')[4]
             role_arn = 'arn:aws:iam::{0}:role/{1}'.format(account_id, role)
         except (botocore.exceptions.ClientError, botocore.exceptions.ValidationError) as e:
-            module.fail_json(msg=str(e))
+            module.fail_json_aws(e, msg="Trying to get AWS account details")
 
     # Get function configuration if present, False otherwise
     current_function = get_current_function(client, name)
@@ -382,7 +382,7 @@ def main():
                     current_version = response['Version']
                 changed = True
             except (botocore.exceptions.ParamValidationError, botocore.exceptions.ClientError) as e:
-                module.fail_json(msg=str(e))
+                module.fail_json_aws(e, msg="Trying to update lambda configuration")
 
         # Update code configuration
         code_kwargs = {'FunctionName': name, 'Publish': True}
@@ -418,7 +418,7 @@ def main():
                     current_version = response['Version']
                 changed = True
             except (botocore.exceptions.ParamValidationError, botocore.exceptions.ClientError) as e:
-                module.fail_json(msg=str(e))
+                module.fail_json_aws(e, msg="Trying to upload new code")
 
         # Describe function code and configuration
         response = get_current_function(client, name, qualifier=current_version)
@@ -484,7 +484,7 @@ def main():
                 current_version = response['Version']
             changed = True
         except (botocore.exceptions.ParamValidationError, botocore.exceptions.ClientError) as e:
-            module.fail_json(msg=str(e))
+            module.fail_json_aws(e, msg="Trying to create function")
 
         response = get_current_function(client, name, qualifier=current_version)
         if not response:
@@ -498,7 +498,7 @@ def main():
                 client.delete_function(FunctionName=name)
             changed = True
         except (botocore.exceptions.ParamValidationError, botocore.exceptions.ClientError) as e:
-            module.fail_json(msg=str(e))
+            module.fail_json_aws(e, msg="Trying to delete Lambda function")
 
         module.exit_json(changed=changed)
 

--- a/lib/ansible/modules/cloud/amazon/lambda_facts.py
+++ b/lib/ansible/modules/cloud/amazon/lambda_facts.py
@@ -155,7 +155,7 @@ def alias_details(client, module):
             if e.response['Error']['Code'] == 'ResourceNotFoundException':
                 lambda_facts.update(aliases=[])
             else:
-                module.fail_json(msg='Unable to get {0} aliases, error: {1}'.format(function_name, e))
+                module.fail_json_aws(e, msg="Trying to get aliases")
     else:
         module.fail_json(msg='Parameter function_name required for query=aliases.')
 
@@ -209,7 +209,7 @@ def config_details(client, module):
             if e.response['Error']['Code'] == 'ResourceNotFoundException':
                 lambda_facts.update(function={})
             else:
-                module.fail_json(msg='Unable to get {0} configuration, error: {1}'.format(function_name, e))
+                module.fail_json_aws(e, msg="Trying to get {0} configuration".format(function_name))
     else:
         params = dict()
         if module.params.get('max_items'):
@@ -224,7 +224,7 @@ def config_details(client, module):
             if e.response['Error']['Code'] == 'ResourceNotFoundException':
                 lambda_facts.update(function_list=[])
             else:
-                module.fail_json(msg='Unable to get function list, error: {0}'.format(e))
+                module.fail_json_aws(e, msg="Trying to get function list".format(function_name))
 
         functions = dict()
         for func in lambda_facts.pop('function_list', []):
@@ -265,7 +265,7 @@ def mapping_details(client, module):
         if e.response['Error']['Code'] == 'ResourceNotFoundException':
             lambda_facts.update(mappings=[])
         else:
-            module.fail_json(msg='Unable to get source event mappings, error: {0}'.format(e))
+            module.fail_json_aws(e, msg="Trying to get source event mappings".format(function_name))
 
     if function_name:
         return {function_name: camel_dict_to_snake_dict(lambda_facts)}
@@ -296,7 +296,7 @@ def policy_details(client, module):
             if e.response['Error']['Code'] == 'ResourceNotFoundException':
                 lambda_facts.update(policy={})
             else:
-                module.fail_json(msg='Unable to get {0} policy, error: {1}'.format(function_name, e))
+                module.fail_json_aws(e, msg="Trying to get {0} policy".format(function_name))
     else:
         module.fail_json(msg='Parameter function_name required for query=policy.')
 
@@ -329,7 +329,7 @@ def version_details(client, module):
             if e.response['Error']['Code'] == 'ResourceNotFoundException':
                 lambda_facts.update(versions=[])
             else:
-                module.fail_json(msg='Unable to get {0} versions, error: {1}'.format(function_name, e))
+                module.fail_json_aws(e, msg="Trying to get {0} versions".format(function_name))
     else:
         module.fail_json(msg='Parameter function_name required for query=versions.')
 

--- a/lib/ansible/modules/cloud/amazon/lambda_facts.py
+++ b/lib/ansible/modules/cloud/amazon/lambda_facts.py
@@ -224,7 +224,7 @@ def config_details(client, module):
             if e.response['Error']['Code'] == 'ResourceNotFoundException':
                 lambda_facts.update(function_list=[])
             else:
-                module.fail_json_aws(e, msg="Trying to get function list".format(function_name))
+                module.fail_json_aws(e, msg="Trying to get function list")
 
         functions = dict()
         for func in lambda_facts.pop('function_list', []):
@@ -265,7 +265,7 @@ def mapping_details(client, module):
         if e.response['Error']['Code'] == 'ResourceNotFoundException':
             lambda_facts.update(mappings=[])
         else:
-            module.fail_json_aws(e, msg="Trying to get source event mappings".format(function_name))
+            module.fail_json_aws(e, msg="Trying to get source event mappings")
 
     if function_name:
         return {function_name: camel_dict_to_snake_dict(lambda_facts)}

--- a/test/units/module_utils/ec2/test_aws.py
+++ b/test/units/module_utils/ec2/test_aws.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+
 try:
     import boto3
     import botocore
@@ -116,21 +119,29 @@ class ErrorReportingTestcase(unittest.TestCase):
             try:
                 raise botocore.exceptions.ClientError(err_msg, 'Could not find you')
             except Exception as e:
-                print "exception is " + str(e)
+                print("exception is " + str(e))
                 module.fail_json_aws(e, msg="Failure looking for you")
 
         assert(len(fail_json_double.mock_calls) > 0), "failed to call fail_json when should have"
         assert(len(fail_json_double.mock_calls) < 2), "called fail_json multiple times when once would do"
 
-        assert("test_botocore_exception_reports_nicely" in fail_json_double.mock_calls[0][2]["traceback"]), "traceback doesn't include correct function, fail call was actually: " + str(fail_json_double.mock_calls[0])
+        assert("test_botocore_exception_reports_nicely"
+               in fail_json_double.mock_calls[0][2]["traceback"]), \
+               "traceback doesn't include correct function, fail call was actually: " \
+                + str(fail_json_double.mock_calls[0])
 
-        assert("Failure looking for you:" in fail_json_double.mock_calls[0][2]["msg"]), "error message doesn't include the local message; was: " + str(fail_json_double.mock_calls[0])
-        assert("Could not find you" in fail_json_double.mock_calls[0][2]["msg"]), "error message doesn't include the botocore exception message; was: " + str(fail_json_double.mock_calls[0])
+        assert("Failure looking for you:" in fail_json_double.mock_calls[0][2]["msg"]), \
+            "error message doesn't include the local message; was: " \
+            + str(fail_json_double.mock_calls[0])
+        assert("Could not find you" in fail_json_double.mock_calls[0][2]["msg"]), \
+            "error message doesn't include the botocore exception message; was: " \
+            + str(fail_json_double.mock_calls[0])
         try:
             fail_json_double.mock_calls[0][2]["error"]
         except KeyError:
             raise Exception("error was missing; call was: " + str(fail_json_double.mock_calls[0]))
-        assert("FakeClass.FakeError" == fail_json_double.mock_calls[0][2]["error"]["code"]), "Failed to find error/code; was: " + str(fail_json_double.mock_calls[0])
+        assert("FakeClass.FakeError" == fail_json_double.mock_calls[0][2]["error"]["code"]), \
+            "Failed to find error/code; was: " + str(fail_json_double.mock_calls[0])
 
 
 
@@ -147,22 +158,29 @@ class ErrorReportingTestcase(unittest.TestCase):
             try:
                 raise botocore.exceptions.ClientError(err_msg, 'Could not find you')
             except Exception as e:
-                print "exception is " + str(e)
+                print("exception is " + str(e))
                 module.fail_json_aws(e, msg="Failure looking for you")
 
         assert(len(fail_json_double.mock_calls) > 0), "failed to call fail_json when should have"
-        assert(len(fail_json_double.mock_calls) < 2), "called fail_json multiple times when once would do"
+        assert(len(fail_json_double.mock_calls) < 2), \
+            "called fail_json multiple times when once would do"
 
-        assert("test_botocore_exception_without_response_reports_nicely_via_fail_json_aws" in fail_json_double.mock_calls[0][2]["traceback"]), "traceback doesn't include correct function, fail call was actually: " + str(fail_json_double.mock_calls[0])
+        assert("test_botocore_exception_without_response_reports_nicely_via_fail_json_aws"
+               in fail_json_double.mock_calls[0][2]["traceback"]), \
+               "traceback doesn't include correct function, fail call was actually: " \
+               + str(fail_json_double.mock_calls[0])
 
-        assert("Failure looking for you:" in fail_json_double.mock_calls[0][2]["msg"]), "error message doesn't include the local message; was: " + str(fail_json_double.mock_calls[0])
+        assert("Failure looking for you:" in fail_json_double.mock_calls[0][2]["msg"]), \
+            "error message doesn't include the local message; was: " \
+            + str(fail_json_double.mock_calls[0])
 
         # I would have thought this should work, however the botocore exception comes back with
         # "argument of type 'NoneType' is not iterable" so it's probably not really designed
         # to handle "None" as an error response.
         #
-        # assert("Could not find you" in fail_json_double.mock_calls[0][2]["msg"]), "error message doesn't include the botocore exception message; was: " + str(fail_json_double.mock_calls[0])
-
+        # assert("Could not find you" in fail_json_double.mock_calls[0][2]["msg"]), \
+        #    "error message doesn't include the botocore exception message; was: " \
+        #    + str(fail_json_double.mock_calls[0])
 
 
 # TODO:

--- a/test/units/module_utils/ec2/test_aws.py
+++ b/test/units/module_utils/ec2/test_aws.py
@@ -120,7 +120,7 @@ class ErrorReportingTestcase(unittest.TestCase):
                 raise botocore.exceptions.ClientError(err_msg, 'Could not find you')
             except Exception as e:
                 print("exception is " + str(e))
-                module.fail_json_aws(e, msg="Failure looking for you")
+                module.fail_json_aws(e, msg="Fake failure for testing boto exception messages")
 
         assert(len(fail_json_double.mock_calls) > 0), "failed to call fail_json when should have"
         assert(len(fail_json_double.mock_calls) < 2), "called fail_json multiple times when once would do"
@@ -130,7 +130,7 @@ class ErrorReportingTestcase(unittest.TestCase):
                "traceback doesn't include correct function, fail call was actually: " \
                 + str(fail_json_double.mock_calls[0])
 
-        assert("Failure looking for you:" in fail_json_double.mock_calls[0][2]["msg"]), \
+        assert("Fake failure for testing boto exception messages:" in fail_json_double.mock_calls[0][2]["msg"]), \
             "error message doesn't include the local message; was: " \
             + str(fail_json_double.mock_calls[0])
         assert("Could not find you" in fail_json_double.mock_calls[0][2]["msg"]), \
@@ -159,7 +159,7 @@ class ErrorReportingTestcase(unittest.TestCase):
                 raise botocore.exceptions.ClientError(err_msg, 'Could not find you')
             except Exception as e:
                 print("exception is " + str(e))
-                module.fail_json_aws(e, msg="Failure looking for you")
+                module.fail_json_aws(e, msg="Fake failure for testing boto exception messages again")
 
         assert(len(fail_json_double.mock_calls) > 0), "failed to call fail_json when should have"
         assert(len(fail_json_double.mock_calls) < 2), \
@@ -170,7 +170,7 @@ class ErrorReportingTestcase(unittest.TestCase):
                "traceback doesn't include correct function, fail call was actually: " \
                + str(fail_json_double.mock_calls[0])
 
-        assert("Failure looking for you:" in fail_json_double.mock_calls[0][2]["msg"]), \
+        assert("Fake failure for testing boto exception messages again:" in fail_json_double.mock_calls[0][2]["msg"]), \
             "error message doesn't include the local message; was: " \
             + str(fail_json_double.mock_calls[0])
 

--- a/test/units/module_utils/ec2/test_aws.py
+++ b/test/units/module_utils/ec2/test_aws.py
@@ -27,7 +27,7 @@ except:
     HAS_BOTO3 = False
 
 from nose.plugins.skip import SkipTest
-from ansible.compat.tests.mock import MagicMock, Mock, patch
+from ansible.compat.tests.mock import Mock, patch
 from ansible.module_utils import basic
 from ansible.compat.tests import unittest
 from ansible.module_utils.ec2 import AWSRetry
@@ -35,8 +35,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_bytes
 import botocore.exceptions
 import json
-
-#from ansible.module_utils.basic import fail_json
 
 if not HAS_BOTO3:
     raise SkipTest("test_aws.py requires the python modules 'boto3' and 'botocore'")
@@ -51,7 +49,7 @@ class RetryTestCase(unittest.TestCase):
         def no_failures():
             self.counter += 1
 
-        r = no_failures()
+        no_failures()
         self.assertEqual(self.counter, 1)
 
     def test_retry_once(self):
@@ -79,7 +77,6 @@ class RetryTestCase(unittest.TestCase):
             self.counter += 1
             raise botocore.exceptions.ClientError(err_msg, 'toooo fast!!')
 
-        #with self.assertRaises(botocore.exceptions.ClientError):
         try:
             fail()
         except Exception as e:
@@ -95,7 +92,6 @@ class RetryTestCase(unittest.TestCase):
             self.counter += 1
             raise botocore.exceptions.ClientError(err_msg, 'unexpected error')
 
-        #with self.assertRaises(botocore.exceptions.ClientError):
         try:
             raise_unexpected_error()
         except Exception as e:
@@ -108,12 +104,12 @@ class ErrorReportingTestcase(unittest.TestCase):
 
     def test_botocore_exception_reports_nicely_via_fail_json_aws(self):
 
-        basic._ANSIBLE_ARGS=to_bytes(json.dumps({'ANSIBLE_MODULE_ARGS': {}}))
-        module = AnsibleModule(argument_spec = dict(
-            fail_mode = dict(type='list', default=['success'])
+        basic._ANSIBLE_ARGS = to_bytes(json.dumps({'ANSIBLE_MODULE_ARGS': {}}))
+        module = AnsibleModule(argument_spec=dict(
+            fail_mode=dict(type='list', default=['success'])
         ))
 
-        fail_json_double=Mock()
+        fail_json_double = Mock()
         err_msg = {'Error': {'Code': 'FakeClass.FakeError'}}
         with patch.object(basic.AnsibleModule, 'fail_json', fail_json_double):
             try:
@@ -126,8 +122,8 @@ class ErrorReportingTestcase(unittest.TestCase):
         assert(len(fail_json_double.mock_calls) < 2), "called fail_json multiple times when once would do"
         assert("test_botocore_exception_reports_nicely"
                in fail_json_double.mock_calls[0][2]["exception"]), \
-               "exception traceback doesn't include correct function, fail call was actually: " \
-                + str(fail_json_double.mock_calls[0])
+            "exception traceback doesn't include correct function, fail call was actually: " \
+            + str(fail_json_double.mock_calls[0])
 
         assert("Fake failure for testing boto exception messages:" in fail_json_double.mock_calls[0][2]["msg"]), \
             "error message doesn't include the local message; was: " \
@@ -143,15 +139,14 @@ class ErrorReportingTestcase(unittest.TestCase):
             "Failed to find error/code; was: " + str(fail_json_double.mock_calls[0])
 
 
-
     def test_botocore_exception_without_response_reports_nicely_via_fail_json_aws(self):
 
-        basic._ANSIBLE_ARGS=to_bytes(json.dumps({'ANSIBLE_MODULE_ARGS': {}}))
-        module = AnsibleModule(argument_spec = dict(
-            fail_mode = dict(type='list', default=['success'])
+        basic._ANSIBLE_ARGS = to_bytes(json.dumps({'ANSIBLE_MODULE_ARGS': {}}))
+        module = AnsibleModule(argument_spec=dict(
+            fail_mode=dict(type='list', default=['success'])
         ))
 
-        fail_json_double=Mock()
+        fail_json_double = Mock()
         err_msg = None
         with patch.object(basic.AnsibleModule, 'fail_json', fail_json_double):
             try:
@@ -166,8 +161,8 @@ class ErrorReportingTestcase(unittest.TestCase):
 
         assert("test_botocore_exception_without_response_reports_nicely_via_fail_json_aws"
                in fail_json_double.mock_calls[0][2]["exception"]), \
-               "exception traceback doesn't include correct function, fail call was actually: " \
-               + str(fail_json_double.mock_calls[0])
+            "exception traceback doesn't include correct function, fail call was actually: " \
+            + str(fail_json_double.mock_calls[0])
 
         assert("Fake failure for testing boto exception messages again:" in fail_json_double.mock_calls[0][2]["msg"]), \
             "error message doesn't include the local message; was: " \

--- a/test/units/module_utils/ec2/test_aws.py
+++ b/test/units/module_utils/ec2/test_aws.py
@@ -124,10 +124,9 @@ class ErrorReportingTestcase(unittest.TestCase):
 
         assert(len(fail_json_double.mock_calls) > 0), "failed to call fail_json when should have"
         assert(len(fail_json_double.mock_calls) < 2), "called fail_json multiple times when once would do"
-
         assert("test_botocore_exception_reports_nicely"
-               in fail_json_double.mock_calls[0][2]["traceback"]), \
-               "traceback doesn't include correct function, fail call was actually: " \
+               in fail_json_double.mock_calls[0][2]["exception"]), \
+               "exception traceback doesn't include correct function, fail call was actually: " \
                 + str(fail_json_double.mock_calls[0])
 
         assert("Fake failure for testing boto exception messages:" in fail_json_double.mock_calls[0][2]["msg"]), \
@@ -166,8 +165,8 @@ class ErrorReportingTestcase(unittest.TestCase):
             "called fail_json multiple times when once would do"
 
         assert("test_botocore_exception_without_response_reports_nicely_via_fail_json_aws"
-               in fail_json_double.mock_calls[0][2]["traceback"]), \
-               "traceback doesn't include correct function, fail call was actually: " \
+               in fail_json_double.mock_calls[0][2]["exception"]), \
+               "exception traceback doesn't include correct function, fail call was actually: " \
                + str(fail_json_double.mock_calls[0])
 
         assert("Fake failure for testing boto exception messages again:" in fail_json_double.mock_calls[0][2]["msg"]), \

--- a/test/units/module_utils/ec2/test_aws.py
+++ b/test/units/module_utils/ec2/test_aws.py
@@ -24,9 +24,16 @@ except:
     HAS_BOTO3 = False
 
 from nose.plugins.skip import SkipTest
-
+from ansible.compat.tests.mock import MagicMock, Mock, patch
+from ansible.module_utils import basic
 from ansible.compat.tests import unittest
 from ansible.module_utils.ec2 import AWSRetry
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_bytes
+import botocore.exceptions
+import json
+
+#from ansible.module_utils.basic import fail_json
 
 if not HAS_BOTO3:
     raise SkipTest("test_aws.py requires the python modules 'boto3' and 'botocore'")
@@ -92,3 +99,73 @@ class RetryTestCase(unittest.TestCase):
             self.assertEqual(e.response['Error']['Code'], 'AuthFailure')
 
         self.assertEqual(self.counter, 1)
+
+
+class ErrorReportingTestcase(unittest.TestCase):
+
+    def test_botocore_exception_reports_nicely_via_fail_json_aws(self):
+
+        basic._ANSIBLE_ARGS=to_bytes(json.dumps({'ANSIBLE_MODULE_ARGS': {}}))
+        module = AnsibleModule(argument_spec = dict(
+            fail_mode = dict(type='list', default=['success'])
+        ))
+
+        fail_json_double=Mock()
+        err_msg = {'Error': {'Code': 'FakeClass.FakeError'}}
+        with patch.object(basic.AnsibleModule, 'fail_json', fail_json_double):
+            try:
+                raise botocore.exceptions.ClientError(err_msg, 'Could not find you')
+            except Exception as e:
+                print "exception is " + str(e)
+                module.fail_json_aws(e, msg="Failure looking for you")
+
+        assert(len(fail_json_double.mock_calls) > 0), "failed to call fail_json when should have"
+        assert(len(fail_json_double.mock_calls) < 2), "called fail_json multiple times when once would do"
+
+        assert("test_botocore_exception_reports_nicely" in fail_json_double.mock_calls[0][2]["traceback"]), "traceback doesn't include correct function, fail call was actually: " + str(fail_json_double.mock_calls[0])
+
+        assert("Failure looking for you:" in fail_json_double.mock_calls[0][2]["msg"]), "error message doesn't include the local message; was: " + str(fail_json_double.mock_calls[0])
+        assert("Could not find you" in fail_json_double.mock_calls[0][2]["msg"]), "error message doesn't include the botocore exception message; was: " + str(fail_json_double.mock_calls[0])
+        try:
+            fail_json_double.mock_calls[0][2]["error"]
+        except KeyError:
+            raise Exception("error was missing; call was: " + str(fail_json_double.mock_calls[0]))
+        assert("FakeClass.FakeError" == fail_json_double.mock_calls[0][2]["error"]["code"]), "Failed to find error/code; was: " + str(fail_json_double.mock_calls[0])
+
+
+
+    def test_botocore_exception_without_response_reports_nicely_via_fail_json_aws(self):
+
+        basic._ANSIBLE_ARGS=to_bytes(json.dumps({'ANSIBLE_MODULE_ARGS': {}}))
+        module = AnsibleModule(argument_spec = dict(
+            fail_mode = dict(type='list', default=['success'])
+        ))
+
+        fail_json_double=Mock()
+        err_msg = None
+        with patch.object(basic.AnsibleModule, 'fail_json', fail_json_double):
+            try:
+                raise botocore.exceptions.ClientError(err_msg, 'Could not find you')
+            except Exception as e:
+                print "exception is " + str(e)
+                module.fail_json_aws(e, msg="Failure looking for you")
+
+        assert(len(fail_json_double.mock_calls) > 0), "failed to call fail_json when should have"
+        assert(len(fail_json_double.mock_calls) < 2), "called fail_json multiple times when once would do"
+
+        assert("test_botocore_exception_without_response_reports_nicely_via_fail_json_aws" in fail_json_double.mock_calls[0][2]["traceback"]), "traceback doesn't include correct function, fail call was actually: " + str(fail_json_double.mock_calls[0])
+
+        assert("Failure looking for you:" in fail_json_double.mock_calls[0][2]["msg"]), "error message doesn't include the local message; was: " + str(fail_json_double.mock_calls[0])
+
+        # I would have thought this should work, however the botocore exception comes back with
+        # "argument of type 'NoneType' is not iterable" so it's probably not really designed
+        # to handle "None" as an error response.
+        #
+        # assert("Could not find you" in fail_json_double.mock_calls[0][2]["msg"]), "error message doesn't include the botocore exception message; was: " + str(fail_json_double.mock_calls[0])
+
+
+
+# TODO:
+#  - an exception without a message
+#  - plain boto exception
+#  - socket errors and other standard things.


### PR DESCRIPTION
##### SUMMARY

This is a proposed new function for handling error messages from AWS in a standardised way.  The aim would be that all cloud/amazon modules should use it.  This is now part of https://github.com/ansible/ansible/pull/25780

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

module_utils

##### ANSIBLE VERSION

```
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/mikedlr/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mikedlr/development/ansible/ansible-add-modules/lib/ansible
  executable location = /home/mikedlr/development/ansible/ansible-add-modules/bin/ansible
  python version = 2.7.11 (default, Jul  8 2016, 19:45:00) [GCC 5.3.1 20160406 (Red Hat 5.3.1-6)]
```


##### ADDITIONAL INFORMATION

This has no user visible changes at present.  Later error messages should be improved.  
