### PR TITLE
Added --url switch and env var support

### DIFF
--- a/contrib/inventory/consul_io.py
+++ b/contrib/inventory/consul_io.py
@@ -41,14 +41,14 @@ This script can be run with the switches
 The following environment variables are also read and, if present, override
 equivalent values set in the config file (switches set on the command line
 always have the highest precedence and override everything else)
-ANSIBLE_DI_CONSUL_DATACENTER
-ANSIBLE_DI_CONSUL_HOST
-ANSIBLE_DI_CONSUL_URL
+ANSIBLE_INVENTORY_CONSUL_DATACENTER
+ANSIBLE_INVENTORY_CONSUL_HOST
+ANSIBLE_INVENTORY_CONSUL_URL
 
 The main configuration for this plugin is read from a consul.ini file located in
 the same directory as this inventory script. All config options in the config file
-are optional except 'url' (unless the --url switch was passed to the script or
-the ANSIBLE_DI_CONSUL_URL environemnt variable was set). 'url' must point to a
+are optional except 'url' (unless the --url switch was passed to the script or the
+ANSIBLE_INVENTORY_CONSUL_URL environemnt variable was set). 'url' must point to a
 valid agent or server running the http api. For more information on enabling
 the endpoint see:
 
@@ -452,9 +452,9 @@ class ConsulConfig(dict):
         ''' Reads settings from environment variables '''
 
         var_names = {
-            'ANSIBLE_DI_CONSUL_HOST': 'host',
-            'ANSIBLE_DI_CONSUL_DATACENTER': 'datacenter',
-            'ANSIBLE_DI_CONSUL_URL': 'url'
+            'ANSIBLE_INVENTORY_CONSUL_HOST': 'host',
+            'ANSIBLE_INVENTORY_CONSUL_DATACENTER': 'datacenter',
+            'ANSIBLE_INVENTORY_CONSUL_URL': 'url'
         }
 
         for var, val in var_names.items():

--- a/contrib/inventory/consul_io.py
+++ b/contrib/inventory/consul_io.py
@@ -231,6 +231,7 @@ class ConsulInventory(object):
         self.consul_api = config.get_consul_api()
 
         if config.has_config('datacenter'):
+            self.current_dc = config.datacenter
             if config.has_config('host'):
                 self.load_data_for_node(config.host, config.datacenter)
             else:

--- a/contrib/inventory/consul_io.py
+++ b/contrib/inventory/consul_io.py
@@ -464,19 +464,18 @@ class ConsulConfig(dict):
 
     def read_cli_args(self):
         ''' Command line argument processing '''
-        parser = argparse.ArgumentParser(description=
-            'Produce an Ansible Inventory file based nodes in a Consul cluster')
+        parser = argparse.ArgumentParser(description='Produce an Ansible Inventory file based nodes in a Consul cluster')
 
         parser.add_argument('--list', action='store_true',
-            help='Get all inventory variables from all nodes in the consul cluster')
+                            help='Get all inventory variables from all nodes in the consul cluster')
         parser.add_argument('--host', action='store',
-            help='Get all inventory variables about a specific consul node, \
-              requires datacenter set in consul.ini.')
+                            help='Get all inventory variables about a specific consul node,'
+                                 'requires datacenter set in consul.ini.')
         parser.add_argument('--datacenter', action='store',
-            help='Get all inventory about a specific consul datacenter')
+                            help='Get all inventory about a specific consul datacenter')
         parser.add_argument('--url', action='store',
-            help='URL of the Consul cluster (if not specified, defaults \
-               to http requests to localhost on port 8500)')
+                            help='URL of the Consul cluster (if not specified, defaults'
+                                'to http requests to localhost on port 8500)')
 
         args = parser.parse_args()
         arg_names = ['host', 'datacenter', 'url']

--- a/contrib/inventory/consul_io.py
+++ b/contrib/inventory/consul_io.py
@@ -464,7 +464,7 @@ class ConsulConfig(dict):
 
     def read_cli_args(self):
         ''' Command line argument processing '''
-        parser = argparse.ArgumentParser(description='Produce an Ansible Inventory file based nodes in a Consul cluster')
+        parser = argparse.ArgumentParser(description='Produce an Ansible Inventory file based on nodes in a Consul cluster')
 
         parser.add_argument('--list', action='store_true',
                             help='Get all inventory variables from all nodes in the consul cluster')
@@ -475,7 +475,7 @@ class ConsulConfig(dict):
                             help='Get all inventory about a specific consul datacenter')
         parser.add_argument('--url', action='store',
                             help='URL of the Consul cluster (if not specified, defaults'
-                                'to http requests to localhost on port 8500)')
+                                  'to http requests to localhost on port 8500)')
 
         args = parser.parse_args()
         arg_names = ['host', 'datacenter', 'url']

--- a/contrib/inventory/consul_io.py
+++ b/contrib/inventory/consul_io.py
@@ -424,7 +424,7 @@ class ConsulConfig(dict):
 
     def __init__(self):
         self.read_settings()
-        self.read_env_vars()    
+        self.read_env_vars()
         self.read_cli_args()
 
     def has_config(self, name):

--- a/contrib/inventory/consul_io.py
+++ b/contrib/inventory/consul_io.py
@@ -33,18 +33,27 @@ group nodes by:
  - values from the k/v store
 
 This script can be run with the switches
---list as expected groups all the nodes in all datacenters
+--list, as expected groups all nodes in all datacenters
 --datacenter, to restrict the nodes to a single datacenter
---host to restrict the inventory to a single named node. (requires datacenter config)
+--host, to restrict the inventory to a single named node (requires datacenter config)
+--url, of the Consul agent to connect to (defaults to http on localhost:8500 if not specified)
 
-The configuration for this plugin is read from a consul.ini file located in the
-same directory as this inventory script. All config options in the config file
-are optional except the host and port, which must point to a valid agent or
-server running the http api. For more information on enabling the endpoint see.
+The following environment variables are also read (and, if present, override
+equivalent values set in the config file or by --datacenter, --host or --url)
+ANSIBLE_DI_CONSUL_DATACENTER
+ANSIBLE_DI_CONSUL_HOST
+ANSIBLE_DI_CONSUL_URL
+
+The main configuration for this plugin is read from a consul.ini file located in
+the same directory as this inventory script. All config options in the config file
+are optional except 'url' (unless the --url switch was passed to the script or
+the ANSIBLE_DI_CONSUL_URL environemnt variable was set). 'url' must point to a
+valid agent or server running the http api. For more information on enabling
+the endpoint see:
 
 http://www.consul.io/docs/agent/options.html
 
-Other options include:
+Available config file options include:
 
 'datacenter':
 
@@ -415,6 +424,7 @@ class ConsulConfig(dict):
     def __init__(self):
         self.read_settings()
         self.read_cli_args()
+        self.read_env_vars()
 
     def has_config(self, name):
         if hasattr(self, name):
@@ -449,13 +459,29 @@ class ConsulConfig(dict):
               requires datacenter set in consul.ini.')
         parser.add_argument('--datacenter', action='store',
             help='Get all inventory about a specific consul datacenter')
+        parser.add_argument('--url', action='store',
+            help='URL of the Consul cluster (if not specified, defaults \
+               to http requests to localhost on port 8500)')
 
         args = parser.parse_args()
-        arg_names = ['host', 'datacenter']
+        arg_names = ['host', 'datacenter', 'url']
 
         for arg in arg_names:
             if getattr(args, arg):
                 setattr(self, arg, getattr(args, arg))
+
+    def read_env_vars(self):
+        ''' Reads settings from environment variables'''
+
+        var_names = {
+            'ANSIBLE_DI_CONSUL_HOST': 'host',
+            'ANSIBLE_DI_CONSUL_DATACENTER': 'datacenter',
+            'ANSIBLE_DI_CONSUL_URL': 'url'
+        }
+
+        for var, val in var_names.items():
+            if os.getenv(var):
+                setattr(self, val, os.getenv(var))
 
     def get_availability_suffix(self, suffix, default):
         if self.has_config(suffix):


### PR DESCRIPTION
##### SUMMARY
It's useful to be able to pass the Consul cluster URL to the script rather than specifying it the INI file. This PR adds an --url switch to allow this.

It's also helpful in certain situations to be able to use environment variables rather than switches (e.g. when invoking ansible with an inventory directory rather than an inventory file). This PR adds the ability to set datacenter, host and url via environment variables (using ANSIBLE_INVENTORY_CONSUL_DATACENTER, ANSIBLE_INVENTORY_CONSUL_HOST and ANSIBLE_INVENTORY_CONSUL_URL respectively).

Unrelated to the above, this PR also fixes a bug with self.current_dc not being set correctly which resulted in custom group memberships for nodes being disregarded when the script was invoked with a specific datacenter (set via the INI file 'datacenter' option or by the '--datacenter' command line switch).

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix

##### COMPONENT NAME
consul-io dynamic inventory script

##### ANSIBLE VERSION
```
ansible 2.4
```
