### PR TITLE
Add ansible_args to call AnsibleModule()

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -718,6 +718,7 @@ def _load_params(ansible_args=None):
         params = json_dict_unicode_to_bytes(params)
 
     try:
+        # ansible_args MAY have an 'ANSIBLE_MODULE_ARGS' key in dict, but it's not MANDATORY
         return params if ansible_args and 'ANSIBLE_MODULE_ARGS' not in params else params['ANSIBLE_MODULE_ARGS']
     except KeyError:
         # This helper does not have access to fail_json so we have to print

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -667,6 +667,7 @@ def is_executable(path):
     # execute bits are set.
     return ((stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH) & os.stat(path)[stat.ST_MODE])
 
+
 def _load_params(ansible_args=None):
     ''' read the modules parameters and store them globally.
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
AnsibleModule calls an internal routine _load_params() to fetch module parameters from input file (or stdin) and transform them into a json including an "ANSIBLE_MODULE_ARGS" list.

Unfortunally, if you elected to receive parameters by some other means, you won't be able to call class AnsibleModule() : The present change allow you to pass your modules' arguments to AnsibleModule in suitable format and benefit of the usual arguments checks as for native Ansible modules.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
AnsibleModule can now be called with an extra parameter "ansible_args" that contains the modules' parameters  in json dumps format (ready to be swallowed by json.loads()).

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Module : Any third party module is concerned

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ansible/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ansible/venv/local/lib/python2.7/site-packages/ansible-2.4.0-py2.7.egg/ansible
  executable location = /home/ansible/venv/bin/ansible
  python version = 2.7.10 (default, Oct 14 2015, 16:09:02) [GCC 5.2.1 20151010]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Suppose that you specify "WANT JSON" as a REPLACER in your module source code, written in Python.
Then you will be able to fetch parameters sent by ansible-playbook using your own load_params() function into a json "dumps" string "ansible_args".
You will be able to call AnsibleModule(......, ansible_args=ansible_args) as would do any "native" Ansible Module, and it will do the job.
AnsibleModule will accept your arguments even if the json resulting doesn't have an ANSIBLE_MODULE_ARGS list.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
No visible change for end users
```
