### PR TITLE
Corrected -su cmdline option to --su to be consistent with the man page entry

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -254,7 +254,7 @@ class CLI(with_metaclass(ABCMeta, object)):
                     (op.sudo or op.sudo_user) and (op.become or op.become_user)):
 
                 self.parser.error("Sudo arguments ('--sudo', '--sudo-user', and '--ask-sudo-pass') "
-                                  "and su arguments ('-su', '--su-user', and '--ask-su-pass') "
+                                  "and su arguments ('--su', '--su-user', and '--ask-su-pass') "
                                   "and become arguments ('--become', '--become-user', and '--ask-become-pass')"
                                   " are exclusive of each other")
 


### PR DESCRIPTION
##### SUMMARY
Corrected -su cmdline option to --su to be consistent with the man page entry

Signed-off-by: Sumedh Sidhaye <ssidhaye@redhat.com>

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
/lib/ansible/cli/__init__.py

##### ANSIBLE VERSION

```
2.4 devel
```