### PR TITLE
Update mount.py

### DIFF
--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -117,7 +117,7 @@ EXAMPLES = '''
     path: /mnt/dvd
     src: /dev/sr0
     fstype: iso9660
-    opts: ro
+    opts: ro,noauto
     state: present
 
 - name: Mount up device by label


### PR DESCRIPTION
##### SUMMARY
added noauto to dvd mount example, simply copy pasting + removed (virtual) optical disc will result in a non booting system (centos7)

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
mount

##### ANSIBLE VERSION
2.3

##### ADDITIONAL INFORMATION
Resulted for me in a non booting vm, would be nice to prevent this for others
