### PR TITLE
Rename fact returned by docker_network to avoid restricted prefix

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -358,7 +358,7 @@ class DockerNetworkManager(object):
         if not self.check_mode and not self.parameters.debug:
             self.results.pop('actions')
 
-        self.results['ansible_facts'] = {u'ansible_docker_network': self.get_existing_network()}
+        self.results['ansible_facts'] = {u'docker_network': self.get_existing_network()}
 
     def absent(self):
         self.remove_network()


### PR DESCRIPTION
This fixes #23918

##### SUMMARY
Rename the fact returned by this module, in order to avoid the reserved `ansible_*` namespace, which ansible core now filters out.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker_network

##### ANSIBLE VERSION

```
ansible 2.4.0 (ansible_docker_network 7976dc1929) last updated 2017/04/24 17:15:04 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/willmerae/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/willmerae/src/ansible/lib/ansible
  executable location = /home/willmerae/src/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION