### PR TITLE
efs: include name in results - fixes #23853

### DIFF
--- a/lib/ansible/modules/cloud/amazon/efs.py
+++ b/lib/ansible/modules/cloud/amazon/efs.py
@@ -243,6 +243,7 @@ class EFSConnection(object):
             **kwargs
         )
         for item in items:
+            item['Name'] = item['CreationToken']
             item['CreationTime'] = str(item['CreationTime'])
             """
             Suffix of network path to be used as NFS device for mount. More detail here:


### PR DESCRIPTION
##### SUMMARY
The return documentation says name is included in results but it isn't. Fixes #23853.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/efs.py

##### ANSIBLE VERSION
```
2.4.0
```
