### PR TITLE
WIP rds: db can trigger a premature break - fixes #22928

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds.py
+++ b/lib/ansible/modules/cloud/amazon/rds.py
@@ -697,8 +697,6 @@ def await_resource(conn, resource, status, module):
                 module.fail_json(msg="There was a problem waiting for RDS instance %s" % resource.instance)
             # Back off if we're getting throttled, since we're just waiting anyway
             resource = AWSRetry.backoff(tries=5, delay=20, backoff=1.5)(conn.get_db_instance)(resource.name)
-            if resource is None:
-                break
         # Some RDS resources take much longer than others to be ready. Check
         # less aggressively for slow ones to avoid throttling.
         if time.time() > start_time + 90:

--- a/lib/ansible/modules/cloud/amazon/rds.py
+++ b/lib/ansible/modules/cloud/amazon/rds.py
@@ -738,7 +738,10 @@ def create_db_instance(module, conn):
     else:
         resource = conn.get_db_instance(instance_name)
 
-    module.exit_json(changed=changed, instance=resource.get_data())
+    if resource:
+        module.exit_json(changed=changed, instance=resource.get_data())
+    else:
+        module.fail_json(msg="Failed to create or await the resource successfully.")
 
 
 def replicate_db_instance(module, conn):


### PR DESCRIPTION
##### SUMMARY
If a DBInstanceNotFound is raised at the beginning of creating the instance a break could be triggered inside await_resource() and then the resource won't be waited for. Since wait and timeout are being used a premature break should not happen since the db may be in the process of being created. Removed it. Hopefully fixes #22928. @michael-dev2rights can you test this out to check? I haven't been able to trigger the exception.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/rds.py

##### ANSIBLE VERSION
```
2.4.0
```