### PR TITLE
Fix duplicated items in zypper module

### DIFF
--- a/lib/ansible/modules/packaging/os/zypper.py
+++ b/lib/ansible/modules/packaging/os/zypper.py
@@ -342,13 +342,21 @@ def package_present(m, name, want_latest):
     retvals = {'rc': 0, 'stdout': '', 'stderr': ''}
     name_install, name_remove, urls = get_want_state(m, name)
 
-    # if a version string is given, pass it to zypper
-    install_version = [p+name_install[p] for p in name_install if name_install[p]]
-    remove_version = [p+name_remove[p] for p in name_remove if name_remove[p]]
+    # filter versioned packages
+    install_version = {p: name_install[p] for p in name_install if name_install[p]}
+    remove_version = {p: name_remove[p] for p in name_remove if name_remove[p]}
 
-    # add oldpackage flag when a version is given to allow downgrades
     if install_version or remove_version:
+        # add oldpackage flag when a version is given to allow downgrades
         m.params['oldpackage'] = True
+
+        # Remove versioned packages from unversioned package list to avoid duplicates
+        name_install = {p for p in name_install if p not in install_version}
+        name_remove = {p for p in name_remove if p not in remove_version}
+
+        # Create a list of versioned packages
+        install_version = [p + install_version[p] for p in install_version]
+        remove_version = [p + remove_version[p] for p in remove_version]
 
     if not want_latest:
         # for state=present: filter out already installed packages
@@ -358,9 +366,10 @@ def package_present(m, name, want_latest):
         # generate lists of packages to install or remove
         name_install = [p for p in name_install if p not in prerun_state]
         name_remove = [p for p in name_remove if p in prerun_state]
-        if not any((name_install, name_remove, urls, install_version, remove_version)):
-            # nothing to install/remove and nothing to update
-            return None, retvals
+
+    if not any((name_install, name_remove, urls, install_version, remove_version)):
+        # nothing to install/remove and nothing to update
+        return None, retvals
 
     # zypper install also updates packages
     cmd = get_cmd(m, 'install')

--- a/lib/ansible/modules/packaging/os/zypper.py
+++ b/lib/ansible/modules/packaging/os/zypper.py
@@ -343,16 +343,16 @@ def package_present(m, name, want_latest):
     name_install, name_remove, urls = get_want_state(m, name)
 
     # filter versioned packages
-    install_version = {p: name_install[p] for p in name_install if name_install[p]}
-    remove_version = {p: name_remove[p] for p in name_remove if name_remove[p]}
+    install_version = dict((p, name_install[p]) for p in name_install if name_install[p])
+    remove_version = dict((p, name_remove[p]) for p in name_remove if name_remove[p])
 
     if install_version or remove_version:
         # add oldpackage flag when a version is given to allow downgrades
         m.params['oldpackage'] = True
 
         # Remove versioned packages from unversioned package list to avoid duplicates
-        name_install = {p for p in name_install if p not in install_version}
-        name_remove = {p for p in name_remove if p not in remove_version}
+        name_install = dict((p, None) for p in name_install if p not in install_version)
+        name_remove = dict((p, None) for p in name_remove if p not in remove_version)
 
         # Create a list of versioned packages
         install_version = [p + install_version[p] for p in install_version]


### PR DESCRIPTION
##### SUMMARY
Remove packages found in install_version from name_install.

Fixes #23516

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/packaging/os/zypper.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (zypper acc2b05f28) last updated 2017/04/24 17:26:56 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/albertom/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/albertom/github/ansible/lib/ansible
  executable location = /Users/albertom/github/ansible/bin/ansible
  python version = 2.7.13 (v2.7.13:a06454b1afa1, Dec 17 2016, 12:39:47) [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
```

##### ADDITIONAL INFORMATION

