### PR TITLE
pacman: Fail fast when 'rc != 0'

### DIFF
--- a/lib/ansible/modules/packaging/os/pacman.py
+++ b/lib/ansible/modules/packaging/os/pacman.py
@@ -256,15 +256,15 @@ def remove_packages(module, pacman_path, packages):
         cmd = "%s -%s %s --noconfirm --noprogressbar" % (pacman_path, args, package)
         rc, stdout, stderr = module.run_command(cmd, check_rc=False)
 
+        if rc != 0:
+            module.fail_json(msg="failed to remove %s" % (package))
+
         if module._diff:
             d = stdout.split('\n')[2].split(' ')[2:]
             for i, pkg in enumerate(d):
                 d[i] = re.sub('-[0-9].*$', '', d[i].split('/')[-1])
                 diff['before'] += "%s\n" % pkg
             data.append('\n'.join(d))
-
-        if rc != 0:
-            module.fail_json(msg="failed to remove %s" % (package))
 
         remove_c += 1
 
@@ -303,30 +303,32 @@ def install_packages(module, pacman_path, state, packages, package_files):
     if to_install_repos:
         cmd = "%s -S %s --noconfirm --noprogressbar --needed" % (pacman_path, " ".join(to_install_repos))
         rc, stdout, stderr = module.run_command(cmd, check_rc=False)
+
+        if rc != 0:
+            module.fail_json(msg="failed to install %s: %s" % (" ".join(to_install_repos), stderr))
+
         data = stdout.split('\n')[3].split(' ')[2:]
         data = [ i for i in data if i != '' ]
         for i, pkg in enumerate(data):
             data[i] = re.sub('-[0-9].*$', '', data[i].split('/')[-1])
             if module._diff:
                 diff['after'] += "%s\n" % pkg
-
-        if rc != 0:
-            module.fail_json(msg="failed to install %s: %s" % (" ".join(to_install_repos), stderr))
 
         install_c += len(to_install_repos)
 
     if to_install_files:
         cmd = "%s -U %s --noconfirm --noprogressbar --needed" % (pacman_path, " ".join(to_install_files))
         rc, stdout, stderr = module.run_command(cmd, check_rc=False)
+
+        if rc != 0:
+            module.fail_json(msg="failed to install %s: %s" % (" ".join(to_install_files), stderr))
+
         data = stdout.split('\n')[3].split(' ')[2:]
         data = [ i for i in data if i != '' ]
         for i, pkg in enumerate(data):
             data[i] = re.sub('-[0-9].*$', '', data[i].split('/')[-1])
             if module._diff:
                 diff['after'] += "%s\n" % pkg
-
-        if rc != 0:
-            module.fail_json(msg="failed to install %s: %s" % (" ".join(to_install_files), stderr))
 
         install_c += len(to_install_files)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
We fail-fast and display 'stderr' in case 'pacman' returns with 'rc != 0'.
There is no point computing 'module._diff' in such case anyway.

This would still be considered a failure case to be consistent with `pacman` cli, but this time the real `stderr` is returned is returned as failure message instead of doing a `MODULE FAILURE`.

Fixes #23910

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
pacman

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0 (pacman-fail-fast 1848bff1ad) last updated 2017/04/24 17:26:47 (GMT -500)

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:

```
fatal: [archlinux-test]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Shared connection to 192.168.56.10 closed.\r\n", "module_stdout": "\r\nTraceback (most recent call last):\r\n  File \"/tmp/ansible_2516wbh0/ansible_module_pacman.py\", line 453, in <module>\r\n    main()\r\n  File \"/tmp/ansible_2516wbh0/ansible_module_pacman.py\", line 445, in main\r\n    install_packages(module, pacman_path, p['state'], pkgs, pkg_files)\r\n  File \"/tmp/ansible_2516wbh0/ansible_module_pacman.py\", line 308, in install_packages\r\n    data = stdout.split('\\n')[3].split(' ')[2:]\r\nIndexError: list index out of range\r\n", "msg": "MODULE FAILURE", "rc": 0}
```

After:
```
fatal: [archlinux-test]: FAILED! => {"changed": false, "failed": true, "msg": "failed to install unknown_package: error: target not found: unknown_package\n"}
```