### PR TITLE
[WIP] force jinja to preserve native types 

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -48,12 +48,14 @@ from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleFilterError, AnsibleUndefinedVariable
 from ansible.module_utils.six import string_types, text_type
 from ansible.module_utils._text import to_native, to_text, to_bytes
+from ansible.module_utils.six import text_type
 from ansible.parsing.yaml.objects import AnsibleUnicode
 from ansible.plugins import filter_loader, lookup_loader, test_loader
 from ansible.template.safe_eval import safe_eval
 from ansible.template.template import AnsibleJ2Template
 from ansible.template.vars import AnsibleJ2Vars
 from ansible.vars.unsafe_proxy import UnsafeProxy, wrap_var
+
 
 try:
     from __main__ import display
@@ -854,7 +856,7 @@ class Templar:
                     display.debug("failing because of a type error, template data is: %s" % to_native(data))
                     raise AnsibleError("Unexpected templating type error occurred on (%s): %s" % (to_native(data),to_native(te)))
 
-            if preserve_trailing_newlines and isinstance(res, (str, bytes, unicode, AnsibleUnicode)):
+            if preserve_trailing_newlines and isinstance(res, (string_types, text_type)):
                 # The low level calls above do not preserve the newline
                 # characters at the end of the input data, so we use the
                 # calculate the difference in newlines and append them

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -873,6 +873,13 @@ class Templar:
                 res_newlines = _count_newlines_from_end(res)
                 if data_newlines is not None and data_newlines > res_newlines:
                     res += self.environment.newline_sequence * (data_newlines - res_newlines)
+
+            # backwards compatibility for the debug module
+            if isinstance(res, StrictUndefined):
+                errmsg  = "Unable to look up a name or access an attribute in template string (%s).\n" % to_native(data)
+                errmsg += "Make sure your variable name does not contain invalid characters like '-'"
+                raise AnsibleUndefinedVariable(errmsg)
+
             return res
         except (UndefinedError, AnsibleUndefinedVariable) as e:
             if fail_on_undefined:

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -36,6 +36,7 @@ except ImportError:
     from sha import sha as sha1
 
 from jinja2 import Environment
+from jinja2 import escape
 from jinja2 import nodes
 from jinja2.compiler import CodeGenerator
 from jinja2.loaders import FileSystemLoader
@@ -47,6 +48,7 @@ from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleFilterError, AnsibleUndefinedVariable
 from ansible.module_utils.six import string_types, text_type
 from ansible.module_utils._text import to_native, to_text, to_bytes
+from ansible.parsing.yaml.objects import AnsibleUnicode
 from ansible.plugins import filter_loader, lookup_loader, test_loader
 from ansible.template.safe_eval import safe_eval
 from ansible.template.template import AnsibleJ2Template
@@ -850,7 +852,7 @@ class Templar:
                     display.debug("failing because of a type error, template data is: %s" % to_native(data))
                     raise AnsibleError("Unexpected templating type error occurred on (%s): %s" % (to_native(data),to_native(te)))
 
-            if preserve_trailing_newlines and isinstance(res, (str, bytes)):
+            if preserve_trailing_newlines and isinstance(res, (str, bytes, unicode, AnsibleUnicode)):
                 # The low level calls above do not preserve the newline
                 # characters at the end of the input data, so we use the
                 # calculate the difference in newlines and append them

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -172,6 +172,8 @@ def ansible_j2_concat(invals):
     if isinstance(invals, list):
         if len(invals) == 1:
             invals = invals[0]
+        elif len(invals) > 1:
+            invals = u''.join(invals)
     return invals
 
 
@@ -863,7 +865,6 @@ class Templar:
                 # newline here if preserve_newlines is False.
                 res_newlines = _count_newlines_from_end(res)
                 if data_newlines is not None and data_newlines > res_newlines:
-                    print('data_newlines > res_newlines')
                     res += self.environment.newline_sequence * (data_newlines - res_newlines)
             return res
         except (UndefinedError, AnsibleUndefinedVariable) as e:

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -629,7 +629,7 @@ class Templar:
 
                         unsafe = hasattr(result, '__UNSAFE__')
                         if convert_data and not self._no_type_regex.match(variable):
-                            if isinstance(result, (str, unicode, bytes)):
+                            if isinstance(result, (string_types, text_type)):
                                 # if this looks like a dictionary or list, convert it to such using the safe_eval method
                                 if (result.startswith("{") and not result.startswith(self.environment.variable_start_string)) or \
                                         result.startswith("[") or result in ("True", "False"):

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -876,8 +876,7 @@ class Templar:
 
             # backwards compatibility for the debug module
             if isinstance(res, StrictUndefined):
-                errmsg  = "Unable to look up a name or access an attribute in template string (%s).\n" % to_native(data)
-                errmsg += "Make sure your variable name does not contain invalid characters like '-'"
+                errmsg = '%s is undefined' % data
                 raise AnsibleUndefinedVariable(errmsg)
 
             return res

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -173,9 +173,11 @@ def ansible_j2_concat(invals):
     invals = [x for x in invals]
     if isinstance(invals, list):
         if len(invals) == 1:
+            # break out the single value
             invals = invals[0]
         elif len(invals) > 1:
-            invals = u''.join(invals)
+            # cast to unicode and join
+            invals = u''.join([u'%s' % x for x in invals])
     return invals
 
 

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -48,7 +48,6 @@ from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleFilterError, AnsibleUndefinedVariable
 from ansible.module_utils.six import string_types, text_type
 from ansible.module_utils._text import to_native, to_text, to_bytes
-from ansible.module_utils.six import text_type
 from ansible.parsing.yaml.objects import AnsibleUnicode
 from ansible.plugins import filter_loader, lookup_loader, test_loader
 from ansible.template.safe_eval import safe_eval

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -691,6 +691,8 @@ class Templar:
                 return True
             except:
                 return False
+            if isinstance(new, StrictUndefined):
+                return True
             return (new != data)
         elif isinstance(data, (list, tuple)):
             for v in data:

--- a/test/units/template/test_templar.py
+++ b/test/units/template/test_templar.py
@@ -319,7 +319,7 @@ class TestTemplarLookup(BaseTemplar, unittest.TestCase):
 
     def test_lookup_jinja_undefined(self):
         self.assertRaisesRegexp(AnsibleUndefinedVariable,
-                                "'an_undefined_jinja_var' is undefined",
+                                "{{ an_undefined_jinja_var }} is undefined",
                                 self.templar._lookup,
                                 'list', '{{ an_undefined_jinja_var }}')
 
@@ -353,7 +353,7 @@ class TestTemplarLookup(BaseTemplar, unittest.TestCase):
 
     def test_lookup_jinja_list_wantlist_undefined(self):
         self.assertRaisesRegexp(AnsibleUndefinedVariable,
-                                "'some_undefined_var' is undefined",
+                                "{{ some_undefined_var }} is undefined",
                                 self.templar._lookup,
                                 'list',
                                 '{{ some_undefined_var }}',


### PR DESCRIPTION
Subclasses the CodeGenerator class and refactors visit_Output to exclude the default to_string() class it injects.

##### SUMMARY
Subclasses the CodeGenerator class and refactors visit_Output to exclude the default to_string() class it injects.

Upstream effort: https://github.com/pallets/jinja/pull/708

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
templar

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```

