### PR TITLE
Improve documentation of 'remote_src' in the file copy module.

### DIFF
--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -29,7 +29,8 @@ module: copy
 version_added: "historical"
 short_description: Copies files to remote locations.
 description:
-    - The C(copy) module copies a file on the local box to remote locations. Use the M(fetch) module to copy files from remote locations to the local box.
+    - The C(copy) module copies a file from the local or remote machine to a location on the remote machine.
+      Use the M(fetch) module to copy files from remote locations to the local box.
       If you need variable interpolation in copied files, use the M(template) module.
 options:
   src:
@@ -146,6 +147,12 @@ EXAMPLES = '''
     src: /mine/sudoers
     dest: /etc/sudoers
     validate: 'visudo -cf %s'
+
+# Copy a "sudoers" file on the remote machine for editing
+- copy:
+    remote_src: true
+    src: /etc/sudoers
+    dest: /etc/sudoers.edit
 '''
 
 RETURN = '''


### PR DESCRIPTION
Now that remote-to-remote copies are supported in the copy module,
the module documentation has been updated to indicate this in the
synopsis and examples to make the capability obvious for someone
skimming the documentation.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Improve the documentation of the `remote_src` in the copy module by updating the synopsis and adding some examples that use it.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
copy

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```