### PR TITLE
Remove idle ShellError exception and get_exception() method from nxos modules

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_bgp_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_af.py
@@ -946,13 +946,9 @@ def main():
     if state == 'present' or (state == 'absent' and existing):
         candidate = CustomNetworkConfig(indent=3)
         invoke('state_%s' % state, module, existing, proposed, candidate)
+        response = load_config(module, candidate)
+        result.update(response)
 
-        try:
-            response = load_config(module, candidate)
-            result.update(response)
-        except ShellError:
-            exc = get_exception()
-            module.fail_json(msg=str(exc))
     else:
         result['updates'] = []
 

--- a/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
@@ -605,13 +605,9 @@ def main():
     if state == 'present' or (state == 'absent' and existing):
         candidate = CustomNetworkConfig(indent=3)
         invoke('state_%s' % state, module, existing, proposed, candidate)
+        response = load_config(module, candidate)
+        result.update(response)
 
-        try:
-            response = load_config(module, candidate)
-            result.update(response)
-        except ShellError:
-            exc = get_exception()
-            module.fail_json(msg=str(exc))
     else:
         result['updates'] = []
 

--- a/lib/ansible/modules/network/nxos/nxos_bgp_neighbor_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_neighbor_af.py
@@ -958,13 +958,9 @@ def main():
     if state == 'present' or (state == 'absent' and existing):
         candidate = CustomNetworkConfig(indent=3)
         invoke('state_%s' % state, module, existing, proposed, candidate)
+        response = load_config(module, candidate)
+        result.update(response)
 
-        try:
-            response = load_config(module, candidate)
-            result.update(response)
-        except ShellError:
-            exc = get_exception()
-            module.fail_json(msg=str(exc))
     else:
         result['updates'] = []
 

--- a/lib/ansible/modules/network/nxos/nxos_evpn_vni.py
+++ b/lib/ansible/modules/network/nxos/nxos_evpn_vni.py
@@ -268,12 +268,8 @@ def state_absent(module, existing, proposed):
 
 def execute_config(module, candidate):
     result = {}
-    try:
-        response = load_config(module, candidate)
-        result.update(response)
-    except ShellError:
-        exc = get_exception()
-        module.fail_json(msg=str(exc))
+    response = load_config(module, candidate)
+    result.update(response)
     return result
 
 

--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -232,12 +232,8 @@ def main():
         file_exists = True
 
     if not module.check_mode and not file_exists:
-        try:
-            transfer_file(module, dest)
-            transfer_status = 'Sent'
-        except ShellError:
-            clie = get_exception()
-            module.fail_json(msg=str(clie))
+        transfer_file(module, dest)
+        transfer_status = 'Sent'
 
     if remote_file is None:
         remote_file = os.path.basename(local_file)

--- a/lib/ansible/modules/network/nxos/nxos_igmp.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp.py
@@ -233,13 +233,9 @@ def main():
             True in existing.values()) or restart):
         candidate = CustomNetworkConfig(indent=3)
         invoke('get_commands', module, existing, proposed_args, candidate)
+        response = load_config(module, candidate)
+        result.update(response)
 
-        try:
-            response = load_config(module, candidate)
-            result.update(response)
-        except ShellError:
-            exc = get_exception()
-            module.fail_json(msg=str(exc))
     else:
         result['updates'] = []
 

--- a/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
@@ -519,13 +519,9 @@ def main():
 
         candidate = CustomNetworkConfig(indent=3)
         invoke('state_%s' % state, module, existing, proposed, candidate)
+        response = load_config(module, candidate)
+        result.update(response)
 
-        try:
-            response = load_config(module, candidate)
-            result.update(response)
-        except ShellError:
-            exc = get_exception()
-            module.fail_json(msg=str(exc))
     else:
         result['updates'] = []
 

--- a/lib/ansible/modules/network/nxos/nxos_ntp_auth.py
+++ b/lib/ansible/modules/network/nxos/nxos_ntp_auth.py
@@ -335,11 +335,7 @@ def main():
         if module.check_mode:
             module.exit_json(changed=True, commands=cmds)
         else:
-            try:
-                load_config(module, cmds)
-            except ShellError:
-                clie = get_exception()
-                module.fail_json(msg=str(clie) + ": " + cmds)
+            load_config(module, cmds)
             end_state = get_ntp_auth_info(key_id, module)
             delta = dict(set(end_state.items()).difference(existing.items()))
             if delta or (len(existing) != len(end_state)):

--- a/lib/ansible/modules/network/nxos/nxos_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_ospf.py
@@ -188,13 +188,9 @@ def main():
     if (state == 'present' or (state == 'absent' and ospf in existing_list)):
         candidate = CustomNetworkConfig(indent=3)
         invoke('state_%s' % state, module, proposed, candidate)
+        response = load_config(module, candidate)
+        result.update(response)
 
-        try:
-            response = load_config(module, candidate)
-            result.update(response)
-        except ShellError:
-            exc = get_exception()
-            module.fail_json(msg=str(exc))
     else:
         result['updates'] = []
 

--- a/lib/ansible/modules/network/nxos/nxos_ospf_vrf.py
+++ b/lib/ansible/modules/network/nxos/nxos_ospf_vrf.py
@@ -434,13 +434,9 @@ def main():
     if state == 'present' or (state == 'absent' and existing):
         candidate = CustomNetworkConfig(indent=3)
         invoke('state_%s' % state, module, existing, proposed, candidate)
+        response = load_config(module, candidate)
+        result.update(response)
 
-        try:
-            response = load_config(module, candidate)
-            result.update(response)
-        except ShellError:
-            exc = get_exception()
-            module.fail_json(msg=str(exc))
     else:
         result['updates'] = []
 

--- a/lib/ansible/modules/network/nxos/nxos_pim.py
+++ b/lib/ansible/modules/network/nxos/nxos_pim.py
@@ -173,13 +173,8 @@ def main():
     result = {}
     candidate = CustomNetworkConfig(indent=3)
     invoke('get_commands', module, existing, proposed, candidate)
-
-    try:
-        response = load_config(module, candidate)
-        result.update(response)
-    except ShellError:
-        exc = get_exception()
-        module.fail_json(msg=str(exc))
+    response = load_config(module, candidate)
+    result.update(response)
 
     if module._verbosity > 0:
         end_state = invoke('get_existing', module, args)

--- a/lib/ansible/modules/network/nxos/nxos_pim_rp_address.py
+++ b/lib/ansible/modules/network/nxos/nxos_pim_rp_address.py
@@ -253,13 +253,8 @@ def main():
     result = {}
     candidate = CustomNetworkConfig(indent=3)
     invoke('state_%s' % state, module, existing, proposed, candidate)
-
-    try:
-        response = load_config(module, candidate)
-        result.update(response)
-    except ShellError:
-        exc = get_exception()
-        module.fail_json(msg=str(exc))
+    response = load_config(module, candidate)
+    result.update(response)
 
     if module._verbosity > 0:
         end_state = invoke('get_existing', module, args)

--- a/lib/ansible/modules/network/nxos/nxos_smu.py
+++ b/lib/ansible/modules/network/nxos/nxos_smu.py
@@ -174,12 +174,8 @@ def main():
 
     commands = get_commands(module, pkg, file_system)
     if not module.check_mode and commands:
-        try:
-            apply_patch(module, commands)
-            changed = True
-        except ShellError:
-            e = get_exception()
-            module.fail_json(msg=str(e))
+        apply_patch(module, commands)
+        changed = True
 
     if 'configure' in commands:
         commands.pop(0)

--- a/lib/ansible/modules/network/nxos/nxos_vrf_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrf_af.py
@@ -270,13 +270,9 @@ def main():
     if state == 'present' or (state == 'absent' and existing):
         candidate = CustomNetworkConfig(indent=3)
         invoke('state_%s' % state, module, existing, proposed, candidate)
+        response = load_config(module, candidate)
+        result.update(response)
 
-        try:
-            response = load_config(module, candidate)
-            result.update(response)
-        except ShellError:
-            exc = get_exception()
-            module.fail_json(msg=str(exc))
     else:
         result['updates'] = []
 

--- a/lib/ansible/modules/network/nxos/nxos_vxlan_vtep.py
+++ b/lib/ansible/modules/network/nxos/nxos_vxlan_vtep.py
@@ -363,13 +363,9 @@ def main():
                             "all logical interfaces.")
         candidate = CustomNetworkConfig(indent=3)
         invoke('state_%s' % state, module, existing, proposed, candidate)
+        response = load_config(module, candidate)
+        result.update(response)
 
-        try:
-            response = load_config(module, candidate)
-            result.update(response)
-        except ShellError:
-            exc = get_exception()
-            module.fail_json(msg=str(exc))
     else:
         result['updates'] = []
 


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Remove idle `ShellError` exception and `get_exception()` method from nxos modules.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- modules/network/nxos/nxos_bgp_af.py
- modules/network/nxos/nxos_bgp_neighbor.py
- modules/network/nxos/nxos_bgp_neighbor_af.py
- modules/network/nxos/nxos_evpn_vni.py
- modules/network/nxos/nxos_file_copy.py
- modules/network/nxos/nxos_igmp.py
- modules/network/nxos/nxos_interface_ospf.py
- modules/network/nxos/nxos_ntp_auth.py
- modules/network/nxos/nxos_ospf.py
- modules/network/nxos/nxos_ospf_vrf.py
- modules/network/nxos/nxos_pim.py
- modules/network/nxos/nxos_pim_rp_address.py
- modules/network/nxos/nxos_smu.py
- modules/network/nxos/nxos_vrf_af.py
- modules/network/nxos/nxos_vxlan_vtep.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```