### PR TITLE
Fixed wrong variable in cumulus network module

### DIFF
--- a/lib/ansible/modules/network/cumulus/nclu.py
+++ b/lib/ansible/modules/network/cumulus/nclu.py
@@ -75,7 +75,7 @@ EXAMPLES = '''
   nclu:
     template: |
         {% for iface in range(1,49) %}
-        add int swp{{i}}
+        add int swp{{iface}}
         {% endfor %}
     commit: true
     description: "Ansible - add swps1-48"


### PR DESCRIPTION
Signed-off-by: Phil Huang <phil_huang@edge-core.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixed wrong variable in Cumulus network module

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
network/cumulus/nclu.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
