### PR TITLE
Allow to specify a custom zone_id for a new Google Cloud DNS zone

### DIFF
--- a/lib/ansible/modules/cloud/google/gcdns_zone.py
+++ b/lib/ansible/modules/cloud/google/gcdns_zone.py
@@ -54,6 +54,12 @@ options:
               create a TLD and will fail.
         required: true
         aliases: ['name']
+    zone_id:
+        description:
+            - Google Cloud DNS zone ID.
+            - Used when a new zone created. If absent, ID is generated from domain name.
+        required: false
+        default: null
     description:
         description:
             - An arbitrary text string to use for the zone description.
@@ -94,6 +100,10 @@ EXAMPLES = '''
 # Basic zone creation example.
 - name: Create a basic zone with the minimum number of parameters.
   gcdns_zone: zone=example.com
+
+# Zone creation example with custom zone ID.
+- name: Create a zone with custom zone ID.
+  gcdns_zone: zone=example.com zone_id=example-com
 
 # Zone removal example.
 - name: Remove a zone.
@@ -163,7 +173,8 @@ def create_zone(module, gcdns, zone):
     """Creates a new Google Cloud DNS zone."""
 
     description = module.params['description']
-    extra       = dict(description = description)
+    zone_id     = module.params['zone_id']
+    extra       = dict(description = description, name = zone_id)
     zone_name   = module.params['zone']
 
     # Google Cloud DNS wants the trailing dot on the domain name.
@@ -316,6 +327,7 @@ def main():
         argument_spec = dict(
             state                 = dict(default='present', choices=['present', 'absent'], type='str'),
             zone                  = dict(required=True, aliases=['name'], type='str'),
+            zone_id               = dict(type='str'),
             description           = dict(default='', type='str'),
             service_account_email = dict(type='str'),
             pem_file              = dict(type='path'),


### PR DESCRIPTION
##### SUMMARY
A current implementation of gcdns_zone relies on `libcloud` to convert a domain name to zone_id for Google Cloud DNS.

However their implementation is buggy when domain name is started with a digit.

https://cloud.google.com/dns/troubleshooting says:

The managed zone creation operation can fail with this error if the managed zone name does not begin with a letter, end with a letter or digit, and contain only lowercase letters, digits, or dashes.

I created a corresponding issue on ASF JIRA: https://issues.apache.org/jira/browse/LIBCLOUD-913

However, I think, that ansible should provide a way to manually customize zone id

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
gcdns_zone

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
