### PR TITLE
exoscale: fix TXT type records handling

### DIFF
--- a/lib/ansible/modules/network/exoscale/exo_dns_record.py
+++ b/lib/ansible/modules/network/exoscale/exo_dns_record.py
@@ -276,10 +276,6 @@ class ExoDnsRecord(ExoDns):
     def __init__(self, module):
         super(ExoDnsRecord, self).__init__(module)
 
-        self.content = self.module.params.get('content')
-        if self.content:
-            self.content = self.content.lower()
-
         self.domain = self.module.params.get('domain').lower()
         self.name = self.module.params.get('name').lower()
         if self.name == self.domain:
@@ -289,6 +285,10 @@ class ExoDnsRecord(ExoDns):
         self.record_type = self.module.params.get('record_type')
         if self.multiple and self.record_type != 'A':
             self.module.fail_json(msg="Multiple is only usable with record_type A")
+
+        self.content = self.module.params.get('content')
+        if self.content and self.record_type != 'TXT':
+            self.content = self.content.lower()
 
     def _create_record(self, record):
         self.result['changed'] = True


### PR DESCRIPTION
##### SUMMARY
TXT records must not be modified.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
exo_dns_record

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```
##### ADDITIONAL INFORMATION
Also see #23210

/cc @mayeu @fagaillard