### PR TITLE
storage/netapp module: Doc fix name description from lun to volume

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_cdot_volume.py
+++ b/lib/ansible/modules/storage/netapp/na_cdot_volume.py
@@ -45,7 +45,7 @@ options:
 
   name:
     description:
-    - The name of the lun to manage.
+    - The name of the volume to manage.
     required: true
 
   infinite:


### PR DESCRIPTION

##### SUMMARY
Help text stated to manage lun name but this module is for managing volumes.  Updated accordingly.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
/lib/modules/storage/netapp/na_cdot_volume.py

##### ANSIBLE VERSION

```
v2.3.0.0-1
```


##### ADDITIONAL INFORMATION
N/A