### PR TITLE
lambda_event: allow arns <= 140 characters - fixes #23959

### DIFF
--- a/lib/ansible/modules/cloud/amazon/lambda_event.py
+++ b/lib/ansible/modules/cloud/amazon/lambda_event.py
@@ -229,8 +229,11 @@ def validate_params(module, aws):
         module.fail_json(
             msg='Function name {0} is invalid. Names must contain only alphanumeric characters and hyphens.'.format(function_name)
         )
-    if len(function_name) > 64:
+    if len(function_name) > 64 and not function_name.startswith('arn:aws:lambda:'):
         module.fail_json(msg='Function name "{0}" exceeds 64 character limit'.format(function_name))
+
+    elif len(function_name) > 140 and function_name.startswith('arn:aws:lambda:'):
+        module.fail_json(msg='ARN "{0}" exceeds 140 character limit'.format(function_name))
 
     # check if 'function_name' needs to be expanded in full ARN format
     if not module.params['lambda_function_arn'].startswith('arn:aws:lambda:'):


### PR DESCRIPTION
##### SUMMARY
An ARN has a different length limit than a function name. Fixes #23959

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/lambda_event.py

##### ANSIBLE VERSION
```
2.4.0
```
