### PR TITLE
ec2_vpc_dhcp_options_facts: if tags don't exist set them to default list instead of crashing - fixes #23825

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_options_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_options_facts.py
@@ -98,11 +98,9 @@ except ImportError:
 
 
 def get_dhcp_options_info(dhcp_option):
-    if 'Tags' not in dhcp_option:
-        dhcp_option['Tags'] = [{'Value': '', 'Key': 'Name'}]
     dhcp_option_info = {'DhcpOptionsId': dhcp_option['DhcpOptionsId'],
                         'DhcpConfigurations': dhcp_option['DhcpConfigurations'],
-                        'Tags': boto3_tag_list_to_ansible_dict(dhcp_option['Tags'])}
+                        'Tags': boto3_tag_list_to_ansible_dict(dhcp_option.get('Tags', [{'Value': '', 'Key': 'Name'}]))}
     return dhcp_option_info
 
 

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_options_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_options_facts.py
@@ -99,7 +99,7 @@ except ImportError:
 
 def get_dhcp_options_info(dhcp_option):
     if 'Tags' not in dhcp_option:
-        dhcp_option['Tags'] = []
+        dhcp_option['Tags'] = [{'Value': '', 'Key': 'Name'}]
     dhcp_option_info = {'DhcpOptionsId': dhcp_option['DhcpOptionsId'],
                         'DhcpConfigurations': dhcp_option['DhcpConfigurations'],
                         'Tags': boto3_tag_list_to_ansible_dict(dhcp_option['Tags'])}

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_options_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_options_facts.py
@@ -98,6 +98,8 @@ except ImportError:
 
 
 def get_dhcp_options_info(dhcp_option):
+    if 'Tags' not in dhcp_option:
+        dhcp_option['Tags'] = []
     dhcp_option_info = {'DhcpOptionsId': dhcp_option['DhcpOptionsId'],
                         'DhcpConfigurations': dhcp_option['DhcpConfigurations'],
                         'Tags': boto3_tag_list_to_ansible_dict(dhcp_option['Tags'])}


### PR DESCRIPTION
##### SUMMARY
Set tags to an default list rather than crashing if they don't exist. If there are no tags boto doesn't return the default Name tag and its empty value. Fixes #23825

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_options_facts.py

##### ANSIBLE VERSION
```
2.4.0
```
