### PR TITLE
remove deprecated -sudo/-su options

### DIFF
--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -104,7 +104,6 @@ class AdHocCLI(CLI):
         sshpass = None
         becomepass = None
 
-        self.normalize_become_options()
         (sshpass, becomepass) = self.ask_passwords()
         passwords = {'conn_pass': sshpass, 'become_pass': becomepass}
 

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -411,7 +411,6 @@ class ConsoleCLI(CLI, cmd.Cmd):
             setattr(self, 'do_' + module, lambda arg, module=module: self.default(module + ' ' + arg))
             setattr(self, 'help_' + module, lambda module=module: self.helpdefault(module))
 
-        self.normalize_become_options()
         (sshpass, becomepass) = self.ask_passwords()
         self.passwords = {'conn_pass': sshpass, 'become_pass': becomepass}
 

--- a/lib/ansible/cli/playbook.py
+++ b/lib/ansible/cli/playbook.py
@@ -97,7 +97,6 @@ class PlaybookCLI(CLI):
 
         # don't deal with privilege escalation or passwords when we don't need to
         if not self.options.listhosts and not self.options.listtasks and not self.options.listtags and not self.options.syntax:
-            self.normalize_become_options()
             (sshpass, becomepass) = self.ask_passwords()
             passwords = {'conn_pass': sshpass, 'become_pass': becomepass}
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Start removing legacy sudo/su cli options

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
cli
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.6
```


##### ADDITIONAL INFORMATION

add deprecation notice to play sudo/su directives