### PR TITLE
Fix broken ASA module in Ansible 2.3

### DIFF
--- a/lib/ansible/module_utils/asa.py
+++ b/lib/ansible/module_utils/asa.py
@@ -53,7 +53,9 @@ class Cli(CliBase):
     NET_PASSWD_RE = re.compile(r"[\r\n]?password: $", re.I)
 
     def __init__(self, *args, **kwargs):
+
         super(Cli, self).__init__(*args, **kwargs)
+        self.default_output = 'text'
 
     def connect(self, params, **kwargs):
         super(Cli, self).connect(params, kickstart=False, **kwargs)


### PR DESCRIPTION
##### SUMMARY
Patch for #23922

There's another PR for this #23376, but the changes in that one didn't help me.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - asa_command

##### ANSIBLE VERSION
```
ansible 2.4.0 (asa_conn d46f7a5b3f) last updated 2017/04/25 20:24:14 (GMT +200)
  config file = /Users/patrick/src/napalm-dev/ansible.cfg
  configured module search path = [u'/Users/patrick/src/forks/napalm-ansible/library']
  ansible python module location = /Users/patrick/src/forks/ansible/lib/ansible
  executable location = /Users/patrick/src/forks/ansible/bin/ansible
  python version = 2.7.12 (default, Dec  5 2016, 11:55:02) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
Before the patch:
```
TASK [Connection test] ***********************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'Cli' object has no attribute 'default_output'
fatal: [172.29.52.33]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/var/folders/9x/3f2j6dpj7r76dhj9q4pnc14m0000gn/T/ansible_FOFY0L/ansible_module_asa_command.py\", line 229, in <module>\n    main()\n  File \"/var/folders/9x/3f2j6dpj7r76dhj9q4pnc14m0000gn/T/ansible_FOFY0L/ansible_module_asa_command.py\", line 180, in main\n    runner = CommandRunner(module)\n  File \"/var/folders/9x/3f2j6dpj7r76dhj9q4pnc14m0000gn/T/ansible_FOFY0L/ansible_modlib.zip/ansible/module_utils/netcli.py\", line 140, in __init__\nAttributeError: 'Cli' object has no attribute 'default_output'\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 0}
```

