### PR TITLE
Strip out \r carriage returns from oneline output

### DIFF
--- a/lib/ansible/plugins/callback/oneline.py
+++ b/lib/ansible/plugins/callback/oneline.py
@@ -36,8 +36,10 @@ class CallbackModule(CallbackBase):
 
     def _command_generic_msg(self, hostname, result,  caption):
         stdout = result.get('stdout','').replace('\n', '\\n')
+        stdout = stdout.replace('\r', '')
         if 'stderr' in result and result['stderr']:
             stderr = result.get('stderr','').replace('\n', '\\n')
+            stderr = stderr.replace('\r', '')
             return "%s | %s | rc=%s | (stdout) %s (stderr) %s" % (hostname, caption, result.get('rc', -1), stdout, stderr)
         else:
             return "%s | %s | rc=%s | (stdout) %s" % (hostname, caption, result.get('rc', -1), stdout)


### PR DESCRIPTION
##### SUMMARY
The carriage returns in one line output munch the display when running oneline output like this:
ansible hosts -m raw -a "echo line1; echo line2" -s -o

By removing the carriage return from the stdout and stderr, the display is as intended.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/callback/oneline.py

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### ADDITIONAL INFORMATION

```
#BEFORE
$ sudo ansible myhost -m raw -a "echo line1; echo line2" -s -o
\n (stderr) Shared connection to myhost closed.

#AFTER
$ sudo ansible myhost -m raw -a "echo line1; echo line2" -s -o
myhost | SUCCESS | rc=0 | (stdout) line1\nline2\n (stderr) Shared connection to myhost closed.\n
```
