### PR TITLE
Added subnetwork parameter to inventory instance dictionary.

### DIFF
--- a/contrib/inventory/gce.py
+++ b/contrib/inventory/gce.py
@@ -40,6 +40,7 @@ based on the data obtained from the libcloud Node object:
  - gce_tags
  - gce_metadata
  - gce_network
+ - gce_subnetwork
 
 When run in --list mode, instances are grouped by the following categories:
  - zone:
@@ -292,6 +293,7 @@ class GceInventory(object):
                 secrets_found = True
             except:
                 pass
+
         if not secrets_found:
             args = [
                 self.config.get('gce','gce_service_account_email_address'),
@@ -350,6 +352,9 @@ class GceInventory(object):
                 md[entry['key']] = entry['value']
 
         net = inst.extra['networkInterfaces'][0]['network'].split('/')[-1]
+        subnet = None
+        if 'subnetwork' in inst.extra['networkInterfaces'][0]:
+            subnet = inst.extra['networkInterfaces'][0]['subnetwork'].split('/')[-1]
         # default to exernal IP unless user has specified they prefer internal
         if self.ip_type == 'internal':
             ssh_host = inst.private_ips[0]
@@ -370,6 +375,7 @@ class GceInventory(object):
             'gce_tags': inst.extra['tags'],
             'gce_metadata': md,
             'gce_network': net,
+            'gce_subnetwork': subnet,
             # Hosts don't have a public name, so we add an IP
             'ansible_ssh_host': ssh_host
         }


### PR DESCRIPTION
##### SUMMARY
Added subnetwork parameter to inventory instance dictionary.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
gce inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (ans-inv-sn 2c4b8bf997) last updated 2017/04/25 20:27:46 (GMT +000)
  config file = /home/supertom/.ansible.cfg
  configured module search path = [u'/home/supertom/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/supertom/virts/ans-inv-sn/code/ansible/lib/ansible
  executable location = /home/supertom/virts/ans-inv-sn/code/ansible/bin/ansible
  python version = 2.7.9 (default, Mar  1 2015, 12:57:24) [GCC 4.9.2]

```


##### ADDITIONAL INFORMATION
Added subnetwork to the dictionary returned for instances.  If the node exists on a legacy (non-subnetwork) network, 'null' will be returned.
