### PR TITLE
Change wait_for time to utc

### DIFF
--- a/lib/ansible/modules/utilities/logic/wait_for.py
+++ b/lib/ansible/modules/utilities/logic/wait_for.py
@@ -442,7 +442,7 @@ def main():
         except:
             module.fail_json(msg="unknown active_connection_state ("+_connection_state+") defined")
 
-    start = datetime.datetime.now()
+    start = datetime.datetime.utcnow()
 
     if delay:
         time.sleep(delay)
@@ -453,7 +453,7 @@ def main():
         ### first wait for the stop condition
         end = start + datetime.timedelta(seconds=timeout)
 
-        while datetime.datetime.now() < end:
+        while datetime.datetime.utcnow() < end:
             if path:
                 try:
                     f = open(path)
@@ -470,7 +470,7 @@ def main():
             # Conditions not yet met, wait and try again
             time.sleep(params['sleep'])
         else:
-            elapsed = datetime.datetime.now() - start
+            elapsed = datetime.datetime.utcnow() - start
             if port:
                 module.fail_json(msg="Timeout when waiting for %s:%s to stop." % (host, port), elapsed=elapsed.seconds)
             elif path:
@@ -479,7 +479,7 @@ def main():
     elif state in ['started', 'present']:
         ### wait for start condition
         end = start + datetime.timedelta(seconds=timeout)
-        while datetime.datetime.now() < end:
+        while datetime.datetime.utcnow() < end:
             if path:
                 try:
                     os.stat(path)
@@ -487,7 +487,7 @@ def main():
                     e = get_exception()
                     # If anything except file not present, throw an error
                     if e.errno != 2:
-                        elapsed = datetime.datetime.now() - start
+                        elapsed = datetime.datetime.utcnow() - start
                         module.fail_json(msg="Failed to stat %s, %s" % (path, e.strerror), elapsed=elapsed.seconds)
                     # file doesn't exist yet, so continue
                 else:
@@ -506,7 +506,7 @@ def main():
                     except IOError:
                         pass
             elif port:
-                alt_connect_timeout = math.ceil(_timedelta_total_seconds(end - datetime.datetime.now()))
+                alt_connect_timeout = math.ceil(_timedelta_total_seconds(end - datetime.datetime.utcnow()))
                 try:
                     s = _create_connection(host, port, min(connect_timeout, alt_connect_timeout))
                 except:
@@ -517,8 +517,8 @@ def main():
                     if compiled_search_re:
                         data = ''
                         matched = False
-                        while datetime.datetime.now() < end:
-                            max_timeout = math.ceil(_timedelta_total_seconds(end - datetime.datetime.now()))
+                        while datetime.datetime.utcnow() < end:
+                            max_timeout = math.ceil(_timedelta_total_seconds(end - datetime.datetime.utcnow()))
                             (readable, w, e) = select.select([s], [], [], max_timeout)
                             if not readable:
                                 # No new data.  Probably means our timeout
@@ -550,7 +550,7 @@ def main():
 
         else:   # while-else
             # Timeout expired
-            elapsed = datetime.datetime.now() - start
+            elapsed = datetime.datetime.utcnow() - start
             if port:
                 if search_regex:
                     module.fail_json(msg="Timeout when waiting for search string %s in %s:%s" % (search_regex, host, port), elapsed=elapsed.seconds)
@@ -566,7 +566,7 @@ def main():
         ### wait until all active connections are gone
         end = start + datetime.timedelta(seconds=timeout)
         tcpconns = TCPConnectionInfo(module)
-        while datetime.datetime.now() < end:
+        while datetime.datetime.utcnow() < end:
             try:
                 if tcpconns.get_active_connections_count() == 0:
                     break
@@ -575,10 +575,10 @@ def main():
             # Conditions not yet met, wait and try again
             time.sleep(params['sleep'])
         else:
-            elapsed = datetime.datetime.now() - start
+            elapsed = datetime.datetime.utcnow() - start
             module.fail_json(msg="Timeout when waiting for %s:%s to drain" % (host, port), elapsed=elapsed.seconds)
 
-    elapsed = datetime.datetime.now() - start
+    elapsed = datetime.datetime.utcnow() - start
     module.exit_json(state=state, port=port, search_regex=search_regex, path=path, elapsed=elapsed.seconds)
 
 # import module snippets


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Change from watching datetime.now() to datetime.utcnow() to avoid timezone changing issues.
Fixes #23937 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
wait_for
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
