### PR TITLE
Mdd psql user aws fix

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -210,8 +210,6 @@ EXAMPLES = '''
 import itertools
 import re
 from distutils.version import StrictVersion
-from hashlib import md5
-
 
 from ansible.module_utils.basic import get_exception, AnsibleModule
 from ansible.module_utils.database import pg_quote_identifier, SQLParseError
@@ -225,7 +223,6 @@ except ImportError:
 else:
     postgresqldb_found = True
 
-from ansible.module_utils._text import to_bytes
 from ansible.module_utils.six import iteritems
 
 try:
@@ -234,9 +231,6 @@ except ImportError:
     passlib_hash_found = False
 else:
     passlib_hash_found = True
-
-
-
 
 FLAGS = ('SUPERUSER', 'CREATEROLE', 'CREATEUSER', 'CREATEDB', 'INHERIT', 'LOGIN', 'REPLICATION')
 FLAGS_BY_VERSION = {'BYPASSRLS': '9.5.0'}
@@ -670,7 +664,6 @@ def parse_role_attrs(cursor, role_attr_flags):
                                 ' '.join(flags.difference(valid_flags)))
 
     return ' '.join(flags)
-
 
 
 def normalize_privileges(privs, type_):

--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -329,7 +329,7 @@ def user_alter(db_connection, module, user, password, role_attr_flags, encrypted
     """Change user password and/or attributes. Return True if changed, False otherwise."""
     changed = False
 
-    cursor = db_connection.cursor( cursor_factory=psycopg2.extras.DictCursor)
+    cursor = db_connection.cursor(cursor_factory=psycopg2.extras.DictCursor)
     # Note: role_attr_flags escaped by parse_role_attrs and encrypted is a
     # literal
     if user == 'PUBLIC':
@@ -409,7 +409,7 @@ def user_alter(db_connection, module, user, password, role_attr_flags, encrypted
             else:
                 raise psycopg2.InternalError(e)
 
-        #Commit changes before next command in case select fails
+        # Commit changes before next command in case select fails
         db_connection.commit()
 
         # Grab new role attributes.
@@ -420,7 +420,7 @@ def user_alter(db_connection, module, user, password, role_attr_flags, encrypted
             db_connection.rollback()
             cursor = db_connection.cursor(
                 cursor_factory=psycopg2.extras.DictCursor)
-            new_role_attrs=None
+            new_role_attrs = None
             changed = True
 
         # Detect any differences between current_ and new_role_attrs.

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -336,16 +336,21 @@
   become: True
   shell: echo "create table test_table2 (field text);" | psql {{ db_name }}
 
-- name: Create a user with some permissions on the db
-  become_user: "{{ pg_user }}"
-  become: True
-  postgresql_user:
-    name: "{{ db_user1 }}"
-    encrypted: 'yes'
-    password: "md55c8ccfd9d6711fc69a7eae647fc54f51"
-    db: "{{ db_name }}"
-    priv: 'test_table1:INSERT,SELECT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER/test_table2:INSERT/CREATE,CONNECT,TEMP'
-    login_user: "{{ pg_user }}"
+- vars:
+    db_password: 'secretù' # use UTF-8
+  block:
+    - name: Create a user with some permissions on the db
+      become_user: "{{ pg_user }}"
+      become: True
+      postgresql_user:
+        name: "{{ db_user1 }}"
+        encrypted: 'yes'
+        password: "md5{{ (db_password ~ db_user1) | hash('md5')}}"
+        db: "{{ db_name }}"
+        priv: 'test_table1:INSERT,SELECT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER/test_table2:INSERT/CREATE,CONNECT,TEMP'
+        login_user: "{{ pg_user }}"
+
+    - include: pg_authid_not_readable.yml
 
 - name: Check that the user has the requested permissions (table1)
   become_user: "{{ pg_user }}"

--- a/test/integration/targets/postgresql/tasks/pg_authid_not_readable.yml
+++ b/test/integration/targets/postgresql/tasks/pg_authid_not_readable.yml
@@ -1,0 +1,50 @@
+- name: "Admin user is allowed to access pg_authid relation: password comparison will succeed, password won't be updated"
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_user:
+    name: "{{ db_user1 }}"
+    encrypted: 'yes'
+    password: "md5{{ (db_password ~ db_user1) | hash('md5')}}"
+    db: "{{ db_name }}"
+    priv: 'test_table1:INSERT,SELECT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER/test_table2:INSERT/CREATE,CONNECT,TEMP'
+    login_user: "{{ pg_user }}"
+  register: redo_as_admin
+
+- name: "Check that task succeeded without any change"
+  assert:
+    that:
+      - 'not redo_as_admin|failed'
+      - 'not redo_as_admin|changed'
+      - 'redo_as_admin|success'
+
+- name: "Check that normal user isn't allowed to access pg_authid"
+  shell: 'psql -c "select * from pg_authid;" {{ db_name }} {{ db_user1 }}'
+  environment:
+    PGPASSWORD: '{{ db_password }}'
+  ignore_errors: True
+  register: pg_authid
+
+- assert:
+    that:
+      - 'pg_authid|failed'
+      - '"permission denied for relation pg_authid" in pg_authid.stderr'
+
+- name: "Normal user isn't allowed to access pg_authid relation: password comparison will fail, password will be updated"
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_user:
+    name: "{{ db_user1 }}"
+    encrypted: 'yes'
+    password: "md5{{ (db_password ~ db_user1) | hash('md5')}}"
+    db: "{{ db_name }}"
+    priv: 'test_table1:INSERT,SELECT,UPDATE,DELETE,TRUNCATE,REFERENCES,TRIGGER/test_table2:INSERT/CREATE,CONNECT,TEMP'
+    login_user: "{{ db_user1 }}"
+    login_password: "{{ db_password }}"
+  register: redo_as_normal_user
+
+- name: "Check that task succeeded and that result is changed"
+  assert:
+    that:
+      - 'not redo_as_normal_user|failed'
+      - 'redo_as_normal_user|changed'
+      - 'redo_as_normal_user|success'


### PR DESCRIPTION
##### SUMMARY

This is an attempt to fix Ansible Bug #18933 - make postgresql user creation work on Amazon RDS instances.  It has worked on our internal branch based off Ansible stable 2.3 and has been cherry picked to devel for upstream inclusion into the project.  

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME

posgresql_user module 

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/mikedd/dev/ansible/ansible-add-modules/library']
  ansible python module location = /home/mikedd/dev/ansible/ansible-add-modules/lib/ansible
  executable location = /home/mikedd/dev/ansible/ansible-add-modules/bin/ansible
  python version = 2.7.12 (default, Jul  1 2016, 15:12:24) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION

Not yet nearly fully tested.  