### PR TITLE
Get tags for RDS instances.

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -623,6 +623,10 @@ class Ec2Inventory(object):
         ''' Makes an AWS API call to the list of RDS instances in a particular
         region '''
 
+        if not HAS_BOTO3:
+            self.fail_with_error("Working with RDS clusters requires boto3 - please install boto3 and try again",
+                                 "getting RDS clusters")
+
         client = ec2_utils.boto3_inventory_conn('client', 'rds', region, **self.credentials)
         db_instances = client.describe_db_instances()
 

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -624,8 +624,8 @@ class Ec2Inventory(object):
         region '''
 
         if not HAS_BOTO3:
-            self.fail_with_error("Working with RDS clusters requires boto3 - please install boto3 and try again",
-                                 "getting RDS clusters")
+            self.fail_with_error("Working with RDS instances requires boto3 - please install boto3 and try again",
+                                 "getting RDS instances")
 
         client = ec2_utils.boto3_inventory_conn('client', 'rds', region, **self.credentials)
         db_instances = client.describe_db_instances()

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -623,6 +623,9 @@ class Ec2Inventory(object):
         ''' Makes an AWS API call to the list of RDS instances in a particular
         region '''
 
+        client = ec2_utils.boto3_inventory_conn('client', 'rds', region, **self.credentials)
+        db_instances = client.describe_db_instances()
+
         try:
             conn = self.connect_to_aws(rds, region)
             if conn:
@@ -630,7 +633,14 @@ class Ec2Inventory(object):
                 while True:
                     instances = conn.get_all_dbinstances(marker=marker)
                     marker = instances.marker
-                    for instance in instances:
+                    for index, instance in enumerate(instances):
+                        # Add tags to instances.
+                        instance.arn = db_instances['DBInstances'][index]['DBInstanceArn']
+                        tags = client.list_tags_for_resource(ResourceName=instance.arn)['TagList']
+                        instance.tags = {}
+                        for tag in tags:
+                            instance.tags[tag['Key']] = tag['Value']
+
                         self.add_rds_instance(instance, region)
                     if not marker:
                         break


### PR DESCRIPTION
##### SUMMARY
Gets tags for RDS instances. More of a working prototype than a solid PR. I also don't expect this to get merged as is since it is Boto3 only at this time. Went off the suggestion of @willthames here https://github.com/ansible/ansible/issues/11569#issuecomment-279364780.

> My view is that this is easy to do in boto3 (because the result of describe_db_instances contains the ARN that is needed to use with list_tags_for_resource

Relates to #11569, #14464.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
inventory/ec2.py

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```

##### ADDITIONAL INFORMATION
None
