### PR TITLE
synchronize: Fix (delegated) local rsync

### DIFF
--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -347,6 +347,14 @@ def substitute_controller(path):
     return path
 
 
+def is_rsh_needed(source, dest):
+    if source.startswith('rsync://') or dest.startswith('rsync://'):
+        return False
+    if ':' in source or ':' in dest:
+        return True
+    return False
+
+
 def main():
     module = AnsibleModule(
         argument_spec = dict(
@@ -465,7 +473,7 @@ def main():
     if source.startswith('rsync://') and dest.startswith('rsync://'):
         module.fail_json(msg='either src or dest must be a localhost', rc=1)
 
-    if not source.startswith('rsync://') and not dest.startswith('rsync://'):
+    if is_rsh_needed(source, dest):
         ssh_cmd = [module.get_bin_path('ssh', required=True), '-S', 'none']
         if private_key is not None:
             ssh_cmd.extend(['-i', private_key])


### PR DESCRIPTION
##### SUMMARY
Makes delegated local rsync work even if ansible_host or ansible_ssh_host is set.
Makes local rsync work when no ssh is installed.

Fixes #17097
Fixes #14686


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/files/synchronize.py
plugins/action/synchronize.py

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /etc/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
works now even if no ssh is installed:
```
---
- hosts: localhost
  become: no
  gather_facts: no

  tasks:
    - synchronize:
        src: "/home"
        dest: "/backups"
```

works now even if ansible_host or ansible_ssh_host is  set in inventory:
```
- synchronize:
    src: "/home"
    dest: "/backups"
    delegate_to: "{{ inventory_hostname }}"
```