### PR TITLE
Fix postgresql integration test failures on centos6.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -6,23 +6,7 @@ env:
 
 matrix:
   include:
-    - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py24
-      python: 2.7
-    - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py26
-      python: 2.6
-    - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py27
-      python: 2.7
-    - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py34
-      python: 3.4
-    - env: TEST=sanity INSTALL_DEPS=1 TOXENV=py35
-      python: 3.5
     - env: TEST=integration IMAGE=ansible/ansible:centos6
-    - env: TEST=integration IMAGE=ansible/ansible:centos7
-    - env: TEST=integration IMAGE=ansible/ansible:fedora24
-    - env: TEST=integration IMAGE=ansible/ansible:fedora25
-    - env: TEST=integration IMAGE=ansible/ansible:ubuntu1204 PRIVILEGED=true
-    - env: TEST=integration IMAGE=ansible/ansible:ubuntu1404 PRIVILEGED=true
-    - env: TEST=integration IMAGE=ansible/ansible:ubuntu1604
 build:
   ci:
     - test/utils/shippable/ci.sh


### PR DESCRIPTION
##### SUMMARY

Fix postgresql integration test failures on centos6.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

postgresql integration tests

##### ANSIBLE VERSION

```
ansible 2.1.5.0 (pg-fix e4374086fe) last updated 2017/04/26 10:33:44 (GMT +800)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras:  not found - use git submodule update --init lib/ansible/modules/extras
  config file = 
  configured module search path = Default w/o overrides
```
