### PR TITLE
Set validate_checksum default yes of fetch to match the doc (#23900)

### DIFF
--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -46,7 +46,7 @@ class ActionModule(ActionBase):
         dest              = self._task.args.get('dest', None)
         flat              = boolean(self._task.args.get('flat'))
         fail_on_missing   = boolean(self._task.args.get('fail_on_missing'))
-        validate_checksum = boolean(self._task.args.get('validate_checksum', self._task.args.get('validate_md5')))
+        validate_checksum = boolean(self._task.args.get('validate_checksum', self._task.args.get('validate_md5', True)))
 
         if 'validate_md5' in self._task.args and 'validate_checksum' in self._task.args:
             result['failed'] = True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #23900 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
fetch

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.10 (default, Feb  6 2017, 23:53:20) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
In the ansible [document](http://docs.ansible.com/ansible/fetch_module.html) the validate_checksum is default set to yes. But actually is "no" in the [fetch.py](https://github.com/ansible/ansible/blob/v2.3.0.0-1/lib/ansible/plugins/action/fetch.py). It was confirmed as a bug (#23900).

