### PR TITLE
Use Shippable image: drydock/u16pytall:master

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -58,10 +58,10 @@ matrix:
     - env: TEST=linux/ubuntu1604py3/3
 build:
   pre_ci:
-    - docker images | grep u14pyt
+    - docker images drydock/u16pytall
   pre_ci_boot:
-    image_name: drydock/u14pyt
-    image_tag: prod
+    image_name: drydock/u16pytall
+    image_tag: master
     pull: false
     options: "--privileged=false --net=bridge"
   ci:

--- a/test/utils/shippable/other.sh
+++ b/test/utils/shippable/other.sh
@@ -2,18 +2,12 @@
 
 set -o pipefail
 
-retry.py add-apt-repository 'deb http://archive.ubuntu.com/ubuntu trusty-backports universe'
-retry.py add-apt-repository 'ppa:ubuntu-toolchain-r/test'
 retry.py add-apt-repository 'ppa:fkrull/deadsnakes'
 
 retry.py apt-get update -qq
 retry.py apt-get install -qq \
     shellcheck \
     python2.4 \
-    g++-4.9 \
-    python3.6-dev \
-
-ln -sf x86_64-linux-gnu-gcc-4.9 /usr/bin/x86_64-linux-gnu-gcc
 
 retry.py pip install tox --disable-pip-version-check
 

--- a/test/utils/shippable/units.sh
+++ b/test/utils/shippable/units.sh
@@ -7,18 +7,6 @@ IFS='/:' read -ra args <<< "${TEST}"
 
 version="${args[1]}"
 
-if [ "${version}" = "3.6" ]; then
-    retry.py add-apt-repository 'ppa:ubuntu-toolchain-r/test'
-    retry.py add-apt-repository 'ppa:fkrull/deadsnakes'
-
-    retry.py apt-get update -qq
-    retry.py apt-get install -qq \
-        g++-4.9 \
-        python3.6-dev \
-
-    ln -sf x86_64-linux-gnu-gcc-4.9 /usr/bin/x86_64-linux-gnu-gcc
-fi
-
 retry.py pip install tox --disable-pip-version-check
 
 ansible-test units --color -v --tox --coverage --python "${version}"


### PR DESCRIPTION
##### SUMMARY

* Use Shippable image: drydock/u16pytall:master
* Do not install python 3.6 on Shippable.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

Shippable

##### ANSIBLE VERSION

```
nsible 2.3.0.0 (ci-update-2.3 4f92fad34e) last updated 2017/04/26 15:15:48 (GMT +800)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
