### PR TITLE
Update validate-modules to ignore *.rst files.

### DIFF
--- a/test/sanity/validate-modules/validate-modules
+++ b/test/sanity/validate-modules/validate-modules
@@ -202,7 +202,7 @@ class Validator(with_metaclass(abc.ABCMeta, object)):
 
 
 class ModuleValidator(Validator):
-    BLACKLIST_PATTERNS = ('.git*', '*.pyc', '*.pyo', '.*', '*.md', '*.txt')
+    BLACKLIST_PATTERNS = ('.git*', '*.pyc', '*.pyo', '.*', '*.md', '*.rst', '*.txt')
     BLACKLIST_FILES = frozenset(('.git', '.gitignore', '.travis.yml',
                                  'shippable.yml',
                                  '.gitattributes', '.gitmodules', 'COPYING',


### PR DESCRIPTION
##### SUMMARY

Update validate-modules to ignore *.rst files.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

validate-modules

##### ANSIBLE VERSION

```
ansible 2.4.0 (validate-rst ee668997ad) last updated 2017/04/26 15:32:26 (GMT +800)
  config file = 
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
