### PR TITLE
[Doc] win_package - product_id is a mandatory parameter

### DIFF
--- a/lib/ansible/modules/windows/win_package.py
+++ b/lib/ansible/modules/windows/win_package.py
@@ -35,7 +35,7 @@ short_description: Installs/Uninstalls an installable package, either from local
 description:
      - Installs or uninstalls a package.
      - >
-       Optionally uses a product_id to check if the package needs installing. You can find product ids for installed programs in the windows registry
+       Use a product_id to check if the package needs installing. You can find product ids for installed programs in the windows registry
        either in C(HKLM:Software\Microsoft\Windows\CurrentVersion\Uninstall) or for 32 bit programs
        C(HKLM:Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall)
 options:


### PR DESCRIPTION
_product_id_ is a mandatory parameter for _windows/win_package_ module.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Missing _product_id_ leads to a "Missing required argument: product_id" message. Thus this parameter should not be described as optionnal in the documentation.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
windows/win_package

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
