### PR TITLE
Fix leading slashes being stripped from mount src

### DIFF
--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -443,19 +443,12 @@ def is_bind_mounted(module, linux_mounts, dest, src=None, fstype=None):
     if get_platform() == 'Linux' and linux_mounts is not None:
         if src is None:
             # That's for unmounted/absent
-            for m in linux_mounts:
-                if m['dst'] == dest:
-                    is_mounted = True
-        else:
-            mounted_src = None
-
-            for m in linux_mounts:
-                if m['dst'] == dest:
-                    mounted_src = m['src']
-
-            # That's for mounted
-            if mounted_src is not None and mounted_src == src:
+            if dest in linux_mounts:
                 is_mounted = True
+        else:
+            if dest in linux_mounts:
+                is_mounted = linux_mounts[dest]['src'] == src
+
     else:
         bin_path = module.get_bin_path('mount', required=True)
         cmd = '%s -l' % bin_path
@@ -512,7 +505,7 @@ def get_linux_mounts(module, mntinfo_file="/proc/self/mountinfo"):
 
         mntinfo[record['id']] = record
 
-    mounts = []
+    mounts = {}
 
     for mnt in mntinfo.values():
         if mnt['parent_id'] != 1 and mnt['parent_id'] in mntinfo:
@@ -547,7 +540,7 @@ def get_linux_mounts(module, mntinfo_file="/proc/self/mountinfo"):
             'fs': mnt['fs']
         }
 
-        mounts.append(record)
+        mounts[mnt['dst']] = record
 
     return mounts
 

--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -530,7 +530,7 @@ def get_linux_mounts(module, mntinfo_file="/proc/self/mountinfo"):
                         # 141 140 253:2 /rootfs/tmp/aaa /tmp/bbb rw - ext4 /dev/sdb2 rw
                         # == Expected result:
                         # src=/tmp/aaa
-                        mnt['root'] = mnt['root'][len(m['root']) + 1:]
+                        mnt['root'] = mnt['root'][len(m['root']):]
 
                     # Prepend the parent's dst to the child's root
                     # == Example:

--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -480,10 +480,8 @@ def is_bind_mounted(module, linux_mounts, dest, src=None, fstype=None):
     return is_mounted
 
 
-def get_linux_mounts(module):
+def get_linux_mounts(module, mntinfo_file="/proc/self/mountinfo"):
     """Gather mount information"""
-
-    mntinfo_file = "/proc/self/mountinfo"
 
     try:
         f = open(mntinfo_file)
@@ -528,7 +526,7 @@ def get_linux_mounts(module):
                             mnt['root'].startswith("%s/" % m['root'])):
                         # Ommit the parent's root in the child's root
                         # == Example:
-                        # 204 136 253:2 /rootfs / rw - ext4 /dev/sdb2 rw
+                        # 140 136 253:2 /rootfs / rw - ext4 /dev/sdb2 rw
                         # 141 140 253:2 /rootfs/tmp/aaa /tmp/bbb rw - ext4 /dev/sdb2 rw
                         # == Expected result:
                         # src=/tmp/aaa
@@ -615,7 +613,7 @@ def main():
     linux_mounts = []
 
     # Cache all mounts here in order we have consistent results if we need to
-    # call is_bind_mouted() multiple times
+    # call is_bind_mounted() multiple times
     if get_platform() == 'Linux':
         linux_mounts = get_linux_mounts(module)
 

--- a/test/units/modules/system/test_linux_mountinfo.py
+++ b/test/units/modules/system/test_linux_mountinfo.py
@@ -1,0 +1,25 @@
+import os
+import tempfile
+
+from ansible.compat.tests import unittest
+from ansible.module_utils._text import to_bytes
+
+from ansible.modules.system.mount import get_linux_mounts
+
+
+class LinuxMountsTestCase(unittest.TestCase):
+
+    def _create_file(self, content):
+        tmp_file = tempfile.NamedTemporaryFile(prefix='ansible-test-', delete=False)
+        tmp_file.write(to_bytes(content))
+        tmp_file.close()
+        self.addCleanup(os.unlink, tmp_file.name)
+        return tmp_file.name
+
+    def test_code_comment(self):
+        path = self._create_file(
+            '140 136 253:2 /rootfs / rw - ext4 /dev/sdb2 rw\n'
+            '141 140 253:2 /rootfs/tmp/aaa /tmp/bbb rw - ext4 /dev/sdb2 rw\n'
+        )
+        mounts = get_linux_mounts(None, path)
+        self.assertEqual(mounts['/tmp/bbb']['src'], '/tmp/aaa')


### PR DESCRIPTION
##### SUMMARY
The first two commits fix the leading slash being stripped from a mount `src` value. This caused problems where a bind mount would always be re-mounted.

The second two commits replaces looking up items by looping and checking with a dict lookup. It doesn't change the functionality, just some cleanup I thought I'd do while I was there. Feel free to cherry-pick.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
mount module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
```

##### ADDITIONAL INFORMATION
Some examples of the output of `get_linux_mounts` are below (taken from the function comments and a real-world case). Note the missing leading slashes in the `src` field.

- Example 1:
  ```
  140 136 253:2 /rootfs / rw - ext4 /dev/sdb2 rw
  141 140 253:2 /rootfs/tmp/aaa /tmp/bbb rw - ext4 /dev/sdb2 rw
  ```

  Current ansible (actually first commit, so I can specify a dummy mountinfo file) shows:
  ```
  {'opts': 'rw', 'src': '/dev/sdb2', 'fs': 'ext4', 'dst': '/'}
  {'opts': 'rw', 'src': 'tmp/aaa', 'fs': 'ext4', 'dst': '/tmp/bbb'}
  ```

  PR shows (printing `.values()`, as output is now a `dict`):
  ```
  {'fs': 'ext4', 'src': '/tmp/aaa', 'dst': '/tmp/bbb', 'opts': 'rw'}
  {'fs': 'ext4', 'src': '/dev/sdb2', 'dst': '/', 'opts': 'rw'}
  ```

- Real-world:
  ```
  22 0 0:20 /rootfs / rw,relatime shared:1 - btrfs /dev/sda2 rw,space_cache,subvolid=258,subvol=/rootfs
  43 22 0:20 /rootfs/var/backups/home /srv/nfs4/archive rw,relatime shared:1 - btrfs /dev/sda2 rw,space_cache,subvolid=258,subvol=/rootfs/var/backups/home
  ```

  Current ansible:
  ```
  {'opts': 'rw,relatime', 'src': '/dev/sda2', 'fs': 'btrfs', 'dst': '/'}
  {'opts': 'rw,relatime', 'src': 'var/backups/home', 'fs': 'btrfs', 'dst': '/srv/nfs4/archive'}
  ```

  PR:
  ```
  {'fs': 'btrfs', 'src': '/var/backups/home', 'dst': '/srv/nfs4/archive', 'opts': 'rw,relatime'}
  {'fs': 'btrfs', 'src': '/dev/sda2', 'dst': '/', 'opts': 'rw,relatime'}
  ```