### PR TITLE
Fix fetch module's validate_checksum default value

### DIFF
--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -48,10 +48,14 @@ class ActionModule(ActionBase):
         fail_on_missing   = boolean(self._task.args.get('fail_on_missing'))
         validate_checksum = boolean(self._task.args.get('validate_checksum', self._task.args.get('validate_md5', True)))
 
+        # validate_md5 is the deprecated way to specify validate_checksum
         if 'validate_md5' in self._task.args and 'validate_checksum' in self._task.args:
             result['failed'] = True
             result['msg'] = "validate_checksum and validate_md5 cannot both be specified"
             return result
+
+        if 'validate_md5' in self._task.args:
+            display.deprecated('Use validate_checksum instead of validate_md5', version='2.8')
 
         if source is None or dest is None:
             result['failed'] = True

--- a/test/integration/targets/fetch/tasks/main.yml
+++ b/test/integration/targets/fetch/tasks/main.yml
@@ -25,6 +25,13 @@
 
 - debug: var=fetched
 
+- name: Assert that we fetched correctly
+  assert:
+    that:
+      - 'fetched["changed"] == True'
+      - 'fetched["checksum"] == "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"'
+      - 'fetched["remote_checksum"] == "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"'
+
 # TODO: check the become and non-become forms of fetch because in one form we'll do
 # the get method of the connection plugin and in the become case we'll use the
 # fetch module.
@@ -37,6 +44,16 @@
   assert:
     that:
       'diff.stdout == ""'
+
+- name: fetch a second time to show idempotence
+  fetch: src={{ output_dir }}/orig dest={{ output_dir }}/fetched
+  register: fetched
+
+- name: Assert that the file was not fetched the second time
+  assert:
+    that:
+      - 'fetched["changed"] == False'
+      - 'fetched["checksum"] == "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"'
 
 - name: attempt to fetch a non-existent file - do not fail on missing
   fetch: src={{ output_dir }}/doesnotexist dest={{ output_dir }}/fetched


### PR DESCRIPTION
validate_checksum is supposed to default to True but it has been
defaulting to False since 2.0.

Also added an integration test for fetch module idempotence.  (Testing
that validate_checksum is doing what it's supposed to is harder as we'd
have to create a race condition with the downloaded data to trigger it.
Probably need to make that a unittest eventually).

Also give a deprecation message to the validate_md5 parameter so that we
can eventually get rid of it.

Fixes #23900

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
plugins/action/fetch.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.3
```