### PR TITLE
Document deprecation of fetch module validate_md5 and update --tags merging deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Ansible Changes By Release
   Ansible-2.3 until you can upgrade the system.
 
 ### Deprecations
-* Specifying --tags (or --skip-tags) multiple times on the command line
+* The behaviour when specifying --tags (or --skip-tags) multiple times on the command line
   has changed so that the tags are merged together by default.  See the
   documentation for how to temporarily use the old behaviour if needed:
   https://docs.ansible.com/ansible/intro_configuration.html#merge-multiple-cli-tags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ Ansible Changes By Release
   Python-2.5 you'll need to install Python-2.6 or better there or run
   Ansible-2.3 until you can upgrade the system.
 
+### Deprecations
+* Specifying --tags (or --skip-tags) multiple times on the command line
+  has changed so that the tags are merged together by default.  See the
+  documentation for how to temporarily use the old behaviour if needed:
+  https://docs.ansible.com/ansible/intro_configuration.html#merge-multiple-cli-tags
+* The fetch module's validate_md5 parameter has been deprecated and will be
+  removed in 2.8.  If you wish to disable post-validation of the downloaded
+  file, use validate_checksum instead.
+
 ### Minor Changes
 * removed previously deprecated config option 'hostfile' and env var 'ANSIBLE_HOSTS'
 * removed unused and deprecated config option 'pattern'

--- a/docs/docsite/rst/intro_configuration.rst
+++ b/docs/docsite/rst/intro_configuration.rst
@@ -607,15 +607,16 @@ merge_multiple_cli_tags
 
 .. versionadded:: 2.3
 
-This allows changing how multiple --tags and --skip-tags arguments are handled
-on the command line.  In Ansible up to and including 2.3, specifying --tags
-more than once will only take the last value of --tags.  Setting this config
-value to True will mean that all of the --tags options will be merged
-together.  The same holds true for --skip-tags.
+This allows changing how multiple :option:`--tags` and :option:`--skip-tags`
+arguments are handled on the command line.  Specifying :option:`--tags` more
+than once merges all of the :option:`--tags` options together.  If you want
+the pre-2.4.x behaviour where only the last value of :option:`--tags` is used,
+then set this to False.  The same holds true for :option:`--skip-tags`.
 
 .. note:: The default value for this in 2.3 is False.  In 2.4, the
-    default value will be True.  After 2.4, the option is going away.
-    Multiple --tags and multiple --skip-tags will always be merged together.
+    default value is True.  After 2.8, the option will be removed.
+    Multiple :option:`--tags` and multiple :option:`--skip-tags` will always
+    be merged together.
 
 .. _module_lang:
 

--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -276,7 +276,8 @@
 # This controls how ansible handles multiple --tags and --skip-tags arguments
 # on the CLI.  If this is True then multiple arguments are merged together.  If
 # it is False, then the last specified argument is used and the others are ignored.
-#merge_multiple_cli_flags = False
+# This option will be removed in 2.8.
+#merge_multiple_cli_flags = True
 
 # Controls showing custom stats at the end, off by default
 #show_custom_stats = True

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -190,7 +190,7 @@ DEFAULTS='defaults'
 # True, merge the lists of tags together.  If False, let the last argument
 # overwrite any previous ones.  Behaviour is overwrite through 2.2.  2.3
 # overwrites but prints deprecation.  2.4 the default is to merge.
-MERGE_MULTIPLE_CLI_TAGS = get_config(p, DEFAULTS, 'merge_multiple_cli_tags', 'ANSIBLE_MERGE_MULTIPLE_CLI_TAGS', False, value_type='boolean')
+MERGE_MULTIPLE_CLI_TAGS = get_config(p, DEFAULTS, 'merge_multiple_cli_tags', 'ANSIBLE_MERGE_MULTIPLE_CLI_TAGS', True, value_type='boolean')
 
 #### GENERALLY CONFIGURABLE THINGS ####
 DEFAULT_DEBUG             = get_config(p, DEFAULTS, 'debug',            'ANSIBLE_DEBUG',            False, value_type='boolean')


### PR DESCRIPTION

##### SUMMARY

Update some deprecation information for 2.4.
* Changed the wording of the --tags merging from future tense since this documentation will be present in 2.4.
* made sure that ansible.cfg has been updated to reflect the new default.
* Added deprecation documentation for fetch's validate_md5 (that code change is in: https://github.com/ansible/ansible/pull/24021 )


##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

