### PR TITLE
Remove unused+circular import in listify.py

### DIFF
--- a/lib/ansible/utils/listify.py
+++ b/lib/ansible/utils/listify.py
@@ -22,7 +22,6 @@ __metaclass__ = type
 from collections import Iterable
 
 from ansible.module_utils.six import string_types
-from ansible.template import Templar
 from ansible.template.safe_eval import safe_eval
 
 


### PR DESCRIPTION
##### SUMMARY
Remove unused+circular import in listify.py

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
listify.py

##### ANSIBLE VERSION

```
2.4
```


##### ADDITIONAL INFORMATION

Fixes ...

```
[jtanner@fedmac ansible.checkout]$ python -c 'import ansible.template; print(ansible.template.__file__)'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/jtanner/workspace/issues/AP-jinja-nostrings/ansible.checkout/lib/ansible/template/__init__.py", line 56, in <module>
    from ansible.vars.unsafe_proxy import UnsafeProxy, wrap_var
  File "/home/jtanner/workspace/issues/AP-jinja-nostrings/ansible.checkout/lib/ansible/vars/__init__.py", line 42, in <module>
    from ansible.utils.listify import listify_lookup_plugin_terms
  File "/home/jtanner/workspace/issues/AP-jinja-nostrings/ansible.checkout/lib/ansible/utils/listify.py", line 25, in <module>
    from ansible.template import Templar
ImportError: cannot import name Templar
```