### PR TITLE
azure_rm_common: only remove tags from new_tags if append_tags is not…

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -464,17 +464,20 @@ class AzureRMModuleBase(object):
         :return: bool, dict
         '''
         new_tags = copy.copy(tags) if isinstance(tags, dict) else dict()
+        param_tags = self.module.params.get('tags') if isinstance(self.module.params.get('tags'), dict) else dict()
+        append_tags = self.module.get('append_tags') if self.module.get('append_tags') != None else True
         changed = False
-        if isinstance(self.module.params.get('tags'), dict):
-            for key, value in self.module.params['tags'].items():
-                if not new_tags.get(key) or new_tags[key] != value:
+        # check add or update
+        for key, value in param_tags.items():
+            if not new_tags.get(key) or new_tags[key] != value:
+                changed = True
+                new_tags[key] = value
+        # check remove
+        if not append_tags:
+            for key, value in tags.items():
+                if not param_tags.get(key):
+                    new_tags.pop(key)
                     changed = True
-                    new_tags[key] = value
-            if not self.module.params.get('append_tags') and isinstance(tags, dict):
-                for key, value in tags.items():
-                    if not self.module.params['tags'].get(key):
-                        new_tags.pop(key)
-                        changed = True
         return changed, new_tags
 
     def has_tags(self, obj_tags, tag_list):

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -465,7 +465,7 @@ class AzureRMModuleBase(object):
         '''
         new_tags = copy.copy(tags) if isinstance(tags, dict) else dict()
         param_tags = self.module.params.get('tags') if isinstance(self.module.params.get('tags'), dict) else dict()
-        append_tags = self.module.get('append_tags') if self.module.get('append_tags') != None else True
+        append_tags = self.module.params.get('append_tags') if self.module.params.get('append_tags') is not None else True
         changed = False
         # check add or update
         for key, value in param_tags.items():

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -470,7 +470,7 @@ class AzureRMModuleBase(object):
                 if not new_tags.get(key) or new_tags[key] != value:
                     changed = True
                     new_tags[key] = value
-            if isinstance(tags, dict):
+            if not self.module.params.get('append_tags') and isinstance(tags, dict):
                 for key, value in tags.items():
                     if not self.module.params['tags'].get(key):
                         new_tags.pop(key)

--- a/test/integration/targets/azure_rm_publicipaddress/tasks/main.yml
+++ b/test/integration/targets/azure_rm_publicipaddress/tasks/main.yml
@@ -15,6 +15,7 @@
       name: "pip{{ rpfx }}"
       allocation_method: Static
       domain_name: "{{ domain_name }}"
+      append_tags: no
       tags:
           testing: testing
           delete: on-exit
@@ -33,6 +34,7 @@
       name: "pip{{ rpfx }}"
       allocation_method: Static
       domain_name: "{{ domain_name }}"
+      append_tags: no
       tags:
           testing: testing
           delete: on-exit
@@ -45,8 +47,8 @@
   azure_rm_publicipaddress:
       resource_group: "{{ resource_group }}"
       name: "pip{{ rpfx }}"
+      append_tags: yes
       tags:
-          testing: testing
           delete: never
           foo: bar
   register: output
@@ -59,6 +61,7 @@
 - name: Gather facts, filtering by tag
   azure_rm_publicipaddress_facts:
       resource_group: "{{ resource_group }}"
+      append_tags: no
       tags:
           - testing
           - foo:bar
@@ -70,6 +73,7 @@
   azure_rm_publicipaddress:
       resource_group: "{{ resource_group }}"
       name: "pip{{ rpfx }}"
+      append_tags: no
       tags: {}
   register: output
 

--- a/test/integration/targets/azure_rm_publicipaddress/tasks/main.yml
+++ b/test/integration/targets/azure_rm_publicipaddress/tasks/main.yml
@@ -61,7 +61,6 @@
 - name: Gather facts, filtering by tag
   azure_rm_publicipaddress_facts:
       resource_group: "{{ resource_group }}"
-      append_tags: no
       tags:
           - testing
           - foo:bar

--- a/test/integration/targets/azure_rm_publicipaddress/tasks/main.yml
+++ b/test/integration/targets/azure_rm_publicipaddress/tasks/main.yml
@@ -15,7 +15,6 @@
       name: "pip{{ rpfx }}"
       allocation_method: Static
       domain_name: "{{ domain_name }}"
-      append_tags: no
       tags:
           testing: testing
           delete: on-exit
@@ -34,10 +33,6 @@
       name: "pip{{ rpfx }}"
       allocation_method: Static
       domain_name: "{{ domain_name }}"
-      append_tags: no
-      tags:
-          testing: testing
-          delete: on-exit
   register: output
 
 - assert:
@@ -73,7 +68,6 @@
       resource_group: "{{ resource_group }}"
       name: "pip{{ rpfx }}"
       append_tags: no
-      tags: {}
   register: output
 
 - assert:

--- a/test/integration/targets/azure_rm_securitygroup/tasks/main.yml
+++ b/test/integration/targets/azure_rm_securitygroup/tasks/main.yml
@@ -94,6 +94,7 @@
           testing: testing
           delete: never
           baz: bar
+      append_tags: false
   register: output
 
 - assert:

--- a/test/integration/targets/azure_rm_securitygroup/tasks/main.yml
+++ b/test/integration/targets/azure_rm_securitygroup/tasks/main.yml
@@ -106,6 +106,7 @@
   azure_rm_securitygroup:
       resource_group: "{{ resource_group }}"
       name: "{{ secgroupname }}"
+      append_tags: false
       tags:
           testing: testing
           delete: on-exit

--- a/test/integration/targets/azure_rm_storageaccount/tasks/main.yml
+++ b/test/integration/targets/azure_rm_storageaccount/tasks/main.yml
@@ -24,6 +24,7 @@
        resource_group: "{{ resource_group }}" 
        name: "{{ storage_account }}"
        account_type: Standard_LRS
+       append_tags: no
        tags:
            test: test
            galaxy: galaxy
@@ -38,6 +39,7 @@
  - name: Gather facts by tags
    azure_rm_storageaccount_facts:
        resource_group: "{{ resource_group }}"
+       append_tags: no
        tags:
          - test
          - galaxy
@@ -72,6 +74,7 @@
    azure_rm_storageaccount:
        resource_group: "{{ resource_group }}"
        name: "{{ storage_account }}"
+       append_tags: no
        tags:
            testing: testing
            delete: never
@@ -87,6 +90,7 @@
    azure_rm_storageaccount:
        resource_group: "{{ resource_group }}"
        name: "{{ storage_account }}"
+       append_tags: no
        tags:
            testing: testing
            delete: never

--- a/test/integration/targets/azure_rm_storageaccount/tasks/main.yml
+++ b/test/integration/targets/azure_rm_storageaccount/tasks/main.yml
@@ -39,7 +39,6 @@
  - name: Gather facts by tags
    azure_rm_storageaccount_facts:
        resource_group: "{{ resource_group }}"
-       append_tags: no
        tags:
          - test
          - galaxy

--- a/test/integration/targets/azure_rm_virtualnetwork/tasks/main.yml
+++ b/test/integration/targets/azure_rm_virtualnetwork/tasks/main.yml
@@ -102,6 +102,7 @@
 - name: Purge tags
   azure_rm_virtualnetwork:
     name: "{{ vnetname }}"
+    append_tags: no
     tags:
       testing: 'always'
     resource_group: "{{ resource_group }}"


### PR DESCRIPTION
##### SUMMARY
Fix #23765
the azure_rm_virtualmachine module
https://docs.ansible.com/ansible/azure_rm_virtualmachine_module.html
has documented a append_tags parameter, which should append tags if set to true, but does not.

This pull request changes the behavior of the azure_rm_common module utility such that the update_tags method will check if append_tags is True, and not remove existing tags from the set of tags it returns in that case.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/azure_rm_common.py
