### PR TITLE
Additional simpler json_query documentation

### DIFF
--- a/docs/docsite/rst/playbooks_filters.rst
+++ b/docs/docsite/rst/playbooks_filters.rst
@@ -286,6 +286,15 @@ This example shows ports from cluster1::
 
 .. note:: You can use a variable to make the query more readable.
 
+Or, alternatively::
+
+    - name: "Display all server names from cluster1"
+      debug:
+        var: item
+      with_items: "{{domain_definition|json_query('domain.server[?cluster=`cluster`].port')}}"
+
+.. note:: Here, quoting literals using backticks avoids escaping quotes and maintains readability.
+
 In this example, we get a hash map with all ports and names of a cluster::
 
     - name: "Display all server ports and names from cluster1"


### PR DESCRIPTION
##### SUMMARY
Since json_query treats backticks as delimiters for literals,
some of the examples in the json_query docs can be made a little
simpler. Rather than replacing such examples, demonstrate the
alternative


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
plugin docs

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel a5d6d3b9af) last updated 2017/04/27 09:28:12 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```
