### PR TITLE
Make ec2_vpc_nat_gateway results consistent

### DIFF
--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -176,7 +176,6 @@ lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_options.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
-lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_net_facts.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py

--- a/test/units/modules/cloud/amazon/test_ec2_vpc_nat_gateway.py
+++ b/test/units/modules/cloud/amazon/test_ec2_vpc_nat_gateway.py
@@ -264,36 +264,6 @@ class AnsibleVpcNatGatewayTasks(unittest.TestCase):
 
 class AnsibleEc2VpcNatGatewayFunctions(unittest.TestCase):
 
-    def test_convert_to_lower(self):
-        example = ng.DRY_RUN_GATEWAY_UNCONVERTED
-        converted_example = ng.convert_to_lower(example[0])
-        keys = list(converted_example.keys())
-        keys.sort()
-        for i in range(len(keys)):
-            if i == 0:
-                self.assertEqual(keys[i], 'create_time')
-            if i == 1:
-                self.assertEqual(keys[i], 'nat_gateway_addresses')
-                gw_addresses_keys = list(converted_example[keys[i]][0].keys())
-                gw_addresses_keys.sort()
-                for j in range(len(gw_addresses_keys)):
-                    if j == 0:
-                        self.assertEqual(gw_addresses_keys[j], 'allocation_id')
-                    if j == 1:
-                        self.assertEqual(gw_addresses_keys[j], 'network_interface_id')
-                    if j == 2:
-                        self.assertEqual(gw_addresses_keys[j], 'private_ip')
-                    if j == 3:
-                        self.assertEqual(gw_addresses_keys[j], 'public_ip')
-            if i == 2:
-                self.assertEqual(keys[i], 'nat_gateway_id')
-            if i == 3:
-                self.assertEqual(keys[i], 'state')
-            if i == 4:
-                self.assertEqual(keys[i], 'subnet_id')
-            if i == 5:
-                self.assertEqual(keys[i], 'vpc_id')
-
     def test_get_nat_gateways(self):
         client = boto3.client('ec2', region_name=aws_region)
         success, err_msg, stream = (


### PR DESCRIPTION
##### SUMMARY
Ensure newly created NAT gateways get converted to snake dict
Remove custom code for generating snake dict and use camel_dict_to_snake_dict
Make use of required_if rather than bespoke parameter checks

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc_nat_gateway

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel a5d6d3b9af) last updated 2017/04/27 09:28:12 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
Behaviour is already correct for existing nat gateways, which get converted to snake case, but new nat gateways don't get converted.