### PR TITLE
Fix bugs in ansible-test units command.

### DIFF
--- a/test/runner/lib/delegation.py
+++ b/test/runner/lib/delegation.py
@@ -16,6 +16,7 @@ from lib.executor import (
     SubprocessError,
     ShellConfig,
     SanityConfig,
+    UnitsConfig,
     create_shell_command,
 )
 
@@ -201,6 +202,10 @@ def delegate_docker(args, exclude, require):
         docker_exec(args, test_id, ['mkdir', '/root/ansible'])
         docker_exec(args, test_id, ['tar', 'oxzf', '/root/ansible.tgz', '-C', '/root/ansible'])
 
+        # docker images are only expected to have a single python version available
+        if isinstance(args, UnitsConfig) and not args.python:
+            cmd += ['--python', 'default']
+
         try:
             docker_exec(args, test_id, cmd, options=cmd_options)
         finally:
@@ -355,6 +360,10 @@ def delegate_remote(args, exclude, require):
         if isinstance(args, IntegrationConfig):
             if not args.allow_destructive:
                 cmd.append('--allow-destructive')
+
+        # remote instances are only expected to have a single python version available
+        if isinstance(args, UnitsConfig) and not args.python:
+            cmd += ['--python', 'default']
 
         manage = ManagePosixCI(core_ci)
         manage.setup()

--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -477,6 +477,9 @@ class EnvironmentConfig(CommonConfig):
 
         self.requirements = args.requirements  # type: bool
 
+        if self.python == 'default':
+            self.python = '.'.join(str(i) for i in sys.version_info[:2])
+
         self.python_version = self.python or '.'.join(str(i) for i in sys.version_info[:2])
 
         self.delegate = self.tox or self.docker or self.remote

--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -12,5 +12,6 @@ pytest-xdist
 python-memcached
 pyyaml
 redis
+setuptools > 0.6 # pytest-xdist installed via requirements does not work with very old setuptools
 unittest2 ; python_version < '2.7'
 netaddr

--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -12,6 +12,6 @@ pytest-xdist
 python-memcached
 pyyaml
 redis
-setuptools > 0.6 # pytest-xdist installed via requirements does not work with very old setuptools
+setuptools > 0.6 # pytest-xdist installed via requirements does not work with very old setuptools (sanity_ok)
 unittest2 ; python_version < '2.7'
 netaddr

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -241,7 +241,7 @@ def parse_args():
 
     units.add_argument('--python',
                        metavar='VERSION',
-                       choices=SUPPORTED_PYTHON_VERSIONS,
+                       choices=SUPPORTED_PYTHON_VERSIONS + ('default',),
                        help='python version: %s' % ', '.join(SUPPORTED_PYTHON_VERSIONS))
 
     units.add_argument('--collect-only',

--- a/test/sanity/code-smell/test-constraints.sh
+++ b/test/sanity/code-smell/test-constraints.sh
@@ -2,6 +2,7 @@
 
 constraints=$(
     grep '.' test/runner/requirements/*.txt \
+        | grep -v '(sanity_ok)$' \
         | sed 's/ *;.*$//; s/ #.*$//' \
         | grep -v '/constraints.txt:' \
         | grep '[<>=]'

--- a/test/units/conftest.py
+++ b/test/units/conftest.py
@@ -7,6 +7,11 @@ try:
 except ImportError:
     coverage = None
 
+try:
+    test = coverage.Coverage
+except AttributeError:
+    coverage = None
+
 
 def pytest_configure():
     if not coverage:


### PR DESCRIPTION
##### SUMMARY

Fix bugs in ansible-test units command:

- Handle old versions of coverage.
- Handle old versions of setuptools.
- Detect python version for docker/remote units.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.4.0 (units-fixes 8d41931e69) last updated 2017/04/27 10:20:30 (GMT +800)
  config file = 
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
