### PR TITLE
Avi 17 1

### DIFF
--- a/lib/ansible/module_utils/avi.py
+++ b/lib/ansible/module_utils/avi.py
@@ -59,7 +59,8 @@ def avi_common_argument_spec():
         username=dict(default=os.environ.get('AVI_USERNAME', '')),
         password=dict(default=os.environ.get('AVI_PASSWORD', ''), no_log=True),
         tenant=dict(default='admin'),
-        tenant_uuid=dict(default=''))
+        tenant_uuid=dict(default=''),
+        api_version=dict(default='16.4'))
 
 
 def ansible_return(module, rsp, changed, req=None, existing_obj=None):

--- a/lib/ansible/module_utils/avi.py
+++ b/lib/ansible/module_utils/avi.py
@@ -41,7 +41,7 @@ try:
     import avi.sdk
     sdk_version = getattr(avi.sdk, '__version__', None)
     if ((sdk_version is None) or (sdk_version and
-            (parse_version(sdk_version) < parse_version('16.3.5.post1')))):
+            (parse_version(sdk_version) < parse_version('17.1')))):
         # It allows the __version__ to be '' as that value is used in development builds
         raise ImportError
     from avi.sdk.utils.ansible_utils import avi_ansible_api

--- a/lib/ansible/modules/network/avi/avi_analyticsprofile.py
+++ b/lib/ansible/modules/network/avi/avi_analyticsprofile.py
@@ -112,6 +112,7 @@ options:
         description:
             - Configure to send logs to a remote syslog server.
             - Field introduced in 17.1.1.
+        version_added: "2.4"
     conn_lossy_ooo_threshold:
         description:
             - A connection between client and avi is considered lossy when more than this percentage of out of order packets are received.

--- a/lib/ansible/modules/network/avi/avi_analyticsprofile.py
+++ b/lib/ansible/modules/network/avi/avi_analyticsprofile.py
@@ -4,7 +4,7 @@
 # @author: Gaurav Rastogi (grastogi@avinetworks.com)
 #          Eric Anderson (eanderson@avinetworks.com)
 # module_check: supported
-# Avi Version: 16.3.8
+# Avi Version: 17.1.1
 #
 #
 # This file is part of Ansible
@@ -26,7 +26,6 @@
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
-
 
 DOCUMENTATION = '''
 ---
@@ -50,20 +49,24 @@ options:
             - If a client receives an http response in less than the satisfactory latency threshold, the request is considered satisfied.
             - It is considered tolerated if it is not satisfied and less than tolerated latency factor multiplied by the satisfactory latency threshold.
             - Greater than this number and the client's request is considered frustrated.
+            - Allowed values are 1-30000.
             - Default value when not specified in API or module is interpreted by Avi Controller as 500.
     apdex_response_tolerated_factor:
         description:
             - Client tolerated response latency factor.
             - Client must receive a response within this factor times the satisfactory threshold (apdex_response_threshold) to be considered tolerated.
+            - Allowed values are 1-1000.
             - Default value when not specified in API or module is interpreted by Avi Controller as 4.0.
     apdex_rtt_threshold:
         description:
             - Satisfactory client to avi round trip time(rtt).
+            - Allowed values are 1-2000.
             - Default value when not specified in API or module is interpreted by Avi Controller as 250.
     apdex_rtt_tolerated_factor:
         description:
             - Tolerated client to avi round trip time(rtt) factor.
             - It is a multiple of apdex_rtt_tolerated_factor.
+            - Allowed values are 1-1000.
             - Default value when not specified in API or module is interpreted by Avi Controller as 4.0.
     apdex_rum_threshold:
         description:
@@ -71,65 +74,83 @@ options:
             - It is considered tolerated if it is greater than satisfied but less than the tolerated latency multiplied by satisifed latency.
             - Greater than this number and the client's request is considered frustrated.
             - A pageload includes the time for dns lookup, download of all http objects, and page render time.
+            - Allowed values are 1-30000.
             - Default value when not specified in API or module is interpreted by Avi Controller as 5000.
     apdex_rum_tolerated_factor:
         description:
             - Virtual service threshold factor for tolerated page load time (plt) as multiple of apdex_rum_threshold.
+            - Allowed values are 1-1000.
             - Default value when not specified in API or module is interpreted by Avi Controller as 4.0.
     apdex_server_response_threshold:
         description:
             - A server http response is considered satisfied if latency is less than the satisfactory latency threshold.
             - The response is considered tolerated when it is greater than satisfied but less than the tolerated latency factor * s_latency.
             - Greater than this number and the server response is considered frustrated.
+            - Allowed values are 1-30000.
             - Default value when not specified in API or module is interpreted by Avi Controller as 400.
     apdex_server_response_tolerated_factor:
         description:
             - Server tolerated response latency factor.
             - Servermust response within this factor times the satisfactory threshold (apdex_server_response_threshold) to be considered tolerated.
+            - Allowed values are 1-1000.
             - Default value when not specified in API or module is interpreted by Avi Controller as 4.0.
     apdex_server_rtt_threshold:
         description:
             - Satisfactory client to avi round trip time(rtt).
+            - Allowed values are 1-2000.
             - Default value when not specified in API or module is interpreted by Avi Controller as 125.
     apdex_server_rtt_tolerated_factor:
         description:
             - Tolerated client to avi round trip time(rtt) factor.
             - It is a multiple of apdex_rtt_tolerated_factor.
+            - Allowed values are 1-1000.
             - Default value when not specified in API or module is interpreted by Avi Controller as 4.0.
     client_log_config:
         description:
-            - Clientlogconfiguration settings for analyticsprofile.
+            - Configure which logs are sent to the avi controller from ses and how they are processed.
+    client_log_syslog_config:
+        description:
+            - Configure to send logs to a remote syslog server.
+            - Field introduced in 17.1.1.
     conn_lossy_ooo_threshold:
         description:
             - A connection between client and avi is considered lossy when more than this percentage of out of order packets are received.
+            - Allowed values are 1-100.
             - Default value when not specified in API or module is interpreted by Avi Controller as 50.
     conn_lossy_timeo_rexmt_threshold:
         description:
             - A connection between client and avi is considered lossy when more than this percentage of packets are retransmitted due to timeout.
+            - Allowed values are 1-100.
             - Default value when not specified in API or module is interpreted by Avi Controller as 20.
     conn_lossy_total_rexmt_threshold:
         description:
             - A connection between client and avi is considered lossy when more than this percentage of packets are retransmitted.
+            - Allowed values are 1-100.
             - Default value when not specified in API or module is interpreted by Avi Controller as 50.
     conn_lossy_zero_win_size_event_threshold:
         description:
             - A client connection is considered lossy when percentage of times a packet could not be trasmitted due to tcp zero window is above this threshold.
+            - Allowed values are 0-100.
             - Default value when not specified in API or module is interpreted by Avi Controller as 2.
     conn_server_lossy_ooo_threshold:
         description:
             - A connection between avi and server is considered lossy when more than this percentage of out of order packets are received.
+            - Allowed values are 1-100.
             - Default value when not specified in API or module is interpreted by Avi Controller as 50.
     conn_server_lossy_timeo_rexmt_threshold:
         description:
             - A connection between avi and server is considered lossy when more than this percentage of packets are retransmitted due to timeout.
+            - Allowed values are 1-100.
             - Default value when not specified in API or module is interpreted by Avi Controller as 20.
     conn_server_lossy_total_rexmt_threshold:
         description:
             - A connection between avi and server is considered lossy when more than this percentage of packets are retransmitted.
+            - Allowed values are 1-100.
             - Default value when not specified in API or module is interpreted by Avi Controller as 50.
     conn_server_lossy_zero_win_size_event_threshold:
         description:
             - A server connection is considered lossy when percentage of times a packet could not be trasmitted due to tcp zero window is above this threshold.
+            - Allowed values are 0-100.
             - Default value when not specified in API or module is interpreted by Avi Controller as 2.
     description:
         description:
@@ -203,14 +224,17 @@ options:
     hs_max_anomaly_penalty:
         description:
             - Maximum penalty that may be deducted from health score for anomalies.
+            - Allowed values are 0-100.
             - Default value when not specified in API or module is interpreted by Avi Controller as 10.
     hs_max_resources_penalty:
         description:
             - Maximum penalty that may be deducted from health score for high resource utilization.
+            - Allowed values are 0-100.
             - Default value when not specified in API or module is interpreted by Avi Controller as 25.
     hs_max_security_penalty:
         description:
             - Maximum penalty that may be deducted from health score based on security assessment.
+            - Allowed values are 0-100.
             - Default value when not specified in API or module is interpreted by Avi Controller as 100.
     hs_min_dos_rate:
         description:
@@ -220,6 +244,7 @@ options:
         description:
             - Adds free performance score credits to health score.
             - It can be used for compensating health score for known slow applications.
+            - Allowed values are 0-100.
             - Default value when not specified in API or module is interpreted by Avi Controller as 0.
     hs_pscore_traffic_threshold_l4_client:
         description:
@@ -232,74 +257,92 @@ options:
     hs_security_certscore_expired:
         description:
             - Score assigned when the certificate has expired.
+            - Allowed values are 0-5.
             - Default value when not specified in API or module is interpreted by Avi Controller as 0.0.
     hs_security_certscore_gt30d:
         description:
             - Score assigned when the certificate expires in more than 30 days.
+            - Allowed values are 0-5.
             - Default value when not specified in API or module is interpreted by Avi Controller as 5.0.
     hs_security_certscore_le07d:
         description:
             - Score assigned when the certificate expires in less than or equal to 7 days.
+            - Allowed values are 0-5.
             - Default value when not specified in API or module is interpreted by Avi Controller as 2.0.
     hs_security_certscore_le30d:
         description:
             - Score assigned when the certificate expires in less than or equal to 30 days.
+            - Allowed values are 0-5.
             - Default value when not specified in API or module is interpreted by Avi Controller as 4.0.
     hs_security_chain_invalidity_penalty:
         description:
             - Penalty for allowing certificates with invalid chain.
+            - Allowed values are 0-5.
             - Default value when not specified in API or module is interpreted by Avi Controller as 1.0.
     hs_security_cipherscore_eq000b:
         description:
             - Score assigned when the minimum cipher strength is 0 bits.
+            - Allowed values are 0-5.
             - Default value when not specified in API or module is interpreted by Avi Controller as 0.0.
     hs_security_cipherscore_ge128b:
         description:
             - Score assigned when the minimum cipher strength is greater than equal to 128 bits.
+            - Allowed values are 0-5.
             - Default value when not specified in API or module is interpreted by Avi Controller as 5.0.
     hs_security_cipherscore_lt128b:
         description:
             - Score assigned when the minimum cipher strength is less than 128 bits.
+            - Allowed values are 0-5.
             - Default value when not specified in API or module is interpreted by Avi Controller as 3.5.
     hs_security_encalgo_score_none:
         description:
             - Score assigned when no algorithm is used for encryption.
+            - Allowed values are 0-5.
             - Default value when not specified in API or module is interpreted by Avi Controller as 0.0.
     hs_security_encalgo_score_rc4:
         description:
             - Score assigned when rc4 algorithm is used for encryption.
+            - Allowed values are 0-5.
             - Default value when not specified in API or module is interpreted by Avi Controller as 2.5.
     hs_security_hsts_penalty:
         description:
             - Penalty for not enabling hsts.
+            - Allowed values are 0-5.
             - Default value when not specified in API or module is interpreted by Avi Controller as 1.0.
     hs_security_nonpfs_penalty:
         description:
             - Penalty for allowing non-pfs handshakes.
+            - Allowed values are 0-5.
             - Default value when not specified in API or module is interpreted by Avi Controller as 1.0.
     hs_security_selfsignedcert_penalty:
         description:
             - Deprecated.
+            - Allowed values are 0-5.
             - Default value when not specified in API or module is interpreted by Avi Controller as 1.0.
     hs_security_ssl30_score:
         description:
             - Score assigned when supporting ssl3.0 encryption protocol.
+            - Allowed values are 0-5.
             - Default value when not specified in API or module is interpreted by Avi Controller as 3.5.
     hs_security_tls10_score:
         description:
             - Score assigned when supporting tls1.0 encryption protocol.
+            - Allowed values are 0-5.
             - Default value when not specified in API or module is interpreted by Avi Controller as 5.0.
     hs_security_tls11_score:
         description:
             - Score assigned when supporting tls1.1 encryption protocol.
+            - Allowed values are 0-5.
             - Default value when not specified in API or module is interpreted by Avi Controller as 5.0.
     hs_security_tls12_score:
         description:
             - Score assigned when supporting tls1.2 encryption protocol.
+            - Allowed values are 0-5.
             - Default value when not specified in API or module is interpreted by Avi Controller as 5.0.
     hs_security_weak_signature_algo_penalty:
         description:
             - Penalty for allowing weak signature algorithm(s).
+            - Allowed values are 0-5.
             - Default value when not specified in API or module is interpreted by Avi Controller as 1.0.
     name:
         description:
@@ -311,6 +354,7 @@ options:
     resp_code_block:
         description:
             - Block of http response codes to be excluded from being classified as an error.
+            - Enum options - AP_HTTP_RSP_4XX, AP_HTTP_RSP_5XX.
     tenant_ref:
         description:
             - It is a reference to an object of type tenant.
@@ -393,7 +437,6 @@ obj:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-
 try:
     from ansible.module_utils.avi import (
         avi_common_argument_spec, HAS_AVI, avi_ansible_api)
@@ -416,6 +459,7 @@ def main():
         apdex_server_rtt_threshold=dict(type='int',),
         apdex_server_rtt_tolerated_factor=dict(type='float',),
         client_log_config=dict(type='dict',),
+        client_log_syslog_config=dict(type='dict',),
         conn_lossy_ooo_threshold=dict(type='int',),
         conn_lossy_timeo_rexmt_threshold=dict(type='int',),
         conn_lossy_total_rexmt_threshold=dict(type='int',),
@@ -478,11 +522,10 @@ def main():
         argument_spec=argument_specs, supports_check_mode=True)
     if not HAS_AVI:
         return module.fail_json(msg=(
-            'Avi python API SDK (avisdk>=16.3.5.post1) is not installed. '
+            'Avi python API SDK (avisdk>=17.1) is not installed. '
             'For more details visit https://github.com/avinetworks/sdk.'))
     return avi_ansible_api(module, 'analyticsprofile',
                            set([]))
-
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/avi/avi_applicationpersistenceprofile.py
+++ b/lib/ansible/modules/network/avi/avi_applicationpersistenceprofile.py
@@ -4,7 +4,7 @@
 # @author: Gaurav Rastogi (grastogi@avinetworks.com)
 #          Eric Anderson (eanderson@avinetworks.com)
 # module_check: supported
-# Avi Version: 16.3.8
+# Avi Version: 17.1.1
 #
 #
 # This file is part of Ansible
@@ -26,7 +26,6 @@
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
-
 
 DOCUMENTATION = '''
 ---
@@ -67,11 +66,14 @@ options:
     persistence_type:
         description:
             - Method used to persist clients to the same server for a duration of time or a session.
+            - Enum options - PERSISTENCE_TYPE_CLIENT_IP_ADDRESS, PERSISTENCE_TYPE_HTTP_COOKIE, PERSISTENCE_TYPE_TLS, PERSISTENCE_TYPE_CLIENT_IPV6_ADDRESS,
+            - PERSISTENCE_TYPE_CUSTOM_HTTP_HEADER, PERSISTENCE_TYPE_APP_COOKIE, PERSISTENCE_TYPE_GSLB_SITE.
             - Default value when not specified in API or module is interpreted by Avi Controller as PERSISTENCE_TYPE_CLIENT_IP_ADDRESS.
         required: true
     server_hm_down_recovery:
         description:
             - Specifies behavior when a persistent server has been marked down by a health monitor.
+            - Enum options - HM_DOWN_PICK_NEW_SERVER, HM_DOWN_ABORT_CONNECTION, HM_DOWN_CONTINUE_PERSISTENT_SERVER.
             - Default value when not specified in API or module is interpreted by Avi Controller as HM_DOWN_PICK_NEW_SERVER.
     tenant_ref:
         description:
@@ -117,7 +119,6 @@ obj:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-
 try:
     from ansible.module_utils.avi import (
         avi_common_argument_spec, HAS_AVI, avi_ansible_api)
@@ -146,11 +147,10 @@ def main():
         argument_spec=argument_specs, supports_check_mode=True)
     if not HAS_AVI:
         return module.fail_json(msg=(
-            'Avi python API SDK (avisdk>=16.3.5.post1) is not installed. '
+            'Avi python API SDK (avisdk>=17.1) is not installed. '
             'For more details visit https://github.com/avinetworks/sdk.'))
     return avi_ansible_api(module, 'applicationpersistenceprofile',
                            set([]))
-
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/avi/avi_applicationprofile.py
+++ b/lib/ansible/modules/network/avi/avi_applicationprofile.py
@@ -4,7 +4,7 @@
 # @author: Gaurav Rastogi (grastogi@avinetworks.com)
 #          Eric Anderson (eanderson@avinetworks.com)
 # module_check: supported
-# Avi Version: 16.3.8
+# Avi Version: 17.1.1
 #
 #
 # This file is part of Ansible
@@ -26,7 +26,6 @@
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
-
 
 DOCUMENTATION = '''
 ---
@@ -75,6 +74,8 @@ options:
     type:
         description:
             - Specifies which application layer proxy is enabled for the virtual service.
+            - Enum options - APPLICATION_PROFILE_TYPE_L4, APPLICATION_PROFILE_TYPE_HTTP, APPLICATION_PROFILE_TYPE_SYSLOG, APPLICATION_PROFILE_TYPE_DNS,
+            - APPLICATION_PROFILE_TYPE_SSL.
         required: true
     url:
         description:
@@ -156,7 +157,6 @@ obj:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-
 try:
     from ansible.module_utils.avi import (
         avi_common_argument_spec, HAS_AVI, avi_ansible_api)
@@ -185,11 +185,10 @@ def main():
         argument_spec=argument_specs, supports_check_mode=True)
     if not HAS_AVI:
         return module.fail_json(msg=(
-            'Avi python API SDK (avisdk>=16.3.5.post1) is not installed. '
+            'Avi python API SDK (avisdk>=17.1) is not installed. '
             'For more details visit https://github.com/avinetworks/sdk.'))
     return avi_ansible_api(module, 'applicationprofile',
                            set([]))
-
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/avi/avi_certificatemanagementprofile.py
+++ b/lib/ansible/modules/network/avi/avi_certificatemanagementprofile.py
@@ -4,7 +4,7 @@
 # @author: Gaurav Rastogi (grastogi@avinetworks.com)
 #          Eric Anderson (eanderson@avinetworks.com)
 # module_check: supported
-# Avi Version: 16.3.8
+# Avi Version: 17.1.1
 #
 #
 # This file is part of Ansible
@@ -26,7 +26,6 @@
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
-
 
 DOCUMENTATION = '''
 ---
@@ -87,7 +86,6 @@ obj:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-
 try:
     from ansible.module_utils.avi import (
         avi_common_argument_spec, HAS_AVI, avi_ansible_api)
@@ -111,11 +109,10 @@ def main():
         argument_spec=argument_specs, supports_check_mode=True)
     if not HAS_AVI:
         return module.fail_json(msg=(
-            'Avi python API SDK (avisdk>=16.3.5.post1) is not installed. '
+            'Avi python API SDK (avisdk>=17.1) is not installed. '
             'For more details visit https://github.com/avinetworks/sdk.'))
     return avi_ansible_api(module, 'certificatemanagementprofile',
                            set([]))
-
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/avi/avi_healthmonitor.py
+++ b/lib/ansible/modules/network/avi/avi_healthmonitor.py
@@ -4,7 +4,7 @@
 # @author: Gaurav Rastogi (grastogi@avinetworks.com)
 #          Eric Anderson (eanderson@avinetworks.com)
 # module_check: supported
-# Avi Version: 16.3.8
+# Avi Version: 17.1.1
 #
 #
 # This file is part of Ansible
@@ -26,7 +26,6 @@
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
-
 
 DOCUMENTATION = '''
 ---
@@ -57,6 +56,7 @@ options:
     failed_checks:
         description:
             - Number of continuous failed health checks before the server is marked down.
+            - Allowed values are 1-50.
             - Default value when not specified in API or module is interpreted by Avi Controller as 2.
     http_monitor:
         description:
@@ -68,6 +68,8 @@ options:
         description:
             - Use this port instead of the port defined for the server in the pool.
             - If the monitor succeeds to this port, the load balanced traffic will still be sent to the port of the server defined within the pool.
+            - Allowed values are 1-65535.
+            - Special values are 0 - 'use server port'.
     name:
         description:
             - A user friendly name for this health monitor.
@@ -77,14 +79,17 @@ options:
             - A valid response from the server is expected within the receive timeout window.
             - This timeout must be less than the send interval.
             - If server status is regularly flapping up and down, consider increasing this value.
+            - Allowed values are 1-300.
             - Default value when not specified in API or module is interpreted by Avi Controller as 4.
     send_interval:
         description:
             - Frequency, in seconds, that monitors are sent to a server.
+            - Allowed values are 1-3600.
             - Default value when not specified in API or module is interpreted by Avi Controller as 10.
     successful_checks:
         description:
             - Number of continuous successful health checks before server is marked up.
+            - Allowed values are 1-50.
             - Default value when not specified in API or module is interpreted by Avi Controller as 2.
     tcp_monitor:
         description:
@@ -95,6 +100,8 @@ options:
     type:
         description:
             - Type of the health monitor.
+            - Enum options - HEALTH_MONITOR_PING, HEALTH_MONITOR_TCP, HEALTH_MONITOR_HTTP, HEALTH_MONITOR_HTTPS, HEALTH_MONITOR_EXTERNAL, HEALTH_MONITOR_UDP,
+            - HEALTH_MONITOR_DNS, HEALTH_MONITOR_GSLB.
         required: true
     udp_monitor:
         description:
@@ -136,7 +143,6 @@ obj:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-
 try:
     from ansible.module_utils.avi import (
         avi_common_argument_spec, HAS_AVI, avi_ansible_api)
@@ -171,11 +177,10 @@ def main():
         argument_spec=argument_specs, supports_check_mode=True)
     if not HAS_AVI:
         return module.fail_json(msg=(
-            'Avi python API SDK (avisdk>=16.3.5.post1) is not installed. '
+            'Avi python API SDK (avisdk>=17.1) is not installed. '
             'For more details visit https://github.com/avinetworks/sdk.'))
     return avi_ansible_api(module, 'healthmonitor',
                            set([]))
-
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/avi/avi_networkprofile.py
+++ b/lib/ansible/modules/network/avi/avi_networkprofile.py
@@ -4,7 +4,7 @@
 # @author: Gaurav Rastogi (grastogi@avinetworks.com)
 #          Eric Anderson (eanderson@avinetworks.com)
 # module_check: supported
-# Avi Version: 16.3.8
+# Avi Version: 17.1.1
 #
 #
 # This file is part of Ansible
@@ -26,7 +26,6 @@
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
-
 
 DOCUMENTATION = '''
 ---
@@ -93,7 +92,6 @@ obj:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-
 try:
     from ansible.module_utils.avi import (
         avi_common_argument_spec, HAS_AVI, avi_ansible_api)
@@ -117,11 +115,10 @@ def main():
         argument_spec=argument_specs, supports_check_mode=True)
     if not HAS_AVI:
         return module.fail_json(msg=(
-            'Avi python API SDK (avisdk>=16.3.5.post1) is not installed. '
+            'Avi python API SDK (avisdk>=17.1) is not installed. '
             'For more details visit https://github.com/avinetworks/sdk.'))
     return avi_ansible_api(module, 'networkprofile',
                            set([]))
-
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/avi/avi_pkiprofile.py
+++ b/lib/ansible/modules/network/avi/avi_pkiprofile.py
@@ -4,7 +4,7 @@
 # @author: Gaurav Rastogi (grastogi@avinetworks.com)
 #          Eric Anderson (eanderson@avinetworks.com)
 # module_check: supported
-# Avi Version: 16.3.8
+# Avi Version: 17.1.1
 #
 #
 # This file is part of Ansible
@@ -26,7 +26,6 @@
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
-
 
 DOCUMENTATION = '''
 ---
@@ -103,7 +102,6 @@ obj:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-
 try:
     from ansible.module_utils.avi import (
         avi_common_argument_spec, HAS_AVI, avi_ansible_api)
@@ -131,11 +129,10 @@ def main():
         argument_spec=argument_specs, supports_check_mode=True)
     if not HAS_AVI:
         return module.fail_json(msg=(
-            'Avi python API SDK (avisdk>=16.3.5.post1) is not installed. '
+            'Avi python API SDK (avisdk>=17.1) is not installed. '
             'For more details visit https://github.com/avinetworks/sdk.'))
     return avi_ansible_api(module, 'pkiprofile',
                            set([]))
-
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/avi/avi_pool.py
+++ b/lib/ansible/modules/network/avi/avi_pool.py
@@ -195,6 +195,7 @@ options:
         description:
             - A list of nsx service groups where the servers for the pool are created.
             - Field introduced in 17.1.1.
+        version_added: "2.4"
     pki_profile_ref:
         description:
             - Avi will validate the ssl certificate present by a server against the selected pki profile.

--- a/lib/ansible/modules/network/avi/avi_pool.py
+++ b/lib/ansible/modules/network/avi/avi_pool.py
@@ -4,7 +4,7 @@
 # @author: Gaurav Rastogi (grastogi@avinetworks.com)
 #          Eric Anderson (eanderson@avinetworks.com)
 # module_check: supported
-# Avi Version: 16.3.8
+# Avi Version: 17.1.1
 #
 #
 # This file is part of Ansible
@@ -26,7 +26,6 @@
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
-
 
 DOCUMENTATION = '''
 ---
@@ -64,7 +63,8 @@ options:
             - It is a reference to an object of type applicationpersistenceprofile.
     autoscale_launch_config_ref:
         description:
-            - Reference to the launch configuration profile.
+            - If configured then avi will trigger orchestration of pool server creation and deletion.
+            - It is only supported for container clouds like mesos, opensift, kubernates, docker etc.
             - It is a reference to an object of type autoscalelaunchconfig.
     autoscale_networks:
         description:
@@ -80,6 +80,8 @@ options:
     capacity_estimation_ttfb_thresh:
         description:
             - The maximum time-to-first-byte of a server.
+            - Allowed values are 1-5000.
+            - Special values are 0 - 'automatic'.
             - Default value when not specified in API or module is interpreted by Avi Controller as 0.
     cloud_config_cksum:
         description:
@@ -92,6 +94,8 @@ options:
         description:
             - Duration for which new connections will be gradually ramped up to a server recently brought online.
             - Useful for lb algorithms that are least connection based.
+            - Allowed values are 1-300.
+            - Special values are 0 - 'immediate'.
             - Default value when not specified in API or module is interpreted by Avi Controller as 10.
     created_by:
         description:
@@ -100,6 +104,7 @@ options:
         description:
             - Traffic sent to servers will use this destination server port unless overridden by the server's specific port attribute.
             - The ssl checkbox enables avi to server encryption.
+            - Allowed values are 1-65535.
             - Default value when not specified in API or module is interpreted by Avi Controller as 80.
     description:
         description:
@@ -123,11 +128,14 @@ options:
     fewest_tasks_feedback_delay:
         description:
             - Periodicity of feedback for fewest tasks server selection algorithm.
+            - Allowed values are 1-300.
             - Default value when not specified in API or module is interpreted by Avi Controller as 10.
     graceful_disable_timeout:
         description:
             - Used to gracefully disable a server.
             - Virtual service waits for the specified time before terminating the existing connections  to the servers that are disabled.
+            - Allowed values are 1-60.
+            - Special values are 0 - 'immediate', -1 - 'infinite'.
             - Default value when not specified in API or module is interpreted by Avi Controller as 1.
     health_monitor_refs:
         description:
@@ -153,6 +161,8 @@ options:
     lb_algorithm:
         description:
             - The load balancing algorithm will pick a server within the pool's list of available servers.
+            - Enum options - LB_ALGORITHM_LEAST_CONNECTIONS, LB_ALGORITHM_ROUND_ROBIN, LB_ALGORITHM_FASTEST_RESPONSE, LB_ALGORITHM_CONSISTENT_HASH,
+            - LB_ALGORITHM_LEAST_LOAD, LB_ALGORITHM_FEWEST_SERVERS, LB_ALGORITHM_RANDOM, LB_ALGORITHM_FEWEST_TASKS, LB_ALGORITHM_NEAREST_SERVER.
             - Default value when not specified in API or module is interpreted by Avi Controller as LB_ALGORITHM_LEAST_CONNECTIONS.
     lb_algorithm_consistent_hash_hdr:
         description:
@@ -160,10 +170,14 @@ options:
     lb_algorithm_hash:
         description:
             - Criteria used as a key for determining the hash between the client and  server.
+            - Enum options - LB_ALGORITHM_CONSISTENT_HASH_SOURCE_IP_ADDRESS, LB_ALGORITHM_CONSISTENT_HASH_SOURCE_IP_ADDRESS_AND_PORT,
+            - LB_ALGORITHM_CONSISTENT_HASH_URI, LB_ALGORITHM_CONSISTENT_HASH_CUSTOM_HEADER.
             - Default value when not specified in API or module is interpreted by Avi Controller as LB_ALGORITHM_CONSISTENT_HASH_SOURCE_IP_ADDRESS.
     max_concurrent_connections_per_server:
         description:
             - The maximum number of concurrent connections allowed to each server within the pool.
+            - Allowed values are 50-10000.
+            - Special values are 0 - 'infinite'.
             - Default value when not specified in API or module is interpreted by Avi Controller as 0.
     max_conn_rate_per_server:
         description:
@@ -177,6 +191,10 @@ options:
             - (internal-use) networks designated as containing servers for this pool.
             - The servers may be further narrowed down by a filter.
             - This field is used internally by avi, not editable by the user.
+    nsx_securitygroup:
+        description:
+            - A list of nsx service groups where the servers for the pool are created.
+            - Field introduced in 17.1.1.
     pki_profile_ref:
         description:
             - Avi will validate the ssl certificate present by a server against the selected pki profile.
@@ -292,7 +310,6 @@ obj:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-
 try:
     from ansible.module_utils.avi import (
         avi_common_argument_spec, HAS_AVI, avi_ansible_api)
@@ -337,6 +354,7 @@ def main():
         max_conn_rate_per_server=dict(type='dict',),
         name=dict(type='str', required=True),
         networks=dict(type='list',),
+        nsx_securitygroup=dict(type='list',),
         pki_profile_ref=dict(type='str',),
         placement_networks=dict(type='list',),
         prst_hdr_name=dict(type='str',),
@@ -363,11 +381,10 @@ def main():
         argument_spec=argument_specs, supports_check_mode=True)
     if not HAS_AVI:
         return module.fail_json(msg=(
-            'Avi python API SDK (avisdk>=16.3.5.post1) is not installed. '
+            'Avi python API SDK (avisdk>=17.1) is not installed. '
             'For more details visit https://github.com/avinetworks/sdk.'))
     return avi_ansible_api(module, 'pool',
                            set([]))
-
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/avi/avi_poolgroup.py
+++ b/lib/ansible/modules/network/avi/avi_poolgroup.py
@@ -4,7 +4,7 @@
 # @author: Gaurav Rastogi (grastogi@avinetworks.com)
 #          Eric Anderson (eanderson@avinetworks.com)
 # module_check: supported
-# Avi Version: 16.3.8
+# Avi Version: 17.1.1
 #
 #
 # This file is part of Ansible
@@ -26,7 +26,6 @@
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
-
 
 DOCUMENTATION = '''
 ---
@@ -72,6 +71,8 @@ options:
     min_servers:
         description:
             - The minimum number of servers to distribute traffic to.
+            - Allowed values are 1-65535.
+            - Special values are 0 - 'disable'.
             - Default value when not specified in API or module is interpreted by Avi Controller as 0.
     name:
         description:
@@ -113,7 +114,6 @@ obj:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-
 try:
     from ansible.module_utils.avi import (
         avi_common_argument_spec, HAS_AVI, avi_ansible_api)
@@ -144,11 +144,10 @@ def main():
         argument_spec=argument_specs, supports_check_mode=True)
     if not HAS_AVI:
         return module.fail_json(msg=(
-            'Avi python API SDK (avisdk>=16.3.5.post1) is not installed. '
+            'Avi python API SDK (avisdk>=17.1) is not installed. '
             'For more details visit https://github.com/avinetworks/sdk.'))
     return avi_ansible_api(module, 'poolgroup',
                            set([]))
-
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/avi/avi_role.py
+++ b/lib/ansible/modules/network/avi/avi_role.py
@@ -4,7 +4,7 @@
 # @author: Gaurav Rastogi (grastogi@avinetworks.com)
 #          Eric Anderson (eanderson@avinetworks.com)
 # module_check: supported
-# Avi Version: 16.3.8
+# Avi Version: 17.1.1
 #
 #
 # This file is part of Ansible
@@ -26,7 +26,6 @@
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
-
 
 DOCUMENTATION = '''
 ---
@@ -83,7 +82,6 @@ obj:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-
 try:
     from ansible.module_utils.avi import (
         avi_common_argument_spec, HAS_AVI, avi_ansible_api)
@@ -106,11 +104,10 @@ def main():
         argument_spec=argument_specs, supports_check_mode=True)
     if not HAS_AVI:
         return module.fail_json(msg=(
-            'Avi python API SDK (avisdk>=16.3.5.post1) is not installed. '
+            'Avi python API SDK (avisdk>=17.1) is not installed. '
             'For more details visit https://github.com/avinetworks/sdk.'))
     return avi_ansible_api(module, 'role',
                            set([]))
-
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/avi/avi_sslkeyandcertificate.py
+++ b/lib/ansible/modules/network/avi/avi_sslkeyandcertificate.py
@@ -4,7 +4,7 @@
 # @author: Gaurav Rastogi (grastogi@avinetworks.com)
 #          Eric Anderson (eanderson@avinetworks.com)
 # module_check: supported
-# Avi Version: 16.3.8
+# Avi Version: 17.1.1
 #
 #
 # This file is part of Ansible
@@ -26,7 +26,6 @@
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
-
 
 DOCUMENTATION = '''
 ---
@@ -84,14 +83,14 @@ options:
         required: true
     status:
         description:
-            - Status of sslkeyandcertificate.
+            - Enum options - ssl_certificate_finished, ssl_certificate_pending.
             - Default value when not specified in API or module is interpreted by Avi Controller as SSL_CERTIFICATE_FINISHED.
     tenant_ref:
         description:
             - It is a reference to an object of type tenant.
     type:
         description:
-            - Type of sslkeyandcertificate.
+            - Enum options - ssl_certificate_type_virtualservice, ssl_certificate_type_system, ssl_certificate_type_ca.
             - Default value when not specified in API or module is interpreted by Avi Controller as SSL_CERTIFICATE_TYPE_VIRTUALSERVICE.
     url:
         description:
@@ -131,7 +130,6 @@ obj:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-
 try:
     from ansible.module_utils.avi import (
         avi_common_argument_spec, HAS_AVI, avi_ansible_api)
@@ -165,11 +163,10 @@ def main():
         argument_spec=argument_specs, supports_check_mode=True)
     if not HAS_AVI:
         return module.fail_json(msg=(
-            'Avi python API SDK (avisdk>=16.3.5.post1) is not installed. '
+            'Avi python API SDK (avisdk>=17.1) is not installed. '
             'For more details visit https://github.com/avinetworks/sdk.'))
     return avi_ansible_api(module, 'sslkeyandcertificate',
                            set(['key']))
-
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/avi/avi_sslprofile.py
+++ b/lib/ansible/modules/network/avi/avi_sslprofile.py
@@ -4,7 +4,7 @@
 # @author: Gaurav Rastogi (grastogi@avinetworks.com)
 #          Eric Anderson (eanderson@avinetworks.com)
 # module_check: supported
-# Avi Version: 16.3.8
+# Avi Version: 17.1.1
 #
 #
 # This file is part of Ansible
@@ -26,7 +26,6 @@
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
-
 
 DOCUMENTATION = '''
 ---
@@ -54,7 +53,12 @@ options:
             - Set of versions accepted by the server.
     cipher_enums:
         description:
-            - Cipher_enums of sslprofile.
+            - Enum options - tls_ecdhe_ecdsa_with_aes_128_gcm_sha256, tls_ecdhe_ecdsa_with_aes_256_gcm_sha384, tls_ecdhe_rsa_with_aes_128_gcm_sha256,
+            - tls_ecdhe_rsa_with_aes_256_gcm_sha384, tls_ecdhe_ecdsa_with_aes_128_cbc_sha256, tls_ecdhe_ecdsa_with_aes_256_cbc_sha384,
+            - tls_ecdhe_rsa_with_aes_128_cbc_sha256, tls_ecdhe_rsa_with_aes_256_cbc_sha384, tls_rsa_with_aes_128_gcm_sha256, tls_rsa_with_aes_256_gcm_sha384,
+            - tls_rsa_with_aes_128_cbc_sha256, tls_rsa_with_aes_256_cbc_sha256, tls_ecdhe_ecdsa_with_aes_128_cbc_sha, tls_ecdhe_ecdsa_with_aes_256_cbc_sha,
+            - tls_ecdhe_rsa_with_aes_128_cbc_sha, tls_ecdhe_rsa_with_aes_256_cbc_sha, tls_rsa_with_aes_128_cbc_sha, tls_rsa_with_aes_256_cbc_sha,
+            - tls_rsa_with_3des_ede_cbc_sha, tls_rsa_with_rc4_128_sha.
     description:
         description:
             - User defined description for the object.
@@ -154,7 +158,6 @@ obj:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-
 try:
     from ansible.module_utils.avi import (
         avi_common_argument_spec, HAS_AVI, avi_ansible_api)
@@ -187,11 +190,10 @@ def main():
         argument_spec=argument_specs, supports_check_mode=True)
     if not HAS_AVI:
         return module.fail_json(msg=(
-            'Avi python API SDK (avisdk>=16.3.5.post1) is not installed. '
+            'Avi python API SDK (avisdk>=17.1) is not installed. '
             'For more details visit https://github.com/avinetworks/sdk.'))
     return avi_ansible_api(module, 'sslprofile',
                            set([]))
-
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/avi/avi_systemconfiguration.py
+++ b/lib/ansible/modules/network/avi/avi_systemconfiguration.py
@@ -4,7 +4,7 @@
 # @author: Gaurav Rastogi (grastogi@avinetworks.com)
 #          Eric Anderson (eanderson@avinetworks.com)
 # module_check: supported
-# Avi Version: 16.3.8
+# Avi Version: 17.1.1
 #
 #
 # This file is part of Ansible
@@ -26,7 +26,6 @@
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
-
 
 DOCUMENTATION = '''
 ---
@@ -126,7 +125,6 @@ obj:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-
 try:
     from ansible.module_utils.avi import (
         avi_common_argument_spec, HAS_AVI, avi_ansible_api)
@@ -161,11 +159,10 @@ def main():
         argument_spec=argument_specs, supports_check_mode=True)
     if not HAS_AVI:
         return module.fail_json(msg=(
-            'Avi python API SDK (avisdk>=16.3.5.post1) is not installed. '
+            'Avi python API SDK (avisdk>=17.1) is not installed. '
             'For more details visit https://github.com/avinetworks/sdk.'))
     return avi_ansible_api(module, 'systemconfiguration',
                            set([]))
-
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/avi/avi_tenant.py
+++ b/lib/ansible/modules/network/avi/avi_tenant.py
@@ -4,7 +4,7 @@
 # @author: Gaurav Rastogi (grastogi@avinetworks.com)
 #          Eric Anderson (eanderson@avinetworks.com)
 # module_check: supported
-# Avi Version: 16.3.8
+# Avi Version: 17.1.1
 #
 #
 # This file is part of Ansible
@@ -26,7 +26,6 @@
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
-
 
 DOCUMENTATION = '''
 ---
@@ -95,7 +94,6 @@ obj:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-
 try:
     from ansible.module_utils.avi import (
         avi_common_argument_spec, HAS_AVI, avi_ansible_api)
@@ -120,11 +118,10 @@ def main():
         argument_spec=argument_specs, supports_check_mode=True)
     if not HAS_AVI:
         return module.fail_json(msg=(
-            'Avi python API SDK (avisdk>=16.3.5.post1) is not installed. '
+            'Avi python API SDK (avisdk>=17.1) is not installed. '
             'For more details visit https://github.com/avinetworks/sdk.'))
     return avi_ansible_api(module, 'tenant',
                            set([]))
-
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/avi/avi_virtualservice.py
+++ b/lib/ansible/modules/network/avi/avi_virtualservice.py
@@ -145,6 +145,7 @@ options:
         description:
             - Dns policies applied on the dns traffic of the virtual service.
             - Field introduced in 17.1.1.
+        version_added: "2.4"
     east_west_placement:
         description:
             - Force placement on all se's in service group (mesos mode only).
@@ -240,6 +241,7 @@ options:
         description:
             - A list of nsx service groups representing the clients which can access the virtual ip of the virtual service.
             - Field introduced in 17.1.1.
+        version_added: "2.4"
     performance_limits:
         description:
             - Optional settings that determine performance limits like max connections or bandwdith etc.
@@ -282,6 +284,7 @@ options:
             - Metadata pertaining to the service provided by this virtual service.
             - In openshift/kubernetes environments, egress pod info is stored.
             - Any user input to this field will be overwritten by avi vantage.
+        version_added: "2.4"
     service_pool_select:
         description:
             - Select pool based on destination port.
@@ -291,6 +294,7 @@ options:
     sideband_profile:
         description:
             - Sideband configuration to be used for this virtualservice.it can be used for sending traffic to sideband vips for external inspection etc.
+        version_added: "2.4"
     snat_ip:
         description:
             - Nat'ted floating source ip address(es) for upstream connection to servers.
@@ -328,6 +332,7 @@ options:
             - Server network or list of servers for cloning traffic.
             - It is a reference to an object of type trafficcloneprofile.
             - Field introduced in 17.1.1.
+        version_added: "2.4"
     type:
         description:
             - Specify if this is a normal virtual service, or if it is the parent or child of an sni-enabled virtual hosted virtual service.
@@ -355,6 +360,7 @@ options:
             - List of virtual service ips.
             - While creating a 'shared vs',please use vsvip_ref to point to the shared entities.
             - Field introduced in 17.1.1.
+        version_added: "2.4"
     vrf_context_ref:
         description:
             - Virtual routing context that the virtual service is bound to.
@@ -368,6 +374,7 @@ options:
             - Mostly used during the creation of shared vs, this fieldrefers to entities that can be shared across virtual services.
             - It is a reference to an object of type vsvip.
             - Field introduced in 17.1.1.
+        version_added: "2.4"
     weight:
         description:
             - The quality of service weight to assign to traffic transmitted from this virtual service.

--- a/lib/ansible/modules/network/avi/avi_virtualservice.py
+++ b/lib/ansible/modules/network/avi/avi_virtualservice.py
@@ -4,7 +4,7 @@
 # @author: Gaurav Rastogi (grastogi@avinetworks.com)
 #          Eric Anderson (eanderson@avinetworks.com)
 # module_check: supported
-# Avi Version: 16.3.8
+# Avi Version: 17.1.1
 #
 #
 # This file is part of Ansible
@@ -26,7 +26,6 @@
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
-
 
 DOCUMENTATION = '''
 ---
@@ -53,6 +52,7 @@ options:
             - If one of the serviceengine's in the serviceenginegroup fails, all virtualservices will end up using the same active serviceengine.
             - Redistribution of the virtualservices can be either manual or automated when the failed serviceengine recovers.
             - Redistribution is based on the auto redistribute property of the serviceenginegroup.
+            - Enum options - ACTIVE_STANDBY_SE_1, ACTIVE_STANDBY_SE_2.
             - Default value when not specified in API or module is interpreted by Avi Controller as ACTIVE_STANDBY_SE_1.
     analytics_policy:
         description:
@@ -68,21 +68,26 @@ options:
     auto_allocate_floating_ip:
         description:
             - Auto-allocate floating/elastic ip from the cloud infrastructure.
+            - Field deprecated in 17.1.1.
             - Default value when not specified in API or module is interpreted by Avi Controller as False.
     auto_allocate_ip:
         description:
             - Auto-allocate vip from the provided subnet.
+            - Field deprecated in 17.1.1.
             - Default value when not specified in API or module is interpreted by Avi Controller as False.
     availability_zone:
         description:
             - Availability-zone to place the virtual service.
+            - Field deprecated in 17.1.1.
     avi_allocated_fip:
         description:
             - (internal-use) fip allocated by avi in the cloud infrastructure.
+            - Field deprecated in 17.1.1.
             - Default value when not specified in API or module is interpreted by Avi Controller as False.
     avi_allocated_vip:
         description:
             - (internal-use) vip allocated by avi in the cloud infrastructure.
+            - Field deprecated in 17.1.1.
             - Default value when not specified in API or module is interpreted by Avi Controller as False.
     client_auth:
         description:
@@ -96,7 +101,8 @@ options:
             - It is a reference to an object of type cloud.
     cloud_type:
         description:
-            - Cloud_type of virtualservice.
+            - Enum options - cloud_none, cloud_vcenter, cloud_openstack, cloud_aws, cloud_vca, cloud_apic, cloud_mesos, cloud_linuxserver, cloud_docker_ucp,
+            - cloud_rancher, cloud_oshift_k8s.
             - Default value when not specified in API or module is interpreted by Avi Controller as CLOUD_NONE.
     connections_rate_limit:
         description:
@@ -120,18 +126,25 @@ options:
             - (internal-use) discovered networks providing reachability for client facing virtual service ip.
             - This field is deprecated.
             - It is a reference to an object of type network.
+            - Field deprecated in 17.1.1.
     discovered_networks:
         description:
             - (internal-use) discovered networks providing reachability for client facing virtual service ip.
             - This field is used internally by avi, not editable by the user.
+            - Field deprecated in 17.1.1.
     discovered_subnet:
         description:
             - (internal-use) discovered subnets providing reachability for client facing virtual service ip.
             - This field is deprecated.
+            - Field deprecated in 17.1.1.
     dns_info:
         description:
             - Service discovery specific data including fully qualified domain name, type and time-to-live of the dns record.
             - Note that only one of fqdn and dns_info setting is allowed.
+    dns_policies:
+        description:
+            - Dns policies applied on the dns traffic of the virtual service.
+            - Field introduced in 17.1.1.
     east_west_placement:
         description:
             - Force placement on all se's in service group (mesos mode only).
@@ -153,18 +166,22 @@ options:
     floating_ip:
         description:
             - Floating ip to associate with this virtual service.
+            - Field deprecated in 17.1.1.
     floating_subnet_uuid:
         description:
             - If auto_allocate_floating_ip is true and more than one floating-ip subnets exist, then the subnet for the floating ip address allocation.
             - This field is applicable only if the virtualservice belongs to an openstack or aws cloud.
             - In openstack or aws cloud it is required when auto_allocate_floating_ip is selected.
+            - Field deprecated in 17.1.1.
     flow_dist:
         description:
             - Criteria for flow distribution among ses.
+            - Enum options - LOAD_AWARE, CONSISTENT_HASH_SOURCE_IP_ADDRESS, CONSISTENT_HASH_SOURCE_IP_ADDRESS_AND_PORT.
             - Default value when not specified in API or module is interpreted by Avi Controller as LOAD_AWARE.
     flow_label_type:
         description:
             - Criteria for flow labelling.
+            - Enum options - NO_LABEL, SERVICE_LABEL.
             - Default value when not specified in API or module is interpreted by Avi Controller as NO_LABEL.
     fqdn:
         description:
@@ -184,6 +201,7 @@ options:
     ip_address:
         description:
             - Ip address of the virtual service.
+            - Field deprecated in 17.1.1.
     ipam_network_subnet:
         description:
             - Subnet and/or network for allocating virtualservice ip by ipam provider module.
@@ -194,6 +212,8 @@ options:
     max_cps_per_client:
         description:
             - Maximum connections per second per client ip.
+            - Allowed values are 10-1000.
+            - Special values are 0- 'unlimited'.
             - Default value when not specified in API or module is interpreted by Avi Controller as 0.
     microservice_ref:
         description:
@@ -211,10 +231,15 @@ options:
         description:
             - Manually override the network on which the virtual service is placed.
             - It is a reference to an object of type network.
+            - Field deprecated in 17.1.1.
     network_security_policy_ref:
         description:
             - Network security policies for the virtual service.
             - It is a reference to an object of type networksecuritypolicy.
+    nsx_securitygroup:
+        description:
+            - A list of nsx service groups representing the clients which can access the virtual ip of the virtual service.
+            - Field introduced in 17.1.1.
     performance_limits:
         description:
             - Optional settings that determine performance limits like max connections or bandwdith etc.
@@ -229,6 +254,7 @@ options:
     port_uuid:
         description:
             - (internal-use) network port assigned to the virtual service ip address.
+            - Field deprecated in 17.1.1.
     remove_listening_port_on_vs_down:
         description:
             - Remove listening port if virtualservice is down.
@@ -251,12 +277,20 @@ options:
             - Determines the network settings profile for the server side of tcp proxied connections.
             - Leave blank to use the same settings as the client to vs side of the connection.
             - It is a reference to an object of type networkprofile.
+    service_metadata:
+        description:
+            - Metadata pertaining to the service provided by this virtual service.
+            - In openshift/kubernetes environments, egress pod info is stored.
+            - Any user input to this field will be overwritten by avi vantage.
     service_pool_select:
         description:
             - Select pool based on destination port.
     services:
         description:
             - List of services defined for this virtual service.
+    sideband_profile:
+        description:
+            - Sideband configuration to be used for this virtualservice.it can be used for sending traffic to sideband vips for external inspection etc.
     snat_ip:
         description:
             - Nat'ted floating source ip address(es) for upstream connection to servers.
@@ -271,6 +305,7 @@ options:
     ssl_sess_cache_avg_size:
         description:
             - Expected number of ssl session cache entries (may be exceeded).
+            - Allowed values are 1024-16383.
             - Default value when not specified in API or module is interpreted by Avi Controller as 1024.
     static_dns_records:
         description:
@@ -279,16 +314,24 @@ options:
     subnet:
         description:
             - Subnet providing reachability for client facing virtual service ip.
+            - Field deprecated in 17.1.1.
     subnet_uuid:
         description:
             - It represents subnet for the virtual service ip address allocation when auto_allocate_ip is true.it is only applicable in openstack or aws cloud.
             - This field is required if auto_allocate_ip is true.
+            - Field deprecated in 17.1.1.
     tenant_ref:
         description:
             - It is a reference to an object of type tenant.
+    traffic_clone_profile_ref:
+        description:
+            - Server network or list of servers for cloning traffic.
+            - It is a reference to an object of type trafficcloneprofile.
+            - Field introduced in 17.1.1.
     type:
         description:
             - Specify if this is a normal virtual service, or if it is the parent or child of an sni-enabled virtual hosted virtual service.
+            - Enum options - VS_TYPE_NORMAL, VS_TYPE_VH_PARENT, VS_TYPE_VH_CHILD.
             - Default value when not specified in API or module is interpreted by Avi Controller as VS_TYPE_NORMAL.
     url:
         description:
@@ -307,6 +350,11 @@ options:
     vh_parent_vs_uuid:
         description:
             - Specifies the virtual service acting as virtual hosting (sni) parent.
+    vip:
+        description:
+            - List of virtual service ips.
+            - While creating a 'shared vs',please use vsvip_ref to point to the shared entities.
+            - Field introduced in 17.1.1.
     vrf_context_ref:
         description:
             - Virtual routing context that the virtual service is bound to.
@@ -315,6 +363,11 @@ options:
     vs_datascripts:
         description:
             - Datascripts applied on the data traffic of the virtual service.
+    vsvip_ref:
+        description:
+            - Mostly used during the creation of shared vs, this fieldrefers to entities that can be shared across virtual services.
+            - It is a reference to an object of type vsvip.
+            - Field introduced in 17.1.1.
     weight:
         description:
             - The quality of service weight to assign to traffic transmitted from this virtual service.
@@ -356,7 +409,6 @@ obj:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-
 try:
     from ansible.module_utils.avi import (
         avi_common_argument_spec, HAS_AVI, avi_ansible_api)
@@ -390,6 +442,7 @@ def main():
         discovered_networks=dict(type='list',),
         discovered_subnet=dict(type='list',),
         dns_info=dict(type='list',),
+        dns_policies=dict(type='list',),
         east_west_placement=dict(type='bool',),
         enable_autogw=dict(type='bool',),
         enable_rhi=dict(type='bool',),
@@ -412,6 +465,7 @@ def main():
         network_profile_ref=dict(type='str',),
         network_ref=dict(type='str',),
         network_security_policy_ref=dict(type='str',),
+        nsx_securitygroup=dict(type='list',),
         performance_limits=dict(type='dict',),
         pool_group_ref=dict(type='str',),
         pool_ref=dict(type='str',),
@@ -421,8 +475,10 @@ def main():
         scaleout_ecmp=dict(type='bool',),
         se_group_ref=dict(type='str',),
         server_network_profile_ref=dict(type='str',),
+        service_metadata=dict(type='str',),
         service_pool_select=dict(type='list',),
         services=dict(type='list',),
+        sideband_profile=dict(type='dict',),
         snat_ip=dict(type='list',),
         ssl_key_and_certificate_refs=dict(type='list',),
         ssl_profile_ref=dict(type='str',),
@@ -431,14 +487,17 @@ def main():
         subnet=dict(type='dict',),
         subnet_uuid=dict(type='str',),
         tenant_ref=dict(type='str',),
+        traffic_clone_profile_ref=dict(type='str',),
         type=dict(type='str',),
         url=dict(type='str',),
         use_bridge_ip_as_vip=dict(type='bool',),
         uuid=dict(type='str',),
         vh_domain_name=dict(type='list',),
         vh_parent_vs_uuid=dict(type='str',),
+        vip=dict(type='list',),
         vrf_context_ref=dict(type='str',),
         vs_datascripts=dict(type='list',),
+        vsvip_ref=dict(type='str',),
         weight=dict(type='int',),
     )
     argument_specs.update(avi_common_argument_spec())
@@ -446,11 +505,10 @@ def main():
         argument_spec=argument_specs, supports_check_mode=True)
     if not HAS_AVI:
         return module.fail_json(msg=(
-            'Avi python API SDK (avisdk>=16.3.5.post1) is not installed. '
+            'Avi python API SDK (avisdk>=17.1) is not installed. '
             'For more details visit https://github.com/avinetworks/sdk.'))
     return avi_ansible_api(module, 'virtualservice',
                            set([]))
-
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/utils/module_docs_fragments/avi.py
+++ b/lib/ansible/utils/module_docs_fragments/avi.py
@@ -42,4 +42,7 @@ options:
         description:
             - UUID of tenant used for all Avi API calls and context of object.
         default: ''
+    api_version:
+        description:
+            - Avi API version of to use for Avi API and objects.
 """


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Updated Avi Ansible 17.1.1 documentation and dependency on avisdk 17.1 releases. This is needed to support api_version in the modules.
 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/avi

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = /home/grastogi/.ansible.cfg
  configured module search path = [u'/home/grastogi/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/grastogi/ansible2.3/local/lib/python2.7/site-packages/ansible
  executable location = /home/grastogi/ansible2.3/bin/ansible
  python version = 2.7.6 (default, Jun 22 2015, 17:58:13) [GCC 4.8.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
