### PR TITLE
Check for an existing docker_network before accessing it in check mode

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -320,6 +320,8 @@ class DockerNetworkManager(object):
                 self.results['changed'] = True
 
     def disconnect_missing(self):
+        if not self.existing_network:
+            return
         containers = self.existing_network['Containers']
         if not containers:
             return


### PR DESCRIPTION
##### ISSUE TYPE
 - Bug Report

##### COMPONENT NAME

docker_network

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /Users/stephen/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```

##### CONFIGURATION
```
[defaults]
roles_path=~/.ansible/roles
[ssh_connection]
pipelining=True
```

##### OS / ENVIRONMENT
N/A

##### SUMMARY
When running in check mode, if a Docker network does not already exist, the docker_network module throws a TypeError.

##### STEPS TO REPRODUCE

1. Install docker on the host (I'm using Docker 17.03.1-ce).
2. Ensure there is **no** Docker network defined named "nsq".
3. Run the following playbook in check mode.

```yaml
---
- hosts: olympic
  tasks:

    - docker_network:
        name: nsq
```


##### EXPECTED RESULTS

The command should report "changed" (because the network would be created).

##### ACTUAL RESULTS

The task does reports "failed". Note that this only happens in check mode; in normal mode, the task succeeds and reports "changed".

Output:

```
Using /Users/stephen/.ansible.cfg as config file
Loading callback plugin default of type stdout, v2.0 from /usr/local/Cellar/ansible/2.3.0.0/libexec/lib/python2.7/site-packages/ansible/plugins/callback/__init__.pyc

PLAYBOOK: test.yml **********************************************************************************************************************************************************************************************
1 plays in test.yml

PLAY [olympic] **************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ******************************************************************************************************************************************************************************************
Using module file /usr/local/Cellar/ansible/2.3.0.0/libexec/lib/python2.7/site-packages/ansible/modules/system/setup.py
<olympic.***********> ESTABLISH SSH CONNECTION FOR USER: stephen
<olympic.***********> SSH: EXEC ssh -vvv -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=stephen -o ConnectTimeout=10 -o ControlPath=/Users/stephen/.ansible/cp/c62349e097 ******************* '/bin/sh -c '"'"'/usr/bin/python && sleep 0'"'"''
<olympic.***********> (0, '\n{"invocation": {"module_args": {"filter": "*", "gather_subset": ["all"], "fact_path": "/etc/ansible/facts.d", "gather_timeout": 10}}, "changed": false, "ansible_facts": {"module_setup": true, "ansible_distribution_version": "16.04", "ansible_env": {"LANG": "en_US.UTF-8", "TMPDIR": "/tmp/stephen", "SHELL": "/usr/bin/zsh", "XDG_RUNTIME_DIR": "/run/user/1000", "LESS": "-F -g -i -M -R -S -w -X -z-4", "SHLVL": "0", "SSH_CLIENT": "108.168.239.92 63353 22", "OLDPWD": "/home/stephen", "PWD": "/home/stephen", "LESSOPEN": "| /usr/bin/env lesspipe %s 2>&-", "XDG_SESSION_ID": "776", "MAIL": "/var/mail/stephen", "VISUAL": "nano", "LOGNAME": "stephen", "USER": "stephen", "HOME": "/home/stephen", "PATH": "/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games", "SSH_CONNECTION": "108.168.239.92 63353 104.207.155.11 22", "PAGER": "less", "_": "/bin/sh", "EDITOR": "nano"}, "ansible_userspace_bits": "64", "ansible_architecture": "x86_64", "ansible_default_ipv4": {"macaddress": "56:00:00:06:69:ee", "network": "104.207.154.0", "mtu": 1500, "broadcast": "104.207.155.255", "alias": "eth0", "netmask": "255.255.254.0", "address": "104.207.155.11", "interface": "eth0", "type": "ether", "gateway": "104.207.154.1"}, "ansible_swapfree_mb": 0, "ansible_default_ipv6": {"macaddress": "56:00:00:06:69:ee", "mtu": 1500, "prefix": "128", "address": "2001:19f0:6000:8041::1234", "interface": "eth0", "scope": "global", "type": "ether", "gateway": "fe80::fc00:ff:fe06:69ee"}, "ansible_cmdline": {"BOOT_IMAGE": "/boot/vmlinuz-4.4.0-72-generic", "ro": true, "root": "UUID=12ebc60e-27ef-4a50-97c3-6cc58043b557", "quiet": true}, "ansible_selinux": false, "ansible_userspace_architecture": "x86_64", "ansible_product_uuid": "NA", "ansible_pkg_mgr": "apt", "ansible_distribution": "Ubuntu", "ansible_veth366b2fa": {"macaddress": "ea:b6:08:9e:c9:8f", "features": {}, "type": "ether", "mtu": 1500, "device": "veth366b2fa", "promisc": true, "ipv6": [{"scope": "link", "prefix": "64", "address": "fe80::e8b6:8ff:fe9e:c98f"}], "active": true, "speed": 10000}, "ansible_all_ipv6_addresses": ["fe80::d851:8bff:febe:c314", "fe80::f4cd:dbff:fe81:4ca4", "fe80::645a:4aff:fe0e:2e6d", "fe80::580f:61ff:fe8d:495d", "fe80::2cc2:44ff:fefd:cc17", "2001:19f0:6000:8041::1234", "2001:19f0:6000:8041::100", "fe80::5400:ff:fe06:69ee", "fe80::42:96ff:fe9b:eecc", "fe80::e8b6:8ff:fe9e:c98f", "fe80::42:ddff:febf:3df1", "fe80::6cd1:d0ff:fe05:574", "fe80::3895:1cff:fe88:8be5"], "ansible_uptime_seconds": 960809, "ansible_kernel": "4.4.0-72-generic", "ansible_system_capabilities_enforced": "True", "ansible_python": {"executable": "/usr/bin/python", "version": {"micro": 12, "major": 2, "releaselevel": "final", "serial": 0, "minor": 7}, "type": "CPython", "has_sslcontext": true, "version_info": [2, 7, 12, "final", 0]}, "ansible_user_shell": "/usr/bin/zsh", "ansible_product_serial": "NA", "ansible_form_factor": "Other", "ansible_fips": false, "ansible_veth3aa2a27": {"macaddress": "f6:cd:db:81:4c:a4", "features": {}, "type": "ether", "mtu": 1500, "device": "veth3aa2a27", "promisc": true, "ipv6": [{"scope": "link", "prefix": "64", "address": "fe80::f4cd:dbff:fe81:4ca4"}], "active": true, "speed": 10000}, "ansible_user_id": "stephen", "ansible_processor_vcpus": 1, "ansible_docker0": {"macaddress": "02:42:dd:bf:3d:f1", "features": {}, "interfaces": ["veth366b2fa", "veth0d838df", "vethcb6766c", "veth3aa2a27", "veth3ce6018"], "mtu": 1500, "device": "docker0", "promisc": false, "stp": false, "ipv4": {"broadcast": "global", "netmask": "255.255.0.0", "network": "172.17.0.0", "address": "172.17.0.1"}, "ipv6": [{"scope": "link", "prefix": "64", "address": "fe80::42:ddff:febf:3df1"}], "active": true, "type": "bridge", "id": "8000.0242ddbf3df1"}, "ansible_processor": ["GenuineIntel", "Virtual CPU e7da7129d3ee"], "ansible_ssh_host_key_ecdsa_public": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEQyFRuYrLrLi4Qv05duNYmfSb7huzZihdvHvnhHSGEFjGjuloD6Ya0HRfbqYVU2nKC4y+1z9bAnTdRZ04uqdlg=", "ansible_user_gid": 1000, "ansible_system_vendor": "QEMU", "ansible_veth573fd39": {"macaddress": "3a:95:1c:88:8b:e5", "features": {}, "type": "ether", "mtu": 1500, "device": "veth573fd39", "promisc": true, "ipv6": [{"scope": "link", "prefix": "64", "address": "fe80::3895:1cff:fe88:8be5"}], "active": true, "speed": 10000}, "ansible_veth0d838df": {"macaddress": "6e:d1:d0:05:05:74", "features": {}, "type": "ether", "mtu": 1500, "device": "veth0d838df", "promisc": true, "ipv6": [{"scope": "link", "prefix": "64", "address": "fe80::6cd1:d0ff:fe05:574"}], "active": true, "speed": 10000}, "ansible_swaptotal_mb": 0, "ansible_distribution_major_version": "16", "ansible_real_group_id": 1000, "ansible_lsb": {"release": "16.04", "major_release": "16", "codename": "xenial", "id": "Ubuntu", "description": "Ubuntu 16.04.2 LTS"}, "ansible_machine": "x86_64", "ansible_ssh_host_key_rsa_public": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDRQ00+ODtDISfoJ2MFvgaU1u+D/ef6TrrZnQa5pFEOs4lvFHIkzTRaLNEVeWDVNewid1tU/RgzzbC7dpBOODLdzlTD+PcFcqb7tBDHsDWh/xYJBQKA6WQkchcPxiZSYvqikSGATVjSx+v+AjWhaMsm362oumQYiQ7oSaFofdqigml2oIwzuVE59B+MtDuBhpC4iqb0ZZjrJub//ENnGS+awFP8Hwory47Om/4ZtjEXViPsGbRV9ar8nbOVf6zokUJQYjaDkwHbdocKI2iYcii1Jo7T2NCjE9jiB+e6PBwdZpWh0X5inl+hRDTv3DPGWDXct0f2OUy/MlDHTSpzdZix", "ansible_user_gecos": "Stephen Jennings,,,", "ansible_processor_threads_per_core": 1, "ansible_eth0": {"macaddress": "56:00:00:06:69:ee", "features": {}, "type": "ether", "pciid": "virtio0", "mtu": 1500, "device": "eth0", "promisc": false, "ipv4": {"broadcast": "104.207.155.255", "netmask": "255.255.254.0", "network": "104.207.154.0", "address": "104.207.155.11"}, "ipv6": [{"scope": "global", "prefix": "128", "address": "2001:19f0:6000:8041::1234"}, {"scope": "global", "prefix": "64", "address": "2001:19f0:6000:8041::100"}, {"scope": "link", "prefix": "64", "address": "fe80::5400:ff:fe06:69ee"}], "active": true, "speed": -1}, "ansible_product_name": "Standard PC (i440FX + PIIX, 1996)", "ansible_all_ipv4_addresses": ["104.207.155.11", "172.18.0.1", "172.17.0.1"], "ansible_python_version": "2.7.12", "ansible_veth3ce6018": {"macaddress": "66:5a:4a:0e:2e:6d", "features": {}, "type": "ether", "mtu": 1500, "device": "veth3ce6018", "promisc": true, "ipv6": [{"scope": "link", "prefix": "64", "address": "fe80::645a:4aff:fe0e:2e6d"}], "active": true, "speed": 10000}, "ansible_product_version": "pc-i440fx-2.4", "ansible_service_mgr": "systemd", "ansible_memory_mb": {"real": {"total": 992, "used": 845, "free": 147}, "swap": {"cached": 0, "total": 0, "free": 0, "used": 0}, "nocache": {"used": 412, "free": 580}}, "ansible_user_dir": "/home/stephen", "ansible_real_user_id": 1000, "ansible_virtualization_role": "guest", "ansible_dns": {"nameservers": ["108.61.10.10"]}, "ansible_effective_group_id": 1000, "ansible_vethcb6766c": {"macaddress": "da:51:8b:be:c3:14", "features": {}, "type": "ether", "mtu": 1500, "device": "vethcb6766c", "promisc": true, "ipv6": [{"scope": "link", "prefix": "64", "address": "fe80::d851:8bff:febe:c314"}], "active": true, "speed": 10000}, "ansible_lo": {"features": {}, "mtu": 65536, "device": "lo", "promisc": false, "ipv4": {"broadcast": "host", "netmask": "255.0.0.0", "network": "127.0.0.0", "address": "127.0.0.1"}, "ipv6": [{"scope": "host", "prefix": "128", "address": "::1"}], "active": true, "type": "loopback"}, "ansible_memtotal_mb": 992, "ansible_veth807892b": {"macaddress": "5a:0f:61:8d:49:5d", "features": {}, "type": "ether", "mtu": 1500, "device": "veth807892b", "promisc": true, "ipv6": [{"scope": "link", "prefix": "64", "address": "fe80::580f:61ff:fe8d:495d"}], "active": true, "speed": 10000}, "ansible_gather_subset": ["hardware", "network", "virtual"], "ansible_apparmor": {"status": "enabled"}, "ansible_memfree_mb": 147, "ansible_processor_count": 1, "ansible_hostname": "olympic", "ansible_interfaces": ["vethc212bd3", "docker0", "veth0d838df", "lo", "vethcb6766c", "veth807892b", "veth3aa2a27", "veth3ce6018", "veth366b2fa", "eth0", "br-078358f6bb2c", "veth573fd39"], "ansible_machine_id": "68f8113ecfadd2e54f7941a254492882", "ansible_fqdn": "localhost", "ansible_mounts": [{"uuid": "12ebc60e-27ef-4a50-97c3-6cc58043b557", "size_total": 26397548544, "mount": "/", "size_available": 15569244160, "fstype": "ext3", "device": "/dev/vda1", "options": "rw,relatime,errors=remount-ro,data=ordered"}, {"uuid": "12ebc60e-27ef-4a50-97c3-6cc58043b557", "size_total": 26397548544, "mount": "/var/lib/docker/aufs", "size_available": 15569244160, "fstype": "ext3", "device": "/dev/vda1", "options": "rw,relatime,errors=remount-ro,data=ordered,bind"}], "ansible_nodename": "olympic", "ansible_br_078358f6bb2c": {"macaddress": "02:42:96:9b:ee:cc", "features": {}, "interfaces": ["vethc212bd3", "veth573fd39", "veth807892b"], "mtu": 1500, "device": "br-078358f6bb2c", "promisc": false, "stp": false, "ipv4": {"broadcast": "global", "netmask": "255.255.0.0", "network": "172.18.0.0", "address": "172.18.0.1"}, "ipv6": [{"scope": "link", "prefix": "64", "address": "fe80::42:96ff:fe9b:eecc"}], "active": true, "type": "bridge", "id": "8000.0242969beecc"}, "ansible_vethc212bd3": {"macaddress": "2e:c2:44:fd:cc:17", "features": {}, "type": "ether", "mtu": 1500, "device": "vethc212bd3", "promisc": true, "ipv6": [{"scope": "link", "prefix": "64", "address": "fe80::2cc2:44ff:fefd:cc17"}], "active": true, "speed": 10000}, "ansible_domain": "", "ansible_date_time": {"weekday_number": "3", "iso8601_basic_short": "20170426T031137", "tz": "UTC", "weeknumber": "17", "hour": "03", "year": "2017", "minute": "11", "tz_offset": "+0000", "month": "04", "epoch": "1493176297", "iso8601_micro": "2017-04-26T03:11:37.667101Z", "weekday": "Wednesday", "time": "03:11:37", "date": "2017-04-26", "iso8601": "2017-04-26T03:11:37Z", "day": "26", "iso8601_basic": "20170426T031137667025", "second": "37"}, "ansible_ssh_host_key_ed25519_public": "AAAAC3NzaC1lZDI1NTE5AAAAIAa5EnFOlOEqJ2zfh02+OSdSgyZjgdqi3IxvgaOwEJbM", "ansible_processor_cores": 1, "ansible_bios_version": "rel-1.10.1-0-g8891697-prebuilt.qemu-project.org", "ansible_virtualization_type": "kvm", "ansible_distribution_release": "xenial", "ansible_os_family": "Debian", "ansible_effective_user_id": 1000, "ansible_system": "Linux", "ansible_devices": {"vda": {"scheduler_mode": "", "rotational": "1", "vendor": "0x1af4", "sectors": "52428800", "sas_device_handle": null, "sas_address": null, "host": "SCSI storage controller: Red Hat, Inc Virtio block device", "sectorsize": "512", "removable": "0", "support_discard": "0", "model": null, "partitions": {"vda1": {"sectorsize": 512, "uuid": "12ebc60e-27ef-4a50-97c3-6cc58043b557", "sectors": "52426719", "start": "2048", "holders": [], "size": "25.00 GB"}}, "holders": [], "size": "25.00 GB"}, "sr0": {"scheduler_mode": "deadline", "rotational": "1", "vendor": "QEMU", "sectors": "2097151", "sas_device_handle": null, "sas_address": null, "host": "IDE interface: Intel Corporation 82371SB PIIX3 IDE [Natoma/Triton II]", "sectorsize": "512", "removable": "1", "support_discard": "0", "model": "QEMU DVD-ROM", "partitions": {}, "holders": [], "size": "1024.00 MB"}}, "ansible_user_uid": 1000, "ansible_ssh_host_key_dsa_public": "AAAAB3NzaC1kc3MAAACBANZsbT2AhDSRdMeeNBfyecD9xOt0+A3g+XcRm5I33opV3IsfTm7Rwnwm9kWtT1z5SthPKOTOxzK+2XDeBLCykrnEaxzg1wE+5P7Dhf+02JN9MHCFmOvzZHR4k3RZ56IRLCiVSFTufaAyYHWIP+K2wQVfFjoaGTwxuntZ4IUo9u+lAAAAFQCPDE7LOHYAL7FdeQLaP+h5eW2TjwAAAIEArTDtZJzMgpoNZGVDZYxroB5ZWN7ZPnybu5Ja0kF1k0cxToiMnKdRAIob6XIhabl9opzH7LN8m5RZGLtz2XqXZBypQ1mFweBZ7YSSxIYXHTfKcWWilh/zRiCnkno8MJaqEZwAxZIIftvKvD7/nDv9+bKDwnlV0AIt6lmxFL2Z6f8AAACBAJ6UqE6YYqseyP+zAvCwHgPNwbvPjMfM0hgoELVSmm/DWwVQopwkhDzV2xS/R/OdtyIqJSzLgFkB7VY3qZ84n0SkFCHnyC7SgyNntbZhgP6E8N+Ehb4rdSQyicUKfgBdR0SC+uO6bm6Rm2JFBfvxMoRjGrVYrEqC9OQBs7sKsb9A", "ansible_bios_date": "04/01/2014", "ansible_system_capabilities": [""]}}\n', 'OpenSSH_7.4p1, LibreSSL 2.5.0\r\ndebug1: Reading configuration data /Users/stephen/.ssh/config\r\ndebug1: /Users/stephen/.ssh/config line 1: Applying options for *\r\ndebug1: Reading configuration data /etc/ssh/ssh_config\r\ndebug1: auto-mux: Trying existing master\r\ndebug2: fd 3 setting O_NONBLOCK\r\ndebug2: mux_client_hello_exchange: master version 4\r\ndebug3: mux_client_forwards: request forwardings: 0 local, 0 remote\r\ndebug3: mux_client_request_session: entering\r\ndebug3: mux_client_request_alive: entering\r\ndebug3: mux_client_request_alive: done pid = 57447\r\ndebug3: mux_client_request_session: session request sent\r\ndebug1: mux_client_request_session: master session id: 2\r\ndebug3: mux_client_read_packet: read header failed: Broken pipe\r\ndebug2: Received exit status from master 0\r\n')
ok: [olympic]
META: ran handlers

TASK [docker_network] *******************************************************************************************************************************************************************************************
task path: /Users/stephen/src/**************************/test.yml:5
Using module file /usr/local/Cellar/ansible/2.3.0.0/libexec/lib/python2.7/site-packages/ansible/modules/cloud/docker/docker_network.py
<olympic.***********> ESTABLISH SSH CONNECTION FOR USER: stephen
<olympic.***********> SSH: EXEC ssh -vvv -C -o ControlMaster=auto -o ControlPersist=60s -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=stephen -o ConnectTimeout=10 -o ControlPath=/Users/stephen/.ansible/cp/c62349e097 ******************* '/bin/sh -c '"'"'/usr/bin/python && sleep 0'"'"''
<olympic.***********> (1, '', 'OpenSSH_7.4p1, LibreSSL 2.5.0\r\ndebug1: Reading configuration data /Users/stephen/.ssh/config\r\ndebug1: /Users/stephen/.ssh/config line 1: Applying options for *\r\ndebug1: Reading configuration data /etc/ssh/ssh_config\r\ndebug1: auto-mux: Trying existing master\r\ndebug2: fd 3 setting O_NONBLOCK\r\ndebug2: mux_client_hello_exchange: master version 4\r\ndebug3: mux_client_forwards: request forwardings: 0 local, 0 remote\r\ndebug3: mux_client_request_session: entering\r\ndebug3: mux_client_request_alive: entering\r\ndebug3: mux_client_request_alive: done pid = 57447\r\ndebug3: mux_client_request_session: session request sent\r\ndebug1: mux_client_request_session: master session id: 2\r\nTraceback (most recent call last):\n  File "/tmp/stephen/ansible_TmRaPl/ansible_module_docker_network.py", line 393, in <module>\n    main()\n  File "/tmp/stephen/ansible_TmRaPl/ansible_module_docker_network.py", line 386, in main\n    cm = DockerNetworkManager(client)\n  File "/tmp/stephen/ansible_TmRaPl/ansible_module_docker_network.py", line 219, in __init__\n    self.present()\n  File "/tmp/stephen/ansible_TmRaPl/ansible_module_docker_network.py", line 353, in present\n    self.disconnect_missing()\n  File "/tmp/stephen/ansible_TmRaPl/ansible_module_docker_network.py", line 324, in disconnect_missing\n    for c in self.existing_network[\'Containers\'].values():\nTypeError: \'NoneType\' object has no attribute \'__getitem__\'\ndebug3: mux_client_read_packet: read header failed: Broken pipe\r\ndebug2: Received exit status from master 1\r\n')
fatal: [olympic]: FAILED! => {
    "changed": false,
    "failed": true,
    "module_stderr": "OpenSSH_7.4p1, LibreSSL 2.5.0\r\ndebug1: Reading configuration data /Users/stephen/.ssh/config\r\ndebug1: /Users/stephen/.ssh/config line 1: Applying options for *\r\ndebug1: Reading configuration data /etc/ssh/ssh_config\r\ndebug1: auto-mux: Trying existing master\r\ndebug2: fd 3 setting O_NONBLOCK\r\ndebug2: mux_client_hello_exchange: master version 4\r\ndebug3: mux_client_forwards: request forwardings: 0 local, 0 remote\r\ndebug3: mux_client_request_session: entering\r\ndebug3: mux_client_request_alive: entering\r\ndebug3: mux_client_request_alive: done pid = 57447\r\ndebug3: mux_client_request_session: session request sent\r\ndebug1: mux_client_request_session: master session id: 2\r\nTraceback (most recent call last):\n  File \"/tmp/stephen/ansible_TmRaPl/ansible_module_docker_network.py\", line 393, in <module>\n    main()\n  File \"/tmp/stephen/ansible_TmRaPl/ansible_module_docker_network.py\", line 386, in main\n    cm = DockerNetworkManager(client)\n  File \"/tmp/stephen/ansible_TmRaPl/ansible_module_docker_network.py\", line 219, in __init__\n    self.present()\n  File \"/tmp/stephen/ansible_TmRaPl/ansible_module_docker_network.py\", line 353, in present\n    self.disconnect_missing()\n  File \"/tmp/stephen/ansible_TmRaPl/ansible_module_docker_network.py\", line 324, in disconnect_missing\n    for c in self.existing_network['Containers'].values():\nTypeError: 'NoneType' object has no attribute '__getitem__'\ndebug3: mux_client_read_packet: read header failed: Broken pipe\r\ndebug2: Received exit status from master 1\r\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE",
    "rc": 1
}
	to retry, use: --limit @/Users/stephen/src/**************************/test.retry

PLAY RECAP ******************************************************************************************************************************************************************************************************
olympic                    : ok=1    changed=0    unreachable=0    failed=1
```

To make the traceback easier to read:

```
Traceback (most recent call last):
  File \"/tmp/stephen/ansible_pr2xap/ansible_module_docker_network.py\", line 393, in <module>
    main()
  File \"/tmp/stephen/ansible_pr2xap/ansible_module_docker_network.py\", line 386, in main
    cm = DockerNetworkManager(client)
  File \"/tmp/stephen/ansible_pr2xap/ansible_module_docker_network.py\", line 219, in __init__
    self.present()
  File \"/tmp/stephen/ansible_pr2xap/ansible_module_docker_network.py\", line 353, in present
    self.disconnect_missing()
  File \"/tmp/stephen/ansible_pr2xap/ansible_module_docker_network.py\", line 324, in disconnect_missing
    for c in self.existing_network['Containers'].values():
TypeError: 'NoneType' object has no attribute '__getitem__'

```

##### Other

Sorry for the lack of tests. I haven't yet figured out how to get the test suite running. But, this change seems to solve the issue in my environment.