### PR TITLE
Fix exception issue in junos_config

### DIFF
--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -185,6 +185,7 @@ backup_path:
 """
 import re
 import json
+import sys
 
 from xml.etree import ElementTree
 
@@ -194,6 +195,12 @@ from ansible.module_utils.junos import junos_argument_spec
 from ansible.module_utils.junos import check_args as junos_check_args
 from ansible.module_utils.netconf import send_request
 from ansible.module_utils.six import string_types
+
+if sys.version < (2, 7):
+    from xml.parsers.expat import ExpatError
+    ParseError = ExpatError
+else:
+    ParseError = ElementTree.ParseError
 
 USE_PERSISTENT_CONNECTION = True
 DEFAULT_COMMENT = 'configured by junos_config'
@@ -217,7 +224,7 @@ def guess_format(config):
     try:
         ElementTree.fromstring(config)
         return 'xml'
-    except ElementTree.ParseError:
+    except ParseError:
         pass
 
     if config.startswith('set') or config.startswith('delete'):


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
`ParseError` exception is added to `ElementTree`
in py2.7. Prior to py2.7 need catch `ExpatError`
exception.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
junos_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
