### PR TITLE
Add a missing leading zero in a mode parameter

### DIFF
--- a/docs/docsite/rst/playbooks_loops.rst
+++ b/docs/docsite/rst/playbooks_loops.rst
@@ -170,7 +170,7 @@ Looping over Fileglobs
             src: "{{ item }}"
             dest: "/etc/fooapp/"
             owner: "root"
-            mode: 600
+            mode: 0600
           with_fileglob:
             - "/playbooks/files/fooapp/*"
 


### PR DESCRIPTION
##### SUMMARY
`600` is an incorrect mode, because mode needs to be octal.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Docs

##### ANSIBLE VERSION
N/A