### PR TITLE
Remove action keyword from do-until example

### DIFF
--- a/docs/docsite/rst/playbooks_loops.rst
+++ b/docs/docsite/rst/playbooks_loops.rst
@@ -349,8 +349,7 @@ Do-Until Loops
 
 Sometimes you would want to retry a task until a certain condition is met.  Here's an example::
 
-    - action:
-        shell /usr/bin/foo
+    - shell: /usr/bin/foo
       register: result
       until: result.stdout.find("all systems go") != -1
       retries: 5


### PR DESCRIPTION
##### SUMMARY
`action:` is old and not needed any more.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Docs

##### ANSIBLE VERSION
N/A