### PR TITLE
Fix style of example about fact_path

### DIFF
--- a/docs/docsite/rst/intro_configuration.rst
+++ b/docs/docsite/rst/intro_configuration.rst
@@ -395,7 +395,7 @@ fact_path
 
 This option allows you to globally configure a custom path for :ref:`_local_facts`:: for the implied `setup` task when using implied fact gathering.
 
-  fact_path = /home/centos/ansible_facts.d
+    fact_path = /home/centos/ansible_facts.d
 
 The default is to use the default from the `setup module  <https://docs.ansible.com/ansible/setup_module.html>`_: ``/etc/ansible/facts.d``
 This ONLY affects fact gathering triggered by a play when `gather_facts: True`.


### PR DESCRIPTION
##### SUMMARY

An example of `fact_path` is currently displays as blockquote, not a code block.
So I fixed this.

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

docs/docsite/rst/intro_configuration.rst

##### ANSIBLE VERSION

devel