### PR TITLE
Refactor openvswitch unit tests

### DIFF
--- a/test/units/modules/network/ovs/ovs_module.py
+++ b/test/units/modules/network/ovs/ovs_module.py
@@ -65,9 +65,9 @@ class AnsibleFailJson(Exception):
 class TestOpenVSwitchModule(unittest.TestCase):
 
     def execute_module(self, failed=False, changed=False,
-                       command=None, fixture_name=None):
+                       command=None, test_name=None):
 
-        self.load_fixtures(fixture_name)
+        self.load_fixtures(test_name)
 
         if failed:
             result = self.failed()
@@ -108,5 +108,5 @@ class TestOpenVSwitchModule(unittest.TestCase):
         self.assertEqual(result['changed'], changed, result)
         return result
 
-    def load_fixtures(self, fixture_name):
+    def load_fixtures(self, test_name):
         pass


### PR DESCRIPTION
Rather than passing a file to load fixture, build a matrix containing
the run_command side_effect per test.
This will allow more code-reuse for other ovs modules unit tests.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
openvswitch

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (refactor_ovs_unit_tests f7fcb7e600) last updated 2017/04/27 14:26:56 (GMT +200)

```
