### PR TITLE
Lineinfile module: add a new option "move" and tests for it and also "firstmatch" option

### DIFF
--- a/test/integration/targets/lineinfile/files/testmultiple.txt
+++ b/test/integration/targets/lineinfile/files/testmultiple.txt
@@ -1,0 +1,9 @@
+This is line 1
+This is the repeating line
+This is line 3
+This is the repeating line
+This is line 5
+This is the repeating line
+This is line 7
+This is the repeating line
+This is line 9

--- a/test/integration/targets/lineinfile/tasks/main.yml
+++ b/test/integration/targets/lineinfile/tasks/main.yml
@@ -368,6 +368,462 @@
     - "result.stat.checksum == '04b7a54d0fb233a4e26c9e625325bb4874841b3c'"
 #######
 
+###################################################################
+# PR 24058
+
+- name: deploy the test file with multiple identical lines for lineinfile
+  copy: src=testmultiple.txt dest={{output_dir}}/testmultiple.txt
+  register: result
+
+- name: replace the first line matching regexp
+  lineinfile:
+    dest: "{{output_dir}}/testmultiple.txt"
+    state: present
+    firstmatch: yes
+    line: "This is the modified repeating line"
+    regexp: "repeating line"
+  register: result
+
+- name: assert that the first matching line was replaced
+  assert:
+    that:
+    - "result.changed == true"
+    - "result.msg == 'line replaced'"
+
+- name: stat the test after the first matching line was replaced
+  stat: path={{output_dir}}/testmultiple.txt
+  register: result
+
+- name: assert test checksum matches after the first matching line was replaced
+  assert:
+    that:
+    - "result.stat.checksum == 'f441c9e5fc6abcda06a68bf5d099ae7d8244ae65'"
+
+####### idempotency - replace first matching
+- name: replace the first line matching regexp again (idempotent)
+  lineinfile:
+    dest: "{{output_dir}}/testmultiple.txt"
+    state: present
+    firstmatch: yes
+    line: "This is the modified repeating line"
+    regexp: "repeating line"
+  register: result
+
+- name: assert that the first matching line was not replaced again
+  assert:
+    that:
+    - "result.changed == false"
+
+- name: stat the test again after the first matching line was replaced
+  stat: path={{output_dir}}/testmultiple.txt
+  register: result
+
+- name: assert test checksum matches after the first matching line was replaced
+  assert:
+    that:
+    - "result.stat.checksum == 'f441c9e5fc6abcda06a68bf5d099ae7d8244ae65'"
+#######
+
+- name: insert a line before the first matching line
+  lineinfile:
+    dest: "{{output_dir}}/testmultiple.txt"
+    state: present
+    firstmatch: yes
+    line: "New line before the first repeating line"
+    before: "repeating line"
+  register: result
+
+- name: assert that the line was added before the first matching line
+  assert:
+    that:
+    - "result.changed == true"
+    - "result.msg == 'line added'"
+
+- name: stat the test after the line was added before the first matching line
+  stat: path={{output_dir}}/testmultiple.txt
+  register: result
+
+- name: assert test checksum matches after the line was added before the first matching line
+  assert:
+    that:
+    - "result.stat.checksum == '4e570eeadcf343708ed13506e00477effd386eb3'"
+
+####### idempotency - insert before first matching
+- name: insert a line before the first matching line again (idempotent)
+  lineinfile:
+    dest: "{{output_dir}}/testmultiple.txt"
+    state: present
+    firstmatch: yes
+    line: "New line before the first repeating line"
+    before: "repeating line"
+  register: result
+
+- name: assert that the line was not added before the first matching line again
+  assert:
+    that:
+    - "result.changed == false"
+
+- name: stat the test again after the line was added before the first matching line
+  stat: path={{output_dir}}/testmultiple.txt
+  register: result
+
+- name: assert test checksum matches after the line was added before the first matching line
+  assert:
+    that:
+    - "result.stat.checksum == '4e570eeadcf343708ed13506e00477effd386eb3'"
+#######
+
+- name: insert a line after the first matching line
+  lineinfile:
+    dest: "{{output_dir}}/testmultiple.txt"
+    state: present
+    firstmatch: yes
+    line: "New line after the first repeating line"
+    after: "This is.*repeating line"
+  register: result
+
+- name: assert that the line was added after the first matching line
+  assert:
+    that:
+    - "result.changed == true"
+    - "result.msg == 'line added'"
+
+- name: stat the test after the line was added after the first matching line
+  stat: path={{output_dir}}/testmultiple.txt
+  register: result
+
+- name: assert test checksum matches after the line was added after the first matching line
+  assert:
+    that:
+    - "result.stat.checksum == '1b92bb2a6467853f45b7011df5b668dd50fd19d1'"
+
+####### idempotency - insert after first matching
+- name: insert a line after the first matching line again (idempotent)
+  lineinfile:
+    dest: "{{output_dir}}/testmultiple.txt"
+    state: present
+    firstmatch: yes
+    line: "New line after the first repeating line"
+    after: "This is.*repeating line"
+  register: result
+
+- name: assert that the line was not added after the first matching line again
+  assert:
+    that:
+    - "result.changed == false"
+
+- name: stat the test again after the line was added after the first matching line
+  stat: path={{output_dir}}/testmultiple.txt
+  register: result
+
+- name: assert test checksum matches after the line was added after the first matching line
+  assert:
+    that:
+    - "result.stat.checksum == '1b92bb2a6467853f45b7011df5b668dd50fd19d1'"
+#######
+
+- name: move the line before the first matching line
+  lineinfile:
+    dest: "{{output_dir}}/testmultiple.txt"
+    state: present
+    firstmatch: yes
+    move: yes
+    line: "This is line 9"
+    before: "repeating line"
+  register: result
+
+- name: assert that the line was moved before the first matching line
+  assert:
+    that:
+    - "result.changed == true"
+    - "result.msg == 'line moved'"
+
+- name: stat the test after the line was moved before the first matching line
+  stat: path={{output_dir}}/testmultiple.txt
+  register: result
+
+- name: assert test checksum matches after the line was moved before the first matching line
+  assert:
+    that:
+    - "result.stat.checksum == '98a643057ac4d11cd7caff8538898ead43c28fbf'"
+
+####### idempotency - move before first matching
+- name: move the line before the first matching line again (idempotent)
+  lineinfile:
+    dest: "{{output_dir}}/testmultiple.txt"
+    state: present
+    firstmatch: yes
+    move: yes
+    line: "This is line 9"
+    before: "repeating line"
+  register: result
+
+- name: assert that the line was not moved before the first matching line again
+  assert:
+    that:
+    - "result.changed == false"
+
+- name: stat the test again after the line was moved before the first matching line
+  stat: path={{output_dir}}/testmultiple.txt
+  register: result
+
+- name: assert test checksum matches after the line was moved before the first matching line
+  assert:
+    that:
+    - "result.stat.checksum == '98a643057ac4d11cd7caff8538898ead43c28fbf'"
+#######
+
+- name: move the line after the first matching line
+  lineinfile:
+    dest: "{{output_dir}}/testmultiple.txt"
+    state: present
+    firstmatch: yes
+    move: yes
+    line: "This is line 9"
+    after: "repeating line"
+  register: result
+
+- name: assert that the line was moved after the first matching line
+  assert:
+    that:
+    - "result.changed == true"
+    - "result.msg == 'line moved'"
+
+- name: stat the test after the line was moved after the first matching line
+  stat: path={{output_dir}}/testmultiple.txt
+  register: result
+
+- name: assert test checksum matches after the line was moved after the first matching line
+  assert:
+    that:
+    - "result.stat.checksum == '9c5b3ad530eed78aa5ebee50dd9f6e3cbd1a28fe'"
+
+####### idempotency - move after first matching
+- name: move the line after the first matching line again (idempotent)
+  lineinfile:
+    dest: "{{output_dir}}/testmultiple.txt"
+    state: present
+    firstmatch: yes
+    move: yes
+    line: "This is line 9"
+    after: "repeating line"
+  register: result
+
+- name: assert that the line was not moved after the first matching line again
+  assert:
+    that:
+    - "result.changed == false"
+
+- name: stat the test again after the line was moved after the first matching line
+  stat: path={{output_dir}}/testmultiple.txt
+  register: result
+
+- name: assert test checksum matches after the line was moved after the first matching line
+  assert:
+    that:
+    - "result.stat.checksum == '9c5b3ad530eed78aa5ebee50dd9f6e3cbd1a28fe'"
+#######
+
+- name: move the line after the last matching line
+  lineinfile:
+    dest: "{{output_dir}}/testmultiple.txt"
+    state: present
+    firstmatch: no
+    move: yes
+    line: "This is line 9"
+    after: "repeating line"
+  register: result
+
+- name: assert that the line was moved after the last matching line
+  assert:
+    that:
+    - "result.changed == true"
+    - "result.msg == 'line moved'"
+
+- name: stat the test after the line was moved after the last matching line
+  stat: path={{output_dir}}/testmultiple.txt
+  register: result
+
+- name: assert test checksum matches after the line was moved after the last matching line
+  assert:
+    that:
+    - "result.stat.checksum == '1b92bb2a6467853f45b7011df5b668dd50fd19d1'"
+
+####### idempotency - move after last matching
+- name: move the line after the last matching line again (idempotent)
+  lineinfile:
+    dest: "{{output_dir}}/testmultiple.txt"
+    state: present
+    firstmatch: no
+    move: yes
+    line: "This is line 9"
+    after: "repeating line"
+  register: result
+
+- name: assert that the line was not moved after the last matching line again
+  assert:
+    that:
+    - "result.changed == false"
+
+- name: stat the test again after the line was moved after the last matching line
+  stat: path={{output_dir}}/testmultiple.txt
+  register: result
+
+- name: assert test checksum matches after the line was moved after the last matching line
+  assert:
+    that:
+    - "result.stat.checksum == '1b92bb2a6467853f45b7011df5b668dd50fd19d1'"
+#######
+
+- name: move the line before the last matching line
+  lineinfile:
+    dest: "{{output_dir}}/testmultiple.txt"
+    state: present
+    firstmatch: no
+    move: yes
+    line: "This is line 9"
+    before: "repeating line"
+  register: result
+
+- name: assert that the line was moved before the last matching line
+  assert:
+    that:
+    - "result.changed == true"
+    - "result.msg == 'line moved'"
+
+- name: stat the test after the line was moved before the last matching line
+  stat: path={{output_dir}}/testmultiple.txt
+  register: result
+
+- name: assert test checksum matches after the line was moved before the last matching line
+  assert:
+    that:
+    - "result.stat.checksum == 'ff326bf21cfc8f0dfc6c479ec5ba158ba1f0bea0'"
+
+####### idempotency - move before last matching
+- name: move the line before the last matching line again (idempotent)
+  lineinfile:
+    dest: "{{output_dir}}/testmultiple.txt"
+    state: present
+    firstmatch: no
+    move: yes
+    line: "This is line 9"
+    before: "repeating line"
+  register: result
+
+- name: assert that the line was not moved before the last matching line again
+  assert:
+    that:
+    - "result.changed == false"
+
+- name: stat the test again after the line was moved before the last matching line
+  stat: path={{output_dir}}/testmultiple.txt
+  register: result
+
+- name: assert test checksum matches after the line was moved before the last matching line
+  assert:
+    that:
+    - "result.stat.checksum == 'ff326bf21cfc8f0dfc6c479ec5ba158ba1f0bea0'"
+#######
+
+- name: make sure the line is before the first matching line
+  lineinfile:
+    dest: "{{output_dir}}/testmultiple.txt"
+    state: present
+    firstmatch: yes
+    move: yes
+    line: "This is line 1"
+    before: "repeating line"
+  register: result
+
+- name: assert that the line was not moved because it is already before the first matching line
+  assert:
+    that:
+    - "result.changed == false"
+
+- name: stat the test after making sure the line is before the first matching line
+  stat: path={{output_dir}}/testmultiple.txt
+  register: result
+
+- name: assert test checksum matches after making sure the line is before the first matching line
+  assert:
+    that:
+    - "result.stat.checksum == 'ff326bf21cfc8f0dfc6c479ec5ba158ba1f0bea0'"
+
+- name: make sure the line is after the first matching line
+  lineinfile:
+    dest: "{{output_dir}}/testmultiple.txt"
+    state: present
+    firstmatch: yes
+    move: yes
+    line: "This is line 3"
+    after: "repeating line"
+  register: result
+
+- name: assert that the line was not moved because it is already after the first matching line
+  assert:
+    that:
+    - "result.changed == false"
+
+- name: stat the test after making sure the line is after the first matching line
+  stat: path={{output_dir}}/testmultiple.txt
+  register: result
+
+- name: assert test checksum matches after making sure the line is after the first matching line
+  assert:
+    that:
+    - "result.stat.checksum == 'ff326bf21cfc8f0dfc6c479ec5ba158ba1f0bea0'"
+
+- name: make sure the line is before the last matching line
+  lineinfile:
+    dest: "{{output_dir}}/testmultiple.txt"
+    state: present
+    firstmatch: no
+    move: yes
+    line: "This is line 5"
+    before: "repeating line"
+  register: result
+
+- name: assert that the line was not moved because it is already before the  mstatching line
+  assert:
+    that:
+    - "result.changed == false"
+
+- name: stat the test after making sure the line is before the last matching line
+  stat: path={{output_dir}}/testmultiple.txt
+  register: result
+
+- name: assert test checksum matches after making sure the line is before the last matching line
+  assert:
+    that:
+    - "result.stat.checksum == 'ff326bf21cfc8f0dfc6c479ec5ba158ba1f0bea0'"
+
+- name: make sure the line is after the last matching line
+  lineinfile:
+    dest: "{{output_dir}}/testmultiple.txt"
+    state: present
+    firstmatch: no
+    move: yes
+    line: "This is line 9"
+    after: "first repeating line"
+  register: result
+
+- name: assert that the line was not moved because it is already after the last matching line
+  assert:
+    that:
+    - "result.changed == false"
+
+- name: stat the test after making sure the line is after the last matching line
+  stat: path={{output_dir}}/testmultiple.txt
+  register: result
+
+- name: assert test checksum matches after making sure the line is after the last matching line
+  assert:
+    that:
+    - "result.stat.checksum == 'ff326bf21cfc8f0dfc6c479ec5ba158ba1f0bea0'"
+
+###################################################################
+
 - name: use create=yes
   lineinfile: dest={{output_dir}}/new_test.txt create=yes insertbefore=BOF state=present line="This is a new file"
   register: result

--- a/test/integration/targets/lineinfile/tasks/main.yml
+++ b/test/integration/targets/lineinfile/tasks/main.yml
@@ -56,6 +56,27 @@
     that:
     - "result.stat.checksum == '7eade4042b23b800958fe807b5bfc29f8541ec09'"
 
+######## idempotency - insert at the beginning, backup
+- name: insert a line at the beginning of the file, and back it up again (idempotent)
+  lineinfile: dest={{output_dir}}/test.txt state=present line="New line at the beginning" insertbefore="BOF" backup=yes
+  register: result
+
+- name: assert that the line was not inserted at the head of the file again
+  assert:
+    that:
+    - "result.changed == false"
+    - "result.backup == ''"
+
+- name: stat the test again after the insert at the head
+  stat: path={{output_dir}}/test.txt
+  register: result
+
+- name: assert test hash is what we expect for the file with the insert at the head
+  assert:
+    that:
+    - "result.stat.checksum == '7eade4042b23b800958fe807b5bfc29f8541ec09'"
+########
+
 - name: insert a line at the end of the file
   lineinfile: dest={{output_dir}}/test.txt state=present line="New line at the end" insertafter="EOF"
   register: result
@@ -74,6 +95,26 @@
   assert:
     that:
     - "result.stat.checksum == 'fb57af7dc10a1006061b000f1f04c38e4bef50a9'"
+
+####### idempotency - insert at the end
+- name: insert a line at the end of the file again (idempotent)
+  lineinfile: dest={{output_dir}}/test.txt state=present line="New line at the end" insertafter="EOF"
+  register: result
+
+- name: assert that the line was not inserted at the end of the file again
+  assert:
+    that:
+    - "result.changed == false"
+
+- name: stat the test again after the insert at the end
+  stat: path={{output_dir}}/test.txt
+  register: result
+
+- name: assert test checksum matches after the insert at the end
+  assert:
+    that:
+    - "result.stat.checksum == 'fb57af7dc10a1006061b000f1f04c38e4bef50a9'"
+#######
 
 - name: insert a line after the first line
   lineinfile: dest={{output_dir}}/test.txt state=present line="New line after line 1" insertafter="^This is line 1$"
@@ -94,6 +135,26 @@
     that:
     - "result.stat.checksum == '5348da605b1bc93dbadf3a16474cdf22ef975bec'"
 
+####### idempotency - insert after first
+- name: insert a line after the first line again (idempotent)
+  lineinfile: dest={{output_dir}}/test.txt state=present line="New line after line 1" insertafter="^This is line 1$"
+  register: result
+
+- name: assert that the line was not inserted after the first line again
+  assert:
+    that:
+    - "result.changed == false"
+
+- name: stat the test again after insert after the first line
+  stat: path={{output_dir}}/test.txt
+  register: result
+
+- name: assert test checksum matches after the insert after the first line
+  assert:
+    that:
+    - "result.stat.checksum == '5348da605b1bc93dbadf3a16474cdf22ef975bec'"
+#######
+
 - name: insert a line before the last line
   lineinfile: dest={{output_dir}}/test.txt state=present line="New line after line 5" insertbefore="^This is line 5$"
   register: result
@@ -112,6 +173,26 @@
   assert:
     that:
     - "result.stat.checksum == 'e1cae425403507feea4b55bb30a74decfdd4a23e'"
+
+####### idempotency - insert before last
+- name: insert a line before the last line again (idempotent)
+  lineinfile: dest={{output_dir}}/test.txt state=present line="New line after line 5" insertbefore="^This is line 5$"
+  register: result
+
+- name: assert that the line was not inserted before the last line again
+  assert:
+    that:
+    - "result.changed == false"
+
+- name: stat the test again after the insert before the last line
+  stat: path={{output_dir}}/test.txt
+  register: result
+
+- name: assert test checksum matches after the insert before the last line
+  assert:
+    that:
+    - "result.stat.checksum == 'e1cae425403507feea4b55bb30a74decfdd4a23e'"
+#######
 
 - name: replace a line with backrefs
   lineinfile: dest={{output_dir}}/test.txt state=present line="This is line 3" backrefs=yes regexp="^(REF) .* \\1$"
@@ -132,6 +213,26 @@
     that:
     - "result.stat.checksum == '2ccdf45d20298f9eaece73b713648e5489a52444'"
 
+####### idempotency - replace with backrefs
+- name: replace a line with backrefs again (idempotent)
+  lineinfile: dest={{output_dir}}/test.txt state=present line="This is line 3" backrefs=yes regexp="^(REF) .* \\1$"
+  register: result
+
+- name: assert that the line with backrefs was not changed again
+  assert:
+    that:
+    - "result.changed == false"
+
+- name: stat the test again after the backref line was replaced
+  stat: path={{output_dir}}/test.txt
+  register: result
+
+- name: assert test checksum matches after backref line was replaced
+  assert:
+    that:
+    - "result.stat.checksum == '2ccdf45d20298f9eaece73b713648e5489a52444'"
+#######
+
 - name: remove the middle line
   lineinfile: dest={{output_dir}}/test.txt state=absent regexp="^This is line 3$"
   register: result
@@ -150,6 +251,26 @@
   assert:
     that:
     - "result.stat.checksum == 'a6ba6865547c19d4c203c38a35e728d6d1942c75'"
+
+####### idempotency - remove line
+- name: remove the middle line again (idempotent)
+  lineinfile: dest={{output_dir}}/test.txt state=absent regexp="^This is line 3$"
+  register: result
+
+- name: assert that the line was not removed again
+  assert:
+    that:
+    - "result.changed == false"
+
+- name: stat the test again after the middle line was removed
+  stat: path={{output_dir}}/test.txt
+  register: result
+
+- name: assert test checksum matches after the middle line was removed
+  assert:
+    that:
+    - "result.stat.checksum == 'a6ba6865547c19d4c203c38a35e728d6d1942c75'"
+#######
 
 - name: run a validation script that succeeds
   lineinfile: dest={{output_dir}}/test.txt state=absent regexp="^This is line 5$" validate="true %s"
@@ -227,6 +348,26 @@
     that:
     - "result.stat.checksum == '04b7a54d0fb233a4e26c9e625325bb4874841b3c'"
 
+####### idempotency - replace with backrefs in line
+- name: replace a line with backrefs included in the line again (idempotent)
+  lineinfile: dest={{output_dir}}/test.txt state=present line="New \\1 created with the backref" backrefs=yes regexp="^This is (line 4)$"
+  register: result
+
+- name: assert that the line with backrefs was not changed again
+  assert:
+    that:
+    - "result.changed == false"
+
+- name: stat the test again after the backref line was replaced
+  stat: path={{output_dir}}/test.txt
+  register: result
+
+- name: assert test checksum matches after backref line was replaced
+  assert:
+    that:
+    - "result.stat.checksum == '04b7a54d0fb233a4e26c9e625325bb4874841b3c'"
+#######
+
 - name: use create=yes
   lineinfile: dest={{output_dir}}/new_test.txt create=yes insertbefore=BOF state=present line="This is a new file"
   register: result
@@ -246,6 +387,27 @@
   assert:
     that:
     - "result.stat.checksum == '038f10f9e31202451b093163e81e06fbac0c6f3a'"
+
+####### idempotency - create file
+- name: use create=yes again (idempotent)
+  lineinfile: dest={{output_dir}}/new_test.txt create=yes insertbefore=BOF state=present line="This is a new file"
+  register: result
+
+- name: assert that the newly created file was not modified
+  assert:
+    that:
+    - "result.changed == false"
+
+- name: stat the newly created file again
+  stat: path={{output_dir}}/new_test.txt
+  register: result
+  ignore_errors: yes
+
+- name: assert the newly created test checksum matches
+  assert:
+    that:
+    - "result.stat.checksum == '038f10f9e31202451b093163e81e06fbac0c6f3a'"
+#######
 
 # Test EOF in cases where file has no newline at EOF
 - name: testnoeof deploy the file for lineinfile

--- a/test/integration/targets/lineinfile/tasks/main.yml
+++ b/test/integration/targets/lineinfile/tasks/main.yml
@@ -189,6 +189,44 @@
     that:
     - "result.stat.checksum == '76955a4516a00a38aad8427afc9ee3e361024ba5'"
 
+- name: insert multiple lines at the end of the file
+  lineinfile: dest={{output_dir}}/test.txt state=present line="This is a line\nwith \\n character" insertafter="EOF"
+  register: result
+
+- name: assert that multiple lines were inserted
+  assert:
+    that:
+    - "result.changed == true"
+    - "result.msg == 'line added'"
+
+- name: stat the test after inserting multiple lines
+  stat: path={{output_dir}}/test.txt
+  register: result
+
+- name: assert test checksum matches after inserting multiple lines
+  assert:
+    that:
+    - "result.stat.checksum == 'bf5b711f8f0509355aaeb9d0d61e3e82337c1365'"
+
+- name: replace a line with backrefs included in the line
+  lineinfile: dest={{output_dir}}/test.txt state=present line="New \\1 created with the backref" backrefs=yes regexp="^This is (line 4)$"
+  register: result
+
+- name: assert that the line with backrefs was changed
+  assert:
+    that:
+    - "result.changed == true"
+    - "result.msg == 'line replaced'"
+
+- name: stat the test after the backref line was replaced
+  stat: path={{output_dir}}/test.txt
+  register: result
+
+- name: assert test checksum matches after backref line was replaced
+  assert:
+    that:
+    - "result.stat.checksum == '04b7a54d0fb233a4e26c9e625325bb4874841b3c'"
+
 - name: use create=yes
   lineinfile: dest={{output_dir}}/new_test.txt create=yes insertbefore=BOF state=present line="This is a new file"
   register: result
@@ -218,17 +256,7 @@
   lineinfile: dest={{output_dir}}/testnoeof.txt state=present line="New line at the end" insertafter="EOF"
   register: result
 
-- name: testempty assert that the line was inserted at the end of the file
-  assert:
-    that:
-    - "result.changed == true"
-    - "result.msg == 'line added'"
-
-- name: insert a multiple lines at the end of the file
-  lineinfile: dest={{output_dir}}/test.txt state=present line="This is a line\nwith \\n character" insertafter="EOF"
-  register: result
-
-- name: assert that the multiple lines was inserted
+- name: testnoeof assert that the line was inserted at the end of the file
   assert:
     that:
     - "result.changed == true"
@@ -266,33 +294,6 @@
   assert:
     that:
     - "result.stat.checksum == 'f440dc65ea9cec3fd496c1479ddf937e1b949412'"
-
-- stat: path={{output_dir}}/test.txt
-  register: result
-
-- name: assert test checksum matches after inserting multiple lines
-  assert:
-    that:
-    - "result.stat.checksum == 'bf5b711f8f0509355aaeb9d0d61e3e82337c1365'"
-
-- name: replace a line with backrefs included in the line
-  lineinfile: dest={{output_dir}}/test.txt state=present line="New \\1 created with the backref" backrefs=yes regexp="^This is (line 4)$"
-  register: result
-
-- name: assert that the line with backrefs was changed
-  assert:
-    that:
-    - "result.changed == true"
-    - "result.msg == 'line replaced'"
-
-- name: stat the test after the backref line was replaced
-  stat: path={{output_dir}}/test.txt
-  register: result
-
-- name: assert test checksum matches after backref line was replaced
-  assert:
-    that:
-    - "result.stat.checksum == '04b7a54d0fb233a4e26c9e625325bb4874841b3c'"
 
 ###################################################################
 # issue 8535


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR adds a new option to the "lineinfile" module. I've also changed the names of options "insertbefore" and "insertafter" to "before" and "after", to be more suitable for current module capabilities. Old option names still work.
Originally, this PR introduced also a new "match_mode" option, however the same thing was introduced in  #33825 as "firstmatch".

The"move" option tells the module to move the line before or after line matching regexp specified in "before" or "after" option. It enables users to control the position of the line, even if it already exists in the specified file. To be more precise, the line is moved (and possibly replaced) when it is after the line matching "before", or before "after". In other words, it does not force the line to be right before/after line matching "before"/"after", just controls its position to be generally "after" or "before".
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
files/lineinfile module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.5.0 (lineinfile_matching_and_moving_options 325294d0c6) last updated 2018/01/19 09:33:56 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/piotrp/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/piotrp/github/ansible/lib/ansible
  executable location = /home/piotrp/github/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 20 2017, 18:23:56) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
The combination of "move=yes" with "firstmatch" works as follows:
- if "firstmatch" = yes, the FIRST line matching "regexp" (or just the "line" itself, if "regexp" is not specified) is moved after or before the FIRST line matching regexp specified in "after" or "before" option, respectively (if it's not already after or before, of course);
- if "firstmatch" = no, the LAST line matching "regexp" (or "line" itself) is moved after or before the LAST line matching regexp specified in "after" or "before" option.

Such approach has been chosen because moving FIRST match of "regexp" after/before LAST match of "before"/"after" or vice versa would cause problems with idempotency in case multiple matching lines before/after line matching "before"/"after".

<!--- Paste verbatim command output below, e.g. before and after your change -->
Capabilities of both new options can be tested by the task:
```
- lineinfile:
    path: /etc/resolv.conf
    firstmatch: yes
    line: 'nameserver 8.8.8.8'
    before: '^nameserver'
    move: yes
```
The contents of resolv.conf before Ansible run:
```
# System DNS configuration
search example.com
nameserver 10.0.0.100
nameserver 10.0.0.101
nameserver 10.0.0.102
nameserver 8.8.8.8
```
Ansible run with --diff and --verbose (debug callback used):
```
--- before: /etc/resolv.conf (content)
+++ after: /etc/resolv.conf (content)
@@ -1,6 +1,6 @@
 # System DNS configuration
 search example.com
+nameserver 8.8.8.8
 nameserver 10.0.0.100
 nameserver 10.0.0.101
 nameserver 10.0.0.102
-nameserver 8.8.8.8

changed: [testserver] => {
    "backup": "", 
    "changed": true
}

MSG:

line moved
```
I have read the [module checklist](http://docs.ansible.com/ansible/dev_guide/developing_modules_checklist.html) and I believe my modifications meet these requirements (except for return values documentation, but this module currently doesn't have this at all).