### PR TITLE
Return commands instead of command on openvswitch_db

### DIFF
--- a/lib/ansible/modules/network/ovs/openvswitch_db.py
+++ b/lib/ansible/modules/network/ovs/openvswitch_db.py
@@ -103,26 +103,26 @@ EXAMPLES = '''
 '''
 
 
-def map_obj_to_command(want, have, module):
+def map_obj_to_commands(want, have, module):
     """ Define ovs-vsctl command to meet desired state """
-    command = None
+    commands = list()
 
     if module.params['state'] == 'absent':
         if 'key' in have.keys():
             templatized_command = "%(ovs-vsctl)s -t %(timeout)s remove %(table)s %(record)s " \
                                   "%(col)s %(key)s=%(value)s"
-            command = templatized_command % module.params
+            commands.append(templatized_command % module.params)
     else:
         if 'key' not in have.keys():
             templatized_command = "%(ovs-vsctl)s -t %(timeout)s add %(table)s %(record)s " \
                                   "%(col)s %(key)s=%(value)s"
-            command = templatized_command % module.params
+            commands.append(templatized_command % module.params)
         elif want['value'] != have['value']:
             templatized_command = "%(ovs-vsctl)s -t %(timeout)s set %(table)s %(record)s " \
                                   "%(col)s:%(key)s=%(value)s"
-            command = templatized_command % module.params
+            commands.append(templatized_command % module.params)
 
-    return command
+    return commands
 
 
 def map_config_to_obj(module):
@@ -190,12 +190,13 @@ def main():
     want = map_params_to_obj(module)
     have = map_config_to_obj(module)
 
-    command = map_obj_to_command(want, have, module)
-    result['command'] = command
+    commands = map_obj_to_commands(want, have, module)
+    result['commands'] = commands
 
-    if command:
+    if commands:
         if not module.check_mode:
-            module.run_command(command, check_rc=True)
+            for c in commands:
+                module.run_command(c, check_rc=True)
         result['changed'] = True
 
     module.exit_json(**result)

--- a/test/units/modules/network/ovs/ovs_module.py
+++ b/test/units/modules/network/ovs/ovs_module.py
@@ -65,7 +65,7 @@ class AnsibleFailJson(Exception):
 class TestOpenVSwitchModule(unittest.TestCase):
 
     def execute_module(self, failed=False, changed=False,
-                       command=None, test_name=None):
+                       commands=None, test_name=None):
 
         self.load_fixtures(test_name)
 
@@ -76,8 +76,8 @@ class TestOpenVSwitchModule(unittest.TestCase):
             result = self.changed(changed)
             self.assertEqual(result['changed'], changed, result)
 
-        if command:
-            self.assertEqual(command, result['command'], result['command'])
+        if commands:
+            self.assertEqual(commands, result['commands'], result['commands'])
 
         return result
 

--- a/test/units/modules/network/ovs/test_openvswitch_db.py
+++ b/test/units/modules/network/ovs/test_openvswitch_db.py
@@ -87,8 +87,8 @@ class TestOpenVSwitchDBModule(TestOpenVSwitchModule):
                              value='True'))
         self.execute_module(
             changed=True,
-            command='/usr/bin/ovs-vsctl -t 5 remove Bridge test-br other_config'
-                    ' disable-in-band=True',
+            commands=['/usr/bin/ovs-vsctl -t 5 remove Bridge test-br other_config'
+                      ' disable-in-band=True'],
             test_name='test_openvswitch_db_absent_removes_key')
 
     def test_openvswitch_db_present_idempotent(self):
@@ -105,8 +105,8 @@ class TestOpenVSwitchDBModule(TestOpenVSwitchModule):
                              value='True'))
         self.execute_module(
             changed=True,
-            command='/usr/bin/ovs-vsctl -t 5 add Bridge test-br other_config'
-                    ' disable-in-band=True',
+            commands=['/usr/bin/ovs-vsctl -t 5 add Bridge test-br other_config'
+                      ' disable-in-band=True'],
             test_name='test_openvswitch_db_present_adds_key')
 
     def test_openvswitch_db_present_updates_key(self):
@@ -116,6 +116,6 @@ class TestOpenVSwitchDBModule(TestOpenVSwitchModule):
                              value='False'))
         self.execute_module(
             changed=True,
-            command='/usr/bin/ovs-vsctl -t 5 set Bridge test-br other_config'
-                    ':disable-in-band=False',
+            commands=['/usr/bin/ovs-vsctl -t 5 set Bridge test-br other_config'
+                      ':disable-in-band=False'],
             test_name='test_openvswitch_db_present_updates_key')


### PR DESCRIPTION
##### SUMMARY

Ok, so for openvswitch_db in particular we just return one command
but in the sake of consistency and code re-use, let's return a list
of "commands", even if it's just one.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
openswitch_db

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (ovs_module_pass_commands_array 20390429bd) last updated 2017/04/27 16:13:59 (GMT +200)

```
