### PR TITLE
Update playbooks_blocks.rst

### DIFF
--- a/docs/docsite/rst/playbooks_blocks.rst
+++ b/docs/docsite/rst/playbooks_blocks.rst
@@ -59,7 +59,9 @@ Blocks also introduce the ability to handle errors in a way similar to exception
 
 The tasks in the ``block`` would execute normally, if there is any error the ``rescue`` section would get executed
 with whatever you need to do to recover from the previous error. The ``always`` section runs no matter what previous
-error did or did not occur in the ``block`` and ``rescue`` sections.
+error did or did not occur in the ``block`` and ``rescue`` sections. It should be noted that the play continues if a
+``rescue`` section completes successfully, regardless of any ``max_fail_percentage`` or ``any_errors_fatal``
+configuration.
 
 
 Another example is how to run handlers after an error occurred :

--- a/docs/docsite/rst/playbooks_blocks.rst
+++ b/docs/docsite/rst/playbooks_blocks.rst
@@ -60,8 +60,7 @@ Blocks also introduce the ability to handle errors in a way similar to exception
 The tasks in the ``block`` would execute normally, if there is any error the ``rescue`` section would get executed
 with whatever you need to do to recover from the previous error. The ``always`` section runs no matter what previous
 error did or did not occur in the ``block`` and ``rescue`` sections. It should be noted that the play continues if a
-``rescue`` section completes successfully, regardless of any ``max_fail_percentage`` or ``any_errors_fatal``
-configuration.
+``rescue`` section completes successfully as it 'erases' the error status (but not the reporting), this means it won't trigger ``max_fail_percentage`` nor ``any_errors_fatal`` configurations but will appear in the playbook statistics.
 
 
 Another example is how to run handlers after an error occurred :


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The rescue section documentation should be clear that successful completion of a rescue section will override other error handling behavior. Hopefully, this helps other hapless admins who don't pick up on this nuance and end up with a cascading failure ;)
<!---

If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
block

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /root/ansible/tom-ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Apr 14 2017, 15:45:34) [GCC 4.2.1 Compatible FreeBSD Clang 3.4.1 (tags/RELEASE_34/dot1-final 208032)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
This fragment shows my intended use case of a rescue section and any_errors_fatal. It does not fail (as expected) unless you explicitly fail in the rescue.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
- hosts: apache_daemons

  # Trump mode.
  gather_facts: false

  # Only run one host at a time. If anything tips over, we don't want to risk
  # losing a cluster.
  serial: 1
  any_errors_fatal: true
  max_fail_percentage: 1

  tasks:

    - block:

      # Ideally, this would be graceful.
      - name: restart apache
        service:
          name: "{{ apache_service_name | default('apache22') }}"
          state: restarted

      rescue:

      - name: Notify if a restart failed
        mail:
          from: root@example.com
          to: tom@example.com
          subject: "Problem with apache restart playbook"
          body: "Do something about that bad thing that happened"

      # Play will resume at this point, in spite of error handling above, 
      # unless you uncomment the following.
      #- fail:
```
