### PR TITLE
Fix orphan resource pool crash (Issue #24078)

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1011,7 +1011,7 @@ class PyVmomiHelper(object):
             if not rp[0]:
                 continue
 
-            if not hasattr(rp[0], 'parent'):
+            if not hasattr(rp[0], 'parent') or not rp[0].parent:
                 continue
 
             # Find resource pool on host


### PR DESCRIPTION
Fixes issue [#24078](https://github.com/ansible/ansible/issues/24078)

Resource pools are retrieved from VSphere regardless of the state of the `resource_pool` parameter. During this process, each retrieved Resource Pool is checked for the `parent` attribute, and if it exists, the currently-scoped parent object is compared against the Resource Pool's parent object. The method doing the check, however, `assert`s that the parent object is not `None`. In some cases, a Resource Pool will have the `parent` attr, but that `parent` object will be `None`, causing the `assert` to fail.

This should avoid that. :-)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
