### PR TITLE
module_iam_role: add_remove_policies_option

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam_role.py
+++ b/lib/ansible/modules/cloud/amazon/iam_role.py
@@ -44,6 +44,12 @@ options:
     description:
       - A list of managed policy ARNs (can't use friendly names due to AWS API limitation) to attach to the role. To embed an inline policy, use M(iam_policy). To remove existing policies, use an empty list item.
     required: true
+  remove_unlisted_policies:
+    description:
+      - Detaches any managed policies not listed in the "managed_policy" option. Set to false if you want to attach policies elsewhere.
+    type: bool
+    default: true
+    version_added: "2.4"
   state:
     description:
       - Create or remove the IAM role
@@ -202,24 +208,25 @@ def create_or_update_role(connection, module):
     # Check attached managed policies
     current_attached_policies = get_attached_policy_list(connection, params['RoleName'])
     if not compare_attached_role_policies(current_attached_policies, managed_policies):
-        # If managed_policies has a single empty element we want to remove all attached policies
-        if len(managed_policies) == 1 and managed_policies[0] == "":
+        if module.params.get('remove_unlisted_policies'):
+            # If managed_policies has a single empty element we want to remove all attached policies
+            if len(managed_policies) == 1 and managed_policies[0] == "":
+                for policy in current_attached_policies:
+                    try:
+                        connection.detach_role_policy(RoleName=params['RoleName'], PolicyArn=policy['PolicyArn'])
+                    except (ClientError, ParamValidationError) as e:
+                        module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+
+            # Detach policies not present
+            current_attached_policies_arn_list = []
             for policy in current_attached_policies:
+                current_attached_policies_arn_list.append(policy['PolicyArn'])
+
+            for policy_arn in list(set(current_attached_policies_arn_list) - set(managed_policies)):
                 try:
-                    connection.detach_role_policy(RoleName=params['RoleName'], PolicyArn=policy['PolicyArn'])
+                    connection.detach_role_policy(RoleName=params['RoleName'], PolicyArn=policy_arn)
                 except (ClientError, ParamValidationError) as e:
                     module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
-
-        # Detach policies not present
-        current_attached_policies_arn_list = []
-        for policy in current_attached_policies:
-            current_attached_policies_arn_list.append(policy['PolicyArn'])
-
-        for policy_arn in list(set(current_attached_policies_arn_list) - set(managed_policies)):
-            try:
-                connection.detach_role_policy(RoleName=params['RoleName'], PolicyArn=policy_arn)
-            except (ClientError, ParamValidationError) as e:
-                module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
 
         # Attach each policy
         for policy_arn in managed_policies:
@@ -228,6 +235,7 @@ def create_or_update_role(connection, module):
             except (ClientError, ParamValidationError) as e:
                 module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
 
+    if current_attached_policies != get_attached_policy_list(connection, params['RoleName']):
         changed = True
 
     # We need to remove any instance profiles from the role before we delete it
@@ -326,6 +334,7 @@ def main():
             path=dict(default="/", required=False, type='str'),
             assume_role_policy_document=dict(required=False, type='json'),
             managed_policy=dict(default=[], required=False, type='list'),
+            remove_unlisted_policies=dict(type='bool', default=True),
             state=dict(default=None, choices=['present', 'absent'], required=True)
         )
     )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

I would like to be able to create an IAM role with this module without precluding the attachment of IAM Managed Policies in some other context. This pull request attempts to reconcile these concerns with as few changes as possible.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

modules/cloud/amazon/iam_role.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

- This PR will not change the default behavior. If the option is omitted, unlisted policies will continue to be detached.
- I wrote this to have as minimal (non-whitespace) changes as possible. If the maintainer would prefer a different form, I am very flexible; my only concern is getting the option into an official release.
  - The raw diff looks bigger than it should, because I indented a fairly large block. To see the condensed diff, add `?w=1` to the GitHub url.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
$ cat test_unlisted_policy_option.yaml

---
- name: test unlisted policy option
  hosts: localhost
  tasks:
    - name: Create role with a Managed Policy listed
      iam_role:
        state: present
        name: "{{ item }}"
        assume_role_policy_document:
          Version: '2012-10-17'
          Statement:
            - Effect: Allow
              Principal:
                Service: ec2.amazonaws.com
              Action: sts:AssumeRole
        managed_policy:
          - arn:aws:iam::aws:policy/SecurityAudit
      with_items:
        - TestOptionTrue
        - TestOptionFalse

    - name: Update role1, removing unlisted policies
      iam_role:
        state: present
        name: TestOptionTrue
        assume_role_policy_document:
          Version: '2012-10-17'
          Statement:
            - Effect: Allow
              Principal:
                Service: ec2.amazonaws.com
              Action: sts:AssumeRole
        remove_unlisted_policies: True

    - name: Update role2, ignoring unlisted policies
      iam_role:
        state: present
        name: TestOptionTrue
        assume_role_policy_document:
          Version: '2012-10-17'
          Statement:
            - Effect: Allow
              Principal:
                Service: ec2.amazonaws.com
              Action: sts:AssumeRole
        remove_unlisted_policies: False
...

$ ansible-playbook test_unlisted_policy_option.yaml

TASK [Create role with a Managed Policy listed] ********************************
changed: [localhost] => (item=TestOptionTrue)
changed: [localhost] => (item=TestOptionFalse)

TASK [Update role1, removing unlisted policies] ********************************
changed: [localhost]

TASK [Update role2, ignoring unlisted policies] ********************************
ok: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=4    changed=2    unreachable=0    failed=0
```
