### PR TITLE
Process `connection:local` after processing the magic variables

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -391,8 +391,9 @@ class PlayContext(Base):
                         setattr(new_info, attr, delegated_vars[variable_name])
                         attrs_considered.append(attr)
                 elif variable_name in variables:
-                    if variable_name == 'ansible_connection' and getattr(task, 'connection'):
-                        setattr(new_info, attr, task.connection)
+                    # Ensure that "connection: local" supersedes "ansible_connection" variable
+                    if variable_name == 'ansible_connection' and getattr(task, 'connection') and task.connection == 'local':
+                        setattr(new_info, attr, 'local')
                     else:
                         setattr(new_info, attr, variables[variable_name])
                     attrs_considered.append(attr)

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -397,7 +397,7 @@ class PlayContext(Base):
                         setattr(new_info, attr, variables[variable_name])
                     attrs_considered.append(attr)
                 # no else, as no other vars should be considered
-                
+
         # become legacy updates -- from commandline
         if not new_info.become_pass:
             if new_info.become_method == 'sudo' and new_info.sudo_pass:

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -318,6 +318,14 @@ class PlayContext(Base):
 
         new_info = self.copy()
 
+        # loop through a subset of attributes on the task object and set
+        # connection fields based on their values
+        for attr in TASK_ATTRIBUTE_OVERRIDES:
+            if hasattr(task, attr):
+                attr_val = getattr(task, attr)
+                if attr_val is not None:
+                    setattr(new_info, attr, attr_val)
+
         # next, use the MAGIC_VARIABLE_MAPPING dictionary to update this
         # connection info object with 'magic' variables from the variable list.
         # If the value 'ansible_delegated_vars' is in the variables, it means
@@ -383,17 +391,12 @@ class PlayContext(Base):
                         setattr(new_info, attr, delegated_vars[variable_name])
                         attrs_considered.append(attr)
                 elif variable_name in variables:
-                    setattr(new_info, attr, variables[variable_name])
+                    if variable_name == 'ansible_connection' and getattr(task, 'connection'):
+                        setattr(new_info, attr, task.connection)
+                    else:
+                        setattr(new_info, attr, variables[variable_name])
                     attrs_considered.append(attr)
                 # no else, as no other vars should be considered
-
-        # loop through a subset of attributes on the task object and set
-        # connection fields based on their values
-        for attr in TASK_ATTRIBUTE_OVERRIDES:
-            if hasattr(task, attr):
-                attr_val = getattr(task, attr)
-                if attr_val is not None:
-                    setattr(new_info, attr, attr_val)
                 
         # become legacy updates -- from commandline
         if not new_info.become_pass:

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -318,14 +318,6 @@ class PlayContext(Base):
 
         new_info = self.copy()
 
-        # loop through a subset of attributes on the task object and set
-        # connection fields based on their values
-        for attr in TASK_ATTRIBUTE_OVERRIDES:
-            if hasattr(task, attr):
-                attr_val = getattr(task, attr)
-                if attr_val is not None:
-                    setattr(new_info, attr, attr_val)
-
         # next, use the MAGIC_VARIABLE_MAPPING dictionary to update this
         # connection info object with 'magic' variables from the variable list.
         # If the value 'ansible_delegated_vars' is in the variables, it means
@@ -395,6 +387,14 @@ class PlayContext(Base):
                     attrs_considered.append(attr)
                 # no else, as no other vars should be considered
 
+        # loop through a subset of attributes on the task object and set
+        # connection fields based on their values
+        for attr in TASK_ATTRIBUTE_OVERRIDES:
+            if hasattr(task, attr):
+                attr_val = getattr(task, attr)
+                if attr_val is not None:
+                    setattr(new_info, attr, attr_val)
+                
         # become legacy updates -- from commandline
         if not new_info.become_pass:
             if new_info.become_method == 'sudo' and new_info.sudo_pass:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
In a heterogeneous environment where more than one connection-method is being used, one has to set `ansible_connection` for sets of hosts deliberately. In this case a play/task `connection: local` stops working as expected because it is superseded by a group/host `ansible_connection`.

There is no situation where a deliberate play/task `connection: local` should be replaced with another connection method. (Think Windows _and_ Unix systems mixed)

This fixes #24076.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
play_context / task_executor

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.4