### PR TITLE
Give example of empty _meta in dyanmic inventory

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_inventory.rst
+++ b/docs/docsite/rst/dev_guide/developing_inventory.rst
@@ -86,6 +86,18 @@ The data to be added to the top level JSON dictionary looks like this::
         }
     }
 
+To satisfy the requirements of using ``_meta``, to prevent ansible from calling your inventory with ``--host`` you must at least populate ``_meta`` with an empty ``hostvars`` dictionary, such as::
+
+    {
+
+        # results of inventory script as above go here
+        # ...
+
+        "_meta": {
+            "hostvars": {}
+        }
+    }
+
 .. seealso::
 
    :doc:`developing_api`


### PR DESCRIPTION
##### SUMMARY

Users often think that using `"meta": {}` is sufficient to prevent ansible from calling `--host`, this clarifies that you need at least `"meta": {"hostvars": {}}`

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
N/A