### PR TITLE
mail: Fix auth over starttls.

### DIFF
--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -246,7 +246,6 @@ def main():
     sender_phrase, sender_addr = parseaddr(sender)
     secure_state = False
     code = 0
-    auth_flag = ""
 
     if not body:
         body = subject
@@ -269,7 +268,6 @@ def main():
                 module.fail_json(rc=1, msg='Unable to Connect to %s:%s: %s' %
                                  (host, port, to_native(e)), exception=traceback.format_exc())
 
-
     if (secure == 'always'):
         try:
             smtp = smtplib.SMTP_SSL(timeout=timeout)
@@ -286,8 +284,6 @@ def main():
             module.fail_json(rc=1, msg='Helo failed for host %s:%s: %s' %
                              (host, port, to_native(e)), exception=traceback.format_exc())
 
-        auth_flag = smtp.has_extn('AUTH')
-
         if secure in ('try', 'starttls'):
             if smtp.has_extn('STARTTLS'):
                 try:
@@ -303,7 +299,7 @@ def main():
                     module.fail_json(rc=1, msg='StartTLS is not offered on server %s:%s' % (host, port))
 
     if username and password:
-        if auth_flag:
+        if smtp.has_extn('AUTH'):
             try:
                 smtp.login(username, password)
             except smtplib.SMTPAuthenticationError:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When only encrypted auth possible, AUTH flag is not present before secured connection established.
This patch moves checks for AUTH flag after **connection is maybe secured**.
```shell
[k0ste@WorkStation ~]$ telnet k0ste.ru 25
Trying 5.128.220.100...
Connected to k0ste.ru.
Escape character is '^]'.
220 k0ste.ru ESMTP
EHLO ansible.com
250-k0ste.ru
250-PIPELINING
250-SIZE
250-VRFY
250-ETRN
250-STARTTLS
250-ENHANCEDSTATUSCODES
250-8BITMIME
250-DSN
250 SMTPUTF8
QUIT
221 2.0.0 Bye
Connection closed by foreign host.
```

After STARTTLS AUTH is present:

```shell
[k0ste@WorkStation ~]$ openssl s_client -starttls smtp -connect k0ste.ru:25
250 SMTPUTF8
EHLO ansible.com
250-k0ste.ru
250-PIPELINING
250-SIZE
250-VRFY
250-ETRN
250-AUTH PLAIN LOGIN
250-ENHANCEDSTATUSCODES
250-8BITMIME
250-DSN
250 SMTPUTF8
QUIT
DONE
```

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/modules/mail.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /home/k0ste/.ansible.cfg
  configured module search path = [u'/home/k0ste/ansible/my_modules/']
  python version = 2.7.13 (default, Feb 11 2017, 12:22:40) [GCC 6.3.1 20170109]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->



<!--- Paste verbatim command output below, e.g. before and after your change -->
Before patch:

```python
TASK [openvpn_ldap : Send mail] **********************************************************************************************************************
fatal: [127.0.0.1 -> localhost]: FAILED! => {"changed": false, "failed": true, "msg": "No Authentication on the server at k0ste.ru:25", "rc": 1}
```

After patch:

```python
TASK [openvpn_ldap : Send mail] **********************************************************************************************************************
ok: [127.0.0.1 -> localhost]
```