### PR TITLE
Add Consul node, agent and session policies from version 0.8.0

### DIFF
--- a/lib/ansible/modules/clustering/consul_acl.py
+++ b/lib/ansible/modules/clustering/consul_acl.py
@@ -28,7 +28,7 @@ short_description: "manipulate consul acl keys and rules"
 description:
  - allows the addition, modification and deletion of ACL keys and associated
    rules in a consul cluster via the agent. For more details on using and
-   configuring ACLs, see https://www.consul.io/docs/internals/acl.html.
+   configuring ACLs, see https://www.consul.io/docs/guides/acl.html.
 requirements:
   - "python >= 2.6"
   - python-consul
@@ -245,8 +245,14 @@ def yml_to_rules(module, yml_rules):
                 rules.add_rule('event', Rule(rule['event'], rule['policy']))
             elif ('query' in rule and 'policy' in rule):
                 rules.add_rule('query', Rule(rule['query'], rule['policy']))
+            elif ('agent' in rule and 'policy' in rule):
+                rules.add_rule('agent', Rule(rule['agent'], rule['policy']))
+            elif ('node' in rule and 'policy' in rule):
+                rules.add_rule('node', Rule(rule['node'], rule['policy']))
+            elif ('session' in rule and 'policy' in rule):
+                rules.add_rule('session', Rule(rule['session'], rule['policy']))
             else:
-                module.fail_json(msg="a rule requires a key/service/event or query and a policy.")
+                module.fail_json(msg="a rule requires a key/service/event/query/agent/node or session and a policy.")
     return rules
 
 template = '''%s "%s" {
@@ -254,7 +260,7 @@ template = '''%s "%s" {
 }
 '''
 
-RULE_TYPES = ['key', 'service', 'event', 'query']
+RULE_TYPES = ['key', 'service', 'event', 'query', 'agent', 'node', 'session']
 
 class Rules:
 


### PR DESCRIPTION
##### SUMMARY
Add support for the new ACL types agent, node and session which Consul introduced in 0.8.0 https://www.consul.io/docs/guides/acl.html#complete-acl-coverage-in-consul-0-8.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
consul_acl

##### ANSIBLE VERSION
```
ansible 2.3.0.0 (stable-2.3 b6f3b27eaa) last updated 2017/04/25 20:35:07 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
They have the same structure as existing policies that this module already implements https://github.com/hashicorp/consul/blob/master/acl/policy.go.

```
- consul_acl:
    rules:
      - agent: 'foo'
        policy: read
      - node: 'foo'
        policy: read
      - session: 'foo'
        policy: read
```