### PR TITLE
Correct RETURN data types for Network modules

### DIFF
--- a/lib/ansible/modules/network/asa/asa_config.py
+++ b/lib/ansible/modules/network/asa/asa_config.py
@@ -223,7 +223,7 @@ updates:
 backup_path:
   description: The full path to the backup file
   returned: when backup is yes
-  type: path
+  type: string
   sample: /playbooks/ansible/backup/asa_config.2016-07-16@22:28:34
 responses:
   description: The set of responses from issuing the commands on the device

--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -200,7 +200,7 @@ commands:
 backup_path:
   description: The full path to the backup file
   returned: when backup is yes
-  type: path
+  type: string
   sample: /playbooks/ansible/backup/eos_config.2016-07-16@22:28:34
 """
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/network/illumos/ipadm_prop.py
+++ b/lib/ansible/modules/network/illumos/ipadm_prop.py
@@ -90,9 +90,9 @@ temporary:
     type: boolean
     sample: "True"
 value:
-    description: value of the property
+    description: value of the property. May be int or string depending on property.
     returned: always
-    type: int/string (depends on property)
+    type: int
     sample: "'1024' or 'never'"
 '''
 

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -199,7 +199,7 @@ updates:
 backup_path:
   description: The full path to the backup file
   returned: when backup is yes
-  type: path
+  type: string
   sample: /playbooks/ansible/backup/ios_config.2016-07-16@22:28:34
 """
 import re

--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -175,7 +175,7 @@ updates:
 backup_path:
   description: The full path to the backup file
   returned: when backup is yes
-  type: path
+  type: string
   sample: /playbooks/ansible/backup/iosxr01.2016-07-16@22:28:34
 """
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -180,7 +180,7 @@ RETURN = """
 backup_path:
   description: The full path to the backup file
   returned: when backup is yes
-  type: path
+  type: string
   sample: /playbooks/ansible/backup/config.2016-07-16@22:28:34
 """
 import re

--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -212,7 +212,7 @@ updates:
 backup_path:
   description: The full path to the backup file
   returned: when backup is yes
-  type: path
+  type: string
   sample: /playbooks/ansible/backup/nxos_config.2016-07-16@22:28:34
 """
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/network/openswitch/ops_config.py
+++ b/lib/ansible/modules/network/openswitch/ops_config.py
@@ -179,7 +179,7 @@ updates:
 backup_path:
   description: The full path to the backup file
   returned: when backup is yes
-  type: path
+  type: string
   sample: /playbooks/ansible/backup/ops_config.2016-07-16@22:28:34
 """
 import re

--- a/lib/ansible/modules/network/ordnance/ordnance_config.py
+++ b/lib/ansible/modules/network/ordnance/ordnance_config.py
@@ -190,7 +190,7 @@ updates:
 backup_path:
   description: The full path to the backup file
   returned: when backup is yes
-  type: path
+  type: string
   sample: /playbooks/ansible/backup/ordnance_config.2016-07-16@22:28:34
 """
 import re

--- a/lib/ansible/modules/network/sros/sros_config.py
+++ b/lib/ansible/modules/network/sros/sros_config.py
@@ -214,7 +214,7 @@ commands:
 backup_path:
   description: The full path to the backup file
   returned: when backup is yes
-  type: path
+  type: string
   sample: /playbooks/ansible/backup/sros_config.2016-07-16@22:28:34
 """
 from ansible.module_utils.basic import AnsibleModule


### PR DESCRIPTION
##### SUMMARY
`path` isn't a datatype

Part of:
https://github.com/ansible/ansible/issues/18185
https://github.com/ansible/ansible/pull/23322

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
eos_config

##### ANSIBLE VERSION
```
2.4.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
