### PR TITLE
Fix manual reference for dmidecode

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1883,9 +1883,9 @@ class OpenBSDHardware(Hardware):
         self.facts['devices'] = devices
 
     def get_dmi_facts(self):
-        # We don't use dmidecode(1) here because:
+        # We don't use dmidecode(8) here because:
         # - it would add dependency on an external package
-        # - dmidecode(1) can only be ran as root
+        # - dmidecode(8) can only be ran as root
         # So instead we rely on sysctl(8) to provide us the information on a
         # best-effort basis. As a bonus we also get facts on non-amd64/i386
         # platforms this way.
@@ -2126,9 +2126,9 @@ class NetBSDHardware(Hardware):
                 })
 
     def get_dmi_facts(self):
-        # We don't use dmidecode(1) here because:
+        # We don't use dmidecode(8) here because:
         # - it would add dependency on an external package
-        # - dmidecode(1) can only be ran as root
+        # - dmidecode(8) can only be ran as root
         # So instead we rely on sysctl(8) to provide us the information on a
         # best-effort basis. As a bonus we also get facts on non-amd64/i386
         # platforms this way.


### PR DESCRIPTION
##### SUMMARY
Fix the manual reference for dmidecode, as dmidecode(1) does not exist (but should be instead dmidecode(8)).

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
facts
