### PR TITLE
#22147 Implementation of the already documented vlan management on nm…

### DIFF
--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -1003,11 +1003,91 @@ class Nmcli(object):
     def create_connection_vlan(self):
         cmd=[self.module.get_bin_path('nmcli', True)]
         # format for creating ethernet interface
+	# To add a Vlan connection with static IP configuration, issue a command as follows
+        # - nmcli: name=add conn_name=my-vlan1 ifname=vlan1 vlandev=eth0 vlanid=1 type=vlan ip4=192.0.2.100/24 gw4=192.0.2.1 state=present
+        # nmcli con add con-name my-vlan1 ifname vlan1 type vlan dev eth0 id 1 ip4 192.0.2.100/24 gw4 192.0.2.1
+        cmd.append('con')
+        cmd.append('add')
+        cmd.append('type')
+        cmd.append('vlan')
+
+        cmd.append('con-name')
+        if self.conn_name is not None:
+            cmd.append(self.conn_name)
+        elif self.ifname is not None:
+            cmd.append(self.ifname)
+        else:
+            cmd.append("vlan%s" % self.vlanid)
+
+        cmd.append('ifname')
+        if self.ifname is not None:
+            cmd.append(self.ifname)
+        elif self.conn_name is not None:
+            cmd.append(self.conn_name)
+        else:
+            cmd.append("vlan%s" % self.vlanid)
+
+        assert self.vlandev, "vlandev required"
+        cmd.append('dev')
+        cmd.append(self.vlandev)
+
+        assert self.vlanid, "vlanid required"
+        cmd.append('id')
+        cmd.append(self.vlanid)
+
+        if self.ip4 is not None:
+            cmd.append('ip4')
+            cmd.append(self.ip4)
+        if self.gw4 is not None:
+            cmd.append('gw4')
+            cmd.append(self.gw4)
+        if self.ip6 is not None:
+            cmd.append('ip6')
+            cmd.append(self.ip6)
+        if self.gw6 is not None:
+            cmd.append('gw6')
+            cmd.append(self.gw6)
+        if self.autoconnect is not None:
+            cmd.append('autoconnect')
+            cmd.append(self.bool_to_string(self.autoconnect))
         return cmd
 
     def modify_connection_vlan(self):
         cmd=[self.module.get_bin_path('nmcli', True)]
         # format for modifying ethernet interface
+	cmd.append('con')
+        cmd.append('mod')
+        cmd.append(self.conn_name)
+
+        if self.vlandev is not None:
+            cmd.append('vlan.parent')
+            cmd.append(self.vlandev)
+
+        if self.vlanid is not None:
+            cmd.append('vlan.id')
+            cmd.append(self.vlanid)
+
+        if self.ip4 is not None:
+            cmd.append('ipv4.address')
+            cmd.append(self.ip4)
+        if self.gw4 is not None:
+            cmd.append('ipv4.gateway')
+            cmd.append(self.gw4)
+        if self.dns4 is not None:
+            cmd.append('ipv4.dns')
+            cmd.append(self.dns4)
+        if self.ip6 is not None:
+            cmd.append('ipv6.address')
+            cmd.append(self.ip6)
+        if self.gw6 is not None:
+            cmd.append('ipv6.gateway')
+            cmd.append(self.gw6)
+        if self.dns6 is not None:
+            cmd.append('ipv6.dns')
+            cmd.append(self.dns6)
+        if self.autoconnect is not None:
+            cmd.append('autoconnect')
+            cmd.append(self.bool_to_string(self.autoconnect))
         return cmd
 
     def create_connection(self):


### PR DESCRIPTION
…cli module.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Fixes   #22147 , half of it. 
Implementation of the vlan section of nmcli management. 
Nmcli module was not using the parameters for vlan management, it was only calling the nmcli command and giving the output as good. 
Documentation on how to use nmcli module to manage vlan is already in place. 


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
module/net_tools/nmcli.py 

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
nsible 2.4.0 (fix_implement_nmcli_vlan_integration a224a4f899) last updated 2017/04/28 13:03:20 (GMT +100)
  config file = /home/marc/.ansible.cfg
  configured module search path = [u'/home/marc/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/marc/.local/src/github/ansible/lib/ansible
  executable location = /home/marc/.local/src/github/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
