### PR TITLE
Fixes minor typo in docs

### DIFF
--- a/docs/docsite/rst/playbooks_delegation.rst
+++ b/docs/docsite/rst/playbooks_delegation.rst
@@ -54,7 +54,7 @@ As of Ansible 2.2, the batch sizes can be specified as a list, as follows::
 In the above example, the first batch would contain a single host, the next would contain 5 hosts, and (if there are any hosts left),
 every following batch would contain 10 hosts until all available hosts are used.
 
-It is also possible to list multiple batche sizes as percentages::
+It is also possible to list multiple batch sizes as percentages::
 
     - name: test play
       hosts: webservers


### PR DESCRIPTION
Removes an extra `e` from the word `batch` in the the
`playbooks_delegation` documentation seen at:
http://docs.ansible.com/ansible/playbooks_delegation.html

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
playbooks_delegation

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel branch
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Minor typo in docs. Apologies for such a small PR.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
