### PR TITLE
Print specific error for BadHostKeyException

### DIFF
--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -245,6 +245,8 @@ class Connection(ConnectionBase):
                 port=port,
                 **sock_kwarg
             )
+        except paramiko.ssh_exception.BadHostKeyException as e:
+            raise AnsibleConnectionFailure('host key mismatch for %s' % e.hostname)
         except Exception as e:
             msg = str(e)
             if "PID check failed" in msg:


### PR DESCRIPTION
##### SUMMARY
Fixes #18510 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
paramiko_ssh

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
This might not be the clearest error message, but it isn't a stacktrace, or worse (the current situation) something like `(u'nxos01', <paramiko.rsakey.RSAKey object at 0x7f5474855350>, <paramiko.rsakey.RSAKey object at 0x7f54748863d0>)`