### PR TITLE
Remove hack for backwards compatible v2_playbook_on_start callback

### DIFF
--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -356,22 +356,7 @@ class TaskQueueManager:
 
             for method in methods:
                 try:
-                    # Previously, the `v2_playbook_on_start` callback API did not accept
-                    # any arguments. In recent versions of the v2 callback API, the play-
-                    # book that started execution is given. In order to support both of
-                    # these method signatures, we need to use this `inspect` hack to send
-                    # no arguments to the methods that don't accept them. This way, we can
-                    # not break backwards compatibility until that API is deprecated.
-                    # FIXME: target for removal and revert to the original code here after a year (2017-01-14)
-                    if method_name == 'v2_playbook_on_start':
-                        import inspect
-                        argspec = inspect.getargspec(method)
-                        if argspec.args == ['self']:
-                            method()
-                        else:
-                            method(*args, **kwargs)
-                    else:
-                        method(*args, **kwargs)
+                    method(*args, **kwargs)
                 except Exception as e:
                     # TODO: add config toggle to make this fatal or not?
                     display.warning(u"Failure using method (%s) in callback plugin (%s): %s" % (to_text(method_name), to_text(callback_plugin), to_text(e)))

--- a/test/units/executor/test_task_queue_manager_callbacks.py
+++ b/test/units/executor/test_task_queue_manager_callbacks.py
@@ -48,30 +48,6 @@ class TestTaskQueueManagerCallbacks(unittest.TestCase):
     def tearDown(self):
         pass
 
-    def test_task_queue_manager_callbacks_v2_playbook_on_start_legacy(self):
-        """
-        Assert that no exceptions are raised when sending a Playbook
-        start callback to a legacy callback module plugin.
-        """
-        register = self._register
-
-        class LegacyCallbackModule(CallbackBase):
-            """
-            This is a callback module with the legacy
-            method signature for `v2_playbook_on_start`.
-            """
-            CALLBACK_VERSION = 2.0
-            CALLBACK_TYPE = 'notification'
-            CALLBACK_NAME = 'legacy_module'
-
-            def v2_playbook_on_start(self):
-                register(self)
-
-        callback_module = LegacyCallbackModule()
-        self._tqm._callback_plugins.append(callback_module)
-        self._tqm.send_callback('v2_playbook_on_start', self._playbook)
-        register.assert_called_once_with(callback_module)
-
     def test_task_queue_manager_callbacks_v2_playbook_on_start(self):
         """
         Assert that no exceptions are raised when sending a Playbook


### PR DESCRIPTION
Late in the development of 2.0 we had a change to the API of callbacks.
We added the playbook to the arguments passed to the callbacks.

This wasn't in the Tower callback at the time.  In order to prevent
breaking that callback we added a temporary hack to inspect the
callback's API to decide if we needed to call it with arguments or not.

We scheduled the hack for removal in January 2017.  Since that's now
past, removing the hack.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
task_queue_manager.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```