### PR TITLE
Speed up env-setup

### DIFF
--- a/hacking/env-setup
+++ b/hacking/env-setup
@@ -59,7 +59,7 @@ fi
 (
 	cd "$ANSIBLE_HOME"
 	if [ "$verbosity" = silent ] ; then
-	    gen_egg_info > /dev/null 2>&1
+	    gen_egg_info > /dev/null 2>&1 &
             find . -type f -name "*.pyc" -exec rm -f {} \; > /dev/null 2>&1
 	else
 	    gen_egg_info


### PR DESCRIPTION
##### SUMMARY

I have `env-setup` run every time I enter my virtualenv for ansible, controlled via `postactivate` from `virtualenvwrapper`.

There is a lot of time spent waiting to get a prompt, due to `gen_egg_info`

Typically, I don't activate that venv, and immediately try to use any of the ansible scripts, or at least not within the amount of time that `gen_egg_info` takes.

I'm usually going to change to a different directory or something, before running a command, and the `gen_egg_info` completes in the background before I need it.

I've only added it for `-q` since you wouldn't see the message anyway.  Without `-q` we don't background the generation.

This at least gives me a usable shell earlier.

I'm open to other suggestions as well.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
env-setup

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
