### PR TITLE
Fix ClearLinux pretty name

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -667,7 +667,7 @@ class Distribution(object):
         'OracleLinux': 'Oracle Linux',
         'RedHat': 'Red Hat',
         'Altlinux': 'ALT Linux',
-        'ClearLinux': 'Clear Linux Software for Intel Architecture',
+        'ClearLinux': 'Clear Linux',
         'SMGL': 'Source Mage GNU/Linux',
     }
 


### PR DESCRIPTION
##### SUMMARY
ClearLinux has changed its pretty name in os-release file
from: 'Clear Linux Software for Intel Architecture'
to: 'Clear Linux OS for Intel Architecture'

This patch makes the SEARCH_STRING 'Clear Linux' rather than
the full name to make it compatible with the old and new name.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (clearlinux 013a8f5302) last updated 2017/04/28 17:43:16 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/albertom/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/albertom/github/ansible/lib/ansible
  executable location = /Users/albertom/github/ansible/bin/ansible
  python version = 2.7.13 (v2.7.13:a06454b1afa1, Dec 17 2016, 12:39:47) [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
```
