### PR TITLE
vmware_guest: Fix VM creation when adding a network device without a MAC address

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -238,13 +238,19 @@ def gather_vm_facts(content, vm):
         if not hasattr(entry, 'macAddress'):
             continue
 
+        if entry.macAddress:
+            mac_addr = entry.macAddress
+            mac_addr_dash = mac_addr.replace(':', '-')
+        else:
+            mac_addr = mac_addr_dash = None
+
         factname = 'hw_eth' + str(ethernet_idx)
         facts[factname] = {
             'addresstype': entry.addressType,
             'label': entry.deviceInfo.label,
-            'macaddress': entry.macAddress,
+            'macaddress': mac_addr,
             'ipaddresses': net_dict.get(entry.macAddress, None),
-            'macaddress_dash': entry.macAddress.replace(':', '-') if entry.macAddress else None,
+            'macaddress_dash': mac_addr_dash,
             'summary': entry.deviceInfo.summary,
         }
         facts['hw_interfaces'].append('eth' + str(ethernet_idx))

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -244,7 +244,7 @@ def gather_vm_facts(content, vm):
             'label': entry.deviceInfo.label,
             'macaddress': entry.macAddress,
             'ipaddresses': net_dict.get(entry.macAddress, None),
-            'macaddress_dash': entry.macAddress.replace(':', '-'),
+            'macaddress_dash': entry.macAddress.replace(':', '-') if entry.macAddress else None,
             'summary': entry.deviceInfo.summary,
         }
         facts['hw_interfaces'].append('eth' + str(ethernet_idx))

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -389,7 +389,6 @@ class PyVmomiDeviceHelper(object):
                                       (device_type, device_infos['name']))
 
         nic.device.wakeOnLanEnabled = True
-        nic.device.addressType = 'assigned'
         nic.device.deviceInfo = vim.Description()
         nic.device.deviceInfo.label = device_label
         nic.device.deviceInfo.summary = device_infos['name']
@@ -398,7 +397,10 @@ class PyVmomiDeviceHelper(object):
         nic.device.connectable.allowGuestControl = True
         nic.device.connectable.connected = True
         if 'mac' in device_infos:
+            nic.device.addressType = 'assigned'
             nic.device.macAddress = device_infos['mac']
+        else:
+            nic.device.addressType = 'generated'
 
         return nic
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
create_nic() sets the nic's address type as 'assigned', which requires you to supply a MAC address. This causes an error when omitting the MAC address from a playbook. 

This patch will set the address type to 'generated' if a MAC address is not specified.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vmware_guest

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Example Playbook: 
```
---
- hosts: test-vms
  gather_facts: false
  connection: local
  vars_prompt:
    - name: "esxi_user"
      prompt: "Enter ESXi username"
      private: no
    - name: "esxi_pass"
      prompt: "Enter ESXi password"
      private: yes
  vars:
    datacenter: 'ha-datacenter'
    notes: 'Created by Ansible'
  tasks:
    - name: "Deploy VM"
      vmware_guest:
        name: "{{ inventory_hostname }}"
        validate_certs: False
        hostname: "{{ esxi_hostname }}"
        username: "{{ esxi_user }}"
        password: "{{ esxi_pass }}"
        state: present
        guest_id: "{{ osid }}"
        disk:
        - size_gb: "{{ disk_size }}"
          type: thin
          datastore: "{{ datastore }}"
        hardware:
          memory_mb: "{{ memory }}"
          num_cpus: "{{ cpucount }}"
        networks:
        - name: VM Network
      delegate_to: localhost
```
Error: 
```
fatal: [test-vm01 -> localhost]: FAILED! => {
    "changed": true,
    "failed": true,
    "invocation": {
        "module_args": {
            "annotation": null,
            "cluster": null,
            "customization": {},
            "customvalues": [],
            "datacenter": "ha-datacenter",
            "disk": [
                {
                    "datastore": "datastore1",
                    "size_gb": 10,
                    "type": "thin"
                }
            ],
            "esxi_hostname": null,
            "folder": "/vm",
            "force": false,
            "guest_id": "centos64Guest",
            "hardware": {
                "memory_mb": 512,
                "num_cpus": 1
            },
            "hostname": "1.1.1.1",
            "is_template": false,
            "name": "test-vm01",
            "name_match": "first",
            "networks": [
                {
                    "name": "VM Network"
                }
            ],
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "resource_pool": null,
            "state": "present",
            "template_src": null,
            "username": "root",
            "uuid": null,
            "validate_certs": false,
            "wait_for_ip_address": false
        }
    },
    "msg": "Invalid configuration for device '2'."
}

```
