### PR TITLE
Win_package argument parser improvements

### DIFF
--- a/lib/ansible/modules/windows/win_package.ps1
+++ b/lib/ansible/modules/windows/win_package.ps1
@@ -850,7 +850,7 @@ function Set-TargetResource
                     if($process)
                     {
                         $exitCode = $process.ExitCode
-                        $result.exit_code = $exitCode
+                        $result["exit_code"] = $exitCode
                     }
                 }
             }
@@ -1259,24 +1259,15 @@ $result = @{
     changed = $false
 }
 
-$path = Get-Attr -obj $params -name path -failifempty $true -resultobj $result
-$name = Get-Attr -obj $params -name name -default $path
-$productid = Get-Attr -obj $params -name productid
-if ($productid -eq $null)
-{
-    #Alias added for backwards compat.
-    $productid = Get-Attr -obj $params -name product_id -failifempty $true -resultobj $result
-}
-$arguments = Get-Attr -obj $params -name arguments
-$normalizeargs = Get-Attr -obj $params -name normalize_arguments -type "bool" 
-$ensure = Get-Attr -obj $params -name state -default "present"
-if ($ensure -eq $null)
-{
-    $ensure = Get-Attr -obj $params -name ensure -default "present"
-}
-$username = Get-Attr -obj $params -name user_name
-$password = Get-Attr -obj $params -name user_password
-$return_code = Get-Attr -obj $params -name expected_return_code -default 0
+$path = Get-AnsibleParam -obj $params -name "path" -failifempty $true -resultobj $result
+$name = Get-AnsibleParam -obj $params -name "name" -default $path
+$productid = Get-AnsibleParam -obj $params -name "productid" -aliases "product_id"
+$arguments = Get-AnsibleParam -obj $params -name "arguments"
+$normalizeargs = Get-AnsibleParam -obj $params -name "normalize_arguments" -type "bool" -aliases "parse_arguments"
+$ensure = Get-AnsibleParam -obj $params -name "state" -default "present" -aliases "ensure"
+$username = Get-AnsibleParam -obj $params -name "user_name"
+$password = Get-AnsibleParam -obj $params -name "user_password"
+$return_code = Get-AnsibleParam -obj $params -name "expected_return_code" -type "int" -default 0
 
 
 if ($normalizeargs -eq $true -and ($arguments -ne $null))
@@ -1306,7 +1297,7 @@ if ($normalizeargs -eq $true -and ($arguments -ne $null))
         }
         $arguments = $NewArgs -join $SplitChar
     }
-    $result.normalized_args = $ReplacedArgs
+    $result["normalized_args"] = $ReplacedArgs
 }
 
 #Construct the DSC param hashtable
@@ -1328,7 +1319,7 @@ if (($username -ne $null) -and ($password -ne $null))
 }
 
 #Always return the name
-$result.name = $name
+$result["name"] = $name
 
 $testdscresult = Test-TargetResource @dscparams
 if ($testdscresult -eq $true)
@@ -1350,11 +1341,11 @@ Else
     #Check if DSC thinks the computer needs a reboot:
     if ((get-variable DSCMachinestatus -Scope Global -ea 0) -and ($global:DSCMachineStatus -eq 1))
     {
-        $result.restart_required = $true
+        $result["restart_required"] = $true
     }
 
     #Set-TargetResource did its job. We can assume a change has happened
-    $result.changed = $true
+    $result["changed"] = $true
     Exit-Json -obj $result
 
 }

--- a/lib/ansible/modules/windows/win_package.ps1
+++ b/lib/ansible/modules/windows/win_package.ps1
@@ -1263,12 +1263,24 @@ $path = Get-AnsibleParam -obj $params -name "path" -failifempty $true -resultobj
 $name = Get-AnsibleParam -obj $params -name "name" -default $path
 $productid = Get-AnsibleParam -obj $params -name "productid" -aliases "product_id"
 $arguments = Get-AnsibleParam -obj $params -name "arguments"
-$normalizeargs = Get-AnsibleParam -obj $params -name "normalize_arguments" -type "bool" -aliases "parse_arguments"
+$options = Get-AnsibleParam -obj $params -name "options"
+#$normalizeargs = Get-AnsibleParam -obj $params -name "normalize_arguments" -type "bool" -aliases "parse_arguments"
 $ensure = Get-AnsibleParam -obj $params -name "state" -default "present" -aliases "ensure"
 $username = Get-AnsibleParam -obj $params -name "user_name"
 $password = Get-AnsibleParam -obj $params -name "user_password"
 $return_code = Get-AnsibleParam -obj $params -name "expected_return_code" -type "int" -default 0
 
+
+if (($arguments -ne $null) -and ($options -ne $null))
+{
+    fail-json "specify either arguments or options"
+}
+
+if ($options -ne $null)
+{
+    $arguments = $options
+    $normalizeargs = $true
+}
 
 if ($normalizeargs -eq $true -and ($arguments -ne $null))
 {

--- a/lib/ansible/modules/windows/win_package.ps1
+++ b/lib/ansible/modules/windows/win_package.ps1
@@ -1264,7 +1264,6 @@ $name = Get-AnsibleParam -obj $params -name "name" -default $path
 $productid = Get-AnsibleParam -obj $params -name "productid" -aliases "product_id"
 $arguments = Get-AnsibleParam -obj $params -name "arguments"
 $options = Get-AnsibleParam -obj $params -name "options"
-#$normalizeargs = Get-AnsibleParam -obj $params -name "normalize_arguments" -type "bool" -aliases "parse_arguments"
 $ensure = Get-AnsibleParam -obj $params -name "state" -default "present" -aliases "ensure"
 $username = Get-AnsibleParam -obj $params -name "user_name"
 $password = Get-AnsibleParam -obj $params -name "user_password"
@@ -1273,7 +1272,7 @@ $return_code = Get-AnsibleParam -obj $params -name "expected_return_code" -type 
 
 if (($arguments -ne $null) -and ($options -ne $null))
 {
-    fail-json "specify either arguments or options"
+    fail-json $result "specify either arguments or options, not both"
 }
 
 if ($options -ne $null)
@@ -1309,7 +1308,7 @@ if ($normalizeargs -eq $true -and ($arguments -ne $null))
         }
         $arguments = $NewArgs -join $SplitChar
     }
-    $result["normalized_args"] = $ReplacedArgs
+    $result.normalized_args = $ReplacedArgs
 }
 
 #Construct the DSC param hashtable
@@ -1327,11 +1326,11 @@ if (($username -ne $null) -and ($password -ne $null))
     #Add network credential to the list
     $secpassword = $password | ConvertTo-SecureString -AsPlainText -Force
     $credential = New-Object pscredential -ArgumentList $username, $secpassword
-    $dscparams.add("Credential",$credential)
+    $dscparams.add("Credential" ,$credential)
 }
 
 #Always return the name
-$result["name"] = $name
+$result.name = $name
 
 $testdscresult = Test-TargetResource @dscparams
 if ($testdscresult -eq $true)
@@ -1353,11 +1352,11 @@ Else
     #Check if DSC thinks the computer needs a reboot:
     if ((get-variable DSCMachinestatus -Scope Global -ea 0) -and ($global:DSCMachineStatus -eq 1))
     {
-        $result["restart_required"] = $true
+        $result.restart_required = $true
     }
 
     #Set-TargetResource did its job. We can assume a change has happened
-    $result["changed"] = $true
+    $result.changed = $true
     Exit-Json -obj $result
 
 }

--- a/lib/ansible/modules/windows/win_package.ps1
+++ b/lib/ansible/modules/windows/win_package.ps1
@@ -1270,6 +1270,10 @@ $password = Get-AnsibleParam -obj $params -name "user_password"
 $return_code = Get-AnsibleParam -obj $params -name "expected_return_code" -type "int" -default 0
 
 
+if ($arguments -ne $null)
+{
+    Add-DeprecationWarning -obj $result -message "'arguments' is being deprecated in favor of 'options'" -version "2.4.0"
+}
 if (($arguments -ne $null) -and ($options -ne $null))
 {
     fail-json $result "specify either arguments or options, not both"

--- a/lib/ansible/modules/windows/win_package.py
+++ b/lib/ansible/modules/windows/win_package.py
@@ -64,7 +64,7 @@ options:
   normalize_arguments:
     description:
       - >
-        Performs argument normalization of the arguments string, replacing json-escaped double backslashes with single ones. 
+        Performs argument normalization of the arguments string, replacing json-escaped double backslashes with single ones.
         This makes it easier to pass in complex argument strings in a way that the installer will understand.
     default: false
     choices:
@@ -141,7 +141,7 @@ EXAMPLES = r'''
 - name: install ravendb using argument normalization
   win_package:
     path: "{{ ravendb_source_url }}"
-    arguments: "/quiet /log C:\\raven_log.txt /msicl RAVEN_TARGET_ENVIRONMENT=PRODUCTION /msicl TARGETDIR=F:\\apps\\RavenDB /msicl F:\\apps\\RavenDB /msicl RAVEN_INSTALLATION_TYPE=SERVICE /msicl REMOVE=IIS /msicl ADDLOCAL=Service /msicl RAVEN_LICENSE_FILE_PATH={{ apps_data_path }}\\NServiceBus_RavenDB_License\\license.xml"
+    arguments: "/quiet /log C:\\raven_log.txt /msicl TARGETDIR=F:\\apps\\RavenDB /msicl F:\\apps\\RavenDB"
     product_id: "{D90279D8-6EB3-417E-983B-4BB5E1E9BF88}"
     normalize_arguments: true
   register: ravendb_install_result

--- a/lib/ansible/modules/windows/win_package.py
+++ b/lib/ansible/modules/windows/win_package.py
@@ -70,6 +70,7 @@ options:
     choices:
       - true
       - false
+    version_added: 2.4
   state:
     description:
       - Install or Uninstall

--- a/lib/ansible/modules/windows/win_package.py
+++ b/lib/ansible/modules/windows/win_package.py
@@ -66,11 +66,9 @@ options:
       - >
         Performs argument normalization of the arguments string, replacing json-escaped double backslashes with single ones.
         This makes it easier to pass in complex argument strings in a way that the installer will understand.
-    default: false
-    choices:
-      - true
-      - false
-    version_added: 2.4
+    type: bool
+    default: 'no'
+    version_added: "2.4"
   state:
     description:
       - Install or Uninstall

--- a/lib/ansible/modules/windows/win_package.py
+++ b/lib/ansible/modules/windows/win_package.py
@@ -61,6 +61,15 @@ options:
       - Any arguments the installer needs
     default: null
     required: false
+  normalize_arguments:
+    description:
+      - >
+        Performs argument normalization of the arguments string, replacing json-escaped double backslashes with single ones. 
+        This makes it easier to pass in complex argument strings in a way that the installer will understand.
+    default: false
+    choices:
+      - true
+      - false
   state:
     description:
       - Install or Uninstall
@@ -128,4 +137,12 @@ EXAMPLES = r'''
     arguments: '/q /norestart'
     ensure: present
     expected_return_code: [0,3010]
+# example of passing in complex args using json-escaped double backslashes with normalization
+- name: install ravendb using argument normalization
+  win_package:
+    path: "{{ ravendb_source_url }}"
+    arguments: "/quiet /log C:\\raven_log.txt /msicl RAVEN_TARGET_ENVIRONMENT=PRODUCTION /msicl TARGETDIR=F:\\apps\\RavenDB /msicl F:\\apps\\RavenDB /msicl RAVEN_INSTALLATION_TYPE=SERVICE /msicl REMOVE=IIS /msicl ADDLOCAL=Service /msicl RAVEN_LICENSE_FILE_PATH={{ apps_data_path }}\\NServiceBus_RavenDB_License\\license.xml"
+    product_id: "{D90279D8-6EB3-417E-983B-4BB5E1E9BF88}"
+    normalize_arguments: true
+  register: ravendb_install_result
 '''

--- a/lib/ansible/modules/windows/win_package.py
+++ b/lib/ansible/modules/windows/win_package.py
@@ -61,13 +61,12 @@ options:
       - Any arguments the installer needs
     default: null
     required: false
-  normalize_arguments:
+  options:
     description:
-      - >
-        Performs argument normalization of the arguments string, replacing json-escaped double backslashes with single ones.
-        This makes it easier to pass in complex argument strings in a way that the installer will understand.
-    type: bool
-    default: 'no'
+      - mutually exclusive with "arguments"
+      - Similar to arguments, however using this instead of arguments will tell the module to attempt to normalize arguments.
+      - See examples below
+    required: false
     version_added: "2.4"
   state:
     description:
@@ -137,11 +136,10 @@ EXAMPLES = r'''
     ensure: present
     expected_return_code: [0,3010]
 # example of passing in complex args using json-escaped double backslashes with normalization
-- name: install ravendb using argument normalization
+- name: install ravendb using argument normalization (paths will be normalized before sent to the installer)
   win_package:
     path: "{{ ravendb_source_url }}"
-    arguments: "/quiet /log C:\\raven_log.txt /msicl TARGETDIR=F:\\apps\\RavenDB /msicl F:\\apps\\RavenDB"
+    options: "/quiet /log C:\\raven_log.txt /msicl TARGETDIR=F:\\apps\\RavenDB /msicl F:\\apps\\RavenDB"
     product_id: "{D90279D8-6EB3-417E-983B-4BB5E1E9BF88}"
-    normalize_arguments: true
   register: ravendb_install_result
 '''

--- a/lib/ansible/modules/windows/win_package.py
+++ b/lib/ansible/modules/windows/win_package.py
@@ -58,15 +58,13 @@ options:
     aliases: [productid]
   arguments:
     description:
-      - Any arguments the installer needs
+      - Any arguments the installer needs. Will be deprecated, use options instead.
     default: null
-    required: false
   options:
     description:
-      - mutually exclusive with "arguments"
+      - Mutually exclusive with "arguments".
       - Similar to arguments, however using this instead of arguments will tell the module to attempt to normalize arguments.
-      - See examples below
-    required: false
+      - See examples below.
     version_added: "2.4"
   state:
     description:
@@ -75,20 +73,17 @@ options:
       - present
       - absent
     default: present
-    required: false
     aliases: [ensure]
   user_name:
     description:
       - Username of an account with access to the package if it's located on a file share. Only needed if the winrm user doesn't have access to the package.
         Also specify user_password for this to function properly.
     default: null
-    required: false
   user_password:
     description:
       - Password of an account with access to the package if it's located on a file share. Only needed if the winrm user doesn't have access to the package.
         Also specify user_name for this to function properly.
     default: null
-    required: false
   expected_return_code:
     description:
       - One or more return codes from the package installation that indicates success.


### PR DESCRIPTION
##### SUMMARY
Flag for normalizing `arguments` into a format the installer will understand. 
This fixes the problem where a path had to be specified in the arguments string, for example `INSTALLDIR=C:\\Test` - this would cause the installer to throw since the double backslashes weren't normalized before passed to the installer.

This PR breaks the arguments string up by ` ` (space) and `=`, and then looks at each block to see if its likely a path (second character is `:`). If so, it will replace `\\` with `\` before the argument string is passed down to the installer



##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
win_package

##### ANSIBLE VERSION
```
2.4.0
```

