### PR TITLE
Add apk available and repository

### DIFF
--- a/lib/ansible/modules/packaging/os/apk.py
+++ b/lib/ansible/modules/packaging/os/apk.py
@@ -37,6 +37,12 @@ options:
       - A package name, like C(foo), or mutliple packages, like C(foo, bar).
     required: false
     default: null
+  repository:
+    description:
+      - A package repository or multiple repositories
+    required: false
+    default: null
+    version_added: "2.4"
   state:
     description:
       - Indicates the desired package(s) state.
@@ -112,6 +118,13 @@ EXAMPLES = '''
 # Update repositories as a separate step
 - apk:
     update_cache: yes
+
+# Install package from a specific repository
+- apk:
+    name: foo
+    state: latest
+    update_cache: yes
+    repository: http://dl-3.alpinelinux.org/alpine/edge/main
 '''
 
 
@@ -235,6 +248,7 @@ def main():
         argument_spec=dict(
             state=dict(default='present', choices=['present', 'installed', 'absent', 'removed', 'latest']),
             name=dict(type='list'),
+            repository=dict(type='list'),
             update_cache=dict(default='no', type='bool'),
             upgrade=dict(default='no', type='bool'),
         ),
@@ -250,6 +264,11 @@ def main():
     APK_PATH = module.get_bin_path('apk', required=True)
 
     p = module.params
+
+    # add repositories to the APK_PATH
+    if p['repository']:
+        for r in p['repository']:
+            APK_PATH = "%s --repository %s" % (APK_PATH, r)
 
     # normalize the state parameter
     if p['state'] in ['present', 'installed']:

--- a/lib/ansible/modules/packaging/os/apk.py
+++ b/lib/ansible/modules/packaging/os/apk.py
@@ -259,7 +259,7 @@ def main():
 
     if p['update_cache']:
         update_package_db(module)
-        if not p['name']:
+        if not p['name'] and not p['upgrade']:
             module.exit_json(changed=True, msg='updated repository indexes')
 
     if p['upgrade']:


### PR DESCRIPTION
##### SUMMARY
Add available and repository options to the apk module, as these features are missing. Combined, these features allow upgrade and rollback by specifying repositories containing different version of packages. The Alpine Linux team recommends using the '--available' option when upgrading from one stable release to another or to edge, the rolling release. Similarly, the '--available' option must be used to rollback to an older release. Also, add stdout/stderr to allow visibility into errors and into which packages are updated. Finally, add packages return value containing a list of the packages that changed.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
apk

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file = 
  configured module search path = Default w/o overrides
```


##### ADDITIONAL INFORMATION
The first commit is a bug fix to allow an update and upgrade in the same command. Previously, this would do an update without an upgrade.

The second and third commits are features to enable clean upgrades / downgrades when changing repositories. With the existing module, you cannot cleanly switch between repositories, such as for a major version upgrade. Adding the available option makes this possible, following the Alpine Linux recommendation. The repository option is needed to see in check mode what will change if you change the repository. If you rely on the /etc/apk/repositories file, you will not see any package changes in check mode for a playbook that modifies the /etc/apk/repositories file and then does an upgrade, because the /etc/apk/repositories file does not actually change.

The fourth and fifth commits add return values to help see what is happening. The stdout / stderr return values are obvious. The packages return values is particularly valuable when performing an update / upgrade to indicate exactly which packages changed. This allows us to trigger a handler to restart a service when it's package is upgraded.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
