### PR TITLE
Add ansible-vault encrypt_string doc

### DIFF
--- a/docs/docsite/rst/playbooks_vault.rst
+++ b/docs/docsite/rst/playbooks_vault.rst
@@ -136,7 +136,26 @@ As of version 2.3, Ansible can now use a vaulted variable that lives in an other
     other_plain_text: othervalue
 
 
-This vaulted variable be decrypted with the supplied vault secret and used as a normal variable. The `ansible-vault` command line supports stdin and stdout for encrypting data on the fly, which can be used from your favorite editor to create these vaulted variables; you just have to be sure to add the `!vault` tag so both Ansible and YAML are aware of the need to decrypt. The `|` is also required, as vault encryption results in a multi-line string.
+This vaulted variable be decrypted with the supplied vault secret and used as a normal variable. The `ansible-vault` command line supports `STDIN` and `STDOUT` for encrypting data on the fly, which can be used from your favorite editor to create these vaulted variables; you just have to be sure to add the `!vault` tag so both Ansible and YAML are aware of the need to decrypt. The `|` is also required, as vault encryption results in a multi-line string. The leading spaces will be ignored and some indentation is required for it to be valid YAML.
+
+As of version 2.3, one way to generate the inline secret is to use `ansible-vault encrypt_string` which will output the secret to `STDOUT`::
+
+   $ ansible-vault encrypt_string "42"
+   !vault-encrypted |
+          $ANSIBLE_VAULT;1.1;AES256
+          <vault cipher text here>
+
+   $ ansible-vault encrypt_string "42" --stdin-name "the_answer"
+    the_answer: !vault-encrypted |
+          $ANSIBLE_VAULT;1.1;AES256
+          <vault cipher text here>
+
+   $ echo -n "the plaintext to encrypt" | ansible-vault encrypt_string
+   !vault-encrypted |
+          $ANSIBLE_VAULT;1.1;AES256
+          <vault cipher text here>
+
+Note the use of `echo -n`. If you use just `echo` the encrypted string will have a new line (`\n`) on the end.
 
 
 .. _speeding_up_vault:

--- a/docs/man/man1/ansible-vault.1.asciidoc.in
+++ b/docs/man/man1/ansible-vault.1.asciidoc.in
@@ -12,7 +12,7 @@ ansible-vault - manage encrypted ansible vars files (YAML).
 
 SYNOPSIS
 --------
-ansible-vault [create|decrypt|edit|encrypt|rekey] [--help] [options] file_name
+ansible-vault [create|decrypt|edit|encrypt|encrypt_string|rekey] [--help] [options] file_name
 
 
 DESCRIPTION
@@ -115,6 +115,24 @@ Thus any of the following invocations can be used:
 
 Reading from stdin and writing only encrypted output is a good way to prevent
 sensitive data from ever hitting disk (either interactively or from a script).
+
+
+ENCRYPT_STRING
+--------------
+
+*$ ansible-vault encrypt_string [options] "string cheese"*
+
+The *encrypt_string* sub-command is used to encrypt a string supplied as an argument.
+
+The *encrypt_string* command works with *STDIN* and has the additional options
+*--name* and *--stdin-name*:
+
+*$ ansible-vault encrypt_string "munster" -name="cheese_du_jour"*
+*$ ansible-vault encrypt_string "$@" -stdin-name="cheese_list" < ./cheese_list.txt*
+
+The output will be on *STDOUT*. This command is useful for creating inline
+secrets introduced in version 2.3.
+
 
 DECRYPT
 -------


### PR DESCRIPTION
##### SUMMARY
Add documentation for the `ansible-vault encrypt_string` sub-command. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
`ansible-vault`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Dec 18 2016, 07:03:34) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
I found the missing documentation while troubleshooting issue #24102.

There is a little bit of UI confusion with the sub-command options `--name` and `--stdin-name`. They seem to be redundant but also work a little differently. Also, when multiple lines are sent in on `STDIN`, `--stdin-name` only applies to the first line. This behavior was odd, but not enough for me to open an issue on it.

