### PR TITLE
Added Composer Command global

### DIFF
--- a/lib/ansible/modules/packaging/language/composer.py
+++ b/lib/ansible/modules/packaging/language/composer.py
@@ -54,6 +54,7 @@ options:
         description:
             - Directory of your project (see --working-dir). This is required when
               the command is not run globally.
+            - Will be ignored if C(global_command=true).
         required: false
         default: null
         aliases: [ "working-dir" ]


### PR DESCRIPTION
Added a parameter to run composer commands globally. The `working_dir`
parameter is only required if `global_command` is `False`.

Fixes #24052

##### SUMMARY
This PR changes the behaviour of the `composer` command so that global commands can be defined in roles see [composer global](https://getcomposer.org/doc/03-cli.md#global). This also makes the parameter `working_dir` optional.

The reason for this change is that composer provides this functionality and it cannot currently be used with Ansible.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Composer

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file = /home/user/.ansible.cfg
  configured module search path = Default w/o overrides
```

##### ADDITIONAL INFORMATION
With this change Ansible can now install packages globally like it is shown in the documentation of composer:

```
composer global require friendsofphp/php-cs-fixer
```

Before that it was impossible to have a command with a white space and no working directory. 