### PR TITLE
Allow setting hash merging per hash

### DIFF
--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -75,12 +75,16 @@ def _validate_mutable_mappings(a, b):
         )
 
 
+def should_merge(a):
+    return isinstance(a, dict) and a.get('_ansible_merge_')
+
+
 def combine_vars(a, b):
     """
     Return a copy of dictionaries of variables based on configured hash behavior
     """
 
-    if C.DEFAULT_HASH_BEHAVIOUR == "merge":
+    if C.DEFAULT_HASH_BEHAVIOUR == "merge" or should_merge(a) or should_merge(b):
         return merge_hash(a, b)
     else:
         # HASH_BEHAVIOUR == 'replace'
@@ -115,6 +119,8 @@ def merge_hash(a, b):
             # otherwise, just copy the value from b to a
             result[k] = v
 
+    if '_ansible_merge_' in result:
+        del result['_ansible_merge_']
     return result
 
 

--- a/test/units/utils/test_vars.py
+++ b/test/units/utils/test_vars.py
@@ -63,6 +63,40 @@ class TestVariableUtils(unittest.TestCase):
             result=defaultdict(a=1, b=2, c=defaultdict(baz='bam'))
             ),
     )
+    test_selective_merge_data = (
+        # Merge cases
+        dict(
+            a=dict(a=1, _ansible_merge_=True),
+            b=dict(b=2, _ansible_merge_=True),
+            result=dict(a=1, b=2)
+            ),
+        dict(
+            a=dict(a=1, c=dict(foo='bar'), _ansible_merge_=True),
+            b=dict(b=2, c=dict(baz='bam'), _ansible_merge_=True),
+            result=dict(a=1, b=2, c=dict(foo='bar', baz='bam'))
+            ),
+        dict(
+            a=defaultdict(a=1, c=defaultdict(foo='bar'), _ansible_merge_=True),
+            b=dict(b=2, c=dict(baz='bam'), _ansible_merge_=True),
+            result=defaultdict(a=1, b=2, c=defaultdict(foo='bar', baz='bam'))
+            ),
+        # Replace cases
+        dict(
+            a=dict(a=1),
+            b=dict(b=2),
+            result=dict(a=1, b=2)
+            ),
+        dict(
+            a=dict(a=1, c=dict(foo='bar')),
+            b=dict(b=2, c=dict(baz='bam')),
+            result=dict(a=1, b=2, c=dict(baz='bam'))
+            ),
+        dict(
+            a=defaultdict(a=1, c=dict(foo='bar')),
+            b=dict(b=2, c=defaultdict(baz='bam')),
+            result=defaultdict(a=1, b=2, c=defaultdict(baz='bam'))
+            ),
+    )
 
     def setUp(self):
         pass
@@ -90,6 +124,11 @@ class TestVariableUtils(unittest.TestCase):
     def test_combine_vars_replace(self):
         with mock.patch('ansible.constants.DEFAULT_HASH_BEHAVIOUR', 'replace'):
             for test in self.test_replace_data:
+                self.assertEqual(combine_vars(test['a'], test['b']), test['result'])
+
+    def test_combine_vars_selective_merge(self):
+        with mock.patch('ansible.constants.DEFAULT_HASH_BEHAVIOUR', 'replace'):
+            for test in self.test_selective_merge_data:
                 self.assertEqual(combine_vars(test['a'], test['b']), test['result'])
 
     def test_combine_vars_merge(self):


### PR DESCRIPTION
##### SUMMARY
This allows using the "merge" hash behavior for specific hashes.
This way, it is possible to have the base system operate with the default "replace" behavior, so as to not break e.g. roles/playbooks or assumptions, while still being able to take advantage of hash merging when it's useful.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
utils/vars

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/srv/web/infra/ansible/library', u'/usr/share/ansible']
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```

##### ADDITIONAL INFORMATION
This PR makes the "merge" behavior triggered by adding a `_ansible_merge_: True` property to the hashes to be merged.