### PR TITLE
Add integration test that modules are loaded from the expected locations

### DIFF
--- a/lib/ansible/modules/system/ping.py
+++ b/lib/ansible/modules/system/ping.py
@@ -48,6 +48,7 @@ ansible webservers -m ping
 
 from ansible.module_utils.basic import AnsibleModule
 
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(
@@ -62,6 +63,6 @@ def main():
         result['ping'] = module.params['data']
     module.exit_json(**result)
 
+
 if __name__ == '__main__':
     main()
-

--- a/test/integration/targets/module_precedence/aliases
+++ b/test/integration/targets/module_precedence/aliases
@@ -1,0 +1,1 @@
+posix/ci/group3

--- a/test/integration/targets/module_precedence/lib_no_extension/ping
+++ b/test/integration/targets/module_precedence/lib_no_extension/ping
@@ -48,6 +48,7 @@ ansible webservers -m ping
 
 from ansible.module_utils.basic import AnsibleModule
 
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(
@@ -63,6 +64,6 @@ def main():
     result['location'] = 'library'
     module.exit_json(**result)
 
+
 if __name__ == '__main__':
     main()
-

--- a/test/integration/targets/module_precedence/lib_no_extension/ping
+++ b/test/integration/targets/module_precedence/lib_no_extension/ping
@@ -1,0 +1,68 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2016, Toshio Kuratomi <tkuratomi@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['stableinterface'],
+                    'supported_by': 'core'}
+
+
+DOCUMENTATION = '''
+---
+module: ping
+version_added: historical
+short_description: Try to connect to host, verify a usable python and return C(pong) on success.
+description:
+   - A trivial test module, this module always returns C(pong) on successful
+     contact. It does not make sense in playbooks, but it is useful from
+     C(/usr/bin/ansible) to verify the ability to login and that a usable python is configured.
+   - This is NOT ICMP ping, this is just a trivial test module.
+options: {}
+author:
+    - "Ansible Core Team"
+    - "Michael DeHaan"
+'''
+
+EXAMPLES = '''
+# Test we can logon to 'webservers' and execute python with json lib.
+ansible webservers -m ping
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            data=dict(required=False, default=None),
+        ),
+        supports_check_mode=True
+    )
+    result = dict(ping='pong')
+    if module.params['data']:
+        if module.params['data'] == 'crash':
+            raise Exception("boom")
+        result['ping'] = module.params['data']
+    result['location'] = 'library'
+    module.exit_json(**result)
+
+if __name__ == '__main__':
+    main()
+

--- a/test/integration/targets/module_precedence/lib_with_extension/ping.py
+++ b/test/integration/targets/module_precedence/lib_with_extension/ping.py
@@ -48,6 +48,7 @@ ansible webservers -m ping
 
 from ansible.module_utils.basic import AnsibleModule
 
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(
@@ -63,6 +64,6 @@ def main():
     result['location'] = 'library'
     module.exit_json(**result)
 
+
 if __name__ == '__main__':
     main()
-

--- a/test/integration/targets/module_precedence/lib_with_extension/ping.py
+++ b/test/integration/targets/module_precedence/lib_with_extension/ping.py
@@ -1,0 +1,68 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2016, Toshio Kuratomi <tkuratomi@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['stableinterface'],
+                    'supported_by': 'core'}
+
+
+DOCUMENTATION = '''
+---
+module: ping
+version_added: historical
+short_description: Try to connect to host, verify a usable python and return C(pong) on success.
+description:
+   - A trivial test module, this module always returns C(pong) on successful
+     contact. It does not make sense in playbooks, but it is useful from
+     C(/usr/bin/ansible) to verify the ability to login and that a usable python is configured.
+   - This is NOT ICMP ping, this is just a trivial test module.
+options: {}
+author:
+    - "Ansible Core Team"
+    - "Michael DeHaan"
+'''
+
+EXAMPLES = '''
+# Test we can logon to 'webservers' and execute python with json lib.
+ansible webservers -m ping
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            data=dict(required=False, default=None),
+        ),
+        supports_check_mode=True
+    )
+    result = dict(ping='pong')
+    if module.params['data']:
+        if module.params['data'] == 'crash':
+            raise Exception("boom")
+        result['ping'] = module.params['data']
+    result['location'] = 'library'
+    module.exit_json(**result)
+
+if __name__ == '__main__':
+    main()
+

--- a/test/integration/targets/module_precedence/modules_test.yml
+++ b/test/integration/targets/module_precedence/modules_test.yml
@@ -1,0 +1,10 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+  - name: Use standard ping module
+    ping:
+    register: result
+
+  - assert:
+      that:
+        - '"location" not in result'

--- a/test/integration/targets/module_precedence/modules_test_envvar.yml
+++ b/test/integration/targets/module_precedence/modules_test_envvar.yml
@@ -1,0 +1,11 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+  - name: Use ping from library path
+    ping:
+    register: result
+
+  - assert:
+      that:
+        - '"location" in result'
+        - 'result["location"] == "library"'

--- a/test/integration/targets/module_precedence/modules_test_multiple_roles.yml
+++ b/test/integration/targets/module_precedence/modules_test_multiple_roles.yml
@@ -1,0 +1,17 @@
+- hosts: localhost
+  gather_facts: no
+  vars:
+    expected_location: "role: foo"
+  roles:
+  - foo
+  - bar
+
+  tasks:
+  - name: Use ping from role
+    ping:
+    register: result
+
+  - assert:
+      that:
+        - '"location" in result'
+        - 'result["location"] == "{{ expected_location}}"'

--- a/test/integration/targets/module_precedence/modules_test_multiple_roles_reverse_order.yml
+++ b/test/integration/targets/module_precedence/modules_test_multiple_roles_reverse_order.yml
@@ -1,0 +1,16 @@
+- hosts: localhost
+  gather_facts: no
+  vars:
+    expected_location: "role: bar"
+  roles:
+    - bar
+    - foo
+  tasks:
+  - name: Use ping from role
+    ping:
+    register: result
+
+  - assert:
+      that:
+        - '"location" in result'
+        - 'result["location"] == "{{ expected_location}}"'

--- a/test/integration/targets/module_precedence/modules_test_role.yml
+++ b/test/integration/targets/module_precedence/modules_test_role.yml
@@ -1,0 +1,13 @@
+- hosts: localhost
+  gather_facts: no
+  roles:
+    - foo
+  tasks:
+  - name: Use ping from role
+    ping:
+    register: result
+
+  - assert:
+      that:
+        - '"location" in result'
+        - 'result["location"] == "role: foo"'

--- a/test/integration/targets/module_precedence/multiple_roles/bar/library/ping.py
+++ b/test/integration/targets/module_precedence/multiple_roles/bar/library/ping.py
@@ -1,0 +1,68 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2016, Toshio Kuratomi <tkuratomi@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['stableinterface'],
+                    'supported_by': 'core'}
+
+
+DOCUMENTATION = '''
+---
+module: ping
+version_added: historical
+short_description: Try to connect to host, verify a usable python and return C(pong) on success.
+description:
+   - A trivial test module, this module always returns C(pong) on successful
+     contact. It does not make sense in playbooks, but it is useful from
+     C(/usr/bin/ansible) to verify the ability to login and that a usable python is configured.
+   - This is NOT ICMP ping, this is just a trivial test module.
+options: {}
+author:
+    - "Ansible Core Team"
+    - "Michael DeHaan"
+'''
+
+EXAMPLES = '''
+# Test we can logon to 'webservers' and execute python with json lib.
+ansible webservers -m ping
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            data=dict(required=False, default=None),
+        ),
+        supports_check_mode=True
+    )
+    result = dict(ping='pong')
+    if module.params['data']:
+        if module.params['data'] == 'crash':
+            raise Exception("boom")
+        result['ping'] = module.params['data']
+    result['location'] = 'role: bar'
+    module.exit_json(**result)
+
+if __name__ == '__main__':
+    main()
+

--- a/test/integration/targets/module_precedence/multiple_roles/bar/library/ping.py
+++ b/test/integration/targets/module_precedence/multiple_roles/bar/library/ping.py
@@ -48,6 +48,7 @@ ansible webservers -m ping
 
 from ansible.module_utils.basic import AnsibleModule
 
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(
@@ -63,6 +64,6 @@ def main():
     result['location'] = 'role: bar'
     module.exit_json(**result)
 
+
 if __name__ == '__main__':
     main()
-

--- a/test/integration/targets/module_precedence/multiple_roles/bar/tasks/main.yml
+++ b/test/integration/targets/module_precedence/multiple_roles/bar/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Use ping from inside foo role
+  ping:
+  register: result
+
+- name: Make sure that we used the ping module from the foo role
+  assert:
+    that:
+      - '"location" in result'
+      - 'result["location"] == "{{ expected_location }}"'

--- a/test/integration/targets/module_precedence/multiple_roles/foo/library/ping.py
+++ b/test/integration/targets/module_precedence/multiple_roles/foo/library/ping.py
@@ -48,6 +48,7 @@ ansible webservers -m ping
 
 from ansible.module_utils.basic import AnsibleModule
 
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(
@@ -63,6 +64,6 @@ def main():
     result['location'] = 'role: foo'
     module.exit_json(**result)
 
+
 if __name__ == '__main__':
     main()
-

--- a/test/integration/targets/module_precedence/multiple_roles/foo/library/ping.py
+++ b/test/integration/targets/module_precedence/multiple_roles/foo/library/ping.py
@@ -1,0 +1,68 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2016, Toshio Kuratomi <tkuratomi@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['stableinterface'],
+                    'supported_by': 'core'}
+
+
+DOCUMENTATION = '''
+---
+module: ping
+version_added: historical
+short_description: Try to connect to host, verify a usable python and return C(pong) on success.
+description:
+   - A trivial test module, this module always returns C(pong) on successful
+     contact. It does not make sense in playbooks, but it is useful from
+     C(/usr/bin/ansible) to verify the ability to login and that a usable python is configured.
+   - This is NOT ICMP ping, this is just a trivial test module.
+options: {}
+author:
+    - "Ansible Core Team"
+    - "Michael DeHaan"
+'''
+
+EXAMPLES = '''
+# Test we can logon to 'webservers' and execute python with json lib.
+ansible webservers -m ping
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            data=dict(required=False, default=None),
+        ),
+        supports_check_mode=True
+    )
+    result = dict(ping='pong')
+    if module.params['data']:
+        if module.params['data'] == 'crash':
+            raise Exception("boom")
+        result['ping'] = module.params['data']
+    result['location'] = 'role: foo'
+    module.exit_json(**result)
+
+if __name__ == '__main__':
+    main()
+

--- a/test/integration/targets/module_precedence/multiple_roles/foo/tasks/main.yml
+++ b/test/integration/targets/module_precedence/multiple_roles/foo/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Use ping from inside foo role
+  ping:
+  register: result
+
+- name: Make sure that we used the ping module from the foo role
+  assert:
+    that:
+      - '"location" in result'
+      - 'result["location"] == "{{ expected_location }}"'

--- a/test/integration/targets/module_precedence/roles_no_extension/foo/library/ping
+++ b/test/integration/targets/module_precedence/roles_no_extension/foo/library/ping
@@ -48,6 +48,7 @@ ansible webservers -m ping
 
 from ansible.module_utils.basic import AnsibleModule
 
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(
@@ -63,6 +64,6 @@ def main():
     result['location'] = 'role: foo'
     module.exit_json(**result)
 
+
 if __name__ == '__main__':
     main()
-

--- a/test/integration/targets/module_precedence/roles_no_extension/foo/library/ping
+++ b/test/integration/targets/module_precedence/roles_no_extension/foo/library/ping
@@ -1,0 +1,68 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2016, Toshio Kuratomi <tkuratomi@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['stableinterface'],
+                    'supported_by': 'core'}
+
+
+DOCUMENTATION = '''
+---
+module: ping
+version_added: historical
+short_description: Try to connect to host, verify a usable python and return C(pong) on success.
+description:
+   - A trivial test module, this module always returns C(pong) on successful
+     contact. It does not make sense in playbooks, but it is useful from
+     C(/usr/bin/ansible) to verify the ability to login and that a usable python is configured.
+   - This is NOT ICMP ping, this is just a trivial test module.
+options: {}
+author:
+    - "Ansible Core Team"
+    - "Michael DeHaan"
+'''
+
+EXAMPLES = '''
+# Test we can logon to 'webservers' and execute python with json lib.
+ansible webservers -m ping
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            data=dict(required=False, default=None),
+        ),
+        supports_check_mode=True
+    )
+    result = dict(ping='pong')
+    if module.params['data']:
+        if module.params['data'] == 'crash':
+            raise Exception("boom")
+        result['ping'] = module.params['data']
+    result['location'] = 'role: foo'
+    module.exit_json(**result)
+
+if __name__ == '__main__':
+    main()
+

--- a/test/integration/targets/module_precedence/roles_no_extension/foo/tasks/main.yml
+++ b/test/integration/targets/module_precedence/roles_no_extension/foo/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Use ping from inside foo role
+  ping:
+  register: result
+
+- name: Make sure that we used the ping module from the foo role
+  assert:
+    that:
+      - '"location" in result'
+      - 'result["location"] == "role: foo"'

--- a/test/integration/targets/module_precedence/roles_with_extension/foo/library/ping.py
+++ b/test/integration/targets/module_precedence/roles_with_extension/foo/library/ping.py
@@ -48,6 +48,7 @@ ansible webservers -m ping
 
 from ansible.module_utils.basic import AnsibleModule
 
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(
@@ -63,6 +64,6 @@ def main():
     result['location'] = 'role: foo'
     module.exit_json(**result)
 
+
 if __name__ == '__main__':
     main()
-

--- a/test/integration/targets/module_precedence/roles_with_extension/foo/library/ping.py
+++ b/test/integration/targets/module_precedence/roles_with_extension/foo/library/ping.py
@@ -1,0 +1,68 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
+# (c) 2016, Toshio Kuratomi <tkuratomi@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['stableinterface'],
+                    'supported_by': 'core'}
+
+
+DOCUMENTATION = '''
+---
+module: ping
+version_added: historical
+short_description: Try to connect to host, verify a usable python and return C(pong) on success.
+description:
+   - A trivial test module, this module always returns C(pong) on successful
+     contact. It does not make sense in playbooks, but it is useful from
+     C(/usr/bin/ansible) to verify the ability to login and that a usable python is configured.
+   - This is NOT ICMP ping, this is just a trivial test module.
+options: {}
+author:
+    - "Ansible Core Team"
+    - "Michael DeHaan"
+'''
+
+EXAMPLES = '''
+# Test we can logon to 'webservers' and execute python with json lib.
+ansible webservers -m ping
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            data=dict(required=False, default=None),
+        ),
+        supports_check_mode=True
+    )
+    result = dict(ping='pong')
+    if module.params['data']:
+        if module.params['data'] == 'crash':
+            raise Exception("boom")
+        result['ping'] = module.params['data']
+    result['location'] = 'role: foo'
+    module.exit_json(**result)
+
+if __name__ == '__main__':
+    main()
+

--- a/test/integration/targets/module_precedence/roles_with_extension/foo/tasks/main.yml
+++ b/test/integration/targets/module_precedence/roles_with_extension/foo/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Use ping from inside foo role
+  ping:
+  register: result
+
+- name: Make sure that we used the ping module from the foo role
+  assert:
+    that:
+      - '"location" in result'
+      - 'result["location"] == "role: foo"'

--- a/test/integration/targets/module_precedence/runme.sh
+++ b/test/integration/targets/module_precedence/runme.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# Standard ping module
+ansible-playbook modules_test.yml -i ../../inventory -v "$@"
+
+# Library path ping module
+ANSIBLE_LIBRARY=$(pwd)/lib_with_extension ansible-playbook modules_test_envvar.yml -i ../../inventory -v "$@"
+ANSIBLE_LIBRARY=$(pwd)/lib_no_extension ansible-playbook modules_test_envvar.yml -i ../../inventory -v "$@"
+
+# ping module from role
+ANSIBLE_ROLES_PATH=$(pwd)/roles_with_extension ansible-playbook modules_test_role.yml -i ../../inventory -v "$@"
+ANSIBLE_ROLES_PATH=$(pwd)/roles_no_extension ansible-playbook modules_test_role.yml -i ../../inventory -v "$@"
+
+# ping module from role when there's a library path module too
+ANSIBLE_LIBRARY=$(pwd)/lib_no_extension ANSIBLE_ROLES_PATH=$(pwd)/roles_with_extension ansible-playbook modules_test_role.yml -i ../../inventory -v "$@"
+ANSIBLE_LIBRARY=$(pwd)/lib_with_extension ANSIBLE_ROLES_PATH=$(pwd)/roles_with_extension ansible-playbook modules_test_role.yml -i ../../inventory -v "$@"
+ANSIBLE_LIBRARY=$(pwd)/lib_no_extension ANSIBLE_ROLES_PATH=$(pwd)/roles_no_extension ansible-playbook modules_test_role.yml -i ../../inventory -v "$@"
+ANSIBLE_LIBRARY=$(pwd)/lib_with_extension ANSIBLE_ROLES_PATH=$(pwd)/roles_no_extension ansible-playbook modules_test_role.yml -i ../../inventory -v "$@"
+
+# ping module in multiple roles: Note that this will use the first module found
+# which is the current way things work but may not be the best way
+ANSIBLE_LIBRARY=$(pwd)/lib_no_extension ANSIBLE_ROLES_PATH=$(pwd)/multiple_roles ansible-playbook modules_test_multiple_roles.yml -i ../../inventory -v "$@"
+ANSIBLE_LIBRARY=$(pwd)/lib_with_extension ANSIBLE_ROLES_PATH=$(pwd)/multiple_roles ansible-playbook modules_test_multiple_roles.yml -i ../../inventory -v "$@"
+ANSIBLE_LIBRARY=$(pwd)/lib_no_extension ANSIBLE_ROLES_PATH=$(pwd)/multiple_roles ansible-playbook modules_test_multiple_roles.yml -i ../../inventory -v "$@"
+ANSIBLE_LIBRARY=$(pwd)/lib_with_extension ANSIBLE_ROLES_PATH=$(pwd)/multiple_roles ansible-playbook modules_test_multiple_roles.yml -i ../../inventory -v "$@"
+
+# And prove that with multiple roles, it's the order the roles are listed in the play that matters
+ANSIBLE_LIBRARY=$(pwd)/lib_with_extension ANSIBLE_ROLES_PATH=$(pwd)/multiple_roles ansible-playbook modules_test_multiple_roles_reverse_order.yml -i ../../inventory -v "$@"

--- a/test/sanity/code-smell/shebang.sh
+++ b/test/sanity/code-smell/shebang.sh
@@ -7,6 +7,7 @@ grep '^#!' -rIn . \
     -e '^\./lib/ansible/modules/' \
     -e '^\./test/integration/targets/[^/]*/library/[^/]*:#!powershell$' \
     -e '^\./test/integration/targets/[^/]*/library/[^/]*:#!/usr/bin/python$' \
+    -e '^\./test/integration/targets/module_precedence/.*lib.*:#!/usr/bin/python$' \
     -e '^\./hacking/cherrypick.py:#!/usr/bin/env python3$' \
     -e ':#!/bin/sh$' \
     -e ':#!/bin/bash( -[eux]|$)' \

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -739,7 +739,6 @@ lib/ansible/modules/system/osx_defaults.py
 lib/ansible/modules/system/pam_limits.py
 lib/ansible/modules/system/pamd.py
 lib/ansible/modules/system/parted.py
-lib/ansible/modules/system/ping.py
 lib/ansible/modules/system/puppet.py
 lib/ansible/modules/system/runit.py
 lib/ansible/modules/system/seboolean.py


### PR DESCRIPTION
##### SUMMARY

we sometimes have regressions with modules not being found in the proper paths (the standard module directory, user defined module locations, or role directories).  Add some integration tests to prevent this from regressing.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
test/integration/module_precedence

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel, 2.3
```


##### ADDITIONAL INFORMATION
@agaffney is reporting that there is some strangeness with module precedence in 2.3 so I'd like to backport this to stable-2.3 as well.