### PR TITLE
Fix typo in rhsm.configure (system -> server)

### DIFF
--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -265,9 +265,9 @@ class Rhsm(RegistrationBase):
 
         # Pass supplied **kwargs as parameters to subscription-manager.  Ignore
         # non-configuration parameters and replace '_' with '.'.  For example,
-        # 'server_hostname' becomes '--system.hostname'.
+        # 'server_hostname' becomes '--server.hostname'.
         for k, v in kwargs.items():
-            if re.search(r'^(system|rhsm)_', k):
+            if re.search(r'^(server|rhsm)_', k):
                 args.append('--%s=%s' % (k.replace('_', '.'), v))
 
         self.module.run_command(args, check_rc=True)


### PR DESCRIPTION
This fix makes it so that the module works as expected when
`server_hostname` is provided. It was being silently ignored
previously. I suppose this may also fix similar behavior with
`server_insecure`, but I did not check that explicitly.

##### SUMMARY
Fix of typo.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
redhat_subscription

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (subscription_manager_server_hostname 96402d5c4b) last updated 2017/05/01 16:09:36 (GMT -400)
  config file = /home/khowell/.ansible.cfg
  configured module search path = [u'/usr/share/ansible']
  ansible python module location = /home/khowell/code/ansible/lib/ansible
  executable location = /home/khowell/code/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
Can be seen when trying to register against a non-default endpoint, such as a Satellite server.
