### PR TITLE
Add the 'ttl' parameter for sensu_check

### DIFF
--- a/lib/ansible/modules/monitoring/sensu_check.py
+++ b/lib/ansible/modules/monitoring/sensu_check.py
@@ -85,6 +85,12 @@ options:
       - Timeout for the check
     required: false
     default: 10
+  ttl:
+    description:
+      - Time to live in seconds until the check is considered stale
+    required: false
+    default: null
+    version_added: 2.4
   handle:
     description:
       - Whether the check should be handled or not
@@ -263,6 +269,7 @@ def sensu_check(module, path, name, state='present', backup=False):
                        'subscribers',
                        'interval',
                        'timeout',
+                       'ttl',
                        'handle',
                        'dependencies',
                        'standalone',
@@ -363,6 +370,7 @@ def main():
                 'subscribers':  {'type': 'list'},
                 'interval':     {'type': 'int'},
                 'timeout':      {'type': 'int'},
+                'ttl':          {'type': 'int'},
                 'handle':       {'type': 'bool'},
                 'subdue_begin': {'type': 'str'},
                 'subdue_end':   {'type': 'str'},


### PR DESCRIPTION
##### SUMMARY
The [TTL](https://sensuapp.org/docs/latest/reference/checks.html#check-attributes) parameter for checks allows Sensu to detect if a check
has gotten stale (i.e, stopped checking).

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
sensu_check

##### ANSIBLE VERSION
ansible 2.3.0.0