### PR TITLE
fixes nxos_interface

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface.py
@@ -221,21 +221,22 @@ def get_manual_interface_attributes(interface, module):
     if get_interface_type(interface) == 'svi':
         command = 'show interface {0}'.format(interface)
         try:
-            body = execute_show_command(command, module)[0]
+            body = run_commands(module, [command])[0]
         except IndexError:
             return None
 
-        command_list = body.split('\n')
-        desc = None
-        admin_state = 'up'
-        for each in command_list:
-            if 'Description:' in each:
-                line = each.split('Description:')
-                desc = line[1].strip().split('MTU')[0].strip()
-            elif 'Administratively down' in each:
-                admin_state = 'down'
+        if body:
+            command_list = body.split('\n')
+            desc = None
+            admin_state = 'up'
+            for each in command_list:
+                if 'Description:' in each:
+                    line = each.split('Description:')
+                    desc = line[1].strip().split('MTU')[0].strip()
+                elif 'Administratively down' in each:
+                    admin_state = 'down'
 
-        return dict(description=desc, admin_state=admin_state)
+            return dict(description=desc, admin_state=admin_state)
     else:
         return None
 


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes `AttributeError: 'dict' object has no attribute 'split'` in `nxos_interface`, #24167 partly.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
```modules/network/nxos_interface```

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```