### PR TITLE
archive: allow ZIP64 by default

### DIFF
--- a/lib/ansible/modules/files/archive.py
+++ b/lib/ansible/modules/files/archive.py
@@ -246,7 +246,7 @@ def main():
                 try:
                     # Slightly more difficult (and less efficient!) compression using zipfile module
                     if format == 'zip':
-                        arcfile = zipfile.ZipFile(dest, 'w', zipfile.ZIP_DEFLATED)
+                        arcfile = zipfile.ZipFile(dest, 'w', zipfile.ZIP_DEFLATED, True)
 
                     # Easier compression using tarfile module
                     elif format == 'gz' or format == 'bz2':
@@ -358,7 +358,7 @@ def main():
 
                 try:
                     if format == 'zip':
-                        arcfile = zipfile.ZipFile(dest, 'w', zipfile.ZIP_DEFLATED)
+                        arcfile = zipfile.ZipFile(dest, 'w', zipfile.ZIP_DEFLATED, True)
                         arcfile.write(path, path[len(arcroot):])
                         arcfile.close()
                         state = 'archive' # because all zip files are archives


### PR DESCRIPTION
##### SUMMARY
Fixes #24125

allowZip64 is True by default since python 3.4,
see https://docs.python.org/3/library/zipfile.html#zipfile-objects

With python 2.7, when the file or folder to zip is >2G,
zipfile raises LargeZipFile.

This commit set allowZip64 to true.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
modules/files/archive.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (issue-24125 ddbe9efe36) last updated 2017/05/02 13:21:03 (GMT +200)
  config file =
  configured module search path = [u'/home/fridim/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/fridim/sync/dev/ansible/lib/ansible
  executable location = /home/fridim/sync/dev/ansible/bin/ansible
  python version = 2.7.13 (default, Feb 11 2017, 12:22:40) [GCC 6.3.1 20170109]

```


##### ADDITIONAL INFORMATION
Currently, with python < 3.4, zipfile will raise if file is large because zip needs ZIP64 extension.

With this patch, at least it will try to add zip64 extension when needed.

