### PR TITLE
adjusted descriptions in DOCUMENTATION, and fixed type in RETURN

### DIFF
--- a/lib/ansible/modules/system/aix_inittab.py
+++ b/lib/ansible/modules/system/aix_inittab.py
@@ -34,14 +34,17 @@ description:
 version_added: "2.3"
 options:
   name:
-    description: Name of the inittab entry.
+    description:
+    - Name of the inittab entry.
     required: True
     aliases: ['service']
   runlevel:
-    description: Runlevel of the entry.
+    description:
+    - Runlevel of the entry.
     required: True
   action:
-    description: Action what the init has to do with this entry.
+    description:
+    - Action what the init has to do with this entry.
     required: True
     choices: [
                'respawn',
@@ -58,12 +61,15 @@ options:
                'sysinit'
               ]
   command:
-    description: What command has to run.
+    description:
+    - What command has to run.
     required: True
   insertafter:
-    description: After which inittabline should the new entry inserted.
+    description:
+    - After which inittabline should the new entry inserted.
   state:
-    description: Whether the entry should be present or absent in the inittab file
+    description:
+    - Whether the entry should be present or absent in the inittab file
     choices: [ "present", "absent" ]
     default: present
 notes:
@@ -112,7 +118,7 @@ name:
     returned: always
     type: string
     sample: startmyservice
-mgs:
+msg:
     description: action done with the inittab entry
     returned: changed
     type: string


### PR DESCRIPTION
##### SUMMARY
Adjusted the description in the documentation, and fixed an typo in the return section

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

module: aix_inittab.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel b8c799b1b2) last updated 2017/05/02 13:05:08 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/EUROPE/os14iy/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/EUROPE/os14iy/devel/ansible/lib/ansible
  executable location = /home/EUROPE/os14iy/devel/ansible/bin/ansible
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]

```


##### ADDITIONAL INFORMATION
Fixed the description in the documentation, to be able to produce better snippets from the ansible-doc command. 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before: 
 ansible-doc -s -M .   aix_inittab.py
- name: Manages the inittab on AIX.
  action: aix_inittab
      action=                # A c t i o n   w h a t   t h e   i n i t   h a s   t o   d o   w i t h   t h i s   e n t r y .
      command=               # W h a t   c o m m a n d   h a s   t o   r u n .
      insertafter            # A f t e r   w h i c h   i n i t t a b l i n e   s h o u l d   t h e   n e w   e n t r y   i n s e r t e d .
      name=                  # N a m e   o f   t h e   i n i t t a b   e n t r y .
      runlevel=              # R u n l e v e l   o f   t h e   e n t r y .
      state                  # W h e t h e r   t h e   e n t r y   s h o u l d   b e   p r e s e n t   o r   a b s e n t   i n   t h e   i n i t t a b   f i l e


After:

 ansible-doc -s -M . aix_inittab.py
- name: Manages the inittab on AIX.
  action: aix_inittab
      action=                # Action what the init has to do with this entry.
      command=               # What command has to run.
      insertafter            # After which inittabline should the new entry inserted.
      name=                  # Name of the inittab entry.
      runlevel=              # Runlevel of the entry.
      state                  # Whether the entry should be present or absent in the inittab file



```
