### PR TITLE
vmware_guest_snapshot: sync datacenter default with vmware_guest

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
@@ -63,7 +63,7 @@ options:
    datacenter:
         description:
             - Destination datacenter for the deploy operation
-        required: True
+        default: ha-datacenter
    snapshot_name:
         description:
         - Sets the snapshot name to manage.
@@ -280,7 +280,7 @@ def main():
             name_match=dict(required=False, type='str', default='first'),
             uuid=dict(required=False, type='str'),
             folder=dict(required=False, type='str', default='/vm'),
-            datacenter=dict(required=True, type='str'),
+            datacenter=dict(required=False, type='str', default='ha-datacenter'),
             snapshot_name=dict(required=False, type='str'),
             description=dict(required=False, type='str', default=''),
         ),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
vmware_guest_snapshot has a different behaviour than vmware_guest on datacenter.
Use default ha-datacenter like vmware_guest

This fixes issue #24203

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vmware_guest_snapshot

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
