### PR TITLE
Allow IAM certificate secrets, body, chains to be strings (e.g. sourced from ansible-vault)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam_cert.py
+++ b/lib/ansible/modules/cloud/amazon/iam_cert.py
@@ -74,13 +74,11 @@ options:
       - The CA certificate chain in PEM encoded format.
     required: false
     default: null
-    aliases: []
   cert_body:
     version_added: "2.4"
     description:
       - The certificate body in PEM encoded format.
     required: false
-    aliases: []
   key_body:
     version_added: "2.4"
     description:
@@ -124,6 +122,16 @@ tasks:
     key: privcertkey
     cert_chain: myverytrustedchain
 
+# Server certificate upload using key from ansible-vault
+tasks:
+- name: Upload Certificate from Vault
+  iam_cert:
+    name: very_ssl
+    state: present
+    path: "/a/cert/path/"
+    cert_body: body_of_somecert
+    key_body: vault_body_of_privcertkey
+    cert_chain_body: body_of_myverytrustedchain
 '''
 import json
 import sys

--- a/lib/ansible/modules/cloud/amazon/iam_cert.py
+++ b/lib/ansible/modules/cloud/amazon/iam_cert.py
@@ -68,6 +68,12 @@ options:
   key:
     description:
       - The path to the private key of the certificate in PEM encoded format.
+  cert_chain_body:
+    description:
+      - The CA certificate chain in PEM encoded format.
+    required: false
+    default: null
+    aliases: []
   cert_body:
     description:
       - The certificate body in PEM encoded format.
@@ -248,6 +254,7 @@ def main():
         key=dict(default=None, required=False, type='path'),
         key_body=dict(default=None, required=False),
         cert_chain=dict(default=None, required=False, type='path'),
+        cert_chain_body=dict(default=None, required=False),
         new_name=dict(default=None, required=False),
         path=dict(default='/', required=False),
         new_path=dict(default=None, required=False),

--- a/lib/ansible/modules/cloud/amazon/iam_cert.py
+++ b/lib/ansible/modules/cloud/amazon/iam_cert.py
@@ -68,6 +68,14 @@ options:
   key:
     description:
       - The path to the private key of the certificate in PEM encoded format.
+  cert_body:
+    description:
+      - The certificate body in PEM encoded format.
+    required: false
+    aliases: []
+  key_body:
+    description:
+      - The private key of the certificate in PEM encoded format.
   dup_ok:
     description:
       - By default the module will not upload a certificate that is already uploaded into AWS. If set to True, it will upload the certificate as
@@ -236,7 +244,9 @@ def main():
             default=None, required=True, choices=['present', 'absent']),
         name=dict(default=None, required=False),
         cert=dict(default=None, required=False, type='path'),
+        cert_body=dict(default=None, required=False),
         key=dict(default=None, required=False, type='path'),
+        key_body=dict(default=None, required=False),
         cert_chain=dict(default=None, required=False, type='path'),
         new_name=dict(default=None, required=False),
         path=dict(default='/', required=False),
@@ -271,8 +281,14 @@ def main():
     cert_chain = module.params.get('cert_chain')
     dup_ok = module.params.get('dup_ok')
     if state == 'present':
-        cert = open(module.params.get('cert'), 'r').read().rstrip()
-        key = open(module.params.get('key'), 'r').read().rstrip()
+        if module.params.get('cert_body') is not None:
+            cert = module.params.get('cert_body')
+        else:
+            cert = open(module.params.get('cert'), 'r').read().rstrip()
+        if module.params.get('key_body') is not None:
+            key = module.params.get('key_body')
+        else:
+            key = open(module.params.get('key'), 'r').read().rstrip()
         if cert_chain is not None:
             cert_chain = open(module.params.get('cert_chain'), 'r').read()
     else:

--- a/lib/ansible/modules/cloud/amazon/iam_cert.py
+++ b/lib/ansible/modules/cloud/amazon/iam_cert.py
@@ -289,7 +289,9 @@ def main():
             key = module.params.get('key_body')
         else:
             key = open(module.params.get('key'), 'r').read().rstrip()
-        if cert_chain is not None:
+        if module.params.get('cert_chain_body') is not None:
+            cert_chain = module.params.get('cert_chain_body')
+        elif cert_chain is not None:
             cert_chain = open(module.params.get('cert_chain'), 'r').read()
     else:
         key=cert=chain=None

--- a/lib/ansible/modules/cloud/amazon/iam_cert.py
+++ b/lib/ansible/modules/cloud/amazon/iam_cert.py
@@ -30,63 +30,46 @@ options:
     description:
       - Name of certificate to add, update or remove.
     required: true
-    aliases: []
   new_name:
     description:
       - When present, this will update the name of the cert with the value passed here.
     required: false
-    aliases: []
   new_path:
     description:
       - When present, this will update the path of the cert with the value passed here.
     required: false
-    aliases: []
   state:
     description:
       - Whether to create, delete certificate. When present is specified it will attempt to make an update if new_path or new_name is specified.
     required: true
     default: null
     choices: [ "present", "absent" ]
-    aliases: []
   path:
     description:
       - When creating or updating, specify the desired path of the certificate
     required: false
     default: "/"
-    aliases: []
   cert_chain:
     description:
       - The CA certificate chain in PEM encoded format.
+      - Note that prior to 2.4, this parameter expected a path to a file. Since 2.4 this is now accomplished using a lookup plugin. See examples for detail
     required: false
     default: null
-    aliases: []
   cert:
     description:
       - The certificate body in PEM encoded format.
+      - Note that prior to 2.4, this parameter expected a path to a file. Since 2.4 this is now accomplished using a lookup plugin. See examples for detail
     required: false
-    aliases: []
   key:
     description:
       - The key of the certificate in PEM encoded format.
+      - Note that prior to 2.4, this parameter expected a path to a file. Since 2.4 this is now accomplished using a lookup plugin. See examples for detail
   dup_ok:
     description:
       - By default the module will not upload a certificate that is already uploaded into AWS. If set to True, it will upload the certificate as
         long as the name is unique.
     required: false
     default: False
-    aliases: []
-  aws_secret_key:
-    description:
-      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used.
-    required: false
-    default: null
-    aliases: [ 'ec2_secret_key', 'secret_key' ]
-  aws_access_key:
-    description:
-      - AWS access key. If not set then the value of the AWS_ACCESS_KEY environment variable is used.
-    required: false
-    default: null
-    aliases: [ 'ec2_access_key', 'access_key' ]
 
 
 requirements: [ "boto" ]

--- a/lib/ansible/modules/cloud/amazon/iam_cert.py
+++ b/lib/ansible/modules/cloud/amazon/iam_cert.py
@@ -69,17 +69,20 @@ options:
     description:
       - The path to the private key of the certificate in PEM encoded format.
   cert_chain_body:
+    version_added: "2.4"
     description:
       - The CA certificate chain in PEM encoded format.
     required: false
     default: null
     aliases: []
   cert_body:
+    version_added: "2.4"
     description:
       - The certificate body in PEM encoded format.
     required: false
     aliases: []
   key_body:
+    version_added: "2.4"
     description:
       - The private key of the certificate in PEM encoded format.
   dup_ok:

--- a/lib/ansible/modules/cloud/amazon/iam_cert.py
+++ b/lib/ansible/modules/cloud/amazon/iam_cert.py
@@ -252,7 +252,7 @@ def main():
         cert=dict(default=None, required=False, type='path'),
         cert_body=dict(default=None, required=False),
         key=dict(default=None, required=False, type='path'),
-        key_body=dict(default=None, required=False),
+        key_body=dict(default=None, required=False, no_log=True),
         cert_chain=dict(default=None, required=False, type='path'),
         cert_chain_body=dict(default=None, required=False),
         new_name=dict(default=None, required=False),


### PR DESCRIPTION
##### SUMMARY
Allow certificate key, body, and chain to be sourced from string parameters in addition to files.  This allows these materials to be sourced from secure stores of information at run time.  In our example we needed to create IAM certificates using certificates stored in ansible-vault.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ansible/modules/cloud/amazon/iam_cert.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel c135f9dd70) last updated 2017/04/28 12:59:23 (GMT +100)
  config file =
  configured module search path = [u'/Users/atkinsch/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/atkinsch/src/ansible/lib/ansible
  executable location = /Users/atkinsch/src/ansible/bin/ansible
  python version = 2.7.10 (default, Oct 23 2015, 19:19:21) [GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)]
```


##### ADDITIONAL INFORMATION

Before:
```
changed: [localhost] => {
    "cert_path": "/a/b/c/",
    "changed": true,
    "expiration_date": "2017-07-12T15:11:00Z",
    "invocation": {
        "module_args": {
            "aws_access_key": "xxxx",
            "aws_secret_key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "cert": "path/to/cert",
            "cert_chain": "path/to/cert_chain",
            "dup_ok": false,
            "ec2_url": null,
            "key": "path/to/key",
            "name": "a.b.c.d.1",
            "new_name": null,
            "new_path": null,
            "path": "/cloudfront/feature/imt/",
            "profile": null,
            "region": "eu-west-1",
            "security_token": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "state": "present",
            "validate_certs": true
        }
    },
    "name": "a.b.c.d.1",
    "upload_date": "2017-04-28T12:28:12Z"
}

```

After:
```
changed: [localhost] => {
    "cert_body": "-----BEGIN CERTIFICATExxxxxxxxxxxxx-----END CERTIFICATE-----",
    "cert_path": "/a/b/c/",
    "changed": true,
    "expiration_date": "2017-07-12T15:11:00Z",
    "invocation": {
        "module_args": {
            "aws_access_key": "xxxx",
            "aws_secret_key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "cert": null,
            "cert_body": "-----BEGIN CERTIFICATE-----xxxxxxxxxx-----END CERTIFICATE-----\n",
            "cert_chain": null,
            "cert_chain_body": "-----BEGIN CERTIFICATE-----xxxxxxxxx-----END CERTIFICATE-----\n",
            "dup_ok": false,
            "ec2_url": null,
            "key": null,
            "key_body": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "name": "a.b.c.d.1",
            "new_name": null,
            "new_path": null,
            "path": "/cloudfront/feature/imt/",
            "profile": null,
            "region": "eu-west-1",
            "security_token": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "state": "present",
            "validate_certs": true
        }
    },
    "name": "a.b.c.d.1",
    "upload_date": "2017-04-28T12:28:12Z"
}

```
