### PR TITLE
Sanitize the output from ovs get-fail-mode

### DIFF
--- a/lib/ansible/modules/network/ovs/openvswitch_bridge.py
+++ b/lib/ansible/modules/network/ovs/openvswitch_bridge.py
@@ -116,6 +116,12 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import iteritems
 from ansible.module_utils.pycompat24 import get_exception
 
+def _fail_mode_to_str(text):
+    if not text:
+        return None
+    else:
+        return text.strip()
+
 def _external_ids_to_dict(text):
     d = {}
 
@@ -213,7 +219,7 @@ def map_config_to_obj(module):
                                " %(bridge)s")
         command = templatized_command % module.params
         rc, out, err = module.run_command(command, check_rc=True)
-        obj['fail_mode'] = out.strip()
+        obj['fail_mode'] = _fail_mode_to_str(out)
 
         templatized_command = ("%(ovs-vsctl)s -t %(timeout)s br-get-external-id"
                                " %(bridge)s")


### PR DESCRIPTION
##### SUMMARY

If a bridge does not have a fail mode set, it returns nothing, i.e.
empty string.
This causes a failure when doing the want vs have compare in plays
where the fail-mode is missing, as we compare "" vs None respectively.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
openvswitch_bridge

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel 4e4fc9cb4c) last updated 2017/05/02 10:55:11 (GMT +200)
```
