### PR TITLE
Sanitize ovs br-get-external-id output on openvswitch_bridge

### DIFF
--- a/lib/ansible/modules/network/ovs/openvswitch_bridge.py
+++ b/lib/ansible/modules/network/ovs/openvswitch_bridge.py
@@ -117,14 +117,17 @@ from ansible.module_utils.six import iteritems
 from ansible.module_utils.pycompat24 import get_exception
 
 def _external_ids_to_dict(text):
-    d = {}
+    if not text:
+        return None
+    else:
+        d = {}
 
-    for l in text.splitlines():
-        if l:
-            k, v = l.split('=')
-            d[k] = v
+        for l in text.splitlines():
+            if l:
+                k, v = l.split('=')
+                d[k] = v
 
-    return d
+        return d
 
 def map_obj_to_commands(want, have, module):
     commands = list()


### PR DESCRIPTION
##### SUMMARY

If a bridge does not have external_ids, ovs-vsctl returns '{}'.
This causes issues on the current want vs have comparison in cases
where the play does not define external_ids, as the comparison
is None vs '{}'.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
openvswitch_bridge

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (sanitize_external_ids_ovs_bridge e7b762d1de) last updated 2017/05/02 16:24:22 (GMT +200)
```
