### PR TITLE
Fix netconf port validation and minor doc change

### DIFF
--- a/lib/ansible/modules/network/junos/junos_facts.py
+++ b/lib/ansible/modules/network/junos/junos_facts.py
@@ -46,6 +46,15 @@ options:
     required: false
     default: "!config"
     version_added: "2.3"
+  config_format:
+    description:
+      - The I(config_format) argument specifies the format of the configuration
+         when serializing output from the device. This argument is applicable
+         only when C(config) value is present in I(gather_subset).
+    required: false
+    default: text
+    choices: ['xml', 'set', 'text', 'json']
+    version_added: "2.3"
 """
 
 EXAMPLES = """

--- a/lib/ansible/modules/network/junos/junos_netconf.py
+++ b/lib/ansible/modules/network/junos/junos_netconf.py
@@ -139,7 +139,7 @@ def map_params_to_obj(module):
     for key, value in iteritems(obj):
         # validate the param value (if validator func exists)
         validator = globals().get('validate_%s' % key)
-        if all((value, validator)):
+        if callable((validator)):
             validator(value, module)
 
     return obj

--- a/lib/ansible/modules/network/junos/junos_netconf.py
+++ b/lib/ansible/modules/network/junos/junos_netconf.py
@@ -139,7 +139,7 @@ def map_params_to_obj(module):
     for key, value in iteritems(obj):
         # validate the param value (if validator func exists)
         validator = globals().get('validate_%s' % key)
-        if callable((validator)):
+        if callable(validator):
             validator(value, module)
 
     return obj


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  Add check to confirm if `validate_*` funcion is
   callable.

* Add `config_format` in `junos_facts` documentation
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
junos_facts
junos_netconf

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
If `netconf_port` is assigned wrong value eg. 0 in playbook, it should throw
appropriate.
```
Playbook
```
      junos_netconf:
        state: present
        netconf_port: 0
```
Actual Output
```
$ ansible-playbook ~/targets/junos_netconf.yml -i hosts

PLAY [Config using the core module] ******************************************************************************************

TASK [Gathering Facts] *******************************************************************************************************
ok: [vsrx01]

TASK [Config Using Core Module] **********************************************************************************************
changed: [vsrx01]

PLAY RECAP *******************************************************************************************************************
vsrx01                     : ok=2    changed=1    unreachable=0    failed=0  
```