### PR TITLE
Allow empty string for EC2 session token from env.

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -208,7 +208,8 @@ def get_aws_connection_info(module, boto3=False):
             security_token = os.environ['AWS_SESSION_TOKEN']
         elif 'EC2_SECURITY_TOKEN' in os.environ:
             security_token = os.environ['EC2_SECURITY_TOKEN']
-        else:
+
+        if not security_token:
             # in case security_token came in as empty string
             security_token = None
 


### PR DESCRIPTION
##### SUMMARY

Allow empty string for EC2 session token from env.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ec2 module_utils

##### ANSIBLE VERSION

```
ansible 2.4.0 (ec2_module_utils-fix fd805169f9) last updated 2017/05/03 10:01:18 (GMT +800)
  config file = 
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```

##### ADDITIONAL INFORMATION

If an empty string is given for the security token as a module argument, it will be ignored. However, if the same value is provided via the environment, the empty value is used, which results in an authentication error.

This fix corrects the empty string check by applying it to the security token value retrieved from the environment as well.
