### PR TITLE
Fixes for EC2 module integration tests.

### DIFF
--- a/test/integration/credentials.template
+++ b/test/integration/credentials.template
@@ -7,6 +7,7 @@ rackspace_region:
 # AWS Credentials
 ec2_access_key:
 ec2_secret_key:
+security_token:
 
 # GCE Credentials
 gce_service_account_email:

--- a/test/integration/roles/setup_sshkey/tasks/main.yml
+++ b/test/integration/roles/setup_sshkey/tasks/main.yml
@@ -1,4 +1,3 @@
-# common setup tasks for ec2 module tests
 # (c) 2014, James Laska <jlaska@ansible.com>
 
 # This file is part of Ansible
@@ -15,12 +14,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-
-- name: generate random string
-  command: '{{ ansible_python.executable }} -c "import string,random; print str().join(random.choice(string.ascii_lowercase) for _ in range(8));"'
-  register: random_string
-  tags:
-    - prepare
 
 - name: create random file
   shell: mktemp /tmp/id_rsa.XXXXXX
@@ -40,16 +33,15 @@
     - prepare
 
 - name: record fingerprint
-  shell: ssh-keygen -lf {{sshkey.stdout}}.pub | awk '{print $2}'
+  shell: ssh-keygen -lf {{sshkey.stdout}}.pub
   register: fingerprint
   tags:
     - prepare
 
 - name: set facts for future roles
   set_fact:
-    random_string: '{{random_string.stdout}}'
     sshkey: '{{sshkey.stdout}}'
     key_material: '{{key_material.stdout}}'
-    fingerprint: '{{fingerprint.stdout}}'
+    fingerprint: '{{fingerprint.stdout.split()[1]}}'
   tags:
     - prepare

--- a/test/integration/roles/test_ec2_elb_lb/tasks/main.yml
+++ b/test/integration/roles/test_ec2_elb_lb/tasks/main.yml
@@ -24,384 +24,401 @@
 # test credentials from environment
 # test credential parameters
 
-# ============================================================
-# create test elb with listeners, certificate, and health check
+- block:
 
-- name: Create ELB
-  ec2_elb_lb:
-    name: "{{ tag_prefix }}"
-    region: "{{ ec2_region }}"
-    ec2_access_key: "{{ ec2_access_key }}"
-    ec2_secret_key: "{{ ec2_secret_key }}"
-    state: present
-    zones:
-      - us-east-1c
-      - us-east-1d
-    listeners:
-      - protocol: http
-        load_balancer_port: 80
-        instance_port: 80
-      - protocol: http
-        load_balancer_port: 8080
-        instance_port: 8080
-    health_check:
-        ping_protocol: http
-        ping_port: 80
-        ping_path: "/index.html"
-        response_timeout: 5
-        interval: 30
-        unhealthy_threshold: 2
-        healthy_threshold: 10
-  register: info
+    # ============================================================
+    # create test elb with listeners, certificate, and health check
 
-- assert:
-    that:
-      - 'info.changed'
-      - '"failed" not in info'
-      - 'info.elb.status == "created"'
-      - '"us-east-1c" in info.elb.zones'
-      - '"us-east-1d" in info.elb.zones'
-      - 'info.elb.health_check.healthy_threshold == 10'
-      - 'info.elb.health_check.interval == 30'
-      - 'info.elb.health_check.target == "HTTP:80/index.html"'
-      - 'info.elb.health_check.timeout == 5'
-      - 'info.elb.health_check.unhealthy_threshold == 2'
-      - '[80, 80, "HTTP", "HTTP"] in info.elb.listeners'
-      - '[8080, 8080, "HTTP", "HTTP"] in info.elb.listeners'
+    - name: Create ELB
+      ec2_elb_lb:
+        name: "{{ tag_prefix }}"
+        region: "{{ ec2_region }}"
+        ec2_access_key: "{{ ec2_access_key }}"
+        ec2_secret_key: "{{ ec2_secret_key }}"
+        security_token: "{{ security_token }}"
+        state: present
+        zones:
+          - us-east-1c
+          - us-east-1d
+        listeners:
+          - protocol: http
+            load_balancer_port: 80
+            instance_port: 80
+          - protocol: http
+            load_balancer_port: 8080
+            instance_port: 8080
+        health_check:
+            ping_protocol: http
+            ping_port: 80
+            ping_path: "/index.html"
+            response_timeout: 5
+            interval: 30
+            unhealthy_threshold: 2
+            healthy_threshold: 10
+      register: info
 
-# ============================================================
+    - assert:
+        that:
+          - 'info.changed'
+          - '"failed" not in info'
+          - 'info.elb.status == "created"'
+          - '"us-east-1c" in info.elb.zones'
+          - '"us-east-1d" in info.elb.zones'
+          - 'info.elb.health_check.healthy_threshold == 10'
+          - 'info.elb.health_check.interval == 30'
+          - 'info.elb.health_check.target == "HTTP:80/index.html"'
+          - 'info.elb.health_check.timeout == 5'
+          - 'info.elb.health_check.unhealthy_threshold == 2'
+          - '[80, 80, "HTTP", "HTTP"] in info.elb.listeners'
+          - '[8080, 8080, "HTTP", "HTTP"] in info.elb.listeners'
 
-# check ports, would be cool, but we are at the mercy of AWS
-# to start things in a timely manner
+    # ============================================================
 
-#- name: check to make sure 80 is listening
-#  wait_for: host={{ info.elb.dns_name }} port=80 timeout=600
-#  register: result
+    # check ports, would be cool, but we are at the mercy of AWS
+    # to start things in a timely manner
 
-#- name: assert can connect to port#
-#  assert: 'result.state == "started"'
+    #- name: check to make sure 80 is listening
+    #  wait_for: host={{ info.elb.dns_name }} port=80 timeout=600
+    #  register: result
 
-#- name: check to make sure 443 is listening
-#  wait_for: host={{ info.elb.dns_name }} port=443 timeout=600
-#  register: result
+    #- name: assert can connect to port#
+    #  assert: 'result.state == "started"'
 
-#- name: assert can connect to port#
-#  assert: 'result.state == "started"'
+    #- name: check to make sure 443 is listening
+    #  wait_for: host={{ info.elb.dns_name }} port=443 timeout=600
+    #  register: result
 
-# ============================================================
+    #- name: assert can connect to port#
+    #  assert: 'result.state == "started"'
 
-# Change AZ's
+    # ============================================================
 
-- name: Change AZ's
-  ec2_elb_lb:
-    name: "{{ tag_prefix }}"
-    region: "{{ ec2_region }}"
-    ec2_access_key: "{{ ec2_access_key }}"
-    ec2_secret_key: "{{ ec2_secret_key }}"
-    state: present
-    zones:
-      - us-east-1b
-    listeners:
-      - protocol: http
-        load_balancer_port: 80
-        instance_port: 80
-    purge_zones: yes
-    health_check:
-        ping_protocol: http
-        ping_port: 80
-        ping_path: "/index.html"
-        response_timeout: 5
-        interval: 30
-        unhealthy_threshold: 2
-        healthy_threshold: 10
-  register: info
+    # Change AZ's
 
-
-
-- assert:
-    that:
-      - '"failed" not in info'
-      - 'info.elb.status == "ok"'
-      - 'info.changed'
-      - 'info.elb.zones[0] == "us-east-1b"'
-
-# ============================================================
-
-# Update AZ's
-
-- name: Update AZ's
-  ec2_elb_lb:
-    name: "{{ tag_prefix }}"
-    region: "{{ ec2_region }}"
-    ec2_access_key: "{{ ec2_access_key }}"
-    ec2_secret_key: "{{ ec2_secret_key }}"
-    state: present
-    zones:
-      - us-east-1b
-      - us-east-1c
-      - us-east-1d
-    listeners:
-      - protocol: http
-        load_balancer_port: 80
-        instance_port: 80
-    purge_zones: yes
-  register: info
-
-- assert:
-    that:
-      - '"failed" not in info'
-      - 'info.changed'
-      - 'info.elb.status == "ok"'
-      - '"us-east-1b" in info.elb.zones'
-      - '"us-east-1c" in info.elb.zones'
-      - '"us-east-1d" in info.elb.zones'
-
-
-# ============================================================
-
-# Purge Listeners
-
-- name: Purge Listeners
-  ec2_elb_lb:
-    name: "{{ tag_prefix }}"
-    region: "{{ ec2_region }}"
-    ec2_access_key: "{{ ec2_access_key }}"
-    ec2_secret_key: "{{ ec2_secret_key }}"
-    state: present
-    zones:
-      - us-east-1b
-      - us-east-1c
-      - us-east-1d
-    listeners:
-      - protocol: http
-        load_balancer_port: 80
-        instance_port: 81
-    purge_listeners: yes
-  register: info
-
-- assert:
-    that:
-      - '"failed" not in info'
-      - 'info.elb.status == "ok"'
-      - 'info.changed'
-      - '[80, 81, "HTTP", "HTTP"] in info.elb.listeners'
-      - 'info.elb.listeners|length == 1'
+    - name: Change AZ's
+      ec2_elb_lb:
+        name: "{{ tag_prefix }}"
+        region: "{{ ec2_region }}"
+        ec2_access_key: "{{ ec2_access_key }}"
+        ec2_secret_key: "{{ ec2_secret_key }}"
+        security_token: "{{ security_token }}"
+        state: present
+        zones:
+          - us-east-1b
+        listeners:
+          - protocol: http
+            load_balancer_port: 80
+            instance_port: 80
+        purge_zones: yes
+        health_check:
+            ping_protocol: http
+            ping_port: 80
+            ping_path: "/index.html"
+            response_timeout: 5
+            interval: 30
+            unhealthy_threshold: 2
+            healthy_threshold: 10
+      register: info
 
 
 
-# ============================================================
+    - assert:
+        that:
+          - '"failed" not in info'
+          - 'info.elb.status == "ok"'
+          - 'info.changed'
+          - 'info.elb.zones[0] == "us-east-1b"'
 
-# add Listeners
+    # ============================================================
 
-- name: Add Listeners
-  ec2_elb_lb:
-    name: "{{ tag_prefix }}"
-    region: "{{ ec2_region }}"
-    ec2_access_key: "{{ ec2_access_key }}"
-    ec2_secret_key: "{{ ec2_secret_key }}"
-    state: present
-    zones:
-      - us-east-1b
-      - us-east-1c
-      - us-east-1d
-    listeners:
-      - protocol: http
-        load_balancer_port: 8081
-        instance_port: 8081
-    purge_listeners: no
-  register: info
+    # Update AZ's
 
-- assert:
-    that:
-      - '"failed" not in info'
-      - 'info.elb.status == "ok"'
-      - 'info.changed'
-      - '[80, 81, "HTTP", "HTTP"] in info.elb.listeners'
-      - '[8081, 8081, "HTTP", "HTTP"] in info.elb.listeners'
-      - 'info.elb.listeners|length == 2'
+    - name: Update AZ's
+      ec2_elb_lb:
+        name: "{{ tag_prefix }}"
+        region: "{{ ec2_region }}"
+        ec2_access_key: "{{ ec2_access_key }}"
+        ec2_secret_key: "{{ ec2_secret_key }}"
+        security_token: "{{ security_token }}"
+        state: present
+        zones:
+          - us-east-1b
+          - us-east-1c
+          - us-east-1d
+        listeners:
+          - protocol: http
+            load_balancer_port: 80
+            instance_port: 80
+        purge_zones: yes
+      register: info
 
-
-# ============================================================
-
-- name: test with no parameters
-  ec2_elb_lb:
-  register: result
-  ignore_errors: true
-
-- name: assert failure when called with no parameters
-  assert:
-    that:
-       - 'result.failed'
-       - 'result.msg == "missing required arguments: name,state"'
+    - assert:
+        that:
+          - '"failed" not in info'
+          - 'info.changed'
+          - 'info.elb.status == "ok"'
+          - '"us-east-1b" in info.elb.zones'
+          - '"us-east-1c" in info.elb.zones'
+          - '"us-east-1d" in info.elb.zones'
 
 
+    # ============================================================
 
-# ============================================================
-- name: test with only name
-  ec2_elb_lb:
-    name="{{ tag_prefix }}"
-  register: result
-  ignore_errors: true
+    # Purge Listeners
 
-- name: assert failure when called with only name
-  assert:
-    that:
-       - 'result.failed'
-       - 'result.msg == "missing required arguments: state"'
+    - name: Purge Listeners
+      ec2_elb_lb:
+        name: "{{ tag_prefix }}"
+        region: "{{ ec2_region }}"
+        ec2_access_key: "{{ ec2_access_key }}"
+        ec2_secret_key: "{{ ec2_secret_key }}"
+        security_token: "{{ security_token }}"
+        state: present
+        zones:
+          - us-east-1b
+          - us-east-1c
+          - us-east-1d
+        listeners:
+          - protocol: http
+            load_balancer_port: 80
+            instance_port: 81
+        purge_listeners: yes
+      register: info
 
-
-# ============================================================
-- name: test invalid region parameter
-  ec2_elb_lb:
-    name="{{ tag_prefix }}"
-    region='asdf querty 1234'
-    state=present
-  register: result
-  ignore_errors: true
-
-- name: assert invalid region parameter
-  assert:
-    that:
-       - 'result.failed'
-       - 'result.msg.startswith("value of region must be one of:")'
-
-
-# ============================================================
-- name: test valid region parameter
-  ec2_elb_lb:
-    name: "{{ tag_prefix }}"
-    region: "{{ ec2_region }}"
-    state: present
-    zones:
-      - us-east-1a
-      - us-east-1d
-    listeners:
-      - protocol: http
-        load_balancer_port: 80
-        instance_port: 80
-
-  register: result
-  ignore_errors: true
-
-- name: assert valid region parameter
-  assert:
-    that:
-       - 'result.failed'
-       - 'result.msg.startswith("No handler was ready to authenticate.")'
+    - assert:
+        that:
+          - '"failed" not in info'
+          - 'info.elb.status == "ok"'
+          - 'info.changed'
+          - '[80, 81, "HTTP", "HTTP"] in info.elb.listeners'
+          - 'info.elb.listeners|length == 1'
 
 
-# ============================================================
 
-- name: test invalid ec2_url parameter
-  ec2_elb_lb:
-    name: "{{ tag_prefix }}"
-    region: "{{ ec2_region }}"
-    state: present
-    zones:
-      - us-east-1a
-      - us-east-1d
-    listeners:
-      - protocol: http
-        load_balancer_port: 80
-        instance_port: 80
-  environment:
-    EC2_URL: bogus.example.com
-  register: result
-  ignore_errors: true
+    # ============================================================
 
-- name: assert invalid ec2_url parameter
-  assert:
-    that:
-       - 'result.failed'
-       - 'result.msg.startswith("No handler was ready to authenticate.")'
+    # add Listeners
 
+    - name: Add Listeners
+      ec2_elb_lb:
+        name: "{{ tag_prefix }}"
+        region: "{{ ec2_region }}"
+        ec2_access_key: "{{ ec2_access_key }}"
+        ec2_secret_key: "{{ ec2_secret_key }}"
+        security_token: "{{ security_token }}"
+        state: present
+        zones:
+          - us-east-1b
+          - us-east-1c
+          - us-east-1d
+        listeners:
+          - protocol: http
+            load_balancer_port: 8081
+            instance_port: 8081
+        purge_listeners: no
+      register: info
 
-# ============================================================
-- name: test valid ec2_url parameter
-  ec2_elb_lb:
-    name: "{{ tag_prefix }}"
-    region: "{{ ec2_region }}"
-    state: present
-    zones:
-      - us-east-1a
-      - us-east-1d
-    listeners:
-      - protocol: http
-        load_balancer_port: 80
-        instance_port: 80
-  environment:
-    EC2_URL: '{{ec2_url}}'
-  register: result
-  ignore_errors: true
-
-- name: assert valid ec2_url parameter
-  assert:
-    that:
-       - 'result.failed'
-       - 'result.msg.startswith("No handler was ready to authenticate.")'
+    - assert:
+        that:
+          - '"failed" not in info'
+          - 'info.elb.status == "ok"'
+          - 'info.changed'
+          - '[80, 81, "HTTP", "HTTP"] in info.elb.listeners'
+          - '[8081, 8081, "HTTP", "HTTP"] in info.elb.listeners'
+          - 'info.elb.listeners|length == 2'
 
 
-# ============================================================
-- name: test credentials from environment
-  ec2_elb_lb:
-    name: "{{ tag_prefix }}"
-    region: "{{ ec2_region }}"
-    state: present
-    zones:
-      - us-east-1a
-      - us-east-1d
-    listeners:
-      - protocol: http
-        load_balancer_port: 80
-        instance_port: 80
-  environment:
-    EC2_ACCESS_KEY: bogus_access_key
-    EC2_SECRET_KEY: bogus_secret_key
-  register: result
-  ignore_errors: true
+    # ============================================================
 
-- name: assert credentials from environment
-  assert:
-    that:
-       - 'result.failed'
-       - '"InvalidClientTokenId" in result.msg'
+    - name: test with no parameters
+      ec2_elb_lb:
+      register: result
+      ignore_errors: true
+
+    - name: assert failure when called with no parameters
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg == "missing required arguments: name,state"'
 
 
-# ============================================================
-- name: test credential parameters
-  ec2_elb_lb:
-    name: "{{ tag_prefix }}"
-    region: "{{ ec2_region }}"
-    state: present
-    zones:
-      - us-east-1a
-      - us-east-1d
-    listeners:
-      - protocol: http
-        load_balancer_port: 80
-        instance_port: 80
-  register: result
-  ignore_errors: true
 
-- name: assert credential parameters
-  assert:
-    that:
-       - 'result.failed'
-       - '"No handler was ready to authenticate. 1 handlers were checked." in result.msg'
+    # ============================================================
+    - name: test with only name
+      ec2_elb_lb:
+        name="{{ tag_prefix }}"
+      register: result
+      ignore_errors: true
 
-# ============================================================
-- name: remove the test load balancer completely
-  ec2_elb_lb:
-    name: "{{ tag_prefix }}"
-    region: "{{ ec2_region }}"
-    state: absent
-    ec2_access_key: "{{ ec2_access_key }}"
-    ec2_secret_key: "{{ ec2_secret_key }}"
-  register: result
+    - name: assert failure when called with only name
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg == "missing required arguments: state"'
 
-- name: assert the load balancer was removed
-  assert:
-    that:
-       - 'result.changed'
-       - 'result.elb.name == "{{tag_prefix}}"'
-       - 'result.elb.status == "deleted"'
+
+    # ============================================================
+    - name: test invalid region parameter
+      ec2_elb_lb:
+        name: "{{ tag_prefix }}"
+        region: 'asdf querty 1234'
+        state: present
+        listeners:
+          - protocol: http
+            load_balancer_port: 80
+            instance_port: 80
+        zones:
+          - us-east-1c
+          - us-east-1d
+      register: result
+      ignore_errors: true
+
+    - name: assert invalid region parameter
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("Region asdf querty 1234 does not seem to be available ")'
+
+
+    # ============================================================
+    - name: test valid region parameter
+      ec2_elb_lb:
+        name: "{{ tag_prefix }}"
+        region: "{{ ec2_region }}"
+        state: present
+        zones:
+          - us-east-1a
+          - us-east-1d
+        listeners:
+          - protocol: http
+            load_balancer_port: 80
+            instance_port: 80
+
+      register: result
+      ignore_errors: true
+
+    - name: assert valid region parameter
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("No handler was ready to authenticate.")'
+
+
+    # ============================================================
+
+    - name: test invalid ec2_url parameter
+      ec2_elb_lb:
+        name: "{{ tag_prefix }}"
+        region: "{{ ec2_region }}"
+        state: present
+        zones:
+          - us-east-1a
+          - us-east-1d
+        listeners:
+          - protocol: http
+            load_balancer_port: 80
+            instance_port: 80
+      environment:
+        EC2_URL: bogus.example.com
+      register: result
+      ignore_errors: true
+
+    - name: assert invalid ec2_url parameter
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("No handler was ready to authenticate.")'
+
+
+    # ============================================================
+    - name: test valid ec2_url parameter
+      ec2_elb_lb:
+        name: "{{ tag_prefix }}"
+        region: "{{ ec2_region }}"
+        state: present
+        zones:
+          - us-east-1a
+          - us-east-1d
+        listeners:
+          - protocol: http
+            load_balancer_port: 80
+            instance_port: 80
+      environment:
+        EC2_URL: '{{ec2_url}}'
+      register: result
+      ignore_errors: true
+
+    - name: assert valid ec2_url parameter
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("No handler was ready to authenticate.")'
+
+
+    # ============================================================
+    - name: test credentials from environment
+      ec2_elb_lb:
+        name: "{{ tag_prefix }}"
+        region: "{{ ec2_region }}"
+        state: present
+        zones:
+          - us-east-1a
+          - us-east-1d
+        listeners:
+          - protocol: http
+            load_balancer_port: 80
+            instance_port: 80
+      environment:
+        EC2_ACCESS_KEY: bogus_access_key
+        EC2_SECRET_KEY: bogus_secret_key
+      register: result
+      ignore_errors: true
+
+    - name: assert credentials from environment
+      assert:
+        that:
+           - 'result.failed'
+           - '"InvalidClientTokenId" in result.exception'
+
+
+    # ============================================================
+    - name: test credential parameters
+      ec2_elb_lb:
+        name: "{{ tag_prefix }}"
+        region: "{{ ec2_region }}"
+        state: present
+        zones:
+          - us-east-1a
+          - us-east-1d
+        listeners:
+          - protocol: http
+            load_balancer_port: 80
+            instance_port: 80
+      register: result
+      ignore_errors: true
+
+    - name: assert credential parameters
+      assert:
+        that:
+           - 'result.failed'
+           - '"No handler was ready to authenticate. 1 handlers were checked." in result.msg'
+
+  always:
+
+    # ============================================================
+    - name: remove the test load balancer completely
+      ec2_elb_lb:
+        name: "{{ tag_prefix }}"
+        region: "{{ ec2_region }}"
+        state: absent
+        ec2_access_key: "{{ ec2_access_key }}"
+        ec2_secret_key: "{{ ec2_secret_key }}"
+        security_token: "{{ security_token }}"
+      register: result
+
+    - name: assert the load balancer was removed
+      assert:
+        that:
+           - 'result.changed'
+           - 'result.elb.name == "{{tag_prefix}}"'
+           - 'result.elb.status == "deleted"'

--- a/test/integration/roles/test_ec2_group/tasks/main.yml
+++ b/test/integration/roles/test_ec2_group/tasks/main.yml
@@ -8,270 +8,280 @@
 
 # - include: ../../setup_ec2/tasks/common.yml module_name=ec2_group
 
-# ============================================================
-- name: test failure with no parameters
-  ec2_group:
-  register: result
-  ignore_errors: true
+- block:
 
-- name: assert failure with no parameters
-  assert:
-    that:
-       - 'result.failed'
-       - 'result.msg == "missing required arguments: name"'
+    # ============================================================
+    - name: test failure with no parameters
+      ec2_group:
+      register: result
+      ignore_errors: true
 
-# ============================================================
-- name: test failure with only name
-  ec2_group:
-    name='{{ec2_group_name}}'
-  register: result
-  ignore_errors: true
+    - name: assert failure with no parameters
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg == "missing required arguments: name"'
 
-- name: assert failure with only name
-  assert:
-    that:
-       - 'result.failed'
-       - 'result.msg == "Must provide description when state is present."'
+    # ============================================================
+    - name: test failure with only name
+      ec2_group:
+        name='{{ec2_group_name}}'
+      register: result
+      ignore_errors: true
 
-# ============================================================
-- name: test failure with only description
-  ec2_group:
-    description='{{ec2_group_description}}'
-  register: result
-  ignore_errors: true
+    - name: assert failure with only name
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg == "Must provide description when state is present."'
 
-- name: assert failure with only description
-  assert:
-    that:
-       - 'result.failed'
-       - 'result.msg == "missing required arguments: name"'
+    # ============================================================
+    - name: test failure with only description
+      ec2_group:
+        description='{{ec2_group_description}}'
+      register: result
+      ignore_errors: true
 
-# ============================================================
-- name: test failure with empty description (AWS API requires non-empty string desc)
-  ec2_group:
-    name='{{ec2_group_name}}'
-    description=''
-    region='{{ec2_region}}'
-  register: result
-  ignore_errors: true
+    - name: assert failure with only description
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg == "missing required arguments: name"'
 
-- name: assert failure with empty description
-  assert:
-    that:
-       - 'result.failed'
-       - 'result.msg == "Must provide description when state is present."'
+    # ============================================================
+    - name: test failure with empty description (AWS API requires non-empty string desc)
+      ec2_group:
+        name='{{ec2_group_name}}'
+        description=''
+        region='{{ec2_region}}'
+      register: result
+      ignore_errors: true
 
-# ============================================================
-- name: test invalid region parameter
-  ec2_group:
-    name='{{ec2_group_name}}'
-    description='{{ec2_group_description}}'
-    region='asdf querty 1234'
-  register: result
-  ignore_errors: true
+    - name: assert failure with empty description
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg == "Must provide description when state is present."'
 
-- name: assert invalid region parameter
-  assert:
-    that:
-       - 'result.failed'
-       - 'result.msg.startswith("Region asdf querty 1234 does not seem to be available for aws module boto.ec2. If the region definitely exists, you may need to upgrade boto or extend with endpoints_path")'
+    # ============================================================
+    - name: test invalid region parameter
+      ec2_group:
+        name='{{ec2_group_name}}'
+        description='{{ec2_group_description}}'
+        region='asdf querty 1234'
+      register: result
+      ignore_errors: true
 
-# ============================================================
-- name: test valid region parameter
-  ec2_group:
-    name='{{ec2_group_name}}'
-    description='{{ec2_group_description}}'
-    region='{{ec2_region}}'
-  register: result
-  ignore_errors: true
+    - name: assert invalid region parameter
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("Region asdf querty 1234 does not seem to be available for aws module boto.ec2. If the region definitely exists, you may need to upgrade boto or extend with endpoints_path")'
 
-- name: assert valid region parameter
-  assert:
-    that:
-       - 'result.failed'
-       - 'result.msg.startswith("No handler was ready to authenticate.")'
+    # ============================================================
+    - name: test valid region parameter
+      ec2_group:
+        name='{{ec2_group_name}}'
+        description='{{ec2_group_description}}'
+        region='{{ec2_region}}'
+      register: result
+      ignore_errors: true
 
-# ============================================================
-- name: test environment variable EC2_REGION
-  ec2_group:
-    name='{{ec2_group_name}}'
-    description='{{ec2_group_description}}'
-  environment:
-    EC2_REGION: '{{ec2_region}}'
-  register: result
-  ignore_errors: true
+    - name: assert valid region parameter
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("No handler was ready to authenticate.")'
 
-- name: assert environment variable EC2_REGION
-  assert:
-    that:
-       - 'result.failed'
-       - 'result.msg.startswith("No handler was ready to authenticate.")'
+    # ============================================================
+    - name: test environment variable EC2_REGION
+      ec2_group:
+        name='{{ec2_group_name}}'
+        description='{{ec2_group_description}}'
+      environment:
+        EC2_REGION: '{{ec2_region}}'
+      register: result
+      ignore_errors: true
 
-# ============================================================
-- name: test invalid ec2_url parameter
-  ec2_group:
-    name='{{ec2_group_name}}'
-    description='{{ec2_group_description}}'
-  environment:
-    EC2_URL: bogus.example.com
-  register: result
-  ignore_errors: true
+    - name: assert environment variable EC2_REGION
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("No handler was ready to authenticate.")'
 
-- name: assert invalid ec2_url parameter
-  assert:
-    that:
-       - 'result.failed'
-       - 'result.msg.startswith("No handler was ready to authenticate.")'
+    # ============================================================
+    - name: test invalid ec2_url parameter
+      ec2_group:
+        name='{{ec2_group_name}}'
+        description='{{ec2_group_description}}'
+      environment:
+        EC2_URL: bogus.example.com
+      register: result
+      ignore_errors: true
 
-# ============================================================
-- name: test valid ec2_url parameter
-  ec2_group:
-    name='{{ec2_group_name}}'
-    description='{{ec2_group_description}}'
-  environment:
-    EC2_URL: '{{ec2_url}}'
-  register: result
-  ignore_errors: true
+    - name: assert invalid ec2_url parameter
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("No handler was ready to authenticate.")'
 
-- name: assert valid ec2_url parameter
-  assert:
-    that:
-       - 'result.failed'
-       - 'result.msg.startswith("No handler was ready to authenticate.")'
+    # ============================================================
+    - name: test valid ec2_url parameter
+      ec2_group:
+        name='{{ec2_group_name}}'
+        description='{{ec2_group_description}}'
+      environment:
+        EC2_URL: '{{ec2_url}}'
+      register: result
+      ignore_errors: true
 
-# ============================================================
-- name: test credentials from environment
-  ec2_group:
-    name='{{ec2_group_name}}'
-    description='{{ec2_group_description}}'
-  environment:
-    EC2_REGION: '{{ec2_region}}'
-    EC2_ACCESS_KEY: bogus_access_key
-    EC2_SECRET_KEY: bogus_secret_key
-  register: result
-  ignore_errors: true
+    - name: assert valid ec2_url parameter
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("No handler was ready to authenticate.")'
 
-- name: assert ec2_group with valid ec2_url
-  assert:
-    that:
-       - 'result.failed'
-       - '"Error in get_all_security_groups: AWS was not able to validate the provided access credentials" in result.msg'
+    # ============================================================
+    - name: test credentials from environment
+      ec2_group:
+        name='{{ec2_group_name}}'
+        description='{{ec2_group_description}}'
+      environment:
+        EC2_REGION: '{{ec2_region}}'
+        EC2_ACCESS_KEY: bogus_access_key
+        EC2_SECRET_KEY: bogus_secret_key
+      register: result
+      ignore_errors: true
 
-# ============================================================
-- name: test credential parameters
-  ec2_group:
-    name='{{ec2_group_name}}'
-    description='{{ec2_group_description}}'
-    ec2_region='{{ec2_region}}'
-    ec2_access_key='bogus_access_key'
-    ec2_secret_key='bogus_secret_key'
-  register: result
-  ignore_errors: true
+    - name: assert ec2_group with valid ec2_url
+      assert:
+        that:
+           - 'result.failed'
+           - '"Error in get_all_security_groups: AWS was not able to validate the provided access credentials" in result.msg'
 
-- name: assert credential parameters
-  assert:
-    that:
-       - 'result.failed'
-       - '"Error in get_all_security_groups: AWS was not able to validate the provided access credentials" in result.msg'
+    # ============================================================
+    - name: test credential parameters
+      ec2_group:
+        name='{{ec2_group_name}}'
+        description='{{ec2_group_description}}'
+        ec2_region='{{ec2_region}}'
+        ec2_access_key='bogus_access_key'
+        ec2_secret_key='bogus_secret_key'
+      register: result
+      ignore_errors: true
 
-# ============================================================
-- name: test state=absent
-  ec2_group:
-    name='{{ec2_group_name}}'
-    description='{{ec2_group_description}}'
-    ec2_region='{{ec2_region}}'
-    ec2_access_key='{{ec2_access_key}}'
-    ec2_secret_key='{{ec2_secret_key}}'
-    state=absent
-  register: result
+    - name: assert credential parameters
+      assert:
+        that:
+           - 'result.failed'
+           - '"Error in get_all_security_groups: AWS was not able to validate the provided access credentials" in result.msg'
 
-- name: assert state=absent
-  assert:
-    that:
-       - '"failed" not in result'
+    # ============================================================
+    - name: test state=absent
+      ec2_group:
+        name='{{ec2_group_name}}'
+        description='{{ec2_group_description}}'
+        ec2_region='{{ec2_region}}'
+        ec2_access_key='{{ec2_access_key}}'
+        ec2_secret_key='{{ec2_secret_key}}'
+        security_token='{{security_token}}'
+        state=absent
+      register: result
 
-# ============================================================
-- name: test state=present (expected changed=true)
-  ec2_group:
-    name='{{ec2_group_name}}'
-    description='{{ec2_group_description}}'
-    ec2_region='{{ec2_region}}'
-    ec2_access_key='{{ec2_access_key}}'
-    ec2_secret_key='{{ec2_secret_key}}'
-    state=present
-  register: result
+    - name: assert state=absent
+      assert:
+        that:
+           - '"failed" not in result'
 
-- name: assert state=present (expected changed=true)
-  assert:
-    that:
-       - 'result.changed'
-       - 'result.group_id.startswith("sg-")'
+    # ============================================================
+    - name: test state=present (expected changed=true)
+      ec2_group:
+        name='{{ec2_group_name}}'
+        description='{{ec2_group_description}}'
+        ec2_region='{{ec2_region}}'
+        ec2_access_key='{{ec2_access_key}}'
+        ec2_secret_key='{{ec2_secret_key}}'
+        security_token='{{security_token}}'
+        state=present
+      register: result
 
-# ============================================================
-- name: test state=present different description raises error
-  ec2_group:
-    name='{{ec2_group_name}}'
-    description='{{ec2_group_description}}CHANGED'
-    ec2_region='{{ec2_region}}'
-    ec2_access_key='{{ec2_access_key}}'
-    ec2_secret_key='{{ec2_secret_key}}'
-    state=present
-  ignore_errors: true
-  register: result
+    - name: assert state=present (expected changed=true)
+      assert:
+        that:
+           - 'result.changed'
+           - 'result.group_id.startswith("sg-")'
 
-- name: assert matching group with non-matching description raises error
-  assert:
-    that:
-       - 'result.failed'
-       - '"Group description does not match existing group. ec2_group does not support this case." in result.msg'
+    # ============================================================
+    - name: test state=present different description raises error
+      ec2_group:
+        name='{{ec2_group_name}}'
+        description='{{ec2_group_description}}CHANGED'
+        ec2_region='{{ec2_region}}'
+        ec2_access_key='{{ec2_access_key}}'
+        ec2_secret_key='{{ec2_secret_key}}'
+        security_token='{{security_token}}'
+        state=present
+      ignore_errors: true
+      register: result
 
-# ============================================================
-- name: test state=present (expected changed=false)
-  ec2_group:
-    name='{{ec2_group_name}}'
-    description='{{ec2_group_description}}'
-    ec2_region='{{ec2_region}}'
-    ec2_access_key='{{ec2_access_key}}'
-    ec2_secret_key='{{ec2_secret_key}}'
-    state=present
-  register: result
+    - name: assert matching group with non-matching description raises error
+      assert:
+        that:
+           - 'result.failed'
+           - '"Group description does not match existing group. ec2_group does not support this case." in result.msg'
 
-- name: assert state=present (expected changed=false)
-  assert:
-    that:
-       - 'not result.changed'
-       - 'result.group_id.startswith("sg-")'
+    # ============================================================
+    - name: test state=present (expected changed=false)
+      ec2_group:
+        name='{{ec2_group_name}}'
+        description='{{ec2_group_description}}'
+        ec2_region='{{ec2_region}}'
+        ec2_access_key='{{ec2_access_key}}'
+        ec2_secret_key='{{ec2_secret_key}}'
+        security_token='{{security_token}}'
+        state=present
+      register: result
 
-# ============================================================
-- name: test state=absent (expected changed=true)
-  ec2_group:
-    name='{{ec2_group_name}}'
-    state=absent
-  environment:
-    EC2_REGION: '{{ec2_region}}'
-    EC2_ACCESS_KEY: '{{ec2_access_key}}'
-    EC2_SECRET_KEY: '{{ec2_secret_key}}'
-  register: result
+    - name: assert state=present (expected changed=false)
+      assert:
+        that:
+           - 'not result.changed'
+           - 'result.group_id.startswith("sg-")'
 
-- name: assert state=absent (expected changed=true)
-  assert:
-    that:
-       - 'result.changed'
-       - 'not result.group_id'
+    # ============================================================
+    - name: test state=absent (expected changed=true)
+      ec2_group:
+        name='{{ec2_group_name}}'
+        state=absent
+      environment:
+        EC2_REGION: '{{ec2_region}}'
+        EC2_ACCESS_KEY: '{{ec2_access_key}}'
+        EC2_SECRET_KEY: '{{ec2_secret_key}}'
+        EC2_SECURITY_TOKEN: '{{security_token|default("")}}'
+      register: result
 
-# ============================================================
-- name: test state=absent (expected changed=false)
-  ec2_group:
-    name='{{ec2_group_name}}'
-    state=absent
-  environment:
-    EC2_REGION: '{{ec2_region}}'
-    EC2_ACCESS_KEY: '{{ec2_access_key}}'
-    EC2_SECRET_KEY: '{{ec2_secret_key}}'
-  register: result
+    - name: assert state=absent (expected changed=true)
+      assert:
+        that:
+           - 'result.changed'
+           - 'not result.group_id'
 
-- name: assert state=absent (expected changed=false)
-  assert:
-    that:
-       - 'not result.changed'
-       - 'not result.group_id'
+  always:
+
+    # ============================================================
+    - name: test state=absent (expected changed=false)
+      ec2_group:
+        name='{{ec2_group_name}}'
+        state=absent
+      environment:
+        EC2_REGION: '{{ec2_region}}'
+        EC2_ACCESS_KEY: '{{ec2_access_key}}'
+        EC2_SECRET_KEY: '{{ec2_secret_key}}'
+        EC2_SECURITY_TOKEN: '{{security_token|default("")}}'
+      register: result
+
+    - name: assert state=absent (expected changed=false)
+      assert:
+        that:
+           - 'not result.changed'
+           - 'not result.group_id'

--- a/test/integration/roles/test_ec2_key/meta/main.yml
+++ b/test/integration/roles/test_ec2_key/meta/main.yml
@@ -1,3 +1,4 @@
 dependencies:
   - prepare_tests
+  - setup_sshkey
   - setup_ec2

--- a/test/integration/roles/test_ec2_key/tasks/main.yml
+++ b/test/integration/roles/test_ec2_key/tasks/main.yml
@@ -13,325 +13,338 @@
 # ============================================================
 # - include: ../../setup_ec2/tasks/common.yml module_name=ec2_key
 
-# ============================================================
-- name: test with no parameters
-  ec2_key:
-  register: result
-  ignore_errors: true
+- block:
 
-- name: assert failure when called with no parameters
-  assert:
-    that:
-       - 'result.failed'
-       - 'result.msg == "missing required arguments: name"'
+    # ============================================================
+    - name: test with no parameters
+      ec2_key:
+      register: result
+      ignore_errors: true
 
-# ============================================================
-- name: test with only name
-  ec2_key:
-    name={{ec2_key_name}}
-  register: result
-  ignore_errors: true
+    - name: assert failure when called with no parameters
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg == "missing required arguments: name"'
 
-- name: assert failure when called with only 'name'
-  assert:
-    that:
-       - 'result.failed'
-       - 'result.msg == "Either region or ec2_url must be specified"'
+    # ============================================================
+    - name: test with only name
+      ec2_key:
+        name={{ec2_key_name}}
+      register: result
+      ignore_errors: true
 
-# ============================================================
-- name: test invalid region parameter
-  ec2_key:
-    name={{ec2_key_name}}
-    region='asdf querty 1234'
-  register: result
-  ignore_errors: true
+    - name: assert failure when called with only 'name'
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg == "Either region or ec2_url must be specified"'
 
-- name: assert invalid region parameter
-  assert:
-    that:
-       - 'result.failed'
-       - 'result.msg.startswith("value of region must be one of:")'
+    # ============================================================
+    - name: test invalid region parameter
+      ec2_key:
+        name={{ec2_key_name}}
+        region='asdf querty 1234'
+      register: result
+      ignore_errors: true
 
-# ============================================================
-- name: test valid region parameter
-  ec2_key:
-    name={{ec2_key_name}}
-    region={{ec2_region}}
-  register: result
-  ignore_errors: true
+    - name: assert invalid region parameter
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("Region asdf querty 1234 does not seem to be available ")'
 
-- name: assert valid region parameter
-  assert:
-    that:
-       - 'result.failed'
-       - 'result.msg.startswith("No handler was ready to authenticate.")'
+    # ============================================================
+    - name: test valid region parameter
+      ec2_key:
+        name={{ec2_key_name}}
+        region={{ec2_region}}
+      register: result
+      ignore_errors: true
 
-# ============================================================
-- name: test environment variable EC2_REGION
-  ec2_key:
-    name={{ec2_key_name}}
-  environment:
-    EC2_REGION: '{{ec2_region}}'
-  register: result
-  ignore_errors: true
+    - name: assert valid region parameter
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("No handler was ready to authenticate.")'
 
-- name: assert environment variable EC2_REGION
-  assert:
-    that:
-       - 'result.failed'
-       - 'result.msg.startswith("No handler was ready to authenticate.")'
+    # ============================================================
+    - name: test environment variable EC2_REGION
+      ec2_key:
+        name={{ec2_key_name}}
+      environment:
+        EC2_REGION: '{{ec2_region}}'
+      register: result
+      ignore_errors: true
 
-# ============================================================
-- name: test invalid ec2_url parameter
-  ec2_key:
-    name={{ec2_key_name}}
-  environment:
-    EC2_URL: bogus.example.com
-  register: result
-  ignore_errors: true
+    - name: assert environment variable EC2_REGION
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("No handler was ready to authenticate.")'
 
-- name: assert invalid ec2_url parameter
-  assert:
-    that:
-       - 'result.failed'
-       - 'result.msg.startswith("No handler was ready to authenticate.")'
+    # ============================================================
+    - name: test invalid ec2_url parameter
+      ec2_key:
+        name={{ec2_key_name}}
+      environment:
+        EC2_URL: bogus.example.com
+      register: result
+      ignore_errors: true
 
-# ============================================================
-- name: test valid ec2_url parameter
-  ec2_key:
-    name={{ec2_key_name}}
-  environment:
-    EC2_URL: '{{ec2_url}}'
-  register: result
-  ignore_errors: true
+    - name: assert invalid ec2_url parameter
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("No handler was ready to authenticate.")'
 
-- name: assert valid ec2_url parameter
-  assert:
-    that:
-       - 'result.failed'
-       - 'result.msg.startswith("No handler was ready to authenticate.")'
+    # ============================================================
+    - name: test valid ec2_url parameter
+      ec2_key:
+        name={{ec2_key_name}}
+      environment:
+        EC2_URL: '{{ec2_url}}'
+      register: result
+      ignore_errors: true
 
-# ============================================================
-- name: test credentials from environment
-  ec2_key:
-    name={{ec2_key_name}}
-  environment:
-    EC2_REGION: '{{ec2_region}}'
-    EC2_ACCESS_KEY: bogus_access_key
-    EC2_SECRET_KEY: bogus_secret_key
-  register: result
-  ignore_errors: true
+    - name: assert valid ec2_url parameter
+      assert:
+        that:
+           - 'result.failed'
+           - 'result.msg.startswith("No handler was ready to authenticate.")'
 
-- name: assert ec2_key with valid ec2_url
-  assert:
-    that:
-       - 'result.failed'
-       - '"EC2ResponseError: 401 Unauthorized" in result.msg'
+    # ============================================================
+    - name: test credentials from environment
+      ec2_key:
+        name={{ec2_key_name}}
+      environment:
+        EC2_REGION: '{{ec2_region}}'
+        EC2_ACCESS_KEY: bogus_access_key
+        EC2_SECRET_KEY: bogus_secret_key
+      register: result
+      ignore_errors: true
 
-# ============================================================
-- name: test credential parameters
-  ec2_key:
-    name={{ec2_key_name}}
-    ec2_region={{ec2_region}}
-    ec2_access_key=bogus_access_key
-    ec2_secret_key=bogus_secret_key
-  register: result
-  ignore_errors: true
+    - name: assert ec2_key with valid ec2_url
+      assert:
+        that:
+           - 'result.failed'
+           - '"EC2ResponseError: 401 Unauthorized" in result.module_stderr'
 
-- name: assert credential parameters
-  assert:
-    that:
-       - 'result.failed'
-       - '"EC2ResponseError: 401 Unauthorized" in result.msg'
+    # ============================================================
+    - name: test credential parameters
+      ec2_key:
+        name={{ec2_key_name}}
+        ec2_region={{ec2_region}}
+        ec2_access_key=bogus_access_key
+        ec2_secret_key=bogus_secret_key
+      register: result
+      ignore_errors: true
 
-# ============================================================
-- name: test state=absent with key_material
-  ec2_key:
-    name='{{ec2_key_name}}'
-    ec2_region={{ec2_region}}
-    ec2_access_key={{ec2_access_key}}
-    ec2_secret_key={{ec2_secret_key}}
-    state=absent
-  register: result
+    - name: assert credential parameters
+      assert:
+        that:
+           - 'result.failed'
+           - '"EC2ResponseError: 401 Unauthorized" in result.module_stderr'
 
-- name: assert state=absent with key_material
-  assert:
-    that:
-       - '"failed" not in result'
+    # ============================================================
+    - name: test state=absent with key_material
+      ec2_key:
+        name='{{ec2_key_name}}'
+        ec2_region={{ec2_region}}
+        ec2_access_key={{ec2_access_key}}
+        ec2_secret_key={{ec2_secret_key}}
+        security_token={{security_token}}
+        state=absent
+      register: result
 
-# ============================================================
-- name: test state=present without key_material
-  ec2_key:
-    name='{{ec2_key_name}}'
-    ec2_region={{ec2_region}}
-    ec2_access_key={{ec2_access_key}}
-    ec2_secret_key={{ec2_secret_key}}
-    state=present
-  register: result
+    - name: assert state=absent with key_material
+      assert:
+        that:
+           - '"failed" not in result'
 
-- name: assert state=present without key_material
-  assert:
-    that:
-       - 'result.changed'
-       - '"failed" not in result'
-       - '"key" in result'
-       - '"name" in result.key'
-       - '"fingerprint" in result.key'
-       - '"private_key" in result.key'
-       - 'result.key.name == "{{ec2_key_name}}"'
+    # ============================================================
+    - name: test state=present without key_material
+      ec2_key:
+        name='{{ec2_key_name}}'
+        ec2_region={{ec2_region}}
+        ec2_access_key={{ec2_access_key}}
+        ec2_secret_key={{ec2_secret_key}}
+        security_token={{security_token}}
+        state=present
+      register: result
 
-# ============================================================
-- name: test state=absent without key_material
-  ec2_key:
-    name='{{ec2_key_name}}'
-    state=absent
-  environment:
-    EC2_REGION: '{{ec2_region}}'
-    EC2_ACCESS_KEY: '{{ec2_access_key}}'
-    EC2_SECRET_KEY: '{{ec2_secret_key}}'
-  register: result
+    - name: assert state=present without key_material
+      assert:
+        that:
+           - 'result.changed'
+           - '"failed" not in result'
+           - '"key" in result'
+           - '"name" in result.key'
+           - '"fingerprint" in result.key'
+           - '"private_key" in result.key'
+           - 'result.key.name == "{{ec2_key_name}}"'
 
-- name: assert state=absent without key_material
-  assert:
-    that:
-       - 'result.changed'
-       - '"failed" not in result'
-       - '"key" in result'
-       - 'result.key == None'
+    # ============================================================
+    - name: test state=absent without key_material
+      ec2_key:
+        name='{{ec2_key_name}}'
+        state=absent
+      environment:
+        EC2_REGION: '{{ec2_region}}'
+        EC2_ACCESS_KEY: '{{ec2_access_key}}'
+        EC2_SECRET_KEY: '{{ec2_secret_key}}'
+        EC2_SECURITY_TOKEN: '{{security_token|default("")}}'
+      register: result
 
-# ============================================================
-- name: test state=present with key_material
-  ec2_key:
-    name='{{ec2_key_name}}'
-    key_material='{{key_material}}'
-    state=present
-  environment:
-    EC2_REGION: '{{ec2_region}}'
-    EC2_ACCESS_KEY: '{{ec2_access_key}}'
-    EC2_SECRET_KEY: '{{ec2_secret_key}}'
-  register: result
+    - name: assert state=absent without key_material
+      assert:
+        that:
+           - 'result.changed'
+           - '"failed" not in result'
+           - '"key" in result'
+           - 'result.key == None'
 
-- name: assert state=present with key_material
-  assert:
-    that:
-       - '"failed" not in result'
-       - 'result.changed == True'
-       - '"key" in result'
-       - '"name" in result.key'
-       - 'result.key.name == "{{ec2_key_name}}"'
-       - '"fingerprint" in result.key'
-       - '"private_key" not in result.key'
-       # FIXME - why don't the fingerprints match?
-       # - 'result.key.fingerprint == "{{fingerprint}}"'
+    # ============================================================
+    - name: test state=present with key_material
+      ec2_key:
+        name='{{ec2_key_name}}'
+        key_material='{{key_material}}'
+        state=present
+      environment:
+        EC2_REGION: '{{ec2_region}}'
+        EC2_ACCESS_KEY: '{{ec2_access_key}}'
+        EC2_SECRET_KEY: '{{ec2_secret_key}}'
+        EC2_SECURITY_TOKEN: '{{security_token|default("")}}'
+      register: result
 
-# ============================================================
-- name: test state=absent with key_material
-  ec2_key:
-    name='{{ec2_key_name}}'
-    key_material='{{key_material}}'
-    ec2_region='{{ec2_region}}'
-    ec2_access_key='{{ec2_access_key}}'
-    ec2_secret_key='{{ec2_secret_key}}'
-    state=absent
-  register: result
+    - name: assert state=present with key_material
+      assert:
+        that:
+           - '"failed" not in result'
+           - 'result.changed == True'
+           - '"key" in result'
+           - '"name" in result.key'
+           - 'result.key.name == "{{ec2_key_name}}"'
+           - '"fingerprint" in result.key'
+           - '"private_key" not in result.key'
+           # FIXME - why don't the fingerprints match?
+           # - 'result.key.fingerprint == "{{fingerprint}}"'
 
-- name: assert state=absent with key_material
-  assert:
-    that:
-       - 'result.changed'
-       - '"failed" not in result'
-       - '"key" in result'
-       - 'result.key == None'
+    # ============================================================
+    - name: test state=absent with key_material
+      ec2_key:
+        name='{{ec2_key_name}}'
+        key_material='{{key_material}}'
+        ec2_region='{{ec2_region}}'
+        ec2_access_key='{{ec2_access_key}}'
+        ec2_secret_key='{{ec2_secret_key}}'
+        security_token='{{security_token}}'
+        state=absent
+      register: result
 
-# ============================================================
-- name: test state=present with key_material with_files (expect changed=true)
-  ec2_key:
-    name='{{ec2_key_name}}'
-    state=present
-    key_material='{{ item }}'
-  with_file: sshkey ~ '.pub'
-  environment:
-    EC2_REGION: '{{ec2_region}}'
-    EC2_ACCESS_KEY: '{{ec2_access_key}}'
-    EC2_SECRET_KEY: '{{ec2_secret_key}}'
-  register: result
+    - name: assert state=absent with key_material
+      assert:
+        that:
+           - 'result.changed'
+           - '"failed" not in result'
+           - '"key" in result'
+           - 'result.key == None'
 
-- name: assert state=present with key_material with_files (expect changed=true)
-  assert:
-    that:
-       - 'result.msg == "All items completed"'
-       - 'result.changed == True'
-       - '"results" in result'
-       - '"item" in result.results[0]'
-       - '"key" in result.results[0]'
-       - '"name" in result.results[0].key'
-       - 'result.results[0].key.name == "{{ec2_key_name}}"'
-       - '"fingerprint" in result.results[0].key'
-       - '"private_key" not in result.results[0].key'
-       # FIXME - why doesn't result.key.fingerprint == {{fingerprint}}
-       # - 'result.key.fingerprint == "{{fingerprint}}"'
+    # ============================================================
+    - name: test state=present with key_material with_files (expect changed=true)
+      ec2_key:
+        name='{{ec2_key_name}}'
+        state=present
+        key_material='{{ item }}'
+      with_file: '{{sshkey}}.pub'
+      environment:
+        EC2_REGION: '{{ec2_region}}'
+        EC2_ACCESS_KEY: '{{ec2_access_key}}'
+        EC2_SECRET_KEY: '{{ec2_secret_key}}'
+        EC2_SECURITY_TOKEN: '{{security_token|default("")}}'
+      register: result
 
-# ============================================================
-- name: test state=present with key_material with_files (expect changed=false)
-  ec2_key:
-    name='{{ec2_key_name}}'
-    state=present
-    key_material='{{ item }}'
-  with_file: sshkey ~ '.pub'
-  environment:
-    EC2_REGION: '{{ec2_region}}'
-    EC2_ACCESS_KEY: '{{ec2_access_key}}'
-    EC2_SECRET_KEY: '{{ec2_secret_key}}'
-  register: result
+    - name: assert state=present with key_material with_files (expect changed=true)
+      assert:
+        that:
+           - 'result.msg == "All items completed"'
+           - 'result.changed == True'
+           - '"results" in result'
+           - '"item" in result.results[0]'
+           - '"key" in result.results[0]'
+           - '"name" in result.results[0].key'
+           - 'result.results[0].key.name == "{{ec2_key_name}}"'
+           - '"fingerprint" in result.results[0].key'
+           - '"private_key" not in result.results[0].key'
+           # FIXME - why doesn't result.key.fingerprint == {{fingerprint}}
+           # - 'result.key.fingerprint == "{{fingerprint}}"'
 
-- name: assert state=present with key_material with_files (expect changed=false)
-  assert:
-    that:
-       - 'result.msg == "All items completed"'
-       - 'not result.changed'
-       - '"results" in result'
-       - '"item" in result.results[0]'
-       - '"key" in result.results[0]'
-       - '"name" in result.results[0].key'
-       - 'result.results[0].key.name == "{{ec2_key_name}}"'
-       - '"fingerprint" in result.results[0].key'
-       - '"private_key" not in result.results[0].key'
-       # FIXME - why doesn't result.key.fingerprint == {{fingerprint}}
-       # - 'result.key.fingerprint == "{{fingerprint}}"'
+    # ============================================================
+    - name: test state=present with key_material with_files (expect changed=false)
+      ec2_key:
+        name='{{ec2_key_name}}'
+        state=present
+        key_material='{{ item }}'
+      with_file: '{{sshkey}}.pub'
+      environment:
+        EC2_REGION: '{{ec2_region}}'
+        EC2_ACCESS_KEY: '{{ec2_access_key}}'
+        EC2_SECRET_KEY: '{{ec2_secret_key}}'
+        EC2_SECURITY_TOKEN: '{{security_token|default("")}}'
+      register: result
 
-# ============================================================
-- name: test state=absent with key_material (expect changed=true)
-  ec2_key:
-    name='{{ec2_key_name}}'
-    ec2_region='{{ec2_region}}'
-    ec2_access_key='{{ec2_access_key}}'
-    ec2_secret_key='{{ec2_secret_key}}'
-    key_material='{{key_material}}'
-    state=absent
-  register: result
+    - name: assert state=present with key_material with_files (expect changed=false)
+      assert:
+        that:
+           - 'result.msg == "All items completed"'
+           - 'not result.changed'
+           - '"results" in result'
+           - '"item" in result.results[0]'
+           - '"key" in result.results[0]'
+           - '"name" in result.results[0].key'
+           - 'result.results[0].key.name == "{{ec2_key_name}}"'
+           - '"fingerprint" in result.results[0].key'
+           - '"private_key" not in result.results[0].key'
+           # FIXME - why doesn't result.key.fingerprint == {{fingerprint}}
+           # - 'result.key.fingerprint == "{{fingerprint}}"'
 
-- name: assert state=absent with key_material (expect changed=true)
-  assert:
-    that:
-       - 'result.changed'
-       - '"failed" not in result'
-       - '"key" in result'
-       - 'result.key == None'
+    # ============================================================
+    - name: test state=absent with key_material (expect changed=true)
+      ec2_key:
+        name='{{ec2_key_name}}'
+        ec2_region='{{ec2_region}}'
+        ec2_access_key='{{ec2_access_key}}'
+        ec2_secret_key='{{ec2_secret_key}}'
+        security_token='{{security_token}}'
+        key_material='{{key_material}}'
+        state=absent
+      register: result
 
-# ============================================================
-- name: test state=absent (expect changed=false)
-  ec2_key:
-    name='{{ec2_key_name}}'
-    ec2_region='{{ec2_region}}'
-    ec2_access_key='{{ec2_access_key}}'
-    ec2_secret_key='{{ec2_secret_key}}'
-    state=absent
-  register: result
+    - name: assert state=absent with key_material (expect changed=true)
+      assert:
+        that:
+           - 'result.changed'
+           - '"failed" not in result'
+           - '"key" in result'
+           - 'result.key == None'
 
-- name: assert state=absent with key_material (expect changed=false)
-  assert:
-    that:
-       - 'not result.changed'
-       - '"failed" not in result'
-       - '"key" in result'
-       - 'result.key == None'
+  always:
+
+    # ============================================================
+    - name: test state=absent (expect changed=false)
+      ec2_key:
+        name='{{ec2_key_name}}'
+        ec2_region='{{ec2_region}}'
+        ec2_access_key='{{ec2_access_key}}'
+        ec2_secret_key='{{ec2_secret_key}}'
+        security_token='{{security_token}}'
+        state=absent
+      register: result
+
+    - name: assert state=absent with key_material (expect changed=false)
+      assert:
+        that:
+           - 'not result.changed'
+           - '"failed" not in result'
+           - '"key" in result'
+           - 'result.key == None'

--- a/test/integration/roles/test_ecs_ecr/meta/main.yml
+++ b/test/integration/roles/test_ecs_ecr/meta/main.yml
@@ -1,4 +1,3 @@
 dependencies:
   - prepare_tests
-  - setup_sshkey
   - setup_ec2

--- a/test/integration/roles/test_ecs_ecr/tasks/main.yml
+++ b/test/integration/roles/test_ecs_ecr/tasks/main.yml
@@ -3,8 +3,14 @@
     ecr_name: 'ecr-test-{{ ansible_date_time.epoch }}'
 
 - block:
+
     - name: When creating with check mode
-      ecs_ecr: name='{{ ecr_name }}' region='{{ ec2_region }}'
+      ecs_ecr:
+        name: '{{ ecr_name }}'
+        region: '{{ ec2_region }}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
       register: result
       check_mode: yes
 
@@ -17,7 +23,13 @@
 
 
     - name: When specifying a registry that is inaccessible
-      ecs_ecr: registry_id=999999999999 name='{{ ecr_name }}' region='{{ ec2_region }}'
+      ecs_ecr:
+        registry_id: 999999999999
+        name: '{{ ecr_name }}'
+        region: '{{ ec2_region }}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
       register: result
       ignore_errors: true
 
@@ -29,7 +41,12 @@
 
 
     - name: When creating a repository
-      ecs_ecr: name='{{ ecr_name }}' region='{{ ec2_region }}'
+      ecs_ecr:
+        name: '{{ ecr_name }}'
+        region: '{{ ec2_region }}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
       register: result
 
     - name: it should change and create
@@ -40,7 +57,12 @@
 
 
     - name: When creating a repository that already exists in check mode
-      ecs_ecr: name='{{ ecr_name }}' region='{{ ec2_region }}'
+      ecs_ecr:
+        name: '{{ ecr_name }}'
+        region: '{{ ec2_region }}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
       register: result
       check_mode: yes
 
@@ -52,7 +74,12 @@
 
 
     - name: When creating a repository that already exists
-      ecs_ecr: name='{{ ecr_name }}' region='{{ ec2_region }}'
+      ecs_ecr:
+        name: '{{ ecr_name }}'
+        region: '{{ ec2_region }}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
       register: result
 
     - name: it should not change
@@ -65,6 +92,9 @@
       ecs_ecr:
         region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
         delete_policy: yes
       register: result
       check_mode: yes
@@ -81,6 +111,9 @@
         region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         policy: '{{ policy }}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
       register: result
       check_mode: yes
 
@@ -97,6 +130,9 @@
         region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         policy: '{{ policy }}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
       register: result
 
     - name: it should change and not create
@@ -111,6 +147,9 @@
         region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         delete_policy: yes
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
       register: result
       check_mode: yes
 
@@ -127,6 +166,9 @@
         region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         delete_policy: yes
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
       register: result
 
     - name: it should change and not create
@@ -141,6 +183,9 @@
         region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         policy: '{{ policy | to_json }}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
       register: result
 
     - name: it should change and not create
@@ -155,6 +200,9 @@
         region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         policy: '{{ policy }}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
       register: result
 
     - name: it should not change
@@ -167,6 +215,9 @@
       ecs_ecr:
         region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
       register: result
 
     - name: it should not change
@@ -181,6 +232,9 @@
         name: '{{ ecr_name }}'
         policy: '{{ policy }}'
         delete_policy: yes
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
       register: result
       ignore_errors: true
 
@@ -195,6 +249,9 @@
         region: '{{ ec2_region }}'
         name: '{{ ecr_name }}'
         policy_text: "Ceci n'est pas une JSON"
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
       register: result
       ignore_errors: true
 
@@ -205,7 +262,13 @@
 
 
     - name: When in check mode, deleting a policy that exists
-      ecs_ecr: name='{{ ecr_name }}' region='{{ ec2_region }}' state=absent
+      ecs_ecr:
+        name: '{{ ecr_name }}'
+        region: '{{ ec2_region }}'
+        state: absent
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
       register: result
       check_mode: yes
 
@@ -218,7 +281,13 @@
 
 
     - name: When deleting a policy that exists
-      ecs_ecr: name='{{ ecr_name }}' region='{{ ec2_region }}' state=absent
+      ecs_ecr:
+        name: '{{ ecr_name }}'
+        region: '{{ ec2_region }}'
+        state: absent
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
       register: result
 
     - name: it should change
@@ -228,7 +297,13 @@
 
 
     - name: When in check mode, deleting a policy that does not exist
-      ecs_ecr: name='{{ ecr_name }}' region='{{ ec2_region }}' state=absent
+      ecs_ecr:
+        name: '{{ ecr_name }}'
+        region: '{{ ec2_region }}'
+        state: absent
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
       register: result
       check_mode: yes
 
@@ -240,7 +315,13 @@
 
 
     - name: When deleting a policy that does not exist
-      ecs_ecr: name='{{ ecr_name }}' region='{{ ec2_region }}' state=absent
+      ecs_ecr:
+        name: '{{ ecr_name }}'
+        region: '{{ ec2_region }}'
+        state: absent
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
       register: result
 
     - name: it should not change
@@ -249,5 +330,12 @@
           - not result|changed
 
   always:
+
     - name: Delete lingering ECR repository
-      ecs_ecr: name='{{ ecr_name }}' region='{{ ec2_region }}' state=absent
+      ecs_ecr:
+        name: '{{ ecr_name }}'
+        region: '{{ ec2_region }}'
+        state: absent
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'


### PR DESCRIPTION
##### SUMMARY

Fixes for EC2 module integration tests:

- ec2_elb_lb
- ec2_group
- ec2_key
- ecs_ecr

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

EC2 integration tests

##### ANSIBLE VERSION

```
ansible 2.4.0 (aws-test-fixes 6b3933c2bf) last updated 2017/05/03 12:52:49 (GMT +800)
  config file = 
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```

##### ADDITIONAL INFORMATION

The following changes were made:

- Added missing block/always cleanup to reduce resource leakage.
- Added missing module credential parameters.
- Added support for running tests with AWS temporary security credentials.
- Split out SSH key pair generation for use only with tests which require it.
- Removed awk dependency for SSH key pair generation.
- Removed unused random string generation.
- Added missing module parameters.
- Corrected assertions.

These tests now pass with the latest boto versions installed:

- boto (2.46.1)
- boto3 (1.4.4)
- botocore (1.5.45)

Tests may fail with much older versions of boto due to differences in error messages.

The credentials template has been updated to add `security_token`. If you have an existing `credentials.yml` it may need to be updated.