### PR TITLE
Updated pip module to always return changed if venv is created

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -441,9 +441,10 @@ def main():
         out = ''
 
         env = module.params['virtualenv']
-
+        venv_created = False
         if env:
             if not os.path.exists(os.path.join(env, 'bin', 'activate')):
+                venv_created = True
                 if module.check_mode:
                     module.exit_json(changed=True)
 
@@ -581,6 +582,8 @@ def main():
             else:
                 _, out_freeze_after, _ = _get_packages(module, pip, chdir)
                 changed = out_freeze_before != out_freeze_after
+
+        changed = changed or venv_created
 
         module.exit_json(changed=changed, cmd=cmd, name=name, version=version,
                          state=state, requirements=requirements, virtualenv=env,

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -166,3 +166,20 @@
   assert:
     that:
       - "not q_check_mode.changed"
+
+# ansible#23204
+- name: ensure is a fresh virtualenv
+  file:
+    state: absent
+    name: "{{ output_dir }}/pipenv"
+
+- name: install pip throught pip into fresh virtualenv
+  pip:
+    name: pip
+    virtualenv: "{{ output_dir }}/pipenv"
+  register: pip_install_venv
+
+- name: make sure pip in fresh virtualenv report changed
+  assert:
+    that:
+      - "pip_install_venv.changed"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #23204

Currently, the pip module may not return changed if a venv is created. This change ensures it does.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
pip module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (pip-fixes f7f22b1ee9) last updated 2017/05/03 01:23:43 (GMT -500)
  config file =
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/user/Development/python/ansible/lib/ansible
  executable location = /home/user/Development/python/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

The following playbook now returns changed on first run, as it should.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
- name: Create Python Virtual Environment
  pip:
    name: pip
    virtualenv: /home/user/venv/
    virtualenv_python: python2
```
