### PR TITLE
cloud: ovirt: Remove extra "the" from descriptions

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_affinity_groups.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_affinity_groups.py
@@ -36,7 +36,7 @@ description:
 options:
     name:
         description:
-            - "Name of the the affinity group to manage."
+            - "Name of the affinity group to manage."
         required: true
     state:
         description:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_affinity_labels.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_affinity_labels.py
@@ -36,7 +36,7 @@ description:
 options:
     name:
         description:
-            - "Name of the the affinity label to manage."
+            - "Name of the affinity label to manage."
         required: true
     state:
         description:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_clusters.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_clusters.py
@@ -35,7 +35,7 @@ description:
 options:
     name:
         description:
-            - "Name of the the cluster to manage."
+            - "Name of the cluster to manage."
         required: true
     state:
         description:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_datacenters.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_datacenters.py
@@ -35,7 +35,7 @@ description:
 options:
     name:
         description:
-            - "Name of the the data center to manage."
+            - "Name of the data center to manage."
         required: true
     state:
         description:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_external_providers.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_external_providers.py
@@ -35,7 +35,7 @@ description:
 options:
     name:
         description:
-            - "Name of the the external provider to manage."
+            - "Name of the external provider to manage."
     state:
         description:
             - "Should the external be present or absent"

--- a/lib/ansible/modules/cloud/ovirt/ovirt_groups.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_groups.py
@@ -35,7 +35,7 @@ description:
 options:
     name:
         description:
-            - "Name of the the group to manage."
+            - "Name of the group to manage."
         required: true
     state:
         description:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_networks.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_networks.py
@@ -35,7 +35,7 @@ description:
 options:
     name:
         description:
-            - "Name of the the host to manage networks for."
+            - "Name of the host to manage networks for."
         required: true
     state:
         description:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_pm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_pm.py
@@ -35,7 +35,7 @@ description:
 options:
     name:
         description:
-            - "Name of the the host to manage."
+            - "Name of the host to manage."
         required: true
         aliases: ['host']
     state:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_hosts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_hosts.py
@@ -35,7 +35,7 @@ description:
 options:
     name:
         description:
-            - "Name of the the host to manage."
+            - "Name of the host to manage."
         required: true
     state:
         description:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_mac_pools.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_mac_pools.py
@@ -35,7 +35,7 @@ description:
 options:
     name:
         description:
-            - "Name of the the MAC pool to manage."
+            - "Name of the MAC pool to manage."
         required: true
     description:
         description:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_networks.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_networks.py
@@ -35,7 +35,7 @@ description:
 options:
     name:
         description:
-            - "Name of the the network to manage."
+            - "Name of the network to manage."
         required: true
     state:
         description:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_permissions.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_permissions.py
@@ -35,7 +35,7 @@ description:
 options:
     role:
         description:
-            - "Name of the the role to be assigned to user/group on specific object."
+            - "Name of the role to be assigned to user/group on specific object."
         default: UserRole
     state:
         description:
@@ -69,13 +69,13 @@ options:
         ]
     user_name:
         description:
-            - "Username of the the user to manage. In most LDAPs it's I(uid) of the user,
+            - "Username of the user to manage. In most LDAPs it's I(uid) of the user,
                but in Active Directory you must specify I(UPN) of the user."
             - "Note that if user don't exist in the system this module will fail,
                you should ensure the user exists by using M(ovirt_users) module."
     group_name:
         description:
-            - "Name of the the group to manage."
+            - "Name of the group to manage."
             - "Note that if group don't exist in the system this module will fail,
                you should ensure the group exists by using M(ovirt_groups) module."
     authz_name:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_permissions_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_permissions_facts.py
@@ -38,10 +38,10 @@ notes:
 options:
     user_name:
         description:
-            - "Username of the the user to manage. In most LDAPs it's I(uid) of the user, but in Active Directory you must specify I(UPN) of the user."
+            - "Username of the user to manage. In most LDAPs it's I(uid) of the user, but in Active Directory you must specify I(UPN) of the user."
     group_name:
         description:
-            - "Name of the the group to manage."
+            - "Name of the group to manage."
     authz_name:
         description:
             - "Authorization provider of the user/group. In previous versions of oVirt/RHV known as domain."

--- a/lib/ansible/modules/cloud/ovirt/ovirt_quotas.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_quotas.py
@@ -35,7 +35,7 @@ description:
 options:
     name:
         description:
-            - "Name of the the quota to manage."
+            - "Name of the quota to manage."
         required: true
     state:
         description:
@@ -48,7 +48,7 @@ options:
         required: true
     description:
         description:
-            - "Description of the the quota to manage."
+            - "Description of the quota to manage."
     cluster_threshold:
         description:
             - "Cluster threshold(soft limit) defined in percentage (0-100)."

--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
@@ -35,7 +35,7 @@ description:
 options:
     name:
         description:
-            - "Name of the the storage domain to manage."
+            - "Name of the storage domain to manage."
     state:
         description:
             - "Should the storage domain be present/absent/maintenance/unattached"

--- a/lib/ansible/modules/cloud/ovirt/ovirt_tags.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_tags.py
@@ -36,7 +36,7 @@ description:
 options:
     name:
         description:
-            - "Name of the the tag to manage."
+            - "Name of the tag to manage."
         required: true
     state:
         description:
@@ -45,7 +45,7 @@ options:
         default: present
     description:
         description:
-            - "Description of the the tag to manage."
+            - "Description of the tag to manage."
     parent:
         description:
             - "Name of the parent tag."

--- a/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
@@ -35,7 +35,7 @@ description:
 options:
     name:
         description:
-            - "Name of the the template to manage."
+            - "Name of the template to manage."
         required: true
     state:
         description:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_users.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_users.py
@@ -35,7 +35,7 @@ description:
 options:
     name:
         description:
-            - "Name of the the user to manage. In most LDAPs it's I(uid) of the user, but in Active Directory you must specify I(UPN) of the user."
+            - "Name of the user to manage. In most LDAPs it's I(uid) of the user, but in Active Directory you must specify I(UPN) of the user."
         required: true
     state:
         description:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vmpools.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vmpools.py
@@ -35,7 +35,7 @@ description:
 options:
     name:
         description:
-            - "Name of the the VM pool to manage."
+            - "Name of the VM pool to manage."
         required: true
     state:
         description:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
@@ -36,11 +36,11 @@ description:
 options:
     name:
         description:
-            - "Name of the the Virtual Machine to manage. If VM don't exists C(name) is required.
+            - "Name of the Virtual Machine to manage. If VM don't exists C(name) is required.
                Otherwise C(id) or C(name) can be used."
     id:
         description:
-            - "ID of the the Virtual Machine to manage."
+            - "ID of the Virtual Machine to manage."
     state:
         description:
             - "Should the Virtual Machine be running/stopped/present/absent/suspended/next_run."


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Remove extra "the" from the description
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
oVirt module
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
