### PR TITLE
rhn+register: do not pass username/passwd for registration if none is specified

### DIFF
--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -254,7 +254,9 @@ class Rhn(redhat.RegistrationBase):
             Register system to RHN.  If enable_eus=True, extended update
             support will be requested.
         '''
-        register_cmd = ['/usr/sbin/rhnreg_ks', '--username', self.username, '--password', self.password, '--force']
+        register_cmd = ['/usr/sbin/rhnreg_ks', '--force']
+        if self.username:
+            register_cmd.extend(['--username', self.username, '--password', self.password])
         if self.server_url:
             register_cmd.extend(['--serverUrl', self.server_url])
         if enable_eus:


### PR DESCRIPTION
… specified.

##### SUMMARY
Do not pass username/password if none is set

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
amodules/packaging/os/rhn_register.py

##### ANSIBLE VERSION

```
ansible 2.4.0 (rhn-register 58e9a6d74c) last updated 2017/05/03 09:22:07 (GMT -400)
  config file = /home/rkhadgar/.ansible.cfg
  configured module search path = [u'/home/rkhadgar/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/rkhadgar/Projects/github/ritz/ansible/lib/ansible
  executable location = /home/rkhadgar/Projects/github/ritz/ansible/bin/ansible
  python version = 2.7.13 (default, Feb 21 2017, 12:00:39) [GCC 7.0.1 20170219 (Red Hat 7.0.1-0.9)]

```


##### ADDITIONAL INFORMATION
The role

```
    - name: register system to rhn
      rhn_register:
        server_url: https://spacewalk/XMLRPC
        state: present
        activationkey: "{{ active_key }}"
        sslcacert: /usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT
```

from module execution 
before
```
"cmd": "/usr/sbin/rhnreg_ks --username --password '********' \
           --serverUrl https://spacewalk/XMLRPC \
           --activationkey VALUE_SPECIFIED_IN_NO_LOG_PARAMETER \
           --sslCACert /usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT", 
```

After
```
"cmd": "/usr/sbin/rhnreg_ks --force --serverUrl https://spacewalk/XMLRPC --activationkey VALUE_SPECIFIED_IN_NO_LOG_PARAMETER --sslCACert /usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT", 
...