### PR TITLE
Add --download-only support for packaging/apt module.

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -126,6 +126,12 @@ options:
     required: false
     default: false
     version_added: "2.1"
+  download_only:
+    description:
+      - Only download package but not install it.
+    required: false
+    default: false
+    version_added: "2.4"
 requirements:
    - python-apt (python 2)
    - python3-apt (python 3)
@@ -458,7 +464,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
             install_recommends=None, force=False,
             dpkg_options=expand_dpkg_options(DPKG_OPTIONS),
             build_dep=False, autoremove=False, only_upgrade=False,
-            allow_unauthenticated=False):
+            allow_unauthenticated=False, download_only=False):
     pkg_list = []
     packages = ""
     pkgspec = expand_pkgspec_from_fnmatches(m, pkgspec, cache)
@@ -503,10 +509,15 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
         else:
             only_upgrade = ''
 
+        if download_only:
+            download_only = '--download-only'
+        else:
+            download_only = ''
+
         if build_dep:
             cmd = "%s -y %s %s %s %s build-dep %s" % (APT_GET_CMD, dpkg_options, only_upgrade, force_yes, check_arg, packages)
         else:
-            cmd = "%s -y %s %s %s %s %s install %s" % (APT_GET_CMD, dpkg_options, only_upgrade, force_yes, autoremove, check_arg, packages)
+            cmd = "%s -y %s %s %s %s %s %s install %s" % (APT_GET_CMD, dpkg_options, only_upgrade, download_only, force_yes, autoremove, check_arg, packages)
 
         if default_release:
             cmd += " -t '%s'" % (default_release,)
@@ -813,6 +824,7 @@ def main():
             autoremove=dict(type='bool', aliases=['autoclean']),
             only_upgrade=dict(type='bool', default=False),
             allow_unauthenticated=dict(default='no', aliases=['allow-unauthenticated'], type='bool'),
+            download_only=dict(type='bool', default=False),
         ),
         mutually_exclusive=[['package', 'upgrade', 'deb']],
         required_one_of=[['package', 'upgrade', 'update_cache', 'deb', 'autoremove']],
@@ -948,7 +960,8 @@ def main():
                 build_dep=state_builddep,
                 autoremove=autoremove,
                 only_upgrade=p['only_upgrade'],
-                allow_unauthenticated=allow_unauthenticated
+                allow_unauthenticated=allow_unauthenticated,
+                download_only=p['download_only']
             )
 
             # Store if the cache has been updated


### PR DESCRIPTION
##### SUMMARY

Add --download-only option to apt module

Fixes #23220

##### ISSUE TYPE

 - Feature Pull Request


##### COMPONENT NAME

lib/ansible/modules/packaging/os/apt.py

##### ANSIBLE VERSION

```
ansible --version
ansible 2.4.0 (apt_download_only 4def437187) last updated 2017/05/03 14:32:40 (GMT +000)
  config file =
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/ansible/lib/ansible
  executable location = /root/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION

- Example playbook

```
---

- name: Test PR for Ansible
  hosts: servers
  become: True

  tasks:
    - name: Download a package only
      apt:
        name: yasat
        state: present
        download_only: true
```

- Output

```
TASK [Download a package only] ***************************************************************************************************************************************************
changed: [ansibledev_ubuntu14] => {"cache_update_time": 1493814974, "cache_updated": false, "changed": true, "stderr": "", "stderr_lines": [], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following NEW packages will be installed:\n  yasat\n0 upgraded, 1 newly installed, 0 to remove and 47 not upgraded.\nNeed to get 106 kB of archives.\nAfter this operation, 606 kB of additional disk space will be used.\nGet:1 http://archive.ubuntu.com/ubuntu/ trusty/universe yasat all 526-1 [106 kB]\nFetched 106 kB in 1s (68.0 kB/s)\nDownload complete and in download only mode\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following NEW packages will be installed:", "  yasat", "0 upgraded, 1 newly installed, 0 to remove and 47 not upgraded.", "Need to get 106 kB of archives.", "After this operation, 606 kB of additional disk space will be used.", "Get:1 http://archive.ubuntu.com/ubuntu/ trusty/universe yasat all 526-1 [106 kB]", "Fetched 106 kB in 1s (68.0 kB/s)", "Download complete and in download only mode"]}

PLAY RECAP ***********************************************************************************************************************************************************************
ansibledev_ubuntu14        : ok=2    changed=1    unreachable=0    failed=0
```