### PR TITLE
Use boto connect_to_region so Elasticache works in AWS China

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elasticache.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache.py
@@ -146,8 +146,7 @@ import time
 
 try:
     import boto
-    from boto.elasticache.layer1 import ElastiCacheConnection
-    from boto.regioninfo import RegionInfo
+    from boto.elasticache import connect_to_region
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
@@ -430,10 +429,8 @@ class ElastiCacheManager(object):
     def _get_elasticache_connection(self):
         """Get an elasticache connection"""
         try:
-            endpoint = "elasticache.%s.amazonaws.com" % self.region
-            connect_region = RegionInfo(name=self.region, endpoint=endpoint)
-            return ElastiCacheConnection(
-                region=connect_region,
+            return connect_to_region(
+                region_name=self.region,
                 **self.aws_connect_kwargs
             )
         except boto.exception.NoAuthHandlerFound as e:


### PR DESCRIPTION
##### SUMMARY

Fixes #23965 

The Elasticache module assumes endpoints live in 'elasticache.region.amazonaws.com', which doesn't work in China - China's AWS service endpoints end in `amazonaws.com.cn`.

Using boto.elasticache.connect_to_region to manage the AWS connection fixes this, and like what most AWS modules that to use regional endpoints use. 

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

elasticache

##### ANSIBLE VERSION

```
(virtualenv-ansible-devel) ukch-ofclt2473:ansible nbailey$ ansible --version
ansible 2.4.0 (devel 4e4fc9cb4c) last updated 2017/05/02 12:29:29 (GMT +100)
  config file = /Users/nbailey/.ansible.cfg
  configured module search path = [u'/Users/nbailey/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/nbailey/virtualenv-ansible-devel/src/ansible/lib/ansible
  executable location = /Users/nbailey/virtualenv-ansible-devel/bin/ansible
  python version = 2.7.10 (default, Oct 23 2015, 19:19:21) [GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)]
```

##### ADDITIONAL INFORMATION

AWS China uses a different top level domain from the rest of Global AWS - so the elasticache service endpoint in cn-north-1 is `elasticache.cn-north-1.amazonaws.com.cn` rather than the `elasticache.cn-north-1.amazonaws.com` the module would construct.

Letting Boto find the endpoints for us instead of having logic in Ansible modules to do that work seems like a solid long-term decision.