### PR TITLE
keep 1 templar

### DIFF
--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -424,7 +424,7 @@ class TestTaskExecutor(unittest.TestCase):
         mock_task.evaluate_conditional.return_value = True
         mock_task.args = dict(_raw_params='foo.yml', a='foo', b='bar')
         mock_task.action = 'include'
-        res = te._execute()
+        res = te._execute(templar=mock_templar)
 
     def test_task_executor_poll_async_result(self):
         fake_loader = DictDataLoader({})


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
since we create templar many times with same params, just do it once and pass it around

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
executor

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3/2.4
```
##### ADDITIONAL INFORMATION

will probably save on ram since now we don't create templar per item/task/host and it's inherit copy of variables.