### PR TITLE
[Fix] Commented out Section due to no Quotes

### DIFF
--- a/lib/ansible/modules/notification/slack.py
+++ b/lib/ansible/modules/notification/slack.py
@@ -139,7 +139,7 @@ EXAMPLES = """
   slack:
     token: thetoken/generatedby/slack
     msg: '{{ inventory_hostname }} completed'
-    channel: #ansible
+    channel: '#ansible'
     username: 'Ansible on {{ inventory_hostname }}'
     icon_url: http://www.example.com/some-image-file.png
     link_names: 0
@@ -159,7 +159,7 @@ EXAMPLES = """
     token: thetoken/generatedby/slack
     attachments:
       - text: Display my system load on host A and B
-        color: #ff00dd
+        color: '#ff00dd'
         title: System load
         fields:
           - title: System A


### PR DESCRIPTION
##### SUMMARY
Variables are not being passed into ansible unless they are quoted since yaml will automatically interpret them as comments

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
modules/notification/slack.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```


##### ADDITIONAL INFORMATION
