### PR TITLE
Fixed #21464 - docker_network: TypeError with existing network

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -194,8 +194,7 @@ class TaskParameters(DockerBaseClass):
 
 
 def container_names_in_network(network):
-    return [c['Name'] for c in network['Containers'].values()]
-
+    return [c['Name'] for c in network['Containers'].values()] if network['Containers'] else []
 
 class DockerNetworkManager(object):
 
@@ -247,7 +246,7 @@ class DockerNetworkManager(object):
                 differences.append('driver_options')
             else:
                 for key, value in self.parameters.driver_options.items():
-                    if not net['Options'].get(key) or value != net['Options'][key]:
+                    if not (key in net['Options']) or value != net['Options'][key]:
                         different = True
                         differences.append('driver_options.%s' % key)
         if self.parameters.ipam_driver:
@@ -286,10 +285,10 @@ class DockerNetworkManager(object):
 
             if HAS_DOCKER_PY_2:
                 ipam_config = IPAMConfig(driver=self.parameters.ipam_driver,
-                                                   pool_configs=ipam_pools)
+                                         pool_configs=ipam_pools)
             else:
                 ipam_config = utils.create_ipam_config(driver=self.parameters.ipam_driver,
-                                                   pool_configs=ipam_pools)
+                                                       pool_configs=ipam_pools)
 
             if not self.check_mode:
                 resp = self.client.create_network(self.parameters.network_name,
@@ -321,13 +320,18 @@ class DockerNetworkManager(object):
                 self.results['changed'] = True
 
     def disconnect_missing(self):
-        for c in self.existing_network['Containers'].values():
+        containers = self.existing_network['Containers']
+        if not containers:
+            return
+        for c in containers.values():
             name = c['Name']
             if name not in self.parameters.connected:
                 self.disconnect_container(name)
 
     def disconnect_all_containers(self):
         containers = self.client.inspect_network(self.parameters.network_name)['Containers']
+        if not containers:
+            return
         for cont in containers.values():
             self.disconnect_container(cont['Name'])
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixed #21464 - docker_network: TypeError with existing network
Fixed #22530 - docker_network Failed but Overlay network created successfully on Docker swarm mode
Fix situation, when driver_options has options without value (encrypted:''). In this case was resource is marked as changed always, because value is empty:
 
```diff
-                    if not (key in net['Options']) or value != net['Options'][key]:
+                    if not net['Options'].get(key) or value != net['Options'][key]:
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
docker_network

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel f97066e1bf) last updated 2017/05/03 23:45:19 (GMT +300)
  executable location = bin/ansible
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```
