### PR TITLE
Switch last remaining decode to to_text

### DIFF
--- a/lib/ansible/modules/commands/expect.py
+++ b/lib/ansible/modules/commands/expect.py
@@ -157,7 +157,7 @@ def main():
         else:
             response = u'%s\n' % to_text(value).rstrip(u'\n')
 
-        events[key.decode()] = response
+        events[to_text(key)] = response
 
     if args.strip() == '':
         module.fail_json(rc=256, msg="no command given")


### PR DESCRIPTION
##### SUMMARY

Fixes #24226 

There was a left over `.decode` that should have been previously switched to `to_text`, this PR resolves this.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
expect

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
N/A