### PR TITLE
vmware_guest: Fix VM creation when creating a VM from a template with network adapters not setting ip/netmask

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -735,28 +735,31 @@ class PyVmomiHelper(object):
         # Network settings
         adaptermaps = []
         for network in self.params['networks']:
+            guest_map = vim.vm.customization.AdapterMapping()
+            guest_map.adapter = vim.vm.customization.IPSettings()
+
             if 'ip' in network and 'netmask' in network:
-                guest_map = vim.vm.customization.AdapterMapping()
-                guest_map.adapter = vim.vm.customization.IPSettings()
                 guest_map.adapter.ip = vim.vm.customization.FixedIp()
                 guest_map.adapter.ip.ipAddress = str(network['ip'])
                 guest_map.adapter.subnetMask = str(network['netmask'])
+            else:
+                guest_map.adapter.ip = vim.vm.customization.DhcpIpGenerator()
 
-                if 'gateway' in network:
-                    guest_map.adapter.gateway = network['gateway']
+            if 'gateway' in network:
+                guest_map.adapter.gateway = network['gateway']
 
-                # On Windows, DNS domain and DNS servers can be set by network interface
-                # https://pubs.vmware.com/vi3/sdk/ReferenceGuide/vim.vm.customization.IPSettings.html
-                if 'domain' in network:
-                    guest_map.adapter.dnsDomain = network['domain']
-                elif self.params['customization'].get('domain'):
-                    guest_map.adapter.dnsDomain = self.params['customization']['domain']
-                if 'dns_servers' in network:
-                    guest_map.adapter.dnsServerList = network['dns_servers']
-                elif self.params['customization'].get('dns_servers'):
-                    guest_map.adapter.dnsServerList = self.params['customization']['dns_servers']
+            # On Windows, DNS domain and DNS servers can be set by network interface
+            # https://pubs.vmware.com/vi3/sdk/ReferenceGuide/vim.vm.customization.IPSettings.html
+            if 'domain' in network:
+                guest_map.adapter.dnsDomain = network['domain']
+            elif self.params['customization'].get('domain'):
+                guest_map.adapter.dnsDomain = self.params['customization']['domain']
+            if 'dns_servers' in network:
+                guest_map.adapter.dnsServerList = network['dns_servers']
+            elif self.params['customization'].get('dns_servers'):
+                guest_map.adapter.dnsServerList = self.params['customization']['dns_servers']
 
-                adaptermaps.append(guest_map)
+            adaptermaps.append(guest_map)
 
         # Global DNS settings
         globalip = vim.vm.customization.GlobalIPSettings()


### PR DESCRIPTION
##### SUMMARY
When using vmware_guest to create a VM from a template with networks that does not explicitly set ip/netmask, the networks are not included in the customization policy.

This causes an error as vcenter expects the same amount of nic's (or more) in the customization policy as ones existing on the vm.

This fixes #19860.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /Users/DMarby/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Feb  2 2017, 09:05:20) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
Example playbook:
```
---

- name: Launch server
  hosts: localhost
  connection: local
  gather_facts: false

  tasks:
    - name: "Deploy VM"
      vmware_guest:
        name: "test"
        validate_certs: False
        hostname: "{{ hostname }}"
        username: "{{ username }}"
        password: "{{ password }}"
        datacenter: "{{ datacenter }}"
        guest_id: "{{ guest_id }}"
        template: "{{ template }}"
        state: present
        disk:
        - size_gb: "10"
          type: thin
          datastore: "{{ datastore }}"
        hardware:
          memory_mb: "512"
          num_cpus: "1"
        networks:
        - name: VM Network
```

Error:
```
fatal: [localhost]: FAILED! => {
    "changed": true,
    "failed": true,
    "invocation": {
        "module_args": {
            "annotation": null,
            "cluster": null,
            "customization": {},
            "customvalues": [],
            "datacenter": "",
            "disk": [
                {
                    "datastore": "",
                    "size_gb": "10",
                    "type": "thin"
                }
            ],
            "esxi_hostname": null,
            "folder": "/vm",
            "force": false,
            "guest_id": "ubuntu64Guest",
            "hardware": {
                "memory_mb": "512",
                "num_cpus": "1"
            },
            "hostname": "",
            "is_template": false,
            "name": "test",
            "name_match": "first",
            "networks": [
                {
                    "name": "VM Network"
                }
            ],
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "resource_pool": null,
            "state": "present",
            "template": "ubuntu-template",
            "template_src": "ubuntu-template",
            "username": "",
            "uuid": null,
            "validate_certs": false,
            "wait_for_ip_address": false
        }
    },
    "msg": "The number of network adapter settings in the customization specification: 0 does not match the number of network adapters present in the virtual machine: 1."
}
```
