### PR TITLE
Add support for AWS China to elasticache_subnet_group role

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elasticache_subnet_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_subnet_group.py
@@ -71,8 +71,7 @@ EXAMPLES = '''
 
 try:
     import boto
-    from boto.elasticache.layer1 import ElastiCacheConnection
-    from boto.regioninfo import RegionInfo
+    from boto.elasticache import connect_to_region
     from boto.exception import BotoServerError
     HAS_BOTO = True
 except ImportError:
@@ -115,9 +114,7 @@ def main():
 
     """Get an elasticache connection"""
     try:
-        endpoint = "elasticache.%s.amazonaws.com" % region
-        connect_region = RegionInfo(name=region, endpoint=endpoint)
-        conn = ElastiCacheConnection(region=connect_region, **aws_connect_kwargs)
+        conn = connect_to_region(region_name=region, **aws_connect_kwargs)
     except boto.exception.NoAuthHandlerFound as e:
         module.fail_json(msg=e.message)
 


### PR DESCRIPTION
##### SUMMARY

Fixes #23965

The Elasticache module assumes endpoints live in 'elasticache.region.amazonaws.com', which doesn't work in China - China's AWS service endpoints end in amazonaws.com.cn.

Using boto.elasticache.connect_to_region to manage the AWS connection fixes this, and like what most AWS modules that to use regional endpoints use.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

elasticache_subnet_group

##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.4.0 (support-china-elasticache-subnet 99ebfa8d28) last updated 2017/05/04 11:31:05 (GMT +100)
  config file = /Users/nbailey/.ansible.cfg
  configured module search path = [u'/Users/nbailey/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/nbailey/ansible/lib/ansible
  executable location = /Users/nbailey/ansible/bin/ansible
  python version = 2.7.10 (default, Oct 23 2015, 19:19:21) [GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)]
```

##### ADDITIONAL INFORMATION

AWS China uses a different top level domain from the rest of Global AWS - so the elasticache service endpoint in cn-north-1 is elasticache.cn-north-1.amazonaws.com.cn rather than the elasticache.cn-north-1.amazonaws.com the module would construct.

Letting Boto find the endpoints for us instead of having logic in Ansible modules to do that work seems like a solid long-term decision.