### PR TITLE
inventory: ovirt4: Add support for devices without IP

### DIFF
--- a/contrib/inventory/ovirt4.py
+++ b/contrib/inventory/ovirt4.py
@@ -182,9 +182,9 @@ def get_dict_of_struct(connection, vm):
             (stat.name, stat.values[0].datum) for stat in stats
         ),
         'devices': dict(
-            (device.name, [ip.address for ip in device.ips]) for device in devices
+            (device.name, [ip.address for ip in device.ips]) for device in devices if device.ips
         ),
-        'ansible_host': devices[0].ips[0].address if len(devices) > 0 else None,
+        'ansible_host': next((device.ips[0].address for device in devices if device.ips), None)
     }
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR add support to create oVirt inventory in case VMs has multiple network devices without IP addresses.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt4.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
