### PR TITLE
ansible-doc snippet format changes

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -262,23 +262,25 @@ class DocCLI(CLI):
         text = []
         desc = CLI.tty_ify(doc['short_description'])
         text.append("- name: %s" % (desc))
-        text.append("  action: %s" % (doc['module']))
+        text.append("  %s:" % (doc['module']))
         pad = 31
         subdent = " " * pad
         limit = display.columns - pad
 
         for o in sorted(doc['options'].keys()):
             opt = doc['options'][o]
-            desc = CLI.tty_ify(" ".join(opt['description']))
+            if isinstance(opt['description'], string_types):
+                desc = CLI.tty_ify(opt['description'])
+            else:
+                desc = CLI.tty_ify(" ".join(opt['description']))
 
             required = opt.get('required', False)
             if not isinstance(required, bool):
                 raise("Incorrect value for 'Required', a boolean is needed.: %s" % required)
             if required:
-                s = o + "="
-            else:
-                s = o
-            text.append("      %-20s   # %s" % (s, textwrap.fill(desc, limit, subsequent_indent=subdent)))
+                desc = "(required) %s" % desc
+            o = '%s:' % o
+            text.append("      %-20s   # %s" % (o, textwrap.fill(desc, limit, subsequent_indent=subdent)))
         text.append('')
 
         return "\n".join(text)


### PR DESCRIPTION
* ansible-doc -s is supposed to output a sample snippet of how you could
  add the module into a playbook.  These changes update the style:
  * Use yaml mappings instead of key=value
  * Use the module name directly instead of action: modulename
* Fixes a bug when displaying option descritpions which are yaml strings
  instead of lists.

This fixes in code the bad formatting reported in #24201

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
ansible-doc

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```