### PR TITLE
Fix version_added for new options in template introduced in #21846

### DIFF
--- a/lib/ansible/modules/files/template.py
+++ b/lib/ansible/modules/files/template.py
@@ -58,32 +58,32 @@ options:
       - Specify the newline sequence to use for templating files.
     choices: [ '\n', '\r', '\r\n' ]
     default: '\n'
-    version_added: '2.3'
+    version_added: '2.4'
   block_start_string:
     description:
       - The string marking the beginning of a block.
     default: '{%'
-    version_added: '2.3'
+    version_added: '2.4'
   block_end_string:
     description:
       - The string marking the end of a block.
     default: '%}'
-    version_added: '2.3'
+    version_added: '2.4'
   variable_start_string:
     description:
       - The string marking the beginning of a print statement.
     default: '{{'
-    version_added: '2.3'
+    version_added: '2.4'
   variable_end_string:
     description:
       - The string marking the end of a print statement.
     default: '}}'
-    version_added: '2.3'
+    version_added: '2.4'
   trim_blocks:
     description:
       - If this is set to True the first newline after a block is removed (block, not variable tag!).
     default: "no"
-    version_added: '2.3'
+    version_added: '2.4'
   force:
     description:
       - the default is C(yes), which will replace the remote file when contents


### PR DESCRIPTION
##### SUMMARY

#21846 introduced some new arguments to the template module.  They indicated they were added in 2.3, but were only merged recently, after the 2.3 release, with a consensus that the changes would not be backported to 2.3

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
template

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```


##### ADDITIONAL INFORMATION
N/A