### PR TITLE
add support for ttl parameter to sensu_check

### DIFF
--- a/lib/ansible/modules/monitoring/sensu_check.py
+++ b/lib/ansible/modules/monitoring/sensu_check.py
@@ -85,6 +85,12 @@ options:
       - Timeout for the check
     required: false
     default: 10
+  ttl:
+    description:
+      - The time to live (TTL) in seconds until check results are considered stale. 
+      - If a client stops publishing results for the check, and the TTL expires, an event will be created for the client. 
+    required: false
+    default: 360
   handle:
     description:
       - Whether the check should be handled or not
@@ -363,6 +369,7 @@ def main():
                 'subscribers':  {'type': 'list'},
                 'interval':     {'type': 'int'},
                 'timeout':      {'type': 'int'},
+                'ttl':          {'type': 'int', 'default': 360},
                 'handle':       {'type': 'bool'},
                 'subdue_begin': {'type': 'str'},
                 'subdue_end':   {'type': 'str'},

--- a/lib/ansible/modules/monitoring/sensu_check.py
+++ b/lib/ansible/modules/monitoring/sensu_check.py
@@ -87,10 +87,11 @@ options:
     default: 10
   ttl:
     description:
-      - The time to live (TTL) in seconds until check results are considered stale. 
-      - If a client stops publishing results for the check, and the TTL expires, an event will be created for the client. 
+      - The time to live (TTL) in seconds until check results are considered stale.
+      - If a client stops publishing results for the check, and the TTL expires, an event will be created for the client.
     required: false
     default: 360
+    version_added: 2.4
   handle:
     description:
       - Whether the check should be handled or not


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Sensu Check Definitions support the definition of a "time to live" for a check result. Ansible doesn't actually support setting it.



<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
sensu_check

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0 (detached HEAD fe33c937c4) last updated 2017/04/12 12:03:14 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 48a3ce1223) last updated 2017/04/12 12:03:15 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 4e720b48ae) last updated 2017/04/12 12:03:16 (GMT -400)
  config file = /home/devon/git/arin/ansible/ansible.cfg
  configured module search path = ['library']

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

A tl;dr version is that if the sensu server doesnt see this check come back in x number of seconds, it turns it into alert.

It is perfect for making sure that checks don't "disappear" from hosts, but Ansible does not support defining it.