### PR TITLE
Fix permissions of coverage scripts

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -838,7 +838,15 @@ def get_coverage_path(args):
     os.chmod(coverage_path, stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
 
     shutil.copytree(src, os.path.join(coverage_path, 'coverage'))
+
+    for root, dirs, files in os.walk(coverage_path):
+        for path in dirs:
+            os.chmod(os.path.join(root, path), stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
+        for path in files:
+            os.chmod(os.path.join(root, path), stat.S_IRWXU | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
+
     shutil.copy('.coveragerc', os.path.join(coverage_path, 'coverage', '.coveragerc'))
+    os.chmod(os.path.join(coverage_path, 'coverage', '.coveragerc'), stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
 
     for directory in 'output', 'logs':
         os.mkdir(os.path.join(coverage_path, directory))


### PR DESCRIPTION
##### SUMMARY

Using `ansible-test` and `postgresql` target (#23686), I encountered this error:
```
TASK [postgresql : Create DB] *******************************************************************************************************************************
fatal: [testhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "/bin/sh: 1: /tmp/ansible-test-coverage-v14s5tsa/coverage/runner3.5: Permission denied\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 126}
```
The permissions are:
```
# ls -l /tmp/ansible-test-coverage-*/coverage/runner3.5
-rwx------ 1 root root 4897 May  4 20:52 /tmp/ansible-test-coverage-v14s5tsa/coverage/runner3.5
```

`/tmp/ansible-test-coverage-*/coverage` directory is already world-executable, this pull-request changes the mode of the scripts below this directory.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ansible-test

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel dce2d5eea9) last updated 2017/05/04 16:15:09 (GMT +000)
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Tested inside an Ubuntu Xenial LXC container using:
```
ansible-test integration -v postgresql --allow-destructive --python 3.5
```