### PR TITLE
Fix vaulted vars templating

### DIFF
--- a/lib/ansible/parsing/yaml/objects.py
+++ b/lib/ansible/parsing/yaml/objects.py
@@ -111,7 +111,7 @@ class AnsibleVaultEncryptedUnicode(yaml.YAMLObject, AnsibleUnicode):
         self._ciphertext = value
 
     def __repr__(self):
-        return 'AnsibleVaultEncryptedUnicode(%s)' % self._ciphertext
+        return repr(self.data)
 
     # Compare a regular str/text_type with the decrypted hypertext
     def __eq__(self, other):


### PR DESCRIPTION
Fix vaulted vars templating

Use the default repr of AnsibleVaultEncryptedUnicode.data instead
of a custom one, since jinja templating ends up using the repr()
results.

Fixes #23846, #24175

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request
 
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/parsing/yaml/objects.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (vault_yaml_repr_23846 7fe2064162) last updated 2017/05/04 18:40:18 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]


```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before:

```
[fedora-25:ansible (devel % u=)]$ cat repro/vault_string_in_dict_23846/test.yml
---
- hosts: localhost
  gather_facts: false
  vars:
      test_without_vaulted_variable:
          - not_vaulted: not vaulted variable
          - another_standard_variable: standard
      test_with_vaulted_variable:
          - not_vaulted: not vaulted variable
          - vaulted: !vault |-
              $ANSIBLE_VAULT;1.1;AES256
              66376230363937306331353166333731633037326166626530393462636666346630366463313134
              6635313236366537346339313338633539643665313931390a373264326437663530616630623734
              31666136343232666235323865653838393830613432343561633465333837633531643564343064
              3237353766313835310a643963313163663632623064313034363531356330653131303833646138
              65366139376134396231353864383662623832376239336433623630383464303161

      test_with_unsafe_variable:
          - not_vaulted: not vaulted variable
          - an_unsafe_var: !unsafe |
              foooJJJJ_unsafe_BLIPPY
  tasks:
    - debug: var=test_without_vaulted_variable
    - debug: var=test_with_vaulted_variable

    - name: show test_with_unsafe_variable
      debug:
        var: test_with_unsafe_variable

    - debug:
      with_items: "{{ test_without_vaulted_variable }}"
    - name: show vaulted variable with_items
      debug:
          msg: "foo {{ item }} "
      with_items: "{{ test_with_vaulted_variable }}"
    - debug:
      with_items: "{{ test_with_unsafe_variable }}"


[fedora-25:ansible (devel % u=)]$ ansible --version
ansible 2.4.0 (devel d31a09ceb7) last updated 2017/05/04 18:42:29 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

[fedora-25:ansible (devel % u=)]$ ansible-playbook -v --vault-password-file repro/vault_string_in_dict_23846/vault_password repro/vault_string_in_dict_23846/test.yml
Using /home/adrian/ansible/ansible.cfg as config file
 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [localhost] **********************************************************************************************************************************************************************************************************************

TASK [debug] **************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "_ansible_no_log": false, 
    "_ansible_verbose_always": true, 
    "changed": false, 
    "test_without_vaulted_variable": [
        {
            "not_vaulted": "not vaulted variable"
        }, 
        {
            "another_standard_variable": "standard"
        }
    ]
}

TASK [debug] **************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "_ansible_no_log": false, 
    "_ansible_verbose_always": true, 
    "changed": false, 
    "test_with_vaulted_variable": "[{u'not_vaulted': u'not vaulted variable'}, {u'vaulted': AnsibleVaultEncryptedUnicode($ANSIBLE_VAULT;1.1;AES256\n66376230363937306331353166333731633037326166626530393462636666346630366463313134\n6635313236366537346339313338633539643665313931390a373264326437663530616630623734\n31666136343232666235323865653838393830613432343561633465333837633531643564343064\n3237353766313835310a643963313163663632623064313034363531356330653131303833646138\n65366139376134396231353864383662623832376239336433623630383464303161)}]"
}

TASK [show test_with_unsafe_variable] *************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "_ansible_no_log": false, 
    "_ansible_verbose_always": true, 
    "changed": false, 
    "test_with_unsafe_variable": [
        {
            "not_vaulted": "not vaulted variable"
        }, 
        {
            "an_unsafe_var": "foooJJJJ_unsafe_BLIPPY\n"
        }
    ]
}

TASK [debug] **************************************************************************************************************************************************************************************************************************
ok: [localhost] => (item={u'another_standard_variable': u'standard'}) => {
    "_ansible_item_result": true, 
    "_ansible_no_log": false, 
    "_ansible_verbose_always": true, 
    "item": {
        "another_standard_variable": "standard"
    }, 
    "msg": "Hello world!"
}
ok: [localhost] => (item={u'not_vaulted': u'not vaulted variable'}) => {
    "_ansible_item_result": true, 
    "_ansible_no_log": false, 
    "_ansible_verbose_always": true, 
    "item": {
        "not_vaulted": "not vaulted variable"
    }, 
    "msg": "Hello world!"
}

TASK [show vaulted variable with_items] ***********************************************************************************************************************************************************************************************
ok: [localhost] => (item=[{u'not_vaulted': u'not vaulted variable'}, {u'vaulted': AnsibleVaultEncryptedUnicode($ANSIBLE_VAULT;1.1;AES256
66376230363937306331353166333731633037326166626530393462636666346630366463313134
6635313236366537346339313338633539643665313931390a373264326437663530616630623734
31666136343232666235323865653838393830613432343561633465333837633531643564343064
3237353766313835310a643963313163663632623064313034363531356330653131303833646138
65366139376134396231353864383662623832376239336433623630383464303161)}]) => {
    "_ansible_item_result": true, 
    "_ansible_no_log": false, 
    "_ansible_verbose_always": true, 
    "item": "[{u'not_vaulted': u'not vaulted variable'}, {u'vaulted': AnsibleVaultEncryptedUnicode($ANSIBLE_VAULT;1.1;AES256\n66376230363937306331353166333731633037326166626530393462636666346630366463313134\n6635313236366537346339313338633539643665313931390a373264326437663530616630623734\n31666136343232666235323865653838393830613432343561633465333837633531643564343064\n3237353766313835310a643963313163663632623064313034363531356330653131303833646138\n65366139376134396231353864383662623832376239336433623630383464303161)}]", 
    "msg": "foo [{u'not_vaulted': u'not vaulted variable'}, {u'vaulted': AnsibleVaultEncryptedUnicode($ANSIBLE_VAULT;1.1;AES256\n66376230363937306331353166333731633037326166626530393462636666346630366463313134\n6635313236366537346339313338633539643665313931390a373264326437663530616630623734\n31666136343232666235323865653838393830613432343561633465333837633531643564343064\n3237353766313835310a643963313163663632623064313034363531356330653131303833646138\n65366139376134396231353864383662623832376239336433623630383464303161)}] "
}

TASK [debug] **************************************************************************************************************************************************************************************************************************
ok: [localhost] => (item={u'an_unsafe_var': u'foooJJJJ_unsafe_BLIPPY\n'}) => {
    "_ansible_item_result": true, 
    "_ansible_no_log": false, 
    "_ansible_verbose_always": true, 
    "item": {
        "an_unsafe_var": "foooJJJJ_unsafe_BLIPPY\n"
    }, 
    "msg": "Hello world!"
}
ok: [localhost] => (item={u'not_vaulted': u'not vaulted variable'}) => {
    "_ansible_item_result": true, 
    "_ansible_no_log": false, 
    "_ansible_verbose_always": true, 
    "item": {
        "not_vaulted": "not vaulted variable"
    }, 
    "msg": "Hello world!"
}

PLAY RECAP ****************************************************************************************************************************************************************************************************************************
localhost                  : ok=6    changed=0    unreachable=0    failed=0   


```


after:


```
[fedora-25:ansible (vault_yaml_repr_23846 %)]$ ansible --version
ansible 2.4.0 (vault_yaml_repr_23846 7fe2064162) last updated 2017/05/04 18:40:18 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]


[fedora-25:ansible (vault_yaml_repr_23846 %)]$ ansible-playbook -v --vault-password-file repro/vault_string_in_dict_23846/vault_password repro/vault_string_in_dict_23846/test.yml
Using /home/adrian/ansible/ansible.cfg as config file
 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [localhost] **********************************************************************************************************************************************************************************************************************

TASK [debug] **************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "_ansible_no_log": false, 
    "_ansible_verbose_always": true, 
    "changed": false, 
    "test_without_vaulted_variable": [
        {
            "not_vaulted": "not vaulted variable"
        }, 
        {
            "another_standard_variable": "standard"
        }
    ]
}

TASK [debug] **************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "_ansible_no_log": false, 
    "_ansible_verbose_always": true, 
    "changed": false, 
    "test_with_vaulted_variable": [
        {
            "not_vaulted": "not vaulted variable"
        }, 
        {
            "vaulted": "vaulted variable\n"
        }
    ]
}

TASK [show test_with_unsafe_variable] *************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "_ansible_no_log": false, 
    "_ansible_verbose_always": true, 
    "changed": false, 
    "test_with_unsafe_variable": [
        {
            "not_vaulted": "not vaulted variable"
        }, 
        {
            "an_unsafe_var": "foooJJJJ_unsafe_BLIPPY\n"
        }
    ]
}

TASK [debug] **************************************************************************************************************************************************************************************************************************
ok: [localhost] => (item={u'another_standard_variable': u'standard'}) => {
    "_ansible_item_result": true, 
    "_ansible_no_log": false, 
    "_ansible_verbose_always": true, 
    "item": {
        "another_standard_variable": "standard"
    }, 
    "msg": "Hello world!"
}
ok: [localhost] => (item={u'not_vaulted': u'not vaulted variable'}) => {
    "_ansible_item_result": true, 
    "_ansible_no_log": false, 
    "_ansible_verbose_always": true, 
    "item": {
        "not_vaulted": "not vaulted variable"
    }, 
    "msg": "Hello world!"
}

TASK [show vaulted variable with_items] ***********************************************************************************************************************************************************************************************
ok: [localhost] => (item={u'vaulted': u'vaulted variable\n'}) => {
    "_ansible_item_result": true, 
    "_ansible_no_log": false, 
    "_ansible_verbose_always": true, 
    "item": {
        "vaulted": "vaulted variable\n"
    }, 
    "msg": "foo {u'vaulted': u'vaulted variable\\n'} "
}
ok: [localhost] => (item={u'not_vaulted': u'not vaulted variable'}) => {
    "_ansible_item_result": true, 
    "_ansible_no_log": false, 
    "_ansible_verbose_always": true, 
    "item": {
        "not_vaulted": "not vaulted variable"
    }, 
    "msg": "foo {u'not_vaulted': u'not vaulted variable'} "
}

TASK [debug] **************************************************************************************************************************************************************************************************************************
ok: [localhost] => (item={u'an_unsafe_var': u'foooJJJJ_unsafe_BLIPPY\n'}) => {
    "_ansible_item_result": true, 
    "_ansible_no_log": false, 
    "_ansible_verbose_always": true, 
    "item": {
        "an_unsafe_var": "foooJJJJ_unsafe_BLIPPY\n"
    }, 
    "msg": "Hello world!"
}
ok: [localhost] => (item={u'not_vaulted': u'not vaulted variable'}) => {
    "_ansible_item_result": true, 
    "_ansible_no_log": false, 
    "_ansible_verbose_always": true, 
    "item": {
        "not_vaulted": "not vaulted variable"
    }, 
    "msg": "Hello world!"
}

PLAY RECAP ****************************************************************************************************************************************************************************************************************************
localhost                  : ok=6    changed=0    unreachable=0    failed=0   

```