### PR TITLE
vca_nat: Remove unused libraries, import specific bits

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vca_nat.py
+++ b/lib/ansible/modules/cloud/vmware/vca_nat.py
@@ -78,8 +78,8 @@ EXAMPLES = '''
 
 '''
 
-import time
-import xmltodict
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.vca import VcaError, vca_argument_spec, vca_login
 
 VALID_RULE_KEYS = ['rule_type', 'original_ip', 'original_port',
                    'translated_ip', 'translated_port', 'protocol']
@@ -211,10 +211,6 @@ def main():
 
     module.exit_json(**result)
 
-
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.vca import *
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
I found that vca_nat was importing 2 libraries it was not actually using.
On top of that, it was importing everything from mod_utils/basic.py and mod_utils/vca.py, so I fixed that too.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vca_nat

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.4