### PR TITLE
New module: Add Sensu Silence  module (monitoring/sensu_silence.py)

### DIFF
--- a/lib/ansible/modules/monitoring/sensu_silence.py
+++ b/lib/ansible/modules/monitoring/sensu_silence.py
@@ -1,4 +1,24 @@
 #!/usr/bin/python
+'''
+-*- coding: utf-8 -*-
+
+(c) 2017, Steven Bambling <smbambling@gmail.com>
+
+This file is part of Ansible
+
+Ansible is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Ansible is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+'''
 
 try:
     import json

--- a/lib/ansible/modules/monitoring/sensu_silence.py
+++ b/lib/ansible/modules/monitoring/sensu_silence.py
@@ -88,7 +88,6 @@ EXAMPLES = '''
     reason: Investigation alert issue
 
 # Silence multiple clients from a dict
-vars:
   silence:
     server1.example.dev:
       reason: 'Deployment in progress'

--- a/lib/ansible/modules/monitoring/sensu_silence.py
+++ b/lib/ansible/modules/monitoring/sensu_silence.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-#
+
 # (c) 2017, Steven Bambling <smbambling@gmail.com>
 #
 # This file is part of Ansible
@@ -40,8 +40,8 @@ options:
       - Specifies the entity responsible for this entry.
   expire:
     description:
-      - If specified, the silence entry will be automatically
-        cleared after this number of seconds.
+      - If specified, the silence entry will be automatically cleared
+        after this number of seconds.
   expire_on_resolve:
     description:
       - If specified as true, the silence entry will be automatically
@@ -72,11 +72,16 @@ options:
 '''
 
 EXAMPLES = '''
-  Some Examples:
 '''
 
 RETURN = '''
+reasons:
+    description: the reasons why the moule changed or did not change something
+    returned: success
+    type: list
+    sample: ["channel subscription was absent and state is `present'"]
 '''
+
 
 try:
     import json

--- a/lib/ansible/modules/monitoring/sensu_silence.py
+++ b/lib/ansible/modules/monitoring/sensu_silence.py
@@ -1,0 +1,367 @@
+#!/usr/bin/python
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
+# import module snippets
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import fetch_url
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '0.1'}
+
+DOCUMENTATION = '''
+---
+module: sensu_silence
+version_added: "2.2"
+author: Steven Bambling(@smbambling)
+short_description: Manage Sensu slience entries
+description:
+  - Create and clear (delete) a silence entries via the Sensu API
+    for subscriptions and checks.
+options:
+  check:
+    description:
+      - Specifies the check which the silence entry applies to.
+    required: false
+    default: []
+  creator:
+    description:
+      - Specifies the entity responsible for this entry.
+    required: false
+    default: []
+  expire:
+    description:
+      - If specified, the silence entry will be automatically
+        cleared after this number of seconds.
+    required: false
+    default: []
+  expire_on_resolve:
+    description:
+      - If specified as true, the silence entry will be automatically
+        cleared once the condition it is silencing is
+      resolved.
+    required: false
+    default: []
+  reason:
+    description:
+      - If specified, this free-form string is used to provide context or
+        rationale for the reason this silence entry
+      was created.
+    required: false
+    default: No reason given, tisk tisk
+  state:
+    description:
+      - Specifies to create or clear (delete) a silence entry via the Sensu API
+    required: true
+    default: create
+    choices: ['create', 'clear']
+  subscription:
+    description:
+      - Specifies the subscription which the silence entry applies to.
+      - To create a silence entry for a client append `client:` to client name
+      - Example: client:server1.example.dev
+    required: true
+    default: []
+  url:
+    description:
+      - Specifies the URL of the Sensu monitoring host server
+    required: false
+    default: http://127.0.01:4567
+'''
+
+EXAMPLES = '''
+# Create Silence Entries
+
+- name: "Create silence entry for server1.example.dev"
+  sensu_silence:
+    url: https://sensu.example.dev:4567
+    subscription: client:server1.example.dev
+    creator: "{{ ansible_user_id }}"
+
+- name: 'Create silence entry for CPU usage check on server2.example.dev'
+  sensu_silence:
+    url: https://sensu.example.dev:4567
+    subscription: client:server1.example.dev
+    reason: "Doing work that will cause this to trigger"
+    check: 'CPU_Usage_on_server2.example.dev'
+    state: create
+    creator: "{{ ansible_user_id }}"
+
+# Create Silence Entries from dictionary
+
+vars:
+    silence:
+      server1.example.dev:
+        url: https://sensu.example.dev:4567
+        reason: "Deployment in process"
+      server2.example.dev:
+        url: https://sensu.example.dev:4567
+        reason: "Deployment in process"
+        check: "CPU_Usage_on_server2.example.dev"
+
+  tasks:
+    - name: "Create 'Global' silence entry for Nodes"
+      sensu_silence:
+        url: "{{ item.value.url }}"
+        subscription: "client:{{ item.key }}"
+        reason: "{{ item.value.reason }}"
+        state: 'create'
+        creator: "{{ ansible_user_id }}"
+      with_dict: "{{ silence }}"
+      when: item.value.check is not defined
+
+    - name: "Create Sensu Silence | Specific checks for nodes"
+      sensu_silence:
+        url: "{{ item.value.url }}"
+        subscription: "client:{{ item.key }}"
+        reason: "{{ item.value.reason }}"
+        check: "{{ item.value.check }}"
+        state: 'create'
+        creator: "{{ ansible_user_id }}"
+      with_dict: "{{ silence }}"
+      when:
+        - item.value.check is defined
+
+# Clear Silence Entries
+- name: "Clear silence entry for server1.example.dev"
+  sensu_silence:
+    url: https://sensu.example.dev:4567
+    subscription: client:server1.example.dev
+    state: clear
+
+- name: 'Create silence entry for CPU usage check on server2.example.dev'
+  sensu_silence:
+    url: https://sensu.example.dev:4567
+    subscription: client:server1.example.dev
+    reason: "Doing work that will cause this to trigger"
+    check: 'CPU_Usage_on_server2.example.dev'
+    state: clear
+
+# Clear Silence Entries from dictionary
+
+vars:
+    silence:
+      server1.example.dev:
+        url: https://sensu.example.dev:4567
+      server2.example.dev:
+        url: https://sensu.example.dev:4567
+        check: "CPU_Usage_on_server2.example.dev"
+
+  tasks:
+    - name: "Create 'Global' silence entry for Nodes"
+      sensu_silence:
+        url: "{{ item.value.url }}"
+        subscription: "client:{{ item.key }}"
+        state: 'clear'
+      with_dict: "{{ silence }}"
+      when: item.value.check is not defined
+
+    - name: "Create Sensu Silence | Specific checks for nodes"
+      sensu_silence:
+        url: "{{ item.value.url }}"
+        subscription: "client:{{ item.key }}"
+        check: "{{ item.value.check }}"
+        state: 'clear'
+      with_dict: "{{ silence }}"
+      when:
+        - item.value.check is defined
+'''
+
+
+def query(module, url, check, subscription):
+    headers = {
+        'Content-Type': 'application/json',
+    }
+
+    url = url + '/silenced'
+
+    request_data = {
+        'check': check,
+        'subscription': subscription,
+    }
+
+    # Remove keys with None value
+    for k, v in dict(request_data).items():
+        if v is None:
+            del request_data[k]
+
+    response, info = fetch_url(
+        module, url, method='GET',
+        headers=headers, data=json.dumps(request_data)
+    )
+
+    if info['status'] == 500:
+        module.fail_json(
+            msg="Failed to query silence %s. Reason: %s" % (subscription, info)
+        )
+
+    try:
+        json_out = json.loads(response.read())
+    except:
+        json_out = ""
+
+    return False, json_out, False
+
+
+def clear(module, url, check, subscription):
+    # Test if silence exists before clearing
+    (rc, out, changed) = query(module, url, check, subscription)
+
+    d = dict((i['subscription'], i['check']) for i in out)
+    subscription_exists = subscription in d
+    if check and subscription_exists:
+        exists = (check == d[subscription])
+    else:
+        exists = subscription_exists
+
+    # If check/subscription doesn't exist
+    # exit with changed state of False
+    if not exists:
+        return False, out, changed
+
+    # module.check_mode is inherited from the AnsibleMOdule class
+    if not module.check_mode:
+        headers = {
+            'Content-Type': 'application/json',
+        }
+
+        url = url + '/silenced/clear'
+
+        request_data = {
+            'check': check,
+            'subscription': subscription,
+        }
+
+        # Remove keys with None value
+        for k, v in dict(request_data).items():
+            if v is None:
+                del request_data[k]
+
+        response, info = fetch_url(
+            module, url, method='POST',
+            headers=headers, data=json.dumps(request_data)
+        )
+
+        if info['status'] != 204:
+            module.fail_json(
+                msg="Failed to silence %s. Reason: %s" % (subscription, info)
+            )
+
+        try:
+            json_out = json.loads(response.read())
+        except:
+            json_out = ""
+
+        return False, json_out, True
+    return False, out, True
+
+
+def create(
+        module, url, check, creator, expire,
+        expire_on_resolve, reason, subscription):
+    (rc, out, changed) = query(module, url, check, subscription)
+    for i in out:
+        if (i['subscription'] == subscription):
+            if (
+                    (check is None or check == i['check']) and
+                    (
+                        creator == 'Created via Ansible' or
+                        creator == i['creator'])and
+                    (
+                        reason == 'No reason given, tisk tisk' or
+                        reason == i['reason']) and
+                    (
+                        expire is None or expire == i['expire']) and
+                    (
+                        expire_on_resolve is None or
+                        expire_on_resolve == i['expire_on_resolve']
+                    )
+               ):
+                return False, out, False
+
+    # module.check_mode is inherited from the AnsibleMOdule class
+    if not module.check_mode:
+        headers = {
+            'Content-Type': 'application/json',
+        }
+
+        url = url + '/silenced'
+
+        request_data = {
+            'check': check,
+            'creator': creator,
+            'expire': expire,
+            'expire_on_resolve': expire_on_resolve,
+            'reason': reason,
+            'subscription': subscription,
+        }
+
+        # Remove keys with None value
+        for k, v in dict(request_data).items():
+            if v is None:
+                del request_data[k]
+
+        response, info = fetch_url(
+            module, url, method='POST',
+            headers=headers, data=json.dumps(request_data)
+        )
+
+        if info['status'] != 201:
+            module.fail_json(
+                msg="Failed to silence %s. Reason: %s" %
+                (subscription, info['msg'])
+            )
+
+        try:
+            json_out = json.loads(response.read())
+        except:
+            json_out = ""
+
+        return False, json_out, True
+    return False, out, True
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            check=dict(required=False),
+            creator=dict(required=False, default='Created via Ansible'),
+            expire=dict(required=False),
+            expire_on_resolve=dict(required=False),
+            reason=dict(required=False, default='No reason given, tisk tisk'),
+            state=dict(default='create', choices=['create', 'clear']),
+            subscription=dict(required=True),
+            url=dict(required=False, default='http://127.0.01:4567'),
+        ),
+        supports_check_mode=True
+    )
+
+    url = module.params['url']
+    check = module.params['check']
+    creator = module.params['creator']
+    expire = module.params['expire']
+    expire_on_resolve = module.params['expire_on_resolve']
+    reason = module.params['reason']
+    subscription = module.params['subscription']
+    state = module.params['state']
+
+    if state == 'create':
+        (rc, out, changed) = create(
+            module, url, check, creator,
+            expire, expire_on_resolve, reason, subscription
+        )
+
+    if state == 'clear':
+        (rc, out, changed) = clear(module, url, check, subscription)
+
+    if rc != 0:
+        module.fail_json(msg="failed", result=out)
+    module.exit_json(msg="success", result=out, changed=changed)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/monitoring/sensu_silence.py
+++ b/lib/ansible/modules/monitoring/sensu_silence.py
@@ -75,11 +75,6 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-reasons:
-    description: the reasons why the moule changed or did not change something
-    returned: success
-    type: list
-    sample: ["channel subscription was absent and state is `present'"]
 '''
 
 
@@ -190,10 +185,10 @@ def create(
             if (
                     (check is None or check == i['check']) and
                     (
-                        creator == 'Created via Ansible' or
+                        creator == '' or
                         creator == i['creator'])and
                     (
-                        reason == 'No reason given, tisk tisk' or
+                        reason == '' or
                         reason == i['reason']) and
                     (
                         expire is None or expire == i['expire']) and
@@ -250,10 +245,10 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             check=dict(required=False),
-            creator=dict(required=False, default='Created via Ansible'),
+            creator=dict(required=False),
             expire=dict(required=False),
             expire_on_resolve=dict(type=bool, required=False),
-            reason=dict(required=False, default='No reason given, tisk tisk'),
+            reason=dict(required=False),
             state=dict(default='present', choices=['present', 'absent']),
             subscription=dict(required=True),
             url=dict(required=False, default='http://127.0.01:4567'),

--- a/lib/ansible/modules/monitoring/sensu_silence.py
+++ b/lib/ansible/modules/monitoring/sensu_silence.py
@@ -18,9 +18,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-ANSIBLE_METADATA = {'status': ['preview'],
-                    'supported_by': 'community',
-                    'version': '1.0'}
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
 
 DOCUMENTATION = '''
 ---
@@ -61,7 +61,7 @@ options:
     description:
       - Specifies the subscription which the silence entry applies to.
       - To create a silence entry for a client append C(client:) to client name.
-      - Example: C(client:server1.example.dev)
+        Example - C(client:)server1.example.dev
     required: true
     default: []
   url:
@@ -72,6 +72,35 @@ options:
 '''
 
 EXAMPLES = '''
+# Silence ALL checks for a given client
+- name: Silence server1.example.dev
+  sensu_silence:
+    subscription: client:server1.example.dev
+    creator: "{{ ansible_user_id }}"
+    reason: Performing maintenance
+
+# Silence specific check for a client
+- name: Silence CPU_Usage check for server1.example.dev
+  sensu_silence:
+    subscription: client:server1.example.dev
+    check: CPU_Usage
+    creator: "{{ ansible_user_id }}"
+    reason: Investigation alert issue
+
+# Silence multiple clients from a dict
+vars:
+  silence:
+    server1.example.dev:
+      reason: 'Deployment in progress'
+    server2.example.dev:
+      reason: 'Deployment in progress'
+
+- name: Silence several clients from a dict
+  sensu_silence:
+    subscription: "client:{{ item.key }}"
+    reason: "{{ item.value.reason }}"
+    creator: "{{ ansible_user_id }}"
+  with_dict: "{{ silence }}"
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/monitoring/sensu_silence.py
+++ b/lib/ansible/modules/monitoring/sensu_silence.py
@@ -61,7 +61,7 @@ options:
     description:
       - Specifies the subscription which the silence entry applies to.
       - To create a silence entry for a client append C(client:) to client name.
-        Example - C(client:)server1.example.dev
+        Example - C(client:server1.example.dev)
     required: true
     default: []
   url:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
sensu_silence module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0 (detached HEAD fe33c937c4) last updated 2017/03/15 09:13:16 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 48a3ce1223) last updated 2017/03/15 09:13:18 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 4e720b48ae) last updated 2017/03/15 09:13:18 (GMT -400)
  config file = /Users/smbambling/Documents/arin/git/bitbucket/operations/ansible/ansible.cfg
  configured module search path = ['library']

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
This module grants the ability to post to the sensu api endpoint creating and verifying the existence of a sensu silence to prevent sensu handlers from alerts on a subscription. 


<!--- Paste verbatim command output below, e.g. before and after your change -->
```
```