### PR TITLE
Fix docs/api sphinx-build err on 'make rpm'

### DIFF
--- a/docs/api/Makefile
+++ b/docs/api/Makefile
@@ -17,11 +17,6 @@ MODULES_PATH  = ../../lib
 EXCLUDE_PATHS = ../../lib/ansible/modules ../../lib/ansible/utils/module_docs_fragments ../../lib/ansible/module_utils/six
 DOC_PROJECTS  = "Ansible API"
 
-# User-friendly check for sphinx-build
-ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
-endif
-
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter


### PR DESCRIPTION

##### SUMMARY
Fix docs/api sphinx-build err on 'make rpm'

remove check/warning about sphinx-build on 'make'

The makefile in docs/api/ had a top level check for the
'sphinx-build' tool, but the check was getting triggered
on 'make clean' when it is not needed and causing 'make rpm'
and similar builds to fail.

So this commit removes the check.

Fixes #24163

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
docs/api/Makefile

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (docs_makefile_24163 bef877c4d3) last updated 2017/05/05 13:12:18 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```

