### PR TITLE
ASGRetry - add retry on throttling and add backoff to calls in ec2_asg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Ansible Changes By Release
 * 'service' tasks can now use async again, we had lost this capability when changed into an action plugin.
 * made any_errors_fatal inheritable from play to task and all other objects in between.
 * many small performance improvements in inventory and variable handling and in task execution.
+* Added a retry class to the ec2_asg module since customers were running into throttling errors (AWSRetry is a solution for modules using boto3 which isn't applicable here).
 
 ### Deprecations
 * Specifying --tags (or --skip-tags) multiple times on the command line

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -81,7 +81,7 @@ class AWSRetry(CloudRetry):
         # http://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html
         retry_on = [
             'RequestLimitExceeded', 'Unavailable', 'ServiceUnavailable',
-            'InternalFailure', 'InternalError', 'Throttling'
+            'InternalFailure', 'InternalError'
         ]
 
         not_found = re.compile(r'^\w+.NotFound')

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -81,7 +81,7 @@ class AWSRetry(CloudRetry):
         # http://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html
         retry_on = [
             'RequestLimitExceeded', 'Unavailable', 'ServiceUnavailable',
-            'InternalFailure', 'InternalError'
+            'InternalFailure', 'InternalError', 'Throttling'
         ]
 
         not_found = re.compile(r'^\w+.NotFound')

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -256,67 +256,67 @@ ASG_ATTRIBUTES = ('availability_zones', 'default_cooldown', 'desired_capacity',
 
 INSTANCE_ATTRIBUTES = ('instance_id', 'health_status', 'lifecycle_state', 'launch_config_name')
 
-@AWSRetry.backoff()
+@AWSRetry.backoff(tries=10, delay=10, backoff=1.5)
 def get_all_groups(asg_connection, group_name):
     return asg_connection.get_all_groups(names=[group_name])
 
 
-@AWSRetry.backoff()
+@AWSRetry.backoff(tries=10, delay=10, backoff=1.5)
 def create_auto_scaling_group(asg_connection, ag):
     asg_connection.create_auto_scaling_group(ag)
 
 
-@AWSRetry.backoff()
+@AWSRetry.backoff(tries=10, delay=10, backoff=1.5)
 def get_all_launch_configurations(asg_connection, launch_config_name):
     return asg_connection.get_all_launch_configurations(names=[launch_config_name])
 
 
-@AWSRetry.backoff()
+@AWSRetry.backoff(tries=10, delay=10, backoff=1.5)
 def delete_tags(asg_connection, dead_tags):
     asg_connection.delete_tags(dead_tags)
 
 
-@AWSRetry.backoff()
+@AWSRetry.backoff(tries=10, delay=10, backoff=1.5)
 def create_or_update_tags(asg_connection, asg_tags):
     asg_connection.create_or_update_tags(asg_tags)
 
 
-@AWSRetry.backoff()
+@AWSRetry.backoff(tries=10, delay=10, backoff=1.5)
 def terminate_instance(asg_connection, instance_id, decrement_capacity):
     asg_connection.terminate_instance(instance_id, decrement_capacity=decrement_capacity)
 
 
-@AWSRetry.backoff()
+@AWSRetry.backoff(tries=10, delay=10, backoff=1.5)
 def update(as_group):
     as_group.update()
 
 
-@AWSRetry.backoff()
+@AWSRetry.backoff(tries=10, delay=10, backoff=1.5)
 def put_notification_configuration(as_group, notification_topic, notification_types):
     as_group.put_notification_configuration(notification_topic, notification_types)
 
 
-@AWSRetry.backoff()
+@AWSRetry.backoff(tries=10, delay=10, backoff=1.5)
 def delete_notification_configuration(as_group, notification_topic):
     as_group.delete_notification_configuration(notification_topic)
 
 
-@AWSRetry.backoff()
+@AWSRetry.backoff(tries=10, delay=10, backoff=1.5)
 def delete(as_group):
     as_group.delete()
 
 
-@AWSRetry.backoff()
+@AWSRetry.backoff(tries=10, delay=10, backoff=1.5)
 def elb_describe_instance_health(elb_connection, lb, instances=None):
     return elb_connection.describe_instance_health(lb, instances=instances)
 
 
-@AWSRetry.backoff()
+@AWSRetry.backoff(tries=10, delay=10, backoff=1.5)
 def elb_deregister_instances(elb_connection, lb, instance_id):
     elb_connection.deregister_instances(lb, instance_id)
 
 
-@AWSRetry.backoff()
+@AWSRetry.backoff(tries=10, delay=10, backoff=1.5)
 def ec2_get_all_zones(ec2_connection):
     return ec2_connection.get_all_zones()
 

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -273,7 +273,7 @@ class ASGRetry(CloudRetry):
 
     @staticmethod
     def status_code_from_exception(error):
-        return error.response['Error']['Code']
+        return error.error_code
 
     @staticmethod
     def found(response_code):


### PR DESCRIPTION
##### SUMMARY
Since AWSRetry is for modules that use boto3 I made an ASGRetry class for this module. I rebased #19459 to merge into stable-2.3 because this is something that should be fixed but will need to be rewritten for 2.4 since ec2_asg will hopefully have been ported to boto3 at that point. Fixes throttling errors in ec2_asg.  

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/ec2.py
lib/ansible/modules/cloud/amazon/ec2_asg.py

##### ANSIBLE VERSION
```
ansible 2.3.0.0 (awsretry_ec2_asg_2.3 8b230d705f) last updated 2017/05/05 16:05:52 (GMT -400)
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.10 (default, Jul 30 2016, 19:40:32) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```