### PR TITLE
Fixes #24251 save config only if it is changed

### DIFF
--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -331,8 +331,10 @@ def main():
 
     if module.params['save']:
         if not module.check_mode:
-            run_commands(module, ['copy running-config startup-config'])
-        result['changed'] = True
+            response = run_commands(module, ['show running-config diffs'])
+            if len(response[0]):
+                run_commands(module, ['copy running-config startup-config'])
+                result['changed'] = True
 
     module.exit_json(**result)
 

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -382,8 +382,10 @@ def main():
 
     if module.params['save']:
         if not module.check_mode:
-            run_commands(module, ['copy running-config startup-config\r'])
-        result['changed'] = True
+            response = run_commands(module, ['show archive config differences'])
+            if response[0].find('!No changes were found') < 0:
+                run_commands(module, ['copy running-config startup-config\r'])
+                result['changed'] = True
 
     module.exit_json(**result)
 

--- a/test/units/modules/network/ios/test_ios_config.py
+++ b/test/units/modules/network/ios/test_ios_config.py
@@ -69,9 +69,10 @@ class TestIosConfigModule(TestIosModule):
         self.assertIn('__backup__', result)
 
     def test_ios_config_save(self):
+        self.run_commands.return_value = "Hostname foo"
         set_module_args(dict(save=True))
         self.execute_module(changed=True)
-        self.assertEqual(self.run_commands.call_count, 1)
+        self.assertEqual(self.run_commands.call_count, 2)
         self.assertEqual(self.get_config.call_count, 0)
         self.assertEqual(self.load_config.call_count, 0)
         args = self.run_commands.call_args[0][1]


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Save to startup configuration only when it is different
from running configuration.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ios_config
eos_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
