### PR TITLE
[WIP] ansible-galaxy: Enable validate subcommand

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -146,7 +146,7 @@ class CLI(with_metaclass(ABCMeta, object)):
         Actually runs a child defined method using the execute_<action> pattern
         """
         fn = getattr(self, "execute_%s" % self.action)
-        fn()
+        return fn()
 
     @abstractmethod
     def run(self):


### PR DESCRIPTION
##### SUMMARY

Create a new validate subcommand to the ansible-galaxy binary that runs a
test suite with several checks:

  * ROLE001: Role has a meta/main.yml file
  * ROLE002: A LICENSE file is present in the role directory
  * ROLE003: A README.md file is present in the role directory
  * ROLE004: meta/main.yml contains basic necessary informations
  * ROLE005: Variables in defaults/ and vars/ are preceeded by role name
  * ROLE006: The dependencies listed in meta/main.yml are in Galaxy

There are some expectations about what an Ansible Role should look like at the filesystem level, this validate subcommand will check that they are respected.

##### ISSUE TYPE

* Feature Pull Request

##### COMPONENT NAME

* lib/ansible/galaxy/role.py

##### ANSIBLE VERSION

```
ansible 2.4.0 (mybranch 4cf3a3d78d) last updated 2017/05/05 23:13:49 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/spredzy/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/spredzy/Projects/github.com/Spredzy/ansible/lib/ansible
  executable location = /home/spredzy/Projects/github.com/Spredzy/ansible/venv/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION

One of the main prupose of this feature is to be able to add `ansible-galaxy validate <path-to-role>` command in a CI pipeline. This would allow to gate every commit, and ensure commit remains "Galaxy Compliant".

* If everything is fine:

```
% ansible-galaxy validate ~/Projects/ansible-role/myansible-role 
% 
```

* if everything is fine (debug mode):

```
 % ansible-galaxy validate ~/Projects/ansible-role/myansible-role  -v
Using /etc/ansible/ansible.cfg as config file
[{'pass': True, 'optional': False, 'name': 'ROLE001', 'description': 'Role has a meta/mail.yml file'}, {'pass': True, 'optional': True, 'name': 'ROLE002', 'description': 'A LICENSE file is present in the role directory'}, {'pass': True, 'optional': False, 'name': 'ROLE003', 'description': 'A README.md file is present in the role directory'}, {'pass': True, 'optional': False, 'name': 'ROLE004', 'description': 'meta/main.yml contains basic necessary informations'}, {'pass': True, 'optional': True, 'name': 'ROLE005', 'description': u'Variables in defaults/ and vars/ are preceded by role name: openstack_certification'}, {'pass': True, 'optional': False, 'name': 'ROLE006', 'description': 'The dependencies listed in meta/main.yml are in Galaxy'}]
%
```

* Let's imagine there is no LICENSE file:

```
% ansible-galaxy validate ~/Projects/ansible-role/myansible-role 
[{'pass': False, 'optional': True, 'name': 'ROLE002', 'description': 'A LICENSE file is present in the role directory'}]
% 
```