### PR TITLE
List all task state filters for use with when statements

### DIFF
--- a/docs/docsite/rst/playbooks_conditionals.rst
+++ b/docs/docsite/rst/playbooks_conditionals.rst
@@ -67,8 +67,24 @@ decide to do something conditionally based on success or failure::
       - command: /bin/still/something_else
         when: result|skipped
 
+      - yum:
+          name: package_name
+          state: latest
+        register: package_installed
+        
+      - command: /bin/other/thing
+        when: package_installed|changed
 
-.. note:: the filters have been updated in 2.1 so both `success` and `succeeded` work (`fail`/`failed`, etc).
+.. note:: As of Ansible 2.2, the complete list of task state filters available for use with when statements is:
+
+    failure
+    failed
+    success
+    succeeded
+    change
+    changed
+    skip
+    skipped
 
 Note that was a little bit of foreshadowing on the 'register' statement.  We'll get to it a bit later in this chapter.
 

--- a/docs/docsite/rst/playbooks_conditionals.rst
+++ b/docs/docsite/rst/playbooks_conditionals.rst
@@ -67,24 +67,8 @@ decide to do something conditionally based on success or failure::
       - command: /bin/still/something_else
         when: result|skipped
 
-      - yum:
-          name: package_name
-          state: latest
-        register: package_installed
-        
-      - command: /bin/other/thing
-        when: package_installed|changed
 
-.. note:: As of Ansible 2.2, the complete list of task state filters available for use with when statements is:
-
-    failure
-    failed
-    success
-    succeeded
-    change
-    changed
-    skip
-    skipped
+.. note:: The complete list of task state filters available for use with when statements can be found here: :doc:`_test_task_results`
 
 Note that was a little bit of foreshadowing on the 'register' statement.  We'll get to it a bit later in this chapter.
 


### PR DESCRIPTION
##### SUMMARY

This changes `ansible/docs/docsite/rst/playbooks_conditionals.rst` to be explicit about the list of task state filters available for use with when statements - and extends the examples to include use of the `changed` filter.

The previous wording was very vague and left the reader to either infer the available filters from the examples - which only used 3 of the 4, or [search the source code](https://github.com/ansible/ansible/blob/stable-2.3/lib/ansible/plugins/filter/core.py#L556) to figure out what the others are - which is what I ended up doing.

It's possible that I've got the version number wrong in the `note`. Here's the relevant section of `core.py` from each version:

https://github.com/ansible/ansible/blob/stable-2.2/lib/ansible/plugins/filter/core.py

```python
# failure testing
'failed'    : failed,
'failure'   : failed,
'success'   : success,
'succeeded' : success,

# changed testing
'changed' : changed,
'change'  : changed,

# skip testing
'skipped' : skipped,
'skip'    : skipped,
```

https://github.com/ansible/ansible/blob/stable-2.3/lib/ansible/plugins/filter/core.py

```python
# failure testing
'failed'    : failed,
'failure'   : failed,
'success'   : success,
'succeeded' : success,

# changed testing
'changed' : changed,
'change'  : changed,

# skip testing
'skipped' : skipped,
'skip'    : skipped,
```

So, 2.2 is the same as 2.3, but in 2.1, these aren't there at all: https://github.com/ansible/ansible/blob/stable-2.1/lib/ansible/plugins/filter/core.py#L400, so maybe these are somewhere else in 2.1???

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
`ansible/docs/docsite/rst/playbooks_conditionals.rst`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
```