### PR TITLE
Add GPL License header to freeipa inventory file.

### DIFF
--- a/contrib/inventory/freeipa.py
+++ b/contrib/inventory/freeipa.py
@@ -1,5 +1,20 @@
 #!/usr/bin/env python
 
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
 import argparse
 from ipalib import api
 import json

--- a/contrib/inventory/freeipa.py
+++ b/contrib/inventory/freeipa.py
@@ -1,19 +1,6 @@
 #!/usr/bin/env python
-
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 import argparse
 from ipalib import api


### PR DESCRIPTION
##### SUMMARY

Add GPL License header to freeipa inventory file

#24341

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

contrib/inventory/freeipa.py

##### ANSIBLE VERSION

```
ansible --version
ansible 2.4.0 (apt_download_only 4def437187) last updated 2017/05/03 14:32:40 (GMT +000)
  config file =
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/ansible/lib/ansible
  executable location = /root/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION

