### PR TITLE
Update nocache to be the proper bool type instead of string

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -572,7 +572,7 @@ def main():
         http_timeout=dict(type='int'),
         load_path=dict(type='path'),
         name=dict(type='str', required=True),
-        nocache=dict(type='str', default=False),
+        nocache=dict(type='bool', default=False),
         path=dict(type='path', aliases=['build_path']),
         pull=dict(type='bool', default=True),
         push=dict(type='bool', default=False),

--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -58,6 +58,7 @@ options:
     default: false
     required: false
     version_added: "2.1"
+    type: bool
   http_timeout:
     description:
       - Timeout for HTTP requests during the image build operation. Provide a positive integer value for the number of
@@ -82,23 +83,27 @@ options:
     default: true
     required: false
     version_added: "2.1"
+    type: bool
   push:
     description:
       - Push the image to the registry. Specify the registry as part of the I(name) or I(repository) parameter.
     default: false
     required: false
     version_added: "2.2"
+    type: bool
   rm:
     description:
       - Remove intermediate containers after build.
     default: true
     required: false
     version_added: "2.1"
+    type: bool
   nocache:
     description:
       - Do not use cache when building an image.
     default: false
     required: false
+    type: bool
   repository:
     description:
       - Full path to a repository. Use with state C(present) to tag the image into the repository. Expects


### PR DESCRIPTION
##### SUMMARY
Fixes the 'nocache' param type for the docker_image module

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker_image

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /home/matt/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
Output from a run with nocache set to true, note that nocache is showing "true".

```
    "invocation": {
        "module_args": {
            "api_version": null, 
            "archive_path": null, 
            "buildargs": null, 
            "cacert_path": null, 
            "cert_path": null, 
            "container_limits": null, 
            "debug": false, 
            "docker_host": null, 
            "dockerfile": null, 
            "filter_logger": false, 
            "force": true, 
            "http_timeout": null, 
            "key_path": null, 
            "load_path": null, 
            "name": "some/image", 
            "nocache": "true", 
            "path": "/var/cache/docker_checkouts/", 
            "pull": true, 
            "push": false, 
            "repository": null, 
            "rm": true, 
            "ssl_version": null, 
            "state": "present", 
            "tag": "25", 
            "timeout": null, 
            "tls": null, 
            "tls_hostname": null, 
            "tls_verify": null, 
            "use_tls": "no"
        }


```
Fixed:
```
    "invocation": {
        "module_args": {
            "api_version": null, 
            "archive_path": null, 
            "buildargs": null, 
            "cacert_path": null, 
            "cert_path": null, 
            "container_limits": null, 
            "debug": false, 
            "docker_host": null, 
            "dockerfile": null, 
            "filter_logger": false, 
            "force": true, 
            "http_timeout": null, 
            "key_path": null, 
            "load_path": null, 
            "name": "some/image", 
            "nocache": true, 
            "path": "/var/cache/docker_checkouts/", 
            "pull": true, 
            "push": false, 
            "repository": null, 
            "rm": true, 
            "ssl_version": null, 
            "state": "present", 
            "tag": "25", 
            "timeout": null, 
            "tls": null, 
            "tls_hostname": null, 
            "tls_verify": null, 
            "use_tls": "no"
```