### PR TITLE
Improve ansible-test code coverage analysis.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ ansible.egg-info/
 # Release directory
 packaging/release/ansible_release
 /.cache/
+/test/results/coverage/*=coverage.*
 /test/results/coverage/coverage*
 /test/results/reports/coverage.xml
 /test/results/reports/coverage/

--- a/test/integration/targets/ansible/runme.sh
+++ b/test/integration/targets/ansible/runme.sh
@@ -2,12 +2,8 @@
 
 set -eux
 
-env
-
-which python
-python --version
-
-which ansible
 ansible --version
-ansible testhost -i ../../inventory -vvv -e "ansible_python_interpreter=$(which python)" -m ping
-ansible testhost -i ../../inventory -vvv -e "ansible_python_interpreter=$(which python)" -m setup
+ansible --help
+
+ansible testhost -i ../../inventory -m ping  "$@"
+ansible testhost -i ../../inventory -m setup "$@"

--- a/test/runner/injector/cover
+++ b/test/runner/injector/cover
@@ -1,1 +1,0 @@
-injector.py

--- a/test/runner/injector/cover2
+++ b/test/runner/injector/cover2
@@ -1,1 +1,0 @@
-injector.py

--- a/test/runner/injector/cover2.4
+++ b/test/runner/injector/cover2.4
@@ -1,1 +1,0 @@
-injector.py

--- a/test/runner/injector/cover2.6
+++ b/test/runner/injector/cover2.6
@@ -1,1 +1,0 @@
-injector.py

--- a/test/runner/injector/cover2.7
+++ b/test/runner/injector/cover2.7
@@ -1,1 +1,0 @@
-injector.py

--- a/test/runner/injector/cover3
+++ b/test/runner/injector/cover3
@@ -1,1 +1,0 @@
-injector.py

--- a/test/runner/injector/cover3.5
+++ b/test/runner/injector/cover3.5
@@ -1,1 +1,0 @@
-injector.py

--- a/test/runner/injector/cover3.6
+++ b/test/runner/injector/cover3.6
@@ -1,1 +1,0 @@
-injector.py

--- a/test/runner/injector/injector.py
+++ b/test/runner/injector/injector.py
@@ -1,9 +1,32 @@
 #!/usr/bin/env python
-"""Code coverage wrapper."""
+"""Interpreter and code coverage injector for use with ansible-test.
+
+The injector serves two main purposes:
+
+1) Control the python interpreter used to run test tools and ansible code.
+2) Provide optional code coverage analysis of ansible code.
+
+The injector is executed one of two ways:
+
+1) On the controller via a symbolic link such as ansible or pytest.
+   This is accomplished by prepending the injector directory to the PATH by ansible-test.
+
+2) As the python interpreter when running ansible modules.
+   This is only supported when connecting to the local host.
+   Otherwise set the ANSIBLE_TEST_REMOTE_INTERPRETER environment variable.
+   It can be empty to auto-detect the python interpreter on the remote host.
+   If not empty it will be used to set ansible_python_interpreter.
+
+NOTE: Running ansible-test with the --tox option or inside a virtual environment
+      may prevent the injector from working for tests which use connection
+      types other than local, or which use become, due to lack of permissions
+      to access the interpreter for the virtual environment.
+"""
 
 from __future__ import absolute_import, print_function
 
 import errno
+import json
 import os
 import sys
 import pipes
@@ -11,10 +34,45 @@ import logging
 import getpass
 
 logger = logging.getLogger('injector')  # pylint: disable=locally-disabled, invalid-name
+# pylint: disable=locally-disabled, invalid-name
+config = None  # type: InjectorConfig
+
+
+class InjectorConfig(object):
+    """Mandatory configuration."""
+    def __init__(self, config_path):
+        """Initialize config."""
+        with open(config_path) as config_fd:
+            _config = json.load(config_fd)
+
+        self.python_interpreter = _config['python_interpreter']
+        self.coverage_file = _config['coverage_file']
+
+        # Read from the environment instead of config since it needs to be changed by integration test scripts.
+        # It also does not need to flow from the controller to the remote. It is only used on the controller.
+        self.remote_interpreter = os.environ.get('ANSIBLE_TEST_REMOTE_INTERPRETER', None)
+
+        self.arguments = [to_text(c) for c in sys.argv]
+
+
+def to_text(value):
+    """
+    :type value: str | None
+    :rtype: str | None
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, bytes):
+        return value.decode('utf-8')
+
+    return u'%s' % value
 
 
 def main():
     """Main entry point."""
+    global config  # pylint: disable=locally-disabled, global-statement
+
     formatter = logging.Formatter('%(asctime)s %(process)d %(levelname)s %(message)s')
     log_name = 'ansible-test-coverage.%s.log' % getpass.getuser()
     self_dir = os.path.dirname(os.path.abspath(__file__))
@@ -31,25 +89,49 @@ def main():
 
     try:
         logger.debug('Self: %s', __file__)
-        logger.debug('Arguments: %s', ' '.join(pipes.quote(c) for c in sys.argv))
 
-        if os.path.basename(__file__).startswith('runner'):
-            args, env = runner()
-        elif os.path.basename(__file__).startswith('cover'):
-            args, env = cover()
+        config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'injector.json')
+
+        try:
+            config = InjectorConfig(config_path)
+        except IOError:
+            logger.exception('Error reading config: %s', config_path)
+            exit('No injector config found. Set ANSIBLE_TEST_REMOTE_INTERPRETER if the test is not connecting to the local host.')
+
+        logger.debug('Arguments: %s', ' '.join(pipes.quote(c) for c in config.arguments))
+        logger.debug('Python interpreter: %s', config.python_interpreter)
+        logger.debug('Remote interpreter: %s', config.remote_interpreter)
+        logger.debug('Coverage file: %s', config.coverage_file)
+
+        require_cwd = False
+
+        if os.path.basename(__file__) == 'injector.py':
+            if config.coverage_file:
+                args, env, require_cwd = cover()
+            else:
+                args, env = runner()
         else:
             args, env = injector()
 
         logger.debug('Run command: %s', ' '.join(pipes.quote(c) for c in args))
 
+        altered_cwd = False
+
         try:
             cwd = os.getcwd()
         except OSError as ex:
+            # some platforms, such as OS X, may not allow querying the working directory when using become to drop privileges
             if ex.errno != errno.EACCES:
                 raise
-            cwd = None
+            if require_cwd:
+                # make sure the program we execute can determine the working directory if it's required
+                cwd = '/'
+                os.chdir(cwd)
+                altered_cwd = True
+            else:
+                cwd = None
 
-        logger.debug('Working directory: %s', cwd or '?')
+        logger.debug('Working directory: %s%s', cwd or '?', ' (altered)' if altered_cwd else '')
 
         for key in sorted(env.keys()):
             logger.debug('%s=%s', key, env[key])
@@ -64,29 +146,28 @@ def injector():
     """
     :rtype: list[str], dict[str, str]
     """
-    self_dir = os.path.dirname(os.path.abspath(__file__))
     command = os.path.basename(__file__)
-    mode = os.environ.get('ANSIBLE_TEST_COVERAGE')
-    version = os.environ.get('ANSIBLE_TEST_PYTHON_VERSION', '')
     executable = find_executable(command)
 
-    if mode in ('coverage', 'version'):
-        if mode == 'coverage':
-            args, env = coverage_command(self_dir, version)
-            args += [executable]
-            tool = 'cover'
-        else:
-            interpreter = find_executable('python' + version)
-            args, env = [interpreter, executable], os.environ.copy()
-            tool = 'runner'
-
-        if command in ('ansible', 'ansible-playbook', 'ansible-pull'):
-            interpreter = find_executable(tool + version)
-            args += ['--extra-vars', 'ansible_python_interpreter=' + interpreter]
+    if config.coverage_file:
+        args, env = coverage_command()
     else:
-        args, env = [executable], os.environ.copy()
+        args, env = [config.python_interpreter], os.environ.copy()
 
-    args += sys.argv[1:]
+    args += [executable]
+
+    if command in ('ansible', 'ansible-playbook', 'ansible-pull'):
+        if config.remote_interpreter is None:
+            interpreter = os.path.join(os.path.dirname(__file__), 'injector.py')
+        elif config.remote_interpreter == '':
+            interpreter = None
+        else:
+            interpreter = config.remote_interpreter
+
+        if interpreter:
+            args += ['--extra-vars', 'ansible_python_interpreter=' + interpreter]
+
+    args += config.arguments[1:]
 
     return args, env
 
@@ -95,61 +176,53 @@ def runner():
     """
     :rtype: list[str], dict[str, str]
     """
-    command = os.path.basename(__file__)
-    version = command.replace('runner', '')
+    args, env = [config.python_interpreter], os.environ.copy()
 
-    interpreter = find_executable('python' + version)
-    args, env = [interpreter], os.environ.copy()
-
-    args += sys.argv[1:]
+    args += config.arguments[1:]
 
     return args, env
 
 
 def cover():
     """
-    :rtype: list[str], dict[str, str]
+    :rtype: list[str], dict[str, str], bool
     """
-    self_dir = os.path.dirname(os.path.abspath(__file__))
-    command = os.path.basename(__file__)
-    version = command.replace('cover', '')
-
-    if len(sys.argv) > 1:
-        executable = sys.argv[1]
+    if len(config.arguments) > 1:
+        executable = config.arguments[1]
     else:
         executable = ''
 
+    require_cwd = False
+
     if os.path.basename(executable).startswith('ansible_module_'):
-        args, env = coverage_command(self_dir, version)
+        args, env = coverage_command()
+        # coverage requires knowing the working directory
+        require_cwd = True
     else:
-        interpreter = find_executable('python' + version)
-        args, env = [interpreter], os.environ.copy()
+        args, env = [config.python_interpreter], os.environ.copy()
 
-    args += sys.argv[1:]
+    args += config.arguments[1:]
 
-    return args, env
+    return args, env, require_cwd
 
 
-def coverage_command(self_dir, version):
+def coverage_command():
     """
-    :type self_dir: str
-    :type version: str
     :rtype: list[str], dict[str, str]
     """
-    executable = 'coverage'
-
-    if version:
-        executable += '-%s' % version
+    self_dir = os.path.dirname(os.path.abspath(__file__))
 
     args = [
-        find_executable(executable),
+        config.python_interpreter,
+        '-m',
+        'coverage.__main__',
         'run',
         '--rcfile',
         os.path.join(self_dir, '.coveragerc'),
     ]
 
     env = os.environ.copy()
-    env['COVERAGE_FILE'] = os.path.abspath(os.path.join(self_dir, '..', 'output', 'coverage'))
+    env['COVERAGE_FILE'] = config.coverage_file
 
     return args, env
 

--- a/test/runner/injector/runner
+++ b/test/runner/injector/runner
@@ -1,1 +1,0 @@
-injector.py

--- a/test/runner/injector/runner2
+++ b/test/runner/injector/runner2
@@ -1,1 +1,0 @@
-injector.py

--- a/test/runner/injector/runner2.4
+++ b/test/runner/injector/runner2.4
@@ -1,1 +1,0 @@
-injector.py

--- a/test/runner/injector/runner2.6
+++ b/test/runner/injector/runner2.6
@@ -1,1 +1,0 @@
-injector.py

--- a/test/runner/injector/runner2.7
+++ b/test/runner/injector/runner2.7
@@ -1,1 +1,0 @@
-injector.py

--- a/test/runner/injector/runner3
+++ b/test/runner/injector/runner3
@@ -1,1 +1,0 @@
-injector.py

--- a/test/runner/injector/runner3.5
+++ b/test/runner/injector/runner3.5
@@ -1,1 +1,0 @@
-injector.py

--- a/test/runner/injector/runner3.6
+++ b/test/runner/injector/runner3.6
@@ -1,1 +1,0 @@
-injector.py

--- a/test/runner/lib/sanity.py
+++ b/test/runner/lib/sanity.py
@@ -644,7 +644,7 @@ def command_sanity_ansible_doc(args, targets, python_version):
     cmd = ['ansible-doc'] + modules
 
     try:
-        stdout, stderr = intercept_command(args, cmd, env=env, capture=True, python_version=python_version)
+        stdout, stderr = intercept_command(args, cmd, target_name='ansible-doc', env=env, capture=True, python_version=python_version)
         status = 0
     except SubprocessError as ex:
         stdout = ex.stdout

--- a/test/runner/lib/test.py
+++ b/test/runner/lib/test.py
@@ -65,6 +65,7 @@ class TestConfig(EnvironmentConfig):
         super(TestConfig, self).__init__(args, command)
 
         self.coverage = args.coverage  # type: bool
+        self.coverage_label = args.coverage_label  # type: str
         self.include = args.include  # type: list [str]
         self.exclude = args.exclude  # type: list [str]
         self.require = args.require  # type: list [str]

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -168,6 +168,10 @@ def parse_args():
                       action='store_true',
                       help='analyze code coverage when running tests')
 
+    test.add_argument('--coverage-label',
+                      default='',
+                      help='label to include in coverage output file names')
+
     test.add_argument('--metadata',
                       help=argparse.SUPPRESS)
 

--- a/test/utils/shippable/cloud.sh
+++ b/test/utils/shippable/cloud.sh
@@ -8,4 +8,4 @@ IFS='/:' read -ra args <<< "${TEST}"
 image="ansible/ansible:${args[1]}"
 target="posix/ci/cloud/"
 
-ansible-test integration --color -v --retry-on-error "${target}" --docker "${image}"
+ansible-test integration --color -v --retry-on-error "${target}" --docker "${image}" "${COVERAGE}"

--- a/test/utils/shippable/freebsd.sh
+++ b/test/utils/shippable/freebsd.sh
@@ -9,4 +9,4 @@ platform="${args[0]}"
 version="${args[1]}"
 target="posix/ci/"
 
-ansible-test integration --color -v --retry-on-error "${target}" --remote "${platform}/${version}" --exclude "posix/ci/cloud/"
+ansible-test integration --color -v --retry-on-error "${target}" --remote "${platform}/${version}" --exclude "posix/ci/cloud/" "${COVERAGE}"

--- a/test/utils/shippable/linux.sh
+++ b/test/utils/shippable/linux.sh
@@ -8,4 +8,4 @@ IFS='/:' read -ra args <<< "${TEST}"
 image="ansible/ansible:${args[1]}"
 target="posix/ci/group${args[2]}/"
 
-ansible-test integration --color -v --retry-on-error "${target}" --docker "${image}"
+ansible-test integration --color -v --retry-on-error "${target}" --docker "${image}" "${COVERAGE}"

--- a/test/utils/shippable/network.sh
+++ b/test/utils/shippable/network.sh
@@ -12,7 +12,7 @@ if [ -s /tmp/network.txt ]; then
 
     echo "Running network integration tests for multiple platforms concurrently."
 
-    ansible-test network-integration --color -v --retry-on-error "${target}" --requirements \
+    ansible-test network-integration --color -v --retry-on-error "${target}" --requirements "${COVERAGE}" \
         --platform vyos/1.1.0 \
         --platform ios/csr1000v \
 
@@ -20,6 +20,6 @@ else
     echo "No changes requiring integration tests specific to networking were detected."
     echo "Running network integration tests for a single platform only."
 
-    ansible-test network-integration --color -v --retry-on-error "${target}" --requirements \
+    ansible-test network-integration --color -v --retry-on-error "${target}" --requirements "${COVERAGE}" \
         --platform vyos/1.1.0
 fi

--- a/test/utils/shippable/osx.sh
+++ b/test/utils/shippable/osx.sh
@@ -9,4 +9,5 @@ platform="${args[0]}"
 version="${args[1]}"
 target="posix/ci/"
 
-ansible-test integration --color -v --retry-on-error "${target}" --remote "${platform}/${version}" --remote-terminate success --exclude "posix/ci/cloud/"
+ansible-test integration --color -v --retry-on-error "${target}" --remote "${platform}/${version}" --remote-terminate success --exclude "posix/ci/cloud/" \
+    "${COVERAGE}"

--- a/test/utils/shippable/other.sh
+++ b/test/utils/shippable/other.sh
@@ -10,8 +10,8 @@ retry.py pip install tox --disable-pip-version-check
 
 echo '{"verified": false, "results": []}' > test/results/bot/ansible-test-failure.json
 
-ansible-test compile --failure-ok --color -v --junit --requirements
-ansible-test sanity  --failure-ok --color -v --junit --tox --skip-test ansible-doc --python 3.5
+ansible-test compile --failure-ok --color -v --junit --requirements --coverage
+ansible-test sanity  --failure-ok --color -v --junit --tox --skip-test ansible-doc --python 3.5 --coverage
 ansible-test sanity  --failure-ok --color -v --junit --tox --test ansible-doc --coverage
 
 rm test/results/bot/ansible-test-failure.json

--- a/test/utils/shippable/shippable.sh
+++ b/test/utils/shippable/shippable.sh
@@ -23,6 +23,12 @@ pip list --disable-pip-version-check
 
 export PATH="test/runner:${PATH}"
 export PYTHONIOENCODING='utf-8'
+export COVERAGE="${COVERAGE:-}"
+
+# run integration coverage if 'ci_coverage' is in the commit message or the COVERAGE var is non-empty
+if [[ "${COMMIT_MESSAGE}" =~ ci_coverage ]] || [ -n "${COVERAGE}" ]; then
+    export COVERAGE="--coverage"
+fi
 
 # remove empty core/extras module directories from PRs created prior to the repo-merge
 find lib/ansible/modules -type d -empty -print -delete

--- a/test/utils/shippable/windows.sh
+++ b/test/utils/shippable/windows.sh
@@ -22,7 +22,7 @@ if [ -s /tmp/windows.txt ]; then
 
     target="windows/ci/"
 
-    ansible-test windows-integration --color -v --retry-on-error "${target}" --requirements \
+    ansible-test windows-integration --color -v --retry-on-error "${target}" --requirements "${COVERAGE}" \
         --windows 2008-SP2 \
         --windows 2008-R2_SP1 \
         --windows 2012-RTM \
@@ -34,6 +34,6 @@ else
 
     target="windows/ci/group${job}/"
 
-    ansible-test windows-integration --color -v --retry-on-error "${target}" --requirements \
+    ansible-test windows-integration --color -v --retry-on-error "${target}" --requirements "${COVERAGE}" \
         --windows 2012-R2_RTM
 fi


### PR DESCRIPTION
##### SUMMARY

Improve ansible-test code coverage analysis:

- Overhauled coverage injector to fix issues with non-local tests.
- Updated integration tests to work with the new coverage injector.
- Fix concurrency issue by using random temp files for delegation.
- Fix handling of coverage files from root user.
- Fix handling of coverage files without arcs.
- Make sure temp copy of injector is world readable and executable.
- Add support for on-demand coverage on Shippable.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

Shippable

##### ANSIBLE VERSION

```
ansible 2.4.0 (shippable-coverage 380975e86e) last updated 2017/05/07 16:32:46 (GMT +800)
  config file = 
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
