### PR TITLE
Update VPC configuration for existing lambda

### DIFF
--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -364,9 +364,9 @@ def main():
                 subnet_net_id_changed = sorted(vpc_subnet_ids) != sorted(current_vpc_subnet_ids)
                 vpc_security_group_ids_changed = sorted(vpc_security_group_ids) != sorted(current_vpc_security_group_ids)
 
-                if any((subnet_net_id_changed, vpc_security_group_ids_changed)):
-                    func_kwargs.update({'VpcConfig':
-                                        {'SubnetIds': vpc_subnet_ids,'SecurityGroupIds': vpc_security_group_ids}})
+            if 'VpcConfig' not in current_config or subnet_net_id_changed or vpc_security_group_ids_changed:
+                func_kwargs.update({'VpcConfig':
+                                    {'SubnetIds': vpc_subnet_ids,'SecurityGroupIds': vpc_security_group_ids}})
         else:
             # No VPC configuration is desired, assure VPC config is empty when present in current config
             if ('VpcConfig' in current_config and


### PR DESCRIPTION
##### SUMMARY
If a lambda exists but does not have a VPC configuration,
add the VPC configuration when it's present in the ansible
parameters.

Prior to this change, setting VPC configuration on a lambda
that did not have any VPC configuration would ignore that config.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lambda

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 986765312f) last updated 2017/05/05 14:45:04 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```
