### PR TITLE
Update Zabbix maintenance if it already exists to set new period, hosts etc.

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix_maintenance.py
+++ b/lib/ansible/modules/monitoring/zabbix_maintenance.py
@@ -355,7 +355,7 @@ def main():
     changed = False
 
     if state == "present":
-        
+
         if not host_names and not host_groups:
             module.fail_json(msg="At least one host_name or host_group must be defined for each created maintenance.")
 


### PR DESCRIPTION
##### SUMMARY
This fixes #24015.

Zabbix maintenances can now be updated with a new period, hosts, host groups etc. So you don't need to delete an expired maintenance first for example.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
zabbix_maintenance module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
```

