### PR TITLE
[WIP] rds_param_group: patch boto bug that prevents some rds params to be modified - fixes #24340

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds_param_group.py
+++ b/lib/ansible/modules/cloud/amazon/rds_param_group.py
@@ -275,7 +275,7 @@ def modify_group(group, params, immediate=False):
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
-        state=dict(required=True,  choices=['present', 'absent']),
+        state=dict(required=True, choices=['present', 'absent']),
         name=dict(required=True),
         engine=dict(required=False, choices=VALID_ENGINES),
         description=dict(required=False),
@@ -288,12 +288,12 @@ def main():
     if not HAS_BOTO:
         module.fail_json(msg='boto required for this module')
 
-    state                   = module.params.get('state')
-    group_name              = module.params.get('name').lower()
-    group_engine            = module.params.get('engine')
-    group_description       = module.params.get('description')
-    group_params            = module.params.get('params') or {}
-    immediate               = module.params.get('immediate') or False
+    state = module.params.get('state')
+    group_name = module.params.get('name').lower()
+    group_engine = module.params.get('engine')
+    group_description = module.params.get('description')
+    group_params = module.params.get('params') or {}
+    immediate = module.params.get('immediate') or False
 
     if state == 'present':
         for required in ['name', 'description', 'engine']:
@@ -369,4 +369,3 @@ from ansible.module_utils.ec2 import *
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/cloud/amazon/rds_param_group.py
+++ b/lib/ansible/modules/cloud/amazon/rds_param_group.py
@@ -177,6 +177,7 @@ INT_MODIFIERS = {
 
 TRUE_VALUES = ('on', 'true', 'yes', '1',)
 
+
 def set_parameter(param, value, immediate):
     """
     Allows setting parameters with 10M = 10* 1024 * 1024 and so on.
@@ -274,12 +275,12 @@ def modify_group(group, params, immediate=False):
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
-        state             = dict(required=True,  choices=['present', 'absent']),
-        name              = dict(required=True),
-        engine            = dict(required=False, choices=VALID_ENGINES),
-        description       = dict(required=False),
-        params            = dict(required=False, aliases=['parameters'], type='dict'),
-        immediate         = dict(required=False, type='bool'),
+        state=dict(required=True,  choices=['present', 'absent']),
+        name=dict(required=True),
+        engine=dict(required=False, choices=VALID_ENGINES),
+        description=dict(required=False),
+        params=dict(required=False, aliases=['parameters'], type='dict'),
+        immediate=dict(required=False, type='bool'),
     )
     )
     module = AnsibleModule(argument_spec=argument_spec)
@@ -297,22 +298,22 @@ def main():
     if state == 'present':
         for required in ['name', 'description', 'engine']:
             if not module.params.get(required):
-                module.fail_json(msg = str("Parameter %s required for state='present'" % required))
+                module.fail_json(msg=str("Parameter %s required for state='present'" % required))
     else:
         for not_allowed in ['description', 'engine', 'params']:
             if module.params.get(not_allowed):
-                module.fail_json(msg = str("Parameter %s not allowed for state='absent'" % not_allowed))
+                module.fail_json(msg=str("Parameter %s not allowed for state='absent'" % not_allowed))
 
     # Retrieve any AWS settings from the environment.
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module)
 
     if not region:
-        module.fail_json(msg = str("Either region or AWS_REGION or EC2_REGION environment variable or boto config aws_region or ec2_region must be set."))
+        module.fail_json(msg=str("Either region or AWS_REGION or EC2_REGION environment variable or boto config aws_region or ec2_region must be set."))
 
     try:
         conn = connect_to_aws(boto.rds, region, **aws_connect_kwargs)
     except boto.exception.BotoServerError as e:
-        module.fail_json(msg = e.error_message)
+        module.fail_json(msg=e.error_message)
 
     group_was_added = False
 
@@ -324,7 +325,7 @@ def main():
             exists = len(all_groups) > 0
         except BotoServerError as e:
             if e.error_code != 'DBParameterGroupNotFound':
-                module.fail_json(msg = e.error_message)
+                module.fail_json(msg=e.error_message)
             exists = False
 
         if state == 'absent':
@@ -352,7 +353,7 @@ def main():
                     break
 
     except BotoServerError as e:
-        module.fail_json(msg = e.error_message)
+        module.fail_json(msg=e.error_message)
 
     except NotModifiableError as e:
         msg = e.error_message

--- a/lib/ansible/modules/cloud/amazon/rds_param_group.py
+++ b/lib/ansible/modules/cloud/amazon/rds_param_group.py
@@ -209,7 +209,7 @@ def set_parameter(param, value, immediate):
 
     elif param.type == 'boolean':
         if isinstance(value, basestring):
-            converted_value = value in TRUE_VALUES
+            converted_value = value.lower() in TRUE_VALUES
         else:
             converted_value = bool(value)
 
@@ -236,7 +236,7 @@ def verify_new_value(param, value):
             if value not in choices:
                 raise ValueError('value must be in %s' % param.allowed_values)
         return value
-    elif isintance(value, bool):
+    elif isinstance(value, bool):
         return value
 
 
@@ -267,7 +267,7 @@ def modify_group(group, params, immediate=False):
                     raise NotModifiableError('Parameter %s is not modifiable.' % key)
 
                 # new and old values should be displayed as the same type; without changing the type old_value is always a string
-                old_value = {"string": str(old_value), "integer": int(old_value), "boolean": old_value in TRUE_VALUES}
+                old_value = {"string": str(old_value), "integer": int(old_value), "boolean": old_value.lower() in TRUE_VALUES}
                 changed[key] = {'old': old_value[param.type], 'new': new_value}
 
                 set_parameter(param, new_value, immediate)

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -198,7 +198,6 @@ lib/ansible/modules/cloud/amazon/iam_policy.py
 lib/ansible/modules/cloud/amazon/iam_server_certificate_facts.py
 lib/ansible/modules/cloud/amazon/lambda.py
 lib/ansible/modules/cloud/amazon/lambda_facts.py
-lib/ansible/modules/cloud/amazon/rds_param_group.py
 lib/ansible/modules/cloud/amazon/rds_subnet_group.py
 lib/ansible/modules/cloud/amazon/redshift.py
 lib/ansible/modules/cloud/amazon/route53_health_check.py


### PR DESCRIPTION
##### SUMMARY
Boto has a couple bugs to update parameters that I believe have been fixed in boto3. 
[Here](https://github.com/boto/boto/blob/develop/boto/rds/parametergroup.py#L150) boto may raise a ValueError (due to invalid literal for int() with base 10) and [here](https://github.com/boto/boto/blob/develop/boto/rds/parametergroup.py#L149) boto may split three values if `min` is negative. Fixed by avoiding calling boto.rds [set_value()](https://github.com/boto/boto/blob/develop/boto/rds/parametergroup.py#L167) and using a regex instead.

Another known issue with this module is that parameters expecting type float cannot be modified. I believe this is also a boto bug but have not tried to make a workaround. 

See #24340 and #7952 for reproducers. Fixes #24340.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/rds_param_group.py

##### ANSIBLE VERSION
```
2.4.0
```
