### PR TITLE
Refactor easy_install module

### DIFF
--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -363,7 +363,6 @@ lib/ansible/modules/notification/slack.py
 lib/ansible/modules/notification/twilio.py
 lib/ansible/modules/packaging/language/bundler.py
 lib/ansible/modules/packaging/language/cpanm.py
-lib/ansible/modules/packaging/language/easy_install.py
 lib/ansible/modules/packaging/language/gem.py
 lib/ansible/modules/packaging/language/maven_artifact.py
 lib/ansible/modules/packaging/language/pear.py


### PR DESCRIPTION
##### SUMMARY
* PEP8 fix
* The fix adds correct string check used by easy_install command for getting information about installed package. Previously, easy_install output was checked for two strings 'Reading' and 'Downloading' but only string 'Downloading' is valid in case of installed package. The fix corrects this check.

Fixes #22245

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/packaging/language/easy_install.py
test/sanity/pep8/legacy-files.txt

##### ANSIBLE VERSION
```
2.4 devel
```