### PR TITLE
Fix missing templates/ in 'ansible-galaxy init' by including .git_keep files in role template skeleton in package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
             'modules/windows/*.ps1',
             'modules/windows/*.ps1',
             'galaxy/data/*/*.*',
+            'galaxy/data/*/*/.*',
             'galaxy/data/*/*/*.*',
             'galaxy/data/*/tests/inventory'
         ],


### PR DESCRIPTION
##### SUMMARY
Include .git_keep files in role template skeleton

setup.py will not install package_data this is just an empty
directory, even if the globs in package_data match it.

So the role skeleton that was being installed to galaxy/data/*/
was excluding the files/ and templates/ directories since they were
empty.

Since the skeleton dir doesnt include those dirs
'ansible-galaxy init' would not set them up.

So this adds a .* glob to those directories so the .git_keep
will be included as well, so that setup.py will create the otherwise
empty directoty. ansible-galaxy init already knows to ignore those
files, so no other changes are needed.

(Including the .git_keep files is a little odd, but the alternative
would be creating our own placeholder files. Since ansible-galaxy
already understands .git_keep files we just reuse that)

Fixes #23597


<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
setup.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/.local/lib/python2.7/site-packages/ansible-2.4.0-py2.7.egg/ansible
  executable location = /home/adrian/.local/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
