### PR TITLE
Added no_log flag for all the sensitive fields

### DIFF
--- a/lib/ansible/modules/network/avi/avi_analyticsprofile.py
+++ b/lib/ansible/modules/network/avi/avi_analyticsprofile.py
@@ -108,9 +108,9 @@ options:
     client_log_config:
         description:
             - Configure which logs are sent to the avi controller from ses and how they are processed.
-    client_log_syslog_config:
+    client_log_streaming_config:
         description:
-            - Configure to send logs to a remote syslog server.
+            - Configure to stream logs to an external server.
             - Field introduced in 17.1.1.
         version_added: "2.4"
     conn_lossy_ooo_threshold:
@@ -460,7 +460,7 @@ def main():
         apdex_server_rtt_threshold=dict(type='int',),
         apdex_server_rtt_tolerated_factor=dict(type='float',),
         client_log_config=dict(type='dict',),
-        client_log_syslog_config=dict(type='dict',),
+        client_log_streaming_config=dict(type='dict',),
         conn_lossy_ooo_threshold=dict(type='int',),
         conn_lossy_timeo_rexmt_threshold=dict(type='int',),
         conn_lossy_total_rexmt_threshold=dict(type='int',),

--- a/lib/ansible/modules/network/avi/avi_cloud.py
+++ b/lib/ansible/modules/network/avi/avi_cloud.py
@@ -75,7 +75,7 @@ options:
     east_west_ipam_provider_ref:
         description:
             - Ipam profile for east-west services.
-            - Please use virtual subnets in this ipam profile that do not conflict with the underlay networks or any overlay networks in the cluster.
+            - Warning - please use virtual subnets in this ipam profile that do not conflict with the underlay networks or any overlay networks in the cluster.
             - For example in aws and gcp, 169.254.0.0/16 is used for storing instance metadata.
             - Hence, it should not be used in this profile.
             - It is a reference to an object of type ipamdnsproviderprofile.
@@ -158,7 +158,7 @@ extends_documentation_fragment:
 
 
 EXAMPLES = '''
-  - name: Create a VMWare cloud with write access mode
+  - name: Create a VMware cloud with write access mode
     avi_cloud:
       username: ''
       controller: ''

--- a/lib/ansible/modules/network/avi/avi_cloudconnectoruser.py
+++ b/lib/ansible/modules/network/avi/avi_cloudconnectoruser.py
@@ -101,7 +101,7 @@ def main():
         state=dict(default='present',
                    choices=['absent', 'present']),
         name=dict(type='str', required=True),
-        private_key=dict(type='str',),
+        private_key=dict(type='str', no_log=True,),
         public_key=dict(type='str',),
         tenant_ref=dict(type='str',),
         url=dict(type='str',),

--- a/lib/ansible/modules/network/avi/avi_sslkeyandcertificate.py
+++ b/lib/ansible/modules/network/avi/avi_sslkeyandcertificate.py
@@ -149,7 +149,7 @@ def main():
         enckey_base64=dict(type='str',),
         enckey_name=dict(type='str',),
         hardwaresecuritymodulegroup_ref=dict(type='str',),
-        key=dict(type='str',),
+        key=dict(type='str', no_log=True,),
         key_params=dict(type='dict',),
         name=dict(type='str', required=True),
         status=dict(type='str',),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added no_log flag for all the sensitive fields. In addition, fixed minor documentation issues as requested in the review.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
network/avi/avi_analyticsprofile.py
network/avi/avi_cloud.py
network/avi/avi_cloudconnectoruser.py
network/avi/avi_sslkeyandcertificate.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = /home/grastogi/.ansible.cfg
  configured module search path = [u'/home/grastogi/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/grastogi/ansible2.3/local/lib/python2.7/site-packages/ansible
  executable location = /home/grastogi/ansible2.3/bin/ansible
  python version = 2.7.6 (default, Jun 22 2015, 17:58:13) [GCC 4.8.2]
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
