### PR TITLE
Update ansible-test change handling and CS plugin.

### DIFF
--- a/test/runner/lib/classification.py
+++ b/test/runner/lib/classification.py
@@ -378,6 +378,16 @@ class PathMapper(object):
 
                 test_path = os.path.dirname(test_path)
 
+        if path.startswith('test/runner/lib/cloud/'):
+            cloud_target = 'cloud/%s/' % name
+
+            if cloud_target in self.integration_targets_by_alias:
+                return {
+                    'integration': cloud_target,
+                }
+
+            return all_tests()  # test infrastructure, run all tests
+
         if path.startswith('test/runner/'):
             return all_tests()  # test infrastructure, run all tests
 

--- a/test/runner/lib/cloud/cs.py
+++ b/test/runner/lib/cloud/cs.py
@@ -51,7 +51,7 @@ class CsCloudProvider(CloudProvider):
         """
         super(CsCloudProvider, self).__init__(args, config_extension='.ini')
 
-        self.image = 'resmo/cloudstack-sim'
+        self.image = 'ansible/ansible:cloudstack-simulator'
         self.container_name = ''
         self.endpoint = ''
         self.host = ''

--- a/test/runner/lib/cloud/cs.py
+++ b/test/runner/lib/cloud/cs.py
@@ -154,7 +154,8 @@ class CsCloudProvider(CloudProvider):
             display.info('Starting a new CloudStack simulator docker container.', verbosity=1)
             docker_pull(self.args, self.image)
             docker_run(self.args, self.image, ['-d', '-p', '8888:8888', '--name', self.container_name])
-            display.notice('The CloudStack simulator will probably be ready in 5 - 10 minutes.')
+            if not self.args.explain:
+                display.notice('The CloudStack simulator will probably be ready in 5 - 10 minutes.')
 
         container_id = get_docker_container_id()
 


### PR DESCRIPTION
##### SUMMARY

Update ansible-test change handling and the CloudStack cloud plugin:

- Use the `ansible/ansible:cloudstack-simulator` image for CloudStack tests.
- Only run cloud plugin related integration tests for changes to cloud plugins.
- Do not show CloudStack starting notice in explain mode.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
nsible 2.4.0 (at-cs-ansible a461b68e9c) last updated 2017/05/09 15:26:06 (GMT +800)
  config file = 
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
