### PR TITLE
Python 3 fixes for CloudStack modules and tests.

### DIFF
--- a/lib/ansible/module_utils/cloudstack.py
+++ b/lib/ansible/module_utils/cloudstack.py
@@ -28,7 +28,11 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import sys
 import time
+
+from ansible.module_utils._text import to_text
+
 try:
     from cs import CloudStack, CloudStackException, read_config
     HAS_LIB_CS = True
@@ -46,6 +50,9 @@ CS_HYPERVISORS = [
     'OVM', 'ovm',
     'Simulator', 'simulator',
 ]
+
+if sys.version_info > (3,):
+    long = int
 
 
 def cs_argument_spec():
@@ -184,20 +191,23 @@ class AnsibleCloudStack(object):
                         self.result['diff']['after'][key] = value
                         result = True
                 else:
+                    before_value = to_text(current_dict[key])
+                    after_value = to_text(value)
+
                     if self.case_sensitive_keys and key in self.case_sensitive_keys:
-                        if value != current_dict[key].encode('utf-8'):
-                            self.result['diff']['before'][key] = current_dict[key].encode('utf-8')
-                            self.result['diff']['after'][key] = value
+                        if before_value != after_value:
+                            self.result['diff']['before'][key] = before_value
+                            self.result['diff']['after'][key] = after_value
                             result = True
 
                     # Test for diff in case insensitive way
-                    elif value.lower() != current_dict[key].encode('utf-8').lower():
-                        self.result['diff']['before'][key] = current_dict[key].encode('utf-8')
-                        self.result['diff']['after'][key] = value
+                    elif before_value.lower() != after_value.lower():
+                        self.result['diff']['before'][key] = before_value
+                        self.result['diff']['after'][key] = after_value
                         result = True
             else:
                 self.result['diff']['before'][key] = None
-                self.result['diff']['after'][key] = value
+                self.result['diff']['after'][key] = to_text(value)
                 result = True
         return result
 

--- a/lib/ansible/modules/cloud/cloudstack/cs_sshkeypair.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_sshkeypair.py
@@ -120,6 +120,7 @@ except ImportError:
     HAS_LIB_SSHPUBKEYS = False
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
 from ansible.module_utils.cloudstack import (
     AnsibleCloudStack,
     CloudStackException,
@@ -232,6 +233,8 @@ class AnsibleCloudStackSshKey(AnsibleCloudStack):
 
     def _get_ssh_fingerprint(self, public_key):
         key = sshpubkeys.SSHKey(public_key)
+        if hasattr(key, 'hash_md5'):
+            return key.hash_md5().replace(to_native('MD5:'), to_native(''))
         return key.hash()
 
 

--- a/test/integration/targets/cs_cluster/aliases
+++ b/test/integration/targets/cs_cluster/aliases
@@ -1,3 +1,2 @@
 cloud/cs
 posix/ci/cloud/cs
-skip/python3

--- a/test/integration/targets/cs_configuration/aliases
+++ b/test/integration/targets/cs_configuration/aliases
@@ -1,3 +1,2 @@
 cloud/cs
 posix/ci/cloud/cs
-skip/python3

--- a/test/integration/targets/cs_configuration/tasks/main.yml
+++ b/test/integration/targets/cs_configuration/tasks/main.yml
@@ -7,7 +7,7 @@
   assert:
     that:
       - config|failed
-      - "config.msg == 'missing required arguments: value,name'"
+      - "config.msg.startswith('missing required arguments: ')"
 
 - name: test configuration
   cs_configuration:

--- a/test/integration/targets/cs_domain/aliases
+++ b/test/integration/targets/cs_domain/aliases
@@ -1,3 +1,2 @@
 cloud/cs
 posix/ci/cloud/cs
-skip/python3

--- a/test/integration/targets/cs_firewall/aliases
+++ b/test/integration/targets/cs_firewall/aliases
@@ -1,3 +1,2 @@
 cloud/cs
 posix/ci/cloud/cs
-skip/python3

--- a/test/integration/targets/cs_instance/aliases
+++ b/test/integration/targets/cs_instance/aliases
@@ -1,3 +1,2 @@
 cloud/cs
 posix/ci/cloud/cs
-skip/python3

--- a/test/integration/targets/cs_instance_facts/aliases
+++ b/test/integration/targets/cs_instance_facts/aliases
@@ -1,3 +1,2 @@
 cloud/cs
 posix/ci/cloud/cs
-skip/python3

--- a/test/integration/targets/cs_iso/aliases
+++ b/test/integration/targets/cs_iso/aliases
@@ -1,3 +1,2 @@
 cloud/cs
 posix/ci/cloud/cs
-skip/python3

--- a/test/integration/targets/cs_loadbalancer_rule/aliases
+++ b/test/integration/targets/cs_loadbalancer_rule/aliases
@@ -1,3 +1,2 @@
 cloud/cs
 posix/ci/cloud/cs
-skip/python3

--- a/test/integration/targets/cs_loadbalancer_rule/tasks/main.yml
+++ b/test/integration/targets/cs_loadbalancer_rule/tasks/main.yml
@@ -57,7 +57,7 @@
   assert:
     that:
     - lb|failed
-    - "'ip_address,name' in lb.msg"
+    - "lb.msg.startswith('missing required arguments: ')"
 
 - name: test create rule
   cs_loadbalancer_rule:
@@ -143,7 +143,7 @@
   assert:
     that:
     - lb|failed
-    - "'vms,name' in lb.msg"
+    - "lb.msg.startswith('missing required arguments: ')"
 
 - name: test add members to rule
   cs_loadbalancer_rule_member:

--- a/test/integration/targets/cs_pod/aliases
+++ b/test/integration/targets/cs_pod/aliases
@@ -1,3 +1,2 @@
 cloud/cs
 posix/ci/cloud/cs
-skip/python3

--- a/test/integration/targets/cs_portforward/aliases
+++ b/test/integration/targets/cs_portforward/aliases
@@ -1,3 +1,2 @@
 cloud/cs
 posix/ci/cloud/cs
-skip/python3

--- a/test/integration/targets/cs_portforward/tasks/main.yml
+++ b/test/integration/targets/cs_portforward/tasks/main.yml
@@ -59,7 +59,7 @@
   assert:
     that:
     - pf|failed
-    - 'pf.msg == "missing required arguments: private_port,ip_address,public_port"'
+    - 'pf.msg.startswith("missing required arguments: ")'
 
 - name: test present port forwarding
   cs_portforward:

--- a/test/integration/targets/cs_project/aliases
+++ b/test/integration/targets/cs_project/aliases
@@ -1,3 +1,2 @@
 cloud/cs
 posix/ci/cloud/cs
-skip/python3

--- a/test/integration/targets/cs_resourcelimit/aliases
+++ b/test/integration/targets/cs_resourcelimit/aliases
@@ -1,3 +1,2 @@
 cloud/cs
 posix/ci/cloud/cs
-skip/python3

--- a/test/integration/targets/cs_sshkeypair/aliases
+++ b/test/integration/targets/cs_sshkeypair/aliases
@@ -1,3 +1,2 @@
 cloud/cs
 posix/ci/cloud/cs
-skip/python3

--- a/test/integration/targets/cs_user/aliases
+++ b/test/integration/targets/cs_user/aliases
@@ -1,3 +1,2 @@
 cloud/cs
 posix/ci/cloud/cs
-skip/python3

--- a/test/integration/targets/cs_vmsnapshot/aliases
+++ b/test/integration/targets/cs_vmsnapshot/aliases
@@ -1,3 +1,2 @@
 cloud/cs
 posix/ci/cloud/cs
-skip/python3

--- a/test/integration/targets/cs_vmsnapshot/tasks/main.yml
+++ b/test/integration/targets/cs_vmsnapshot/tasks/main.yml
@@ -29,7 +29,7 @@
   assert:
     that:
     - snap|failed
-    - 'snap.msg == "missing required arguments: vm,name"'
+    - 'snap.msg.startswith("missing required arguments: ")'
 
 - name: test create snapshot
   cs_vmsnapshot:

--- a/test/integration/targets/cs_volume/aliases
+++ b/test/integration/targets/cs_volume/aliases
@@ -1,3 +1,2 @@
 cloud/cs
 posix/ci/cloud/cs
-skip/python3

--- a/test/integration/targets/cs_vpc/aliases
+++ b/test/integration/targets/cs_vpc/aliases
@@ -1,3 +1,2 @@
 cloud/cs
 posix/ci/cloud/cs
-skip/python3


### PR DESCRIPTION
##### SUMMARY

Python 3 fixes for CloudStack modules and tests.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

CloudStack modules and integration tests

##### ANSIBLE VERSION

```
ansible 2.4.0 (cs-python3 82b81ea90e) last updated 2017/05/09 18:23:22 (GMT +800)
  config file = 
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
