### PR TITLE
Reference correct variable and key for role expiry (#23397)

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -314,7 +314,7 @@ def user_alter(cursor, module, user, password, role_attr_flags, encrypted, expir
                 if current_role_attrs[PRIV_TO_AUTHID_COLUMN[role_attr_name]] != role_attr_value:
                     role_attr_flags_changing = True
 
-        expires_changing = (expires is not None and expires == current_roles_attrs['rol_valid_until'])
+        expires_changing = (expires is not None and expires == current_role_attrs['rolvaliduntil'])
 
         if not pwchanging and not role_attr_flags_changing and not expires_changing:
             return False


### PR DESCRIPTION
##### SUMMARY

Previously, this module could throw the following error message:
    NameError: global name 'current_roles_attrs' is not defined

The referencing key should also match the name of the column, which is
rolvaliduntil, not rol_valid_until
(cherry picked from commit c5adf08c40db740e1481130b97c206ab371b31d0)

Original PR https://github.com/ansible/ansible/pull/23397

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
postgresql_user

##### ANSIBLE VERSION
```
2.3.0
```
