### PR TITLE
remove option checking for azure vm sizes (enum will not contain all)…

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -90,8 +90,7 @@ options:
         description:
             - A valid Azure VM size value. For example, 'Standard_D4'. The list of choices varies depending on the
               subscription and location. Check your subscription for available choices.
-        default: Standard_D1
-        required: false
+        required: true
     admin_username:
         description:
             - Admin username used to access the host after it is created. Required when creating a VM.
@@ -487,7 +486,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
             state=dict(choices=['present', 'absent'], default='present', type='str'),
             location=dict(type='str'),
             short_hostname=dict(type='str'),
-            vm_size=dict(type='str', choices=[], default='Standard_D1'),
+            vm_size=dict(type='str', required=True),
             admin_username=dict(type='str'),
             admin_password=dict(type='str', no_log=True),
             ssh_password_enabled=dict(type='bool', default=True),
@@ -510,9 +509,6 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
             restarted=dict(type='bool', default=False),
             started=dict(type='bool', default=True),
         )
-
-        for key in VirtualMachineSizeTypes:
-            self.module_arg_spec['vm_size']['choices'].append(getattr(key, 'value'))
 
         self.resource_group = None
         self.name = None


### PR DESCRIPTION
… as well as default and start requiring the vm_size param

##### SUMMARY
This bug fix is in response to a issue #21825. As per the [Azure SDK for Python team, the enum for hard-coded vm sizes will not contain all possibilities](https://github.com/Azure/azure-sdk-for-python/issues/1135). There shouldn't be a choices list for this `vm_size` parameter. And likewise, the default is not in every region, causing the default to fail in certain regions.

This PR does three things:

1. Removes the choices population and hard requirement
1. Removes the default option
1. Requires the user specify `vm_size` param

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_virtualmachine.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (azure-vmsize-fix e53baca91a) last updated 2017/05/09 09:27:31 (GMT -400)
```