### PR TITLE
in zabbix_host check for empty proxy in existing host entry, fixes #24407

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix_host.py
@@ -375,8 +375,9 @@ class Host(object):
         if set(list(template_ids)) != set(exist_template_ids):
             return True
 
-        if host['proxy_hostid'] != proxy_id:
-            return True
+        if proxy_id is not None:
+            if host['proxy_hostid'] != proxy_id:
+                return True
 
         if host['name'] != visible_name:
             return True


### PR DESCRIPTION
##### SUMMARY

If the host exists then `proxy_id` is always set to None and will never match the data from host['proxy_hostid'], hence an additional check is necessary.

Bug and fix were described in https://github.com/ansible/ansible-modules-extras/issues/3280, it only got lost at some time in between release 2.2 and 2.3.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module zabbix_host

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```
