### PR TITLE
vmware_guest_facts: require either UUID or name

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
@@ -41,7 +41,6 @@ options:
    name:
         description:
             - Name of the VM to work with
-        required: True
    name_match:
         description:
             - If multiple VMs matching the name, use the first or last found
@@ -182,12 +181,14 @@ def main():
                 default=os.environ.get('VMWARE_PASSWORD')
             ),
             validate_certs=dict(required=False, type='bool', default=True),
-            name=dict(required=True, type='str'),
+            name=dict(type='str'),
             name_match=dict(required=False, type='str', default='first'),
             uuid=dict(required=False, type='str'),
             folder=dict(required=False, type='str', default='/vm'),
             datacenter=dict(required=True, type='str'),
         ),
+        required_one_of=[['name', 'uuid']],
+        supports_check_mode=True,
     )
 
     # Prepend /vm if it was missing from the folder path, also strip trailing slashes
@@ -208,6 +209,8 @@ def main():
         except Exception:
             e = get_exception()
             module.fail_json(msg="Fact gather failed with exception %s" % e)
+    elif module.params['uuid'] is not None:
+        module.fail_json(msg="Unable to gather facts for non-existing VM %(uuid)s" % module.params)
     else:
         module.fail_json(msg="Unable to gather facts for non-existing VM %(name)s" % module.params)
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
vmware_guest_facts required name, whereas you add a uuid
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fix issue #24398

A backport to 2.3 is required
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vmware_guest_facts
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
