### PR TITLE
Allow filtering RDS instances by tags in the ec2 dynamic inventory script

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -628,7 +628,7 @@ class Ec2Inventory(object):
                 if filter_name[:4] != 'tag:':
                     continue
                 filter_name = filter_name[4:]
-                if not filter_name in tags:
+                if filter_name not in tags:
                     match = False
                     break
                 if isinstance(filter_value, list):
@@ -646,7 +646,7 @@ class Ec2Inventory(object):
                 if filter_name[:4] != 'tag:':
                     continue
                 filter_name = filter_name[4:]
-                if not filter_name in tags:
+                if filter_name not in tags:
                     continue
                 if isinstance(filter_value, list):
                     if tags[filter_name] in filter_value:

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -621,41 +621,30 @@ class Ec2Inventory(object):
         ''' return True if given tags match configured filters '''
         if not self.ec2_instance_filters:
             return True
-        match = True
-        if self.stack_filters:
-            for ec2_filter in self.ec2_instance_filters.items():
-                filter_name, filter_value = ec2_filter
-                if filter_name[:4] != 'tag:':
-                    continue
-                filter_name = filter_name[4:]
-                if filter_name not in tags:
+        match = self.stack_filters
+        for filter_name, filter_value in self.ec2_instance_filters.items():
+            if filter_name[:4] != 'tag:':
+                continue
+            filter_name = filter_name[4:]
+            if filter_name not in tags:
+                if self.stack_filters:
                     match = False
                     break
-                if isinstance(filter_value, list):
-                    if tags[filter_name] not in filter_value:
-                        match = False
-                        break
-                if isinstance(filter_value, six.string_types):
-                    if tags[filter_name] != filter_value:
-                        match = False
-                        break
-        else:
-            match = False
-            for ec2_filter in self.ec2_instance_filters.items():
-                filter_name, filter_value = ec2_filter
-                if filter_name[:4] != 'tag:':
-                    continue
-                filter_name = filter_name[4:]
-                if filter_name not in tags:
-                    continue
-                if isinstance(filter_value, list):
-                    if tags[filter_name] in filter_value:
-                        match = True
-                        break
-                if isinstance(filter_value, six.string_types):
-                    if tags[filter_name] == filter_value:
-                        match = True
-                        break
+                continue
+            if isinstance(filter_value, list):
+                if self.stack_filters and tags[filter_name] not in filter_value:
+                    match = False
+                    break
+                if not self.stack_filters and tags[filter_name] in filter_value:
+                    match = True
+                    break
+            if isinstance(filter_value, six.string_types):
+                if self.stack_filters and tags[filter_name] != filter_value:
+                    match = False
+                    break
+                if not self.stack_filters and tags[filter_name] == filter_value:
+                    match = True
+                    break
         return match
 
     def get_rds_instances_by_region(self, region):

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -635,7 +635,7 @@ class Ec2Inventory(object):
                     if tags[filter_name] not in filter_value:
                         match = False
                         break
-                if isinstance(filter_value, basestring):
+                if isinstance(filter_value, six.string_types):
                     if tags[filter_name] != filter_value:
                         match = False
                         break
@@ -652,7 +652,7 @@ class Ec2Inventory(object):
                     if tags[filter_name] in filter_value:
                         match = True
                         break
-                if isinstance(filter_value, basestring):
+                if isinstance(filter_value, six.string_types):
                     if tags[filter_name] == filter_value:
                         match = True
                         break


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Follow up to #23989, which enabled fetching of RDS tags as part of the ec2 dynamic inventory script. One unfortunate side effect of RDS support in ec2.py though is that it does not respect the tag filter settings in ec2.ini. This PR adds that support.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
<!--
- New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request
-->

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
`contrib/inventory/ec2.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel 8517fbf936) last updated 2017/04/21 12:14:39 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/jchristi/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/share/ansible/lib/ansible
  executable location = /usr/local/share/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```