### PR TITLE
Fixed import of urlencode and pathname2url from urllib for python3

### DIFF
--- a/contrib/inventory/collins.py
+++ b/contrib/inventory/collins.py
@@ -74,7 +74,6 @@ import re
 import sys
 from time import time
 import traceback
-import urllib
 
 try:
     import json
@@ -82,6 +81,7 @@ except ImportError:
     import simplejson as json
 
 from six import iteritems
+from six.moves.urllib.parse import urlencode
 
 from ansible.module_utils.urls import open_url
 
@@ -194,7 +194,7 @@ class CollinsInventory(object):
             query_parameters['page'] = cur_page
             query_url = "%s?%s" % (
                 (CollinsDefaults.ASSETS_API_ENDPOINT % self.collins_host),
-                urllib.urlencode(query_parameters, doseq=True)
+                urlencode(query_parameters, doseq=True)
             )
             try:
                 response = open_url(query_url,

--- a/contrib/inventory/proxmox.py
+++ b/contrib/inventory/proxmox.py
@@ -25,7 +25,6 @@
 #
 # { "groups": ["utility", "databases"], "a": false, "b": true }
 
-import urllib
 try:
     import json
 except ImportError:
@@ -35,6 +34,7 @@ import sys
 from optparse import OptionParser
 
 from six import iteritems
+from six.moves.urllib.parse import urlencode
 
 from ansible.module_utils.urls import open_url
 
@@ -97,7 +97,7 @@ class ProxmoxAPI(object):
     def auth(self):
         request_path = '{}api2/json/access/ticket'.format(self.options.url)
 
-        request_params = urllib.urlencode({
+        request_params = urlencode({
             'username': self.options.username,
             'password': self.options.password,
         })

--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
@@ -225,9 +225,9 @@ from datetime import datetime, timedelta
 import json
 import os
 from time import sleep
-from urllib import urlencode
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.urls import fetch_url
 
 API_URL      = 'https://api.cloudscale.ch/v1/'

--- a/lib/ansible/modules/cloud/vmware/vsphere_copy.py
+++ b/lib/ansible/modules/cloud/vmware/vsphere_copy.py
@@ -96,13 +96,13 @@ EXAMPLES = '''
 '''
 
 import atexit
-import urllib
 import mmap
 import errno
 import socket
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.urls import open_url
 
 def vmware_path(datastore, datacenter, path):
@@ -116,7 +116,7 @@ def vmware_path(datastore, datacenter, path):
     params = dict( dsName = datastore )
     if datacenter:
         params["dcPath"] = datacenter
-    params = urllib.urlencode(params)
+    params = urlencode(params)
     return "%s?%s" % (path, params)
 
 def main():

--- a/lib/ansible/modules/monitoring/airbrake_deployment.py
+++ b/lib/ansible/modules/monitoring/airbrake_deployment.py
@@ -77,7 +77,7 @@ EXAMPLES = '''
     revision: '4.2'
 '''
 
-import urllib
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 # ===========================================
 # Module execution.
@@ -122,7 +122,7 @@ def main():
         module.exit_json(changed=True)
 
     # Send the data to airbrake
-    data = urllib.urlencode(params)
+    data = urlencode(params)
     response, info = fetch_url(module, url, data=data)
     if info['status'] == 200:
         module.exit_json(changed=True)

--- a/lib/ansible/modules/monitoring/honeybadger_deployment.py
+++ b/lib/ansible/modules/monitoring/honeybadger_deployment.py
@@ -82,11 +82,10 @@ EXAMPLES = '''
 
 RETURN = '''# '''
 
-import urllib
-
 # import module snippets
 from ansible.module_utils.basic import *
 from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.urls import *
 
 # ===========================================
@@ -131,7 +130,7 @@ def main():
         module.exit_json(changed=True)
 
     try:
-        data = urllib.urlencode(params)
+        data = urlencode(params)
         response, info = fetch_url(module, url, data=data)
     except Exception:
         e = get_exception()
@@ -144,4 +143,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/monitoring/logicmonitor.py
+++ b/lib/ansible/modules/monitoring/logicmonitor.py
@@ -530,7 +530,8 @@ import platform
 import socket
 import sys
 import types
-import urllib
+
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 HAS_LIB_JSON = True
 try:
@@ -575,8 +576,8 @@ class LogicMonitor(object):
         and return the response"""
         self.module.debug("Running LogicMonitor.rpc")
 
-        param_str = urllib.urlencode(params)
-        creds = urllib.urlencode(
+        param_str = urlencode(params)
+        creds = urlencode(
             {"c": self.company,
                 "u": self.user,
                 "p": self.password})
@@ -614,8 +615,8 @@ class LogicMonitor(object):
          server \"do\" function"""
         self.module.debug("Running LogicMonitor.do...")
 
-        param_str = urllib.urlencode(params)
-        creds = (urllib.urlencode(
+        param_str = urlencode(params)
+        creds = (urlencode(
             {"c": self.company,
                 "u": self.user,
                 "p": self.password}))

--- a/lib/ansible/modules/monitoring/logicmonitor_facts.py
+++ b/lib/ansible/modules/monitoring/logicmonitor_facts.py
@@ -135,7 +135,8 @@ RETURN = '''
 
 import socket
 import types
-import urllib
+
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 HAS_LIB_JSON = True
 try:
@@ -179,8 +180,8 @@ class LogicMonitor(object):
         and return the response"""
         self.module.debug("Running LogicMonitor.rpc")
 
-        param_str = urllib.urlencode(params)
-        creds = urllib.urlencode(
+        param_str = urlencode(params)
+        creds = urlencode(
             {"c": self.company,
                 "u": self.user,
                 "p": self.password})

--- a/lib/ansible/modules/monitoring/newrelic_deployment.py
+++ b/lib/ansible/modules/monitoring/newrelic_deployment.py
@@ -88,7 +88,7 @@ EXAMPLES = '''
     revision: '1.0'
 '''
 
-import urllib
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 # ===========================================
 # Module execution.
@@ -135,7 +135,7 @@ def main():
 
     # Send the data to NewRelic
     url = "https://rpm.newrelic.com/deployments.xml"
-    data = urllib.urlencode(params)
+    data = urlencode(params)
     headers = {
         'x-api-key': module.params["token"],
     }

--- a/lib/ansible/modules/monitoring/rollbar_deployment.py
+++ b/lib/ansible/modules/monitoring/rollbar_deployment.py
@@ -82,10 +82,9 @@ EXAMPLES = '''
     comment: Test Deploy
 '''
 
-import urllib
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.urls import fetch_url
 
 
@@ -129,7 +128,7 @@ def main():
     url = module.params.get('url')
 
     try:
-        data = urllib.urlencode(params)
+        data = urlencode(params)
         response, info = fetch_url(module, url, data=data)
     except Exception:
         e = get_exception()

--- a/lib/ansible/modules/monitoring/uptimerobot.py
+++ b/lib/ansible/modules/monitoring/uptimerobot.py
@@ -79,8 +79,9 @@ except ImportError:
         # Let snippet from module_utils/basic.py return a proper error in this case
         pass
 
-import urllib
 import time
+
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 API_BASE = "http://api.uptimerobot.com/"
 
@@ -97,7 +98,7 @@ SUPPORTS_CHECK_MODE = False
 
 def checkID(module, params):
 
-    data = urllib.urlencode(params)
+    data = urlencode(params)
     full_uri = API_BASE + API_ACTIONS['status'] + data
     req, info = fetch_url(module, full_uri)
     result = req.read()
@@ -109,7 +110,7 @@ def checkID(module, params):
 def startMonitor(module, params):
 
     params['monitorStatus'] = 1
-    data = urllib.urlencode(params)
+    data = urlencode(params)
     full_uri = API_BASE + API_ACTIONS['editMonitor'] + data
     req, info = fetch_url(module, full_uri)
     result = req.read()
@@ -121,7 +122,7 @@ def startMonitor(module, params):
 def pauseMonitor(module, params):
 
     params['monitorStatus'] = 0
-    data = urllib.urlencode(params)
+    data = urlencode(params)
     full_uri = API_BASE + API_ACTIONS['editMonitor'] + data
     req, info = fetch_url(module, full_uri)
     result = req.read()

--- a/lib/ansible/modules/net_tools/cloudflare_dns.py
+++ b/lib/ansible/modules/net_tools/cloudflare_dns.py
@@ -289,10 +289,9 @@ except ImportError:
         # Let snippet from module_utils/basic.py return a proper error in this case
         pass
 
-import urllib
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.urls import fetch_url
 
 
@@ -449,7 +448,7 @@ class CloudflareAPI(object):
             name = self.zone
         param = ''
         if name:
-            param = '?' + urllib.urlencode({'name' : name})
+            param = '?' + urlencode({'name' : name})
         zones,status = self._cf_api_call('/zones' + param)
         return zones
 
@@ -475,7 +474,7 @@ class CloudflareAPI(object):
         if value:
             query['content'] = value
         if query:
-            api_call += '?' + urllib.urlencode(query)
+            api_call += '?' + urlencode(query)
 
         records,status = self._cf_api_call(api_call)
         return records

--- a/lib/ansible/modules/net_tools/dnsmadeeasy.py
+++ b/lib/ansible/modules/net_tools/dnsmadeeasy.py
@@ -154,7 +154,7 @@ EXAMPLES = '''
 # DNSMadeEasy module specific support methods.
 #
 
-import urllib
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 IMPORT_ERROR = None
 try:
@@ -204,7 +204,7 @@ class DME2:
     def query(self, resource, method, data=None):
         url = self.baseurl + resource
         if data and not isinstance(data, basestring):
-            data = urllib.urlencode(data)
+            data = urlencode(data)
 
         response, info = fetch_url(self.module, url, data=data, method=method, headers=self._headers())
         if info['status'] not in (200, 201, 204):

--- a/lib/ansible/modules/network/citrix/netscaler.py
+++ b/lib/ansible/modules/network/citrix/netscaler.py
@@ -117,7 +117,9 @@ EXAMPLES = '''
 
 import base64
 import socket
-import urllib
+
+from ansible.module_utils.six.moves.urllib.parse import urlencode
+
 
 class netscaler(object):
 
@@ -129,7 +131,7 @@ class netscaler(object):
     def http_request(self, api_endpoint, data_json={}):
         request_url = self._nsc_protocol + '://' + self._nsc_host + self._nitro_base_url + api_endpoint
 
-        data_json = urllib.urlencode(data_json)
+        data_json = urlencode(data_json)
         if not len(data_json):
             data_json = None
 

--- a/lib/ansible/modules/notification/flowdock.py
+++ b/lib/ansible/modules/notification/flowdock.py
@@ -110,7 +110,7 @@ EXAMPLES = '''
     tags: tag1,tag2,tag3
 '''
 
-import urllib
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 # ===========================================
 # Module execution.
@@ -185,7 +185,7 @@ def main():
         module.exit_json(changed=False)
 
     # Send the data to Flowdock
-    data = urllib.urlencode(params)
+    data = urlencode(params)
     response, info = fetch_url(module, url, data=data)
     if info['status'] != 200:
         module.fail_json(msg="unable to send msg: %s" % info['msg'])

--- a/lib/ansible/modules/notification/grove.py
+++ b/lib/ansible/modules/notification/grove.py
@@ -69,7 +69,7 @@ EXAMPLES = '''
     message=deployed {{ target }}
 '''
 
-import urllib
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 BASE_URL = 'https://grove.io/api/notice/%s/'
 
@@ -85,7 +85,7 @@ def do_notify_grove(module, channel_token, service, message, url=None, icon_url=
     if icon_url is not None:
         my_data['icon_url'] = icon_url
 
-    data = urllib.urlencode(my_data)
+    data = urlencode(my_data)
     response, info = fetch_url(module, my_url, data=data)
     if info['status'] != 200:
         module.fail_json(msg="failed to send notification: %s" % info['msg'])

--- a/lib/ansible/modules/notification/hipchat.py
+++ b/lib/ansible/modules/notification/hipchat.py
@@ -103,15 +103,17 @@ EXAMPLES = '''
 # HipChat module specific support methods.
 #
 
-import urllib
 try:
     import json
 except ImportError:
     import simplejson as json
 
+
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils.six.moves.urllib.parse import urlencode
+from ansible.module_utils.six.moves.urllib.request import pathname2url
 from ansible.module_utils.urls import fetch_url
 
 DEFAULT_URI = "https://api.hipchat.com/v1"
@@ -135,7 +137,7 @@ def send_msg_v1(module, token, room, msg_from, msg, msg_format='text',
     params['notify'] = int(notify)
 
     url = api + MSG_URI_V1 + "?auth_token=%s" % (token)
-    data = urllib.urlencode(params)
+    data = urlencode(params)
 
     if module.check_mode:
         # In check mode, exit before actually sending the message
@@ -162,7 +164,7 @@ def send_msg_v2(module, token, room, msg_from, msg, msg_format='text',
 
     POST_URL = api + NOTIFY_URI_V2
 
-    url = POST_URL.replace('{id_or_name}', urllib.pathname2url(room))
+    url = POST_URL.replace('{id_or_name}', pathname2url(room))
     data = json.dumps(body)
 
     if module.check_mode:

--- a/lib/ansible/modules/notification/nexmo.py
+++ b/lib/ansible/modules/notification/nexmo.py
@@ -76,7 +76,7 @@ EXAMPLES = """
   delegate_to: localhost
 """
 
-import urllib
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 NEXMO_API = 'https://rest.nexmo.com/sms/json'
 
@@ -92,7 +92,7 @@ def send_msg(module):
     }
     for number in module.params.get('dest'):
         msg['to'] = number
-        url = "%s?%s" % (NEXMO_API, urllib.urlencode(msg))
+        url = "%s?%s" % (NEXMO_API, urlencode(msg))
 
         headers = dict(Accept='application/json')
         response, info = fetch_url(module, url, headers=headers)

--- a/lib/ansible/modules/notification/pushover.py
+++ b/lib/ansible/modules/notification/pushover.py
@@ -65,7 +65,7 @@ EXAMPLES = '''
   delegate_to: localhost
 '''
 
-import urllib
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 
 class Pushover(object):
@@ -87,7 +87,7 @@ class Pushover(object):
                 token=self.token,
                 priority=priority,
                 message=msg)
-        data = urllib.urlencode(options)
+        data = urlencode(options)
 
         headers = { "Content-type": "application/x-www-form-urlencoded"}
         r, info = fetch_url(self.module, url, method='POST', data=data, headers=headers)

--- a/lib/ansible/modules/notification/sendgrid.py
+++ b/lib/ansible/modules/notification/sendgrid.py
@@ -140,7 +140,7 @@ EXAMPLES = '''
 # =======================================
 # sendgrid module support methods
 #
-import urllib
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 try:
     import sendgrid
@@ -157,7 +157,7 @@ def post_sendgrid_api(module, username, password, from_address, to_addresses,
         AGENT = "Ansible"
         data = {'api_user': username, 'api_key':password,
                 'from':from_address, 'subject': subject, 'text': body}
-        encoded_data = urllib.urlencode(data)
+        encoded_data = urlencode(data)
         to_addresses_api = ''
         for recipient in to_addresses:
             if isinstance(recipient, unicode):

--- a/lib/ansible/modules/notification/twilio.py
+++ b/lib/ansible/modules/notification/twilio.py
@@ -109,7 +109,7 @@ EXAMPLES = '''
 # =======================================
 # twilio module support methods
 #
-import urllib
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 
 def post_twilio_api(module, account_sid, auth_token, msg, from_number,
@@ -121,7 +121,7 @@ def post_twilio_api(module, account_sid, auth_token, msg, from_number,
     data = {'From':from_number, 'To':to_number, 'Body':msg}
     if media_url:
         data['MediaUrl'] = media_url
-    encoded_data = urllib.urlencode(data)
+    encoded_data = urlencode(data)
 
     headers = {'User-Agent': AGENT,
             'Content-type': 'application/x-www-form-urlencoded',

--- a/lib/ansible/modules/notification/typetalk.py
+++ b/lib/ansible/modules/notification/typetalk.py
@@ -56,8 +56,6 @@ EXAMPLES = '''
     msg: install completed
 '''
 
-import urllib
-
 try:
     import json
 except ImportError:
@@ -69,11 +67,12 @@ except ImportError:
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.urls import fetch_url, ConnectionError
 
 
 def do_request(module, url, params, headers=None):
-    data = urllib.urlencode(params)
+    data = urlencode(params)
     if headers is None:
         headers = dict()
     headers = dict(headers, **{

--- a/lib/ansible/modules/remote_management/stacki/stacki_host.py
+++ b/lib/ansible/modules/remote_management/stacki/stacki_host.py
@@ -112,8 +112,8 @@ import os
 import re
 import tempfile
 import json
-import urllib
 
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 
 class StackiHost:
@@ -152,7 +152,7 @@ class StackiHost:
 
         # Get Final CSRF and Session ID
         login_req = self.do_request(self.module, login_endpoint, headers=header,
-                                    payload=urllib.urlencode(auth_creds), method="POST")
+                                    payload=urlencode(auth_creds), method='POST')
 
         cookie_f = login_req.headers.get('Set-Cookie').split(';')
         csrftoken = None

--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -296,6 +296,7 @@ state:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.urls import fetch_url, url_argument_spec
 from ansible.module_utils._text import to_native
 import base64
@@ -304,7 +305,6 @@ import json
 import os
 import tempfile
 import time
-import urllib
 
 
 class JenkinsPlugin(object):
@@ -435,7 +435,7 @@ class JenkinsPlugin(object):
                     'script': install_script
                 }
                 script_data.update(self.crumb)
-                data = urllib.urlencode(script_data)
+                data = urlencode(script_data)
 
                 # Send the installation request
                 r = self._get_url_data(
@@ -723,7 +723,7 @@ class JenkinsPlugin(object):
     def _pm_query(self, action, msg):
         url = "%s/pluginManager/plugin/%s/%s" % (
             self.params['url'], self.params['name'], action)
-        data = urllib.urlencode(self.crumb)
+        data = urlencode(self.crumb)
 
         # Send the request
         self._get_url_data(

--- a/lib/ansible/modules/web_infrastructure/jenkins_script.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_script.py
@@ -119,13 +119,8 @@ output:
 import json
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.urls import fetch_url
-try:
-    # python2
-    from urllib import urlencode
-except ImportError:
-    # python3
-    from urllib.parse import urlencode
 
 
 def is_csrf_protection_enabled(module):

--- a/lib/ansible/plugins/callback/hipchat.py
+++ b/lib/ansible/plugins/callback/hipchat.py
@@ -20,7 +20,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
-import urllib
 
 try:
     import prettytable
@@ -29,6 +28,7 @@ except ImportError:
     HAS_PRETTYTABLE = False
 
 from ansible.plugins.callback import CallbackBase
+from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.urls import open_url
 
 
@@ -89,7 +89,7 @@ class CallbackModule(CallbackBase):
 
         url = ('%s?auth_token=%s' % (self.msg_uri, self.token))
         try:
-            response = open_url(url, data=urllib.urlencode(params))
+            response = open_url(url, data=urlencode(params))
             return response.read()
         except:
             self._display.warning('Could not submit message to hipchat')


### PR DESCRIPTION
##### SUMMARY

`urllib.urlencode` fails on python 3, because `urlencode` has been moved to `urllib.parse .urlencode`.

try-except block taken from https://github.com/ansible/ansible/blob/a07d42e16d6f53d2cacb4a270f36a79ff6cebabd/test/runner/lib/http.py#L10-L14


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
multiple

##### ANSIBLE VERSION
```
ansible-playbook 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 3.6.1 (default, Apr 26 2017, 20:20:42) [GCC 4.9.2]
```
