### PR TITLE
 Added GPL header to vmware_inventory.py

### DIFF
--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -1,4 +1,19 @@
 #!/usr/bin/env python
+#
+# This file is part of Ansible,
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 # Requirements
 #   - pyvmomi >= 6.0.0.2016.4


### PR DESCRIPTION
##### SUMMARY
Added GPL header to vmware_inventory

Addresses #24343 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vmware_inventory.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
$ ansible --version
ansible 2.4.0 (gpl_header_vmware_inventory c519c6f091) last updated 2017/05/10 13:20:09 (GMT +000)
  config file =
  configured module search path = [u'/home/ubuntu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /vagrant/lib/ansible
  executable location = /vagrant/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
N/A
