### PR TITLE
Fix systemd task status when service start failed

### DIFF
--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -457,6 +457,12 @@ def main():
                         (rc, out, err) = module.run_command("%s %s '%s'" % (systemctl, action, unit))
                         if rc != 0:
                             module.fail_json(msg="Unable to %s service %s: %s" % (action, unit, err))
+
+                    # Test real state after systemctl start
+                    (rc, out, err) = module.run_command("%s status '%s'" % (systemctl, unit))
+                    if action == "start":
+                        if rc != 0:
+                            module.fail_json(msg="%s service failed to start" % unit)
             else:
                 # this should not happen?
                 module.fail_json(msg="Service is in unknown state", status=result['status'])


### PR DESCRIPTION
##### SUMMARY

As described in #24450 , systemd module doesn't check service status after "systemctl start". The problem is that exit code of "systemctl start myservice" is 0 even if service start failed. So, to return a true task state, I propose to check real service status with "systemctl status myservice".

Fixes #24450 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module systemd

##### ANSIBLE VERSION
ansible 2.3.0.0
config file =
configured module search path = Default w/o overrides
python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]