### PR TITLE
Docs for multiple asynchronous tasks 

### DIFF
--- a/docs/docsite/rst/playbooks_loops.rst
+++ b/docs/docsite/rst/playbooks_loops.rst
@@ -59,10 +59,9 @@ Also be aware that when combining `when` with `with_items` (or any other loop st
 
 Loops are actually a combination of things `with_` + `lookup()`, so any lookup plugin can be used as a source for a loop, 'items' is lookup.
 
-Additionally, take note that, for convenience, ``with_items`` flattens the
-first depth of the list it is provided and can yield unexpected results if you
-pass a list which is composed of lists. You can work around this by wrapping
-your nested list inside a list::
+Please note that ``with_items`` flattens the first depth of the list it is
+provided and can yield unexpected results if you pass a list which is composed
+of lists. You can work around this by wrapping your nested list inside a list::
 
     # This will run debug three times since the list is flattened
     - debug:

--- a/docs/docsite/rst/playbooks_loops.rst
+++ b/docs/docsite/rst/playbooks_loops.rst
@@ -59,6 +59,32 @@ Also be aware that when combining `when` with `with_items` (or any other loop st
 
 Loops are actually a combination of things `with_` + `lookup()`, so any lookup plugin can be used as a source for a loop, 'items' is lookup.
 
+Additionally, take note that, for convenience, ``with_items`` flattens the
+first depth of the list it is provided and can yield unexpected results if you
+pass a list which is composed of lists. You can work around this by wrapping
+your nested list inside a list::
+
+    # This will run debug three times since the list is flattened
+    - debug:
+        msg: "{{ item }}"
+      vars:
+        nested_list:
+          - - one
+            - two
+            - three
+      with_items: "{{ nested_list }}"
+
+    # This will run debug once with the three items
+    - debug:
+        msg: "{{ item }}"
+      vars:
+        nested_list:
+          - - one
+            - two
+            - three
+      with_items:
+        - "{{ nested_list }}"
+
 .. _nested_loops:
 
 Nested Loops


### PR DESCRIPTION
##### SUMMARY
This improves documentation on the behavior of with_items with nested lists and provides users an example of how to limit the amount of concurrent tasks ran at once.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Ansible

##### ANSIBLE VERSION
```
ansible 2.3.0.0
```