### PR TITLE
Allow specifying VPC ID for ec2_lc security group name lookups

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_lc.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_lc.py
@@ -121,6 +121,11 @@ options:
       - A list of security group id's with which to associate the ClassicLink VPC instances.
     required: false
     version_added: "2.0"
+  vpc_id:
+    description:
+      - VPC ID, used when resolving security group names to IDs.
+    required: false
+    version_added: "2.4"
 extends_documentation_fragment:
     - aws
     - ec2
@@ -189,8 +194,9 @@ def create_launch_config(connection, module):
     name = module.params.get('name')
     image_id = module.params.get('image_id')
     key_name = module.params.get('key_name')
+    vpc_id = module.params.get('vpc_id')
     try:
-        security_groups = get_ec2_security_group_ids_from_names(module.params.get('security_groups'), ec2_connect(module), vpc_id=None, boto3=False)
+        security_groups = get_ec2_security_group_ids_from_names(module.params.get('security_groups'), ec2_connect(module), vpc_id=vpc_id, boto3=False)
     except ValueError as e:
         module.fail_json(msg=str(e))
     user_data = module.params.get('user_data')
@@ -319,7 +325,8 @@ def main():
             instance_monitoring=dict(default=False, type='bool'),
             assign_public_ip=dict(type='bool'),
             classic_link_vpc_security_groups=dict(type='list'),
-            classic_link_vpc_id=dict(type='str')
+            classic_link_vpc_id=dict(type='str'),
+            vpc_id=dict(type='str')
         )
     )
 


### PR DESCRIPTION
##### SUMMARY
Since 2.4, ec2_lc has allowed specifying security group names instead of IDs. It does not, however, allow specifying the vpc in which these groups should be found. If there are multiple security groups with the same name in different vps, the module will fail.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloud/amazon/ec2_lc.py

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = /home/ec2-user/repos/cmb-infosec-ansible/ansible.cfg
  configured module search path = [u'/home/ec2-user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ec2-user/ansible-env/lib/python2.7/site-packages/ansible
  executable location = /home/ec2-user/ansible-env/bin/ansible
  python version = 2.7.13+ (default, Feb 24 2017, 13:51:49) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```