### PR TITLE
Downgrading module from core to community

### DIFF
--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -17,7 +17,7 @@
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
-                    'supported_by': 'core'}
+                    'supported_by': 'community'}
 
 
 DOCUMENTATION = '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Changed from core to community as the module was improperly classified.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- Module edit request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
redhat_subscription

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (downgrade_rehat_subscription b09f41def5) last updated 2017/05/10 13:28:22 (GMT -700)
  config file = /Users/dsilva/.ansible.cfg
  configured module search path = [u'/Users/dsilva/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dsilva/Development/ansible/lib/ansible
  executable location = /Users/dsilva/Development/ansible/bin/ansible
```


##### ADDITIONAL INFORMATION
<!---

  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
