### PR TITLE
ec2.py: region is documented as optional; allow endpoints to be used - fixes #24382

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -1620,10 +1620,10 @@ def main():
         module.fail_json(msg='boto required for this module')
 
     try:
+        _, ec2_url, aws_connect_kwargs = get_aws_connection_info(module)
         if module.params.get('region') or not module.params.get('ec2_url'):
             ec2 = ec2_connect(module)
         elif module.params.get('ec2_url'):
-            _, ec2_url, aws_connect_kwargs = get_aws_connection_info(module)
             ec2 = connect_ec2_endpoint(ec2_url, **aws_connect_kwargs)
 
         vpc = connect_vpc(**aws_connect_kwargs)

--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -1628,7 +1628,7 @@ def main():
 
         vpc = connect_vpc(**aws_connect_kwargs)
     except boto.exception.NoAuthHandlerFound as e:
-        module.fail_json(msg="Failed to get connection.", exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.message))
+        module.fail_json(msg="Failed to get connection: %s" % e.message, exception=traceback.format_exc())
 
     tagged_instances = []
 


### PR DESCRIPTION
##### SUMMARY
Fixes #24382. Region isn't needed to connect to VPC. Also fixed ec2_url being overridden by environment variable for AWS region (variable specified in playbook > environment variable). ~But that should probably actually be fixed in module_utils.ec2 instead (hence WIP).~ Actually, I think it may break other modules that rely on that behavior (like the ones that fail if region isn't specified). Most modules don't provide ec2_url as an alternative to region.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2.py

##### ANSIBLE VERSION
```
2.4.0
```
