### PR TITLE
Fix pam_limits writing text to a file opened in binary mode

### DIFF
--- a/lib/ansible/modules/system/pam_limits.py
+++ b/lib/ansible/modules/system/pam_limits.py
@@ -133,8 +133,11 @@ EXAMPLES = '''
 
 import os
 import os.path
-import shutil
+import tempfile
 import re
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
 
 
 def main():
@@ -192,15 +195,15 @@ def main():
     space_pattern = re.compile(r'\s+')
 
     message = ''
-    f = open (limits_conf, 'r')
+    f = open (limits_conf, 'rb')
     # Tempfile
-    nf = tempfile.NamedTemporaryFile()
+    nf = tempfile.NamedTemporaryFile(mode='w+')
 
     found = False
     new_value = value
 
     for line in f:
-
+        line = to_native(line, errors='surrogate_or_strict')
         if line.startswith('#'):
             nf.write(line)
             continue
@@ -304,9 +307,6 @@ def main():
 
     module.exit_json(**res_args)
 
-
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION


##### SUMMARY
pam_limits reads data from the limits.conf file, manipulates it, and then writes it back to a temporary file.  The reading and manipulation are done in text mode but the writing was occurring in binary mode.  As a quick fix, write the file in text mode instead.

A better fix would be to buffer the output lines in an array and then convert them back into bytes just prior to writing them to the tempfile but that's a larger refactor that I'll leave to the module maintainer.

Fixes #24392

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
modules/system/pam_limits.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.3
```