### PR TITLE
Fix template not showing a diff with a directory

### DIFF
--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -97,9 +97,14 @@ class ActionModule(ActionBase):
 
         directory_prepended = False
         if dest.endswith(os.sep):
+            # Optimization.  trailing slash means we know it's a directory
             directory_prepended = True
-            base = os.path.basename(source)
-            dest = os.path.join(dest, base)
+            dest = self._connection._shell.join_path(dest, os.path.basename(source))
+        else:
+            # Find out if it's a directory
+            dest_stat = self._execute_remote_stat(dest, task_vars, True, tmp=tmp)
+            if dest_stat['exists'] and dest_stat['isdir']:
+                dest = self._connection._shell.join_path(dest, os.path.basename(source))
 
         # template the source data locally & get ready to transfer
         b_source = to_bytes(source)


### PR DESCRIPTION
Template can take a directory as the destination.  When that's the case,
we need to diff between the source and the file inside of the directory.
That happened when the directory was specified with a trailing slash but
not when it was specified on its own.  This change fixes that.

Fixes #24413
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/template.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel, 2.3
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
