### PR TITLE
Fix inconsistent default value for network mode when `net` unspecified

### DIFF
--- a/lib/ansible/modules/cloud/docker/_docker.py
+++ b/lib/ansible/modules/cloud/docker/_docker.py
@@ -956,7 +956,7 @@ class DockerManager(object):
             'publish_all_ports': self.module.params.get('publish_all_ports'),
             'privileged': self.module.params.get('privileged'),
             'links': self.links,
-            'network_mode': self.module.params.get('net'),
+            'network_mode': self.module.params.get('net') or 'bridge',
         }
 
         optionals = {}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
`cloud/docker`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Dec 19 2016, 09:15:10) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```
This applied to all versions with docker module supporting `net` and `bridge`, which should be 2.0+

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Originally submitted as 
https://github.com/ansible/ansible-modules-core/pull/4045

The default value of network mode being used is inconsistent when `net` is unspecified
For actual container it uses `None` (in python), which translates to `default` in docker.
But in comparison it uses `bridge`.


<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before:
"reload_reasons": "net (default => bridge)"

After:
"reload_reasons": null
```
