### PR TITLE
Fix cron module to consider value input in `job` with trailing new line same as the old `job` without trailing new line

### DIFF
--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -705,6 +705,11 @@ def main():
                 crontab.remove_env(name)
                 changed = True
     else:
+        # Remove trailing new lines to properly compare job content after
+        # The `old_job` always got newline stripped due to nature of cron files
+        # But it's common to put a very long `job` into several lines with `key: >` or `key: |` YAML syntax
+        job = job.rstrip('\n')
+
         if do_install:
             job = crontab.get_cron_job(minute, hour, day, month, weekday, job, special_time, disabled)
             old_job = crontab.find_job(name, job)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The `old_job` always got newline stripped due to nature of cron files
But it's common to put a very long `job` into several lines with `key: >` or `key: |` YAML syntax

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
`system/cron`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Dec 19 2016, 09:15:10) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Originally submitted as 
https://github.com/ansible/ansible-modules-core/pull/4044

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before:
changed: [app_server_02] => (item={u'job': u'docker restart $(sudo docker ps -a | grep "app\\.web\\.[2468]" | awk \'{print($1)}\')\n', u'state': u'present', u'name': u'restart_docker_containers_for_prefix_app_dot_web_with_even_suffixes_regularly', u'minute': u'45', u'hour': u'*'}) => {"backup_file": "/tmp/crontabuC0mJ4", "changed": true, "cron_file": "restart_docker_containers_for_prefix_app_dot_web_with_even_suffixes_regularly", "item": {"hour": "*", "job": "docker restart $(sudo docker ps -a | grep \"app\\.web\\.[2468]\" | awk '{print($1)}')\n", "minute": "45", "name": "restart_docker_containers_for_prefix_app_dot_web_with_even_suffixes_regularly", "state": "present"}, "job": "45 * * * * root docker restart $(sudo docker ps -a | grep \"app\\.web\\.[2468]\" | awk '{print($1)}')\n", "jobs": ["restart_docker_containers_for_prefix_app_dot_web_with_even_suffixes_regularly"], "old_job": ["restart_docker_containers_for_prefix_app_dot_web_with_even_suffixes_regularly", "45 * * * * root docker restart"]}

After:
ok: [app_server_02] => (item={u'job': u'docker restart $(sudo docker ps -a | grep "app\\.web\\.[2468]" | awk \'{print($1)}\')\n', u'state': u'present', u'name': u'restart_docker_containers_for_prefix_app_dot_web_with_even_suffixes_regularly', u'minute': u'45', u'hour': u'*'}) => {"changed": false, "cron_file": "restart_docker_containers_for_prefix_app_dot_web_with_even_suffixes_regularly", "item": {"hour": "*", "job": "docker restart $(sudo docker ps -a | grep \"app\\.web\\.[2468]\" | awk '{print($1)}')\n", "minute": "45", "name": "restart_docker_containers_for_prefix_app_dot_web_with_even_suffixes_regularly", "state": "present"}, "job": "45 * * * * root docker restart $(sudo docker ps -a | grep \"app\\.web\\.[2468]\" | awk '{print($1)}')", "jobs": ["restart_docker_containers_for_prefix_app_dot_web_with_even_suffixes_regularly"], "old_job": ["restart_docker_containers_for_prefix_app_dot_web_with_even_suffixes_regularly", "45 * * * * root docker restart $(sudo docker ps -a | grep \"app\\.web\\.[2468]\" | awk '{print($1)}')"]}
```
