### PR TITLE
Update hpilo_boot.py

### DIFF
--- a/lib/ansible/modules/remote_management/hpilo/hpilo_boot.py
+++ b/lib/ansible/modules/remote_management/hpilo/hpilo_boot.py
@@ -80,6 +80,7 @@ options:
       - Change the ssl_version used
     default: TLSv1
     choices: ['SSLv3','SSLv23','TLSv1','TLSv1_1','TLSv1_2']
+    version_added: '2.4' 
 requirements:
 - hpilo
 notes:

--- a/lib/ansible/modules/remote_management/hpilo/hpilo_boot.py
+++ b/lib/ansible/modules/remote_management/hpilo/hpilo_boot.py
@@ -75,6 +75,11 @@ options:
     - As a safeguard, without force, hpilo_boot will refuse to reboot a server that is already running.
     default: no
     choices: [ "yes", "no" ]
+  ssl_version:
+    description:
+      - Change the ssl_version used
+    default: TLSv1
+    choices: ['SSLv3','SSLv23','TLSv1','TLSv1_1','TLSv1_2']
 requirements:
 - hpilo
 notes:
@@ -134,6 +139,7 @@ def main():
             image = dict(default=None, type='str'),
             state = dict(default='boot_once', type='str', choices=['boot_always', 'boot_once', 'connect', 'disconnect', 'no_boot', 'poweroff']),
             force = dict(default=False, type='bool'),
+            ssl_version = dict(default='TLSv1', choices=['SSLv3','SSLv23','TLSv1','TLSv1_1','TLSv1_2']),
         )
     )
 
@@ -147,8 +153,9 @@ def main():
     image = module.params['image']
     state = module.params['state']
     force = module.params['force']
+    ssl_version = getattr(hpilo.ssl, 'PROTOCOL_' + module.params.get('ssl_version').upper().replace('V','v'))
 
-    ilo = hpilo.Ilo(host, login=login, password=password)
+    ilo = hpilo.Ilo(host, login=login, password=password, ssl_version=ssl_version)
     changed = False
     status = {}
     power_status = 'UNKNOWN'

--- a/lib/ansible/modules/remote_management/hpilo/hpilo_boot.py
+++ b/lib/ansible/modules/remote_management/hpilo/hpilo_boot.py
@@ -77,9 +77,9 @@ options:
     choices: [ "yes", "no" ]
   ssl_version:
     description:
-      - Change the ssl_version used
+      - Change the ssl_version used.
     default: TLSv1
-    choices: ['SSLv3','SSLv23','TLSv1','TLSv1_1','TLSv1_2']
+    choices: [ "SSLv3", "SSLv23", "TLSv1", "TLSv1_1", "TLSv1_2" ]
     version_added: '2.4'
 requirements:
 - hpilo
@@ -140,7 +140,7 @@ def main():
             image = dict(default=None, type='str'),
             state = dict(default='boot_once', type='str', choices=['boot_always', 'boot_once', 'connect', 'disconnect', 'no_boot', 'poweroff']),
             force = dict(default=False, type='bool'),
-            ssl_version = dict(default='TLSv1', choices=['SSLv3','SSLv23','TLSv1','TLSv1_1','TLSv1_2']),
+            ssl_version = dict(default='TLSv1', choices=['SSLv3', 'SSLv23', 'TLSv1', 'TLSv1_1', 'TLSv1_2']),
         )
     )
 

--- a/lib/ansible/modules/remote_management/hpilo/hpilo_boot.py
+++ b/lib/ansible/modules/remote_management/hpilo/hpilo_boot.py
@@ -80,7 +80,7 @@ options:
       - Change the ssl_version used
     default: TLSv1
     choices: ['SSLv3','SSLv23','TLSv1','TLSv1_1','TLSv1_2']
-    version_added: '2.4' 
+    version_added: '2.4'
 requirements:
 - hpilo
 notes:


### PR DESCRIPTION
Add option to change the ssl version to connect to the remotr iLO

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Default ssl connections may be unsupported, or disabled due to security requirements, hence the need to be able to change the type used.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
hpilo_boot
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
