### PR TITLE
Optionally return raw data from URL lookup

### DIFF
--- a/lib/ansible/plugins/lookup/url.py
+++ b/lib/ansible/plugins/lookup/url.py
@@ -36,6 +36,7 @@ class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
 
         validate_certs = kwargs.get('validate_certs', True)
+        split_lines = kwargs.get('split_lines', True)
 
         ret = []
         for term in terms:
@@ -51,6 +52,9 @@ class LookupModule(LookupBase):
             except ConnectionError as e:
                 raise AnsibleError("Error connecting to %s: %s" % (term, str(e)))
 
-            for line in response.read().splitlines():
-                ret.append(to_text(line))
+            if split_lines:
+                for line in response.read().splitlines():
+                    ret.append(to_text(line))
+            else:
+                ret.append(to_text(response.read()))
         return ret


### PR DESCRIPTION
##### SUMMARY

Optionally return raw data from URL lookup. The url lookup splits the data
and returns a list of strings; this patch adds an optional `split_lines=' to URL
in order to force it to return data unchanged. The default is True, which means
existing behavior is unchanged.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
url lookup plugin

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /Users/jpm/.ansible.cfg
  configured module search path = [u'/etc/ansible/library', u'/Users/jpm/Auto/projects/on-github/ansible/pdns_zone/library']
  python version = 2.7.13 (default, Apr 10 2017, 13:51:30) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]

```


##### ADDITIONAL INFORMATION
The fact that URL lookup returns a list of strings makes it impossible to use it to, say, read JSON as that gets munged with. In the example below, compare the first debug (with its commas) with the second.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
$ curl http://localhost/~jpm/something.txt
The quick
brown fox jumped

over the lazy dog.
```

```yaml
- hosts: localhost
  connection: local
  gather_facts: False
  vars:
    - site: 'http://localhost/~jpm/something.txt'
    - data_before: "{{ lookup('url', site) }}"
    - data_after: "{{ lookup('url', site, split_lines=false) }}"
  tasks:
  - debug: msg="{{ data_before }}"
  - debug: msg="{{ data_after }}"
```

```
$ ansible-playbook url.yml
TASK [debug] ***************************************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "The quick,brown fox jumped,  ,over the lazy dog."
}

TASK [debug] ***************************************************************************************
ok: [localhost] => {
    "changed": false,
    "msg": "The quick\nbrown fox jumped\n  \nover the lazy dog.\n"
}
```