### PR TITLE
Update hpilo_facts.py

### DIFF
--- a/lib/ansible/modules/remote_management/hpilo/hpilo_facts.py
+++ b/lib/ansible/modules/remote_management/hpilo/hpilo_facts.py
@@ -47,6 +47,12 @@ options:
     description:
     - The password to authenticate to the HP iLO interface.
     default: admin
+  ssl_version:
+    description:
+      - Change the ssl_version used.
+    default: TLSv1
+    choices: [ "SSLv3", "SSLv23", "TLSv1", "TLSv1_1", "TLSv1_2" ]
+    version_added: '2.4'
 requirements:
 - hpilo
 notes:
@@ -158,6 +164,7 @@ def main():
             host = dict(required=True, type='str'),
             login = dict(default='Administrator', type='str'),
             password = dict(default='admin', type='str', no_log=True),
+            ssl_version = dict(default='TLSv1', choices=['SSLv3','SSLv23','TLSv1','TLSv1_1','TLSv1_2']),
         ),
         supports_check_mode=True,
     )
@@ -168,8 +175,9 @@ def main():
     host = module.params['host']
     login = module.params['login']
     password = module.params['password']
+    ssl_version = getattr(hpilo.ssl, 'PROTOCOL_' + module.params.get('ssl_version').upper().replace('V','v'))
 
-    ilo = hpilo.Ilo(host, login=login, password=password)
+    ilo = hpilo.Ilo(host, login=login, password=password, ssl_version=ssl_version)
 
     facts = {
         'module_hw': True,

--- a/lib/ansible/modules/remote_management/hpilo/hpilo_facts.py
+++ b/lib/ansible/modules/remote_management/hpilo/hpilo_facts.py
@@ -164,7 +164,7 @@ def main():
             host = dict(required=True, type='str'),
             login = dict(default='Administrator', type='str'),
             password = dict(default='admin', type='str', no_log=True),
-            ssl_version = dict(default='TLSv1', choices=['SSLv3','SSLv23','TLSv1','TLSv1_1','TLSv1_2']),
+            ssl_version = dict(default='TLSv1', choices=['SSLv3', 'SSLv23', 'TLSv1', 'TLSv1_1', 'TLSv1_2']),
         ),
         supports_check_mode=True,
     )
@@ -175,7 +175,7 @@ def main():
     host = module.params['host']
     login = module.params['login']
     password = module.params['password']
-    ssl_version = getattr(hpilo.ssl, 'PROTOCOL_' + module.params.get('ssl_version').upper().replace('V','v'))
+    ssl_version = getattr(hpilo.ssl, 'PROTOCOL_' + module.params.get('ssl_version').upper().replace('V', 'v'))
 
     ilo = hpilo.Ilo(host, login=login, password=password, ssl_version=ssl_version)
 


### PR DESCRIPTION
Add option to change the ssl version used to connect to the remote iLO

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Default ssl connections may be unsupported, or disabled due to security requirements, hence the need to be able to change the type used.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
hpilo_facts
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
2.3.0.0
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
