### PR TITLE
ec2.py: ensures instids is a list - fixes #24419

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -914,7 +914,7 @@ def await_spot_requests(module, ec2, spot_requests, count):
         if len(spot_req_inst_ids) < count:
             time.sleep(5)
         else:
-            return spot_req_inst_ids.values()
+            return list(spot_req_inst_ids.values())
     module.fail_json(msg="wait for spot requests timeout on %s" % time.asctime())
 
 


### PR DESCRIPTION
##### SUMMARY
Fixes #24419. dict.values() was a list in python2 but in python3 it's a view.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2.py

##### ANSIBLE VERSION
```
2.4.0
```
