### PR TITLE
Add `--remote-terminate` option to ansible-test.

### DIFF
--- a/test/runner/lib/delegation.py
+++ b/test/runner/lib/delegation.py
@@ -245,6 +245,7 @@ def delegate_remote(args, exclude, require):
     version = parts[1]
 
     core_ci = AnsibleCoreCI(args, platform, version, stage=args.remote_stage)
+    success = False
 
     try:
         core_ci.start()
@@ -277,11 +278,13 @@ def delegate_remote(args, exclude, require):
 
         try:
             manage.ssh(cmd, ssh_options)
+            success = True
         finally:
             manage.ssh('rm -rf /tmp/results && cp -a ansible/test/results /tmp/results')
             manage.download('/tmp/results', 'test')
     finally:
-        pass
+        if args.remote_terminate == 'always' or (args.remote_terminate == 'success' and success):
+            core_ci.stop()
 
 
 def generate_command(args, path, options, exclude, require):

--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -467,6 +467,7 @@ class EnvironmentConfig(CommonConfig):
 
         self.remote_stage = args.remote_stage  # type: str
         self.remote_aws_region = args.remote_aws_region  # type: str
+        self.remote_terminate = args.remote_terminate  # type: str
 
         self.requirements = args.requirements  # type: bool
 

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -456,6 +456,7 @@ def add_environments(parser, tox_version=False, tox_only=False):
             remote=None,
             remote_stage=None,
             remote_aws_region=None,
+            remote_terminate=None,
         )
 
         return
@@ -485,6 +486,12 @@ def add_environments(parser, tox_version=False, tox_only=False):
                         help='remote aws region to use: %(choices)s (default: auto)',
                         choices=sorted(AWS_ENDPOINTS),
                         default=None)
+
+    remote.add_argument('--remote-terminate',
+                        metavar='WHEN',
+                        help='terminate remote instance: %(choices)s (default: %(default)s)',
+                        choices=['never', 'always', 'success'],
+                        default='never')
 
 
 def add_extra_docker_options(parser, integration=True):

--- a/test/utils/shippable/osx.sh
+++ b/test/utils/shippable/osx.sh
@@ -9,4 +9,4 @@ platform="${args[0]}"
 version="${args[1]}"
 target="posix/ci/"
 
-ansible-test integration --color -v --retry-on-error "${target}" --remote "${platform}/${version}" --exclude "posix/ci/cloud/"
+ansible-test integration --color -v --retry-on-error "${target}" --remote "${platform}/${version}" --remote-terminate success --exclude "posix/ci/cloud/"


### PR DESCRIPTION
##### SUMMARY

Add `--remote-terminate` option to ansible-test.

Set `--remote-terminate success` for osx tests.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (at-remote-terminate d0d929d24d) last updated 2017/05/11 21:21:58 (GMT +800)
  config file = 
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
