### PR TITLE
contrib/inventory/ec2.py: the default filename is documented as ec2.ini - fixes #24396

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -220,9 +220,14 @@ class Ec2Inventory(object):
     def read_settings(self):
         ''' Reads the settings from the ec2.ini file '''
 
+        scriptbasename = __file__
+        scriptbasename = os.path.basename(scriptbasename)
+        scriptbasename = scriptbasename.replace('.py', '')
+
         defaults = {
             'ec2': {
-                'ini_path': os.path.join(os.path.dirname(__file__), 'ec2.ini')
+                'ini_fallback': os.path.join(os.path.dirname(__file__), 'ec2.ini'),
+                'ini_path': os.path.join(os.path.dirname(__file__), '%s.ini' % scriptbasename)
             }
         }
 
@@ -232,6 +237,10 @@ class Ec2Inventory(object):
             config = configparser.SafeConfigParser()
         ec2_ini_path = os.environ.get('EC2_INI_PATH', defaults['ec2']['ini_path'])
         ec2_ini_path = os.path.expanduser(os.path.expandvars(ec2_ini_path))
+
+        if not os.path.isfile(ec2_ini_path):
+            ec2_ini_path = os.path.expanduser(defaults['ec2']['ini_fallback'])
+
         config.read(ec2_ini_path)
 
         # is eucalyptus?

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -220,13 +220,9 @@ class Ec2Inventory(object):
     def read_settings(self):
         ''' Reads the settings from the ec2.ini file '''
 
-        scriptbasename = __file__
-        scriptbasename = os.path.basename(scriptbasename)
-        scriptbasename = scriptbasename.replace('.py', '')
-
         defaults = {
             'ec2': {
-                'ini_path': os.path.join(os.path.dirname(__file__), '%s.ini' % scriptbasename)
+                'ini_path': os.path.join(os.path.dirname(__file__), 'ec2.ini')
             }
         }
 


### PR DESCRIPTION
##### SUMMARY
Fixes #24396. 
The order of precedence of what ini file to use is env var EC2_INI_PATH, the counterpart to the inventory script (i.e. hosts.py could have the counterpart hosts.ini), and finally the fallback which is ec2.ini.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
contrib/inventory/ec2.py

##### ANSIBLE VERSION
```
2.4.0
```
