### PR TITLE
Fix unicode in network_cli

### DIFF
--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -28,6 +28,7 @@ import logging
 
 from ansible import constants as C
 from ansible.errors import AnsibleConnectionFailure
+from ansible.module_utils._text import to_text
 from ansible.module_utils.six.moves import StringIO
 from ansible.plugins import terminal_loader
 from ansible.plugins.connection import ensure_connect
@@ -193,10 +194,11 @@ class Connection(_Connection):
         cleaned = []
         command = obj.get('command') if obj else None
         for line in resp.splitlines():
+            line = to_text(line, 'utf8').strip()
             if (command and line.startswith(command.strip())) or self._matched_prompt.strip() in line:
                 continue
             cleaned.append(line)
-        return str("\n".join(cleaned)).strip()
+        return "\n".join(cleaned).strip()
 
     def _find_prompt(self, response):
         """Searches the buffered response for a matching command prompt"""


### PR DESCRIPTION
##### SUMMARY
Fixes #24447 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
connection/network_cli.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
This presumably also fixes issues in other modules that use network_cli