### PR TITLE
maven_artifact: Add classifier to default dest

### DIFF
--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -470,7 +470,11 @@ def main():
         version_part = version
         if keep_name and version == 'latest':
             version_part = downloader.find_latest_version_available(artifact)
-        dest = posixpath.join(dest, "%s-%s.%s" % (artifact_id, version_part, extension))
+
+        if classifier:
+            dest = posixpath.join(dest, "%s-%s-%s.%s" % (artifact_id, version_part, classifier, extension))
+        else:
+            dest = posixpath.join(dest, "%s-%s.%s" % (artifact_id, version_part, extension))
         b_dest = to_bytes(dest, errors='surrogate_or_strict')
 
     if os.path.lexists(b_dest) and downloader.verify_md5(dest, downloader.find_uri_for_artifact(artifact) + '.md5'):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add classifier to the dest if given dest is a directory. Allows for fetching related artifacts to the same directory without jinja cruft.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
maven_artifact

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel e3bcf1ff66) last updated 2017/05/11 13:39:56 (GMT -500)
  config file = /Users/phy1729/ansible/ansible.cfg
  configured module search path = [u'./library']
  ansible python module location = /Users/phy1729/ansible_bin/lib/ansible
  executable location = /Users/phy1729/ansible_bin/bin/ansible
  python version = 2.7.10 (default, Feb  6 2017, 23:53:20) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```