### PR TITLE
Little documentation fix

### DIFF
--- a/lib/ansible/modules/utilities/helper/meta.py
+++ b/lib/ansible/modules/utilities/helper/meta.py
@@ -46,7 +46,7 @@ options:
         - "C(clear_host_errors) (added in 2.1) clears the failed state (if any) from hosts specified in the play's list of hosts."
         - "C(end_play) (added in 2.2) causes the play to end without failing the host."
         - "C(reset_connection) (added in 2.3) interrupts a persistent connection (i.e. ssh + control persist)"
-    choices: ['noop', 'flush_handlers', 'refresh_inventory', 'clear_facts', 'clear_host_errors', 'end_play']
+    choices: ['noop', 'flush_handlers', 'refresh_inventory', 'clear_facts', 'clear_host_errors', 'end_play', 'reset_connection']
     required: true
     default: null
 notes:


### PR DESCRIPTION

##### SUMMARY
Added the 'reset_connection' option to the available choices documentation

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
utilities/helper/meta.py

##### ANSIBLE VERSION
```
ansible 2.3.1.0                                                                                                                                                        
  config file = /home/user/ansible-things/config/ansible.cfg                                                                                                          
  configured module search path = Default w/o overrides                                                                                                                
  python version = 2.7.12 (default, Jul  1 2016, 15:12:24) [GCC 5.4.0 20160609]                                                                                        
```
##### ADDITIONAL INFORMATION
Improvement to the auto-generated documentation
