### PR TITLE
Added win_copy recursive integration test with trailing path separator.

### DIFF
--- a/test/integration/targets/win_copy/tasks/main.yml
+++ b/test/integration/targets/win_copy/tasks/main.yml
@@ -162,6 +162,50 @@
     that:
     - not recursive_copy_result_again|changed
 
+# Recursive folder copy with trailing slash (see issue 23559)
+
+
+- name: make an output subdirectory
+  win_file:
+    path: "{{win_output_dir}}\\subtrailing\\"
+    state: directory
+
+- name: test recursive copy to directory
+  win_copy:
+    src: subdir/
+    dest: "{{win_output_dir}}\\subtrailing\\"
+  register: recursive_copy_result2
+
+- name: get stats on files within sub directory
+  win_find:
+    paths: "{{win_output_dir}}\\subtrailing\\"
+    recurse: True
+  register: recurse_find_results2
+
+- name: assert recursive copy worked
+  assert:
+    that:
+    - recursive_copy_result2|changed
+    - recurse_find_results2.examined == 6 # checks that it found 3 folders and 3 files.  
+# Note this is different from the test above because, by including the trailing
+# slash on the source, we only get the *contents* of the source folder
+# without the trailing slash, we would get the source folder *and* its
+# contents.  
+# See 'src' parameter documentation 
+# here: http://docs.ansible.com/ansible/win_copy_module.html
+
+- name: test recursive copy to directory again with source slash
+  win_copy:
+    src: subdir/
+    dest: "{{win_output_dir}}\\subtrailing\\"
+  register: recursive_copy_result_again2
+
+- name: assert recursive copy worked
+  assert:
+    that:
+    - not recursive_copy_result_again2|changed
+
+# test 'content' parameter
 - name: create file with content
   win_copy:
     content: abc


### PR DESCRIPTION
This is a reproducer for https://github.com/ansible/ansible/issues/23559

Tests will fail until https://github.com/ansible/ansible/pull/23581 is merged

Note that I believe another commit is also needed for this to work,
specifically the change from: https://github.com/ansible/ansible/pull/23326

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This is a reproducer for https://github.com/ansible/ansible/issues/23559

Tests will fail until https://github.com/ansible/ansible/pull/23581 is merged

Note that I believe another commit is also needed for this to work,
specifically the change from: https://github.com/ansible/ansible/pull/23326


<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
integration tests for win_copy

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (win_copy-test-for-trailing-slash 68dc13ea93) last updated 2017/05/11 21:02:16 (GMT +100)
  config file =
  configured module search path = [u'/home/jon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jon/ansible-dev/lib/ansible
  executable location = /home/jon/ansible-dev/bin/ansible
  python version = 2.7.6 (default, Jun 22 2015, 17:58:13) [GCC 4.8.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Created as result of this bug report: https://github.com/ansible/ansible/issues/23559

See also https://github.com/ansible/ansible/pull/23581 and https://github.com/ansible/ansible/pull/23326

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
