### PR TITLE
fix typo in softlayer vm module

### DIFF
--- a/lib/ansible/modules/cloud/softlayer/sl_vm.py
+++ b/lib/ansible/modules/cloud/softlayer/sl_vm.py
@@ -64,7 +64,7 @@ options:
     default: false
   dedicated:
     description:
-      - Falg to determine if the instance should be deployed in dedicated space
+      - Flag to determine if the instance should be deployed in dedicated space
     required: false
     default: false
   local_disk:


### PR DESCRIPTION
##### SUMMARY
Fix a typo in softlayer module doc.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
modules/cloud/softlayer/sl_vm.py

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /home/xiaket/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Jun 28 2016, 06:57:42) [GCC]
```