### PR TITLE
Tower user remove organization

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_user.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_user.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # coding: utf-8 -*-
 
-# (c) 2017, Wayne Witzel III <wayne@riotousliving.com>
+# (c) 2017, Wayne  Witzel III <wayne@riotousliving.com>
 #
 # This module is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -138,20 +138,20 @@ except ImportError:
 
 def main():
     module = AnsibleModule(
-        argument_spec = dict(
-            username = dict(required=True),
-            first_name = dict(),
-            last_name = dict(),
-            password = dict(no_log=True),
-            email = dict(required=True),
-            superuser = dict(type='bool', default=False),
-            auditor = dict(type='bool', default=False),
-            tower_host = dict(),
-            tower_username = dict(),
-            tower_password = dict(no_log=True),
-            tower_verify_ssl = dict(type='bool', default=True),
-            tower_config_file = dict(type='path'),
-            state = dict(choices=['present', 'absent'], default='present'),
+        argument_spec=dict(
+            username=dict(required=True),
+            first_name=dict(),
+            last_name=dict(),
+            password=dict(no_log=True),
+            email=dict(required=True),
+            superuser=dict(type='bool', default=False),
+            auditor=dict(type='bool', default=False),
+            tower_host=dict(),
+            tower_username=dict(),
+            tower_password=dict(no_log=True),
+            tower_verify_ssl=dict(type='bool', default=True),
+            tower_config_file=dict(type='path'),
+            state=dict(choices=['present', 'absent'], default='present'),
         ),
         supports_check_mode=True
     )
@@ -177,8 +177,8 @@ def main():
         try:
             if state == 'present':
                 result = user.modify(username=username, first_name=first_name, last_name=last_name,
-                                    email=email, password=password, is_superuser=superuser,
-                                    is_auditor=auditor, create_on_missing=True)
+                                     email=email, password=password, is_superuser=superuser,
+                                     is_auditor=auditor, create_on_missing=True)
                 json_output['id'] = result['id']
             elif state == 'absent':
                 result = user.delete(username=username)

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_user.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_user.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # coding: utf-8 -*-
 
-# (c) 2017, Wayne  Witzel III <wayne@riotousliving.com>
+# (c) 2017, Wayne Witzel III <wayne@riotousliving.com>
 #
 # This module is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_user.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_user.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-#coding: utf-8 -*-
+# coding: utf-8 -*-
 
 # (c) 2017, Wayne Witzel III <wayne@riotousliving.com>
 #
@@ -177,7 +177,7 @@ def main():
         try:
             if state == 'present':
                 result = user.modify(username=username, first_name=first_name, last_name=last_name,
-                                    email=email, password=password, is_superuser=superuser, 
+                                    email=email, password=password, is_superuser=superuser,
                                     is_auditor=auditor, create_on_missing=True)
                 json_output['id'] = result['id']
             elif state == 'absent':

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_user.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_user.py
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-# coding: utf-8 -*-
+#coding: utf-8 -*-
 
 # (c) 2017, Wayne Witzel III <wayne@riotousliving.com>
 #
@@ -52,11 +52,6 @@ options:
     password:
       description:
         - Password of the user.
-      required: False
-      default: null
-    organization:
-      description:
-        - Organization the user should be made a member of.
       required: False
       default: null
     superuser:
@@ -143,21 +138,20 @@ except ImportError:
 
 def main():
     module = AnsibleModule(
-        argument_spec=dict(
-            username=dict(required=True),
-            first_name=dict(),
-            last_name=dict(),
-            password=dict(no_log=True),
-            email=dict(required=True),
-            organization=dict(),
-            superuser=dict(type='bool', default=False),
-            auditor=dict(type='bool', default=False),
-            tower_host=dict(),
-            tower_username=dict(),
-            tower_password=dict(no_log=True),
-            tower_verify_ssl=dict(type='bool', default=True),
-            tower_config_file=dict(type='path'),
-            state=dict(choices=['present', 'absent'], default='present'),
+        argument_spec = dict(
+            username = dict(required=True),
+            first_name = dict(),
+            last_name = dict(),
+            password = dict(no_log=True),
+            email = dict(required=True),
+            superuser = dict(type='bool', default=False),
+            auditor = dict(type='bool', default=False),
+            tower_host = dict(),
+            tower_username = dict(),
+            tower_password = dict(no_log=True),
+            tower_verify_ssl = dict(type='bool', default=True),
+            tower_config_file = dict(type='path'),
+            state = dict(choices=['present', 'absent'], default='present'),
         ),
         supports_check_mode=True
     )
@@ -170,7 +164,6 @@ def main():
     last_name = module.params.get('last_name')
     password = module.params.get('password')
     email = module.params.get('email')
-    organization = module.params.get('organization')
     superuser = module.params.get('superuser')
     auditor = module.params.get('auditor')
     state = module.params.get('state')
@@ -184,8 +177,8 @@ def main():
         try:
             if state == 'present':
                 result = user.modify(username=username, first_name=first_name, last_name=last_name,
-                                     email=email, password=password, organization=organization,
-                                     is_superuser=superuser, is_auditor=auditor, create_on_missing=True)
+                                    email=email, password=password, is_superuser=superuser, 
+                                    is_auditor=auditor, create_on_missing=True)
                 json_output['id'] = result['id']
             elif state == 'absent':
                 result = user.delete(username=username)


### PR DESCRIPTION
##### SUMMARY
The tower-user module suggests that when adding a user it should be added to an organisation when the organization option is set on the task : "Organization the user should be made a member of."  This fails and user is not made a member of the specified organisation.  Fixes #24510 


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module: tower_user

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /Users/xxxxxxx/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Mar  3 2017, 11:49:06) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```

##### ADDITIONAL INFORMATION
Fixes issue : https://github.com/ansible/ansible/issues/24510

Removed the organization fields from the tower_user module and doc string.