### PR TITLE
new lookup plugin: LMDB

### DIFF
--- a/lib/ansible/plugins/lookup/lmdb_kv.py
+++ b/lib/ansible/plugins/lookup/lmdb_kv.py
@@ -1,0 +1,107 @@
+# (c) 2017-2018, Jan-Piet Mens <jpmens(at)gmail.com>
+# (c) 2018 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+    lookup: lmdb
+    author:
+      - Jan-Piet Mens (@jpmens) <jpmens(at)gmail.com>
+      - Ansible Core
+    version_added: "2.5"
+    short_description: fetch data from LMDB
+    description:
+      - This lookup returns a list of results from an LMDB DB corresponding to a list of items given to it
+    requirements:
+      - lmdb (python library https://lmdb.readthedocs.io/en/release/)
+    options:
+      _terms:
+        description: list of keys to query
+      db:
+        description: path to LMDB database
+        default: 'ansible.mdb'
+"""
+
+EXAMPLES = """
+- name: query LMDB for a list of country codes
+  debug: msg="{{ lookup('lmdb_kv', 'nl', 'be', 'lu', db='jp.mdb') }}"
+
+- name: use list of values in a loop
+  debug: msg="Hello from {{ item.0 }} a.k.a. {{ item.1 }}"
+  with_lmdb_kv:
+     - "n*"
+
+"""
+
+RETURN = """
+_raw:
+  description: value(s) stored in LMDB
+"""
+
+
+from ansible.errors import AnsibleError
+from ansible.plugins.lookup import LookupBase
+
+HAVE_LMDB = True
+try:
+    import lmdb
+except ImportError:
+    HAVE_LMDB = False
+
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, variables, **kwargs):
+
+        '''
+        terms contain any number of keys to be retrieved.
+        If terms is None, all keys from the database are returned
+        with their values, and if term ends in an asterisk, we
+        start searching there
+
+        The LMDB database defaults to 'ansible.mdb' if Ansible's
+        variable 'lmdb_kv_db' is not set:
+
+              vars:
+                - lmdb_kv_db: "jp.mdb"
+        '''
+
+        if HAVE_LMDB is False:
+            raise AnsibleError("Can't LOOKUP(lmdb_kv): this module requires lmdb to be installed")
+
+        db = variables.get('lmdb_kv_db', None)
+        if db is None:
+            db = kwargs.get('db', 'ansible.mdb')
+        db = str(db)
+
+        try:
+            env = lmdb.open(db, readonly=True)
+        except Exception as e:
+            raise AnsibleError("LMDB can't open database %s: %s" % (db, str(e)))
+
+        ret = []
+        if len(terms) == 0:
+            with env.begin() as txn:
+                cursor = txn.cursor()
+                cursor.first()
+                for key, value in cursor:
+                    ret.append((key, value))
+
+        else:
+            for term in terms:
+                with env.begin() as txn:
+                    if term.endswith('*'):
+                        cursor = txn.cursor()
+                        prefix = term[:-1]           # strip asterisk
+                        # cursor.set_range(prefix)
+                        cursor.set_range(term)
+                        while cursor.key().startswith(prefix):
+                            ret.append(cursor.item())
+                            cursor.next()
+                    else:
+                        value = txn.get(term)
+                        if value is not None:
+                            ret.append(value)
+
+        return ret


### PR DESCRIPTION
##### SUMMARY
This implements a lookup plugin for [LMDB](https://en.wikipedia.org/wiki/Lightning_Memory-Mapped_Database) databases using a required `pip install lmdb`. I have called it `lmdb_kv` because it cannot be named `lmdb` due to our having to import `lmdb` and the name goes well (I think) with, say, `redis_kv`.

This module is able to get specific keys and also enumerate the whole content of a database.

This PR also adds an example to the Ansible lookups Web site documentation.


##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
lookup/lmdb_kv

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /Users/jpm/.ansible.cfg
  configured module search path = [u'/etc/ansible/library', u'/Users/jpm/Auto/projects/on-github/ansible/pdns_zone/library']
  python version = 2.7.13 (default, Apr 10 2017, 13:51:30) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]

```


##### ADDITIONAL INFORMATION

#### create database

```python
#!/usr/bin/env python

import lmdb

map_size = 1024 * 100

env = lmdb.open('jp.mdb', map_size=map_size)

with env.begin(write=True) as txn:
    txn.put('fr', 'France')
    txn.put('nl', 'Netherlands')
    txn.put('es', 'Spain')
    txn.put('lu', 'Luxemburg')
```

#### playbook

```yaml
- hosts: localhost
  connection: local
  gather_facts: False
  vars:
    - benelux: "{{ lookup('lmdb_kv', 'nl', 'be', 'lu', db='jp.mdb') }}"
    - countries: "{{ lookup('lmdb_kv', db='jp.mdb') }}"
  tasks:
  - name: Get specific keys (in terms)
    debug: var=benelux

  - name: Nice country list
    debug: msg="Country code {{ item.0 | upper}} is actually {{ item.1 }}"
    with_items:
      - "{{ countries }}"

  - name: Template Europe
    template: src=europe.in dest=./output.txt

  - debug: msg="Hello from {{ item.0 }} a.k.a. {{ item.1 }}"
    with_lmdb_kv:
      - "n*"

```

#### template (europe.in)

```django
{% for cc,country in countries %}
  {{ cc|upper }} is actually {{ country }}
{% endfor %}
```

#### playbook run

```

PLAY [localhost] ***********************************************************************************

TASK [Get specific keys (in terms)] ****************************************************************
ok: [localhost] => {
    "benelux": "Netherlands,Luxemburg", 
    "changed": false
}

TASK [Nice country list] ***************************************************************************
ok: [localhost] => (item=('es', 'Spain')) => {
    "item": [
        "es", 
        "Spain"
    ], 
    "msg": "Country code ES is actually Spain"
}
ok: [localhost] => (item=('fr', 'France')) => {
    "item": [
        "fr", 
        "France"
    ], 
    "msg": "Country code FR is actually France"
}
ok: [localhost] => (item=('lu', 'Luxemburg')) => {
    "item": [
        "lu", 
        "Luxemburg"
    ], 
    "msg": "Country code LU is actually Luxemburg"
}
ok: [localhost] => (item=('nl', 'Netherlands')) => {
    "item": [
        "nl", 
        "Netherlands"
    ], 
    "msg": "Country code NL is actually Netherlands"
}

TASK [Template Europe] *****************************************************************************
ok: [localhost]

TASK [debug] ***************************************************************************************
ok: [localhost] => (item=('nl', 'Netherlands')) => {
    "item": [
        "nl", 
        "Netherlands"
    ], 
    "msg": "Hello from nl a.k.a. Netherlands"
}

PLAY RECAP *****************************************************************************************
localhost                  : ok=4    changed=0    unreachable=0    failed=0   

```

#### template output

```
  ES is actually Spain
  FR is actually France
  LU is actually Luxemburg
  NL is actually Netherlands
```

