### PR TITLE
route53: `value` may not be specified; default to empty list instead of None - fixes #24471

### DIFF
--- a/lib/ansible/modules/cloud/amazon/route53.py
+++ b/lib/ansible/modules/cloud/amazon/route53.py
@@ -411,7 +411,7 @@ def main():
         alias=dict(required=False, type='bool'),
         alias_hosted_zone_id=dict(required=False),
         alias_evaluate_target_health=dict(required=False, type='bool', default=False),
-        value=dict(required=False, type='list'),
+        value=dict(required=False, type='list', default=[]),
         overwrite=dict(required=False, type='bool'),
         retry_interval=dict(required=False, default=500),
         private_zone=dict(required=False, type='bool', default=False),
@@ -565,7 +565,7 @@ def main():
 
     if command_in == 'get':
         if type_in == 'NS':
-            ns = record['values']
+            ns = record.get('values', [])
         else:
             # Retrieve name servers associated to the zone.
             z = invoke_with_throttling_retries(conn.get_zone, zone_in)


### PR DESCRIPTION
##### SUMMARY
Updates value to default to an empty list. On line [516](https://github.com/ansible/ansible/compare/devel...s-hertel:route53_get?expand=1#diff-ee65e55980e15661bf789266142f496cL516) the value of the option `value` is iterated over. Broken in #23156. Fixes #24471

Also allowed the results from `get` to be empty without failing.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/route53.py

##### ANSIBLE VERSION
```
2.4.0
```