### PR TITLE
Allows for stringification of the host class

### DIFF
--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -93,7 +93,7 @@ class Host:
             self._uuid = get_unique_id()
         self.implicit = False
 
-    def __repr__(self):
+    def __str__(self):
         return "Host(name='{0}')".format(self.get_name())
 
     def get_name(self):

--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -94,7 +94,7 @@ class Host:
         self.implicit = False
 
     def __repr__(self):
-        return self.get_name()
+        return "Host(name='{0}')".format(self.get_name())
 
     def get_name(self):
         return self.name

--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -94,7 +94,7 @@ class Host:
         self.implicit = False
 
     def __str__(self):
-        return "Host(name='{0}')".format(self.get_name())
+        return '%s' % self.get_name()
 
     def get_name(self):
         return self.name


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
First and foremost, this removes the possibility of `__repr__` returning None (Fixes #24545).

Secondly it changes `__repr__` to `__str__` since the returned string has always been a casual representation of the host, which fits the [definition of `__str__`](https://docs.python.org/2/reference/datamodel.html#object.__str__) and not the  [definition of `__repr__`](https://docs.python.org/2/reference/datamodel.html#object.__repr__)

No Python code should be using the output of `__repr__` or `__str__` in their logic, so this change will not break functionality. In the off-chance that they were, they can easily change to use either `get_name()` or the `name` attribute directly, which will return the same string functionality they've been expecting.

If there is code that relying on the TypeError raised by this issue, then may the [Flying Spaghetti Monster](https://en.wikipedia.org/wiki/Flying_Spaghetti_Monster) have mercy on them.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
Ansible

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```

##### ADDITIONAL INFORMATION
See #24545 for more details.