### PR TITLE
Fixes Cobbler inventory script to ignore hosts with `dns_name is None

### DIFF
--- a/contrib/inventory/cobbler.py
+++ b/contrib/inventory/cobbler.py
@@ -190,7 +190,7 @@ class CobblerInventory(object):
                         if this_dns_name is not None and this_dns_name is not "":
                             dns_name = this_dns_name
 
-            if dns_name == '':
+            if dns_name == '' or dns_name is None:
                 continue
 
             status = host['status']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Also catch the case where dns_name is still None.
This can occur when the interfaces for the system are all static interfaces, (but not management interfaces). 

Fix #24546

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
c:inventory/contrib_script

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION
See #24546 for more details.
