### PR TITLE
Fixes #19766 add support for azure plan

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -452,8 +452,7 @@ try:
                                           StorageProfile, OSProfile, OSDisk, \
                                           VirtualHardDisk, ImageReference,\
                                           NetworkProfile, LinuxConfiguration, \
-                                          SshConfiguration, SshPublicKey, \
-                                          Plan
+                                          SshConfiguration, SshPublicKey
     from azure.mgmt.network.models import PublicIPAddress, NetworkSecurityGroup, NetworkInterface, \
                                           NetworkInterfaceIPConfiguration, Subnet
     from azure.mgmt.storage.models import StorageAccountCreateParameters, Sku
@@ -494,7 +493,6 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
             ssh_password_enabled=dict(type='bool', default=True),
             ssh_public_keys=dict(type='list'),
             image=dict(type='dict'),
-            plan=dict(type='dict'),
             storage_account_name=dict(type='str', aliases=['storage_account']),
             storage_container_name=dict(type='str', aliases=['storage_container'], default='vhds'),
             storage_blob_name=dict(type='str', aliases=['storage_blob']),
@@ -527,7 +525,6 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
         self.ssh_password_enabled = None
         self.ssh_public_keys = None
         self.image = None
-        self.plan = None
         self.storage_account_name = None
         self.storage_container_name = None
         self.storage_blob_name = None
@@ -608,10 +605,6 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                 if self.image['version'] == 'latest':
                     self.image['version'] = image_version.name
                     self.log("Using image version {0}".format(self.image['version']))
-
-            if self.plan:
-                if not self.plan.get('name') or not self.plan.get('product') or not self.plan.get('publisher'):
-                    self.error("parameter error: expecting plan to contain publisher, offer, & a name.")
 
             if not self.storage_blob_name:
                 self.storage_blob_name = self.name + '.vhd'
@@ -744,69 +737,35 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
 
                     nics = [NetworkInterfaceReference(id=id) for id in network_interfaces]
                     vhd = VirtualHardDisk(uri=requested_vhd_uri)
-                    if self.plan:
-                        vm_resource = VirtualMachine(
-                            self.location,
-                            tags=self.tags,
-                            os_profile=OSProfile(
-                                admin_username=self.admin_username,
-                                computer_name=self.short_hostname,
+                    vm_resource = VirtualMachine(
+                        self.location,
+                        tags=self.tags,
+                        os_profile=OSProfile(
+                            admin_username=self.admin_username,
+                            computer_name=self.short_hostname,
+                        ),
+                        hardware_profile=HardwareProfile(
+                            vm_size=self.vm_size
+                        ),
+                        storage_profile=StorageProfile(
+                            os_disk=OSDisk(
+                                self.storage_blob_name,
+                                vhd,
+                                DiskCreateOptionTypes.from_image,
+                                caching=self.os_disk_caching,
                             ),
-                            hardware_profile=HardwareProfile(
-                                vm_size=self.vm_size
+                            image_reference=ImageReference(
+                                publisher=self.image['publisher'],
+                                offer=self.image['offer'],
+                                sku=self.image['sku'],
+                                version=self.image['version'],
                             ),
-                            plan=Plan(
-                                name=self.plan['name'],
-                                publisher=self.plan['publisher'],
-                                product=self.plan['product'],
-                            ),
-                            storage_profile=StorageProfile(
-                                os_disk=OSDisk(
-                                    self.storage_blob_name,
-                                    vhd,
-                                    DiskCreateOptionTypes.from_image,
-                                    caching=self.os_disk_caching,
-                                ),
-                                image_reference=ImageReference(
-                                    publisher=self.image['publisher'],
-                                    offer=self.image['offer'],
-                                    sku=self.image['sku'],
-                                    version=self.image['version'],
-                                ),
-                            ),
-                            network_profile=NetworkProfile(
-                                network_interfaces=nics
-                            ),
-                        )
-                    else:
-                        vm_resource = VirtualMachine(
-                            self.location,
-                            tags=self.tags,
-                            os_profile=OSProfile(
-                                admin_username=self.admin_username,
-                                computer_name=self.short_hostname,
-                            ),
-                            hardware_profile=HardwareProfile(
-                                vm_size=self.vm_size
-                            ),
-                            storage_profile=StorageProfile(
-                                os_disk=OSDisk(
-                                    self.storage_blob_name,
-                                    vhd,
-                                    DiskCreateOptionTypes.from_image,
-                                    caching=self.os_disk_caching,
-                                ),
-                                image_reference=ImageReference(
-                                    publisher=self.image['publisher'],
-                                    offer=self.image['offer'],
-                                    sku=self.image['sku'],
-                                    version=self.image['version'],
-                                ),
-                            ),
-                            network_profile=NetworkProfile(
-                                network_interfaces=nics
-                            ),
-                        )
+                        ),
+                        network_profile=NetworkProfile(
+                            network_interfaces=nics
+                        ),
+                    )
+
                     if self.admin_password:
                         vm_resource.os_profile.admin_password = self.admin_password
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #19766 
There was previously no support for the (sometimes) necessary Azure VM creation param: `plan`.  
`plan` is necessary when creating a VM with an image obtained via the Azure Marketplace.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ansible\lib\ansible\modules\cloud\azure\azure_rm_virtualmachines.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
