### PR TITLE
Fix python3 traceback in netconf connection plugin

### DIFF
--- a/lib/ansible/module_utils/connection.py
+++ b/lib/ansible/module_utils/connection.py
@@ -72,4 +72,4 @@ def exec_command(module, command):
 
     sf.close()
 
-    return (rc, to_native(stdout), to_native(stderr))
+    return (rc, to_native(stdout, errors='surrogate_or_strict'), to_native(stderr, errors='surrogate_or_strict'))

--- a/lib/ansible/module_utils/netconf.py
+++ b/lib/ansible/module_utils/netconf.py
@@ -25,7 +25,9 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+import traceback
 from contextlib import contextmanager
+
 from xml.etree.ElementTree import Element, SubElement
 from xml.etree.ElementTree import tostring, fromstring
 
@@ -43,7 +45,7 @@ def send_request(module, obj, check_rc=True):
         try:
             error_root = fromstring(err)
         except Exception as e:
-            module.fail_json(msg=to_native(e), out=to_native(out), err=to_native(err), rc=rc)
+            module.fail_json(msg=to_native(e), out=to_native(out), err=to_native(err), rc=rc, exception=traceback.format_exc)
         ### END DEBUGGING: TAKE OUT BEFORE MERGING
         #error_root = fromstring(err)
         fake_parent = Element('root')

--- a/lib/ansible/module_utils/netconf.py
+++ b/lib/ansible/module_utils/netconf.py
@@ -30,6 +30,7 @@ from xml.etree.ElementTree import Element, SubElement
 from xml.etree.ElementTree import tostring, fromstring
 
 from ansible.module_utils.connection import exec_command
+from ansible.module_utils._text impot to_native
 
 
 NS_MAP = {'nc': "urn:ietf:params:xml:ns:netconf:base:1.0"}
@@ -38,7 +39,13 @@ def send_request(module, obj, check_rc=True):
     request = tostring(obj)
     rc, out, err = exec_command(module, request)
     if rc != 0 and check_rc:
-        error_root = fromstring(err)
+        ### DEBUGGING: TAKE OUT BEFORE MERGING
+        try:
+            error_root = fromstring(err)
+        except Exception as e:
+            module.fail_json(msg=to_native(e), out=to_native(out), err=to_native(err), rc=rc)
+        ### END DEBUGGING: TAKE OUT BEFORE MERGING
+        #error_root = fromstring(err)
         fake_parent = Element('root')
         fake_parent.append(error_root)
 

--- a/lib/ansible/module_utils/netconf.py
+++ b/lib/ansible/module_utils/netconf.py
@@ -32,7 +32,7 @@ from xml.etree.ElementTree import Element, SubElement
 from xml.etree.ElementTree import tostring, fromstring
 
 from ansible.module_utils.connection import exec_command
-from ansible.module_utils._text impot to_native
+from ansible.module_utils._text import to_native
 
 
 NS_MAP = {'nc': "urn:ietf:params:xml:ns:netconf:base:1.0"}

--- a/lib/ansible/module_utils/netconf.py
+++ b/lib/ansible/module_utils/netconf.py
@@ -32,7 +32,7 @@ from xml.etree.ElementTree import Element, SubElement
 from xml.etree.ElementTree import tostring, fromstring
 
 from ansible.module_utils.connection import exec_command
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_native, to_bytes
 
 
 NS_MAP = {'nc': "urn:ietf:params:xml:ns:netconf:base:1.0"}

--- a/lib/ansible/module_utils/netconf.py
+++ b/lib/ansible/module_utils/netconf.py
@@ -45,7 +45,19 @@ def send_request(module, obj, check_rc=True):
         try:
             error_root = fromstring(err)
         except Exception as e:
-            module.fail_json(msg=to_native(e), out=to_native(out), err=to_native(err), rc=rc, exception=traceback.format_exc)
+            with open('/tmp/outfile', 'wb') as f:
+                f.write(to_bytes(out, errors='surrogate_then_replace'))
+
+            with open('/tmp/errfile', 'wb') as f:
+                f.write(to_bytes(out, errors='surrogate_then_replace'))
+
+            with open('/tmp/rcfile', 'wb') as f:
+                f.write(to_bytes(rc, errors='surrogate_then_replace'))
+
+            with open('/tmp/traceback_file', 'wb') as f:
+                f.write(to_bytes(traceback.format_exc(), errors='surrogate_then_replace'))
+
+            raise
         ### END DEBUGGING: TAKE OUT BEFORE MERGING
         #error_root = fromstring(err)
         fake_parent = Element('root')


### PR DESCRIPTION
The ncclient API that's being used here requires request is a text
string on Python3 and appears to anticipate a byte string on python2.

This was reported in a comment on #24431:

https://github.com/ansible/ansible/pull/24431#issuecomment-300999221

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/plugins/connection/netconf.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.3
```


##### ADDITIONAL INFORMATION
From the report in https://github.com/ansible/ansible/pull/24431#issuecomment-300999221

> I'll see about setting up some docker containers for testing both on the special case of Arch with Python3 as well as the more common scenario with ansible_python_interpreter = /usr/bin/python3 on Ubuntu.

> With the latest commits:
```
2017-05-12 08:46:03,521 p=6697 u=tjuberg |  Using /home/tjuberg/work/gitlab/bachelor_ansible/ansible.cfg as config file 
2017-05-12 08:46:03,722 p=6697 u=tjuberg |  Loading callback plugin default of type stdout, v2.0 from /home/tjuberg/.local/badger-ansible/lib/ansible/plugins/callback/__init__.py 
2017-05-12 08:46:03,777 p=6697 u=tjuberg |  PLAYBOOK: junos_facts.yml ****************************************************************************************************** 
2017-05-12 08:46:03,777 p=6697 u=tjuberg |  1 plays in junos_facts.yml 
2017-05-12 08:46:03,811 p=6697 u=tjuberg |  PLAY [Get JunOS facts] ********************************************************************************************************* 
2017-05-12 08:46:03,825 p=6697 u=tjuberg |  META: ran handlers 
2017-05-12 08:46:03,827 p=6697 u=tjuberg |  TASK [Gather Junos facts] ****************************************************************************************************** 
2017-05-12 08:46:03,827 p=6697 u=tjuberg |  task path: /home/tjuberg/work/gitlab/bachelor_ansible/junos_facts.yml:9 
2017-05-12 08:46:04,428 p=6706 u=tjuberg |  creating new control socket for host xxx.xxx.xxx.xxx:22 as user ansible 
2017-05-12 08:46:04,428 p=6706 u=tjuberg |  control socket path is /home/tjuberg/.ansible/pc/d930766c35 
2017-05-12 08:46:04,428 p=6706 u=tjuberg |  current working directory is /home/tjuberg/work/gitlab/bachelor_ansible 
2017-05-12 08:46:04,429 p=6706 u=tjuberg |  using connection plugin netconf 
2017-05-12 08:46:04,530 p=6706 u=tjuberg |  network_os is set to junos 
2017-05-12 08:46:04,530 p=6706 u=tjuberg |  ssh connection done, stating ncclient 
2017-05-12 08:46:04,544 ncclient.transport.ssh Connected (version 2.0, client OpenSSH_6.6.1) 
2017-05-12 08:46:04,866 ncclient.transport.ssh Authentication (password) successful! 
2017-05-12 08:46:05,019 ncclient.transport.session initialized: session-id=19666 | server_capabilities=<dict_keyiterator object at 0x7f348c13ef48> 
2017-05-12 08:46:05,019 p=6706 u=tjuberg |  ncclient manager object created successfully 
2017-05-12 08:46:05,020 p=6706 u=tjuberg |  connection established to xxx.xxx.xxx.xxx in 0:00:00.590981 
2017-05-12 08:46:05,427 p=6706 u=tjuberg |  incoming request accepted on persistent socket 
2017-05-12 08:46:05,427 p=6706 u=tjuberg |  socket operation is CONTEXT 
2017-05-12 08:46:05,428 p=6706 u=tjuberg |  socket operation is EXEC 
2017-05-12 08:46:05,429 p=6706 u=tjuberg |  socket operation completed with rc 255 
2017-05-12 08:46:05,493 p=6697 u=tjuberg |  open_session() returned 255 b'' b'Traceback (most recent call last):\n  
File "/home/tjuberg/.local/badger-ansible/bin/ansible-connection", line 199, in run\n
(rc, stdout, stderr) = self.conn.exec_command(cmd)\n
File "/home/tjuberg/.local/badger-ansible/lib/ansible/plugins/connection/__init__.py", line 52, in wrapped\n
return func(self, *args, **kwargs)\n
File "/home/tjuberg/.local/badger-ansible/lib/ansible/plugins/connection/netconf.py", line 113, in exec_command\n
req = to_ele(request)\n
File "/home/tjuberg/.local/lib/python3.6/site-packages/ncclient/xml_.py", line 109, in to_ele\n
return x if etree.iselement(x) else etree.fromstring(x.encode(\'UTF-8\'), parser=parser)\n
AttributeError: \'bytes\' object has no attribute \'encode\'\n' 
2017-05-12 08:46:05,495 p=6697 u=tjuberg |  fatal: [trd-gw]: FAILED! => { 
    "changed": false, 
    "failed": true, 
    "msg": "unable to open shell. Please see: https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell", 
    "rc": 255 
} 
2017-05-12 08:46:05,496 p=6697 u=tjuberg |  	to retry, use: --limit @/home/tjuberg/work/gitlab/bachelor_ansible/junos_facts.retry 

2017-05-12 08:46:05,497 p=6697 u=tjuberg |  PLAY RECAP ********************************************************************************************************************* 
2017-05-12 08:46:05,497 p=6697 u=tjuberg |  trd-gw                     : ok=0    changed=0    unreachable=0    failed=1    
2017-05-12 08:46:35,429 p=6706 u=tjuberg |  shutting down control socket, connection was active for 0:00:31.000909 secs 
2017-05-12 08:46:35,430 ncclient.operations.rpc Requesting 'CloseSession' 
```