### PR TITLE
Implement ability to limit module documentation building

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -197,7 +197,7 @@ def generate_parser():
     p.add_option("-v", "--verbose", action='store_true', default=False, help="Verbose")
     p.add_option("-o", "--output-dir", action="store", dest="output_dir", default=None, help="Output directory for module files")
     p.add_option("-I", "--includes-file", action="store", dest="includes_file", default=None, help="Create a file containing list of processed modules")
-    p.add_option("-l", "--limit-to-modules", action="store", dest="limit_to_modules", default="",
+    p.add_option("-l", "--limit-to-modules", action="store", dest="limit_to_modules", default=None,
                  help="Limit building module documentation to comma-separated list of modules. Specify non-existing module name for no modules.")
     p.add_option('-V', action='version', help='Show version number and exit')
     return p
@@ -453,12 +453,10 @@ def main():
     env, template, outputname = jinja2_environment(options.template_dir, options.type)
 
     # Convert passed-in limit_to_modules to None or list of modules.
-    if options.limit_to_modules == "":
-        limit_to_modules = None
-    else:
-        limit_to_modules = [s.lower() for s in options.limit_to_modules.split(",")]
+    if options.limit_to_modules is not None:
+        options.limit_to_modules = [s.lower() for s in options.limit_to_modules.split(",")]
 
-    mod_info, categories, aliases = list_modules(options.module_dir, limit_to_modules=limit_to_modules)
+    mod_info, categories, aliases = list_modules(options.module_dir, limit_to_modules=options.limit_to_modules)
     categories['all'] = mod_info
     categories['_aliases'] = aliases
     category_names = [c for c in categories.keys() if not c.startswith('_')]

--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -8,6 +8,10 @@ else
 CPUS ?= $(shell nproc)
 endif
 
+# Assume we are building documentation for all modules unless specified
+# otherwise via environment variable.
+MODULES ?= all
+
 all: docs
 
 docs: clean htmldocs
@@ -44,7 +48,7 @@ keywords: $(FORMATTER) ../templates/playbooks_keywords.rst.j2
 	PYTHONPATH=../../lib $(DUMPER) --template-dir=../templates --output-dir=rst/ -d ./keyword_desc.yml
 
 modules: $(FORMATTER) ../templates/plugin.rst.j2
-	PYTHONPATH=../../lib $(FORMATTER) -t rst --template-dir=../templates --module-dir=../../lib/ansible/modules -o rst/
+	PYTHONPATH=../../lib $(FORMATTER) -t rst --template-dir=../templates --module-dir=../../lib/ansible/modules -o rst/ -l $(MODULES)
 
 staticmin:
 	cat _themes/srtd/static/css/theme.css | sed -e 's/^[ 	]*//g; s/[ 	]*$$//g; s/\([:{;,]\) /\1/g; s/ {/{/g; s/\/\*.*\*\///g; /^$$/d' | sed -e :a -e '$$!N; s/\n\(.\)/\1/; ta' > _themes/srtd/static/css/theme.min.css

--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -10,7 +10,7 @@ endif
 
 # Assume we are building documentation for all modules unless specified
 # otherwise via environment variable.
-MODULES ?= all
+MODULES ?= ""
 
 all: docs
 

--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -8,10 +8,6 @@ else
 CPUS ?= $(shell nproc)
 endif
 
-# Assume we are building documentation for all modules unless specified
-# otherwise via environment variable.
-MODULES ?= ""
-
 all: docs
 
 docs: clean htmldocs
@@ -48,7 +44,12 @@ keywords: $(FORMATTER) ../templates/playbooks_keywords.rst.j2
 	PYTHONPATH=../../lib $(DUMPER) --template-dir=../templates --output-dir=rst/ -d ./keyword_desc.yml
 
 modules: $(FORMATTER) ../templates/plugin.rst.j2
-	PYTHONPATH=../../lib $(FORMATTER) -t rst --template-dir=../templates --module-dir=../../lib/ansible/modules -o rst/ -l $(MODULES)
+# Limit building of module documentation if requested.
+ifdef MODULES
+	PYTHONPATH=../../lib $(FORMATTER) -t rst --template-dir=../templates --module-dir=../../lib/ansible/modules -o rst/ -l $(MODULES)	
+else
+	PYTHONPATH=../../lib $(FORMATTER) -t rst --template-dir=../templates --module-dir=../../lib/ansible/modules -o rst/
+endif
 
 staticmin:
 	cat _themes/srtd/static/css/theme.css | sed -e 's/^[ 	]*//g; s/[ 	]*$$//g; s/\([:{;,]\) /\1/g; s/ {/{/g; s/\/\*.*\*\///g; /^$$/d' | sed -e :a -e '$$!N; s/\n\(.\)/\1/; ta' > _themes/srtd/static/css/theme.min.css

--- a/docs/docsite/README.md
+++ b/docs/docsite/README.md
@@ -17,7 +17,8 @@ html files are in docsite/htmlout/.
 To limit module documentation building to a specific module, run `MODULES=NAME
 make webdocs` instead. This should make testing module documentation syntax much
 faster. Instead of a single module, you can also specify a comma-separated list
-of modules, or keywords `all` and `none`.
+of modules. In order to skip building documentation for all modules, specify
+non-existing module name, for example `MODULES=none make webdocs`.
 
 If you do not want to learn the reStructuredText format, you can also [file issues] about
 documentation problems on the Ansible GitHub project.

--- a/docs/docsite/README.md
+++ b/docs/docsite/README.md
@@ -14,6 +14,11 @@ such as link references, you may install sphinx and build the documentation by r
 To include module documentation you'll need to run `make webdocs` at the top level of the repository.  The generated
 html files are in docsite/htmlout/.
 
+To limit module documentation building to a specific module, run `MODULES=NAME
+make webdocs` instead. This should make testing module documentation syntax much
+faster. Instead of a single module, you can also specify a comma-separated list
+of modules, or keywords `all` and `none`.
+
 If you do not want to learn the reStructuredText format, you can also [file issues] about
 documentation problems on the Ansible GitHub project.
 

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -338,6 +338,13 @@ Put your completed module file into the ``lib/ansible/modules/$CATEGORY/`` direc
 run the command: ``make webdocs``. The new 'modules.html' file will be
 built in the ``docs/docsite/_build/html/$MODULENAME_module.html`` directory.
 
+In order to limit module documentation building to the module you are working on
+(and therefore speeding the build process by quite a bit), run the command:
+``MODULES=$MODULENAME make webdocs``. The ``MODULES`` environment variable
+accepts a comma-separated list of module names, or special keywords ``all`` (for
+building documentation for all modules) and ``none`` (for skipping the module
+documentation building process entirely).
+
 To test your documentation against your ``argument_spec`` you can use ``validate-modules``. Note that this option isn't currently enabled in Shippable due to the time it takes to run.
 
 .. code-block:: bash

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -341,9 +341,9 @@ built in the ``docs/docsite/_build/html/$MODULENAME_module.html`` directory.
 In order to limit module documentation building to the module you are working on
 (and therefore speeding the build process by quite a bit), run the command:
 ``MODULES=$MODULENAME make webdocs``. The ``MODULES`` environment variable
-accepts a comma-separated list of module names, or special keywords ``all`` (for
-building documentation for all modules) and ``none`` (for skipping the module
-documentation building process entirely).
+accepts a comma-separated list of module names. In order to skip building
+documentation for all modules, specify non-existing module name, for example
+``MODULES=none make webdocs``.
 
 To test your documentation against your ``argument_spec`` you can use ``validate-modules``. Note that this option isn't currently enabled in Shippable due to the time it takes to run.
 

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -338,11 +338,11 @@ Put your completed module file into the ``lib/ansible/modules/$CATEGORY/`` direc
 run the command: ``make webdocs``. The new 'modules.html' file will be
 built in the ``docs/docsite/_build/html/$MODULENAME_module.html`` directory.
 
-In order to limit module documentation building to the module you are working on
-(and therefore speeding the build process by quite a bit), run the command:
+In order to speed up the build process, you can limit the documentation build to 
+only include modules you specify, or no modules at all. To do this, run the command:
 ``MODULES=$MODULENAME make webdocs``. The ``MODULES`` environment variable
-accepts a comma-separated list of module names. In order to skip building
-documentation for all modules, specify non-existing module name, for example
+accepts a comma-separated list of module names. To skip building
+documentation for all modules, specify a non-existent module name, for example:
 ``MODULES=none make webdocs``.
 
 To test your documentation against your ``argument_spec`` you can use ``validate-modules``. Note that this option isn't currently enabled in Shippable due to the time it takes to run.


### PR DESCRIPTION
##### SUMMARY

The purpose of this pull request is to introduce option for limiting which module documentation gets built. Implementation achieves this via `MODULES` environment variable that can get passed-in to `make webdocs`.

The reason for this change is to allow both module developers and documentation contributors to more quickly see and test their changes. Building entire documentation for all modules can take quite a while, and it deters from fixing small syntax, typos and similar errors.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Documentation build system

##### ANSIBLE VERSION

```
ansible 2.4.0 (doc_module_selection 7b6dd1f4d0) last updated 2017/05/13 13:43:50 (GMT +200)
  config file = 
  configured module search path = [u'REDACTED', u'/usr/share/ansible/plugins/modules']
  ansible python module location = REDACTED
  executable location = REDACTED
  python version = 2.7.12 (default, Dec 13 2016, 14:29:11) [GCC 4.9.3]
```

##### ADDITIONAL INFORMATION

In order to test the change, you can do the following:

```
cd docs/docsite/

# Build documentation for apt module.
MODULES=apt make webdocs

# Build documentation for a couple of modules.
MODULES=apt,setup,yum make webdocs

# Don't build documentation for modules.
MODULES=none make webdocs

# Build documentation for all modules.
MODULES=all make webdocs
make webdocs
```