### PR TITLE
Fix timeout issue in ansible-connection (#24556)

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -188,7 +188,7 @@ class Server():
                     if not data:
                         break
 
-                    signal.alarm(C.DEFAULT_TIMEOUT)
+                    signal.alarm(self.play_context.timeout)
 
                     rc = 255
                     try:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #24520 ansible-connection needs
to wait on timeout value of play-context
instead of ssh default timeout
(cherry picked from commit 5ec7f401969839da66018b8753edf5caf045fb0c)
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bin/ansible-connection
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
Merged to devel https://github.com/ansible/ansible/pull/24556
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
