### PR TITLE
Add boto3 session cache

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -64,7 +64,7 @@ class JSONFileCache(object):
 
     # This provides a dict like interface that stores JSON serializable objects.
     # The objects are serialized to JSON and stored in a file.  These values can be retrieved at a later time.
-    
+
     CACHE_DIR = os.path.expanduser(os.path.join('~', '.aws', 'cli', 'cache'))
 
     def __init__(self, working_dir=CACHE_DIR):
@@ -150,7 +150,7 @@ def _boto3_conn(conn_type=None, resource=None, region=None, endpoint=None, **par
                          'must specify either both, resource, or client to '
                          'the conn_type parameter in the boto3_conn function '
                          'call')
-    
+
     # Create a session with assume role provider credentials cache
     session = botocore.session.get_session()
     cred_chain = session.get_component('credential_provider')

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -29,8 +29,8 @@
 import os
 import re
 import json
+import datetime
 from time import sleep
-from datetime import datetime
 
 from ansible.module_utils.cloud import CloudRetry
 
@@ -86,7 +86,7 @@ class JSONFileCache(object):
     def __setitem__(self, cache_key, value):
         full_key = self._convert_cache_key(cache_key)
         try:
-            file_content = json.dumps(value, default=lambda d: d.isoformat() if isinstance(d, datetime) else d)
+            file_content = json.dumps(value, default=lambda d: d.isoformat() if isinstance(d, datetime.datetime) else d)
         except (TypeError, ValueError):
             raise ValueError("Value cannot be cached, must be "
                              "JSON serializable: %s" % value)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR provides a session cache for boto3 assume role provider.

This is useful if you use AWS CLI profiles locally and use MFA when running Ansible locally, and don't want to have to input your MFA token each time you run your playbook.

Note that this cache is only invoked if boto3 invokes the assume-role provider, hence it does not affect operation if you have configured AWS credentials that don't require role assumption.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ec2 utils

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file =
  configured module search path = [u'/Users/jmenga/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before this PR:
```
$ ansible-playbook site.yml 
PLAY [Test Play]

TASK [Execute a boto3 based module] ***************************************
Enter MFA code: *****
ok: [localhost]

PLAY RECAP ************************************************************************************
localhost                     : ok=1   changed=1    unreachable=0    failed=0

# Re-running the playbook requires you to enter your MFA token every time
$ ansible-playbook site.yml 
PLAY [Test Play]

TASK [Execute a boto3 based module] ***************************************
Enter MFA code: *****
ok: [localhost]

PLAY RECAP ************************************************************************************
localhost                     : ok=1   changed=1    unreachable=0    failed=0
```

After this PR:
```
$ ansible-playbook site.yml 
PLAY [Test Play]

TASK [Execute a boto3 based module] ***************************************
Enter MFA code: *****
ok: [localhost]

PLAY RECAP ************************************************************************************
localhost                     : ok=1   changed=1    unreachable=0    failed=0

# We can now run the playbook without MFA for up to the temporary session credential lifetime (typically one hour)
$ ansible-playbook site.yml 
PLAY [Test Play]

TASK [Execute a boto3 based module] ***************************************
ok: [localhost]

PLAY RECAP ************************************************************************************
localhost                     : ok=1   changed=1    unreachable=0    failed=0
```