### PR TITLE
Fix for Windows Server 2008/2008 R2

### DIFF
--- a/examples/scripts/upgrade_to_ps3.ps1
+++ b/examples/scripts/upgrade_to_ps3.ps1
@@ -112,5 +112,9 @@ else
 $FileName = $DownLoadUrl.Split('/')[-1]
 download-file $downloadurl "$powershellpath\$filename"
 
-Start-Process -FilePath "$powershellpath\$filename" -ArgumentList /quiet
+# Extraction is needed if run remotely: https://support.microsoft.com/en-us/help/2773898/
+
+Start-Process wusa.exe "$powershellpath\$filename /extract:$powershellpath"
+$filenamecab = (Get-Item $powershellpath\$filename).Basename
+Start-Process dism.exe "/online /add-package /PackagePath:$powershellpath\$filenamecab.cab /quiet"
 Write-HostLog "Installing Powershell 3.0 (with reboot)"

--- a/examples/scripts/upgrade_to_ps3.ps1
+++ b/examples/scripts/upgrade_to_ps3.ps1
@@ -43,7 +43,7 @@ If ([System.Diagnostics.EventLog]::Exists('Application') -eq $False -or [System.
 
 if ($PSVersionTable.psversion.Major -ge 3)
 {
-    Write-LogOutput "Powershell 3 Installed already; You don't need this"
+    Write-HostLog "Powershell 3 Installed already; You don't need this"
     Exit
 }
 
@@ -69,7 +69,7 @@ if (!(test-path $powershellpath))
     $FileName = $DownLoadUrl.Split('/')[-1]
     download-file $downloadurl "$powershellpath\$filename"
     Start-Process -FilePath "$powershellpath\$filename" -Wait -ArgumentList '/quiet','/norestart'
-    Write-LogOutput ".NET Framework 4.5 is installed."
+    Write-HostLog ".NET Framework 4.5 is installed."
 }
 
 }
@@ -77,7 +77,7 @@ if (!(test-path $powershellpath))
 # If the Operating System is above 6.2, then you already have PowerShell Version > 3
 if ([Environment]::OSVersion.Version.Major -gt 6)
 {
-    Write-LogOutput "OS is new; upgrade not needed."
+    Write-HostLog "OS is new; upgrade not needed."
     Exit
 }
 
@@ -113,4 +113,4 @@ $FileName = $DownLoadUrl.Split('/')[-1]
 download-file $downloadurl "$powershellpath\$filename"
 
 Start-Process -FilePath "$powershellpath\$filename" -ArgumentList /quiet
-Write-LogOutput "Installing Powershell 3.0 (with reboot)"
+Write-HostLog "Installing Powershell 3.0 (with reboot)"

--- a/examples/scripts/upgrade_to_ps3.ps1
+++ b/examples/scripts/upgrade_to_ps3.ps1
@@ -48,9 +48,8 @@ if (($PSVersionTable.CLRVersion.Major) -lt 3)
     $FileName = $DownLoadUrl.Split('/')[-1]
     download-file $downloadurl "$powershellpath\$filename"
     ."$powershellpath\$filename" /quiet /norestart
+    write-host ".NET Framework 4.5 is installed, please reboot and run this script again."
 }
-
-#You may need to reboot after the .NET install if so just run the script again.
 
 # If the Operating System is above 6.2, then you already have PowerShell Version > 3
 if ([Environment]::OSVersion.Version.Major -gt 6)

--- a/examples/scripts/upgrade_to_ps3.ps1
+++ b/examples/scripts/upgrade_to_ps3.ps1
@@ -46,7 +46,7 @@ if (!(test-path $powershellpath))
     $FileName = $DownLoadUrl.Split('/')[-1]
     download-file $downloadurl "$powershellpath\$filename"
     Start-Process -FilePath "$powershellpath\$filename" -Wait -ArgumentList '/quiet','/norestart'
-    write-host ".NET Framework 4.5 is installed, please reboot and run this script again."
+    write-host ".NET Framework 4.5 is installed."
 }
 
 }
@@ -90,3 +90,4 @@ $FileName = $DownLoadUrl.Split('/')[-1]
 download-file $downloadurl "$powershellpath\$filename"
 
 Start-Process -FilePath "$powershellpath\$filename" -ArgumentList /quiet
+write-host "Installing Powershell 3.0 (with reboot)"

--- a/examples/scripts/upgrade_to_ps3.ps1
+++ b/examples/scripts/upgrade_to_ps3.ps1
@@ -24,6 +24,12 @@ Function Write-LogOutput
     Write-host $Message
 }
 
+$EventSource = $MyInvocation.MyCommand.Name
+If (-Not $EventSource)
+{
+    $EventSource = "Powershell CLI"
+}
+
 if ($PSVersionTable.psversion.Major -ge 3)
 {
     Write-LogOutput "Powershell 3 Installed already; You don't need this"

--- a/examples/scripts/upgrade_to_ps3.ps1
+++ b/examples/scripts/upgrade_to_ps3.ps1
@@ -45,7 +45,7 @@ if (!(test-path $powershellpath))
     $DownloadUrl = "http://download.microsoft.com/download/B/A/4/BA4A7E71-2906-4B2D-A0E1-80CF16844F5F/dotNetFx45_Full_x86_x64.exe"
     $FileName = $DownLoadUrl.Split('/')[-1]
     download-file $downloadurl "$powershellpath\$filename"
-    Start-Process -FilePath "$powershellpath\$filename" -Wait /quiet /norestart
+    Start-Process -FilePath "$powershellpath\$filename" -Wait -ArgumentList /quiet /norestart
     write-host ".NET Framework 4.5 is installed, please reboot and run this script again."
 }
 

--- a/examples/scripts/upgrade_to_ps3.ps1
+++ b/examples/scripts/upgrade_to_ps3.ps1
@@ -36,7 +36,7 @@ function download-file
 
 if (!(test-path $powershellpath))
 {
-    New-Item -ItemType directory -Path $powershellpath
+    New-Item -ItemType directory -Path $powershellpath | Out-Null
 }
 
 

--- a/examples/scripts/upgrade_to_ps3.ps1
+++ b/examples/scripts/upgrade_to_ps3.ps1
@@ -34,21 +34,21 @@ function download-file
     $client.downloadfile($path, $local)
 }
 
-if (!(test-path $powershellpath))
-{
-    New-Item -ItemType directory -Path $powershellpath | Out-Null
-}
-
-
 # .NET Framework 4.0 is necessary.
 
 if (($PSVersionTable.CLRVersion.Major) -lt 3)
 {
+
+if (!(test-path $powershellpath))
+{
+    New-Item -ItemType directory -Path $powershellpath | Out-Null
     $DownloadUrl = "http://download.microsoft.com/download/B/A/4/BA4A7E71-2906-4B2D-A0E1-80CF16844F5F/dotNetFx45_Full_x86_x64.exe"
     $FileName = $DownLoadUrl.Split('/')[-1]
     download-file $downloadurl "$powershellpath\$filename"
     ."$powershellpath\$filename" /quiet /norestart
     write-host ".NET Framework 4.5 is installed, please reboot and run this script again."
+}
+
 }
 
 # If the Operating System is above 6.2, then you already have PowerShell Version > 3

--- a/examples/scripts/upgrade_to_ps3.ps1
+++ b/examples/scripts/upgrade_to_ps3.ps1
@@ -17,10 +17,16 @@
 # 6.2 is 2012
 # 6.3 is 2012 R2
 
+Function Write-LogOutput
+{
+    $Message = $args[0]
+    Write-EventLog -LogName Application -Source $EventSource -EntryType Information -EventId 1 -Message $Message
+    Write-host $Message
+}
 
 if ($PSVersionTable.psversion.Major -ge 3)
 {
-    write-host "Powershell 3 Installed already; You don't need this"
+    Write-LogOutput "Powershell 3 Installed already; You don't need this"
     Exit
 }
 
@@ -46,7 +52,7 @@ if (!(test-path $powershellpath))
     $FileName = $DownLoadUrl.Split('/')[-1]
     download-file $downloadurl "$powershellpath\$filename"
     Start-Process -FilePath "$powershellpath\$filename" -Wait -ArgumentList '/quiet','/norestart'
-    write-host ".NET Framework 4.5 is installed."
+    Write-LogOutput ".NET Framework 4.5 is installed."
 }
 
 }
@@ -54,7 +60,7 @@ if (!(test-path $powershellpath))
 # If the Operating System is above 6.2, then you already have PowerShell Version > 3
 if ([Environment]::OSVersion.Version.Major -gt 6)
 {
-    write-host "OS is new; upgrade not needed."
+    Write-LogOutput "OS is new; upgrade not needed."
     Exit
 }
 
@@ -90,4 +96,4 @@ $FileName = $DownLoadUrl.Split('/')[-1]
 download-file $downloadurl "$powershellpath\$filename"
 
 Start-Process -FilePath "$powershellpath\$filename" -ArgumentList /quiet
-write-host "Installing Powershell 3.0 (with reboot)"
+Write-LogOutput "Installing Powershell 3.0 (with reboot)"

--- a/examples/scripts/upgrade_to_ps3.ps1
+++ b/examples/scripts/upgrade_to_ps3.ps1
@@ -45,7 +45,7 @@ if (!(test-path $powershellpath))
     $DownloadUrl = "http://download.microsoft.com/download/B/A/4/BA4A7E71-2906-4B2D-A0E1-80CF16844F5F/dotNetFx45_Full_x86_x64.exe"
     $FileName = $DownLoadUrl.Split('/')[-1]
     download-file $downloadurl "$powershellpath\$filename"
-    Start-Process -FilePath "$powershellpath\$filename" -Wait -ArgumentList /quiet /norestart
+    Start-Process -FilePath "$powershellpath\$filename" -Wait -ArgumentList '/quiet','/norestart'
     write-host ".NET Framework 4.5 is installed, please reboot and run this script again."
 }
 

--- a/examples/scripts/upgrade_to_ps3.ps1
+++ b/examples/scripts/upgrade_to_ps3.ps1
@@ -112,5 +112,5 @@ else
 $FileName = $DownLoadUrl.Split('/')[-1]
 download-file $downloadurl "$powershellpath\$filename"
 
-Start-Process -FilePath "$powershellpath\$filename" -ArgumentList /quiet -Verb runAs
+Start-Process -FilePath "$powershellpath\$filename" -ArgumentList /quiet
 Write-HostLog "Installing Powershell 3.0 (with reboot)"

--- a/examples/scripts/upgrade_to_ps3.ps1
+++ b/examples/scripts/upgrade_to_ps3.ps1
@@ -112,5 +112,5 @@ else
 $FileName = $DownLoadUrl.Split('/')[-1]
 download-file $downloadurl "$powershellpath\$filename"
 
-Start-Process -FilePath "$powershellpath\$filename" -Verb runAs -ArgumentList /quiet
+Start-Process -FilePath "$powershellpath\$filename" -ArgumentList /quiet -Verb runAs
 Write-HostLog "Installing Powershell 3.0 (with reboot)"

--- a/examples/scripts/upgrade_to_ps3.ps1
+++ b/examples/scripts/upgrade_to_ps3.ps1
@@ -42,13 +42,13 @@ if (!(test-path $powershellpath))
 
 # .NET Framework 4.0 is necessary.
 
-#if (($PSVersionTable.CLRVersion.Major) -lt 2)
-#{
-#    $DownloadUrl = "http://download.microsoft.com/download/B/A/4/BA4A7E71-2906-4B2D-A0E1-80CF16844F5F/dotNetFx45_Full_x86_x64.exe"
-#    $FileName = $DownLoadUrl.Split('/')[-1]
-#    download-file $downloadurl "$powershellpath\$filename"
-#    ."$powershellpath\$filename" /quiet /norestart
-#}
+if (($PSVersionTable.CLRVersion.Major) -lt 3)
+{
+    $DownloadUrl = "http://download.microsoft.com/download/B/A/4/BA4A7E71-2906-4B2D-A0E1-80CF16844F5F/dotNetFx45_Full_x86_x64.exe"
+    $FileName = $DownLoadUrl.Split('/')[-1]
+    download-file $downloadurl "$powershellpath\$filename"
+    ."$powershellpath\$filename" /quiet /norestart
+}
 
 #You may need to reboot after the .NET install if so just run the script again.
 

--- a/examples/scripts/upgrade_to_ps3.ps1
+++ b/examples/scripts/upgrade_to_ps3.ps1
@@ -112,5 +112,5 @@ else
 $FileName = $DownLoadUrl.Split('/')[-1]
 download-file $downloadurl "$powershellpath\$filename"
 
-Start-Process -FilePath "$powershellpath\$filename" -ArgumentList /quiet
+Start-Process -FilePath "$powershellpath\$filename" -Verb runAs -ArgumentList /quiet
 Write-HostLog "Installing Powershell 3.0 (with reboot)"

--- a/examples/scripts/upgrade_to_ps3.ps1
+++ b/examples/scripts/upgrade_to_ps3.ps1
@@ -17,17 +17,28 @@
 # 6.2 is 2012
 # 6.3 is 2012 R2
 
-Function Write-LogOutput
+Function Write-Log
 {
     $Message = $args[0]
     Write-EventLog -LogName Application -Source $EventSource -EntryType Information -EventId 1 -Message $Message
-    Write-host $Message
+}
+
+Function Write-HostLog
+{
+    $Message = $args[0]
+    Write-Host $Message
+    Write-Log $Message
 }
 
 $EventSource = $MyInvocation.MyCommand.Name
 If (-Not $EventSource)
 {
     $EventSource = "Powershell CLI"
+}
+
+If ([System.Diagnostics.EventLog]::Exists('Application') -eq $False -or [System.Diagnostics.EventLog]::SourceExists($EventSource) -eq $False)
+{
+    New-EventLog -LogName Application -Source $EventSource
 }
 
 if ($PSVersionTable.psversion.Major -ge 3)

--- a/examples/scripts/upgrade_to_ps3.ps1
+++ b/examples/scripts/upgrade_to_ps3.ps1
@@ -45,7 +45,7 @@ if (!(test-path $powershellpath))
     $DownloadUrl = "http://download.microsoft.com/download/B/A/4/BA4A7E71-2906-4B2D-A0E1-80CF16844F5F/dotNetFx45_Full_x86_x64.exe"
     $FileName = $DownLoadUrl.Split('/')[-1]
     download-file $downloadurl "$powershellpath\$filename"
-    ."$powershellpath\$filename" /quiet /norestart
+    Start-Process -FilePath "$powershellpath\$filename" -Wait /quiet /norestart
     write-host ".NET Framework 4.5 is installed, please reboot and run this script again."
 }
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes Powershell upgrade for Windows Server 2008/R2 : re-enabling .NET Framework requirement, raising PS version detection, adding some logs.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
upgrade_to_ps3.ps1
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
