### PR TITLE
Fix UnboundLocalError in basic.py

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1999,7 +1999,7 @@ class AnsibleModule(object):
                     else:
                         self.deprecate(d)
             else:
-                self.deprecate(d)
+                self.deprecate(kwargs['deprecations'])
 
         if self._deprecations:
             kwargs['deprecations'] = self._deprecations

--- a/test/units/module_utils/basic/test_deprecate_warn.py
+++ b/test/units/module_utils/basic/test_deprecate_warn.py
@@ -69,3 +69,21 @@ class TestAnsibleModuleWarnDeprecate(unittest.TestCase):
                     {u'msg': u'deprecation4', u'version': '2.4'},
                 ])
 
+    def test_deprecate_without_list(self):
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={}))
+        with swap_stdin_and_argv(stdin_data=args):
+            with swap_stdout():
+
+                ansible.module_utils.basic._ANSIBLE_ARGS = None
+                am = ansible.module_utils.basic.AnsibleModule(
+                    argument_spec = dict(),
+                )
+                am._name = 'unittest'
+
+                with self.assertRaises(SystemExit):
+                    am.exit_json(deprecations='Simple deprecation warning')
+                output = json.loads(sys.stdout.getvalue())
+                self.assertTrue('warnings' not in output or output['warnings'] == [])
+                self.assertEquals(output['deprecations'], [
+                    {u'msg': u'Simple deprecation warning', u'version': None},
+                ])


### PR DESCRIPTION
##### SUMMARY
* Fix for UnboundLocalError while accessing deprecations in result
* Add Unit test

Fixes #24592

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py
test/units/module_utils/basic/test_deprecate_warn.py

##### ANSIBLE VERSION
```
2.4 devel
```