### PR TITLE
Added property validate_certs

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix_group.py
+++ b/lib/ansible/modules/monitoring/zabbix_group.py
@@ -55,6 +55,12 @@ options:
         required: false
         default: None
         version_added: "2.1"
+    validate_certs:
+        description:
+            - If False, SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
+        required: false
+        default: True
+        version_added: "2.4"
     state:
         description:
             - Create or delete host group.
@@ -163,6 +169,7 @@ def main():
             login_password=dict(type='str', required=True, no_log=True),
             http_login_user=dict(type='str',required=False, default=None),
             http_login_password=dict(type='str',required=False, default=None, no_log=True),
+            validate_certs=dict(type='bool',required=False, default=True),
             host_groups=dict(type='list', required=True, aliases=['host_group']),
             state=dict(default="present", choices=['present','absent']),
             timeout=dict(type='int', default=10)
@@ -178,6 +185,7 @@ def main():
     login_password = module.params['login_password']
     http_login_user = module.params['http_login_user']
     http_login_password = module.params['http_login_password']
+    validate_certs = module.params['validate_certs']
     host_groups = module.params['host_groups']
     state = module.params['state']
     timeout = module.params['timeout']
@@ -186,7 +194,8 @@ def main():
 
     # login to zabbix
     try:
-        zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password)
+        zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
+                        validate_certs=validate_certs)
         zbx.login(login_user, login_password)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)

--- a/lib/ansible/modules/monitoring/zabbix_group.py
+++ b/lib/ansible/modules/monitoring/zabbix_group.py
@@ -55,12 +55,6 @@ options:
         required: false
         default: None
         version_added: "2.1"
-    validate_certs:
-        description:
-            - If False, SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-        required: false
-        default: True
-        version_added: "2.4"
     state:
         description:
             - Create or delete host group.
@@ -76,6 +70,10 @@ options:
             - List of host groups to create or delete.
         required: true
         aliases: [ "host_group" ]
+
+extends_documentation_fragment:
+    - validate_certs
+
 notes:
     - Too many concurrent updates to the same group may cause Zabbix to return errors, see examples for a workaround if needed.
 '''

--- a/lib/ansible/modules/monitoring/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix_host.py
@@ -53,6 +53,12 @@ options:
         required: false
         default: None
         version_added: "2.1"
+    validate_certs:
+        description:
+            - If False, SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
+        required: false
+        default: True
+        version_added: "2.4"
     host_name:
         description:
             - Name of the host in Zabbix.
@@ -164,8 +170,8 @@ try:
     class ZabbixAPIExtends(ZabbixAPI):
         hostinterface = None
 
-        def __init__(self, server, timeout, user, passwd, **kwargs):
-            ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd)
+        def __init__(self, server, timeout, user, passwd, validate_certs, **kwargs):
+            ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd, validate_certs=validate_certs)
             self.hostinterface = ZabbixAPISubClass(self, dict({"prefix": "hostinterface"}, **kwargs))
 
     HAS_ZABBIX_API = True
@@ -426,6 +432,7 @@ def main():
             host_name=dict(type='str', required=True),
             http_login_user=dict(type='str', required=False, default=None),
             http_login_password=dict(type='str', required=False, default=None, no_log=True),
+            validate_certs=dict(type='book', required=False, default=True),
             host_groups=dict(type='list', required=False),
             link_templates=dict(type='list', required=False),
             status=dict(default="enabled", choices=['enabled', 'disabled']),
@@ -449,6 +456,7 @@ def main():
     login_password = module.params['login_password']
     http_login_user = module.params['http_login_user']
     http_login_password = module.params['http_login_password']
+    validate_certs = module.params['validate_certs']
     host_name = module.params['host_name']
     visible_name = module.params['visible_name']
     host_groups = module.params['host_groups']
@@ -467,7 +475,8 @@ def main():
     zbx = None
     # login to zabbix
     try:
-        zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password)
+        zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
+                               validate_certs=validate_certs)
         zbx.login(login_user, login_password)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)

--- a/lib/ansible/modules/monitoring/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix_host.py
@@ -53,12 +53,6 @@ options:
         required: false
         default: None
         version_added: "2.1"
-    validate_certs:
-        description:
-            - If False, SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-        required: false
-        default: True
-        version_added: "2.4"
     host_name:
         description:
             - Name of the host in Zabbix.
@@ -122,6 +116,9 @@ options:
         default: "yes"
         choices: [ "yes", "no" ]
         version_added: "2.0"
+
+extends_documentation_fragment:
+    - validate_certs
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/monitoring/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix_host.py
@@ -429,7 +429,7 @@ def main():
             host_name=dict(type='str', required=True),
             http_login_user=dict(type='str', required=False, default=None),
             http_login_password=dict(type='str', required=False, default=None, no_log=True),
-            validate_certs=dict(type='book', required=False, default=True),
+            validate_certs=dict(type='bool', required=False, default=True),
             host_groups=dict(type='list', required=False),
             link_templates=dict(type='list', required=False),
             status=dict(default="enabled", choices=['enabled', 'disabled']),

--- a/lib/ansible/modules/monitoring/zabbix_hostmacro.py
+++ b/lib/ansible/modules/monitoring/zabbix_hostmacro.py
@@ -52,6 +52,12 @@ options:
         required: false
         default: None
         version_added: "2.1"
+    validate_certs:
+        description:
+            - If False, SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
+        required: false
+        default: True
+        version_added: "2.4"
     host_name:
         description:
             - Name of the host.
@@ -177,6 +183,7 @@ def main():
             login_password=dict(type='str', required=True, no_log=True),
             http_login_user=dict(type='str', required=False, default=None),
             http_login_password=dict(type='str', required=False, default=None, no_log=True),
+            validate_certs=dict(type='bool', required=False, default=True),
             host_name=dict(type='str', required=True),
             macro_name=dict(type='str', required=True),
             macro_value=dict(type='str', required=True),
@@ -194,6 +201,7 @@ def main():
     login_password = module.params['login_password']
     http_login_user = module.params['http_login_user']
     http_login_password = module.params['http_login_password']
+    validate_certs = module.params['validate_certs']
     host_name = module.params['host_name']
     macro_name  = (module.params['macro_name']).upper()
     macro_value = module.params['macro_value']
@@ -203,7 +211,8 @@ def main():
     zbx = None
     # login to zabbix
     try:
-        zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password)
+        zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
+                               validate_certs=validate_certs)
         zbx.login(login_user, login_password)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)

--- a/lib/ansible/modules/monitoring/zabbix_hostmacro.py
+++ b/lib/ansible/modules/monitoring/zabbix_hostmacro.py
@@ -52,12 +52,6 @@ options:
         required: false
         default: None
         version_added: "2.1"
-    validate_certs:
-        description:
-            - If False, SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-        required: false
-        default: True
-        version_added: "2.4"
     host_name:
         description:
             - Name of the host.
@@ -82,6 +76,9 @@ options:
         description:
             - The timeout of API request (seconds).
         default: 10
+
+extends_documentation_fragment:
+    - validate_certs
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/monitoring/zabbix_maintenance.py
+++ b/lib/ansible/modules/monitoring/zabbix_maintenance.py
@@ -58,12 +58,6 @@ options:
         required: false
         default: None
         version_added: "2.1"
-    validate_certs:
-        description:
-            - If False, SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-        required: false
-        default: True
-        version_added: "2.4"
     host_names:
         description:
             - Hosts to manage maintenance window for.
@@ -109,6 +103,10 @@ options:
         default: 10
         version_added: "2.1"
         required: false
+
+extends_documentation_fragment:
+    - validate_certs
+
 notes:
     - Useful for setting hosts in maintenance mode before big update,
       and removing maintenance window after update.

--- a/lib/ansible/modules/monitoring/zabbix_maintenance.py
+++ b/lib/ansible/modules/monitoring/zabbix_maintenance.py
@@ -58,6 +58,12 @@ options:
         required: false
         default: None
         version_added: "2.1"
+    validate_certs:
+        description:
+            - If False, SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
+        required: false
+        default: True
+        version_added: "2.4"
     host_names:
         description:
             - Hosts to manage maintenance window for.
@@ -279,6 +285,7 @@ def main():
             host_groups=dict(type='list', required=False, default=None, aliases=['host_group']),
             login_user=dict(type='str', required=True),
             login_password=dict(type='str', required=True, no_log=True),
+            validate_certs=dict(type='bool', required=False, default=True),
             http_login_user=dict(type='str', required=False, default=None),
             http_login_password=dict(type='str', required=False, default=None, no_log=True),
             name=dict(type='str', required=True),
@@ -299,6 +306,7 @@ def main():
     login_password = module.params['login_password']
     http_login_user = module.params['http_login_user']
     http_login_password = module.params['http_login_password']
+    validate_certs = module.params['validate_certs']
     minutes = module.params['minutes']
     name = module.params['name']
     desc = module.params['desc']
@@ -312,7 +320,8 @@ def main():
         maintenance_type = 1
 
     try:
-        zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password)
+        zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
+                        validate_certs=validate_certs)
         zbx.login(login_user, login_password)
     except BaseException as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)

--- a/lib/ansible/modules/monitoring/zabbix_screen.py
+++ b/lib/ansible/modules/monitoring/zabbix_screen.py
@@ -54,12 +54,6 @@ options:
         required: false
         default: None
         version_added: "2.1"
-    validate_certs:
-        description:
-            - If False, SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
-        required: false
-        default: True
-        version_added: "2.4"
     timeout:
         description:
             - The timeout of API request (seconds).
@@ -74,6 +68,10 @@ options:
               The available states are: C(present) (default) and C(absent). If the screen(s) already exists, and the state is not C(absent), the screen(s)
               will just be updated as needed.
         required: true
+
+extends_documentation_fragment:
+    - validate_certs
+
 notes:
     - Too many concurrent updates to the same screen may cause Zabbix to return errors, see examples for a workaround if needed.
 '''

--- a/lib/ansible/modules/monitoring/zabbix_screen.py
+++ b/lib/ansible/modules/monitoring/zabbix_screen.py
@@ -54,6 +54,12 @@ options:
         required: false
         default: None
         version_added: "2.1"
+    validate_certs:
+        description:
+            - If False, SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
+        required: false
+        default: True
+        version_added: "2.4"
     timeout:
         description:
             - The timeout of API request (seconds).
@@ -146,8 +152,8 @@ try:
     class ZabbixAPIExtends(ZabbixAPI):
         screenitem = None
 
-        def __init__(self, server, timeout, user, passwd, **kwargs):
-            ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd)
+        def __init__(self, server, timeout, user, passwd, validate_certs, **kwargs):
+            ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd, validate_certs=validate_certs)
             self.screenitem = ZabbixAPISubClass(self, dict({"prefix": "screenitem"}, **kwargs))
 
     HAS_ZABBIX_API = True
@@ -330,6 +336,7 @@ def main():
             login_password=dict(type='str', required=True, no_log=True),
             http_login_user=dict(type='str', required=False, default=None),
             http_login_password=dict(type='str', required=False, default=None, no_log=True),
+            validate_certs=dict(type='bool', required=False, default=True),
             timeout=dict(type='int', default=10),
             screens=dict(type='list', required=True)
         ),
@@ -344,13 +351,15 @@ def main():
     login_password = module.params['login_password']
     http_login_user = module.params['http_login_user']
     http_login_password = module.params['http_login_password']
+    validate_certs = module.params['validate_certs']
     timeout = module.params['timeout']
     screens = module.params['screens']
 
     zbx = None
     # login to zabbix
     try:
-        zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password)
+        zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password,
+                               validate_certs=validate_certs)
         zbx.login(login_user, login_password)
     except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)

--- a/lib/ansible/utils/module_docs_fragments/validate_certs.py
+++ b/lib/ansible/utils/module_docs_fragments/validate_certs.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2017 Ansible, Inc
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class ModuleDocFragment(object):
+
+    # Standard documentation fragment
+    DOCUMENTATION = '''
+options:
+    validate_certs:
+      required: false
+      description:
+       - If set to False, SSL certificates will not be validated. This should only be used on personally controlled sites using self-signed certificates.
+      default: true
+      choices: ['true', 'false']
+'''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Adding the `validate_certs` option to disable certificate checking when using self signed certificates.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
zabbix_host
zabbix_group
zabbix_hostmacro
zabbix_maintenance
zabbix_screen

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```

##### ADDITIONAL INFORMATION

Adding the `validate_certs` option to disable certificate checking when using self signed certificates.

