### PR TITLE
Fixes #24578: ROLLBACK_COMPLETE is a failure state

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -343,8 +343,10 @@ def stack_operation(cfn, stack_name, operation):
             else:
                 ret.update({'changed': False, 'failed': True, 'output' : 'Stack not found.'})
                 return ret
+        # it covers ROLLBACK_COMPLETE, UPDATE_ROLLBACK_COMPLETE and UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS
+        # Possible states: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-describing-stacks.html#w1ab2c15c17c21c13
         elif stack['StackStatus'].endswith('ROLLBACK_COMPLETE'):
-            ret.update({'changed': True, 'failed' :True, 'output': 'Problem with %s. Rollback complete' % operation})
+            ret.update({'changed': True, 'failed': True, 'output': 'Problem with %s. Rollback complete' % operation})
             return ret
         # note the ordering of ROLLBACK_COMPLETE and COMPLETE, because otherwise COMPLETE will match both cases.
         elif stack['StackStatus'].endswith('_COMPLETE'):

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -343,7 +343,7 @@ def stack_operation(cfn, stack_name, operation):
             else:
                 ret.update({'changed': False, 'failed': True, 'output' : 'Stack not found.'})
                 return ret
-        # it covers ROLLBACK_COMPLETE, UPDATE_ROLLBACK_COMPLETE and UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS
+        # it covers ROLLBACK_COMPLETE and UPDATE_ROLLBACK_COMPLETE
         # Possible states: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-describing-stacks.html#w1ab2c15c17c21c13
         elif stack['StackStatus'].endswith('ROLLBACK_COMPLETE'):
             ret.update({'changed': True, 'failed': True, 'output': 'Problem with %s. Rollback complete' % operation})

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -343,7 +343,7 @@ def stack_operation(cfn, stack_name, operation):
             else:
                 ret.update({'changed': False, 'failed': True, 'output' : 'Stack not found.'})
                 return ret
-        elif stack['StackStatus'].endswith('_ROLLBACK_COMPLETE'):
+        elif stack['StackStatus'].endswith('ROLLBACK_COMPLETE'):
             ret.update({'changed': True, 'failed' :True, 'output': 'Problem with %s. Rollback complete' % operation})
             return ret
         # note the ordering of ROLLBACK_COMPLETE and COMPLETE, because otherwise COMPLETE will match both cases.


### PR DESCRIPTION
##### SUMMARY
Fixes #24578. When CloudFormation fails to create stack and ends up in ROLLBACK_COMPLETED status, should be a failure state for this module.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloudformation

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /Users/jose.armesto/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Feb  7 2017, 22:08:53) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```

