### PR TITLE
Add 'datacenter' keyword arg to secrets.py for GCE dyn inventory

### DIFF
--- a/docs/docsite/rst/guide_gce.rst
+++ b/docs/docsite/rst/guide_gce.rst
@@ -83,7 +83,7 @@ Create a file ``secrets.py`` looking like following, and put it in some folder w
 .. code-block:: python
 
     GCE_PARAMS = ('i...@project.googleusercontent.com', '/path/to/project.json')
-    GCE_KEYWORD_PARAMS = {'project': 'project_id'}
+    GCE_KEYWORD_PARAMS = {'project': 'project_id', 'datacenter': 'gce_zone'}
 
 Ensure to enter the email address from the created services account and not the one from your main account.
 


### PR DESCRIPTION
I setup GCE dynamic inventory for the first time today and gce.py --list failed unless I set 'datacenter' as a keyword argument in secrets.py. I do not have any env variables related to GCE set.

The error in question:
```
de5450-01% ansible-playbook playbooks/home/workstations.yml -D -t remove_me
ERROR! Attempted to execute "/home/hb/git/control-repo/inventory/gce.py" as inventory script: Inventory script (/home/hb/git/control-repo/inventory/gce.py) had an execution error: Traceback (most recent call last):
  File "/home/hb/git/control-repo/inventory/gce.py", line 496, in <module>
    GceInventory()
  File "/home/hb/git/control-repo/inventory/gce.py", line 168, in __init__
    self.driver = self.get_gce_driver()
  File "/home/hb/git/control-repo/inventory/gce.py", line 310, in get_gce_driver
    kwargs['datacenter'] = os.environ.get('GCE_ZONE', kwargs['datacenter'])
KeyError: 'datacenter'
```

Looking at gce.py, I added 'datacenter': 'europe-west1' to GCE_KEYWORD_PARAMS and my inventory works now. I have little experience with GCE, libcloud or this dynamic inventory, so somebody might want to double check what I'm saying here :)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 5cb5228cde) last updated 2017/05/14 11:47:24 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/hb/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/hb/git/ansible/lib/ansible
  executable location = /home/hb/git/ansible/bin/ansible
  python version = 2.7.13 (default, Feb 11 2017, 12:22:40) [GCC 6.3.1 20170109]
```
