### PR TITLE
Set facts type to dict

### DIFF
--- a/lib/ansible/modules/system/puppet.py
+++ b/lib/ansible/modules/system/puppet.py
@@ -162,7 +162,7 @@ def main():
             show_diff=dict(
                 # internal code to work with --diff, do not use
                 default=False, aliases=['show-diff'], type='bool'),
-            facts=dict(default=None),
+            facts=dict(default=None, type='dict'),
             facter_basename=dict(default='ansible'),
             environment=dict(required=False, default=None),
             certname=dict(required=False, default=None),


### PR DESCRIPTION
With newer versions of ansible, module arguments are assumed to
be strings unless otherwise specified.  Our 'facts' argument is
expected to be a dictionary, so tell ansible that.

Without this, the argument will arrive as a string and be written
to the facter file inside string quotes.  Facter will produce the
following error:

  undefined method `each' for #<String:0x000000016ee640>

This was originally fixed and found in the Ansible Puppet role which
is maintained by the OpenStack infrastructure team.

https://github.com/openstack-infra/ansible-role-puppet/commit/8d0f0bfd0a7288b4bdc2782ed2d1dcf626e8a3ba

Cherry-picked from https://github.com/ansible/ansible/pull/24597