### PR TITLE
cloudstack: test: fix setup cs_vpc not using zone

### DIFF
--- a/test/integration/targets/cs_network_acl/aliases
+++ b/test/integration/targets/cs_network_acl/aliases
@@ -1,1 +1,2 @@
 cloud/cs
+posix/ci/cloud/cs

--- a/test/integration/targets/cs_vpc/tasks/main.yml
+++ b/test/integration/targets/cs_vpc/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: setup
   cs_vpc:
     name: "{{ cs_resource_prefix }}_vpc"
+    zone: "{{ cs_common_zone_adv }}"
     state: absent
   register: vpc
 - name: verify setup
@@ -11,6 +12,7 @@
 
 - name: test fail missing name of vpc
   cs_vpc:
+    zone: "{{ cs_common_zone_adv }}"
   ignore_errors: true
   register: vpc
 - name: verify test fail missing name of vpc
@@ -22,6 +24,7 @@
 - name: test fail missing cidr for vpc
   cs_vpc:
     name: "{{ cs_resource_prefix }}_vpc"
+    zone: "{{ cs_common_zone_adv }}"
   ignore_errors: true
   register: vpc
 - name: verify test fail missing cidr for vpc


### PR DESCRIPTION
##### SUMMARY
fix setup vpc not using zone, an existing vpc was not found for the initial setup cleanup. causing it to fail.

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
tests: cs_vpc, cs_network_acl

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


/cc @mattclay 