### PR TITLE
Lookup credential id and pass in credential rather than scm_credential

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
@@ -210,11 +210,13 @@ def main():
             if state == 'present':
                 org_res = tower_cli.get_resource('organization')
                 org = org_res.get(name=organization)
+                cred_res = tower_cli.get_resource('credential')
+                cred = cred_res.get(name=scm_credential)
 
                 result = project.modify(name=name, description=description,
                                         organization=org['id'],
                                         scm_type=scm_type, scm_url=scm_url, local_path=local_path,
-                                        scm_branch=scm_branch, scm_clean=scm_clean, scm_credential=scm_credential,
+                                        scm_branch=scm_branch, scm_clean=scm_clean, credential=cred['id'],
                                         scm_delete_on_update=scm_delete_on_update,
                                         scm_update_on_launch=scm_update_on_launch,
                                         create_on_missing=True)

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
@@ -212,12 +212,12 @@ def main():
                     org_res = tower_cli.get_resource('organization')
                     org = org_res.get(name=organization)
                 except (exc.NotFound) as excinfo:
-                    module.fail_json(msg='Failed to update project, organization not found: {0}'.format(excinfo), changed=False)
+                    module.fail_json(msg='Failed to update project, organization not found: {0}'.format(organization), changed=False)
                 try:
                     cred_res = tower_cli.get_resource('credential')
                     cred = cred_res.get(name=scm_credential)
                 except (exc.NotFound) as excinfo:
-                    module.fail_json(msg='Failed to update project, credential not found: {0}'.format(excinfo), changed=False)
+                    module.fail_json(msg='Failed to update project, credential not found: {0}'.format(scm_credential), changed=False)
 
                 result = project.modify(name=name, description=description,
                                         organization=org['id'],


### PR DESCRIPTION
##### SUMMARY
Fixes issue 24547.

Looks up the credential to get it's ID and passes "credential" to the tower-cli module rather than scm-credential, which was being ignored.   

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Module : tower_project 

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /Users/xxxxxxx/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Mar  3 2017, 11:49:06) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```
- Tower CLI 3.1.3
- Tower 3.1.3

##### ADDITIONAL INFORMATION
N/A