### PR TITLE
Allow setting/unsetting BYPASSRLS Postgres role attribute

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -210,6 +210,8 @@ EXAMPLES = '''
 import re
 import itertools
 
+from distutils.version import StrictVersion
+
 try:
     import psycopg2
     import psycopg2.extras
@@ -219,8 +221,8 @@ else:
     postgresqldb_found = True
 from ansible.module_utils.six import iteritems
 
-_flags = ('SUPERUSER', 'CREATEROLE', 'CREATEUSER', 'CREATEDB', 'INHERIT', 'LOGIN', 'REPLICATION', 'BYPASSRLS')
-VALID_FLAGS = frozenset(itertools.chain(_flags, ('NO%s' % f for f in _flags)))
+_flags = ('SUPERUSER', 'CREATEROLE', 'CREATEUSER', 'CREATEDB', 'INHERIT', 'LOGIN', 'REPLICATION')
+_flags_by_version = {'BYPASSRLS': '9.5.0'}
 
 VALID_PRIVS = dict(table=frozenset(('SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER', 'ALL')),
         database=frozenset(('CREATE', 'CONNECT', 'TEMPORARY', 'TEMP', 'ALL')),
@@ -558,7 +560,7 @@ def grant_privileges(cursor, user, privs):
                 changed = True
     return changed
 
-def parse_role_attrs(role_attr_flags):
+def parse_role_attrs(cursor, role_attr_flags):
     """
     Parse role attributes string for user creation.
     Format:
@@ -572,16 +574,21 @@ def parse_role_attrs(role_attr_flags):
                             "[NO]INHERIT", "[NO]LOGIN", "[NO]REPLICATION",
                             "[NO]BYPASSRLS" ]
 
+    Note: "[NO]BYPASSRLS" role attribute introduced in 9.5
+
     """
+    flags = frozenset(itertools.chain(_flags, get_valid_flags_by_version(cursor)))
+    valid_flags = frozenset(itertools.chain(flags, ('NO%s' % f for f in flags)))
+
     if ',' in role_attr_flags:
         flag_set = frozenset(r.upper() for r in role_attr_flags.split(","))
     elif role_attr_flags:
         flag_set = frozenset((role_attr_flags.upper(),))
     else:
         flag_set = frozenset()
-    if not flag_set.issubset(VALID_FLAGS):
+    if not flag_set.issubset(valid_flags):
         raise InvalidFlagsError('Invalid role_attr_flags specified: %s' %
-                ' '.join(flag_set.difference(VALID_FLAGS)))
+                ' '.join(flag_set.difference(valid_flags)))
     o_flags = ' '.join(flag_set)
     return o_flags
 
@@ -634,6 +641,35 @@ def parse_privs(privs, db):
 
     return o_privs
 
+def get_pg_server_version(cursor):
+    """
+    Queries Postgres for its server version.
+
+    server_version should be just the server version itself:
+
+    postgres=# SHOW SERVER_VERSION;
+    server_version
+    ----------------
+     9.6.2
+    (1 row)
+    """
+    cursor.execute("SHOW SERVER_VERSION")
+    return cursor.fetchone()['server_version']
+
+def get_valid_flags_by_version(cursor):
+    """
+    Some role attributes were introduced after certain versions. We want to
+    compile a list of valid flags against the current Postgres version.
+    """
+    current_version = StrictVersion(get_pg_server_version(cursor))
+
+    return [
+        flag
+        for flag, version_introduced in _flags_by_version.items()
+        if current_version >= StrictVersion(version_introduced)
+    ]
+
+
 # ===========================================
 # Module execution.
 #
@@ -672,11 +708,6 @@ def main():
     privs = parse_privs(module.params["priv"], db)
     port = module.params["port"]
     no_password_changes = module.params["no_password_changes"]
-    try:
-        role_attr_flags = parse_role_attrs(module.params["role_attr_flags"])
-    except InvalidFlagsError:
-        e = get_exception()
-        module.fail_json(msg=str(e))
     if module.params["encrypted"]:
         encrypted = "ENCRYPTED"
     else:
@@ -723,6 +754,12 @@ def main():
     except Exception:
         e = get_exception()
         module.fail_json(msg="unable to connect to database: %s" % e)
+
+    try:
+        role_attr_flags = parse_role_attrs(cursor, module.params["role_attr_flags"])
+    except InvalidFlagsError:
+        e = get_exception()
+        module.fail_json(msg=str(e))
 
     kw = dict(user=user)
     changed = False

--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -103,7 +103,7 @@ options:
     required: false
     default: ""
     choices: [ "[NO]SUPERUSER","[NO]CREATEROLE", "[NO]CREATEUSER", "[NO]CREATEDB",
-                    "[NO]INHERIT", "[NO]LOGIN", "[NO]REPLICATION" ]
+                    "[NO]INHERIT", "[NO]LOGIN", "[NO]REPLICATION", "[NO]BYPASSRLS" ]
   state:
     description:
       - The user (role) state
@@ -219,7 +219,7 @@ else:
     postgresqldb_found = True
 from ansible.module_utils.six import iteritems
 
-_flags = ('SUPERUSER', 'CREATEROLE', 'CREATEUSER', 'CREATEDB', 'INHERIT', 'LOGIN', 'REPLICATION')
+_flags = ('SUPERUSER', 'CREATEROLE', 'CREATEUSER', 'CREATEDB', 'INHERIT', 'LOGIN', 'REPLICATION', 'BYPASSRLS')
 VALID_FLAGS = frozenset(itertools.chain(_flags, ('NO%s' % f for f in _flags)))
 
 VALID_PRIVS = dict(table=frozenset(('SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER', 'ALL')),
@@ -230,7 +230,7 @@ VALID_PRIVS = dict(table=frozenset(('SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRU
 PRIV_TO_AUTHID_COLUMN = dict(SUPERUSER='rolsuper', CREATEROLE='rolcreaterole',
                              CREATEUSER='rolcreateuser', CREATEDB='rolcreatedb',
                              INHERIT='rolinherit', LOGIN='rolcanlogin',
-                             REPLICATION='rolreplication')
+                             REPLICATION='rolreplication', BYPASSRLS='rolbypassrls')
 
 class InvalidFlagsError(Exception):
     pass
@@ -569,7 +569,8 @@ def parse_role_attrs(role_attr_flags):
 
         attributes := CREATEDB,CREATEROLE,NOSUPERUSER,...
         [ "[NO]SUPERUSER","[NO]CREATEROLE", "[NO]CREATEUSER", "[NO]CREATEDB",
-                            "[NO]INHERIT", "[NO]LOGIN", "[NO]REPLICATION" ]
+                            "[NO]INHERIT", "[NO]LOGIN", "[NO]REPLICATION",
+                            "[NO]BYPASSRLS" ]
 
     """
     if ',' in role_attr_flags:

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -268,92 +268,27 @@
     that:
       - "result.changed == False"
 
-- name: Create a user with all role attributes
+# BYPASSRLS role attribute was introduced in Postgres 9.5, so 
+# we want to test atrribute management differently depending
+# on the version. See https://github.com/ansible/ansible/pull/24625
+# for more details.
+- name: Get Postgres version 
   become_user: "{{ pg_user }}"
   become: True
-  postgresql_user:
-    name: "{{ db_user1 }}"
-    state: "present"
-    role_attr_flags: "SUPERUSER,CREATEROLE,CREATEDB,INHERIT,login"
-    login_user: "{{ pg_user }}"
-    db: postgres
+  shell: echo 'SHOW SERVER_VERSION' | psql -d postgres
+  register: postgres_version_resp
 
-- name: Check that the user has the requested role attributes
-  become_user: "{{ pg_user }}"
-  become: True
-  shell: echo "select 'super:'||rolsuper, 'createrole:'||rolcreaterole, 'create:'||rolcreatedb, 'inherit:'||rolinherit, 'login:'||rolcanlogin from pg_roles where rolname='{{ db_user1 }}';" | psql -d postgres
-  register: result
+- name: Print Postgres server version
+  debug:
+    msg: "{{ postgres_version_resp.stdout_lines[-2] | trim }}"
 
-- assert:
-    that:
-      - "result.stdout_lines[-1] == '(1 row)'"
-      - "'super:t' in result.stdout_lines[-2]"
-      - "'createrole:t' in result.stdout_lines[-2]"
-      - "'create:t' in result.stdout_lines[-2]"
-      - "'inherit:t' in result.stdout_lines[-2]"
-      - "'login:t' in result.stdout_lines[-2]"
+- name: Role attribute testing for Postgres 9.5+
+  include: postgresql_user_9.5_or_greater.yml
+  when: (postgres_version_resp.stdout_lines[-2] | trim) | version_compare('9.5.0', '>=')
 
-- name: Modify a user to have no role attributes
-  become_user: "{{ pg_user }}"
-  become: True
-  postgresql_user:
-    name: "{{ db_user1 }}"
-    state: "present"
-    role_attr_flags: "NOSUPERUSER,NOCREATEROLE,NOCREATEDB,noinherit,NOLOGIN"
-    login_user: "{{ pg_user }}"
-    db: postgres
-  register: result
-
-- name: Check that ansible reports it modified the role
-  assert:
-    that:
-      - "result.changed == True"
-
-- name: Check that the user has the requested role attributes
-  become_user: "{{ pg_user }}"
-  become: True
-  shell: echo "select 'super:'||rolsuper, 'createrole:'||rolcreaterole, 'create:'||rolcreatedb, 'inherit:'||rolinherit, 'login:'||rolcanlogin from pg_roles where rolname='{{ db_user1 }}';" | psql -d postgres
-  register: result
-
-- assert:
-    that:
-      - "result.stdout_lines[-1] == '(1 row)'"
-      - "'super:f' in result.stdout_lines[-2]"
-      - "'createrole:f' in result.stdout_lines[-2]"
-      - "'create:f' in result.stdout_lines[-2]"
-      - "'inherit:f' in result.stdout_lines[-2]"
-      - "'login:f' in result.stdout_lines[-2]"
-
-- name: Modify a single role attribute on a user
-  become_user: "{{ pg_user }}"
-  become: True
-  postgresql_user:
-    name: "{{ db_user1 }}"
-    state: "present"
-    role_attr_flags: "LOGIN"
-    login_user: "{{ pg_user }}"
-    db: postgres
-  register: result
-
-- name: Check that ansible reports it modified the role
-  assert:
-    that:
-      - "result.changed == True"
-
-- name: Check that the user has the requested role attributes
-  become_user: "{{ pg_user }}"
-  become: True
-  shell: echo "select 'super:'||rolsuper, 'createrole:'||rolcreaterole, 'create:'||rolcreatedb, 'inherit:'||rolinherit, 'login:'||rolcanlogin  from pg_roles where rolname='{{ db_user1 }}';" | psql -d postgres
-  register: result
-
-- assert:
-    that:
-      - "result.stdout_lines[-1] == '(1 row)'"
-      - "'super:f' in result.stdout_lines[-2]"
-      - "'createrole:f' in result.stdout_lines[-2]"
-      - "'create:f' in result.stdout_lines[-2]"
-      - "'inherit:f' in result.stdout_lines[-2]"
-      - "'login:t' in result.stdout_lines[-2]"
+- name: Role attribute testing for Postgres versions below 9.5 
+  include: postgresql_user_less_than_9.5.yml
+  when: (postgres_version_resp.stdout_lines[-2] | trim) | version_compare('9.5.0', '<')
 
 - name: Cleanup the user
   become_user: "{{ pg_user }}"

--- a/test/integration/targets/postgresql/tasks/postgresql_user_9.5_or_greater.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_user_9.5_or_greater.yml
@@ -1,0 +1,90 @@
+---
+- name: Create a user with all role attributes
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_user:
+    name: "{{ db_user1 }}"
+    state: "present"
+    role_attr_flags: "SUPERUSER,CREATEROLE,CREATEDB,INHERIT,login,BYPASSRLS"
+    login_user: "{{ pg_user }}"
+    db: postgres
+
+- name: Check that the user has the requested role attributes
+  become_user: "{{ pg_user }}"
+  become: True
+  shell: echo "select 'super:'||rolsuper, 'createrole:'||rolcreaterole, 'create:'||rolcreatedb, 'inherit:'||rolinherit, 'login:'||rolcanlogin, 'bypassrls:'||rolbypassrls from pg_roles where rolname='{{ db_user1 }}';" | psql -d postgres
+  register: result
+
+- assert:
+    that:
+      - "result.stdout_lines[-1] == '(1 row)'"
+      - "'super:t' in result.stdout_lines[-2]"
+      - "'createrole:t' in result.stdout_lines[-2]"
+      - "'create:t' in result.stdout_lines[-2]"
+      - "'inherit:t' in result.stdout_lines[-2]"
+      - "'login:t' in result.stdout_lines[-2]"
+      - "'bypassrls:t' in result.stdout_lines[-2]"
+
+- name: Modify a user to have no role attributes
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_user:
+    name: "{{ db_user1 }}"
+    state: "present"
+    role_attr_flags: "NOSUPERUSER,NOCREATEROLE,NOCREATEDB,noinherit,NOLOGIN,NOBYPASSRLS"
+    login_user: "{{ pg_user }}"
+    db: postgres
+  register: result
+
+- name: Check that ansible reports it modified the role
+  assert:
+    that:
+      - "result.changed == True"
+
+- name: Check that the user has the requested role attributes
+  become_user: "{{ pg_user }}"
+  become: True
+  shell: echo "select 'super:'||rolsuper, 'createrole:'||rolcreaterole, 'create:'||rolcreatedb, 'inherit:'||rolinherit, 'login:'||rolcanlogin, 'bypassrls:'||rolbypassrls from pg_roles where rolname='{{ db_user1 }}';" | psql -d postgres
+  register: result
+
+- assert:
+    that:
+      - "result.stdout_lines[-1] == '(1 row)'"
+      - "'super:f' in result.stdout_lines[-2]"
+      - "'createrole:f' in result.stdout_lines[-2]"
+      - "'create:f' in result.stdout_lines[-2]"
+      - "'inherit:f' in result.stdout_lines[-2]"
+      - "'login:f' in result.stdout_lines[-2]"
+      - "'bypassrls:f' in result.stdout_lines[-2]"
+
+- name: Modify a single role attribute on a user
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_user:
+    name: "{{ db_user1 }}"
+    state: "present"
+    role_attr_flags: "LOGIN"
+    login_user: "{{ pg_user }}"
+    db: postgres
+  register: result
+
+- name: Check that ansible reports it modified the role
+  assert:
+    that:
+      - "result.changed == True"
+
+- name: Check that the user has the requested role attributes
+  become_user: "{{ pg_user }}"
+  become: True
+  shell: echo "select 'super:'||rolsuper, 'createrole:'||rolcreaterole, 'create:'||rolcreatedb, 'inherit:'||rolinherit, 'login:'||rolcanlogin, 'bypassrls:'||rolbypassrls  from pg_roles where rolname='{{ db_user1 }}';" | psql -d postgres
+  register: result
+
+- assert:
+    that:
+      - "result.stdout_lines[-1] == '(1 row)'"
+      - "'super:f' in result.stdout_lines[-2]"
+      - "'createrole:f' in result.stdout_lines[-2]"
+      - "'create:f' in result.stdout_lines[-2]"
+      - "'inherit:f' in result.stdout_lines[-2]"
+      - "'login:t' in result.stdout_lines[-2]"
+      - "'bypassrls:f' in result.stdout_lines[-2]"

--- a/test/integration/targets/postgresql/tasks/postgresql_user_less_than_9.5.yml
+++ b/test/integration/targets/postgresql/tasks/postgresql_user_less_than_9.5.yml
@@ -1,0 +1,87 @@
+---
+- name: Create a user with all role attributes
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_user:
+    name: "{{ db_user1 }}"
+    state: "present"
+    role_attr_flags: "SUPERUSER,CREATEROLE,CREATEDB,INHERIT,login"
+    login_user: "{{ pg_user }}"
+    db: postgres
+
+- name: Check that the user has the requested role attributes
+  become_user: "{{ pg_user }}"
+  become: True
+  shell: echo "select 'super:'||rolsuper, 'createrole:'||rolcreaterole, 'create:'||rolcreatedb, 'inherit:'||rolinherit, 'login:'||rolcanlogin from pg_roles where rolname='{{ db_user1 }}';" | psql -d postgres
+  register: result
+
+- assert:
+    that:
+      - "result.stdout_lines[-1] == '(1 row)'"
+      - "'super:t' in result.stdout_lines[-2]"
+      - "'createrole:t' in result.stdout_lines[-2]"
+      - "'create:t' in result.stdout_lines[-2]"
+      - "'inherit:t' in result.stdout_lines[-2]"
+      - "'login:t' in result.stdout_lines[-2]"
+
+- name: Modify a user to have no role attributes
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_user:
+    name: "{{ db_user1 }}"
+    state: "present"
+    role_attr_flags: "NOSUPERUSER,NOCREATEROLE,NOCREATEDB,noinherit,NOLOGIN"
+    login_user: "{{ pg_user }}"
+    db: postgres
+  register: result
+
+- name: Check that ansible reports it modified the role
+  assert:
+    that:
+      - "result.changed == True"
+
+- name: Check that the user has the requested role attributes
+  become_user: "{{ pg_user }}"
+  become: True
+  shell: echo "select 'super:'||rolsuper, 'createrole:'||rolcreaterole, 'create:'||rolcreatedb, 'inherit:'||rolinherit, 'login:'||rolcanlogin from pg_roles where rolname='{{ db_user1 }}';" | psql -d postgres
+  register: result
+
+- assert:
+    that:
+      - "result.stdout_lines[-1] == '(1 row)'"
+      - "'super:f' in result.stdout_lines[-2]"
+      - "'createrole:f' in result.stdout_lines[-2]"
+      - "'create:f' in result.stdout_lines[-2]"
+      - "'inherit:f' in result.stdout_lines[-2]"
+      - "'login:f' in result.stdout_lines[-2]"
+
+- name: Modify a single role attribute on a user
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_user:
+    name: "{{ db_user1 }}"
+    state: "present"
+    role_attr_flags: "LOGIN"
+    login_user: "{{ pg_user }}"
+    db: postgres
+  register: result
+
+- name: Check that ansible reports it modified the role
+  assert:
+    that:
+      - "result.changed == True"
+
+- name: Check that the user has the requested role attributes
+  become_user: "{{ pg_user }}"
+  become: True
+  shell: echo "select 'super:'||rolsuper, 'createrole:'||rolcreaterole, 'create:'||rolcreatedb, 'inherit:'||rolinherit, 'login:'||rolcanlogin  from pg_roles where rolname='{{ db_user1 }}';" | psql -d postgres
+  register: result
+
+- assert:
+    that:
+      - "result.stdout_lines[-1] == '(1 row)'"
+      - "'super:f' in result.stdout_lines[-2]"
+      - "'createrole:f' in result.stdout_lines[-2]"
+      - "'create:f' in result.stdout_lines[-2]"
+      - "'inherit:f' in result.stdout_lines[-2]"
+      - "'login:t' in result.stdout_lines[-2]"


### PR DESCRIPTION
##### SUMMARY
Add the `BYPASSRLS` Postgres role attribute into the list of valid role attributes, allowing for the setting and unsetting of `BYPASSRLS`.

Row security is a feature introduced in Postgres 9.5 that allows for "policies that restrict, on a per-user basis, which rows can be returned by normal queries or inserted, updated, or deleted by data modification commands." There are instances where it would be beneficial for certain roles to bypass row security by setting the `BYPASSRLS` role attribute (or removing the attribute  with `NOBYPASSRLS`).

This simple change allows for the setting or unsetting of the "bypass row security" attribute using `BYPASSRLS` or `NOBYPASSRLS`.

See [the official Postgres Row Security docs](https://www.postgresql.org/docs/9.5/static/ddl-rowsecurity.html) for more details on row security and the BYPASSRLS attribute.

##### ISSUE TYPE
 - Bug Fix

##### COMPONENT NAME
postgresql_user module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.2.0.0
```

#### Output
*Before (with high verbosity)*
```
fatal: [myhost]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "invocation": {
        "module_args": {
            "db": "", 
            "encrypted": false, 
            "expires": null, 
            "fail_on_user": true, 
            "login_host": "", 
            "login_password": "", 
            "login_unix_socket": "", 
            "login_user": "postgres", 
            "name": "<redacted>", 
            "no_password_changes": false, 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": "5432", 
            "priv": null, 
            "role_attr_flags": "BYPASSRLS", 
            "state": "present", 
            "user": "<redacted>"
        }, 
        "module_name": "postgresql_user"
    }, 
    "msg": "Invalid role_attr_flags specified: BYPASSRLS"
}
```

*After (with high verbosity)*
```
changed: [myhost] => {
    "changed": true, 
    "invocation": {
        "module_args": {
            "db": "", 
            "encrypted": false, 
            "expires": null, 
            "fail_on_user": true, 
            "login_host": "", 
            "login_password": "", 
            "login_unix_socket": "", 
            "login_user": "postgres", 
            "name": "<redacted>", 
            "no_password_changes": false, 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": "5432", 
            "priv": null, 
            "role_attr_flags": "BYPASSRLS", 
            "state": "present", 
            "user": "<redacted>"
        }, 
        "module_name": "postgresql_user"
    }, 
    "user": "<redacted>"
}
```
