### PR TITLE
Remove PEP8 compliant files from being skipped

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -17,13 +17,13 @@ import sys
 import os
 
 # pip install sphinx_rtd_theme
-#import sphinx_rtd_theme
-#html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+# import sphinx_rtd_theme
+# html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # If your extensions are in another directory, add it here. If the directory
 # is relative to the documentation root, use os.path.abspath to make it
 # absolute, like shown here.
-#sys.path.append(os.path.abspath('some/directory'))
+# sys.path.append(os.path.abspath('some/directory'))
 #
 sys.path.insert(0, os.path.join('ansible', 'lib'))
 sys.path.append(os.path.abspath('_themes'))
@@ -67,16 +67,16 @@ release = VERSION
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
 today_fmt = '%B %d, %Y'
 
 # List of documents that shouldn't be included in the build.
-#unused_docs = []
+# unused_docs = []
 
 # List of directories, relative to source directories, that shouldn't be
 # searched for source files.
-#exclude_dirs = []
+# exclude_dirs = []
 
 # A list of glob-style patterns that should be excluded when looking
 # for source files.
@@ -84,26 +84,26 @@ exclude_patterns = ['modules']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-#default_role = None
+# default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+# add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
-#show_authors = False
+# show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
 
 highlight_language = 'YAML+Jinja'
 
-#Substitutions, variables, entities, & shortcuts for text which do not need to link to anything.
-#For titles which should be a link, use the intersphinx anchors set at the index, chapter, and section levels, such as  qi_start_:
+# Substitutions, variables, entities, & shortcuts for text which do not need to link to anything.
+# For titles which should be a link, use the intersphinx anchors set at the index, chapter, and section levels, such as  qi_start_:
 rst_epilog = """
 .. |acapi| replace:: *Ansible Core API Guide*
 .. |acrn| replace:: *Ansible Core Release Notes*
@@ -128,28 +128,28 @@ html_short_title = 'Ansible Documentation'
 # The style sheet to use for HTML and HTML Help pages. A file of that name
 # must exist either in Sphinx' static/ path, or in one of the custom paths
 # given in html_static_path.
-#html_style = 'solar.css'
+# html_style = 'solar.css'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
 html_title = 'Ansible Documentation'
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (within the static path) to place at the top of
 # the sidebar.
-#html_logo = None
+# html_logo = None
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = 'favicon.ico'
+# html_favicon = 'favicon.ico'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['.static']
+# html_static_path = ['.static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
@@ -157,23 +157,23 @@ html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+# html_sidebars = {}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
-#html_use_modindex = True
+# html_use_modindex = True
 
 # If false, no index is generated.
-#html_use_index = True
+# html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
-#html_split_index = False
+# html_split_index = False
 
 # If true, the reST sources are included in the HTML build as _sources/<name>.
 html_copy_source = False
@@ -181,10 +181,10 @@ html_copy_source = False
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+# html_use_opensearch = ''
 
 # If nonempty, this is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = ''
+# html_file_suffix = ''
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'Poseidodoc'
@@ -194,10 +194,10 @@ htmlhelp_basename = 'Poseidodoc'
 # ------------------------
 
 # The paper size ('letter' or 'a4').
-#latex_paper_size = 'letter'
+# latex_paper_size = 'letter'
 
 # The font size ('10pt', '11pt' or '12pt').
-#latex_font_size = '10pt'
+# latex_font_size = '10pt'
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class
@@ -208,20 +208,20 @@ latex_documents = [
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-#latex_logo = None
+# latex_logo = None
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+# latex_use_parts = False
 
 # Additional stuff for the LaTeX preamble.
-#latex_preamble = ''
+# latex_preamble = ''
 
 # Documents to append as an appendix to all manuals.
-#latex_appendices = []
+# latex_appendices = []
 
 # If false, no module index is generated.
-#latex_use_modindex = True
+# latex_use_modindex = True
 
 autoclass_content = 'both'
 

--- a/lib/ansible/inventory/ini.py
+++ b/lib/ansible/inventory/ini.py
@@ -69,7 +69,7 @@ class InventoryParser(object):
             for line in b_data.splitlines():
                 if line and line[0] in self.b_COMMENT_MARKERS:
                     # Replace is okay for comment lines
-                    #data.append(to_text(line, errors='surrogate_then_replace'))
+                    # data.append(to_text(line, errors='surrogate_then_replace'))
                     # Currently we only need these lines for accurate lineno in errors
                     data.append(u'')
                 else:
@@ -155,7 +155,7 @@ class InventoryParser(object):
                 for h in hosts:
                     self.groups[groupname].add_host(h)
 
-                #FIXME: needed to save hosts to group, find out why
+                # FIXME: needed to save hosts to group, find out why
                 self.groups[groupname].get_hosts()
 
             # [groupname:vars] contains variable definitions that must be

--- a/lib/ansible/module_utils/_text.py
+++ b/lib/ansible/module_utils/_text.py
@@ -44,9 +44,10 @@ except LookupError:
     HAS_SURROGATEESCAPE = False
 
 
-_COMPOSED_ERROR_HANDLERS = frozenset((None, 'surrogate_or_escape',
-                                     'surrogate_or_strict',
-                                     'surrogate_then_replace'))
+_COMPOSED_ERROR_HANDLERS = frozenset((None,
+                                      'surrogate_or_escape',
+                                      'surrogate_or_strict',
+                                      'surrogate_then_replace'))
 
 
 def to_bytes(obj, encoding='utf-8', errors=None, nonstring='simplerepr'):

--- a/lib/ansible/module_utils/cloudengine.py
+++ b/lib/ansible/module_utils/cloudengine.py
@@ -261,7 +261,9 @@ def prepare_config(commands):
 def prepare_commands(commands):
     """ prepare_commands """
 
-    jsonify = lambda x: '%s | json' % x
+    def jsonify(x):
+        return '%s | json' % x
+
     for cmd in to_list(commands):
         if cmd.output == 'json':
             cmd.command_string = jsonify(cmd)

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -4,7 +4,6 @@ contrib/inventory/vmware_inventory.py
 docs/api/conf.py
 docs/bin/dump_keywords.py
 docs/bin/plugin_formatter.py
-docs/docsite/rst/conf.py
 examples/scripts/uptime.py
 hacking/cherrypick.py
 hacking/get_library.py
@@ -43,22 +42,18 @@ lib/ansible/inventory/dir.py
 lib/ansible/inventory/expand_hosts.py
 lib/ansible/inventory/group.py
 lib/ansible/inventory/host.py
-lib/ansible/inventory/ini.py
 lib/ansible/inventory/script.py
 lib/ansible/inventory/vars_plugins/__init__.py
 lib/ansible/inventory/vars_plugins/noop.py
 lib/ansible/inventory/yaml.py
-lib/ansible/module_utils/_text.py
 lib/ansible/module_utils/a10.py
 lib/ansible/module_utils/ansible_tower.py
 lib/ansible/module_utils/aos.py
 lib/ansible/module_utils/api.py
-lib/ansible/module_utils/asa.py
 lib/ansible/module_utils/avi.py
 lib/ansible/module_utils/azure_rm_common.py
 lib/ansible/module_utils/basic.py
 lib/ansible/module_utils/bigswitch_utils.py
-lib/ansible/module_utils/cloudengine.py
 lib/ansible/module_utils/connection.py
 lib/ansible/module_utils/database.py
 lib/ansible/module_utils/docker_common.py
@@ -92,8 +87,6 @@ lib/ansible/module_utils/postgres.py
 lib/ansible/module_utils/pycompat24.py
 lib/ansible/module_utils/redhat.py
 lib/ansible/module_utils/service.py
-lib/ansible/module_utils/shell.py
-lib/ansible/module_utils/six/_six.py
 lib/ansible/module_utils/splitter.py
 lib/ansible/module_utils/sros.py
 lib/ansible/module_utils/univention_umc.py
@@ -149,7 +142,6 @@ lib/ansible/modules/cloud/amazon/ecs_service.py
 lib/ansible/modules/cloud/amazon/ecs_service_facts.py
 lib/ansible/modules/cloud/amazon/ecs_task.py
 lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
-lib/ansible/modules/cloud/amazon/efs.py
 lib/ansible/modules/cloud/amazon/efs_facts.py
 lib/ansible/modules/cloud/amazon/elasticache.py
 lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
@@ -191,7 +183,6 @@ lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
 lib/ansible/modules/cloud/azure/azure_rm_virtualmachineimage_facts.py
 lib/ansible/modules/cloud/azure/azure_rm_virtualnetwork.py
 lib/ansible/modules/cloud/azure/azure_rm_virtualnetwork_facts.py
-lib/ansible/modules/cloud/centurylink/clc_loadbalancer.py
 lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
 lib/ansible/modules/cloud/cloudstack/cs_account.py
 lib/ansible/modules/cloud/cloudstack/cs_cluster.py
@@ -274,11 +265,8 @@ lib/ansible/modules/cloud/openstack/os_user_group.py
 lib/ansible/modules/cloud/openstack/os_user_role.py
 lib/ansible/modules/cloud/openstack/os_zone.py
 lib/ansible/modules/cloud/ovh/ovh_ip_loadbalancing_backend.py
-lib/ansible/modules/cloud/ovirt/ovirt_affinity_groups.py
 lib/ansible/modules/cloud/ovirt/ovirt_disks.py
 lib/ansible/modules/cloud/ovirt/ovirt_nics.py
-lib/ansible/modules/cloud/ovirt/ovirt_permissions.py
-lib/ansible/modules/cloud/ovirt/ovirt_vms.py
 lib/ansible/modules/cloud/packet/packet_device.py
 lib/ansible/modules/cloud/packet/packet_sshkey.py
 lib/ansible/modules/cloud/profitbricks/profitbricks.py
@@ -286,23 +274,13 @@ lib/ansible/modules/cloud/profitbricks/profitbricks_datacenter.py
 lib/ansible/modules/cloud/profitbricks/profitbricks_nic.py
 lib/ansible/modules/cloud/profitbricks/profitbricks_volume.py
 lib/ansible/modules/cloud/profitbricks/profitbricks_volume_attachments.py
-lib/ansible/modules/cloud/rackspace/rax_cbs_attachments.py
 lib/ansible/modules/cloud/rackspace/rax_cdb.py
-lib/ansible/modules/cloud/rackspace/rax_clb.py
 lib/ansible/modules/cloud/rackspace/rax_clb_ssl.py
-lib/ansible/modules/cloud/rackspace/rax_dns.py
-lib/ansible/modules/cloud/rackspace/rax_dns_record.py
-lib/ansible/modules/cloud/rackspace/rax_facts.py
-lib/ansible/modules/cloud/rackspace/rax_files.py
-lib/ansible/modules/cloud/rackspace/rax_keypair.py
-lib/ansible/modules/cloud/rackspace/rax_meta.py
 lib/ansible/modules/cloud/rackspace/rax_mon_alarm.py
 lib/ansible/modules/cloud/rackspace/rax_mon_check.py
 lib/ansible/modules/cloud/rackspace/rax_mon_entity.py
 lib/ansible/modules/cloud/rackspace/rax_mon_notification.py
 lib/ansible/modules/cloud/rackspace/rax_mon_notification_plan.py
-lib/ansible/modules/cloud/rackspace/rax_network.py
-lib/ansible/modules/cloud/rackspace/rax_queue.py
 lib/ansible/modules/cloud/smartos/vmadm.py
 lib/ansible/modules/cloud/softlayer/sl_vm.py
 lib/ansible/modules/cloud/univention/udm_dns_record.py
@@ -317,7 +295,6 @@ lib/ansible/modules/cloud/vmware/vmware_cluster.py
 lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
 lib/ansible/modules/cloud/vmware/vmware_guest.py
 lib/ansible/modules/cloud/vmware/vmware_local_user_manager.py
-lib/ansible/modules/cloud/vmware/vmware_migrate_vmk.py
 lib/ansible/modules/cloud/vmware/vmware_target_canonical_facts.py
 lib/ansible/modules/cloud/vmware/vmware_vm_shell.py
 lib/ansible/modules/cloud/vmware/vmware_vmotion.py
@@ -604,7 +581,6 @@ lib/ansible/modules/packaging/os/macports.py
 lib/ansible/modules/packaging/os/openbsd_pkg.py
 lib/ansible/modules/packaging/os/opkg.py
 lib/ansible/modules/packaging/os/pacman.py
-lib/ansible/modules/packaging/os/pkg5.py
 lib/ansible/modules/packaging/os/pkg5_publisher.py
 lib/ansible/modules/packaging/os/pkgin.py
 lib/ansible/modules/packaging/os/pkgng.py
@@ -643,7 +619,6 @@ lib/ansible/modules/storage/infinidat/infini_vol.py
 lib/ansible/modules/storage/netapp/na_cdot_qtree.py
 lib/ansible/modules/storage/netapp/na_cdot_volume.py
 lib/ansible/modules/storage/netapp/netapp_e_amg.py
-lib/ansible/modules/storage/netapp/netapp_e_storagepool.py
 lib/ansible/modules/storage/netapp/sf_account_manager.py
 lib/ansible/modules/storage/netapp/sf_snapshot_schedule_manager.py
 lib/ansible/modules/storage/netapp/sf_volume_access_group_manager.py
@@ -673,7 +648,6 @@ lib/ansible/modules/system/kernel_blacklist.py
 lib/ansible/modules/system/locale_gen.py
 lib/ansible/modules/system/lvg.py
 lib/ansible/modules/system/lvol.py
-lib/ansible/modules/system/modprobe.py
 lib/ansible/modules/system/mount.py
 lib/ansible/modules/system/ohai.py
 lib/ansible/modules/system/open_iscsi.py
@@ -748,7 +722,6 @@ lib/ansible/plugins/action/fetch.py
 lib/ansible/plugins/action/group_by.py
 lib/ansible/plugins/action/ios_template.py
 lib/ansible/plugins/action/iosxr_template.py
-lib/ansible/plugins/action/junos.py
 lib/ansible/plugins/action/junos_template.py
 lib/ansible/plugins/action/normal.py
 lib/ansible/plugins/action/nxos.py
@@ -760,7 +733,6 @@ lib/ansible/plugins/action/patch.py
 lib/ansible/plugins/action/pause.py
 lib/ansible/plugins/action/script.py
 lib/ansible/plugins/action/service.py
-lib/ansible/plugins/action/set_stats.py
 lib/ansible/plugins/action/sros_config.py
 lib/ansible/plugins/action/synchronize.py
 lib/ansible/plugins/action/template.py
@@ -853,7 +825,6 @@ lib/ansible/plugins/strategy/free.py
 lib/ansible/plugins/strategy/linear.py
 lib/ansible/plugins/terminal/asa.py
 lib/ansible/plugins/terminal/eos.py
-lib/ansible/plugins/terminal/ios.py
 lib/ansible/plugins/terminal/iosxr.py
 lib/ansible/plugins/terminal/junos.py
 lib/ansible/plugins/terminal/nxos.py
@@ -864,10 +835,8 @@ lib/ansible/plugins/test/mathstuff.py
 lib/ansible/plugins/vars/__init__.py
 lib/ansible/release.py
 lib/ansible/template/__init__.py
-lib/ansible/template/safe_eval.py
 lib/ansible/template/template.py
 lib/ansible/template/vars.py
-lib/ansible/utils/cmd_functions.py
 lib/ansible/utils/color.py
 lib/ansible/utils/display.py
 lib/ansible/utils/encrypt.py
@@ -875,7 +844,6 @@ lib/ansible/utils/helpers.py
 lib/ansible/utils/listify.py
 lib/ansible/utils/path.py
 lib/ansible/utils/ssh_functions.py
-lib/ansible/utils/unicode.py
 lib/ansible/utils/vars.py
 lib/ansible/vars/__init__.py
 lib/ansible/vars/hostvars.py
@@ -910,7 +878,6 @@ test/units/module_utils/basic/test_no_log.py
 test/units/module_utils/basic/test_run_command.py
 test/units/module_utils/basic/test_safe_eval.py
 test/units/module_utils/basic/test_set_mode_if_different.py
-test/units/module_utils/ec2/test_aws.py
 test/units/module_utils/gcp/test_auth.py
 test/units/module_utils/json_utils/test_filter_non_json_lines.py
 test/units/module_utils/test_basic.py
@@ -923,7 +890,6 @@ test/units/modules/cloud/amazon/test_lambda.py
 test/units/modules/cloud/amazon/test_s3.py
 test/units/modules/cloud/docker/test_docker.py
 test/units/modules/cloud/google/test_gce_tag.py
-test/units/modules/cloud/openstack/test_os_server.py
 test/units/modules/network/cumulus/test_nclu.py
 test/units/modules/network/eos/eos_module.py
 test/units/modules/network/eos/test_eos_command.py
@@ -954,7 +920,6 @@ test/units/parsing/test_mod_args.py
 test/units/parsing/utils/test_addresses.py
 test/units/parsing/utils/test_jsonify.py
 test/units/parsing/vault/test_vault.py
-test/units/parsing/vault/test_vault_editor.py
 test/units/parsing/yaml/test_dumper.py
 test/units/parsing/yaml/test_loader.py
 test/units/parsing/yaml/test_objects.py
@@ -962,8 +927,6 @@ test/units/playbook/role/test_role.py
 test/units/playbook/test_attribute.py
 test/units/playbook/test_base.py
 test/units/playbook/test_block.py
-test/units/playbook/test_conditional.py
-test/units/playbook/test_helpers.py
 test/units/playbook/test_play_context.py
 test/units/playbook/test_playbook.py
 test/units/playbook/test_taggable.py
@@ -987,4 +950,3 @@ test/units/test_constants.py
 test/units/utils/test_helpers.py
 test/units/utils/test_shlex.py
 test/units/utils/test_vars.py
-test/units/vars/test_variable_manager.py


### PR DESCRIPTION
##### SUMMARY
By getting rid of these, `make pep8` is outputting less stuff so it's easier to start fixing other issues.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
pep8/legacy-files.txt

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.4