### PR TITLE
allow var as loop control pause

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -259,7 +259,13 @@ class TaskExecutor:
             # the value may be 'None', so we still need to default it back to 'item'
             loop_var = self._task.loop_control.loop_var or 'item'
             label = self._task.loop_control.label or ('{{' + loop_var + '}}')
-            loop_pause = self._task.loop_control.pause or 0
+            # Check if a variable has been passed as the 'pause' var
+            if self._task.loop_control.pause is not None and not isinstance(self._task.loop_control.pause,float):
+                templar = Templar(loader=self._loader, shared_loader_obj=self._shared_loader_obj, variables=self._job_vars)
+                loop_pause = float(templar.template(self._task.loop_control.pause))
+            else:
+                loop_pause = self._task.loop_control.pause or 0
+
 
         if loop_var in task_vars:
             display.warning(u"The loop variable '%s' is already in use. "


### PR DESCRIPTION
##### SUMMARY
[Loop control](http://docs.ansible.com/ansible/playbooks_loops.html#loop-control) `pause` does not accept variable

We should be able to pass a variable to the `loop_control.pause` when using `with_items` like we can when using the [pause module](http://docs.ansible.com/ansible/pause_module.html)


**Run the following code:**

```yaml
  vars:
    components: ["a","b","c"]
    pause_for: 2
  tasks:
      -
        name: "Do stuff"
        shell: echo {{ item }}
        register: result
        with_items:
          - "{{ components }}"
        loop_control:
          pause: "{{ pause_for}}"
```

Expected result:
Expect that when a variable is defined and can be cast as a float, that it should be accepted

Actual result:
```bash
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: a float is required
fatal: [local.feedhenry.io]: FAILED! => {"failed": true, "msg": "Unexpected failure during module execution.", "stdout": ""}
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
/lib/ansible/playbook/loop_control.py
/lib/ansible/executor/task_executor.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (loop_control_pause 18a9b35070) last updated 2017/05/16 10:36:55 (GMT +100)
  config file = 
  configured module search path = [u'/Users/philipgough/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/philipgough/work/ansible/lib/ansible
  executable location = /Users/philipgough/work/ansible/bin/ansible
  python version = 2.7.13 (default, Dec 17 2016, 23:03:43) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION

Output after making changes:

```
time ansible-playbook playbooks/test.yml 

PLAY [Test play]
changed: [local.feedhenry.io] => (item=a)
changed: [local.feedhenry.io] => (item=b)
changed: [local.feedhenry.io] => (item=c)

PLAY RECAP 
local.feedhenry.io         : ok=2    changed=1    unreachable=0    failed=0   

real	0m6.755s
user	0m1.216s
sys	0m0.517s

```
