### PR TITLE
module/yum: skip_broken even if we've got package with broken headers

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -583,6 +583,9 @@ def local_nvra(module, path):
     fd = os.open(path, os.O_RDONLY)
     try:
         header = ts.hdrFromFdno(fd)
+    except:
+        if module.params.get('skip_broken'):
+            return None
     finally:
         os.close(fd)
 
@@ -687,6 +690,8 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, i
             # download package so that we can check if it's already installed
             package = fetch_rpm_from_url(spec, module=module)
             nvra = local_nvra(module, package)
+            if not nvra and module.params.get('skip_broken'):
+                continue
             if is_installed(module, repoq, nvra, conf_file, en_repos=en_repos, dis_repos=dis_repos, installroot=installroot):
                 # if it's there, skip it
                 continue


### PR DESCRIPTION
##### SUMMARY
skip_broken flag will skip also packages those got with broken headers. I.e. packages specified as URIs. And those URIs occasionally returns HTTP/200 and kind of garbage instead of rpm package.

current ansible will fail with error like:
```
Error in launch ansible playbook: /tmp/tmp.RkLCrRo5iy
Error log: ./logs/localhost/2017-05-14_13:05:02.log
2017-05-14 13:07:53,374 p=3D28801 u=3Drobot |  fatal: [localhost]=
: FAILED! =3D> {"changed": false, "failed": true, "module_stderr": "Tra=
ceback (most recent call last):\n  File \"/tmp/ansible_2KaU9y/ansible_m=
odule_yum.py\", line 1275, in <module>\n    main()\n  File \"/tmp/ansib=
le_2KaU9y/ansible_module_yum.py\", line 1266, in main\n    skip_broken,=
 params['installroot'])\n  File \"/tmp/ansible_2KaU9y/ansible_module_yu=
m.py\", line 1164, in ensure\n    res =3D install(module, pkgs, repoq, =
yum_basecmd, conf_file, en_repos, dis_repos, installroot=3Dinstallroot)=
\n  File \"/tmp/ansible_2KaU9y/ansible_module_yum.py\", line 696, in in=
stall\n    nvra =3D local_nvra(module, package)\n  File \"/tmp/ansible_=
2KaU9y/ansible_module_yum.py\", line 589, in local_nvra\n    header =3D=
 ts.hdrFromFdno(fd)\n  File \"/usr/lib64/python2.7/site-packages/rpm/tr=
ansaction.py\", line 160, in hdrFromFdno\n    raise rpm.error(\"error r=
eading package header\")\n_rpm.error: error reading package header\n", =
"module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}
2017-05-14 13:08:13,914 p=3D28801 u=3Drobot |  localhost         =
   : ok=3D117  changed=3D0    unreachable=3D0    failed=3D1  =20
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible yum module

##### ANSIBLE VERSION
up to HEAD