### PR TITLE
Support glob pattern for creates= and removes=

### DIFF
--- a/lib/ansible/modules/commands/expect.py
+++ b/lib/ansible/modules/commands/expect.py
@@ -40,10 +40,10 @@ options:
     required: true
   creates:
     description:
-      - A filename, when it already exists, this step will B(not) be run.
+      - A filename or (since 2.4) a glob pattern, when it already exists, this step will B(not) be run.
   removes:
     description:
-      - A filename, when it does not exist, this step will B(not) be run.
+      - A filename or (since 2.4) a glob pattern, when it does not exist, this step will B(not) be run.
   chdir:
     description:
       - Change into this directory before running the command.
@@ -99,6 +99,7 @@ EXAMPLES = r'''
 
 import datetime
 import os
+import glob
 
 try:
     import pexpect
@@ -170,7 +171,7 @@ def main():
         # do not run the command if the line contains creates=filename
         # and the filename already exists.  This allows idempotence
         # of command executions.
-        if os.path.exists(creates):
+        if glob.glob(creates):
             module.exit_json(
                 cmd=args,
                 stdout="skipped, since %s exists" % creates,
@@ -182,7 +183,7 @@ def main():
         # do not run the command if the line contains removes=filename
         # and the filename does not exist.  This allows idempotence
         # of command executions.
-        if not os.path.exists(removes):
+        if not glob.glob(removes):
             module.exit_json(
                 cmd=args,
                 stdout="skipped, since %s does not exist" % removes,


### PR DESCRIPTION
##### SUMMARY
To be consistent with the command module allow glob patterns as the
creates and removes module parameters.

Use case was a command that creates a seemingly random named file (hash?) in a known subfolder.

I haven't found a related issue after a quick search.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
modules/commands/expect.py

##### ANSIBLE VERSION
```
devel 2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Executing a `svn update` filling in the username password, a file gets created under $HOME/.subversion/auth/svn.simple/$HASH

Before this change the solution seemed to be to run a pre-task, like:
```
- shell: ls $HOME/.subversion/auth/svn.simple/
  register: var

- expect: ...
  creates: {{ var.stdout }}
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
