### PR TITLE
Azure SDK 2.0.0

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -31,6 +31,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves import configparser
 
 AZURE_COMMON_ARGS = dict(
+    cli_default_profile=dict(type='bool'),
     profile=dict(type='str'),
     subscription_id=dict(type='str', no_log=True),
     client_id=dict(type='str', no_log=True),
@@ -42,6 +43,7 @@ AZURE_COMMON_ARGS = dict(
 )
 
 AZURE_CREDENTIAL_ENV_MAPPING = dict(
+    cli_default_profile='AZURE_CLI_DEFAULT_PROFILE',
     profile='AZURE_PROFILE',
     subscription_id='AZURE_SUBSCRIPTION_ID',
     client_id='AZURE_CLIENT_ID',
@@ -70,6 +72,7 @@ AZURE_FAILED_STATE = "Failed"
 
 HAS_AZURE = True
 HAS_AZURE_EXC = None
+HAS_AZURE_CLI_CORE = True
 
 HAS_MSRESTAZURE = True
 HAS_MSRESTAZURE_EXC = None
@@ -91,14 +94,22 @@ try:
     from azure.mgmt.storage.version import VERSION as storage_client_version
     from azure.mgmt.compute.version import VERSION as compute_client_version
     from azure.mgmt.resource.version import VERSION as resource_client_version
-    from azure.mgmt.network.network_management_client import NetworkManagementClient
-    from azure.mgmt.resource.resources.resource_management_client import ResourceManagementClient
-    from azure.mgmt.storage.storage_management_client import StorageManagementClient
-    from azure.mgmt.compute.compute_management_client import ComputeManagementClient
+    from azure.mgmt.network import NetworkManagementClient
+    from azure.mgmt.resource.resources import ResourceManagementClient
+    from azure.mgmt.storage import StorageManagementClient
+    from azure.mgmt.compute import ComputeManagementClient
     from azure.storage.cloudstorageaccount import CloudStorageAccount
 except ImportError as exc:
     HAS_AZURE_EXC = exc
     HAS_AZURE = False
+
+
+try:
+    from azure.cli.core.util import CLIError
+    from azure.common.credentials import get_azure_cli_credentials, get_cli_profile
+    from azure.common.cloud import get_cli_active_cloud
+except ImportError:
+    HAS_AZURE_CLI_CORE = False
 
 
 def azure_id_to_dict(id):
@@ -112,13 +123,13 @@ def azure_id_to_dict(id):
 
 
 AZURE_EXPECTED_VERSIONS = dict(
-    storage_client_version="0.30.0rc5",
-    compute_client_version="0.30.0rc5",
-    network_client_version="0.30.0rc5",
-    resource_client_version="0.30.0rc5"
+    storage_client_version="1.0.0",
+    compute_client_version="1.0.0",
+    network_client_version="1.0.0",
+    resource_client_version="1.1.0"
 )
 
-AZURE_MIN_RELEASE = '2.0.0rc5'
+AZURE_MIN_RELEASE = '2.0.0'
 
 
 class AzureRMModuleBase(object):
@@ -171,7 +182,7 @@ class AzureRMModuleBase(object):
         self.credentials = self._get_credentials(self.module.params)
         if not self.credentials:
             self.fail("Failed to get credentials. Either pass as parameters, set environment variables, "
-                      "or define a profile in ~/.azure/credentials.")
+                      "or define a profile in ~/.azure/credentials or be logged using AzureCLI.")
 
         if self.credentials.get('subscription_id', None) is None:
             self.fail("Credentials did not include a subscription_id value.")
@@ -186,9 +197,18 @@ class AzureRMModuleBase(object):
                                                                  tenant=self.credentials['tenant'])
         elif self.credentials.get('ad_user') is not None and self.credentials.get('password') is not None:
             self.azure_credentials = UserPassCredentials(self.credentials['ad_user'], self.credentials['password'])
+        elif self.credentials.get('credentials') is not None:
+            self.azure_credentials = self.credentials.get('credentials')
         else:
             self.fail("Failed to authenticate with provided credentials. Some attributes were missing. "
-                      "Credentials must include client_id, secret and tenant or ad_user and password.")
+                      "Credentials must include client_id, secret and tenant or ad_user and password or "
+                      "be logged using AzureCLI.")
+
+        # base_url for sovereign cloud support. For now only if AzureCLI
+        if self.credentials.get('base_url') is not None:
+            self.base_url = self.credentials.get('base_url')
+        else:
+            self.base_url = None
 
         # common parameter validation
         if self.module.params.get('tags'):
@@ -309,6 +329,20 @@ class AzureRMModuleBase(object):
         except Exception as exc:
             self.fail("Error retrieving resource group {0} - {1}".format(resource_group, str(exc)))
 
+    def _get_azure_cli_profile(self):
+        if not HAS_AZURE_CLI_CORE:
+            self.fail("Do you have azure-cli-core installed? Try `pip install 'azure-cli-core' --upgrade`")
+        try:
+            credentials, subscription_id = get_azure_cli_credentials()
+            base_url = get_cli_active_cloud().endpoints.resource_manager
+            return {
+                'credentials': credentials,
+                'subscription_id': subscription_id,
+                'base_url': base_url
+            }
+        except CLIError as err:
+            self.fail("AzureCLI profile cannot be loaded - {0}".format(err))
+
     def _get_profile(self, profile="default"):
         path = expanduser("~/.azure/credentials")
         try:
@@ -334,6 +368,9 @@ class AzureRMModuleBase(object):
         for attribute, env_variable in AZURE_CREDENTIAL_ENV_MAPPING.items():
             env_credentials[attribute] = os.environ.get(env_variable, None)
 
+        if (env_credentials['cli_default_profile'] or '').lower() in ["true", "yes", "1"]:
+            return self._get_azure_cli_profile()
+
         if env_credentials['profile']:
             credentials = self._get_profile(env_credentials['profile'])
             return credentials
@@ -352,6 +389,10 @@ class AzureRMModuleBase(object):
         arg_credentials = dict()
         for attribute, env_variable in AZURE_CREDENTIAL_ENV_MAPPING.items():
             arg_credentials[attribute] = params.get(attribute, None)
+
+        if arg_credentials['cli_default_profile']:
+            self.log('Retrieving credentials from Azure CLI current profile')
+            return self._get_azure_cli_profile()
 
         # try module params
         if arg_credentials['profile'] is not None:
@@ -591,7 +632,7 @@ class AzureRMModuleBase(object):
         self.log('Getting storage client...')
         if not self._storage_client:
             self.check_client_version('storage', storage_client_version, AZURE_EXPECTED_VERSIONS['storage_client_version'])
-            self._storage_client = StorageManagementClient(self.azure_credentials, self.subscription_id)
+            self._storage_client = StorageManagementClient(self.azure_credentials, self.subscription_id, base_url=self.base_url)
             self._register('Microsoft.Storage')
         return self._storage_client
 
@@ -600,7 +641,7 @@ class AzureRMModuleBase(object):
         self.log('Getting network client')
         if not self._network_client:
             self.check_client_version('network', network_client_version, AZURE_EXPECTED_VERSIONS['network_client_version'])
-            self._network_client = NetworkManagementClient(self.azure_credentials, self.subscription_id)
+            self._network_client = NetworkManagementClient(self.azure_credentials, self.subscription_id, base_url=self.base_url)
             self._register('Microsoft.Network')
         return self._network_client
 
@@ -609,7 +650,9 @@ class AzureRMModuleBase(object):
         self.log('Getting resource manager client')
         if not self._resource_client:
             self.check_client_version('resource', resource_client_version, AZURE_EXPECTED_VERSIONS['resource_client_version'])
-            self._resource_client = ResourceManagementClient(self.azure_credentials, self.subscription_id)
+            self._resource_client = ResourceManagementClient(self.azure_credentials,
+                                                             self.subscription_id,
+                                                             base_url=self.base_url)
         return self._resource_client
 
     @property
@@ -617,6 +660,6 @@ class AzureRMModuleBase(object):
         self.log('Getting compute client')
         if not self._compute_client:
             self.check_client_version('compute', compute_client_version, AZURE_EXPECTED_VERSIONS['compute_client_version'])
-            self._compute_client = ComputeManagementClient(self.azure_credentials, self.subscription_id)
+            self._compute_client = ComputeManagementClient(self.azure_credentials, self.subscription_id, base_url=self.base_url)
             self._register('Microsoft.Compute')
         return self._compute_client

--- a/lib/ansible/modules/cloud/azure/azure_rm_deployment.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_deployment.py
@@ -386,7 +386,6 @@ from ansible.module_utils.azure_rm_common import *
 
 try:
     from itertools import chain
-    from azure.common.credentials import ServicePrincipalCredentials
     from azure.common.exceptions import CloudError
     from azure.mgmt.resource.resources.models import (DeploymentProperties,
                                                       ParametersLink,

--- a/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup.py
@@ -245,7 +245,7 @@ class AzureRMResourceGroup(AzureRMModuleBase):
     def resources_exist(self):
         found = False
         try:
-            response = self.rm_client.resource_groups.list_resources(self.name)
+            response = self.rm_client.resources.list_by_resource_group(self.name)
         except Exception as exc:
             self.fail("Error checking for resource existence in {0} - {1}".format(self.name, str(exc)))
         for item in response:

--- a/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup_facts.py
@@ -94,7 +94,6 @@ from ansible.module_utils.azure_rm_common import *
 
 try:
     from msrestazure.azure_exceptions import CloudError
-    from azure.common import AzureMissingResourceHttpError, AzureHttpError
 except:
     # This is handled in azure_rm_common
     pass
@@ -155,7 +154,7 @@ class AzureRMResourceGroupFacts(AzureRMModuleBase):
         self.log('List all items')
         try:
             response = self.rm_client.resource_groups.list()
-        except AzureHttpError as exc:
+        except CloudError as exc:
             self.fail("Failed to list all items - {1}".format(str(exc)))
 
         results = []

--- a/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
@@ -341,7 +341,6 @@ from ansible.module_utils.azure_rm_common import *
 
 try:
     from msrestazure.azure_exceptions import CloudError
-    from azure.common import AzureHttpError
     from azure.mgmt.network.models import NetworkSecurityGroup, SecurityRule
     from azure.mgmt.network.models.network_management_client_enums import (SecurityRuleAccess,
                                                                            SecurityRuleDirection,
@@ -700,7 +699,7 @@ class AzureRMSecurityGroup(AzureRMModuleBase):
                                                                                   self.name,
                                                                                   parameters)
             result = self.get_poller_result(poller)
-        except AzureHttpError as exc:
+        except CloudError as exc:
             self.fail("Error creating/updating security group {0} - {1}".format(self.name, str(exc)))
         return create_network_security_group_dict(result)
 
@@ -708,7 +707,7 @@ class AzureRMSecurityGroup(AzureRMModuleBase):
         try:
             poller = self.network_client.network_security_groups.delete(self.resource_group, self.name)
             result = self.get_poller_result(poller)
-        except AzureHttpError as exc:
+        except CloudError as exc:
             raise Exception("Error deleting security group {0} - {1}".format(self.name, str(exc)))
         return result
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_securitygroup_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_securitygroup_facts.py
@@ -208,7 +208,6 @@ from ansible.module_utils.azure_rm_common import *
 
 try:
     from msrestazure.azure_exceptions import CloudError
-    from azure.common import AzureMissingResourceHttpError, AzureHttpError
 except:
     # This is handled in azure_rm_common
     pass

--- a/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
@@ -156,7 +156,7 @@ from ansible.module_utils.azure_rm_common import *
 try:
     from msrestazure.azure_exceptions import CloudError
     from azure.storage.cloudstorageaccount import CloudStorageAccount
-    from azure.common import AzureMissingResourceHttpError, AzureHttpError
+    from azure.common import AzureMissingResourceHttpError
     from azure.mgmt.storage.models.storage_management_client_enums import ProvisioningState, SkuName, SkuTier, Kind
     from azure.mgmt.storage.models import StorageAccountUpdateParameters, CustomDomain, \
                                           StorageAccountCreateParameters, Sku
@@ -251,7 +251,7 @@ class AzureRMStorageAccount(AzureRMModuleBase):
         self.log('Checking name availability for {0}'.format(self.name))
         try:
             response = self.storage_client.storage_accounts.check_name_availability(self.name)
-        except AzureHttpError as e:
+        except CloudError as e:
             self.log('Error attempting to validate name.')
             self.fail("Error checking name availability: {0}".format(str(e)))
         if not response.name_available:
@@ -400,7 +400,7 @@ class AzureRMStorageAccount(AzureRMModuleBase):
         try:
             poller = self.storage_client.storage_accounts.create(self.resource_group, self.name, parameters)
             self.get_poller_result(poller)
-        except AzureHttpError as e:
+        except CloudError as e:
             self.log('Error creating storage account.')
             self.fail("Failed to create account: {0}".format(str(e)))
         # the poller doesn't actually return anything
@@ -418,7 +418,7 @@ class AzureRMStorageAccount(AzureRMModuleBase):
                 status = self.storage_client.storage_accounts.delete(self.resource_group, self.name)
                 self.log("delete status: ")
                 self.log(str(status))
-            except AzureHttpError as e:
+            except CloudError as e:
                 self.fail("Failed to delete the account: {0}".format(str(e)))
         return True
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_storageaccount_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageaccount_facts.py
@@ -113,7 +113,6 @@ from ansible.module_utils.azure_rm_common import *
 
 try:
     from msrestazure.azure_exceptions import CloudError
-    from azure.common import AzureMissingResourceHttpError, AzureHttpError
 except:
     # This is handled in azure_rm_common
     pass

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachineimage_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachineimage_facts.py
@@ -117,7 +117,6 @@ from ansible.module_utils.azure_rm_common import *
 
 try:
     from msrestazure.azure_exceptions import CloudError
-    from azure.common import AzureMissingResourceHttpError, AzureHttpError
 except:
     # This is handled in azure_rm_common
     pass

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualnetwork_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualnetwork_facts.py
@@ -105,7 +105,6 @@ from ansible.module_utils.azure_rm_common import *
 
 try:
     from msrestazure.azure_exceptions import CloudError
-    from azure.common import AzureMissingResourceHttpError, AzureHttpError
 except:
     # This is handled in azure_rm_common
     pass
@@ -168,7 +167,7 @@ class AzureRMNetworkInterfaceFacts(AzureRMModuleBase):
         self.log('List items for resource group')
         try:
             response = self.network_client.virtual_networks.list(self.resource_group)
-        except AzureHttpError as exc:
+        except CloudError as exc:
             self.fail("Failed to list for resource group {0} - {1}".format(self.resource_group, str(exc)))
 
         results = []
@@ -181,7 +180,7 @@ class AzureRMNetworkInterfaceFacts(AzureRMModuleBase):
         self.log('List all for items')
         try:
             response = self.network_client.virtual_networks.list_all()
-        except AzureHttpError as exc:
+        except CloudError as exc:
             self.fail("Failed to list all items - {0}".format(str(exc)))
 
         results = []


### PR DESCRIPTION
##### SUMMARY

This PR updates the Azure modules to [azure sdk 2.0.0](https://github.com/Azure/azure-sdk-for-python/releases/tag/azure_2.0.0).

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/azure/azure_rm_resource_group
module_utils/azure_rm_common

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```

##### ADDITIONAL INFORMATION
We just released azure SDK 2.0.0, with a feature that I thought would be nice in Ansible: the ability to use AzureCLI credentials to use the SDK. Meaning, you can use the "az login" command to authenticate through azure, and then run Ansible direcly:

```
$ export AZURE_CLI_DEFAULT_PROFILE=true
$ az login
To sign in, use a web browser to open the page https://aka.ms/devicelogin and enter the code FKKB8T54Q to authenticate.
$ ansible-playbook rg_test.yml --connection=local

TASK [Create a resource group] **************************************************************************************************************************************************************************************************************
changed: [localhost]

TASK [Delete a resource group] **************************************************************************************************************************************************************************************************************
changed: [localhost]

PLAY RECAP **********************************************************************************************************************************************************************************************************************************
localhost                  : ok=3    changed=2    unreachable=0    failed=0
```

This uses the authentication method used for CLI (you can define service principal, user password or device login)+ default subscription_id + default cloud (then could be German Cloud, etc). This allows Ansible to be easily used for sovereign cloud (fix #19451)

- [az login](https://docs.microsoft.com/cli/azure/authenticate-azure-cli): access to credentials
- [az account set --subscriptions](https://docs.microsoft.com/cli/azure/manage-azure-subscriptions-azure-cli): access to subscription_id
- [az cloud set --name](https://docs.microsoft.com/cli/azure/cloud#set): access to base_url (sovereign cloud)

This first commit is just step one, I wanted your opinion on this before doing more.

TODO for this PR:
- Check/adapt all `azure` module against SDK 2.0.0. This should simple, with small changes (see azure_rm_resourcegroup in this first commit)

Future roadmap (another PR this summer)
- Autoadapt the api-version passed to the RestAPI using the CLI profile. The endpoint URL is step1, but it's possible that a given api-version is still not available in a not-public Azure cloud, meaning changing the endpoint is not enough. We have the information in the CLI, but this requires a little more work right now to plug at the SDK level. So users might get "api-version not supported" error message in the meantime an api-version is not deployed to sovereign cloud they want to use. Also AzureStack support for Ansible will need this for sure (api-version are not the latest one).

@nitzmahone @chouseknecht @devigned
