### PR TITLE
not using update or `|=` as referring will not change

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -305,13 +305,13 @@ class PlayContext(Base):
         # get the tag info from options. We check to see if the options have
         # the attribute, as it is not always added via the CLI
         if hasattr(options, 'tags'):
-            self.only_tags.update(options.tags)
+            self.only_tags = self.only_tags | set(options.tags)
 
         if len(self.only_tags) == 0:
             self.only_tags = set(['all'])
 
         if hasattr(options, 'skip_tags'):
-            self.skip_tags.update(options.skip_tags)
+            self.skip_tags = self.skip_tags | set(options.skip_tags)
 
     def set_task_and_variable_override(self, task, variables, templar):
         '''


### PR DESCRIPTION
I'm working on a using ansible API to invoke playbook, running into a trouble as reported in https://github.com/ansible/ansible/issues/24734, it seems I solved it by this commit.

##### SUMMARY

I know issue #17103 is closed, but after studying, I think it is not the same thing. The point is  only_tags in new PlayContext is the extract same object of the old one. If we have multiple plays in one script, this will be confused.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request


##### ANSIBLE VERSION
```
# ansible --version
 28622 1495007969.71502: starting run
ansible 2.2.3.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
