### PR TITLE
Restore disabled opensuse integration tests.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -30,6 +30,8 @@ matrix:
     - env: TEST=linux/centos7/1
     - env: TEST=linux/fedora24/1
     - env: TEST=linux/fedora25/1
+    - env: TEST=linux/opensuse42.1/1
+    - env: TEST=linux/opensuse42.2/1
     - env: TEST=linux/ubuntu1404/1
     - env: TEST=linux/ubuntu1604/1
     - env: TEST=linux/ubuntu1604py3/1

--- a/test/integration/targets/zypper/aliases
+++ b/test/integration/targets/zypper/aliases
@@ -1,1 +1,2 @@
 destructive
+posix/ci/group1


### PR DESCRIPTION
##### SUMMARY

Restore disabled opensuse integration tests.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

Shippable

##### ANSIBLE VERSION

```
ansible 2.4.0 (opensuse 01b37faa76) last updated 2017/05/17 16:23:35 (GMT +800)
  config file = 
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
