### PR TITLE
Adds Maven artifact classifier into file path - fixes #24724

### DIFF
--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -402,7 +402,10 @@ def main():
 
     prev_state = "absent"
     if os.path.isdir(dest):
-        dest = posixpath.join(dest, artifact_id + "-" + version + "." + extension)
+        if classifier:
+            dest = posixpath.join(dest, artifact_id + "-" + version + "-" + classifier + "." + extension)
+        else:
+            dest = posixpath.join(dest, artifact_id + "-" + version + "." + extension)
     if os.path.lexists(dest) and downloader.verify_md5(dest, downloader.find_uri_for_artifact(artifact) + '.md5'):
         prev_state = "present"
     else:


### PR DESCRIPTION
##### SUMMARY
Previously, when passing a classifier to the maven_artifact module, the correct Maven artifact would be downloaded but the classifier would not be part of the output filename. This led to situations where two artifacts with the same group ID, artifact ID and version but different classifiers could be downloaded with exactly the same output filename, resulting in inconsistent output.

Fixes #24724

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/packaging/language/maven_artifact.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (fix_maven_artifact_classifier 9fa457be84) last updated 2017/05/17 15:09:42 (GMT +100)
  config file =
  configured module search path = [u'/Users/gusluxton/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/gusluxton/git/ansible/lib/ansible
  executable location = /Users/gusluxton/git/ansible/bin/ansible
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```