### PR TITLE
Fix logic surrounding copy and remote_src in unarchive module

### DIFF
--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -770,7 +770,6 @@ def main():
             src               = dict(required=True, type='path'),
             original_basename = dict(required=False, type='str'), # used to handle 'dest is a directory' via template, a slight hack
             dest              = dict(required=True, type='path'),
-            copy              = dict(required=False, default=True, type='bool'),
             remote_src        = dict(required=False, default=False, type='bool'),
             creates           = dict(required=False, type='path'),
             list_files        = dict(required=False, default=False, type='bool'),
@@ -780,21 +779,19 @@ def main():
             validate_certs    = dict(required=False, default=True, type='bool'),
         ),
         add_file_common_args = True,
-        mutually_exclusive   = [("copy", "remote_src"),],
         # check-mode only works for zip files, we cover that later
         supports_check_mode = True,
     )
 
     src        = module.params['src']
     dest       = module.params['dest']
-    copy       = module.params['copy']
     remote_src = module.params['remote_src']
     file_args = module.load_file_common_arguments(module.params)
     # did tar file arrive?
     if not os.path.exists(src):
-        if not remote_src and copy:
+        if not remote_src:
             module.fail_json(msg="Source '%s' failed to transfer" % src)
-        # If copy=false, and src= contains ://, try and download the file to a temp directory.
+        # If remote_src=true, and src= contains ://, try and download the file to a temp directory.
         elif '://' in src:
             tempdir = os.path.dirname(os.path.realpath(__file__))
             package = os.path.join(tempdir, str(src.rsplit('/', 1)[1]))

--- a/lib/ansible/plugins/action/unarchive.py
+++ b/lib/ansible/plugins/action/unarchive.py
@@ -53,7 +53,7 @@ class ActionModule(ActionBase):
                 return result
             # We will take the information from copy and store it in
             # the remote_src var to use later in this file.
-            remote_src = not boolean(self._task.args.get('copy'))
+            self._task.args['remote_src'] = remote_src = not boolean(self._task.args.pop('copy'))
 
         if source is None or dest is None:
             result['failed'] = True
@@ -128,7 +128,7 @@ class ActionModule(ActionBase):
             )
 
         # remove action plugin only key
-        for key in ('remote_src', 'decrypt'):
+        for key in ('decrypt',):
             if key in new_module_args:
                 del new_module_args[key]
 


### PR DESCRIPTION
##### SUMMARY
Fix logic surrounding copy and remote_src, remote_src is preferred, make copy action plugin only. Fixes #23591

This is done by making `copy` an action plugin only argument and ensuring that `remote_src` is properly set.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
unarchive

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
It seems the logic here has always been a little strange, and it was further broken in https://github.com/ansible/ansible/commit/7b197d823ee775b0138495bcd3954dff28851dd5 by making `remote_src` action plugin only.

The `mutually_exclusive` definition was removed, as it was already being handled in the action plugin, and would never apply in the module now.