### PR TITLE
add force option for mysql_db import state

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -78,7 +78,7 @@ options:
       - Option use to skip errors when importing malformed sql files.
     required: false
     default: false
-    version_added: 2.4
+    version_added: "2.4"
 author: "Ansible Core Team"
 requirements:
    - mysql (command line binary)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Idea validation

##### COMPONENT NAME
mysql_db

##### ANSIBLE VERSION
```
2.4
```

##### OS / ENVIRONMENT
N/A

##### SUMMARY
When sql files are malformed, mysql_db import stops running.
mysql use the option force (-f) to avoid this problem when importing big sql files.

I think it is a good idea to integrate this option in mysql_db module and set it to false by default.

This has been tested with mysql 