### PR TITLE
[GCP] remove ansible.utils.display for deprecations

### DIFF
--- a/lib/ansible/module_utils/gcp.py
+++ b/lib/ansible/module_utils/gcp.py
@@ -60,13 +60,6 @@ except ImportError:
     HAS_GOOGLE_API_LIB = False
 
 
-# Ansible Display object for warnings
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
-
 import ansible.module_utils.six.moves.urllib.parse as urlparse
 
 GCP_DEFAULT_SCOPES = ['https://www.googleapis.com/auth/cloud-platform']
@@ -106,7 +99,7 @@ def _get_gcp_environment_credentials(service_account_email, credentials_file, pr
     return (service_account_email, credentials_file, project_id)
 
 
-def _get_gcp_libcloud_credentials(service_account_email=None, credentials_file=None, project_id=None):
+def _get_gcp_libcloud_credentials(module, service_account_email=None, credentials_file=None, project_id=None):
     """
     Helper to look for libcloud secrets.py file.
 
@@ -130,9 +123,9 @@ def _get_gcp_libcloud_credentials(service_account_email=None, credentials_file=N
     if service_account_email is None or credentials_file is None:
         try:
             import secrets
-            display.deprecated(msg=("secrets file found at '%s'.  This method of specifying "
-                                    "credentials is deprecated.  Please use env vars or "
-                                    "Ansible YAML files instead" % (secrets.__file__)), version=2.5)
+            module.deprecate(msg=("secrets file found at '%s'.  This method of specifying "
+                                  "credentials is deprecated.  Please use env vars or "
+                                  "Ansible YAML files instead" % (secrets.__file__)), version=2.5)
         except ImportError:
             secrets = None
         if hasattr(secrets, 'GCE_PARAMS'):
@@ -199,7 +192,7 @@ def _get_gcp_credentials(module, require_valid_json=True, check_libcloud=False):
     # get the remaining values from the libcloud secrets file.
     (service_account_email,
      credentials_file,
-     project_id) = _get_gcp_libcloud_credentials(service_account_email,
+     project_id) = _get_gcp_libcloud_credentials(module, service_account_email,
                                                  credentials_file, project_id)
 
     if credentials_file is None or project_id is None or service_account_email is None:
@@ -274,9 +267,9 @@ def _validate_credentials_file(module, credentials_file, require_valid_json=True
             module.fail_json(
                 msg='GCP Credentials File %s invalid.  Must be valid JSON.' % credentials_file, changed=False)
         else:
-            display.deprecated(msg=("Non-JSON credentials file provided. This format is deprecated. "
-                                    " Please generate a new JSON key from the Google Cloud console"),
-                               version=2.5)
+            module.deprecate(msg=("Non-JSON credentials file provided. This format is deprecated. "
+                                  " Please generate a new JSON key from the Google Cloud console"),
+                             version=2.5)
             return True
 
 

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -890,7 +890,6 @@ test/units/module_utils/basic/test_run_command.py
 test/units/module_utils/basic/test_safe_eval.py
 test/units/module_utils/basic/test_set_mode_if_different.py
 test/units/module_utils/ec2/test_aws.py
-test/units/module_utils/gcp/test_auth.py
 test/units/module_utils/json_utils/test_filter_non_json_lines.py
 test/units/module_utils/test_basic.py
 test/units/module_utils/test_distribution_version.py


### PR DESCRIPTION
##### SUMMARY

gcp.py is currently using ansible.utils.display to print deprecation warnings.  That module is not available on remote hosts.  This PR changes this to use AnsibleModule.deprecate, which is available.  Unit tests have also been updated.

Fixes #24626

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (display-check 6ae6ebda66) last updated 2017/05/17 16:14:29 (GMT +000)
  config file = 
  configured module search path = [u'/home/supertom/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/supertom/virts/ans-http-lb/code/ansible/lib/ansible
  executable location = /home/supertom/virts/ans-http-lb/code/ansible/bin/ansible
  python version = 2.7.9 (default, Jun 29 2016, 13:08:31) [GCC 4.9.2]
```

