### PR TITLE
Deal with server.security_groups being None

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -631,7 +631,11 @@ def _check_security_groups(module, cloud, server):
         return changed, server
 
     module_security_groups = set(module.params['security_groups'])
-    server_security_groups = set(sg.name for sg in server.security_groups)
+    # Workaround a bug in shade <= 1.20.0
+    if server.security_groups is not None:
+        server_security_groups = set(sg.name for sg in server.security_groups)
+    else:
+        server_security_groups = set()
 
     add_sgs = module_security_groups - server_security_groups
     remove_sgs = server_security_groups - module_security_groups


### PR DESCRIPTION
It shouldn't happen - but there is a bug in shade where it can be None
but should be [] instead. Work around it.

Fixes #24675