### PR TITLE
Base changes required to allow winrm to work on py3

### DIFF
--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -839,14 +839,14 @@ def modify_module(module_name, module_path, module_args, task_vars=dict(), modul
 
 def build_windows_module_payload(module_name, module_path, b_module_data, module_args, task_vars, task, play_context, environment):
     exec_manifest = dict(
-        module_entry=base64.b64encode(b_module_data),
+        module_entry=to_text(base64.b64encode(b_module_data)),
         powershell_modules=dict(),
         module_args=module_args,
         actions=['exec'],
         environment=environment
     )
 
-    exec_manifest['exec'] = base64.b64encode(to_bytes(leaf_exec))
+    exec_manifest['exec'] = to_text(base64.b64encode(to_bytes(leaf_exec)))
 
     if task.async > 0:
         exec_manifest["actions"].insert(0, 'async_watchdog')
@@ -874,8 +874,14 @@ def build_windows_module_payload(module_name, module_path, b_module_data, module
             # TODO: add #Requires checks for Ansible.ModuleUtils.X
 
     for m in module_names:
-        exec_manifest["powershell_modules"][m] = base64.b64encode(
-            to_bytes(_slurp(os.path.join(_MODULE_UTILS_PATH, m + ".ps1"))))
+        m = to_text(m)
+        exec_manifest["powershell_modules"][m] = to_text(
+            base64.b64encode(
+                to_bytes(
+                    _slurp(os.path.join(_MODULE_UTILS_PATH, m + ".ps1"))
+                )
+            )
+        )
 
     # FUTURE: smuggle this back as a dict instead of serializing here; the connection plugin may need to modify it
     b_module_data = json.dumps(exec_manifest)

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -392,11 +392,11 @@ class Connection(ConnectionBase):
         return (result.status_code, result.std_out, result.std_err)
 
     def is_clixml(self, value):
-        return value.startswith("#< CLIXML")
+        return value.startswith(b"#< CLIXML")
 
     # hacky way to get just stdout- not always sure of doc framing here, so use with care
     def parse_clixml_stream(self, clixml_doc, stream_name='Error'):
-        clear_xml = clixml_doc.replace('#< CLIXML\r\n', '')
+        clear_xml = clixml_doc.replace(b'#< CLIXML\r\n', b'')
         doc = xmltodict.parse(clear_xml)
         lines = [l.get('#text', '').replace('_x000D__x000A_', '') for l in doc.get('Objs', {}).get('S', {}) if l.get('@S') == stream_name]
         return '\r\n'.join(lines)


### PR DESCRIPTION
##### SUMMARY

There are a number of bytes/string related issues with building the winrm module, and handling the responses.  This PR fixes those issues for py3.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
winrm

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION

before:
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: can't concat bytes to str
winders12r2 | FAILED! => {
    "failed": true,
    "msg": "Unexpected failure during module execution.",
    "stdout": ""
}
```

after:

```
$ ansible all -i windows -m win_ping
winders12r2 | SUCCESS => {
    "changed": false,
    "ping": "pong"
}
```