### PR TITLE
module_utils/ec2.py: boto3_conn shouldn't overwrite param variables if already set.

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -100,6 +100,10 @@ def boto3_conn(module, conn_type=None, resource=None, region=None, endpoint=None
 
 def _boto3_conn(conn_type=None, resource=None, region=None, endpoint=None, **params):
     profile = params.pop('profile_name', None)
+    if 'aws_session_token' not in params:
+        params['aws_session_token'] = params.pop('security_token', None)
+    if 'verify' not in params:
+        params['verify'] = params.pop('validate_certs', None)
 
     if conn_type not in ['both', 'resource', 'client']:
         raise ValueError('There is an issue in the calling code. You '


### PR DESCRIPTION
Rebased #14355 

##### SUMMARY
This was the summary in #14355. (I'm aware the link is dead.)

Since get_aws_connection_info() correctly sets config parameters
boto_params['aws_session_token'] and boto_params['verify'] when
boto3 is detected we must detect whether these have already
been set in boto3_conn() before overwriting them from old-style
boto (not boto3) parameters ('security_token' and 'validate_certs'
respectively).

By the way - without this patch ecs_taskdefinition module and probably others that use boto3_conn() fail in situations where the AWS_SECURITY_TOKEN / AWS_SESSION_TOKEN is supplied in the OS environment. For example when running ansible under http://aws.nz/aws-utils/assume-role script to use a different IAM Role.

Without this patch the boto3-based modules fail with:

An exception occurred during task execution. To see the full traceback, use -vvv. The error was: botocore.exceptions.ClientError: An error occurred (UnrecognizedClientException) when calling the RegisterTaskDefinition operation: The security token included in the request is invalid.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/ec2.py

##### ANSIBLE VERSION
```
2.4.0
```