### PR TITLE
eos_user Add documentation and example to change password

### DIFF
--- a/lib/ansible/modules/network/eos/eos_user.py
+++ b/lib/ansible/modules/network/eos/eos_user.py
@@ -46,15 +46,12 @@ options:
       - The username to be configured on the remote Arista EOS
         device.  This argument accepts a stringv value and is mutually
         exclusive with the C(users) argument.
-<<<<<<< HEAD
         Please note that this option is not same as C(provider username).
-=======
   password:
     description:
       - The password to be configured on the remote Arista EOS device. The
         password needs to be provided in clear and it will be encrypted
         on the device
->>>>>>> Add doc for password
   update_password:
     description:
       - Since passwords are encrypted in the device running config, this

--- a/lib/ansible/modules/network/eos/eos_user.py
+++ b/lib/ansible/modules/network/eos/eos_user.py
@@ -52,7 +52,7 @@ options:
       - The password to be configured on the remote Arista EOS device. The
         password needs to be provided in clear and it will be encrypted
         on the device.
-        Please note that this option is not same as C(provider username).
+        Please note that this option is not same as C(provider password).
   update_password:
     description:
       - Since passwords are encrypted in the device running config, this

--- a/lib/ansible/modules/network/eos/eos_user.py
+++ b/lib/ansible/modules/network/eos/eos_user.py
@@ -122,6 +122,13 @@ EXAMPLES = """
       - username: netend
     privilege: 15
     state: present
+    
+- name: Change Password for User netop
+  eos_user:
+    username: netop
+    password: "{{ new_password }}"
+    update_password: always
+    state: present
 """
 
 RETURN = """

--- a/lib/ansible/modules/network/eos/eos_user.py
+++ b/lib/ansible/modules/network/eos/eos_user.py
@@ -46,7 +46,15 @@ options:
       - The username to be configured on the remote Arista EOS
         device.  This argument accepts a stringv value and is mutually
         exclusive with the C(users) argument.
+<<<<<<< HEAD
         Please note that this option is not same as C(provider username).
+=======
+  password:
+    description:
+      - The password to be configured on the remote Arista EOS device. The
+        password needs to be provided in clear and it will be encrypted
+        on the device
+>>>>>>> Add doc for password
   update_password:
     description:
       - Since passwords are encrypted in the device running config, this

--- a/lib/ansible/modules/network/eos/eos_user.py
+++ b/lib/ansible/modules/network/eos/eos_user.py
@@ -51,7 +51,8 @@ options:
     description:
       - The password to be configured on the remote Arista EOS device. The
         password needs to be provided in clear and it will be encrypted
-        on the device
+        on the device.
+        Please note that this option is not same as C(provider username).
   update_password:
     description:
       - Since passwords are encrypted in the device running config, this
@@ -119,7 +120,7 @@ EXAMPLES = """
       - username: netend
     privilege: 15
     state: present
-    
+
 - name: Change Password for User netop
   eos_user:
     username: netop


### PR DESCRIPTION
##### SUMMARY
Add documentation for parameter `password` and add an example to show how to change the password of an existing user

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
modules/network/eos/eos_user.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (fix-eos-user 87959c6578) last updated 2017/05/17 12:56:06 (GMT -700)
  config file = /Users/damien/projects/cloudlabs-topologies/vpod-l2-xs/ansible.cfg
  configured module search path = [u'/Users/damien/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/damien/projects/ansible/lib/ansible
  executable location = /Users/damien/projects/ansible/bin/ansible
  python version = 2.7.10 (default, Feb  6 2017, 23:53:20) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```
