### PR TITLE
aos_login change default port and add version check

### DIFF
--- a/lib/ansible/modules/network/aos/aos_login.py
+++ b/lib/ansible/modules/network/aos/aos_login.py
@@ -81,6 +81,7 @@ aos_session:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.aos import check_aos_version
 
 try:
     from apstra.aosom.session import Session
@@ -121,6 +122,9 @@ def main():
     if not HAS_AOS_PYEZ:
         module.fail_json(msg='aos-pyez is not installed.  Please see details '
                              'here: https://github.com/Apstra/aos-pyez')
+
+    # Check if aos-pyez is present and match the minimum version
+    check_aos_version(module, '0.6.1')
 
     aos_login(module)
 

--- a/lib/ansible/modules/network/aos/aos_login.py
+++ b/lib/ansible/modules/network/aos/aos_login.py
@@ -114,7 +114,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             server=dict(required=True),
-            port=dict(default='8888'),
+            port=dict(default='443', type="int"),
             user=dict(default='admin'),
             passwd=dict(default='admin', no_log=True)))
 

--- a/lib/ansible/modules/network/aos/aos_login.py
+++ b/lib/ansible/modules/network/aos/aos_login.py
@@ -37,7 +37,7 @@ description:
     ansible facts with the variable I(aos_session)
     This module is not idempotent and do not support check mode.
 requirements:
-  - "aos-pyez >= 0.6.0"
+  - "aos-pyez >= 0.6.1"
 options:
   server:
     description:

--- a/lib/ansible/modules/network/aos/aos_login.py
+++ b/lib/ansible/modules/network/aos/aos_login.py
@@ -46,7 +46,7 @@ options:
   port:
     description:
       - Port number to use when connecting to the AOS server.
-    default: 8888
+    default: 443
   user:
     description:
       - Login username to use when connecting to the AOS server.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/network/aos/aos_login.py
##### ANSIBLE VERSION
```
ansible 2.4.0 (fix-eos-user 87959c6578) last updated 2017/05/17 12:56:06 (GMT -700)
  config file = /Users/damien/projects/cloudlabs-topologies/vpod-l2-xs/ansible.cfg
  configured module search path = [u'/Users/damien/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/damien/projects/ansible/lib/ansible
  executable location = /Users/damien/projects/ansible/bin/ansible
  python version = 2.7.10 (default, Feb  6 2017, 23:53:20) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```

##### ADDITIONAL INFORMATION
 - Updating the default port number from 8888 to 443
 - Enforce the port number to be an integer
 - Add a minimum version check for a dependency lib 

