### PR TITLE
Fix installation instructions link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Read the documentation and more at https://ansible.com/
 
 Many users run straight from the development branch (it's generally fine to do so), but you might also wish to consume a release.
 
-You can find instructions [here](http://docs.ansible.com/ansible/intro_installation.html) for a variety of platforms.
+You can find instructions [here](https://docs.ansible.com/ansible/intro_installation.html) for a variety of platforms.
 
 Design Principles
 =================

--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ Read the documentation and more at https://ansible.com/
 
 Many users run straight from the development branch (it's generally fine to do so), but you might also wish to consume a release.
 
-You can find instructions [here](https://docs.ansible.com/intro_getting_started.html) for a variety of platforms.
-
-If you want to download a tarball of a release, go to [releases.ansible.com](https://releases.ansible.com/ansible), though most users use `yum` (using the EPEL instructions linked above), `apt` (using the PPA instructions linked above), or `pip install ansible`.
+You can find instructions [here](http://docs.ansible.com/ansible/intro_installation.html) for a variety of platforms.
 
 Design Principles
 =================


### PR DESCRIPTION
##### SUMMARY
The original linked page (Getting started) assumed the user already had an installed system, which clearly was not the intention of the link.
So I replaced it with a link to the installation instructions, and removed the quick advice. The installation instructions are well structured and complete.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
README

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.3+