### PR TITLE
ec2_group_facts tag list should have case preserved

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group_facts.py
@@ -153,11 +153,13 @@ def main():
     except ClientError as e:
         module.fail_json(msg=e.message, exception=traceback.format_exc())
 
-    # Modify boto3 tags list to be ansible friendly dict and then camel_case
     snaked_security_groups = []
     for security_group in security_groups['SecurityGroups']:
-        security_group['Tags'] = boto3_tag_list_to_ansible_dict(security_group['Tags'])
-        snaked_security_groups.append(camel_dict_to_snake_dict(security_group))
+        # Modify boto3 tags list to be ansible friendly dict
+        # but don't camel case tags
+        security_group = camel_dict_to_snake_dict(security_group)
+        security_group['tags'] = boto3_tag_list_to_ansible_dict(security_group['tags'], tag_name_key_name='key', tag_value_key_name='value')
+        snaked_security_groups.append(security_group)
 
     module.exit_json(security_groups=snaked_security_groups)
 


### PR DESCRIPTION
##### SUMMARY
Tags should retain case, and should not be snake cased.
Easiest way to do this is to snake before converting tag
list as while that affects the keys of the boto3 tag lists,
it doesn't affect the values. Need to use `tag_value_key_name`
and `tag_name_key_name` following recent change to
`boto3_tag_list_to_ansible_dict`, which used to handle both
`key`/`Key` and `value`/`Value`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_group_facts

##### ANSIBLE VERSION
```ansible 2.4.0 (devel e7d8ebf080) last updated 2017/05/18 11:01:16 (GMT +1000)
  config file = /home/will/src/xvt-dpe-cloud-infrastructure-stream2/ansible.cfg
  configured module search path = [u'./library']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
