### PR TITLE
Save commit_timeout as string in junos_config

### DIFF
--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -138,7 +138,7 @@ def commit_configuration(module, confirm=False, check=False, comment=None, confi
         subele.text = str(comment)
     if confirm_timeout:
         subele = SubElement(obj, 'confirm-timeout')
-        subele.text = int(confirm_timeout)
+        subele.text = str(confirm_timeout)
     return send_request(module, obj)
 
 def command(module, command, format='text', rpc_only=False):


### PR DESCRIPTION
##### SUMMARY
Fix converts commit_timeout to string as
Elementree.SubElement requires text as string.

Fixes #24611

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/junos.py

##### ANSIBLE VERSION
```
2.4 devel
```
