### PR TITLE
Allow idempotent use of ec2_ami_copy

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
@@ -74,6 +74,12 @@ options:
       - A hash/dictionary of tags to add to the new copied AMI; '{"key":"value"}' and '{"key":"value","key":"value"}'
     required: false
     default: null
+  tag_equality:
+    description:
+      - Whether to use tags if the source AMI already exists in the target region. If this is set, and all tags match
+        in an existing AMI, the AMI will not be copied again.
+    default: false
+    version_added: 2.4
 author: "Amir Moulavi <amir.moulavi@gmail.com>, Tim C <defunct@defunct.io>"
 extends_documentation_fragment:
     - aws
@@ -105,7 +111,7 @@ EXAMPLES = '''
     name: My-Awesome-AMI
     description: latest patch
 
-# Tagged AMI copy
+# Tagged AMI copy (will not copy the same AMI twice)
 - ec2_ami_copy:
     source_region: us-east-1
     region: eu-west-1
@@ -113,6 +119,7 @@ EXAMPLES = '''
     tags:
         Name: My-Super-AMI
         Patch: 1.2.3
+    tag_equality: yes
 
 # Encrypted AMI copy
 - ec2_ami_copy:
@@ -138,25 +145,14 @@ image_id:
   sample: ami-e689729e
 '''
 
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ec2 import (boto3_conn, ec2_argument_spec, get_aws_connection_info)
-
-import traceback
-
-try:
-    import boto
-    import boto.ec2
-    HAS_BOTO = True
-except ImportError:
-    HAS_BOTO = False
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict, ansible_dict_to_boto3_tag_list
 
 try:
-    import boto3
-    from botocore.exceptions import ClientError, NoCredentialsError, NoRegionError, WaiterError
-    HAS_BOTO3 = True
+    import botocore
 except ImportError:
-    HAS_BOTO3 = False
-
+    pass  # caught by AnsibleAWSModule
 
 def copy_image(module, ec2):
     """
@@ -167,6 +163,8 @@ def copy_image(module, ec2):
     """
 
     tags = module.params.get('tags')
+    image = None
+    changed = False
 
     params = {'SourceRegion': module.params.get('source_region'),
               'SourceImageId': module.params.get('source_image_id'),
@@ -178,22 +176,28 @@ def copy_image(module, ec2):
         params['KmsKeyId'] = module.params.get('kms_key_id')
 
     try:
-        image_id = ec2.copy_image(**params)['ImageId']
-        if module.params.get('wait'):
-            ec2.get_waiter('image_available').wait(ImageIds=[image_id])
-        if module.params.get('tags'):
-            ec2.create_tags(
-                Resources=[image_id],
-                Tags=[{'Key': k, 'Value': v} for k, v in module.params.get('tags').items()]
-            )
+        if module.params.get('tag_equality'):
+            filters = [{'Name': 'tag:%s' % k, 'Values': [v]} for (k, v) in module.params.get('tags').items()]
+            filters.append(dict(Name='state', Values=['available', 'pending']))
+            images = ec2.describe_images(Filters=filters)
+            if len(images['Images']) > 0:
+                image = images['Images'][0]
+        if not image:
+            image = ec2.copy_image(**params)
+            image_id = image['ImageId']
+            if tags:
+                ec2.create_tags(Resources=[image_id],
+                                Tags=ansible_dict_to_boto3_tag_list(tags))
+            changed = True
 
-        module.exit_json(changed=True, image_id=image_id)
-    except WaiterError as we:
-        module.fail_json(msg='An error occurred waiting for the image to become available. (%s)' % str(we), exception=traceback.format_exc())
-    except ClientError as ce:
-        module.fail_json(msg=ce.message)
-    except NoCredentialsError:
-        module.fail_json(msg='Unable to authenticate, AWS credentials are invalid.')
+        if module.params.get('wait'):
+            ec2.get_waiter('image_available').wait(ImageIds=[image['ImageId']])
+
+        module.exit_json(changed=changed, **camel_dict_to_snake_dict(image))
+    except botocore.exceptions.WaiterError as e:
+        module.fail_json_aws(e, msg='An error occurred waiting for the image to become available')
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Could not copy AMI")
     except Exception as e:
         module.fail_json(msg='Unhandled exception. (%s)' % str(e))
 
@@ -209,24 +213,21 @@ def main():
         kms_key_id=dict(type='str', required=False),
         wait=dict(type='bool', default=False),
         wait_timeout=dict(default=1200),
-        tags=dict(type='dict')))
+        tags=dict(type='dict')),
+        tag_equality=dict(type='bool', default=False))
 
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec)
 
-    if not HAS_BOTO:
-        module.fail_json(msg='boto required for this module')
     # TODO: Check botocore version
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
 
-    if HAS_BOTO3:
-
-        try:
-            ec2 = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url,
-                             **aws_connect_params)
-        except NoRegionError:
-            module.fail_json(msg='AWS Region is required')
-    else:
-        module.fail_json(msg='boto3 required for this module')
+    if not region:
+        module.fail_json(msg='AWS Region is required')
+    try:
+        ec2 = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url,
+                         **aws_connect_params)
+    except botocore.exceptions.ProfileNotFound as e:
+        module.fail_json_aws(e)
 
     copy_image(module, ec2)
 

--- a/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
@@ -220,14 +220,8 @@ def main():
 
     # TODO: Check botocore version
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
-
-    if not region:
-        module.fail_json(msg='AWS Region is required')
-    try:
-        ec2 = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url,
-                         **aws_connect_params)
-    except botocore.exceptions.ProfileNotFound as e:
-        module.fail_json_aws(e)
+    ec2 = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url,
+                     **aws_connect_params)
 
     copy_image(module, ec2)
 

--- a/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
@@ -154,6 +154,7 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
+
 def copy_image(module, ec2):
     """
     Copies an AMI

--- a/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
@@ -79,7 +79,7 @@ options:
       - Whether to use tags if the source AMI already exists in the target region. If this is set, and all tags match
         in an existing AMI, the AMI will not be copied again.
     default: false
-    version_added: 2.4
+    version_added: 2.5
 author: "Amir Moulavi <amir.moulavi@gmail.com>, Tim C <defunct@defunct.io>"
 extends_documentation_fragment:
     - aws


### PR DESCRIPTION


##### SUMMARY
When `tag_equality` is set true, use tags to determine
if AMIs in different accounts are the same, and don't
copy the AMI twice if they are the same.

Some minor pep-8 tidy ups

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ec2_ami_copy

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel e7d8ebf080) last updated 2017/05/18 11:01:16 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
