### PR TITLE
module_utils/ec2.py: get AWS access and secret keys from boto config

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -168,8 +168,9 @@ def get_aws_connection_info(module, boto3=False):
         elif 'EC2_ACCESS_KEY' in os.environ:
             access_key = os.environ['EC2_ACCESS_KEY']
         else:
-            # in case access_key came in as empty string
-            access_key = None
+            access_key = boto.config.get('Credentials', 'aws_access_key_id')
+            if not access_key:
+                access_key = boto.config.get('default', 'aws_access_key_id')
 
     if not secret_key:
         if 'AWS_SECRET_ACCESS_KEY' in os.environ:
@@ -179,8 +180,9 @@ def get_aws_connection_info(module, boto3=False):
         elif 'EC2_SECRET_KEY' in os.environ:
             secret_key = os.environ['EC2_SECRET_KEY']
         else:
-            # in case secret_key came in as empty string
-            secret_key = None
+            secret_key = boto.config.get('Credentials', 'aws_secret_access_key')
+            if not secret_key:
+                secret_key = boto.config.get('default', 'aws_secret_access_key')
 
     if not region:
         if 'AWS_REGION' in os.environ:
@@ -208,10 +210,10 @@ def get_aws_connection_info(module, boto3=False):
             security_token = os.environ['AWS_SESSION_TOKEN']
         elif 'EC2_SECURITY_TOKEN' in os.environ:
             security_token = os.environ['EC2_SECURITY_TOKEN']
-
-        if not security_token:
-            # in case security_token came in as empty string
-            security_token = None
+        else:
+            security_token = boto.config.get('Credentials', 'aws_security_token')
+            if not security_token:
+                security_token = boto.config.get('default', 'aws_security_token')
 
     if HAS_BOTO3 and boto3:
         boto_params = dict(aws_access_key_id=access_key,

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -167,10 +167,12 @@ def get_aws_connection_info(module, boto3=False):
             access_key = os.environ['AWS_ACCESS_KEY']
         elif 'EC2_ACCESS_KEY' in os.environ:
             access_key = os.environ['EC2_ACCESS_KEY']
-        else:
+        elif boto.config.get('Credentials', 'aws_access_key_id'):
             access_key = boto.config.get('Credentials', 'aws_access_key_id')
-            if not access_key:
-                access_key = boto.config.get('default', 'aws_access_key_id')
+        elif boto.config.get('default', 'aws_access_key_id'):
+            access_key = boto.config.get('default', 'aws_access_key_id')
+        else:
+            access_key = None
 
     if not secret_key:
         if 'AWS_SECRET_ACCESS_KEY' in os.environ:
@@ -179,10 +181,12 @@ def get_aws_connection_info(module, boto3=False):
             secret_key = os.environ['AWS_SECRET_KEY']
         elif 'EC2_SECRET_KEY' in os.environ:
             secret_key = os.environ['EC2_SECRET_KEY']
-        else:
+        elif boto.config.get('Credentials', 'aws_secret_access_key'):
             secret_key = boto.config.get('Credentials', 'aws_secret_access_key')
-            if not secret_key:
-                secret_key = boto.config.get('default', 'aws_secret_access_key')
+        elif boto.config.get('default', 'aws_secret_access_key'):
+            secret_key = boto.config.get('default', 'aws_secret_access_key')
+        else:
+            secret_key = None
 
     if not region:
         if 'AWS_REGION' in os.environ:
@@ -210,10 +214,12 @@ def get_aws_connection_info(module, boto3=False):
             security_token = os.environ['AWS_SESSION_TOKEN']
         elif 'EC2_SECURITY_TOKEN' in os.environ:
             security_token = os.environ['EC2_SECURITY_TOKEN']
-        else:
+        elif boto.config.get('Credentials', 'aws_security_token'):
             security_token = boto.config.get('Credentials', 'aws_security_token')
-            if not security_token:
-                security_token = boto.config.get('default', 'aws_security_token')
+        elif boto.config.get('default', 'aws_security_token'):
+            security_token = boto.config.get('default', 'aws_security_token')
+        else:
+            security_token = None
 
     if HAS_BOTO3 and boto3:
         boto_params = dict(aws_access_key_id=access_key,

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -161,11 +161,11 @@ def get_aws_connection_info(module, boto3=False):
             ec2_url = os.environ['EC2_URL']
 
     if not access_key:
-        if os.environ.get('AWS_ACCESS_KEY_ID', None):
+        if os.environ.get('AWS_ACCESS_KEY_ID'):
             access_key = os.environ['AWS_ACCESS_KEY_ID']
-        elif os.environ.get('AWS_ACCESS_KEY', None):
+        elif os.environ.get('AWS_ACCESS_KEY'):
             access_key = os.environ['AWS_ACCESS_KEY']
-        elif os.environ.get('EC2_ACCESS_KEY', None):
+        elif os.environ.get('EC2_ACCESS_KEY'):
             access_key = os.environ['EC2_ACCESS_KEY']
         elif boto.config.get('Credentials', 'aws_access_key_id'):
             access_key = boto.config.get('Credentials', 'aws_access_key_id')
@@ -176,11 +176,11 @@ def get_aws_connection_info(module, boto3=False):
             access_key = None
 
     if not secret_key:
-        if os.environ.get('AWS_SECRET_ACCESS_KEY', None):
+        if os.environ.get('AWS_SECRET_ACCESS_KEY'):
             secret_key = os.environ['AWS_SECRET_ACCESS_KEY']
-        elif os.environ.get('AWS_SECRET_KEY', None):
+        elif os.environ.get('AWS_SECRET_KEY'):
             secret_key = os.environ['AWS_SECRET_KEY']
-        elif os.environ.get('EC2_SECRET_KEY', None):
+        elif os.environ.get('EC2_SECRET_KEY'):
             secret_key = os.environ['EC2_SECRET_KEY']
         elif boto.config.get('Credentials', 'aws_secret_access_key'):
             secret_key = boto.config.get('Credentials', 'aws_secret_access_key')
@@ -210,11 +210,11 @@ def get_aws_connection_info(module, boto3=False):
                 module.fail_json(msg="Boto3 is required for this module. Please install boto3 and try again")
 
     if not security_token:
-        if os.environ.get('AWS_SECURITY_TOKEN', None):
+        if os.environ.get('AWS_SECURITY_TOKEN'):
             security_token = os.environ['AWS_SECURITY_TOKEN']
-        elif os.environ.get('AWS_SESSION_TOKEN', None):
+        elif os.environ.get('AWS_SESSION_TOKEN'):
             security_token = os.environ['AWS_SESSION_TOKEN']
-        elif os.environ.get('EC2_SECURITY_TOKEN', None):
+        elif os.environ.get('EC2_SECURITY_TOKEN'):
             security_token = os.environ['EC2_SECURITY_TOKEN']
         elif boto.config.get('Credentials', 'aws_security_token'):
             security_token = boto.config.get('Credentials', 'aws_security_token')

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -161,31 +161,33 @@ def get_aws_connection_info(module, boto3=False):
             ec2_url = os.environ['EC2_URL']
 
     if not access_key:
-        if 'AWS_ACCESS_KEY_ID' in os.environ:
+        if os.environ.get('AWS_ACCESS_KEY_ID', None):
             access_key = os.environ['AWS_ACCESS_KEY_ID']
-        elif 'AWS_ACCESS_KEY' in os.environ:
+        elif os.environ.get('AWS_ACCESS_KEY', None):
             access_key = os.environ['AWS_ACCESS_KEY']
-        elif 'EC2_ACCESS_KEY' in os.environ:
+        elif os.environ.get('EC2_ACCESS_KEY', None):
             access_key = os.environ['EC2_ACCESS_KEY']
         elif boto.config.get('Credentials', 'aws_access_key_id'):
             access_key = boto.config.get('Credentials', 'aws_access_key_id')
         elif boto.config.get('default', 'aws_access_key_id'):
             access_key = boto.config.get('default', 'aws_access_key_id')
         else:
+            # in case access_key came in as empty string
             access_key = None
 
     if not secret_key:
-        if 'AWS_SECRET_ACCESS_KEY' in os.environ:
+        if os.environ.get('AWS_SECRET_ACCESS_KEY', None):
             secret_key = os.environ['AWS_SECRET_ACCESS_KEY']
-        elif 'AWS_SECRET_KEY' in os.environ:
+        elif os.environ.get('AWS_SECRET_KEY', None):
             secret_key = os.environ['AWS_SECRET_KEY']
-        elif 'EC2_SECRET_KEY' in os.environ:
+        elif os.environ.get('EC2_SECRET_KEY', None):
             secret_key = os.environ['EC2_SECRET_KEY']
         elif boto.config.get('Credentials', 'aws_secret_access_key'):
             secret_key = boto.config.get('Credentials', 'aws_secret_access_key')
         elif boto.config.get('default', 'aws_secret_access_key'):
             secret_key = boto.config.get('default', 'aws_secret_access_key')
         else:
+            # in case secret_key came in as empty string
             secret_key = None
 
     if not region:
@@ -208,17 +210,18 @@ def get_aws_connection_info(module, boto3=False):
                 module.fail_json(msg="Boto3 is required for this module. Please install boto3 and try again")
 
     if not security_token:
-        if 'AWS_SECURITY_TOKEN' in os.environ:
+        if os.environ.get('AWS_SECURITY_TOKEN', None):
             security_token = os.environ['AWS_SECURITY_TOKEN']
-        elif 'AWS_SESSION_TOKEN' in os.environ:
+        elif os.environ.get('AWS_SESSION_TOKEN', None):
             security_token = os.environ['AWS_SESSION_TOKEN']
-        elif 'EC2_SECURITY_TOKEN' in os.environ:
+        elif os.environ.get('EC2_SECURITY_TOKEN', None):
             security_token = os.environ['EC2_SECURITY_TOKEN']
         elif boto.config.get('Credentials', 'aws_security_token'):
             security_token = boto.config.get('Credentials', 'aws_security_token')
         elif boto.config.get('default', 'aws_security_token'):
             security_token = boto.config.get('default', 'aws_security_token')
         else:
+            # in case secret_token came in as empty string
             security_token = None
 
     if HAS_BOTO3 and boto3:


### PR DESCRIPTION
##### SUMMARY
I rebased #11374. 

The summary from #11374:
"I noticed when I was trying to manage my AWS servers using the ec2 module I was getting the following error:

msg: No handler was ready to authenticate. 1 handlers were checked. ['HmacAuthV4Handler'] Check your credentials
This is caused when the credentials are not configured properly. However, I have a valid ${HOME}/.boto with the '[Credentials]' section correctly configured. The ec2 dynamic inventory script and connecting with plain boto work fine.

I googled the problem and found this issue: #9984 was having a similar problem.

I fixed the problem by adding a boto config lookup to the ec2 module utils."

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/ec2.py

##### ANSIBLE VERSION
```
2.4.0
```


