### PR TITLE
Make role required in lambda module per AWS docs

### DIFF
--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -49,7 +49,6 @@ options:
       - The Amazon Resource Name (ARN) of the IAM role that Lambda assumes when it executes your function to access any other Amazon Web Services (AWS)
         resources. You may use the bare ARN if the role belongs to the same AWS account.
     required: true
-    default: null
   handler:
     description:
       - The function within your code that Lambda calls to begin execution

--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -48,6 +48,7 @@ options:
     description:
       - The Amazon Resource Name (ARN) of the IAM role that Lambda assumes when it executes your function to access any other Amazon Web Services (AWS)
         resources. You may use the bare ARN if the role belongs to the same AWS account.
+    required: true
     default: null
   handler:
     description:
@@ -234,7 +235,7 @@ def main():
         name=dict(type='str', required=True),
         state=dict(type='str', default='present', choices=['present', 'absent']),
         runtime=dict(type='str', required=True),
-        role=dict(type='str', default=None),
+        role=dict(type='str', required=True),
         handler=dict(type='str', default=None),
         zip_file=dict(type='str', default=None, aliases=['src']),
         s3_bucket=dict(type='str'),

--- a/test/units/modules/cloud/amazon/test_lambda.py
+++ b/test/units/modules/cloud/amazon/test_lambda.py
@@ -272,3 +272,21 @@ def test_warn_region_not_specified():
             except AnsibleFailJson as e:
                 result = e.args[0]
                 assert("region must be specified" in result['msg'])
+
+def test_no_role_specified():
+
+    # Test with 'role' key removed from base_module_args
+    module_args = dict((k, v) for (k, v) in base_module_args.items() if k != 'role')
+    set_module_args(module_args)
+
+    get_aws_connection_info_double=Mock(return_value=(None,None,None))
+
+    with patch.object(lda, 'get_aws_connection_info', get_aws_connection_info_double):
+        with patch.object(basic.AnsibleModule, 'fail_json', fail_json_double):
+            try:
+                lda.main()
+            except AnsibleFailJson as e:
+                result = e.args[0]
+                assert("missing required arguments: role" in result['msg'])
+
+


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Per the [AWS Docs](http://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html), role is a required parameter for Lambda functions. This makes the role required in the lambda module, updates the docs to indicate that it is, and creates a unit test to enforce this behvior.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #24757
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lambda
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (require-lambda-role 968d8e6f6f) last updated 2017/05/18 14:12:47 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/howie/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/howie/thirdparty/ansible/lib/ansible
  executable location = /Users/howie/thirdparty/ansible/bin/ansible
  python version = 2.7.13 (default, Apr 27 2017, 10:40:33) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
This is a fairly straight-forward pull request, so additional information is not needed.

