### PR TITLE
haproxy: fix fail_on_not_found behaviour

### DIFF
--- a/lib/ansible/modules/net_tools/haproxy.py
+++ b/lib/ansible/modules/net_tools/haproxy.py
@@ -274,12 +274,13 @@ class HAProxy(object):
         for backend in backends:
             # Fail when backends were not found
             state = self.get_state_for(backend, svname)
-            if (self.fail_on_not_found or self.wait) and state is None:
+            if (self.fail_on_not_found) and state is None:
                 self.module.fail_json(msg="The specified backend '%s/%s' was not found!" % (backend, svname))
 
-            self.execute(Template(cmd).substitute(pxname=backend, svname=svname))
-            if self.wait:
-                self.wait_until_status(backend, svname, wait_for_status)
+            if state is not None:
+                self.execute(Template(cmd).substitute(pxname = backend, svname = svname))
+                if self.wait:
+                    self.wait_until_status(backend, svname, wait_for_status)
 
     def get_state_for(self, pxname, svname):
         """

--- a/lib/ansible/modules/net_tools/haproxy.py
+++ b/lib/ansible/modules/net_tools/haproxy.py
@@ -278,7 +278,7 @@ class HAProxy(object):
                 self.module.fail_json(msg="The specified backend '%s/%s' was not found!" % (backend, svname))
 
             if state is not None:
-                self.execute(Template(cmd).substitute(pxname = backend, svname = svname))
+                self.execute(Template(cmd).substitute(pxname=backend, svname=svname))
                 if self.wait:
                     self.wait_until_status(backend, svname, wait_for_status)
 


### PR DESCRIPTION
##### SUMMARY
With the current code, setting 'wait' to yes causes the value of fail_on_not_found to be ignored.

With the patch, fail_on_not_found is honored, regardless of the value of wait.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
haproxy module

##### ANSIBLE VERSION
ansible 2.4.0 (detached HEAD ba3a0e8e34) last updated 2017/05/18 22:40:35 (GMT +300)

##### ADDITIONAL INFORMATION
This was previously suggested under PR #24067
