### PR TITLE
Convert some more base64 strings to text for winrm

### DIFF
--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -850,9 +850,9 @@ def build_windows_module_payload(module_name, module_path, b_module_data, module
 
     if task.async > 0:
         exec_manifest["actions"].insert(0, 'async_watchdog')
-        exec_manifest["async_watchdog"] = base64.b64encode(to_bytes(async_watchdog))
+        exec_manifest["async_watchdog"] = to_text(base64.b64encode(to_bytes(async_watchdog)))
         exec_manifest["actions"].insert(0, 'async_wrapper')
-        exec_manifest["async_wrapper"] = base64.b64encode(to_bytes(async_wrapper))
+        exec_manifest["async_wrapper"] = to_text(base64.b64encode(to_bytes(async_wrapper)))
         exec_manifest["async_jid"] = str(random.randint(0, 999999999999))
         exec_manifest["async_timeout_sec"] = task.async
 
@@ -860,7 +860,7 @@ def build_windows_module_payload(module_name, module_path, b_module_data, module
         exec_manifest["actions"].insert(0, 'become')
         exec_manifest["become_user"] = play_context.become_user
         exec_manifest["become_password"] = play_context.become_pass
-        exec_manifest["become"] = base64.b64encode(to_bytes(become_wrapper))
+        exec_manifest["become"] = to_text(base64.b64encode(to_bytes(become_wrapper)))
 
     lines = b_module_data.split(b'\n')
     module_names = set()

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -307,10 +307,10 @@ class Connection(ConnectionBase):
 
     def _create_raw_wrapper_payload(self, cmd, environment=dict()):
         payload = {
-            'module_entry': base64.b64encode(to_bytes(cmd)),
+            'module_entry': to_text(base64.b64encode(to_bytes(cmd))),
             'powershell_modules': {},
             'actions': ['exec'],
-            'exec': base64.b64encode(to_bytes(leaf_exec)),
+            'exec': to_text(base64.b64encode(to_bytes(leaf_exec))),
             'environment': environment
         }
 


### PR DESCRIPTION
##### SUMMARY
These changes address python3 incompatibilities with `raw`, `async` and `become` for winrm.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
winrm

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
