### PR TITLE
fix deprecation import ansible.vars.unsafe_proxy 

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -593,7 +593,7 @@ class Templar:
                 ran = None
 
             if ran and not allow_unsafe:
-                from ansible.vars.unsafe_proxy import UnsafeProxy, wrap_var
+                from ansible.utils.unsafe_proxy import UnsafeProxy, wrap_var
                 if wantlist:
                     ran = wrap_var(ran)
                 else:

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -593,7 +593,6 @@ class Templar:
                 ran = None
 
             if ran and not allow_unsafe:
-                from ansible.utils.unsafe_proxy import UnsafeProxy, wrap_var
                 if wantlist:
                     ran = wrap_var(ran)
                 else:


### PR DESCRIPTION
##### SUMMARY

When i run this task:
```
- name: set public key for authorized
  authorized_key:
    user: "{{ lsyncd_user }}"
    key: "{{ lookup('file','~/.ansible-store/lsyncd/'~lsyncd_instance~'/'~lsyncd_user~'/id_rsa.pub') }}"
```
last version of ansible show Deprecation warning:

>  [DEPRECATION WARNING]: ansible.vars.unsafe_proxy is deprecated.  Use
> ansible.utils.unsafe_proxy instead..
> This feature will be removed in version
> 2.8. Deprecation warnings can be disabled by setting deprecation_warnings=False
>  in ansible.cfg.

grep by code found one string with import
from ansible.vars.unsafe_proxy import UnsafeProxy, wrap_var

change it to from ansible.utils.unsafe_proxy import UnsafeProxy, wrap_var
and warning does not show anymore

##### ISSUE TYPE
 - Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible-2.4.0-100.git201705150857.3ca3163.devel
```
