### PR TITLE
Changes skip test for bigip user

### DIFF
--- a/test/units/modules/network/f5/test_bigip_user.py
+++ b/test/units/modules/network/f5/test_bigip_user.py
@@ -25,7 +25,7 @@ import pytest
 
 if sys.version_info < (2, 7):
     from nose.plugins.skip import SkipTest
-    raise SkipTest("test_bigip_user.py requires Python >= 2.7")
+    raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
 import os
 import json


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
All of the F5 Ansible modules will come to require the same major
dependencies over time. This mentions that.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bigip_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (bugfix.change-skip-test-message ed68fbbe24) last updated 2017/05/18 15:52:11 (GMT -700)
  config file = 
  configured module search path = [u'/Users/trupp/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/trupp/src/trupp/ansible/lib/ansible
  executable location = /Users/trupp/src/trupp/ansible/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]

```
