### PR TITLE
Alternatives module: Add a check that the path to the executable exist

### DIFF
--- a/lib/ansible/modules/system/alternatives.py
+++ b/lib/ansible/modules/system/alternatives.py
@@ -80,6 +80,7 @@ EXAMPLES = '''
     priority: -10
 '''
 
+import os
 import re
 from ansible.module_utils.basic import *
 from ansible.module_utils.pycompat24 import get_exception
@@ -146,6 +147,8 @@ def main():
         try:
             # install the requested path if necessary
             if path not in all_alternatives:
+                if not os.path.exists(path):
+                    module.fail_json(msg="Specfied path %s does not exist" % path)
                 if not link:
                     module.fail_json(msg="Needed to install the alternative, but unable to do so as we are missing the link")
 

--- a/lib/ansible/modules/system/alternatives.py
+++ b/lib/ansible/modules/system/alternatives.py
@@ -148,7 +148,7 @@ def main():
             # install the requested path if necessary
             if path not in all_alternatives:
                 if not os.path.exists(path):
-                    module.fail_json(msg="Specfied path %s does not exist" % path)
+                    module.fail_json(msg="Specified path %s does not exist" % path)
                 if not link:
                     module.fail_json(msg="Needed to install the alternative, but unable to do so as we are missing the link")
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
By default, the alternatives tool does not verify the path to the executable that the link should point to. I've added a check that should prevent installation of requested path if the path does not exist in a system.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
alternatives

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```