### PR TITLE
lambda: role isn't necessary when not creating function - fixes #24757

### DIFF
--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -298,7 +298,9 @@ def main():
     except (botocore.exceptions.ClientError, botocore.exceptions.ValidationError) as e:
         module.fail_json(msg=str(e))
 
-    if role.startswith('arn:aws:iam'):
+    if not role:
+        role_arn = None
+    elif role.startswith('arn:aws:iam'):
         role_arn = role
     else:
         # get account ID and assemble ARN

--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -247,7 +247,7 @@ def main():
         vpc_security_group_ids=dict(type='list', default=None),
         environment_variables=dict(type='dict', default=None),
         dead_letter_arn=dict(type='str', default=None),
-        )
+    )
     )
 
     mutually_exclusive = [['zip_file', 's3_key'],
@@ -306,7 +306,7 @@ def main():
         # get account ID and assemble ARN
         try:
             iam_client = boto3_conn(module, conn_type='client', resource='iam',
-                                region=region, endpoint=ec2_url, **aws_connect_kwargs)
+                                    region=region, endpoint=ec2_url, **aws_connect_kwargs)
             account_id = iam_client.get_user()['User']['Arn'].split(':')[4]
             role_arn = 'arn:aws:iam::{0}:role/{1}'.format(account_id, role)
         except (botocore.exceptions.ClientError, botocore.exceptions.ValidationError) as e:
@@ -337,7 +337,7 @@ def main():
         if memory_size and current_config['MemorySize'] != memory_size:
             func_kwargs.update({'MemorySize': memory_size})
         if (environment_variables is not None) and (current_config.get('Environment', {}).get('Variables', {}) != environment_variables):
-            func_kwargs.update({'Environment':{'Variables': environment_variables}})
+            func_kwargs.update({'Environment': {'Variables': environment_variables}})
         if dead_letter_arn is not None:
             if current_config.get('DeadLetterConfig'):
                 if current_config['DeadLetterConfig']['TargetArn'] != dead_letter_arn:
@@ -368,13 +368,13 @@ def main():
 
             if 'VpcConfig' not in current_config or subnet_net_id_changed or vpc_security_group_ids_changed:
                 func_kwargs.update({'VpcConfig':
-                                    {'SubnetIds': vpc_subnet_ids,'SecurityGroupIds': vpc_security_group_ids}})
+                                    {'SubnetIds': vpc_subnet_ids, 'SecurityGroupIds': vpc_security_group_ids}})
         else:
             # No VPC configuration is desired, assure VPC config is empty when present in current config
             if ('VpcConfig' in current_config and
                     'VpcId' in current_config['VpcConfig'] and
                     current_config['VpcConfig']['VpcId'] != ''):
-                func_kwargs.update({'VpcConfig':{'SubnetIds': [], 'SecurityGroupIds': []}})
+                func_kwargs.update({'VpcConfig': {'SubnetIds': [], 'SecurityGroupIds': []}})
 
         # Upload new configuration if configuration has changed
         if len(func_kwargs) > 1:

--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -432,6 +432,9 @@ def main():
 
     # Function doesn't exists, create new Lambda function
     elif state == 'present':
+        if not role_arn:
+            module.fail_json(msg='A role is required for Lambda function creation')
+
         if s3_bucket and s3_key:
             # If function is stored on S3
             code = {'S3Bucket': s3_bucket,

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -137,7 +137,6 @@ lib/ansible/modules/cloud/amazon/iam.py
 lib/ansible/modules/cloud/amazon/iam_cert.py
 lib/ansible/modules/cloud/amazon/iam_policy.py
 lib/ansible/modules/cloud/amazon/iam_server_certificate_facts.py
-lib/ansible/modules/cloud/amazon/lambda.py
 lib/ansible/modules/cloud/amazon/lambda_facts.py
 lib/ansible/modules/cloud/amazon/rds_param_group.py
 lib/ansible/modules/cloud/amazon/rds_subnet_group.py


### PR DESCRIPTION
##### SUMMARY
Allow role to be optional unless creating a lambda function. Alternative to #24789 as a fix for #24757.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/lambda.py

##### ANSIBLE VERSION
```
2.4.0
```