### PR TITLE
added privilege escalation method for pmrun(Unix Privilege Manager 6.0)

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -276,7 +276,8 @@ BECOME_ERROR_STRINGS = {
     'pfexec': '',
     'doas': 'Permission denied',
     'dzdo': '',
-    'ksu': 'Password incorrect'
+    'ksu': 'Password incorrect',
+    'pmrun': 'You are not permitted to run this command'
 }  # FIXME: deal with i18n
 BECOME_MISSING_STRINGS = {
     'sudo': 'sorry, a password is required to run sudo',
@@ -285,9 +286,10 @@ BECOME_MISSING_STRINGS = {
     'pfexec': '',
     'doas': 'Authorization required',
     'dzdo': '',
-    'ksu': 'No password given'
+    'ksu': 'No password given',
+    'pmrun': ''
 }  # FIXME: deal with i18n
-BECOME_METHODS = ['sudo', 'su', 'pbrun', 'pfexec', 'doas', 'dzdo', 'ksu', 'runas']
+BECOME_METHODS = ['sudo', 'su', 'pbrun', 'pfexec', 'doas', 'dzdo', 'ksu', 'runas', 'pmrun']
 BECOME_ALLOW_SAME_USER = get_config(p, 'privilege_escalation', 'become_allow_same_user', 'ANSIBLE_BECOME_ALLOW_SAME_USER', False, value_type='boolean')
 DEFAULT_BECOME_METHOD = get_config(p, 'privilege_escalation', 'become_method', 'ANSIBLE_BECOME_METHOD',
                                    'sudo' if DEFAULT_SUDO else 'su' if DEFAULT_SU else 'sudo').lower()
@@ -296,7 +298,6 @@ DEFAULT_BECOME_USER = get_config(p, 'privilege_escalation', 'become_user', 'ANSI
 DEFAULT_BECOME_EXE = get_config(p, 'privilege_escalation', 'become_exe', 'ANSIBLE_BECOME_EXE', None)
 DEFAULT_BECOME_FLAGS = get_config(p, 'privilege_escalation', 'become_flags', 'ANSIBLE_BECOME_FLAGS', None)
 DEFAULT_BECOME_ASK_PASS = get_config(p, 'privilege_escalation', 'become_ask_pass', 'ANSIBLE_BECOME_ASK_PASS', False, value_type='boolean')
-
 
 # PLUGINS
 

--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -119,7 +119,7 @@ def check_command(commandline):
                   'mount': 'mount', 'rpm': 'yum, dnf or zypper', 'yum': 'yum', 'apt-get': 'apt',
                   'tar': 'unarchive', 'unzip': 'unarchive', 'sed': 'template or lineinfile',
                   'dnf': 'dnf', 'zypper': 'zypper' }
-    become   = [ 'sudo', 'su', 'pbrun', 'pfexec', 'runas' ]
+    become   = [ 'sudo', 'su', 'pbrun', 'pfexec', 'runas', 'pmrun' ]
     warnings = list()
     command = os.path.basename(commandline.split()[0])
     if command in arguments:

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -125,7 +125,7 @@ options:
       description:
         - Become method to Use for privledge escalation.
       required: False
-      choices: ["None", "sudo", "su", "pbrun", "pfexec"]
+      choices: ["None", "sudo", "su", "pbrun", "pfexec", "pmrun"]
       default: "None"
     become_username:
       description:

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -587,6 +587,13 @@ class PlayContext(Base):
                 else:
                     becomecmd = '%s -u %s %s' % (exe, self.become_user, command)
 
+            elif self.become_method == 'pmrun':
+
+                exe = self.become_exe or 'pmrun'
+
+                prompt='Enter UPM user password:'
+                becomecmd = '%s %s su - %s -c %s' % (exe, flags, self.become_user, shlex_quote(command))
+
             else:
                 raise AnsibleError("Privilege escalation method not found: %s" % self.become_method)
 


### PR DESCRIPTION
works with rule format: pmrun su - root -c "*"

##### SUMMARY
This is a feature request to support a new privilege escalation method: pmrun.

This is part of the Unix Privilege Manager product maintained by a company called Quest.  It is used extensively at our company instead of sudo and we are looking to have it included in the core distro and Tower.

##### ISSUE TYPE
 - Feature Pull Request
 
##### COMPONENT NAME
become

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, Aug 2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```


##### ADDITIONAL INFORMATION
Unfortunately the way this product works it does not allow us to simply specify "*" as a command as it must be a fully qualified base path and command.  For this reason I had to chain privilege commands in the form of: pmrun su - \<user\> -c *.  

I saw that this is frowned upon/forbidden but there is no other way I have found after extensive talks with our IAM team and the vendor to make this functionality work with the product.  I was told by our Ansible account rep that our company(V) is the only current customer using this particular privilege manager so I am hoping a possible exception might be made, or worst case if we maintain our own branch(current strategy) we have an easy way to integrate it with Tower.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
