### PR TITLE
Fix for linode module requiring name for state=restarted (untested, rebased, migrated)

### DIFF
--- a/lib/ansible/modules/cloud/linode/linode.py
+++ b/lib/ansible/modules/cloud/linode/linode.py
@@ -371,7 +371,7 @@ def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_thres
         if not servers:
             for arg in (name, plan, distribution, datacenter):
                 if not arg:
-                    module.fail_json(msg='%s is required for active state' % arg)
+                    module.fail_json(msg='%s is required for %s state' % (arg, state))
             # Create linode entity
             new_server = True
 
@@ -407,7 +407,7 @@ def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_thres
         if not disks:
             for arg in (name, linode_id, distribution):
                 if not arg:
-                    module.fail_json(msg='%s is required for active state' % arg)
+                    module.fail_json(msg='%s is required for %s state' % (arg, state))
             # Create disks (1 from distrib, 1 for SWAP)
             new_server = True
             try:
@@ -423,11 +423,14 @@ def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_thres
                     res = api.linode_disk_createfromdistribution(
                         LinodeId=linode_id, DistributionID=distribution,
                         rootPass=password, rootSSHKey=ssh_pub_key,
-                        Label='%s data disk (lid: %s)' % (name, linode_id), Size=size)
+                        Label='%s data disk (lid: %s)' % (name, linode_id),
+                        Size=size)
                 else:
                     res = api.linode_disk_createfromdistribution(
-                        LinodeId=linode_id, DistributionID=distribution, rootPass=password,
-                        Label='%s data disk (lid: %s)' % (name, linode_id), Size=size)
+                        LinodeId=linode_id, DistributionID=distribution,
+                        rootPass=password,
+                        Label='%s data disk (lid: %s)' % (name, linode_id),
+                        Size=size)
                 jobs.append(res['JobID'])
                 # Create SWAP disk
                 res = api.linode_disk_create(LinodeId=linode_id, Type='swap',
@@ -449,7 +452,7 @@ def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_thres
         if not configs:
             for arg in (name, linode_id, distribution):
                 if not arg:
-                    module.fail_json(msg='%s is required for active state' % arg)
+                    module.fail_json(msg='%s is required for %s state' % (arg, state))
 
             # Check architecture
             for distrib in api.avail_distributions():
@@ -540,7 +543,7 @@ def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_thres
                 module.fail_json(msg='%s is required for active state' % arg)
 
         if not servers:
-            module.fail_json(msg = 'Server %s (lid: %s) not found' % (name, linode_id))
+            module.fail_json(msg = 'Server (lid: %s) not found' % (linode_id))
 
         for server in servers:
             instance = getInstanceDetails(api, server)
@@ -589,6 +592,7 @@ def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_thres
     # Ease parsing if only 1 instance
     if len(instances) == 1:
         module.exit_json(changed=changed, instance=instances[0])
+
     module.exit_json(changed=changed, instances=instances)
 
 def main():

--- a/lib/ansible/modules/cloud/linode/linode.py
+++ b/lib/ansible/modules/cloud/linode/linode.py
@@ -556,9 +556,11 @@ def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_thres
             instances.append(instance)
 
     elif state in ('restarted'):
-        for arg in ('name', 'linode_id'):
-            if not eval(arg):
-                module.fail_json(msg='%s is required for restarted state' % arg)
+        if not linode_id:
+            module.fail_json(msg='linode_id is required for restarted state')
+
+        if not name:
+            module.fail_json(msg='name is required for restarted state')
 
         if not servers:
             module.fail_json(msg = 'Server (lid: %s) not found' % (linode_id))

--- a/lib/ansible/modules/cloud/linode/linode.py
+++ b/lib/ansible/modules/cloud/linode/linode.py
@@ -556,12 +556,12 @@ def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_thres
             instances.append(instance)
 
     elif state in ('restarted'):
-        for arg in (name, linode_id):
-            if not arg:
+        for arg in ('name', 'linode_id'):
+            if not eval(arg):
                 module.fail_json(msg='%s is required for active state' % arg)
 
         if not servers:
-            module.fail_json(msg = 'Server %s (lid: %s) not found' % (name, linode_id))
+            module.fail_json(msg = 'Server (lid: %s) not found' % (linode_id))
 
         for server in servers:
             instance = getInstanceDetails(api, server)

--- a/lib/ansible/modules/cloud/linode/linode.py
+++ b/lib/ansible/modules/cloud/linode/linode.py
@@ -558,7 +558,7 @@ def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_thres
     elif state in ('restarted'):
         for arg in ('name', 'linode_id'):
             if not eval(arg):
-                module.fail_json(msg='%s is required for active state' % arg)
+                module.fail_json(msg='%s is required for restarted state' % arg)
 
         if not servers:
             module.fail_json(msg = 'Server (lid: %s) not found' % (linode_id))

--- a/lib/ansible/modules/cloud/linode/linode.py
+++ b/lib/ansible/modules/cloud/linode/linode.py
@@ -538,9 +538,8 @@ def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_thres
             instances.append(instance)
 
     elif state in ('stopped'):
-        for arg in (name, linode_id):
-            if not arg:
-                module.fail_json(msg='%s is required for active state' % arg)
+        if not linode_id:
+            module.fail_json(msg='linode_id is required for stopped state')
 
         if not servers:
             module.fail_json(msg = 'Server (lid: %s) not found' % (linode_id))
@@ -561,9 +560,6 @@ def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_thres
     elif state in ('restarted'):
         if not linode_id:
             module.fail_json(msg='linode_id is required for restarted state')
-
-        if not name:
-            module.fail_json(msg='name is required for restarted state')
 
         if not servers:
             module.fail_json(msg = 'Server (lid: %s) not found' % (linode_id))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Rebase of migrated pr https://github.com/ansible/ansible/pull/24825 in a new branch

Fix for ansible/ansible-modules-core#3873
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/clould/linode/linode.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

ansible 2.4.0 (linode_rebase c4df7e1db5) last updated 2017/05/19 09:22:28 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
