### PR TITLE
Fixed Windows NSSM error when removing a stopped service

### DIFF
--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -96,8 +96,7 @@ Function Nssm-Remove
 
     if (Service-Exists -name $name)
     {
-        $cmd = "stop ""$name"""
-        $results = Nssm-Invoke $cmd
+        Nssm-Stop $name
 
         $cmd = "remove ""$name"" confirm"
         $results = Nssm-Invoke $cmd


### PR DESCRIPTION
##### SUMMARY
Fixes problem where trying to remove a stopped service throws the following error;
`an exception occurred when invoking NSSM: MyServiceName: STOP: The service has not been started.`

Currently Remove calls 'nssm stop' directly with no state check; the existing command (Nssm-Stop) checks the state before calling 'nssm stop' which is presumably the desired functionality at this point. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/windows/win_nssm

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
