### PR TITLE
Include error exception in AnsibleError

### DIFF
--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -43,7 +43,7 @@ from ansible.module_utils.six import iteritems
 from ansible.module_utils.six.moves import input
 from ansible.plugins.connection import ConnectionBase
 from ansible.utils.path import makedirs_safe
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils._text import to_bytes, to_native
 
 try:
     from __main__ import display
@@ -376,7 +376,7 @@ class Connection(ConnectionBase):
         try:
             self.sftp = self._connect_sftp()
         except Exception as e:
-            raise AnsibleError("failed to open a SFTP connection (%s)", e)
+            raise AnsibleError("failed to open a SFTP connection (%s)" % to_native(e))
 
         try:
             self.sftp.get(to_bytes(in_path, errors='surrogate_or_strict'), to_bytes(out_path, errors='surrogate_or_strict'))

--- a/lib/ansible/plugins/connection/zone.py
+++ b/lib/ansible/plugins/connection/zone.py
@@ -66,7 +66,7 @@ class Connection(ConnectionBase):
     def _search_executable(executable):
         cmd = distutils.spawn.find_executable(executable)
         if not cmd:
-            raise AnsibleError("%s command not found in PATH") % executable
+            raise AnsibleError("%s command not found in PATH" % executable)
         return cmd
 
     def list_zones(self):

--- a/lib/ansible/plugins/lookup/dig.py
+++ b/lib/ansible/plugins/lookup/dig.py
@@ -19,6 +19,7 @@ __metaclass__ = type
 
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils._text import to_native
 import socket
 
 try:
@@ -146,7 +147,7 @@ class LookupModule(LookupBase):
                             nsaddr = dns.resolver.query(ns)[0].address
                             nameservers.append(nsaddr)
                         except Exception as e:
-                            raise AnsibleError("dns lookup NS: ", str(e))
+                            raise AnsibleError("dns lookup NS: %s" % to_native(e))
                     myres.nameservers = nameservers
                 continue
             if '=' in t:
@@ -163,7 +164,7 @@ class LookupModule(LookupBase):
                     try:
                         rdclass = dns.rdataclass.from_text(arg)
                     except Exception as e:
-                        raise errors.AnsibleError("dns lookup illegal CLASS: ", str(e))
+                        raise AnsibleError("dns lookup illegal CLASS: %s" % to_native(e))
 
                 continue
 
@@ -186,7 +187,7 @@ class LookupModule(LookupBase):
             except dns.exception.SyntaxError:
                 pass
             except Exception as e:
-                raise AnsibleError("dns.reversename unhandled exception", str(e))
+                raise AnsibleError("dns.reversename unhandled exception %s" % to_native(e))
 
         try:
             answers = myres.query(domain, qtype, rdclass=rdclass)
@@ -216,6 +217,6 @@ class LookupModule(LookupBase):
         except dns.resolver.Timeout:
             ret.append('')
         except dns.exception.DNSException as e:
-            raise AnsibleError("dns.resolver unhandled exception", e)
+            raise AnsibleError("dns.resolver unhandled exception %s" % to_native(e))
 
         return ret

--- a/lib/ansible/plugins/lookup/dnstxt.py
+++ b/lib/ansible/plugins/lookup/dnstxt.py
@@ -27,6 +27,7 @@ except ImportError:
 
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils._text import to_native
 
 # ==============================================================
 # DNSTXT: DNS TXT records
@@ -57,7 +58,7 @@ class LookupModule(LookupBase):
             except dns.resolver.Timeout:
                 string = ''
             except DNSException as e:
-                raise AnsibleError("dns.resolver unhandled exception", e)
+                raise AnsibleError("dns.resolver unhandled exception %s" % to_native(e))
 
             ret.append(''.join(string))
 

--- a/lib/ansible/plugins/lookup/sequence.py
+++ b/lib/ansible/plugins/lookup/sequence.py
@@ -178,7 +178,7 @@ class LookupModule(LookupBase):
                 yield formatted
             except (ValueError, TypeError):
                 raise AnsibleError(
-                    "problem formatting %r with %r" % self.format
+                    "problem formatting %r with %r" % (i, self.format)
                 )
 
     def run(self, terms, variables, **kwargs):


### PR DESCRIPTION
##### SUMMARY
Use to_native instead of str

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- lib/ansible/plugins/connection/paramiko_ssh.py
- lib/ansible/plugins/connection/zone.py
- lib/ansible/plugins/lookup/dig.py
- lib/ansible/plugins/lookup/dnstxt.py
- lib/ansible/plugins/lookup/sequence.py

##### ANSIBLE VERSION
```
2.4 devel
```