### PR TITLE
Added feature to allow ignoring extra network devices during the

### DIFF
--- a/lib/ansible/modules/cloud/lxd/lxd_container.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_container.py
@@ -107,6 +107,7 @@ options:
           - This will add additional devices to the ignore list which
             currently only ignores the loopback device "lo".
         required: false
+        version_added: 2.4
     force_stop:
         description:
           - If this is true, the C(lxd_container) forces to stop the container

--- a/lib/ansible/modules/cloud/lxd/lxd_container.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_container.py
@@ -107,7 +107,8 @@ options:
           - This will add additional devices to the ignore list which
             currently only ignores the loopback device "lo".
         required: false
-        version_added: 2.4
+        version_added: "2.4"
+        default: ['lo']
     force_stop:
         description:
           - If this is true, the C(lxd_container) forces to stop the container
@@ -308,7 +309,7 @@ class LXDContainerManagement(object):
 
         self.timeout = self.module.params['timeout']
         self.wait_for_ipv4_addresses = self.module.params['wait_for_ipv4_addresses']
-        self.wait_for_ipv4_addresses_ignore_devices = self.module.params['wait_for_ipv4_addresses_ignore_devices']
+        self.wait_for_ipv4_addresses_ignore_devices = ['lo'] + self.module.params['wait_for_ipv4_addresses_ignore_devices']
         self.force_stop = self.module.params['force_stop']
         self.addresses = None
 
@@ -389,7 +390,7 @@ class LXDContainerManagement(object):
 
     def _container_ipv4_addresses(self, ignore_devices=['lo']):
         if self.wait_for_ipv4_addresses_ignore_devices:
-            ignore_devices = ['lo'] + self.wait_for_ipv4_addresses_ignore_devices
+            ignore_devices = self.wait_for_ipv4_addresses_ignore_devices
         resp_json = self._get_container_state_json()
         network = resp_json['metadata']['network'] or {}
         network = dict((k, v) for k, v in network.items() if k not in ignore_devices) or {}

--- a/lib/ansible/modules/cloud/lxd/lxd_container.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_container.py
@@ -102,6 +102,11 @@ options:
             starting or restarting.
         required: false
         default: false
+    wait_for_ipv4_addresses_ignore_devices:
+        description:
+          - This will add additional devices to the ignore list which
+            currently only ignores the loopback device "lo".
+        required: false
     force_stop:
         description:
           - If this is true, the C(lxd_container) forces to stop the container
@@ -302,6 +307,7 @@ class LXDContainerManagement(object):
 
         self.timeout = self.module.params['timeout']
         self.wait_for_ipv4_addresses = self.module.params['wait_for_ipv4_addresses']
+        self.wait_for_ipv4_addresses_ignore_devices = self.module.params['wait_for_ipv4_addresses_ignore_devices']
         self.force_stop = self.module.params['force_stop']
         self.addresses = None
 
@@ -381,6 +387,8 @@ class LXDContainerManagement(object):
         self.actions.append('unfreez')
 
     def _container_ipv4_addresses(self, ignore_devices=['lo']):
+        if self.wait_for_ipv4_addresses_ignore_devices:
+            ignore_devices = ['lo'] + self.wait_for_ipv4_addresses_ignore_devices
         resp_json = self._get_container_state_json()
         network = resp_json['metadata']['network'] or {}
         network = dict((k, v) for k, v in network.items() if k not in ignore_devices) or {}
@@ -583,6 +591,9 @@ def main():
             wait_for_ipv4_addresses=dict(
                 type='bool',
                 default=False
+            ),
+            wait_for_ipv4_addresses_ignore_devices=dict(
+                type='list',
             ),
             force_stop=dict(
                 type='bool',


### PR DESCRIPTION
optional wait period specified by "wait_for_ipv4_addresses"

##### SUMMARY
When a container has some nics that you don't want to "wait_for_ipv4_addresses" on.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lxd
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
