### PR TITLE
apt: include arch in check for installed packages on multi-arch systems

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -551,8 +551,13 @@ def install_deb(m, debs, cache, force, install_recommends, allow_unauthenticated
             pkg = apt.debfile.DebPackage(deb_file)
             pkg_name = get_field_of_deb(m, deb_file, "Package")
             pkg_version = get_field_of_deb(m, deb_file, "Version")
+            if len(apt_pkg.get_architectures()) > 1:
+                pkg_arch = get_field_of_deb(m, deb_file, "Architecture")
+                pkg_key = "%s:%s" % (pkg_name, pkg_arch)
+            else:
+                pkg_key = pkg_name
             try:
-                installed_pkg = apt.Cache()[pkg_name]
+                installed_pkg = apt.Cache()[pkg_key]
                 installed_version = installed_pkg.installed.version
                 if package_version_compare(pkg_version, installed_version) == 0:
                     # Does not need to down-/upgrade, move on to next package

--- a/test/integration/targets/apt/defaults/main.yml
+++ b/test/integration/targets/apt/defaults/main.yml
@@ -1,0 +1,1 @@
+apt_foreign_arch: i386

--- a/test/integration/targets/apt/tasks/apt-multiarch.yml
+++ b/test/integration/targets/apt/tasks/apt-multiarch.yml
@@ -1,0 +1,32 @@
+# verify that apt is handling multi-arch systems properly
+- name: add architecture {{ apt_foreign_arch }}
+  command: dpkg --add-architecture {{ apt_foreign_arch }}
+
+- name: install hello:{{ apt_foreign_arch }} with apt
+  apt: pkg=hello:{{ apt_foreign_arch }} state=present update_cache=yes
+
+- name: uninstall hello:{{ apt_foreign_arch }} with apt
+  apt: pkg=hello:{{ apt_foreign_arch }} state=absent purge=yes
+
+- name: install deb file
+  apt: deb="/var/cache/apt/archives/hello_{{ hello_version.stdout }}_{{ apt_foreign_arch }}.deb"
+  register: apt_multi_initial
+
+- name: install deb file again
+  apt: deb="/var/cache/apt/archives/hello_{{ hello_version.stdout }}_{{ apt_foreign_arch }}.deb"
+  register: apt_multi_secondary
+
+- name: verify installation of hello:{{ apt_foreign_arch }}
+  assert:
+    that:
+        - "apt_multi_initial.changed"
+        - "not apt_multi_secondary.changed"
+
+- name: remove all {{ apt_foreign_arch }} packages
+  apt:
+    name: "*:{{ apt_foreign_arch }}"
+    state: absent
+    purge: yes
+
+- name: remove {{ apt_foreign_arch }} architecture
+  command: dpkg --remove-architecture {{ apt_foreign_arch }}

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -18,5 +18,8 @@
 - include: 'apt.yml'
   when: ansible_distribution in ('Ubuntu', 'Debian')
 
+- include: 'apt-multiarch.yml'
+  when: ansible_distribution in ('Ubuntu', 'Debian') and ansible_userspace_architecture != apt_foreign_arch
+
 - include: 'apt-builddep.yml'
   when: ansible_distribution in ('Ubuntu', 'Debian')


### PR DESCRIPTION
##### SUMMARY
See #24673 and #24703.

On systems that have multi-arch enabled, you need to lookup packages via `package:arch` from `apt.Cache()`. Newer versions of `python-apt` also accept this notation when multi-arch is not enabled, but the version shipped in Debian Jessie and Ubuntu 14.04 does not.

Thanks: Stefan Löwen <stefan.loewen@gmail.com>

Fixes: #24673 
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
apt

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 7563d93901) last updated 2017/05/19 23:17:35 (GMT +200)
```