### PR TITLE
Remove redeclared module variable

### DIFF
--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -160,7 +160,6 @@ fw_offline = False
 Rich_Rule = None
 FirewallClientZoneSettings = None
 
-module = None
 
 #####################
 # exception handling


### PR DESCRIPTION

##### SUMMARY
Fix removes redeclared module variable defined
previously without any usage.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/system/firewalld.py

##### ANSIBLE VERSION
```
2.4 devel
```