### PR TITLE
Allows for testing binary modules

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -248,7 +248,7 @@ def main():
 
     argspath = None
     if module_style not in ('new', 'ansiballz'):
-        if module_style == 'non_native_want_json':
+        if module_style in ('non_native_want_json', 'binary'):
             argspath = write_argsfile(options.module_args, json=True)
         elif module_style == 'old':
             argspath = write_argsfile(options.module_args, json=False)


### PR DESCRIPTION
##### SUMMARY
Fixes #24856 by applying a small change to the test script

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
hacking/test-module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel 85afb8b244) last updated 2017/05/20 16:44:48 (GMT +100)
  config file =
  configured module search path = [u'/home/martyn/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /space/src/ansible/lib/ansible
  executable location = /space/src/ansible/bin/ansible
  python version = 2.7.9 (default, Jun 29 2016, 13:08:31) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
Provided in the bug report #24856 