### PR TITLE
Replace - workaround for non-utf8 text

### DIFF
--- a/lib/ansible/modules/files/replace.py
+++ b/lib/ansible/modules/files/replace.py
@@ -160,7 +160,7 @@ import os
 import re
 import tempfile
 
-from ansible.module_utils._text import to_text, to_bytes
+from ansible.module_utils._text import to_native, to_bytes
 from ansible.module_utils.basic import AnsibleModule
 
 
@@ -226,7 +226,7 @@ def main():
         f = open(path, 'rb')
         data = f.read()
         try:
-            contents = to_text(data, errors='surrogate_or_strict')
+            contents = to_native(data, errors='surrogate_or_strict')
         except:
             contents = bytes(data)
         f.close()

--- a/lib/ansible/modules/files/replace.py
+++ b/lib/ansible/modules/files/replace.py
@@ -216,7 +216,13 @@ def main():
 
     params = module.params
     path = params['path']
+    encoding = params['encoding']
     res_args = dict()
+
+    params['after'] = to_text(params['after'], errors='surrogate_or_strict', nonstring='passthru')
+    params['before'] = to_text(params['before'], errors='surrogate_or_strict', nonstring='passthru')
+    params['regexp'] = to_text(params['regexp'], errors='surrogate_or_strict', nonstring='passthru')
+    params['replace'] = to_text(params['replace'], errors='surrogate_or_strict', nonstring='passthru')
 
     if os.path.isdir(path):
         module.fail_json(rc=256, msg='Path %s is a directory !' % path)
@@ -228,13 +234,13 @@ def main():
         contents = to_text(f.read(), errors='surrogate_or_strict', encoding=encoding)
         f.close()
 
-    pattern = ''
-    if params['after']:
-        pattern = '%s(.*)' % params['after']
+    pattern = u''
+    if params['after'] and params['before']:
+        pattern = u'%s(.*?)%s' % (params['before'], params['after'])
+    elif params['after']:
+        pattern = u'%s(.*)' % params['after']
     elif params['before']:
-        pattern = '(.*)%s' % params['before']
-    elif params['after'] and params['before']:
-        pattern = '%s(.*?)%s' % (params['before'], params['after'])
+        pattern = u'(.*)%s' % params['before']
 
     if pattern:
         section_re = re.compile(pattern, re.DOTALL)

--- a/lib/ansible/modules/files/replace.py
+++ b/lib/ansible/modules/files/replace.py
@@ -224,7 +224,11 @@ def main():
         module.fail_json(rc=257, msg='Path %s does not exist !' % path)
     else:
         f = open(path, 'rb')
-        contents = to_text(f.read(), errors='surrogate_or_strict')
+        data = f.read()
+        try:
+            contents = to_text(data, errors='surrogate_or_strict')
+        except:
+            contents = bytes(data)
         f.close()
 
     pattern = ''


### PR DESCRIPTION
##### SUMMARY
Implemented a suggested workaround for non-utf8 input files that would otherwise raise exception.

Fixes ansible/ansible#24521

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`replace` module

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel e9e661ebbb) last updated 2017/05/20 17:49:52 (GMT +000)
  config file = 
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/ansible/lib/ansible
  executable location = /home/vagrant/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:32:47) [GCC 4.8.4]
```
