### PR TITLE
Ensure Exit-Json returns failed = $false

### DIFF
--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -62,6 +62,17 @@ Function Exit-Json($obj)
         $obj = @{ }
     }
 
+    if (-not $obj.ContainsKey("changed")) {
+        # Still using Set-Attr for PSObject compatibility
+        Set-Attr $obj "changed" $false
+    }
+
+    # Required, especially for modules returning a (potentially) non-zero rc value
+    if (-not $obj.ContainsKey("failed")) {
+        # Still using Set-Attr for PSObject compatibility
+        Set-Attr $obj "failed" $false
+    }
+
     echo $obj | ConvertTo-Json -Compress -Depth 99
     Exit
 }
@@ -82,6 +93,11 @@ Function Fail-Json($obj, $message = $null)
         # If the first argument is undefined or a different type,
         # make it a Hashtable
         $obj = @{ }
+    }
+
+    if (-not $obj.ContainsKey("changed")) {
+        # Still using Set-Attr for PSObject compatibility
+        Set-Attr $obj "changed" $false
     }
 
     # Still using Set-Attr for PSObject compatibility


### PR DESCRIPTION
##### SUMMARY
This is required for modules that may return a non-zero `rc` value for a
successful run, line **win_chocolatey**.

We also added 'changed' to both Exit-Json and Fail-Json, much like the
python calls.

This fixes #24652 !

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
powershell / win_chocolatey

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.4 (elegible to be backported to v2.3 or older)