### PR TITLE
[WIP] User module: Selinux and permissions fixes.

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -759,7 +759,7 @@ class User(object):
             skeleumask = os.stat(self.skeleton).st_mode
         else:
             skeleumask = os.stat('/etc/skele').st_mode
-        os.chmod(path, skeleumask & ~self.newumask & 0777)
+        os.chmod(path, skeleumask & ~self.newumask & 0o777)
 
 # ===========================================
 

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -638,7 +638,7 @@ class User(object):
                 os.mkdir(ssh_dir, int('0700', 8))
                 os.chown(ssh_dir, info[2], info[3])
                 if HAVE_SELINUX and self.module.selinux_enabled():
-                self.set_selinux_type(ssh_dir, 'ssh_home_t')
+                    self.set_selinux_type(ssh_dir, 'ssh_home_t')
             except OSError:
                 e = get_exception()
                 return (1, '', 'Failed to create %s: %s' % (ssh_dir, str(e)))

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -747,7 +747,7 @@ class User(object):
             if self.skeleton is None:
                 f = open('/etc/default/useradd', 'r')
                 if 'SKELE' in line and '#' not in line.split()[0]:
-                   self.skeleton = line.split('=')[1]
+                    self.skeleton = line.split('=')[1]
                 f.close()
         except:
             pass

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -637,7 +637,10 @@ class User(object):
                     cmd.append('-t')
                     cmd.append('ssh_home_t')
                     cmd.append(ssh_dir)
-                    self.execute_command(cmd)
+                    try:
+                        self.execute_command(cmd)
+                    except:
+                        pass
             except OSError:
                 e = get_exception()
                 return (1, '', 'Failed to create %s: %s' % (ssh_dir, str(e)))
@@ -2264,7 +2267,10 @@ def main():
                     cmd.append('-t')
                     cmd.append('user_home_dir_t')
                     cmd.append(user.home)
-                    user.execute_command(cmd)
+                    try:
+                        user.execute_command(cmd)
+                    except:
+                        pass
             result['changed'] = True
 
         # deal with ssh key

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -636,7 +636,7 @@ class User(object):
                 if cmd[0] is not None:
                     cmd.append('-t')
                     cmd.append('ssh_home_t')
-                    cmd.append(ssh_dir) 
+                    cmd.append(ssh_dir)
                     self.execute_command(cmd)
             except OSError:
                 e = get_exception()
@@ -734,23 +734,23 @@ class User(object):
             self.module.exit_json(failed=True, msg="%s" % e)
 
     def parse_defaults(self):
-      try:
-        f = open('/etc/login.defs', 'r')
-        for line in f:
-            if 'UMASK' in line and '#' not in line.split()[0]:
-                maskvalue=line.split()[1]
-                self.newumask = int(maskvalue, 8)
-        f.close()
-      except:
-        pass
-      try:
-        if self.skeleton is None:
-            f = open('/etc/default/useradd', 'r')
-            if 'SKELE' in line and '#' not in line.split()[0]:
-               self.skeleton = line.split('=')[1]
+        try:
+            f = open('/etc/login.defs', 'r')
+            for line in f:
+                if 'UMASK' in line and '#' not in line.split()[0]:
+                    maskvalue=line.split()[1]
+                    self.newumask = int(maskvalue, 8)
             f.close()
-      except:
-        pass
+        except:
+            pass
+        try:
+            if self.skeleton is None:
+                f = open('/etc/default/useradd', 'r')
+                if 'SKELE' in line and '#' not in line.split()[0]:
+                   self.skeleton = line.split('=')[1]
+                f.close()
+        except:
+            pass
 
     def chmod_homedir(self, path):
         if self.newumask is None:
@@ -758,7 +758,7 @@ class User(object):
         if self.skeleton is not None:
             skeleumask = os.stat(self.skeleton).st_mode
         else:
-            skeleumask = os.stat('/etc/skele').st_mode
+            skeleumask = os.stat('/etc/skel').st_mode
         os.chmod(path, skeleumask & ~self.newumask & 0o777)
 
 # ===========================================

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -121,13 +121,6 @@
         state: present
         createhome: false
         home: /Users/dennis
-# debugging
-  - name: ls users
-    command: ls -l /Users/
-    register: mac_debug
-  - name: list debug
-    debug: msg={{mac_debug.stdout_lines}}
-  when: ansible_distribution == 'MacOSX'
 
 - name: try to create a second user
   user:
@@ -153,6 +146,7 @@
   with_items:
       - "{{user_test3.home}}"
       - "{{user_test3.home}}/.ssh"
+  register: homedirrun
 
 - name: Verify existence, ownership, and permissions on SSH key
   file:
@@ -160,6 +154,13 @@
       state=file
       mode=0600
       owner=dennis
+  register: sshkeyrun
+
+- name: Verify file checks
+  assert:
+      that:
+          - "not sshkeyrun.changed"
+          - "not homedirrun.changed"
 
 ###
 # SELinux checks only if Python bindings are installed, and SELinux is on.

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -22,6 +22,20 @@
   delegate_to: localhost
 - debug: var=jinja2_version
 
+# Install SELinux bindings
+# Install SELinux bindings for python
+- name: Install python selinux (yum)
+  yum:
+    name=libselinux-python
+    state=installed
+  when: ansible_pkg_mgr == 'yum'
+
+- name: Install python selinux (dnf)
+  dnf:
+    name=libselinux-python
+    state=installed
+  when: ansible_pkg_mgr == 'dnf'
+
 ##
 ## user add
 ##

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -127,7 +127,7 @@
     register: mac_debug
   - name: list debug
     debug: msg={{mac_debug.stdout_lines}}
-when: ansible_distribution == 'MacOSX'
+  when: ansible_distribution == 'MacOSX'
 
 - name: try to create a second user
   user:

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -199,7 +199,7 @@
       force: yes
       remove: yes
   register: user_test2
-  with_item:
+  with_items:
       - dennis
       - ansibulluser
 

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -22,20 +22,6 @@
   delegate_to: localhost
 - debug: var=jinja2_version
 
-# Install SELinux bindings
-# Install SELinux bindings for python
-- name: Install python selinux (yum)
-  yum:
-    name=policycoreutils-python
-    state=installed
-  when: ansible_pkg_mgr == 'yum'
-
-- name: Install python selinux (dnf)
-  dnf:
-    name=libselinux-python
-    state=installed
-  when: ansible_pkg_mgr == 'dnf'
-
 ##
 ## user add
 ##
@@ -105,6 +91,7 @@
           - "user_test1.results[4]['state'] == 'present'"
   when: "jinja2_version.stdout|version_compare('2.6', '<')"
 
+
 ##
 ## Create home and ssh keys for existing user
 ##
@@ -115,12 +102,13 @@
         name: dennis
         state: absent
 
-  - name: try to create a second user
+  - name: try to create a second user (Mac)
     user:
         name: dennis
         state: present
         createhome: false
         home: /Users/dennis
+  when: ansible_distribution == 'MacOSX'
 
 - name: try to create a second user
   user:
@@ -137,7 +125,8 @@
       generate_ssh_key: yes
   register: user_test3
 
-- name: Verify existence, ownership and permissions on home and .ssh directories.
+# Fedora defaults to mode 0700 for home dirs.
+- name: Verify existence, ownership and permissions on home and .ssh directories. (Fedora)
   file:
       name="{{item}}"
       state=directory
@@ -145,8 +134,20 @@
       owner=dennis
   with_items:
       - "{{user_test3.home}}"
-      - "{{user_test3.home}}/.ssh"
-  register: homedirrun
+  register: homedircheck
+  when: ansible_distribution == 'Fedora'
+
+# Other OSs default to mode 0755 for home dirs.
+- name: Verify existence, ownership and permissions on home and .ssh directories. (Fedora)
+  file:
+      name="{{item}}"
+      state=directory
+      mode=0700
+      owner=dennis
+  with_items:
+      - "{{user_test3.home}}"
+  register: homedircheck
+  when: ansible_distribution != 'Fedora'
 
 - name: Verify existence, ownership, and permissions on SSH key
   file:
@@ -154,30 +155,22 @@
       state=file
       mode=0600
       owner=dennis
-  register: sshkeyrun
+  register: sshkeycheck
 
-### debug
-- name: debug fresh user home
-  command: ls -ld {{user_test0.home}}
-  register: debugrun
-- name: ls output
-  debug: msg=debugrun.stdout_lines
-###
-
-- name: Verify home directory settings on fresh user
+- name: Verify ssh directory settings on fresh user
   file:
-      name="{{user_test0.home}}"
+      name="{{user_test0.home}}/.ssh"
       state=directory
       mode=0700
       owner="{{user_test0.name}}"
-  register: freshhomedirrun
+  register: sshdircheck 
 
 - name: Verify file checks
   assert:
       that:
-          - "not sshkeyrun.changed"
-          - "not homedirrun.changed"
-          - "not freshhomedirrun.changed"
+          - "not sshkeycheck.changed"
+          - "not homedircheck.changed"
+          - "not homedircheck.changed"
 
 ###
 # SELinux checks only if Python bindings are installed, and SELinux is on.
@@ -198,20 +191,18 @@
 ##
 ## user remove
 ##
-
-
-- name: remove user and home directory
-  user:
-      name=dennis
-      state=absent
-      force=yes
-      remove=yes
-
+            
 - name: try to delete the user
   user:
-      name: ansibulluser
+      name: "{{item}}"
       state: absent
+      force: yes
+      remove: yes
   register: user_test2
+  with_item:
+      - dennis
+      - ansibulluser
+
 - name: make a new list of users
   script: userlist.sh "{{ ansible_distribution }}"
   register: user_names2

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -114,6 +114,15 @@
       name: dennis
       state: present
       createhome: false
+      home: /Users/dennis
+when: ansible_distribution == 'MacOSX'
+
+- name: try to create a second user
+  user:
+      name: dennis
+      state: present
+      createhome: false
+when: ansible_distribution != 'MacOSX'
 
 - name: try to create home directory and ssh keys for existing user
   user:

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -161,7 +161,7 @@
       name="{{user_test0.home}}"
       state=directory
       mode=0700
-      owner="{{user_test0}}"
+      owner="{{user_test0.name}}"
   register: freshhomedirrun
 
 - name: Verify file checks

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -156,11 +156,20 @@
       owner=dennis
   register: sshkeyrun
 
+- name: Verify home directory settings on fresh user
+  file:
+      name="{{user_test0.home}}"
+      state=directory
+      mode=0700
+      owner="{{user_test0}}"
+  register: freshhomedirrun
+
 - name: Verify file checks
   assert:
       that:
           - "not sshkeyrun.changed"
           - "not homedirrun.changed"
+          - "not freshhomedirrun.changed"
 
 ###
 # SELinux checks only if Python bindings are installed, and SELinux is on.

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -124,6 +124,13 @@
       createhome: false
   when: ansible_distribution != 'MacOSX'
 
+# debugging
+- name: ls users
+  command: ls -l /Users/
+  register: mac_debug
+- name: list debug
+  debug: msg={{mac_debug.stdout_lines}}
+
 - name: try to create home directory and ssh keys for existing user
   user:
       name: dennis

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -26,10 +26,15 @@
 ## user add
 ##
 #
-- name: remove the test user
+- name: remove the test users
   user:
-      name: ansibulluser
+      name: "{{item}}"
       state: absent
+      force: yes
+      remove: yes
+  with_items:
+      - ansibulluser
+      - dennis
 
 - name: try to create a user
   user:
@@ -138,7 +143,7 @@
   when: ansible_distribution == 'Fedora'
 
 # Other OSs default to mode 0755 for home dirs.
-- name: Verify existence, ownership and permissions on home and .ssh directories. (non-Fedora)
+- name: Verify existence, ownership and permissions on home directories. (non-Fedora)
   file:
       name="{{item}}"
       state=directory

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -115,14 +115,14 @@
       state: present
       createhome: false
       home: /Users/dennis
-when: ansible_distribution == 'MacOSX'
+  when: ansible_distribution == 'MacOSX'
 
 - name: try to create a second user
   user:
       name: dennis
       state: present
       createhome: false
-when: ansible_distribution != 'MacOSX'
+  when: ansible_distribution != 'MacOSX'
 
 - name: try to create home directory and ssh keys for existing user
   user:

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -92,6 +92,45 @@
   when: "jinja2_version.stdout|version_compare('2.6', '<')"
 
 ##
+## Create home and ssh keys for existing user
+##
+
+- name: try to create a second user
+  user:
+      name: dennis
+      state: present
+      createhome: false
+
+- name: try to create home directory and ssh keys for existing user
+  user:
+      name: dennis
+      state: present
+      createhome: true
+      generate_ssh_key: yes
+  register: user_test0c
+
+- name: get context for new directories
+  command: ls -lZd {{user_test0c.home}} {{user_test0c.home}}/.ssh
+  register: user_test0d
+
+- name: validate ownership, permissions, and SELinux context
+  assert:
+      that:
+          - '"user_home_dir_t" in user_test0d.stdout_lines[0]'
+          - '"drwx------" in user_test0d.stdout_lines[0]'
+          - '"dennis dennis" in user_test0d.stdout_lines[0]'
+          - '"ssh_home_t" in user_test0d.stdout_lines[1]'
+          - '"drwx------" in user_test0d.stdout_lines[1]'
+          - '"dennis dennis" in user_test0d.stdout_lines[1]'
+
+- name: Remove user
+  user:
+    name=dennis
+    state=absent
+    force=yes
+    remove=yes
+
+##
 ## user remove
 ##
             
@@ -108,3 +147,4 @@
   assert:
       that:
           - '"ansibulluser" not in user_names2.stdout_lines'
+          - '"dennis" not in user_names2.stdout_lines'

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -108,14 +108,26 @@
 ##
 ## Create home and ssh keys for existing user
 ##
+# Debug
+- block: 
+  - name: user cleanup
+    user:
+        name: dennis
+        state: absent
 
-- name: try to create a second user
-  user:
-      name: dennis
-      state: present
-      createhome: false
-      home: /Users/dennis
-  when: ansible_distribution == 'MacOSX'
+  - name: try to create a second user
+    user:
+        name: dennis
+        state: present
+        createhome: false
+        home: /Users/dennis
+# debugging
+  - name: ls users
+    command: ls -l /Users/
+    register: mac_debug
+  - name: list debug
+    debug: msg={{mac_debug.stdout_lines}}
+when: ansible_distribution == 'MacOSX'
 
 - name: try to create a second user
   user:
@@ -123,13 +135,6 @@
       state: present
       createhome: false
   when: ansible_distribution != 'MacOSX'
-
-# debugging
-- name: ls users
-  command: ls -l /Users/
-  register: mac_debug
-- name: list debug
-  debug: msg={{mac_debug.stdout_lines}}
 
 - name: try to create home directory and ssh keys for existing user
   user:

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -107,33 +107,53 @@
       state: present
       createhome: true
       generate_ssh_key: yes
-  register: user_test0c
+  register: user_test3
 
-- name: get context for new directories
-  command: ls -lZd {{user_test0c.home}} {{user_test0c.home}}/.ssh
-  register: user_test0d
+- name: Verify existence, ownership and permissions on home and .ssh directories.
+  file:
+      name="{{item}}"
+      state=directory
+      mode=0700
+      owner=dennis
+  with_items:
+      - "{{user_test3.home}}"
+      - "{{user_test3.home}}/.ssh"
 
-- name: validate ownership, permissions, and SELinux context
-  assert:
-      that:
-          - '"user_home_dir_t" in user_test0d.stdout_lines[0]'
-          - '"drwx------" in user_test0d.stdout_lines[0]'
-          - '"dennis dennis" in user_test0d.stdout_lines[0]'
-          - '"ssh_home_t" in user_test0d.stdout_lines[1]'
-          - '"drwx------" in user_test0d.stdout_lines[1]'
-          - '"dennis dennis" in user_test0d.stdout_lines[1]'
+- name: Verify existence, ownership, and permissions on SSH key
+  file:
+      name="{{user_test3.home}}/.ssh/id_rsa"
+      state=file
+      mode=0600
+      owner=dennis
 
-- name: Remove user
-  user:
-    name=dennis
-    state=absent
-    force=yes
-    remove=yes
+###
+# SELinux checks only if Python bindings are installed, and SELinux is on.
+- block:
+      - name: get context for new directories
+        command: ls -lZd {{user_test3.home}} {{user_test3.home}}/.ssh
+        register: user_test3a
+
+      - name: validate ownership, permissions, and SELinux context
+        assert:
+            that:
+                - '"user_home_dir_t" in user_test3a.stdout_lines[0]'
+                - '"ssh_home_t" in user_test3a.stdout_lines[1]'
+  when: ansible_selinux != False and ansible_selinux.status != "disabled"
+###
+
 
 ##
 ## user remove
 ##
-            
+
+
+- name: remove user and home directory
+  user:
+      name=dennis
+      state=absent
+      force=yes
+      remove=yes
+
 - name: try to delete the user
   user:
       name: ansibulluser

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -156,13 +156,6 @@
       owner=dennis
   register: sshkeyrun
 
-- name: Verify home directory settings on fresh user
-  file:
-      name="{{user_test0.home}}"
-      state=directory
-      mode=0700
-      owner="{{user_test0.name}}"
-  register: freshhomedirrun
 ### debug
 - name: debug fresh user home
   command: ls -ld {{user_test0.home}}
@@ -170,6 +163,15 @@
 - name: ls output
   debug: msg=debugrun.stdout_lines
 ###
+
+- name: Verify home directory settings on fresh user
+  file:
+      name="{{user_test0.home}}"
+      state=directory
+      mode=0700
+      owner="{{user_test0.name}}"
+  register: freshhomedirrun
+
 - name: Verify file checks
   assert:
       that:

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -163,7 +163,13 @@
       mode=0700
       owner="{{user_test0.name}}"
   register: freshhomedirrun
-
+### debug
+- name: debug fresh user home
+  command: ls -ld {{user_test0.home}}
+  register: debugrun
+- name: ls output
+  debug: msg=debugrun.stdout_lines
+###
 - name: Verify file checks
   assert:
       that:

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -138,11 +138,11 @@
   when: ansible_distribution == 'Fedora'
 
 # Other OSs default to mode 0755 for home dirs.
-- name: Verify existence, ownership and permissions on home and .ssh directories. (Fedora)
+- name: Verify existence, ownership and permissions on home and .ssh directories. (non-Fedora)
   file:
       name="{{item}}"
       state=directory
-      mode=0700
+      mode=0755
       owner=dennis
   with_items:
       - "{{user_test3.home}}"

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -26,7 +26,7 @@
 # Install SELinux bindings for python
 - name: Install python selinux (yum)
   yum:
-    name=libselinux-python
+    name=policycoreutils-python
     state=installed
   when: ansible_pkg_mgr == 'yum'
 

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -140,7 +140,7 @@
   with_items:
       - "{{user_test3.home}}"
   register: homedircheck
-  when: ansible_distribution == 'Fedora'
+  when: ansible_distribution == 'Fedora' or ansible_distribution == 'CentOS'
 
 # Other OSs default to mode 0755 for home dirs.
 - name: Verify existence, ownership and permissions on home directories. (non-Fedora)
@@ -152,22 +152,22 @@
   with_items:
       - "{{user_test3.home}}"
   register: homedircheck
-  when: ansible_distribution != 'Fedora'
+  when: ansible_distribution != 'Fedora' and ansible_distribution != 'CentOS'
 
 - name: Verify existence, ownership, and permissions on SSH key
   file:
       name="{{user_test3.home}}/.ssh/id_rsa"
       state=file
       mode=0600
-      owner=dennis
+      owner="{{user_test3.name}}"
   register: sshkeycheck
 
 - name: Verify ssh directory settings on fresh user
   file:
-      name="{{user_test0.home}}/.ssh"
+      name="{{user_test3.home}}/.ssh"
       state=directory
       mode=0700
-      owner="{{user_test0.name}}"
+      owner="{{user_test3.name}}"
   register: sshdircheck 
 
 - name: Verify file checks


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #24862
This PR corrects issues when the user module is called to create a home directory or generate SSH keys with a user that already exists.  Now the home and .ssh directories will be created with the correct SELinux types.  And in the case of the home directory, it will also properly have its permissions set to 0700.

If SELinux bindings aren't installed, or SELinux is not enabled, the new context changes will simply not run.  

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
User module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

For Dennis.  I love you little buddy.
<!--- Paste verbatim command output below, e.g. before and after your change -->
