### PR TITLE
Handle None and Blank value for sysctl module

### DIFF
--- a/lib/ansible/modules/system/sysctl.py
+++ b/lib/ansible/modules/system/sysctl.py
@@ -386,8 +386,20 @@ def main():
             ignoreerrors = dict(default=False, type='bool'),
             sysctl_file = dict(default='/etc/sysctl.conf', type='path')
         ),
-        supports_check_mode=True
+        supports_check_mode=True,
+        required_if=[('state', 'present', ['value'])],
     )
+
+    if module.params['name'] is None:
+        module.fail_json(msg="name can not be None")
+    if module.params['state'] == 'present' and module.params['value'] is None:
+        module.fail_json(msg="value can not be None")
+
+    # In case of in-line params
+    if module.params['name'] == '':
+        module.fail_json(msg="name can not be blank")
+    if module.params['state'] == 'present' and module.params['value'] == '':
+        module.fail_json(msg="value can not be blank")
 
     result = SysctlModule(module)
 


### PR DESCRIPTION
##### SUMMARY
Fix adds check for values provided by user for
name and value in sysctl module.
While providing name and value as in-line params,
check for blank values

Fixes #20176

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/system/sysctl.py

##### ANSIBLE VERSION
```
2.4 devel
```