### PR TITLE
cloudstack: test: improve startup time, fix network dependency on run

### DIFF
--- a/test/utils/docker/cloudstack-simulator/Dockerfile
+++ b/test/utils/docker/cloudstack-simulator/Dockerfile
@@ -45,6 +45,8 @@ RUN wget https://github.com/apache/cloudstack/archive/4.9.2.0.tar.gz -O /opt/clo
 WORKDIR /opt/cloudstack
 
 RUN mvn -Pdeveloper -Dsimulator -DskipTests clean install
+RUN mvn -Pdeveloper -Dsimulator dependency:go-offline
+RUN mvn -pl client jetty:run -Dsimulator -Djetty.skip -Dorg.eclipse.jetty.annotations.maxWait=120
 
 RUN (/usr/bin/mysqld_safe &); \
     sleep 5; \
@@ -53,11 +55,11 @@ RUN (/usr/bin/mysqld_safe &); \
     MARVIN_FILE=$(find /opt/cloudstack/tools/marvin/dist/ -name "Marvin*.tar.gz"); \
     pip install $MARVIN_FILE;
 
-COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY zones.cfg /opt/zones.cfg
 COPY nginx_default.conf /etc/nginx/sites-available/default
 RUN pip install cs
 COPY run.sh /opt/run.sh
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 EXPOSE 8888 8080 8096
 

--- a/test/utils/docker/cloudstack-simulator/supervisord.conf
+++ b/test/utils/docker/cloudstack-simulator/supervisord.conf
@@ -8,7 +8,7 @@ autorestart=true
 user=root
 
 [program:cloudstack]
-command=/bin/bash -c "mvn -pl client jetty:run -Dsimulator -Dorg.eclipse.jetty.annotations.maxWait=120"
+command=/bin/bash -c "mvn -pl client jetty:run-forked -Dsimulator -Dorg.eclipse.jetty.annotations.maxWait=120"
 directory=/opt/cloudstack
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
##### SUMMARY
Currently the docker image has not all dependency installed. They get installed on container start which results in a network dependency. I removed this dependency by make sure all dependencies are installed. This also reduces startup time.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
cloudstack simulator docker image

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```
/cc @mattclay @gundalow 