### PR TITLE
New module: manage 1&1 cloud compute  (cloud/oneandone/oneandone_server)

### DIFF
--- a/lib/ansible/module_utils/oneandone.py
+++ b/lib/ansible/module_utils/oneandone.py
@@ -23,22 +23,11 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-
-
 import time
-from enum import Enum
 
 
-class OneAndOneResources(Enum):
-    firewall_policy = 1
-    load_balancer = 2
-    monitoring_policy = 3
-    private_network = 4
-    public_ip = 5
-    role = 6
-    server = 7
-    user = 8
-    vpn = 9
+class OneAndOneResources:
+    firewall_policy, load_balancer, monitoring_policy, private_network, public_ip, role, server, user, vpn = range(9)
 
 
 def get_resource(oneandone_conn, resource_type, resource_id):

--- a/lib/ansible/module_utils/oneandone.py
+++ b/lib/ansible/module_utils/oneandone.py
@@ -1,0 +1,266 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+
+import time
+from enum import Enum
+
+
+class OneAndOneResources(Enum):
+    firewall_policy = 1
+    load_balancer = 2
+    monitoring_policy = 3
+    private_network = 4
+    public_ip = 5
+    role = 6
+    server = 7
+    user = 8
+    vpn = 9
+
+
+def get_resource(oneandone_conn, resource_type, resource_id):
+    switcher = {
+        'firewall_policy': oneandone_conn.get_firewall,
+        'load_balancer': oneandone_conn.get_load_balancer,
+        'monitoring_policy': oneandone_conn.get_monitoring_policy,
+        'private_network': oneandone_conn.get_private_network,
+        'public_ip': oneandone_conn.get_public_ip,
+        'role': oneandone_conn.get_role,
+        'server': oneandone_conn.get_server,
+        'user': oneandone_conn.get_user,
+        'vpn': oneandone_conn.get_vpn,
+    }
+
+    return switcher.get(resource_type.name, None)(resource_id)
+
+
+def get_datacenter(oneandone_conn, datacenter, full_object=False):
+    """
+    Validates the datacenter exists by ID or country code.
+    Returns the datacenter ID.
+    """
+    for _datacenter in oneandone_conn.list_datacenters():
+        if datacenter in (_datacenter['id'], _datacenter['country_code']):
+            if full_object:
+                return _datacenter
+            return _datacenter['id']
+
+
+def get_fixed_instance_size(oneandone_conn, fixed_instance_size, full_object=False):
+    """
+    Validates the fixed instance size exists by ID or name.
+    Return the instance size ID.
+    """
+    for _fixed_instance_size in oneandone_conn.fixed_server_flavors():
+        if fixed_instance_size in (_fixed_instance_size['id'],
+                                   _fixed_instance_size['name']):
+            if full_object:
+                return _fixed_instance_size
+            return _fixed_instance_size['id']
+
+
+def get_appliance(oneandone_conn, appliance, full_object=False):
+    """
+    Validates the appliance exists by ID or name.
+    Return the appliance ID.
+    """
+    for _appliance in oneandone_conn.list_appliances(q='IMAGE'):
+        if appliance in (_appliance['id'], _appliance['name']):
+            if full_object:
+                return _appliance
+            return _appliance['id']
+
+
+def get_private_network(oneandone_conn, private_network, full_object=False):
+    """
+    Validates the private network exists by ID or name.
+    Return the private network ID.
+    """
+    for _private_network in oneandone_conn.list_private_networks():
+        if private_network in (_private_network['name'],
+                               _private_network['id']):
+            if full_object:
+                return _private_network
+            return _private_network['id']
+
+
+def get_monitoring_policy(oneandone_conn, monitoring_policy, full_object=False):
+    """
+    Validates the monitoring policy exists by ID or name.
+    Return the monitoring policy ID.
+    """
+    for _monitoring_policy in oneandone_conn.list_monitoring_policies():
+        if monitoring_policy in (_monitoring_policy['name'],
+                                 _monitoring_policy['id']):
+            if full_object:
+                return _monitoring_policy
+            return _monitoring_policy['id']
+
+
+def get_firewall_policy(oneandone_conn, firewall_policy, full_object=False):
+    """
+    Validates the firewall policy exists by ID or name.
+    Return the firewall policy ID.
+    """
+    for _firewall_policy in oneandone_conn.list_firewall_policies():
+        if firewall_policy in (_firewall_policy['name'],
+                               _firewall_policy['id']):
+            if full_object:
+                return _firewall_policy
+            return _firewall_policy['id']
+
+
+def get_load_balancer(oneandone_conn, load_balancer, full_object=False):
+    """
+    Validates the load balancer exists by ID or name.
+    Return the load balancer ID.
+    """
+    for _load_balancer in oneandone_conn.list_load_balancers():
+        if load_balancer in (_load_balancer['name'],
+                             _load_balancer['id']):
+            if full_object:
+                return _load_balancer
+            return _load_balancer['id']
+
+
+def get_server(oneandone_conn, instance, full_object=False):
+    """
+    Validates that the server exists whether by ID or name.
+    Returns the server if one was found.
+    """
+    for server in oneandone_conn.list_servers(per_page=1000):
+        if instance in (server['id'], server['name']):
+            if full_object:
+                return server
+            return server['id']
+
+
+def get_user(oneandone_conn, user, full_object=False):
+    """
+    Validates that the user exists by ID or a name.
+    Returns the user if one was found.
+    """
+    for _user in oneandone_conn.list_users(per_page=1000):
+        if user in (_user['id'], _user['name']):
+            if full_object:
+                return _user
+            return _user['id']
+
+
+def get_role(oneandone_conn, role, full_object=False):
+    """
+    Given a name, validates that the role exists
+    whether it is a proper ID or a name.
+    Returns the role if one was found, else None.
+    """
+    for _role in oneandone_conn.list_roles(per_page=1000):
+        if role in (_role['id'], _role['name']):
+            if full_object:
+                return _role
+            return _role['id']
+
+
+def get_vpn(oneandone_conn, vpn, full_object=False):
+    """
+    Validates that the vpn exists by ID or a name.
+    Returns the vpn if one was found.
+    """
+    for _vpn in oneandone_conn.list_vpns(per_page=1000):
+        if vpn in (_vpn['id'], _vpn['name']):
+            if full_object:
+                return _vpn
+            return _vpn['id']
+
+
+def wait_for_resource_creation_completion(oneandone_conn,
+                                          resource_type,
+                                          resource_id,
+                                          wait_timeout):
+    """
+    Waits for the resource create operation to complete based on the timeout period.
+    """
+    wait_timeout = time.time() + wait_timeout
+    while wait_timeout > time.time():
+        time.sleep(5)
+
+        # Refresh the resource info
+        resource = get_resource(oneandone_conn, resource_type, resource_id)
+
+        if resource_type == OneAndOneResources.server:
+            resource_state = resource['status']['state']
+        else:
+            resource_state = resource['state']
+
+        if ((resource_type == OneAndOneResources.server and resource_state.lower() == 'powered_on') or
+                (resource_type != OneAndOneResources.server and resource_state.lower() == 'active')):
+            return
+        elif resource_state.lower() == 'failed':
+            raise Exception('%s creation failed for %s' % (resource_type, resource_id))
+        elif resource_state.lower() in ('active',
+                                        'enabled',
+                                        'deploying',
+                                        'configuring'):
+            continue
+        else:
+            raise Exception(
+                'Unknown %s state %s' % (resource_type.name, resource_state))
+
+    raise Exception(
+        'Timed out waiting for %s completion for %s' % (resource_type.name, resource_id))
+
+
+def wait_for_resource_deletion_completion(oneandone_conn,
+                                          resource_type,
+                                          resource_id,
+                                          wait_timeout):
+    """
+    Waits for the resource delete operation to complete based on the timeout period.
+    """
+    wait_timeout = time.time() + wait_timeout
+    while wait_timeout > time.time():
+        time.sleep(5)
+
+        # Refresh the operation info
+        logs = oneandone_conn.list_logs(q='DELETE',
+                                        period='LAST_HOUR',
+                                        sort='-start_date')
+
+        if resource_type == OneAndOneResources.server:
+            _type = 'VM'
+        elif resource_type == OneAndOneResources.private_network:
+            _type = 'PRIVATENETWORK'
+        else:
+            raise Exception(
+                'Unsupported wait_for delete operation for %s resource' % resource_type.name)
+
+        for log in logs:
+            if (log['resource']['id'] == resource_id and
+                    log['action'] == 'DELETE' and
+                    log['type'] == _type and
+                    log['status']['state'] == 'OK'):
+                return
+    raise Exception(
+        'Timed out waiting for %s deletion for %s' % (resource_type.name, resource_id))

--- a/lib/ansible/modules/cloud/oneandone/oneandone_server.py
+++ b/lib/ansible/modules/cloud/oneandone/oneandone_server.py
@@ -14,7 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-ANSIBLE_METADATA = {'metadata_version': '1.0',
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
@@ -26,7 +29,7 @@ short_description: Create, destroy, start, stop, and reboot a 1&1 Host server.
 description:
      - Create, destroy, update, start, stop, and reboot a 1&1 Host server.
        When the server is created it can optionally wait for it to be 'running' before returning.
-version_added: "2.4"
+version_added: "2.5"
 options:
   state:
     description:
@@ -209,6 +212,7 @@ machines:
 
 import os
 import time
+from ansible.module_utils.six.moves import xrange
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.oneandone import (
     get_datacenter,

--- a/lib/ansible/modules/cloud/oneandone/oneandone_server.py
+++ b/lib/ansible/modules/cloud/oneandone/oneandone_server.py
@@ -1,0 +1,657 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: oneandone_server
+short_description: Create, destroy, start, stop, and reboot a 1&1 Host machine.
+description:
+     - Create, destroy, update, start, stop, and reboot a 1&1 Host machine.
+       When the machine is created it can optionally wait for it to be 'running' before returning.
+version_added: "2.4"
+options:
+  state:
+    description:
+      - Define a machine's state to create, remove, start or stop it.
+    required: false
+    default: present
+    choices: [ "present", "absent", "running", "stopped" ]
+  auth_token:
+    description:
+      - Authenticating API token provided by 1&1. Overrides the
+        ONEANDONE_AUTH_TOKEN environement variable.
+    required: true
+  datacenter:
+    description:
+      - The datacenter location.
+    required: false
+    default: US
+    choices: [ "US", "ES", "DE", "GB" ]
+  hostname:
+    description:
+      - The hostname or ID of the machine. Only used when state is 'present'.
+    required: true
+  description:
+    description:
+      - The description of the machine.
+    required: false
+  appliance:
+    description:
+      - The operating system name or ID for the machine.
+        It is required only for 'present' state.
+    required: true
+  fixed_instance_size:
+    description:
+      - The instance size name or ID of the machine.
+        It is required only for 'present' state, and it is mutually exclusive with
+        vcore, cores_per_processor, ram, and hdds parameters.
+    required: true
+    choices: [ "S", "M", "L", "XL", "XXL", "3XL", "4XL", "5XL" ]
+  vcore:
+    description:
+      - The total number of processors.
+        It must be provided with cores_per_processor, ram, and hdds parameters.
+    required: true
+  cores_per_processor:
+    description:
+      - The number of cores per processor.
+        It must be provided with vcore, ram, and hdds parameters.
+    required: true
+  ram:
+    description:
+      - The amount of RAM memory.
+        It must be provided with with vcore, cores_per_processor, and hdds parameters.
+    required: true
+  hdds:
+    description:
+      - A list of hard disks with nested "size" and "is_main" properties.
+        It must be provided with vcore, cores_per_processor, and ram parameters.
+    required: true
+  private_network:
+    description:
+      - The private network name or ID.
+    required: false
+  firewall_policy:
+    description:
+      - The firewall policy name or ID.
+    required: false
+  load_balancer:
+    description:
+      - The load balancer name or ID.
+    required: false
+  monitoring_policy:
+    description:
+      - The monitoring policy name or ID.
+    required: false
+  instance_ids:
+    description:
+      - List of machine IDs or hostnames. It is required for all states except 'running'.
+    required: true
+  count:
+    description:
+      - The number of machines to create.
+    required: false
+    default: 1
+  ssh_key:
+    description:
+      - User's public SSH key (contents, not path).
+    required: false
+    default: None
+  wait:
+    description:
+      - Wait for the instance to be in state 'running' before returning.
+        Also used for delete operation (set to 'false' if you don't want to wait
+        for each individual server to be deleted before moving on with
+        other tasks.)
+    required: false
+    default: "yes"
+    choices: [ "yes", "no" ]
+  wait_timeout:
+    description:
+      - how long before wait gives up, in seconds
+    default: 600
+  auto_increment:
+    description:
+      - When creating multiple machines at once, whether to differentiate
+        hostnames by appending a count after them or substituting the count
+        where there is a %02d or %03d in the hostname string.
+    default: "yes"
+    choices: [ "yes", "no" ]
+
+requirements:
+  - "1and1"
+  - "python >= 2.6"
+author: "Amel Ajdinovic (@aajdinov), Ethan Devenport (@edevenport)"
+'''
+
+EXAMPLES = '''
+
+# Provisioning example. Creates three servers and enumerate their names.
+
+- oneandone_server:
+    auth_token: oneandone_private_api_key
+    hostname: node%02d
+    fixed_instance_size: XL
+    datacenter: US
+    appliance: C5A349786169F140BCBC335675014C08
+    auto_increment: true
+    count: 3
+
+# Create three machines, passing in an ssh_key.
+
+- oneandone_server:
+    auth_token: oneandone_private_api_key
+    hostname: node%02d
+    vcore: 2
+    cores_per_processor: 4
+    ram: 8.0
+    hdds:
+      - size: 50
+        is_main: false
+    datacenter: ES
+    appliance: C5A349786169F140BCBC335675014C08
+    count: 3
+    wait: yes
+    wait_timeout: 600
+    ssh_key: SSH_PUBLIC_KEY
+
+# Removing machines
+
+- oneandone_server:
+    auth_token: oneandone_private_api_key
+    state: absent
+    instance_ids:
+      - 'node01'
+      - 'node02'
+      - 'node03'
+
+# Starting Machines.
+
+- oneandone_server:
+    auth_token: oneandone_private_api_key
+    state: running
+    instance_ids:
+      - 'node01'
+      - 'node02'
+      - 'node03'
+
+# Stopping Machines
+
+- oneandone_server:
+    auth_token: oneandone_private_api_key
+    state: stopped
+    instance_ids:
+      - 'node01'
+      - 'node02'
+      - 'node03'
+'''
+
+RETURN = '''
+changed:
+    description: True if a machine created, modified or removed
+    type: bool
+    sample: True
+    returned: always
+machines:
+    description: Information about each machine that was processed
+    type: list
+    sample: '[{"hostname": "my-server", "id": "server-id"}]'
+    returned: always
+'''
+
+import os
+import time
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.oneandone import (
+    get_datacenter,
+    get_fixed_instance_size,
+    get_appliance,
+    get_private_network,
+    get_monitoring_policy,
+    get_firewall_policy,
+    get_load_balancer,
+    get_server,
+    OneAndOneResources,
+    wait_for_resource_creation_completion,
+    wait_for_resource_deletion_completion
+)
+
+HAS_ONEANDONE_SDK = True
+
+try:
+    import oneandone.client
+except ImportError:
+    HAS_ONEANDONE_SDK = False
+
+DATACENTERS = ['US', 'ES', 'DE', 'GB']
+
+ONEANDONE_MACHINE_STATES = (
+    'DEPLOYING',
+    'POWERED_OFF',
+    'POWERED_ON',
+    'POWERING_ON',
+    'POWERING_OFF',
+)
+
+
+def _create_machine(module, oneandone_conn, hostname, description,
+                    fixed_instance_size_id, vcore, cores_per_processor, ram,
+                    hdds, datacenter_id, appliance_id, ssh_key,
+                    private_network_id, firewall_policy_id, load_balancer_id,
+                    monitoring_policy_id, wait, wait_timeout):
+
+    try:
+        machine = oneandone_conn.create_server(
+            oneandone.client.Server(
+                name=hostname,
+                description=description,
+                fixed_instance_size_id=fixed_instance_size_id,
+                vcore=vcore,
+                cores_per_processor=cores_per_processor,
+                ram=ram,
+                appliance_id=appliance_id,
+                datacenter_id=datacenter_id,
+                rsa_key=ssh_key,
+                private_network_id=private_network_id,
+                firewall_policy_id=firewall_policy_id,
+                load_balancer_id=load_balancer_id,
+                monitoring_policy_id=monitoring_policy_id,), hdds)
+
+        if wait:
+            wait_for_resource_creation_completion(
+                oneandone_conn,
+                OneAndOneResources.server,
+                machine['id'],
+                wait_timeout)
+            machine = oneandone_conn.get_server(machine['id'])  # refresh
+
+        return machine
+    except Exception as ex:
+        module.fail_json(msg=str(ex))
+
+
+def _insert_network_data(machine):
+    for addr_data in machine['ips']:
+        if addr_data['type'] == 'IPV6':
+            machine['public_ipv6'] = addr_data['ip']
+        elif addr_data['type'] == 'IPV4':
+            machine['public_ipv4'] = addr_data['ip']
+    return machine
+
+
+def create_machine(module, oneandone_conn):
+    """
+    Create new machine
+
+    module : AnsibleModule object
+    oneandone_conn: authenticated oneandone object
+
+    Returns a dictionary containing a 'changed' attribute indicating whether
+    any machine was added, and a 'machines' attribute with the list of the
+    created machines's hostname, id and ip addresses.
+    """
+    hostname = module.params.get('hostname')
+    description = module.params.get('description')
+    auto_increment = module.params.get('auto_increment')
+    count = module.params.get('count')
+    fixed_instance_size = module.params.get('fixed_instance_size')
+    vcore = module.params.get('vcore')
+    cores_per_processor = module.params.get('cores_per_processor')
+    ram = module.params.get('ram')
+    hdds = module.params.get('hdds')
+    datacenter = module.params.get('datacenter')
+    appliance = module.params.get('appliance')
+    ssh_key = module.params.get('ssh_key')
+    private_network = module.params.get('private_network')
+    monitoring_policy = module.params.get('monitoring_policy')
+    firewall_policy = module.params.get('firewall_policy')
+    load_balancer = module.params.get('load_balancer')
+    wait = module.params.get('wait')
+    wait_timeout = module.params.get('wait_timeout')
+
+    datacenter_id = get_datacenter(oneandone_conn, datacenter)
+    if datacenter_id is None:
+        module.fail_json(
+            msg='datacenter %s not found.' % datacenter)
+
+    fixed_instance_size_id = None
+    if fixed_instance_size:
+        fixed_instance_size_id = get_fixed_instance_size(
+            oneandone_conn,
+            fixed_instance_size)
+        if fixed_instance_size_id is None:
+            module.fail_json(
+                msg='fixed_instance_size %s not found.' % fixed_instance_size)
+
+    appliance_id = get_appliance(oneandone_conn, appliance)
+    if appliance_id is None:
+        module.fail_json(
+            msg='datacenter %s not found.' % appliance)
+
+    private_network_id = None
+    if private_network:
+        private_network_id = get_private_network(
+            oneandone_conn,
+            private_network)
+        if private_network_id is None:
+            module.fail_json(
+                msg='private network %s not found.' % private_network)
+
+    monitoring_policy_id = None
+    if monitoring_policy:
+        monitoring_policy_id = get_monitoring_policy(
+            oneandone_conn,
+            monitoring_policy)
+        if monitoring_policy_id is None:
+            module.fail_json(
+                msg='monitoring policy %s not found.' % monitoring_policy)
+
+    firewall_policy_id = None
+    if firewall_policy:
+        firewall_policy_id = get_firewall_policy(
+            oneandone_conn,
+            firewall_policy)
+        if firewall_policy_id is None:
+            module.fail_json(
+                msg='firewall policy %s not found.' % firewall_policy)
+
+    load_balancer_id = None
+    if load_balancer:
+        load_balancer_id = get_load_balancer(
+            oneandone_conn,
+            load_balancer)
+        if load_balancer_id is None:
+            module.fail_json(
+                msg='load balancer %s not found.' % load_balancer)
+
+    if auto_increment:
+        hostnames = _auto_increment_hostname(count, hostname)
+        descriptions = _auto_increment_description(count, description)
+    else:
+        hostnames = [hostname] * count
+        descriptions = [description] * count
+
+    hdd_objs = []
+    if hdds:
+        for hdd in hdds:
+            hdd_objs.append(oneandone.client.Hdd(
+                size=hdd['size'],
+                is_main=hdd['is_main']
+            ))
+
+    machines = []
+    for index, name in enumerate(hostnames):
+        machines.append(
+            _create_machine(
+                module=module,
+                oneandone_conn=oneandone_conn,
+                hostname=name,
+                description=descriptions[index],
+                fixed_instance_size_id=fixed_instance_size_id,
+                vcore=vcore,
+                cores_per_processor=cores_per_processor,
+                ram=ram,
+                hdds=hdd_objs,
+                datacenter_id=datacenter_id,
+                appliance_id=appliance_id,
+                ssh_key=ssh_key,
+                private_network_id=private_network_id,
+                monitoring_policy_id=monitoring_policy_id,
+                firewall_policy_id=firewall_policy_id,
+                load_balancer_id=load_balancer_id,
+                wait=wait,
+                wait_timeout=wait_timeout))
+
+    changed = True if machines else False
+    machines = [_insert_network_data(machine) for machine in machines]
+
+    return (changed, machines)
+
+
+def remove_machine(module, oneandone_conn):
+    """
+    Remove machines.
+
+    module : AnsibleModule object
+    oneandone_conn: authenticated oneandone object.
+
+    Returns a dictionary containing a 'changed' attribute indicating whether
+    any machines were removed, and a 'machines' attribute with the list of the
+    removed machines's hostname and id.
+    """
+    instance_ids = module.params.get('instance_ids')
+    wait = module.params.get('wait')
+    wait_timeout = module.params.get('wait_timeout')
+
+    if not isinstance(instance_ids, list) or len(instance_ids) < 1:
+        module.fail_json(
+            msg='instance_ids should be a list of machine ids or names.')
+
+    removed_machines = []
+    for instance in instance_ids:
+        machine = get_server(oneandone_conn, instance, True)
+        if machine is None:
+            continue
+
+        try:
+            oneandone_conn.delete_server(server_id=machine['id'])
+            if wait:
+                wait_for_resource_deletion_completion(oneandone_conn, OneAndOneResources.server, machine['id'], wait_timeout)
+            removed_machines.append(machine)
+        except Exception as ex:
+            module.fail_json(
+                msg="failed to terminate the machine: %s" % str(ex))
+
+    changed = True if removed_machines else False
+    machines = [{
+        'id': removed_machine['id'],
+        'hostname': removed_machine['name'],
+    } for removed_machine in removed_machines]
+
+    return (changed, machines)
+
+
+def startstop_machine(module, oneandone_conn):
+    """
+    Starts or Stops a machine.
+
+    module : AnsibleModule object
+    oneandone_conn: authenticated oneandone object.
+
+    Returns a dictionary with a 'changed' attribute indicating whether
+    anything has changed for any of the machines as a result of this function
+    being run, and a 'machines' attribute with basic information for
+    each machine.
+    """
+    state = module.params.get('state')
+    instance_ids = module.params.get('instance_ids')
+    wait = module.params.get('wait')
+    wait_timeout = module.params.get('wait_timeout')
+
+    if not isinstance(instance_ids, list) or len(instance_ids) < 1:
+        module.fail_json(msg='instance_ids should be a list of virtual machine ids or names.')
+
+    machines = []
+    changed = False
+    for instance_id in instance_ids:
+
+        # Resolve machine
+        machine = get_server(oneandone_conn, instance_id, True)
+        if machine is None:
+            continue
+
+        # Attempt to change the machine state, only if it's not already there
+        # or on its way.
+        try:
+            if state == 'stopped':
+                if machine['status']['state'] == 'POWERED_OFF':
+                    machines.append(machine)
+                    continue
+                oneandone_conn.modify_server_status(
+                    server_id=machine['id'],
+                    action='POWER_OFF',
+                    method='SOFTWARE')
+            elif state == 'running':
+                if machine['status']['state'] == 'POWERED_ON':
+                    machines.append(machine)
+                    continue
+                oneandone_conn.modify_server_status(
+                    server_id=machine['id'],
+                    action='POWER_ON',
+                    method='SOFTWARE')
+        except Exception as ex:
+            module.fail_json(
+                msg="failed to set machine %s to state %s: %s" % (
+                    instance_id, state, str(ex)))
+
+        # Make sure the machine has reached the desired state
+        if wait:
+            operation_completed = False
+            wait_timeout = time.time() + wait_timeout
+            while wait_timeout > time.time():
+                time.sleep(5)
+                machine = oneandone_conn.get_server(machine['id'])  # refresh
+                machine_state = machine['status']['state']
+                if state == 'stopped' and machine_state == 'POWERED_OFF':
+                    operation_completed = True
+                    break
+                if state == 'running' and machine_state == 'POWERED_ON':
+                    operation_completed = True
+                    break
+            if not operation_completed:
+                module.fail_json(
+                    msg="Timeout waiting for machine %s to get to state %s" % (
+                        instance_id, state))
+
+        changed = True
+        machines.append(machine)
+
+    machines = [_insert_network_data(_machine) for _machine in machines]
+
+    return (changed, machines)
+
+
+def _auto_increment_hostname(count, hostname):
+    """
+    Allow a custom incremental count in the hostname when defined with the
+    string formatting (%) operator. Otherwise, increment using name-01,
+    name-02, name-03, and so forth.
+    """
+    if '%' not in hostname:
+        hostname = "%s-%%01d" % hostname
+
+    return [
+        hostname % i
+        for i in xrange(1, count + 1)
+    ]
+
+
+def _auto_increment_description(count, description):
+    """
+    Allow the incremental count in the description when defined with the
+    string formatting (%) operator. Otherwise, repeat the same description.
+    """
+    if '%' in description:
+        return [
+            description % i
+            for i in xrange(1, count + 1)
+        ]
+    else:
+        return [description] * count
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            auth_token=dict(
+                type='str',
+                default=os.environ.get('ONEANDONE_AUTH_TOKEN'),
+                no_log=True),
+            hostname=dict(type='str'),
+            description=dict(type='str'),
+            appliance=dict(type='str'),
+            fixed_instance_size=dict(type='str'),
+            vcore=dict(type='int'),
+            cores_per_processor=dict(type='int'),
+            ram=dict(type='float'),
+            hdds=dict(type='list'),
+            count=dict(type='int', default=1),
+            ssh_key=dict(type='raw', default=None),
+            auto_increment=dict(type='bool', default=True),
+            instance_ids=dict(type='list'),
+            datacenter=dict(
+                choices=DATACENTERS,
+                default='US'),
+            private_network=dict(type='str'),
+            firewall_policy=dict(type='str'),
+            load_balancer=dict(type='str'),
+            monitoring_policy=dict(type='str'),
+            wait=dict(type='bool', default=True),
+            wait_timeout=dict(type='int', default=600),
+            state=dict(type='str', default='present'),
+        ),
+        mutually_exclusive=(['fixed_instance_size', 'vcore'], ['fixed_instance_size', 'cores_per_processor'],
+                            ['fixed_instance_size', 'ram'], ['fixed_instance_size', 'hdds'],),
+        required_together=(['vcore', 'cores_per_processor', 'ram', 'hdds'],)
+    )
+
+    if not HAS_ONEANDONE_SDK:
+        module.fail_json(msg='1and1 required for this module')
+
+    if not module.params.get('auth_token'):
+        module.fail_json(
+            msg='The "auth_token" parameter or ' +
+            'ONEANDONE_AUTH_TOKEN environment variable is required.')
+
+    oneandone_conn = oneandone.client.OneAndOneService(
+        api_token=module.params.get('auth_token'))
+
+    state = module.params.get('state')
+
+    if state == 'absent':
+        try:
+            (changed, machines) = remove_machine(module, oneandone_conn)
+        except Exception as ex:
+            module.fail_json(msg=str(ex))
+
+    elif state in ('running', 'stopped'):
+        try:
+            (changed, machines) = startstop_machine(module, oneandone_conn)
+        except Exception as ex:
+            module.fail_json(msg=str(ex))
+
+    elif state == 'present':
+        for param in ('hostname',
+                      'appliance',
+                      'datacenter'):
+            if not module.params.get(param):
+                module.fail_json(
+                    msg="%s parameter is required for new instance." % param)
+        try:
+            (changed, machines) = create_machine(module, oneandone_conn)
+        except Exception as ex:
+            module.fail_json(msg=str(ex))
+
+    module.exit_json(changed=changed, machines=machines)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY
This module adds support for the 1&1 Cloud Server platform. The oneandone submodule allows the virtual servers to be built and destroyed.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
oneandone

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
Below is the output from test playbooks utilizing the new module:

```
Server create
=============

PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [Create a server] *********************************************************
changed: [localhost]

TASK [Print create server output] **********************************************
ok: [localhost] => {
    "msg": "Create server output: {u'changed': True, u'machines': [{u'cloudpanel_id': u'F59F06F', u'datacenter': {u'id': u'908DC2072407C94C8054610AD5A53B8C', u'country_code': u'US', u'location': u'United States of America'}, u'description': u'testing server creation with ansible', u'public_ipv4': u'74.208.131.201', u'private_networks': None, u'first_password': u'********', u'dvd': None, u'image': {u'id': u'8E3BAA98E3DFD37857810E0288DD8FBA', u'name': u'centos6-32min'}, u'alerts': [], u'creation_date': u'2017-05-23T17:35:30+00:00', u'hardware': {u'vcore': 2, u'ram': 1, u'cores_per_processor': 1, u'fixed_instance_size_id': None, u'hdds': [{u'is_main': True, u'id': u'C3B658910012ABC84BA021D677579914', u'size': 20}, {u'is_main': False, u'id': u'2F0F2119F6C9833821CC1B9484F3C657', u'size': 20}]}, u'ips': [{u'firewall_policy': {u'id': u'A4D6302FA44955C797772E34880CBA42', u'name': u'centos7-64cpanel'}, u'ip': u'74.208.131.201', u'reverse_dns': None, u'load_balancers': [], u'main': True, u'type': u'IPV4', u'id': u'955F9D1AF64BB502BCE6A6829AFAE9DD'}], u'status': {u'state': u'POWERED_ON', u'percent': None}, u'rsa_key': 0, u'snapshot': None, u'monitoring_policy': None, u'id': u'702BADAD7EACD7D00705F2589163F821', u'name': u'server01'}]}"
}

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=1    unreachable=0    failed=0   
```

```
Server stop
===========

PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [Stop the server] *********************************************************
changed: [localhost]

TASK [Print server stop output] ************************************************
ok: [localhost] => {
    "msg": "Server stop: {u'changed': True, u'machines': [{u'cloudpanel_id': u'F59F06F', u'datacenter': {u'id': u'908DC2072407C94C8054610AD5A53B8C', u'country_code': u'US', u'location': u'United States of America'}, u'description': u'testing server creation with ansible', u'public_ipv4': u'74.208.131.201', u'private_networks': None, u'first_password': u'********', u'dvd': None, u'image': {u'id': u'8E3BAA98E3DFD37857810E0288DD8FBA', u'name': u'centos6-32min'}, u'alerts': [], u'creation_date': u'2017-05-23T17:35:30+00:00', u'hardware': {u'vcore': 2, u'ram': 1, u'cores_per_processor': 1, u'fixed_instance_size_id': None, u'hdds': [{u'is_main': True, u'id': u'C3B658910012ABC84BA021D677579914', u'size': 20}, {u'is_main': False, u'id': u'2F0F2119F6C9833821CC1B9484F3C657', u'size': 20}]}, u'ips': [{u'firewall_policy': {u'id': u'A4D6302FA44955C797772E34880CBA42', u'name': u'centos7-64cpanel'}, u'ip': u'74.208.131.201', u'reverse_dns': None, u'load_balancers': [], u'main': True, u'type': u'IPV4', u'id': u'955F9D1AF64BB502BCE6A6829AFAE9DD'}], u'status': {u'state': u'POWERED_OFF', u'percent': None}, u'rsa_key': 0, u'snapshot': None, u'monitoring_policy': None, u'id': u'702BADAD7EACD7D00705F2589163F821', u'name': u'server01'}]}"
}

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=1    unreachable=0    failed=0   
```

```
Server start
============

PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [Start the server] ********************************************************
changed: [localhost]

TASK [Print server start output] ***********************************************
ok: [localhost] => {
    "msg": "Server start: {u'changed': True, u'machines': [{u'cloudpanel_id': u'F59F06F', u'datacenter': {u'id': u'908DC2072407C94C8054610AD5A53B8C', u'country_code': u'US', u'location': u'United States of America'}, u'description': u'testing server creation with ansible', u'public_ipv4': u'74.208.131.201', u'private_networks': None, u'first_password': u'********', u'dvd': None, u'image': {u'id': u'8E3BAA98E3DFD37857810E0288DD8FBA', u'name': u'centos6-32min'}, u'alerts': [], u'creation_date': u'2017-05-23T17:35:30+00:00', u'hardware': {u'vcore': 2, u'ram': 1, u'cores_per_processor': 1, u'fixed_instance_size_id': None, u'hdds': [{u'is_main': True, u'id': u'C3B658910012ABC84BA021D677579914', u'size': 20}, {u'is_main': False, u'id': u'2F0F2119F6C9833821CC1B9484F3C657', u'size': 20}]}, u'ips': [{u'firewall_policy': {u'id': u'A4D6302FA44955C797772E34880CBA42', u'name': u'centos7-64cpanel'}, u'ip': u'74.208.131.201', u'reverse_dns': None, u'load_balancers': [], u'main': True, u'type': u'IPV4', u'id': u'955F9D1AF64BB502BCE6A6829AFAE9DD'}], u'status': {u'state': u'POWERED_ON', u'percent': 53}, u'rsa_key': 0, u'snapshot': None, u'monitoring_policy': None, u'id': u'702BADAD7EACD7D00705F2589163F821', u'name': u'server01'}]}"
}

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=1    unreachable=0    failed=0  
```

```
Server delete
=============

PLAY [localhost] ***************************************************************

TASK [setup] *******************************************************************
ok: [localhost]

TASK [Delete a server] *********************************************************
changed: [localhost]

TASK [Print server delete output] **********************************************
ok: [localhost] => {
    "msg": "Server delete: {u'changed': True, u'machines': [{u'hostname': u'server01', u'id': u'702BADAD7EACD7D00705F2589163F821'}]}"
}

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=1    unreachable=0    failed=0 
```