### PR TITLE
Correct string formating in sequence lookup plugin

### DIFF
--- a/lib/ansible/plugins/lookup/sequence.py
+++ b/lib/ansible/plugins/lookup/sequence.py
@@ -178,7 +178,7 @@ class LookupModule(LookupBase):
                 yield formatted
             except (ValueError, TypeError):
                 raise AnsibleError(
-                    "problem formatting %r with %r" % self.format
+                    "problem formatting %r with %r" % (i, self.format)
                 )
 
     def run(self, terms, variables, **kwargs):


### PR DESCRIPTION
##### SUMMARY
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/lookup/sequence.py

##### ANSIBLE VERSION
```
2.4 devel
```