### PR TITLE
extracting list from CustomerGateways to match create

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_customer_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_customer_gateway.py
@@ -228,7 +228,7 @@ def main():
     existing = gw_mgr.describe_gateways(module.params['ip_address'])
     # describe_gateways returns a key of CustomerGateways where as create_gateway returns a
     # key of CustomerGateway. For consistency, change it here
-    existing['CustomerGateway'] = existing['CustomerGateways']
+    existing['CustomerGateway'] = existing['CustomerGateways'][0]
 
     results = dict(changed=False)
     if module.params['state'] == 'present':

--- a/lib/ansible/modules/cloud/amazon/ec2_customer_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_customer_gateway.py
@@ -226,22 +226,20 @@ def main():
     name = module.params.get('name')
 
     existing = gw_mgr.describe_gateways(module.params['ip_address'])
-    # describe_gateways returns a key of CustomerGateways where as create_gateway returns a
-    # key of CustomerGateway. For consistency, change it here
-    existing['CustomerGateway'] = existing['CustomerGateways'][0]
 
     results = dict(changed=False)
     if module.params['state'] == 'present':
-        if existing['CustomerGateway']:
+        if existing['CustomerGateways']:
+            existing['CustomerGateway'] = existing['CustomerGateways'][0]
             results['gateway'] = existing
-            if existing['CustomerGateway'][0]['Tags']:
-                tag_array = existing['CustomerGateway'][0]['Tags']
+            if existing['CustomerGateway']['Tags']:
+                tag_array = existing['CustomerGateway']['Tags']
                 for key, value in enumerate(tag_array):
                     if value['Key'] == 'Name':
                         current_name = value['Value']
                         if current_name != name:
                             results['name'] = gw_mgr.tag_cgw_name(
-                                results['gateway']['CustomerGateway'][0]['CustomerGatewayId'],
+                                results['gateway']['CustomerGateway']['CustomerGatewayId'],
                                 module.params['name'],
                             )
                             results['changed'] = True
@@ -258,11 +256,12 @@ def main():
             results['changed'] = True
 
     elif module.params['state'] == 'absent':
-        if existing['CustomerGateway']:
+        if existing['CustomerGateways']:
+            existing['CustomerGateway'] = existing['CustomerGateways'][0]
             results['gateway'] = existing
             if not module.check_mode:
                 results['gateway'] = gw_mgr.ensure_cgw_absent(
-                    existing['CustomerGateway'][0]['CustomerGatewayId']
+                    existing['CustomerGateway']['CustomerGatewayId']
                 )
             results['changed'] = True
 


### PR DESCRIPTION
##### SUMMARY
Fixes #24747 
Uses list 0 from dict CustomerGateways in dict CustomerGateway to match the results returned during the create operation.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_customer_gateway.py

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
Output of 
````
- debug: var=cgw_spoke.results[0].gateway
````
Before:
```
ok: [localhost] => {
    "cgw_spoke.results[0].gateway": {
        "customer_gateway": [
            {
                "bgp_asn": "65000", 
                "customer_gateway_id": "cgw-ce33e8d0", 
                "ip_address": "34.209.88.17", 
                "state": "available", 
                "tags": [
                    {
                        "key": "Name", 
                        "value": "cgw-spoke"
                    }
                ], 
                "type": "ipsec.1"
            }
        ], 
        "customer_gateways": [
            {
                "bgp_asn": "65000", 
                "customer_gateway_id": "cgw-ce33e8d0", 
                "ip_address": "34.209.88.17", 
                "state": "available", 
                "tags": [
                    {
                        "key": "Name", 
                        "value": "cgw-spoke"
                    }
                ], 
                "type": "ipsec.1"
            }
        ], 
        "response_metadata": {
            "http_headers": {
                "content-_type": "text/xml;charset=UTF-8", 
                "date": "Mon, 22 May 2017 16:34:26 GMT", 
                "server": "AmazonEC2", 
                "transfer-_encoding": "chunked", 
                "vary": "Accept-Encoding"
            }, 
            "http_status_code": 200, 
            "request_id": "fa980219-d39d-4cff-84be-25d0488c53c3", 
            "retry_attempts": 0
        }
    }, 
    "changed": false
}
```
After:
````
ok: [localhost] => {
    "cgw_spoke.results[0].gateway": {
        "customer_gateway": {
            "bgp_asn": "65000", 
            "customer_gateway_id": "cgw-ce33e8d0", 
            "ip_address": "34.209.88.17", 
            "state": "available", 
            "tags": [
                {
                    "key": "Name", 
                    "value": "cgw-spoke"
                }
            ], 
            "type": "ipsec.1"
        }, 
        "customer_gateways": [
            {
                "bgp_asn": "65000", 
                "customer_gateway_id": "cgw-ce33e8d0", 
                "ip_address": "34.209.88.17", 
                "state": "available", 
                "tags": [
                    {
                        "key": "Name", 
                        "value": "cgw-spoke"
                    }
                ], 
                "type": "ipsec.1"
            }
        ], 
        "response_metadata": {
            "http_headers": {
                "content-_type": "text/xml;charset=UTF-8", 
                "date": "Mon, 22 May 2017 16:06:38 GMT", 
                "server": "AmazonEC2", 
                "transfer-_encoding": "chunked", 
                "vary": "Accept-Encoding"
            }, 
            "http_status_code": 200, 
            "request_id": "4462d648-79cf-4b84-86f1-88e0d0512e5c", 
            "retry_attempts": 0
        }
    }, 
    "changed": false
}
````
