### PR TITLE
Cron - Explicitly fail on Solaris when given a special_time

### DIFF
--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -656,6 +656,10 @@ def main():
        (True in [(x != '*') for x in [minute, hour, day, month, weekday]]):
         module.fail_json(msg="You must specify time and date fields or special time.")
 
+    # cannot support special_time on solaris
+    if (special_time or reboot) and os.uname()[0] == 'SunOS':
+        module.fail_json(msg="Solaris does not support special_time=... or @reboot")
+
     if cron_file and do_install:
         if not user:
             module.fail_json(msg="To use cron_file=... parameter you must specify user=... as well")

--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -657,7 +657,7 @@ def main():
         module.fail_json(msg="You must specify time and date fields or special time.")
 
     # cannot support special_time on solaris
-    if (special_time or reboot) and os.uname()[0] == 'SunOS':
+    if (special_time or reboot) and get_platform() == 'SunOS':
         module.fail_json(msg="Solaris does not support special_time=... or @reboot")
 
     if cron_file and do_install:


### PR DESCRIPTION
##### SUMMARY
As Solaris does not support special times (like `@reboot`), we should fail early and explicitly if one is provided.

Fixes ansible/ansible#22145

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`cron` module

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file = /etc/opt/csw/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```