### PR TITLE
Cron - Backup file behavior in check mode

### DIFF
--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -752,12 +752,11 @@ def main():
             res_args['diff'] = diff
 
     # retain the backup only if crontab or cron file have changed
-    if backup:
+    if backup and not module.check_mode:
         if changed:
             res_args['backup_file'] = backup_file
         else:
-            if not module.check_mode:
-                os.unlink(backup_file)
+            os.unlink(backup_file)
 
     if cron_file:
         res_args['cron_file'] = cron_file


### PR DESCRIPTION
##### SUMMARY
Addressing a bug regarding cleanup of backup files while in check mode

Fixes ansible/ansible#21523

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`cron` module

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 014f33655c) last updated 2017/05/22 18:04:15 (GMT +000)
  config file = 
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/ansible/lib/ansible
  executable location = /home/vagrant/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:32:47) [GCC 4.8.4]
```