### PR TITLE
docker_container: do not split command on commas

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -814,7 +814,8 @@ class TaskParameters(DockerBaseClass):
 
         if self.command:
             # convert from list to str
-            self.command = ' '.join([str(x) for x in self.command])
+            if isinstance(self.command, list):
+                self.command = ' '.join([str(x) for x in self.command])
 
     def fail(self, msg):
         self.client.module.fail_json(msg=msg)
@@ -1970,7 +1971,7 @@ def main():
         blkio_weight=dict(type='int'),
         capabilities=dict(type='list'),
         cleanup=dict(type='bool', default=False),
-        command=dict(type='list'),
+        command=dict(type='raw'),
         cpu_period=dict(type='int'),
         cpu_quota=dict(type='int'),
         cpuset_cpus=dict(type='str'),

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -59,6 +59,8 @@ options:
   command:
     description:
       - Command to execute when the container starts.
+        A command may be either a string or a list.
+        Prior to version 2.4, strings were split on commas.
     default: null
     required: false
   cpu_period:


### PR DESCRIPTION


##### SUMMARY
If a command string includes commas, then it is split into a list and converted back to a string without commas. This non-intuitive behavior was caused by defining the type of the command argument as a list. Changing the type to raw and only joining command if it is a list retains current list behavior and keeps commas in strings.

Fixes #24430  

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker/docker_container

##### ANSIBLE VERSION
```
ansible 2.4.0 (issue_24430_command_splits_commas 55bace6f9b) last updated 2017/05/22 19:46:19 (GMT +100)
  config file = 
  configured module search path = [u'/home/osboxes/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/osboxes/src/ansible/lib/ansible
  executable location = /home/osboxes/src/ansible/bin/ansible
  python version = 2.7.12+ (default, Sep 17 2016, 12:08:02) [GCC 6.2.0 20160914]
```


##### ADDITIONAL INFORMATION
Tested with the following commands:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
./hacking/test-module -m lib/ansible/modules/cloud/docker/docker_container.py -a \
"{ \
  \"name\": \"etcd\", \
  \"image\": \"quay.io/coreos/etcd\", \
  \"state\": \"started\", \
  \"volumes\": [ \
    \"/data\" \
  ], \
  \"published_ports\": [ \
    4001, \
    2380, \
    2379 \
  ], \
  \"command\": \"/usr/local/bin/etcd  -name etcd{{ node }} -advertise-client-urls http://{{ myip }}:2379,http://{{ myip }}:4001 -listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001 -initial-advertise-peer-urls http://{{ myip }}:2380 -listen-peer-urls http://0.0.0.0:2380 -initial-cluster-token etcd-cluster-1 -initial-cluster etcd0=http://{{ groups['kube-nodes'][0] }}:2380,etcd1=http://{{ groups['kube-nodes'][1] }}:2380,etcd2=http://{{ groups['kube-nodes'][2] }}:2380 -initial-cluster-state new\" \
}"
```

```
./hacking/test-module -m lib/ansible/modules/cloud/docker/docker_container.py -a \
"{ \
  \"name\": \"etcd\", \
  \"image\": \"quay.io/coreos/etcd\", \
  \"state\": \"started\", \
  \"volumes\": [ \
    \"/data\" \
  ], \
  \"published_ports\": [ \
    4001, \
    2380, \
    2379 \
  ], \
  \"command\": [ \
    \"/usr/local/bin/etcd\", \
    \"-name etcd{{ node }}\", \
    \"-advertise-client-urls http://{{ myip }}:2379,http://{{ myip }}:4001\", \
    \"-listen-client-urls http://0.0.0.0:2379,http://0.0.0.0:4001\", \
    \"-initial-advertise-peer-urls http://{{ myip }}:2380\", \
    \"-listen-peer-urls http://0.0.0.0:2380\", \
    \"-initial-cluster-token etcd-cluster-1\", \
    \"-initial-cluster etcd0=http://{{ groups['kube-nodes'][0] }}:2380,etcd1=http://{{ groups['kube-nodes'][1] }}:2380,etcd2=http://{{ groups['kube-nodes'][2] }}:2380\", \
    \"-initial-cluster-state new\" \
  ], \
}"
```
