### PR TITLE
Changed assemble_from_fragments to use os.path.join

### DIFF
--- a/lib/ansible/modules/files/assemble.py
+++ b/lib/ansible/modules/files/assemble.py
@@ -142,7 +142,7 @@ def assemble_from_fragments(src_path, delimiter=None, compiled_regexp=None, igno
     for f in sorted(os.listdir(src_path)):
         if compiled_regexp and not compiled_regexp.search(f):
             continue
-        fragment = u"%s/%s" % (src_path, f)
+        fragment = os.path.join(src_path, f)
         if not os.path.isfile(fragment) or (ignore_hidden and os.path.basename(fragment).startswith('.')):
             continue
         fragment_content = open(fragment, 'rb').read()

--- a/test/integration/targets/assemble/tasks/main.yml
+++ b/test/integration/targets/assemble/tasks/main.yml
@@ -29,6 +29,15 @@
   copy: src="./" dest="{{output_dir}}/src"
   register: result
 
+- name: create unicode file for test
+  shell: echo "π" > {{ output_dir }}/src/ßΩ.txt
+  register: result
+
+- name: assert that the new file was created
+  assert:
+    that:
+    - "result.changed == true"
+
 - name: test assemble with all fragments
   assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled1"
   register: result
@@ -38,7 +47,7 @@
     that:
     - "result.state == 'file'"
     - "result.changed == True"
-    - "result.checksum == '048a1bd1951aa5ccc427eeb4ca19aee45e9c68b3'"
+    - "result.checksum == '74152e9224f774191bc0bedf460d35de86ad90e6'"
 
 - name: test assemble with all fragments
   assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled1"
@@ -49,7 +58,7 @@
     that:
     - "result.state == 'file'"
     - "result.changed == False"
-    - "result.checksum == '048a1bd1951aa5ccc427eeb4ca19aee45e9c68b3'"
+    - "result.checksum == '74152e9224f774191bc0bedf460d35de86ad90e6'"
 
 - name: test assemble with fragments matching a regex
   assemble: src="{{output_dir}}/src" dest="{{output_dir}}/assembled2" regexp="^fragment[1-3]$"
@@ -69,7 +78,7 @@
   assert:
     that:
     - "result.state == 'file'"
-    - "result.checksum == '505359f48c65b3904127cf62b912991d4da7ed6d'"
+    - "result.checksum == 'd986cefb82e34e4cf14d33a3cda132ff45aa2980'"
 
 - name: test assemble with remote_src=False
   assemble: src="./" dest="{{output_dir}}/assembled4" remote_src=no


### PR DESCRIPTION
Fixes #19437

##### SUMMARY
Changed assemble_from_fragments to use os.path.join which no longer 
throws an error when a unicode filename is seen.

Also updated the integration test to create a unicode file during the test.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- lib/ansible/modules/files/assemble.py -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
