### PR TITLE
apt: suppress automatic daemon startups

### DIFF
--- a/test/integration/targets/apt/tasks/apt-suppress-daemon-actions.yml
+++ b/test/integration/targets/apt/tasks/apt-suppress-daemon-actions.yml
@@ -1,0 +1,254 @@
+### suppress_daemon_actions testing
+
+- name: configure the name of the debian package and daemon process we want to use for suppress_daemon_actions testing
+  set_fact:
+    apt_sda_test_package: ntp
+    apt_sda_test_daemon: ntp
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: apply some fixes to the container in case the base image does not have them already
+  shell: apt-get update -y; apt-get install -y apt-utils; rm /usr/sbin/policy-rc.d; rm /sbin/initctl; dpkg-divert --rename --remove /sbin/initctl
+  ignore_errors: yes
+  tags: ['test_apt_suppress_daemon_actions']
+
+# UNINSTALL package
+- name: uninstall {{apt_sda_test_package}} with apt
+  apt: name={{apt_sda_test_package}} state=absent purge=yes
+  register: apt_result
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: check {{apt_sda_test_package}} with dpkg
+  shell: dpkg-query -l {{apt_sda_test_package}}
+  failed_when: False
+  register: dpkg_result
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: verify uninstallation of {{apt_sda_test_package}}
+  assert:
+    that:
+        - "dpkg_result.rc == 1"
+  tags: ['test_apt_suppress_daemon_actions']
+
+# INSTALL package
+- name: install {{apt_sda_test_package}} with apt, without suppressing daemon startup
+  apt: name={{apt_sda_test_package}} state=present
+  register: apt_result
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: check {{apt_sda_test_package}} with dpkg
+  shell: dpkg-query -l {{apt_sda_test_package}}
+  failed_when: False
+  register: dpkg_result
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: check whether {{apt_sda_test_daemon}} is running
+  shell: ps ax | grep {{apt_sda_test_daemon}} | grep -v grep
+  failed_when: False
+  register: daemon_running
+  tags: ['test_apt_suppress_daemon_actions']
+
+- debug: var=apt_result
+  tags: ['test_apt_suppress_daemon_actions']
+- debug: var=dpkg_result
+  tags: ['test_apt_suppress_daemon_actions']
+- debug: var=daemon_running
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: verify installation of {{apt_sda_test_package}}
+  assert:
+    that:
+        - "apt_result.changed"
+        - "dpkg_result.rc == 0"
+        - "daemon_running.rc == 0"
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: verify apt module outputs
+  assert:
+    that:
+        - "'changed' in apt_result"
+        - "'stderr' in apt_result"
+        - "'stdout' in apt_result"
+        - "'stdout_lines' in apt_result"
+        - "daemon_running.stdout_lines"
+  tags: ['test_apt_suppress_daemon_actions']
+
+
+# UNINSTALL package
+- name: uninstall {{apt_sda_test_package}} with apt
+  apt: name={{apt_sda_test_package}} state=absent purge=yes
+  register: apt_result
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: check {{apt_sda_test_package}} with dpkg
+  shell: dpkg-query -s {{apt_sda_test_package}}
+  failed_when: False
+  register: dpkg_result
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: verify uninstallation of {{apt_sda_test_package}}
+  assert:
+    that:
+        - "'changed' in apt_result"
+        - "dpkg_result.rc == 1"
+  tags: ['test_apt_suppress_daemon_actions']
+
+
+# INSTALL package with start suppression
+- name: install {{apt_sda_test_package}} with apt, suppressing daemon startup
+  apt: name={{apt_sda_test_package}} state=present suppress_daemon_actions=yes
+  register: apt_result
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: check {{apt_sda_test_package}} with dpkg
+  shell: dpkg-query -l {{apt_sda_test_package}}
+  failed_when: False
+  register: dpkg_result
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: check whether {{apt_sda_test_daemon}} is running
+  shell: ps ax | grep {{apt_sda_test_daemon}} | grep -v grep
+  failed_when: False
+  register: daemon_running
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: check whether the policy file has been removed
+  file: path=/usr/sbin/policy-rc.d
+  ignore_errors: yes
+  register: policy_file_found
+
+- debug: var=apt_result
+  tags: ['test_apt_suppress_daemon_actions']
+- debug: var=dpkg_result
+  tags: ['test_apt_suppress_daemon_actions']
+- debug: var=daemon_running
+  tags: ['test_apt_suppress_daemon_actions']
+- debug: var=policy_file_found
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: verify installation and daemon status of {{apt_sda_test_package}}
+  assert:
+    that:
+        - "apt_result.changed"
+        - "dpkg_result.rc == 0"
+        - "daemon_running.rc == 1"
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: verify command outputs
+  assert:
+    that:
+        - "'changed' in apt_result"
+        - "'stderr' in apt_result"
+        - "'stdout' in apt_result"
+        - "'stdout_lines' in apt_result"
+        - "not daemon_running.stdout_lines"
+        - "policy_file_found | failed"
+  tags: ['test_apt_suppress_daemon_actions']
+
+
+# UNINSTALL package
+- name: uninstall {{apt_sda_test_package}} with apt
+  apt: name={{apt_sda_test_package}} state=absent purge=yes
+  register: apt_result
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: check {{apt_sda_test_package}} with dpkg
+  shell: dpkg-query -s {{apt_sda_test_package}}
+  failed_when: False
+  register: dpkg_result
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: verify uninstallation of {{apt_sda_test_package}}
+  assert:
+    that:
+        - "'changed' in apt_result"
+        - "dpkg_result.rc == 1"
+  tags: ['test_apt_suppress_daemon_actions']
+
+
+
+# INSTALL package with start suppression and pre-existing policy file
+
+- name: write pre-existing policy file
+  copy: content="hello world" dest="/usr/sbin/policy-rc.d"
+
+- name: get policy file checksum
+  shell: md5sum /usr/sbin/policy-rc.d
+  failed_when: False
+  register: checksum
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: install {{apt_sda_test_package}} with apt, suppressing daemon startup
+  apt: name={{apt_sda_test_package}} state=present suppress_daemon_actions=yes
+  register: apt_result
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: check {{apt_sda_test_package}} with dpkg
+  shell: dpkg-query -l {{apt_sda_test_package}}
+  failed_when: False
+  register: dpkg_result
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: check whether {{apt_sda_test_daemon}} is running
+  shell: ps ax | grep {{apt_sda_test_daemon}} | grep -v grep
+  failed_when: False
+  register: daemon_running
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: get policy file checksum
+  shell: md5sum /usr/sbin/policy-rc.d
+  failed_when: False
+  register: checksum2
+  tags: ['test_apt_suppress_daemon_actions']
+
+- debug: var=checksum
+  tags: ['test_apt_suppress_daemon_actions']
+- debug: var=apt_result
+  tags: ['test_apt_suppress_daemon_actions']
+- debug: var=dpkg_result
+  tags: ['test_apt_suppress_daemon_actions']
+- debug: var=daemon_running
+  tags: ['test_apt_suppress_daemon_actions']
+- debug: var=checksum2
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: verify installation and daemon check status of {{apt_sda_test_package}}
+  assert:
+    that:
+        - "apt_result.changed"
+        - "dpkg_result.rc == 0"
+        - "daemon_running.rc == 1"
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: verify command outputs and check that previous policy file was restored
+  assert:
+    that:
+        - "'changed' in apt_result"
+        - "'stderr' in apt_result"
+        - "'stdout' in apt_result"
+        - "'stdout_lines' in apt_result"
+        - "not daemon_running.stdout_lines"
+        - "checksum.stdout == checksum2.stdout"
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: delete policy file
+  file: path=/usr/sbin/policy-rc.d state=absent
+
+
+# UNINSTALL package
+- name: uninstall {{apt_sda_test_package}} with apt
+  apt: name={{apt_sda_test_package}} state=absent purge=yes
+  register: apt_result
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: check {{apt_sda_test_package}} with dpkg
+  shell: dpkg-query -s {{apt_sda_test_package}}
+  failed_when: False
+  register: dpkg_result
+  tags: ['test_apt_suppress_daemon_actions']
+
+- name: verify uninstallation of {{apt_sda_test_package}}
+  assert:
+    that:
+        - "'changed' in apt_result"
+        - "dpkg_result.rc == 1"
+  tags: ['test_apt_suppress_daemon_actions']

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -20,3 +20,6 @@
 
 - include: 'apt-builddep.yml'
   when: ansible_distribution in ('Ubuntu', 'Debian')
+
+- include: 'apt-suppress-daemon-actions.yml'
+  when: ansible_distribution in ('Ubuntu', 'Debian')


### PR DESCRIPTION
##### SUMMARY
This PR adds a new parameter `suppress_daemon_actions` (bool, default false) to the apt module. When the parameter is enabled, daemon startups (or, more generally, any service actions like start, stop, restart) will be suppressed during the module's operation. This is useful when you're installing a package like apache2 or ntp and want to explicitly start the corresponding daemon in a later task, rather than having apt (or rather, one of the package maintainer scripts) start it automatically during package installation.

The flag works by temporarily installing a policy script (`/usr/sbin/policy-rc.d`, see https://people.debian.org/~hmh/invokerc.d-policyrc.d-specification.txt) suppressing daemon actions for the runtime of the module, and removing it again (or replacing it with the previously existing policy file, if any) at the end.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
apt

##### ANSIBLE VERSION
```
ansible 2.4.0 (apt-suppress-daemons 64367c3d2d) last updated 2017/05/23 02:27:50 (GMT +200)
  config file = /Users/oklischat/src/ansible/ansible.cfg
  configured module search path = [u'/Users/oklischat/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/oklischat/src/ansible/lib/ansible
  executable location = /Users/oklischat/src/ansible/bin/ansible
  python version = 2.7.10 (default, Oct 23 2015, 19:19:21) [GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)]
```
(upstream base commit is e9e661ebbbf59c1ab397ab386517242a37e9f857)

##### ADDITIONAL INFORMATION

Sample session:

Install ntp, first without `suppress_daemon_actions`:

```
root@5c7d0b46c97f:~# ansible localhost -m apt -a 'name=ntp state=present'
localhost | SUCCESS => {
...
}
# check that the package is installed and the daemon is running
root@5c7d0b46c97f:~# dpkg -l ntp; ps ax | grep ntp | grep -v grep
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name                                                          Version                             Architecture                        Description
+++-=============================================================-===================================-===================================-================================================================================================================================
ii  ntp                                                           1:4.2.8p4+dfsg-3ubuntu5.4           amd64                               Network Time Protocol daemon and utility programs
 6420 ?        Ss     0:00 /usr/sbin/ntpd -p /var/run/ntpd.pid -g -u 107:109
root@5c7d0b46c97f:~#
```

Test again, with `suppress_daemon_actions` set:

```
# purge the package first
root@5c7d0b46c97f:~# apt-get purge ntp
....
root@5c7d0b46c97f:~#
root@5c7d0b46c97f:~# dpkg -l ntp; ps ax | grep ntp | grep -v grep
dpkg-query: no packages found matching ntp
root@5c7d0b46c97f:~#

# install again, with suppress_daemon_actions
root@5c7d0b46c97f:~# ansible localhost -m apt -a 'name=ntp state=present suppress_daemon_actions=yes'
localhost | SUCCESS => {
.....
        "invoke-rc.d: policy-rc.d denied execution of start.",
.....     
}

# package installed, daemon NOT running
root@5c7d0b46c97f:~# dpkg -l ntp; ps ax | grep ntp | grep -v grep
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name                                                          Version                             Architecture                        Description
+++-=============================================================-===================================-===================================-================================================================================================================================
ii  ntp                                                           1:4.2.8p4+dfsg-3ubuntu5.4           amd64                               Network Time Protocol daemon and utility programs
root@5c7d0b46c97f:~#
```
