### PR TITLE
Added timeout to jenkins_script POST request

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_script.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_script.py
@@ -65,6 +65,11 @@ options:
       - The password to connect to the jenkins server with.
     required: false
     default: null
+  timeout:
+    description:
+      - The request timeout in seconds
+    required: false
+    default: 10
   args:
     description:
       - A dict of key-value pairs used in formatting the script.
@@ -154,6 +159,7 @@ def main():
             validate_certs=dict(required=False, type="bool", default=True),
             user=dict(required=False, no_log=True, type="str", default=None),
             password=dict(required=False, no_log=True, type="str", default=None),
+            timeout=dict(required=False, no_log=True, type="int", default=10),
             args=dict(required=False, type="dict", default=None)
         )
     )
@@ -180,7 +186,8 @@ def main():
                            module.params['url'] + "/scriptText",
                            data=urlencode({'script': script_contents}),
                            headers=headers,
-                           method="POST")
+                           method="POST",
+                           timeout=module.params['timeout'])
 
     if info["status"] != 200:
         module.fail_json(msg="HTTP error " + str(info["status"]) + " " + info["msg"])

--- a/lib/ansible/modules/web_infrastructure/jenkins_script.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_script.py
@@ -70,6 +70,7 @@ options:
       - The request timeout in seconds
     required: false
     default: 10
+    version_added: "2.4"
   args:
     description:
       - A dict of key-value pairs used in formatting the script.
@@ -159,7 +160,7 @@ def main():
             validate_certs=dict(required=False, type="bool", default=True),
             user=dict(required=False, no_log=True, type="str", default=None),
             password=dict(required=False, no_log=True, type="str", default=None),
-            timeout=dict(required=False, no_log=True, type="int", default=10),
+            timeout=dict(required=False, type="int", default=10),
             args=dict(required=False, type="dict", default=None)
         )
     )


### PR DESCRIPTION
##### SUMMARY
The timeout value is passed to fetch_url to allow a custom timeout bigger than the predefined 10 seconds. Bigger scripts send to the Jenkins API will often fail otherwise.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
jenkins_script

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 4ac135c1b5) last updated 2017/05/23 11:23:15 (GMT +200)
```
