### PR TITLE
Python 3 compatibility for ec2_elb_lb module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
@@ -405,6 +405,11 @@ try:
 except ImportError:
     HAS_BOTO = False
 
+try:
+    basestring
+except NameError:
+    basestring = str
+
 import time
 import traceback
 import random

--- a/lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
@@ -405,11 +405,6 @@ try:
 except ImportError:
     HAS_BOTO = False
 
-try:
-    basestring
-except NameError:
-    basestring = str
-
 import time
 import traceback
 import random
@@ -417,6 +412,7 @@ import random
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import ec2_argument_spec, connect_to_aws, AnsibleAWSError
 from ansible.module_utils.ec2 import get_aws_connection_info
+from ansible.module_utils.six import string_types
 
 
 def _throttleable_operation(max_retries):
@@ -1337,7 +1333,7 @@ def main():
             grp_details = ec2.get_all_security_groups(filters=filters)
 
             for group_name in security_group_names:
-                if isinstance(group_name, basestring):
+                if isinstance(group_name, string_types):
                     group_name = [group_name]
 
                 group_id = [ str(grp.id) for grp in grp_details if str(grp.name) in group_name ]


### PR DESCRIPTION
##### SUMMARY
Python 3 compatibility for ec2_elb_lb module

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_elb_lb

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 9e14176bb1) last updated 2017/05/23 12:45:44 (GMT +200)
  config file = REDACTED
  configured module search path = ['/home/USERNAME/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = REDACTED
  executable location = REDACTED
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
Without this, on python 3.X the module fails with
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: NameError: name 'basestring' is not defined
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_zus2q91i/ansible_module_ec2_elb_lb.py\", line 1
359, in <module>\n    main()\n  File \"/tmp/ansible_zus2q91i/ansible_module_ec2_elb_lb.py\", line 1316, in main\n    if isinstance(group_name, basestring):\nNameError: name 'basestring' is 
not defined\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}
```
