### PR TITLE
AzureRM: allow specifiying tenant when using UserPassCredentials.

### DIFF
--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -274,7 +274,10 @@ class AzureRM(object):
                                                                  secret=self.credentials['secret'],
                                                                  tenant=self.credentials['tenant'])
         elif self.credentials.get('ad_user') is not None and self.credentials.get('password') is not None:
-            self.azure_credentials = UserPassCredentials(self.credentials['ad_user'], self.credentials['password'])
+            if self.credentials['tenant']:
+                self.azure_credentials = UserPassCredentials(self.credentials['ad_user'], self.credentials['password'], tenant=self.credentials['tenant'])
+            else:
+                self.azure_credentials = UserPassCredentials(self.credentials['ad_user'], self.credentials['password'])
         else:
             self.fail("Failed to authenticate with provided credentials. Some attributes were missing. "
                       "Credentials must include client_id, secret and tenant or ad_user and password.")


### PR DESCRIPTION
Fixes #24927

##### ISSUE TYPE
 - Feature Idea

##### COMPONENT NAME
contrib/inventory/azure_rm.py

##### ANSIBLE VERSION
```
ansible 2.0.2.0
  config file = /vagrant/provisioning/ansible.cfg
  configured module search path = Default w/o overrides
```

##### CONFIGURATION

```
[defaults]
transport = ssh
roles_path = roles/
host_key_checking = no
sudo_flags = -HE

[ssh_connection]
ssh_args = -o ForwardAgent=yes
```

##### OS / ENVIRONMENT
macOS Sierra

##### SUMMARY
When trying to setup credentials for dynamic inventory for azure, I'm unable to specify a tenant id.

##### STEPS TO REPRODUCE
1. Get an Azure Public Cloud with 2 Active Directory accounts.
2. Type `ansible -i hosts/azure/ --list all`

##### EXPECTED RESULTS
List of hosts in the azure account, for the given subscription, and given tenant.

##### ACTUAL RESULTS
```
ERROR! The file hosts/azure/azure_rm.py is marked as executable, but failed to execute correctly. If this is not supposed to be an executable script, correct this with `chmod -x hosts/azure/azure_rm.py`.
Inventory script (hosts/azure/azure_rm.py) had an execution error: Traceback (most recent call last):
  File '/home/archit/Projects/waltz/provisioning/hosts/azure/azure_rm.py', line 802, in <module>
    main()
  File '/home/archit/Projects/waltz/provisioning/hosts/azure/azure_rm.py', line 799, in main
    AzureInventory()
  File '/home/archit/Projects/waltz/provisioning/hosts/azure/azure_rm.py', line 442, in __init__
    self.get_inventory()
  File '/home/archit/Projects/waltz/provisioning/hosts/azure/azure_rm.py', line 507, in get_inventory
    self._load_machines(virtual_machines)
  File '/home/archit/Projects/waltz/provisioning/hosts/azure/azure_rm.py', line 510, in _load_machines
    for machine in machines:
  File '/usr/local/lib/python2.7/dist-packages/msrest/paging.py', line 109, in __next__
    self.advance_page()
  File '/usr/local/lib/python2.7/dist-packages/msrest/paging.py', line 95, in advance_page
    self._response = self._get_next(self.next_link)
  File '/usr/local/lib/python2.7/dist-packages/azure/mgmt/compute/operations/virtual_machines_operations.py', line 647, in internal_paging
    raise exp
msrestazure.azure_exceptions.CloudError: Azure Error: InvalidAuthenticationTokenTenant
Message: The access token is from the wrong issuer 'https://sts.windows.net/<redacted1>/'. It must match the tenant 'https://sts.windows.net/<redacted2>/' associated with this subscription. Please use the authority (URL) 'https://login.windows.net/<redacted2>' to get the token. Note, if the subscription is transferred to another tenant there is no impact to the services, but information about new tenant could take time to propagate (up to an hour). If you just transferred your subscription and see this error message, please try back later.
```
Updated description to make @ansibot happy.