### PR TITLE
Adds documentation of implicit regex match removal

### DIFF
--- a/docs/docsite/rst/playbooks_filters.rst
+++ b/docs/docsite/rst/playbooks_filters.rst
@@ -588,6 +588,9 @@ To replace text in a string with regex, use the "regex_replace" filter::
 
     # convert "localhost:80" to "localhost, 80" using named groups
     {{ 'localhost:80' | regex_replace('^(?P<host>.+):(?P<port>\\d+)$', '\\g<host>, \\g<port>') }}
+    
+    # convert "localhost:80" to "localhost"
+    {{ 'localhost:80' | regex_replace(':80') }}
 
 .. note:: Prior to ansible 2.0, if "regex_replace" filter was used with variables inside YAML arguments (as opposed to simpler 'key=value' arguments),
    then you needed to escape backreferences (e.g. ``\\1``) with 4 backslashes (``\\\\``) instead of 2 (``\\``).


### PR DESCRIPTION
##### SUMMARY
The filter `regex_replace` has a implicit parameter for `replacement` and thus can remove the matched string without explicitly defining `regex_replace('foo','')`.



##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Playbook Filters

##### ANSIBLE VERSION

```
ansible 2.3.0.0
  config file = /Users/timosand/dotfiles/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```
