### PR TITLE
ConfigureRemotingForAnsible.ps1 enable using existing machine certificate

### DIFF
--- a/examples/scripts/ConfigureRemotingForAnsible.ps1
+++ b/examples/scripts/ConfigureRemotingForAnsible.ps1
@@ -15,6 +15,12 @@
 # starting from today. So you would specify -CertValidityDays 3650 to get
 # a 10-year valid certificate.
 #
+# Use option -CreateSelfSignedCert to specify whether to create a new self-signed
+# certificate or use an existing machine certificate (typically in domain-joined
+# scenarios). If a machine certificate does exist and is used, it will also
+# grant access to its private key for the NETWORK SERVICE account. If a machine 
+# certificate doesn't exist, it will fallback to using a self-signed cert.
+#
 # Use option -ForceNewSSLCert if the system has been SysPreped and a new
 # SSL Certifcate must be forced on the WinRM Listener when re-running this
 # script. This is necessary when a new SID and CN name is created.
@@ -34,6 +40,7 @@
 # Updated by Nicolas Simond <contact@nicolas-simond.com>
 # Updated by Dag Wieërs <dag@wieers.com>
 # Updated by Jordan Borean <jborean93@gmail.com>
+# Updated by Kamran Ayub <kamran.ayub@gmail.com>
 #
 # Version 1.0 - 2014-07-06
 # Version 1.1 - 2014-11-11


### PR DESCRIPTION
Fixes #24931 

##### SUMMARY

This change adds the ability to use an existing machine certificate in domain-joined scenarios rather than always creating a self-signed certificate. This is backwards compatible and falls back to creating a self-signed cert if no machine cert exists.

There should be no conflicts in cases where a self-signed certificate exists because the self-signed ones are created using non-domain suffix hostnames whereas domain-joined machines must have domain suffixed certificates. In fact, the machine I had tested on did have some self-signed ones in the store as I was testing.

I'd like feedback on:

1. Whether or not I should repurpose the unused parameter `CreateSelfSignedCert` like I did or use a new parameter switch (`-UseExistingMachineCert`)

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ConfigureRemotingForAnsible.ps1

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.2.3
```


##### ADDITIONAL INFORMATION

I have tested this on a 2012 R2 box with the following output:

```
PS C:\Users\Kamran> .\EnableRemoting.ps1 -CreateSelfSignedCert $false -EnableCredSSP -Verbose
VERBOSE: Verifying WinRM service.
VERBOSE: PS Remoting is already enabled.
Using existing machine certificate: <thumbprint>. Granted access to priv
ate key to NETWORK SERVICE.
VERBOSE: Enabling SSL listener.
VERBOSE: Basic auth is already enabled.
VERBOSE: Firewall rule already exists to allow WinRM HTTPS.
VERBOSE: HTTP: Enabled | HTTPS: Enabled
VERBOSE: PS Remoting has been successfully configured for Ansible.
```
