### PR TITLE
ConfigureRemotingForAnsible.ps1 allow specifying auth types and force SSL only

### DIFF
--- a/examples/scripts/ConfigureRemotingForAnsible.ps1
+++ b/examples/scripts/ConfigureRemotingForAnsible.ps1
@@ -46,6 +46,7 @@
 # Updated by Nicolas Simond <contact@nicolas-simond.com>
 # Updated by Dag Wieërs <dag@wieers.com>
 # Updated by Jordan Borean <jborean93@gmail.com>
+# Updated by Kamran Ayub <kamran.ayub@gmail.com>
 #
 # Version 1.0 - 2014-07-06
 # Version 1.1 - 2014-11-11


### PR DESCRIPTION
Closes #24933 

##### SUMMARY
In situations where this script is run against a machine that has WinRM enabled and has an HTTP listener, it may be undesirable to enable Basic or CredSSP. Additionally, in some situations it'd be best to ensure only HTTPS is allowed to prevent traffic to the WinRM HTTP listener.

- Added AuthTypes parameter supporting:
  - Basic
  - CredSSP
  - Kerberos
- Added EnsureSslOnly which will remove HTTP listener if it exists and remove firewall rule(s)
- Warn user when `AllowUnencrypted` is enabled, which is bad for production scenarios
- Remove assumption that firewall rules are named specifically and rely on port mappings
- Move some common vars to constants

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ConfigureRemotingForAnsible.ps1


##### ADDITIONAL INFORMATION

Would like feedback on:

1. Changes to firewall commands. My changes allow support for existing rules that may have different names and also updating multiple matching rules in cases where there are separate profiles like in vanilla images.

2. The `EnsureSslOnly` switch--does it make sense, should it instead be a list of protocols you want to enable (HTTP or HTTPS or Both)? Right now, if you *wanted* to enable an HTTP listener explictly, you can't.

I've tested this on a 2012 R2 box.

**Existing firewall rule(s)**

```
PS C:\Users\Kamran> .\EnableRemoting.ps1 -Verbose -EnableCredSSP
VERBOSE: Verifying WinRM service.
VERBOSE: PS Remoting is already enabled.
VERBOSE: SSL listener is already active.
VERBOSE: Basic auth is already enabled.
VERBOSE: CredSSP auth is already enabled.
VERBOSE: Firewall rule already exists to allow WinRM HTTPS.
VERBOSE: HTTP: Enabled | HTTPS: Enabled
VERBOSE: PS Remoting has been successfully configured for Ansible.
```

**HTTP listener exists**

```
PS C:\Users\Kamran> .\EnableRemoting.ps1 -Verbose -UseSslOnly
VERBOSE: Verifying WinRM service.
VERBOSE: PS Remoting is already enabled.
VERBOSE: SSL listener is already active.
Removed WinRM HTTP listener
Removed WinRM HTTP firewall rule
VERBOSE: Basic auth is already enabled.
VERBOSE: CredSSP auth is already enabled.
VERBOSE: Firewall rule already exists to allow WinRM HTTPS.
VERBOSE: HTTP: Disabled | HTTPS: Enabled
VERBOSE: PS Remoting has been successfully configured for Ansible.
```

**Firewall rules missing**

```
PS C:\Users\Kamran> .\EnableRemoting.ps1 -Verbose -EnableCredSSP
VERBOSE: Verifying WinRM service.
VERBOSE: PS Remoting is already enabled.
VERBOSE: SSL listener is already active.
VERBOSE: Basic auth is already enabled.
VERBOSE: CredSSP auth is already enabled.
VERBOSE: Adding firewall rule to allow WinRM HTTPS.


Name                  : {ceb74636-9cbb-49aa-b58f-e32a6db69e5a}
DisplayName           : Allow WinRM HTTPS
Description           : 
DisplayGroup          : 
Group                 : 
Enabled               : True
Profile               : Any
Platform              : {}
Direction             : Inbound
Action                : Allow
EdgeTraversalPolicy   : Block
LooseSourceMapping    : False
LocalOnlyMapping      : False
Owner                 : 
PrimaryStatus         : OK
Status                : The rule was parsed successfully from the store. (65536)
EnforcementStatus     : NotApplicable
PolicyStoreSource     : PersistentStore
PolicyStoreSourceType : Local

VERBOSE: HTTP: Enabled | HTTPS: Enabled
VERBOSE: PS Remoting has been successfully configured for Ansible.
```

**Firewall rules do not contain a Any profile**

```
PS C:\Users\Kamran> .\EnableRemoting.ps1 -Verbose -EnableCredSSP
VERBOSE: Verifying WinRM service.
VERBOSE: PS Remoting is already enabled.
VERBOSE: SSL listener is already active.
VERBOSE: Basic auth is already enabled.
VERBOSE: CredSSP auth is already enabled.
VERBOSE: Updating firewall rule to allow WinRM HTTPS for any profile.
VERBOSE: HTTP: Enabled | HTTPS: Enabled
VERBOSE: PS Remoting has been successfully configured for Ansible.
```

**Auth types**

```
PS C:\Users\Kamran> .\EnableRemoting.ps1 -AuthTypes Basic, CredSSP -Verbose
VERBOSE: Verifying WinRM service.
VERBOSE: PS Remoting is already enabled.
VERBOSE: SSL listener is already active.
VERBOSE: Basic auth is already enabled.
VERBOSE: CredSSP auth is already enabled.
VERBOSE: Firewall rule already exists to allow WinRM HTTPS.
VERBOSE: HTTP: Enabled | HTTPS: Enabled
VERBOSE: PS Remoting has been successfully configured for Ansible.
```

```
PS C:\Users\Kamran> .\EnableRemoting.ps1 -AuthTypes Basic -Verbose
VERBOSE: Verifying WinRM service.
VERBOSE: PS Remoting is already enabled.
VERBOSE: SSL listener is already active.
VERBOSE: Basic auth is already enabled.
VERBOSE: CredSSP auth is already enabled.
VERBOSE: Firewall rule already exists to allow WinRM HTTPS.
VERBOSE: HTTP: Enabled | HTTPS: Enabled
VERBOSE: PS Remoting has been successfully configured for Ansible.
```

```
PS C:\Users\Kamran> .\EnableRemoting.ps1 -AuthTypes Basic -Verbose -EnableCredSSP
VERBOSE: Verifying WinRM service.
VERBOSE: PS Remoting is already enabled.
VERBOSE: SSL listener is already active.
VERBOSE: Basic auth is already enabled.
VERBOSE: CredSSP auth is already enabled.
VERBOSE: Firewall rule already exists to allow WinRM HTTPS.
VERBOSE: HTTP: Enabled | HTTPS: Enabled
VERBOSE: PS Remoting has been successfully configured for Ansible.
```