### PR TITLE
Read directory_mode as 'raw' type

### DIFF
--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -262,7 +262,7 @@ def main():
             backup            = dict(default=False, type='bool'),
             force             = dict(default=True, aliases=['thirsty'], type='bool'),
             validate          = dict(required=False, type='str'),
-            directory_mode    = dict(required=False),
+            directory_mode    = dict(required=False, type='raw'),
             remote_src        = dict(required=False, type='bool'),
         ),
         add_file_common_args=True,


### PR DESCRIPTION
Fixes #24202

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Reads the `directory_mode` param as 'raw' type to mirror the same behavior as `mode`. This'll cause non-quoted values to be represented as an int, rather than a str.

Covered by 'assert recursive copied directories mode' test.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
copy

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (bugfix/dir_mode_octal 2ad6627e53) last updated 2017/05/23 10:58:24 (GMT -700)
  config file =
  configured module search path = [u'/Users/x/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/x/src/ansible/lib/ansible
  executable location = /Users/x/src/ansible/bin/ansible
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```
