### PR TITLE
add xattr integration tests to ci

### DIFF
--- a/test/integration/targets/xattr/aliases
+++ b/test/integration/targets/xattr/aliases
@@ -1,1 +1,2 @@
+posix/ci/group2
 destructive

--- a/test/integration/targets/xattr/aliases
+++ b/test/integration/targets/xattr/aliases
@@ -1,2 +1,4 @@
 posix/ci/group2
+skip/freebsd
+skip/osx
 destructive

--- a/test/integration/targets/xattr/tasks/setup.yml
+++ b/test/integration/targets/xattr/tasks/setup.yml
@@ -1,7 +1,7 @@
 - name: Install
   package:
     name: attr
-    state: installed
+    state: present
   become: true
 
 - name: Create file

--- a/test/integration/targets/xattr/tasks/setup.yml
+++ b/test/integration/targets/xattr/tasks/setup.yml
@@ -2,7 +2,6 @@
   package:
     name: attr
     state: present
-  become: true
 
 - name: Create file
   file:


### PR DESCRIPTION
##### SUMMARY
Enable xattr tests in CI

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
xattr
##### ANSIBLE VERSION
25aac6151f8848b701c5b952c1749cbe20ad134b


##### ADDITIONAL INFORMATION
These tests were turned off because they were not working in Docker. The problem is likely related to the backing filesystem, so this PR is to test if they work in CI.