### PR TITLE
Python3 chokes on casting int to bytes

### DIFF
--- a/lib/ansible/plugins/terminal/vyos.py
+++ b/lib/ansible/plugins/terminal/vyos.py
@@ -45,6 +45,6 @@ class TerminalModule(TerminalBase):
         try:
             for cmd in (b'set terminal length 0', b'set terminal width 512'):
                 self._exec_cli_command(cmd)
-            self._exec_cli_command(b'set terminal length %s' % self.terminal_length)
+            self._exec_cli_command(b'set terminal length %d' % self.terminal_length)
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
%s in a bytestring is an alias to %b which does not handle numbers.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
plugins/terminal/vyos.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```

