### PR TITLE
rebuild docker containers if there are less ports exposed

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1302,7 +1302,7 @@ class Container(DockerBaseClass):
                         self.log("comparing lists: %s" % key)
                         set_a = set(getattr(self.parameters, key))
                         set_b = set(value)
-                        match = (set_a <= set_b)
+                        match = (set_a == set_b)
                 elif isinstance(getattr(self.parameters, key), list) and not len(getattr(self.parameters, key)) \
                         and value is None:
                     # an empty list and None are ==


### PR DESCRIPTION
##### SUMMARY
Currently, when docker container compares parameters that are lists in the running config and desired config, we consider the running config list correct if it contains the desired config list. This change considers the running config correct if the two lists are equal.

For example, if you have a container exposing ports 80 and 443, and your playbook has `published_ports: [443]`, the current container will not be changed.

fixes #24892 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker_container

##### ANSIBLE VERSION
25aac6151f8848b701c5b952c1749cbe20ad134b


##### ADDITIONAL INFORMATION
