### PR TITLE
Added the docker_volume module

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_volume.py
+++ b/lib/ansible/modules/cloud/docker/docker_volume.py
@@ -45,7 +45,8 @@ options:
 
   driver_options:
     description:
-      - Dictionary of volume settings. Consult docker docs for valid options and values:
+      - >
+        Dictionary of volume settings. Consult docker docs for valid options and values:
         U(https://docs.docker.com/engine/reference/commandline/volume_create/#driver-specific-options)
     default: null
 

--- a/lib/ansible/modules/cloud/docker/docker_volume.py
+++ b/lib/ansible/modules/cloud/docker/docker_volume.py
@@ -45,7 +45,8 @@ options:
 
   driver_options:
     description:
-      - Dictionary of volume settings. Consult docker docs for valid options and values.
+      - Dictionary of volume settings. Consult docker docs for valid options and values:
+        U(https://docs.docker.com/engine/reference/commandline/volume_create/#driver-specific-options)
     default: null
 
   force:

--- a/lib/ansible/modules/cloud/docker/docker_volume.py
+++ b/lib/ansible/modules/cloud/docker/docker_volume.py
@@ -1,0 +1,243 @@
+# coding: utf-8
+#!/usr/bin/python
+#
+# Copyright 2017 Red Hat | Ansible
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = u'''
+module: docker_volume
+version_added: "2.4"
+short_description: Manage Docker volumes
+description:
+  - Create/remove Docker volumes.
+  - Performs largely the same function as the "docker volume" CLI subcommand.
+options:
+  name:
+    description:
+      - Name of the volume to operate on.
+    required: true
+    aliases:
+      - volume_name
+
+  driver:
+    description:
+      - Specify the type of volume. Docker provides the C(local) driver, but 3rd party drivers can also be used.
+    default: local
+
+  driver_options:
+    description:
+      - Dictionary of volume settings. Consult docker docs for valid options and values.
+    default: null
+
+  force:
+    description:
+      - With state I(present) causes the volume to be deleted and recreated if the volume already
+        exist and the driver, driver options or labels differ.
+        This will cause any data in the existing volume to be lost.
+    default: false
+
+  state:
+    description:
+      - I(absent) deletes the volume.
+      - I(present) creates the volume, if it does not already exist.
+    default: present
+    choices:
+      - absent
+      - present
+
+extends_documentation_fragment:
+    - docker
+
+author:
+    - "Alex Grönholm (@agronholm)"
+
+requirements:
+    - "python >= 2.6"
+    - "docker-py >= 1.10.0"
+    - "The docker server >= 1.9.0"
+'''
+
+EXAMPLES = '''
+- name: Create a volume
+  docker_volume:
+    name: volume_one
+
+- name: Remove a volume
+  docker_volume:
+    name: volume_one
+    state: absent
+
+- name: Create a volume with options
+  docker_volume:
+    name: volume_two
+    driver_options:
+      type: btrfs
+      device: /dev/sda2
+'''
+
+RETURN = '''
+facts:
+    description: Volume inspection results for the affected volume.
+    returned: success
+    type: dict
+    sample: {}
+'''
+
+from ansible.module_utils.docker_common import *
+
+
+class TaskParameters(DockerBaseClass):
+    def __init__(self, client):
+        super(TaskParameters, self).__init__()
+        self.client = client
+
+        self.volume_name = None
+        self.driver = None
+        self.driver_options = None
+        self.labels = None
+        self.force = None
+        self.debug = None
+
+        for key, value in client.module.params.items():
+            setattr(self, key, value)
+
+
+class DockerVolumeManager(object):
+
+    def __init__(self, client):
+        self.client = client
+        self.parameters = TaskParameters(client)
+        self.check_mode = self.client.check_mode
+        self.results = {
+            u'changed': False,
+            u'actions': []
+        }
+        self.diff = self.client.module._diff
+
+        self.existing_volume = self.get_existing_volume()
+
+        state = self.parameters.state
+        if state == 'present':
+            self.present()
+        elif state == 'absent':
+            self.absent()
+
+    def get_existing_volume(self):
+        volumes = self.client.volumes()
+        for volume in volumes[u'Volumes']:
+            if volume['Name'] == self.parameters.volume_name:
+                return volume
+
+        return None
+
+    def has_different_config(self):
+        """
+        Evaluates an existing volume and returns a tuple containing a boolean
+        indicating if the configuration is different and a list of differences.
+
+        :return: list of options that differ
+        """
+        differences = []
+        if self.parameters.driver and self.parameters.driver != self.existing_volume['Driver']:
+            differences.append('driver')
+        if self.parameters.driver_options:
+            if not self.existing_volume.get('Options'):
+                differences.append('driver_options')
+            else:
+                for key, value in self.parameters.driver_options.items():
+                    if (not self.existing_volume['Options'].get(key) or
+                            value != self.existing_volume['Options'][key]):
+                        differences.append('driver_options.%s' % key)
+        if self.parameters.labels:
+            existing_labels = self.existing_volume.get('Labels', {})
+            all_labels = set(self.parameters.labels) | set(existing_labels)
+            for label in all_labels:
+                if existing_labels.get(label) != self.parameters.labels.get(label):
+                    differences.append('labels.%s' % label)
+
+        return differences
+
+    def create_volume(self):
+        if not self.existing_volume:
+            if not self.check_mode:
+                resp = self.client.create_volume(self.parameters.volume_name,
+                                                 driver=self.parameters.driver,
+                                                 driver_opts=self.parameters.driver_options,
+                                                 labels=self.parameters.labels)
+
+                self.existing_volume = self.client.inspect_volume(resp['Name'])
+
+            self.results['actions'].append("Created volume %s with driver %s" % (self.parameters.volume_name, self.parameters.driver))
+            self.results['changed'] = True
+
+    def remove_volume(self):
+        if self.existing_volume:
+            if not self.check_mode:
+                self.client.remove_volume(self.parameters.volume_name)
+
+            self.results['actions'].append("Removed volume %s" % (self.parameters.volume_name,))
+            self.results['changed'] = True
+
+    def present(self):
+        differences = []
+        if self.existing_volume:
+            differences = self.has_different_config()
+
+        if differences and self.parameters.force:
+            self.remove_volume()
+            self.existing_volume = None
+
+        self.create_volume()
+
+        if self.diff or self.check_mode or self.parameters.debug:
+            self.results['diff'] = differences
+
+        if not self.check_mode and not self.parameters.debug:
+            self.results.pop('actions')
+
+        self.results['ansible_facts'] = {u'docker_volume': self.get_existing_volume()}
+
+    def absent(self):
+        self.remove_volume()
+
+
+def main():
+    argument_spec = dict(
+        volume_name        = dict(type='str', required=True, aliases=['name']),
+        state              = dict(type='str', default='present', choices=['present', 'absent']),
+        driver             = dict(type='str', default='local'),
+        driver_options     = dict(type='dict', default={}),
+        labels             = dict(type='dict', default={}),
+        force              = dict(type='bool', default=False),
+        debug              = dict(type='bool', default=False)
+    )
+
+    client = AnsibleDockerClient(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    cm = DockerVolumeManager(client)
+    client.module.exit_json(**cm.results)
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/docker/docker_volume.py
+++ b/lib/ansible/modules/cloud/docker/docker_volume.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # coding: utf-8
 #
-# Copyright 2017 Red Hat | Ansible
+# Copyright 2017 Red Hat | Ansible, Alex Grönholm <alex.gronholm@nextday.fi>
 #
 # This file is part of Ansible
 #

--- a/lib/ansible/modules/cloud/docker/docker_volume.py
+++ b/lib/ansible/modules/cloud/docker/docker_volume.py
@@ -1,5 +1,5 @@
-# coding: utf-8
 #!/usr/bin/python
+# coding: utf-8
 #
 # Copyright 2017 Red Hat | Ansible
 #
@@ -102,7 +102,8 @@ facts:
     sample: {}
 '''
 
-from ansible.module_utils.docker_common import *
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.docker_common import DockerBaseClass, AnsibleDockerClient
 
 
 class TaskParameters(DockerBaseClass):
@@ -117,7 +118,7 @@ class TaskParameters(DockerBaseClass):
         self.force = None
         self.debug = None
 
-        for key, value in client.module.params.items():
+        for key, value in iteritems(client.module.params):
             setattr(self, key, value)
 
 
@@ -151,8 +152,7 @@ class DockerVolumeManager(object):
 
     def has_different_config(self):
         """
-        Evaluates an existing volume and returns a tuple containing a boolean
-        indicating if the configuration is different and a list of differences.
+        Return the list of differences between the current parameters and the existing volume.
 
         :return: list of options that differ
         """
@@ -163,7 +163,7 @@ class DockerVolumeManager(object):
             if not self.existing_volume.get('Options'):
                 differences.append('driver_options')
             else:
-                for key, value in self.parameters.driver_options.items():
+                for key, value in iteritems(self.parameters.driver_options):
                     if (not self.existing_volume['Options'].get(key) or
                             value != self.existing_volume['Options'][key]):
                         differences.append('driver_options.%s' % key)
@@ -194,7 +194,7 @@ class DockerVolumeManager(object):
             if not self.check_mode:
                 self.client.remove_volume(self.parameters.volume_name)
 
-            self.results['actions'].append("Removed volume %s" % (self.parameters.volume_name,))
+            self.results['actions'].append("Removed volume %s" % self.parameters.volume_name)
             self.results['changed'] = True
 
     def present(self):
@@ -222,13 +222,13 @@ class DockerVolumeManager(object):
 
 def main():
     argument_spec = dict(
-        volume_name        = dict(type='str', required=True, aliases=['name']),
-        state              = dict(type='str', default='present', choices=['present', 'absent']),
-        driver             = dict(type='str', default='local'),
-        driver_options     = dict(type='dict', default={}),
-        labels             = dict(type='dict', default={}),
-        force              = dict(type='bool', default=False),
-        debug              = dict(type='bool', default=False)
+        volume_name=dict(type='str', required=True, aliases=['name']),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+        driver=dict(type='str', default='local'),
+        driver_options=dict(type='dict', default={}),
+        labels=dict(type='dict', default={}),
+        force=dict(type='bool', default=False),
+        debug=dict(type='bool', default=False)
     )
 
     client = AnsibleDockerClient(

--- a/lib/ansible/modules/cloud/docker/docker_volume.py
+++ b/lib/ansible/modules/cloud/docker/docker_volume.py
@@ -107,10 +107,8 @@ facts:
     sample: {}
 '''
 
-from docker.errors import APIError
-
 from ansible.module_utils.six import iteritems, text_type
-from ansible.module_utils.docker_common import DockerBaseClass, AnsibleDockerClient
+from ansible.module_utils.docker_common import DockerBaseClass, AnsibleDockerClient, APIError
 
 
 class TaskParameters(DockerBaseClass):

--- a/lib/ansible/modules/cloud/docker/docker_volume.py
+++ b/lib/ansible/modules/cloud/docker/docker_volume.py
@@ -49,7 +49,7 @@ options:
         U(https://docs.docker.com/engine/reference/commandline/volume_create/#driver-specific-options)
 
   labels:
-    descriptions:
+    description:
       - List of labels to set for the volume
 
   force:

--- a/lib/ansible/modules/cloud/docker/docker_volume.py
+++ b/lib/ansible/modules/cloud/docker/docker_volume.py
@@ -48,19 +48,19 @@ options:
       - >
         Dictionary of volume settings. Consult docker docs for valid options and values:
         U(https://docs.docker.com/engine/reference/commandline/volume_create/#driver-specific-options)
-    default: null
 
   force:
     description:
-      - With state I(present) causes the volume to be deleted and recreated if the volume already
+      - With state C(present) causes the volume to be deleted and recreated if the volume already
         exist and the driver, driver options or labels differ.
         This will cause any data in the existing volume to be lost.
-    default: false
+    type: bool
+    default: 'no'
 
   state:
     description:
-      - I(absent) deletes the volume.
-      - I(present) creates the volume, if it does not already exist.
+      - C(absent) deletes the volume.
+      - C(present) creates the volume, if it does not already exist.
     default: present
     choices:
       - absent
@@ -70,7 +70,7 @@ extends_documentation_fragment:
     - docker
 
 author:
-    - "Alex Grönholm (@agronholm)"
+    - Alex Grönholm (@agronholm)
 
 requirements:
     - "python >= 2.6"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This module provides the ability to create and delete Docker volumes.

The "force" option deletes and recreates the volume with state=present to ensure that a volume exists
with the exact given options.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
docker_volume
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (docker_volume 80ec8c49ba) last updated 2017/05/23 15:48:45 (GMT -700)
  config file = /home/alex/.ansible.cfg
  configured module search path = [u'/home/alex/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/alex/checkout/ansible/lib/ansible
  executable location = /home/alex/checkout/ansible/venv/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
I've done manual testing using both docker-py 1.10.6 and docker 2.3.0 and the code worked fine with either one.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
