### PR TITLE
Resolves issue with new script inventory plugin

### DIFF
--- a/lib/ansible/plugins/inventory/script.py
+++ b/lib/ansible/plugins/inventory/script.py
@@ -113,12 +113,12 @@ class InventoryModule(BaseInventoryPlugin):
 
             group = None
             data_from_meta = None
-            for (group, gdata) in data.items():
+            for (group, gdata) in processed.items():
                 if group == '_meta':
                     if 'hostvars' in data:
                         data_from_meta = data['hostvars']
                 else:
-                    self.parse_group(group, gdata)
+                    self._parse_group(group, gdata)
 
             # in Ansible 1.3 and later, a "_meta" subelement may contain
             # a variable "hostvars" which contains a hash for each host


### PR DESCRIPTION
##### SUMMARY
This pull request resolves a couple minor issues with the new script inventory plugin.  I was about to submit another PR for a kubernetes dynamic inventory script and I ran into this while testing.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
- `lib/ansible/plugins/inventory/script.py`

##### ANSIBLE VERSION

```
ansible 2.4.0 (fix_script_inventory 9834f3b996) last updated 2017/05/23 21:12:06 (GMT -400)
  config file = /home/jcallen/Development/ansible-kube-connect-test/ansible.cfg
  configured module search path = [u'/home/jcallen/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jcallen/Development/ansible/lib/ansible
  executable location = /home/jcallen/Development/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```

