### PR TITLE
Support list for baseurl and gpgkey params in yum_repository (fixes #24948)

### DIFF
--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -9,10 +9,11 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'metadata_version': '1.0',
-                    'status': ['stableinterface'],
-                    'supported_by': 'core'}
-
+ANSIBLE_METADATA = {
+    'metadata_version': '1.0',
+    'status': ['stableinterface'],
+    'supported_by': 'core'
+}
 
 DOCUMENTATION = '''
 ---
@@ -47,6 +48,7 @@ options:
     description:
       - URL to the directory where the yum repository's 'repodata' directory
         lives.
+      - It can also be a list of multiple URLs.
       - This or the I(mirrorlist) parameter is required if I(state) is set to
         C(present).
   cost:
@@ -130,6 +132,7 @@ options:
     default: null
     description:
       - A URL pointing to the ASCII-armored GPG key file for the repository.
+      - It can also be a list of multiple URLs.
   http_caching:
     required: false
     choices: [all, packages, none]
@@ -635,7 +638,7 @@ def main():
         argument_spec=dict(
             async=dict(type='bool'),
             bandwidth=dict(),
-            baseurl=dict(),
+            baseurl=dict(type='list'),
             cost=dict(),
             deltarpm_metadata_percentage=dict(),
             deltarpm_percentage=dict(),
@@ -647,7 +650,7 @@ def main():
             file=dict(),
             gpgcakey=dict(),
             gpgcheck=dict(type='bool'),
-            gpgkey=dict(),
+            gpgkey=dict(type='list'),
             http_caching=dict(choices=['all', 'packages', 'none']),
             include=dict(),
             includepkgs=dict(),
@@ -716,6 +719,13 @@ def main():
     module.params['repoid'] = module.params['name']
     module.params['name'] = module.params['description']
     del module.params['description']
+
+    # Change list type to string for baseurl and gpgkey
+    for list_param in ['baseurl', 'gpgkey']:
+        if (
+                list_param in module.params and
+                module.params[list_param] is not None):
+            module.params[list_param] = "\n".join(module.params[list_param])
 
     # Define repo file name if it doesn't exist
     if module.params['file'] is None:

--- a/test/integration/targets/yum_repository/tasks/yum_repository_centos.yml
+++ b/test/integration/targets/yum_repository/tasks/yum_repository_centos.yml
@@ -146,3 +146,31 @@
 - name: check Idempotant
   assert:
     that: not epel_add.changed
+
+- name: Test list for baseurl and gpgkey
+  yum_repository:
+    name: listtest
+    description: Testing list feature
+    baseurl:
+      - https://download.fedoraproject.org/pub/epel/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/
+      - https://download2.fedoraproject.org/pub/epel/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/
+    gpgkey:
+      - gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}
+      - gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG2-KEY-EPEL-{{ ansible_distribution_major_version }}
+
+- set_fact:
+    repofile: "{{ lookup('file', '/etc/yum.repos.d/listtest.repo') }}"
+
+- name: Assert that lists were properly inserted
+  assert:
+    that:
+      - "'download.fedoraproject.org' in repofile"
+      - "'download2.fedoraproject.org' in repofile"
+      - "'RPM-GPG-KEY-EPEL' in repofile"
+      - "'RPM-GPG2-KEY-EPEL' in repofile"
+    value:
+
+- name: Cleanup list test repo
+  yum_repository:
+    name: listtest
+    state: absent


### PR DESCRIPTION
##### SUMMARY
This PR is allows to define the `baseurl` and `gpgkey` params as a list. It simplifies the way of declaring multiple URLs as described in the issue #24948.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
`yum_repository`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Feb 11 2017, 12:22:40) [GCC 6.3.1 20170109]
```


##### ADDITIONAL INFORMATION

This playbook:

```
- hosts: all
  tasks:
    - yum_repository:
        name: myrepo
        description: My YUM Repo
        baseurl:
          - http://example1.com/yum
          - http://example2.com/yum
        gpgkey:
          - http://example1.com/key
          - http://example2.com/key
```

creates the following repo file:

```
[myrepo]
baseurl = http://example1.com/yum
	http://example2.com/yum
gpgkey = http://example1.com/key
	http://example2.com/key
name = My YUM Repo
```