### PR TITLE
Add name_servers alias to name_server vyos_system parameter

### DIFF
--- a/lib/ansible/modules/network/vyos/vyos_system.py
+++ b/lib/ansible/modules/network/vyos/vyos_system.py
@@ -175,7 +175,7 @@ def main():
         host_name=dict(type='str'),
         domain_name=dict(type='str'),
         domain_search=dict(type='list'),
-        name_server=dict(type='list'),
+        name_server=dict(type='list', aliases=['name_servers']),
         state=dict(type='str', default='present', choices=['present', 'absent']),
     )
 


### PR DESCRIPTION
Other modules use name_servers, we need to have a consistent interface
for the platform agnostic modules work.