### PR TITLE
Revert: Warn when jinja2 delimiters are found in a when statement

### DIFF
--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -30,13 +30,6 @@ from ansible.module_utils.six import text_type
 from ansible.module_utils._text import to_native
 from ansible.playbook.attribute import FieldAttribute
 
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
-
-
 DEFINED_REGEX = re.compile(r'(hostvars\[.+\]|[\w_]+)\s+(not\s+is|is|is\s+not)\s+(defined|undefined)')
 LOOKUP_REGEX = re.compile(r'lookup\s*\(')
 VALID_VAR_REGEX = re.compile("^[_A-Za-z][_a-zA-Z0-9]*$")
@@ -136,11 +129,6 @@ class Conditional:
         #   - 1 == 1
         if conditional in all_vars and VALID_VAR_REGEX.match(conditional):
             conditional = all_vars[conditional]
-
-        if templar.is_template(conditional):
-            display.warning('when statements should not include jinja2 '
-                            'templating delimiters such as {{ }} or {%% %%}. '
-                            'Found: %s' % conditional)
 
         # make sure the templar is using the variables specified with this method
         templar.set_available_variables(variables=all_vars)


### PR DESCRIPTION
##### SUMMARY
Removes the warning for having Jinja2 filters present in `when:` statements. The rationale for this is it is very hard to develop highly re-usable playbooks without generating warnings. A lot of use cases have not had workarounds identified.

Please see issue: https://github.com/ansible/ansible/issues/22397
Fixes: 22397

I am aware this issue is closed but I (and others it seems) do not feel it is resolved.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/playbook/conditional.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
```


##### ADDITIONAL INFORMATION
Have built and tested Ansible from the code within this PR and it works fine. I am however not aware of the official testing procedures for Ansible.

I have never contributed to Ansible before so apologies for any requirements this PR does not meet.

```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/rich/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Feb 11 2017, 12:22:40) [GCC 6.3.1 20170109]

```
