### PR TITLE
Add working_dir to docker_container (#20044)

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -471,6 +471,7 @@ options:
       - Path to the working directory.
     default: null
     required: false
+    version_added: "2.4"
 extends_documentation_fragment:
     - docker
 

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -466,6 +466,11 @@ options:
       - List of container names or Ids to get volumes from.
     default: null
     required: false
+  working_dir:
+    description:
+      - Path to the working directory.
+    default: null
+    required: false
 extends_documentation_fragment:
     - docker
 
@@ -763,6 +768,7 @@ class TaskParameters(DockerBaseClass):
         self.volume_binds = dict()
         self.volumes_from = None
         self.volume_driver = None
+        self.working_dir = None
 
         for key, value in client.module.params.items():
             setattr(self, key, value)
@@ -866,6 +872,7 @@ class TaskParameters(DockerBaseClass):
             labels='labels',
             stop_signal='stop_signal',
             volume_driver='volume_driver',
+            working_dir='working_dir',
         )
 
         result = dict(
@@ -1285,7 +1292,8 @@ class Container(DockerBaseClass):
             expected_volumes=config.get('Volumes'),
             expected_binds=host_config.get('Binds'),
             volumes_from=host_config.get('VolumesFrom'),
-            volume_driver=host_config.get('VolumeDriver')
+            volume_driver=host_config.get('VolumeDriver'),
+            working_dir=host_config.get('WorkingDir')
         )
 
         differences = []
@@ -2039,6 +2047,7 @@ def main():
         volumes=dict(type='list'),
         volumes_from=dict(type='list'),
         volume_driver=dict(type='str'),
+        working_dir=dict(type='str'),
     )
 
     required_if = [


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Fixes #20044 and adds a [working_dir](https://docker-py.readthedocs.io/en/stable/containers.html#docker.models.containers.ContainerCollection.run) option to the `docker_container` module.

This is a very convenient option when interacting with certain containers. For example, I needed this when trying to use the public `node` container and I wanted over-ride the default command but needed it to be run under a specific mounted folder. Could I have worked around it with some tomfoolery? Sure - but this seemed like a really no nonsense addition.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
`docker_container.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /home/mike/Documents/Git/docker_testing/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

This is a new argument that is added to `docker_container`, here is an example of a valid usage in a playbook:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
    - name: Start node
      docker_container:
        name: node
        image: node:6.10.3-alpine
        volumes:
          - ../../:/var/www/django
        state: started
        working_dir: /var/www/django
        command: /bin/ash -c "npm install; npm run start"
```