### PR TITLE
Add some clarifying docs regarding module search paths

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules.rst
@@ -18,7 +18,7 @@ as we work through this tutorial.
 
 See :doc:`../modules` for a list of existing modules.
 
-Modules can be written in any language and are found in the `./library` folder relative to 
+Modules can be written in any language and are found in the ``./library`` folder relative to 
 the executing playbook, the path specified by :envvar:`ANSIBLE_LIBRARY`, the ``--module-path`` 
 command line option or in the `library section of the Ansible configuration file <http://docs.ansible.com/ansible/intro_configuration.html#library>`_.
 For more information about where Ansible discovers modules, see `Module Paths <http://docs.ansible.com/ansible/dev_guide/developing_modules_best_practices.html#module-paths>`_

--- a/docs/docsite/rst/dev_guide/developing_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules.rst
@@ -18,9 +18,10 @@ as we work through this tutorial.
 
 See :doc:`../modules` for a list of existing modules.
 
-Modules can be written in any language and are found in the path specified
-by :envvar:`ANSIBLE_LIBRARY` or the ``--module-path`` command line option or
-in the `library section of the Ansible configuration file <http://docs.ansible.com/ansible/intro_configuration.html#library>`_.
+Modules can be written in any language and are found in the `./library` folder relative to 
+the executing playbook, the path specified by :envvar:`ANSIBLE_LIBRARY`, the ``--module-path`` 
+command line option or in the `library section of the Ansible configuration file <http://docs.ansible.com/ansible/intro_configuration.html#library>`_.
+For more information about where Ansible discovers modules, see `Module Paths <http://docs.ansible.com/ansible/dev_guide/developing_modules_best_practices.html#module-paths>`_
 
 .. _module_dev_should_you:
 

--- a/docs/docsite/rst/dev_guide/developing_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules.rst
@@ -18,9 +18,14 @@ as we work through this tutorial.
 
 See :doc:`../modules` for a list of existing modules.
 
-Modules can be written in any language and are found in the ``./library`` directory relative to 
-the executing playbook or inside a role, the path specified by :envvar:`ANSIBLE_LIBRARY`, the ``--module-path`` 
-command line option or in the `library section of the Ansible configuration file <http://docs.ansible.com/ansible/intro_configuration.html#library>`_.
+Modules can be written in any language, and can be found in several places:
+
+- the ``./library`` directory relative to the executing playbook
+- inside a role
+- in the path specified by :envvar:`ANSIBLE_LIBRARY`
+- in the ``--module-path`` command line option
+- in the `library section of the Ansible configuration file <http://docs.ansible.com/ansible/intro_configuration.html#library>`_
+
 For more information about where Ansible discovers modules, see `Module Paths <http://docs.ansible.com/ansible/dev_guide/developing_modules_best_practices.html#module-paths>`_
 
 .. _module_dev_should_you:

--- a/docs/docsite/rst/dev_guide/developing_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules.rst
@@ -19,7 +19,7 @@ as we work through this tutorial.
 See :doc:`../modules` for a list of existing modules.
 
 Modules can be written in any language and are found in the ``./library`` directory relative to 
-the executing playbook or inside a ``role`` directory, the path specified by :envvar:`ANSIBLE_LIBRARY`, the ``--module-path`` 
+the executing playbook or inside a role, the path specified by :envvar:`ANSIBLE_LIBRARY`, the ``--module-path`` 
 command line option or in the `library section of the Ansible configuration file <http://docs.ansible.com/ansible/intro_configuration.html#library>`_.
 For more information about where Ansible discovers modules, see `Module Paths <http://docs.ansible.com/ansible/dev_guide/developing_modules_best_practices.html#module-paths>`_
 

--- a/docs/docsite/rst/dev_guide/developing_modules.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules.rst
@@ -18,8 +18,8 @@ as we work through this tutorial.
 
 See :doc:`../modules` for a list of existing modules.
 
-Modules can be written in any language and are found in the ``./library`` folder relative to 
-the executing playbook, the path specified by :envvar:`ANSIBLE_LIBRARY`, the ``--module-path`` 
+Modules can be written in any language and are found in the ``./library`` directory relative to 
+the executing playbook or inside a ``role`` directory, the path specified by :envvar:`ANSIBLE_LIBRARY`, the ``--module-path`` 
 command line option or in the `library section of the Ansible configuration file <http://docs.ansible.com/ansible/intro_configuration.html#library>`_.
 For more information about where Ansible discovers modules, see `Module Paths <http://docs.ansible.com/ansible/dev_guide/developing_modules_best_practices.html#module-paths>`_
 

--- a/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
@@ -156,6 +156,13 @@ Ansible can find modules in several locations.
 The easiest way to include a module is by adding a ``library`` folder to your project 
 relative to your playbooks. Module files (.py, etc.) can be added there.
 
+The structure will look like this::
+
+    ├── playbook.yml
+    └── library
+        ├── my_module.py
+        └── my_other_module.py
+
 .. note::
 
     Currently Ansible does not support organizing modules into sub-folders under the ``library``

--- a/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
@@ -149,9 +149,22 @@ module file and test that the real module works via :command:`ansible` or
 
 Module Paths
 ````````````
+Ansible can find modules in several locations. The easiest way to include a module is by
+adding a `library` folder to your project relative to your playbooks. Module files (.py, etc.)
+can be added there.
 
-If you are having trouble getting your module "found" by ansible, be
-sure it is in the :envvar:`ANSIBLE_LIBRARY` environment variable.
+.. note::
+
+    Currently Ansible does not support organizing modules into sub-folders under the `library`
+    folder.
+
+In the Ansible configuration file you can modify the `library <http://docs.ansible.com/ansible/intro_configuration.html#library>`_
+setting to add additional module search paths.
+
+You may also specify paths in the :envvar:`ANSIBLE_LIBRARY` environment variable. 
+
+If you are having trouble getting your module "found" by ansible, be sure it is in one of 
+those search paths.
 
 If you have a fork of one of the ansible module projects, do something like this::
 

--- a/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
@@ -149,19 +149,30 @@ module file and test that the real module works via :command:`ansible` or
 
 Module Paths
 ````````````
-Ansible can find modules in several locations. The easiest way to include a module is by
-adding a `library` folder to your project relative to your playbooks. Module files (.py, etc.)
+Ansible can find modules in several locations. 
+
+**Relative to Playbooks**
+
+The easiest way to include a module is by
+adding a ``library`` folder to your project relative to your playbooks. Module files (.py, etc.)
 can be added there.
 
 .. note::
 
-    Currently Ansible does not support organizing modules into sub-folders under the `library`
+    Currently Ansible does not support organizing modules into sub-folders under the ``library``
     folder.
+
+**Ansible Configuration File**
 
 In the Ansible configuration file you can modify the `library <http://docs.ansible.com/ansible/intro_configuration.html#library>`_
 setting to add additional module search paths.
 
-You may also specify paths in the :envvar:`ANSIBLE_LIBRARY` environment variable. 
+**Environment & Command-Line**
+
+You can specify additional module paths using the ``--module-path`` command-line option. You may also 
+specify paths in the :envvar:`ANSIBLE_LIBRARY` environment variable. 
+
+**Troubleshooting Module Discovery**
 
 If you are having trouble getting your module "found" by ansible, be sure it is in one of 
 those search paths.

--- a/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
@@ -153,9 +153,8 @@ Ansible can find modules in several locations.
 
 **Relative to Playbooks**
 
-The easiest way to include a module is by
-adding a ``library`` folder to your project relative to your playbooks. Module files (.py, etc.)
-can be added there.
+The easiest way to include a module is by adding a ``library`` folder to your project 
+relative to your playbooks. Module files (.py, etc.) can be added there.
 
 .. note::
 

--- a/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
@@ -167,6 +167,21 @@ The structure will look like this::
 
     Currently Ansible does not support organizing modules into sub-folders under the ``library``
     folder.
+    
+**Inside a Role**
+
+The library folder can also exist within a role following the same layout above.
+
+The structure would look like this for a "webservers" role::
+
+    └── roles
+        └── webservers
+            ├── tasks
+            ├── vars
+            ├── ...
+            └── library
+                ├── my_module.py
+                └── my_other_module.py
 
 **Ansible Configuration File**
 

--- a/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_best_practices.rst
@@ -149,54 +149,11 @@ module file and test that the real module works via :command:`ansible` or
 
 Module Paths
 ````````````
-Ansible can find modules in several locations. 
-
-**Relative to Playbooks**
-
-The easiest way to include a module is by adding a ``library`` folder to your project 
-relative to your playbooks. Module files (.py, etc.) can be added there.
-
-The structure will look like this::
-
-    ├── playbook.yml
-    └── library
-        ├── my_module.py
-        └── my_other_module.py
-
-.. note::
-
-    Currently Ansible does not support organizing modules into sub-folders under the ``library``
-    folder.
-    
-**Inside a Role**
-
-The library folder can also exist within a role following the same layout above.
-
-The structure would look like this for a "webservers" role::
-
-    └── roles
-        └── webservers
-            ├── tasks
-            ├── vars
-            ├── ...
-            └── library
-                ├── my_module.py
-                └── my_other_module.py
-
-**Ansible Configuration File**
-
-In the Ansible configuration file you can modify the `library <http://docs.ansible.com/ansible/intro_configuration.html#library>`_
-setting to add additional module search paths.
-
-**Environment & Command-Line**
-
-You can specify additional module paths using the ``--module-path`` command-line option. You may also 
-specify paths in the :envvar:`ANSIBLE_LIBRARY` environment variable. 
 
 **Troubleshooting Module Discovery**
 
-If you are having trouble getting your module "found" by ansible, be sure it is in one of 
-those search paths.
+If you are having trouble getting your module "found" by ansible, be sure it 
+is in the correct path, see `Module Paths <http://docs.ansible.com/ansible/modules_intro.html#module-paths>`_.
 
 If you have a fork of one of the ansible module projects, do something like this::
 
@@ -234,5 +191,4 @@ Avoid creating a module that does the work of other modules; this leads to code 
 
 Avoid creating 'caches'. Ansible is designed without a central server or authority, so you cannot guarantee it will not run with different permissions, options or locations. If you need a central authority, have it on top of Ansible (for example, using bastion/cm/ci server or tower); do not try to build it into modules.
 
-Always use the hacking/test-module script when developing modules and it will warn
-you about these kind of things.
+Always use the hacking/test-module script when developing modules to receive warnings about these issues.

--- a/docs/docsite/rst/intro_configuration.rst
+++ b/docs/docsite/rst/intro_configuration.rst
@@ -550,8 +550,8 @@ This is the default location Ansible looks to find modules::
      library = /usr/share/ansible
 
 Ansible can look in multiple locations if you feed it a colon
-separated path, and it also will look for modules in the :file:`./library`
-directory alongside a playbook.
+separated path. In addition to library paths, Ansible also searches other 
+`module paths <http://docs.ansible.com/ansible/modules_intro.html#module-paths>`_.
 
 This can be used to manage modules pulled from several different locations.
 For instance, a site wishing to checkout modules from several different git

--- a/docs/docsite/rst/modules_intro.rst
+++ b/docs/docsite/rst/modules_intro.rst
@@ -48,6 +48,52 @@ A list of all installed modules is also available::
 
     ansible-doc -l
 
+Module Paths
+````````````
+
+Ansible can discover modules in several locations. 
+
+**Relative to Playbooks**
+
+The easiest way to include a module is by adding a ``library`` folder to your project 
+relative to your playbooks. Module files (.py, etc.) can be added there.
+
+The structure will look like this::
+
+    ├── playbook.yml
+    └── library
+        ├── my_module.py
+        └── my_other_module.py
+
+.. note::
+
+    Currently Ansible does not support organizing modules into sub-folders under the ``library``
+    folder.
+    
+**Inside a Role**
+
+The library folder can also exist within a role following the same layout above.
+
+The structure would look like this for a "webservers" role::
+
+    └── roles
+        └── webservers
+            ├── tasks
+            ├── vars
+            ├── ...
+            └── library
+                ├── my_module.py
+                └── my_other_module.py
+
+**Ansible Configuration File**
+
+In the Ansible configuration file you can modify the `library <http://docs.ansible.com/ansible/intro_configuration.html#library>`_
+setting to add additional module search paths.
+
+**Environment & Command-Line**
+
+You can specify additional module paths using the ``--module-path`` command-line option. You may also 
+specify paths in the :envvar:`ANSIBLE_LIBRARY` environment variable. 
 
 .. seealso::
 


### PR DESCRIPTION
Fixes #7633

##### SUMMARY

Add some clarifying documentation regarding how Ansible discovers modules. As a new user, I was unable to find the `library` relative search path--it looks like the only page that mentions it in passing is the Ansible Configuration File docs.

Let me know if any of the info is wrong or has to be reworded.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
dev_guide