### PR TITLE
Remove true/yes from ignore_error parameter (should be boolean)

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -230,7 +230,7 @@ In addition to positive testing, negative tests are required to ensure user frie
        gather_subset:
          - "foobar"
      register: result
-     ignore_errors: true
+     ignore_errors: True
 
    - assert:
        that:

--- a/docs/docsite/rst/playbooks_error_handling.rst
+++ b/docs/docsite/rst/playbooks_error_handling.rst
@@ -23,7 +23,7 @@ Sometimes, though, you want to continue on.  To do so, write a task that looks l
 
     - name: this will not be counted as a failure
       command: /bin/false
-      ignore_errors: yes
+      ignore_errors: True
 
 Note that the above system only governs the return value of failure of the particular task,
 so if you have an undefined variable used or a syntax error, it will still raise an error that users will need to address.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The parameter `ignore_errors` is defined as a boolean. This means that the only values that are admitted are `True` or `False`. 

In some examples in the documentations values like `yes` and `true` which are not correct. This commit fixes them.

##### ISSUE TYPE
 - Docs Pull Request