### PR TITLE
[WIP] Switch to argparse

### DIFF
--- a/docs/bin/dump_keywords.py
+++ b/docs/bin/dump_keywords.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import optparse
+import argparse
 import yaml
 
 from jinja2 import Environment, FileSystemLoader
@@ -10,21 +10,28 @@ from ansible.playbook.block import Block
 from ansible.playbook.role import Role
 from ansible.playbook.task import Task
 
+try:
+    import argcomplete
+except ImportError:
+    argcomplete = None
+
 template_file = 'playbooks_keywords.rst.j2'
 oblist = {}
 clist = []
 class_list = [Play, Role, Block, Task]
 
-p = optparse.OptionParser(
-    version='%prog 1.0',
-    usage='usage: %prog [options]',
+p = argparse.ArgumentParser(
     description='Generate module documentation from metadata',
 )
-p.add_option("-T", "--template-dir", action="store", dest="template_dir", default="../templates", help="directory containing Jinja2 templates")
-p.add_option("-o", "--output-dir", action="store", dest="output_dir", default='/tmp/', help="Output directory for rst files")
-p.add_option("-d", "--docs-source", action="store", dest="docs", default=None, help="Source for attribute docs")
+p.add_argument('--version', action='version', version='%(prog)s 1.0')
+p.add_argument("-T", "--template-dir", action="store", dest="template_dir", default="../templates", help="directory containing Jinja2 templates")
+p.add_argument("-o", "--output-dir", action="store", dest="output_dir", default='/tmp/', help="Output directory for rst files")
+p.add_argument("-d", "--docs-source", action="store", dest="docs", default=None, help="Source for attribute docs")
 
-(options, args) = p.parse_args()
+if argcomplete:
+    argcomplete.autocomplete(p, always_complete_options=False, validator=lambda i, k: True)
+
+options = p.parse_args()
 
 for aclass in class_list:
     aobj = aclass()

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -20,10 +20,10 @@
 from __future__ import print_function
 __metaclass__ = type
 
+import argparse
 import cgi
 import datetime
 import glob
-import optparse
 import os
 import re
 import sys
@@ -37,6 +37,11 @@ from six import iteritems
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_bytes
 from ansible.utils import plugin_docs
+
+try:
+    import argcomplete
+except ImportError:
+    argcomplete = None
 
 #####################################################################################
 # constants and paths
@@ -170,22 +175,24 @@ def list_modules(module_dir, depth=0):
 
 
 def generate_parser():
-    ''' generate an optparse parser '''
+    ''' generate a parser '''
 
-    p = optparse.OptionParser(
-        version='%prog 1.0',
-        usage='usage: %prog [options] arg1 arg2',
+    p = argparse.ArgumentParser(
         description='Generate module documentation from metadata',
     )
 
-    p.add_option("-A", "--ansible-version", action="store", dest="ansible_version", default="unknown", help="Ansible version number")
-    p.add_option("-M", "--module-dir", action="store", dest="module_dir", default=MODULEDIR, help="Ansible library path")
-    p.add_option("-T", "--template-dir", action="store", dest="template_dir", default="hacking/templates", help="directory containing Jinja2 templates")
-    p.add_option("-t", "--type", action='store', dest='type', choices=['rst'], default='rst', help="Document type")
-    p.add_option("-v", "--verbose", action='store_true', default=False, help="Verbose")
-    p.add_option("-o", "--output-dir", action="store", dest="output_dir", default=None, help="Output directory for module files")
-    p.add_option("-I", "--includes-file", action="store", dest="includes_file", default=None, help="Create a file containing list of processed modules")
-    p.add_option('-V', action='version', help='Show version number and exit')
+    p.add_argument('--version', '-V', action='version', version='%(prog)s 1.0')
+    p.add_argument("-A", "--ansible-version", action="store", dest="ansible_version", default="unknown", help="Ansible version number")
+    p.add_argument("-M", "--module-dir", action="store", dest="module_dir", default=MODULEDIR, help="Ansible library path")
+    p.add_argument("-T", "--template-dir", action="store", dest="template_dir", default="hacking/templates", help="directory containing Jinja2 templates")
+    p.add_argument("-t", "--type", action='store', dest='type', choices=['rst'], default='rst', help="Document type")
+    p.add_argument("-v", "--verbose", action='store_true', default=False, help="Verbose")
+    p.add_argument("-o", "--output-dir", action="store", dest="output_dir", default=None, help="Output directory for module files")
+    p.add_argument("-I", "--includes-file", action="store", dest="includes_file", default=None, help="Create a file containing list of processed modules")
+
+    if argcomplete:
+        argcomplete.autocomplete(p, always_complete_options=False, validator=lambda i, k: True)
+
     return p
 
 
@@ -430,7 +437,7 @@ def main():
 
     p = generate_parser()
 
-    (options, args) = p.parse_args()
+    options = p.parse_args()
     validate_options(options)
 
     env, template, outputname = jinja2_environment(options.template_dir, options.type)

--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -255,13 +255,13 @@ def process_module(module, options, env, template, outputname, module_map, alias
 
     # crash if module is missing documentation and not explicitly hidden from docs index
     if doc is None:
-        sys.exit("*** ERROR: MODULE MISSING DOCUMENTATION: %s, %s ***\n" % (fname, module))
+        raise SystemExit("*** ERROR: MODULE MISSING DOCUMENTATION: %s, %s ***\n" % (fname, module))
 
     if metadata is None:
-        sys.exit("*** ERROR: MODULE MISSING METADATA: %s, %s ***\n" % (fname, module))
+        raise SystemExit("*** ERROR: MODULE MISSING METADATA: %s, %s ***\n" % (fname, module))
 
     if deprecated and 'deprecated' not in doc:
-        sys.exit("*** ERROR: DEPRECATED MODULE MISSING 'deprecated' DOCUMENTATION: %s, %s ***\n" % (fname, module))
+        raise SystemExit("*** ERROR: DEPRECATED MODULE MISSING 'deprecated' DOCUMENTATION: %s, %s ***\n" % (fname, module))
 
     if module in aliases:
         doc['aliases'] = aliases[module]
@@ -269,7 +269,7 @@ def process_module(module, options, env, template, outputname, module_map, alias
     all_keys = []
 
     if 'version_added' not in doc:
-        sys.exit("*** ERROR: missing version_added in: %s ***\n" % module)
+        raise SystemExit("*** ERROR: missing version_added in: %s ***\n" % module)
 
     added = 0
     if doc['version_added'] == 'historical':
@@ -426,11 +426,11 @@ def validate_options(options):
     ''' validate option parser options '''
 
     if not options.module_dir:
-        sys.exit("--module-dir is required", file=sys.stderr)
+        raise SystemExit("--module-dir is required")
     if not os.path.exists(options.module_dir):
-        sys.exit("--module-dir does not exist: %s" % options.module_dir, file=sys.stderr)
+        raise SystemExit("--module-dir does not exist: %s" % options.module_dir)
     if not options.template_dir:
-        sys.exit("--template-dir must be specified")
+        raise SystemExit("--template-dir must be specified")
 
 
 def main():

--- a/hacking/test-module
+++ b/hacking/test-module
@@ -29,7 +29,7 @@
 #    test-module -m ../library/file/lineinfile -a "dest=/etc/exports line='/srv/home hostname1(rw,sync)'" --check
 #    test-module -m ../library/commands/command -a "echo hello" -n -o "test_hello"
 
-import optparse
+import argparse
 import os
 import subprocess
 import sys
@@ -48,37 +48,39 @@ try:
 except ImportError:
     import simplejson as json
 
+try:
+    import argcomplete
+except ImportError:
+    argcomplete = None
+
 
 def parse():
     """parse command line
 
     :return : (options, args)"""
-    parser = optparse.OptionParser()
+    parser = argparse.ArgumentParser()
 
-    parser.usage = "%prog -[options] (-h for help)"
-
-    parser.add_option('-m', '--module-path', dest='module_path',
+    parser.add_argument('-m', '--module-path', dest='module_path', required=True,
         help="REQUIRED: full path of module source to execute")
-    parser.add_option('-a', '--args', dest='module_args', default="",
+    parser.add_argument('-a', '--args', dest='module_args', default="",
         help="module argument string")
-    parser.add_option('-D', '--debugger', dest='debugger',
+    parser.add_argument('-D', '--debugger', dest='debugger',
         help="path to python debugger (e.g. /usr/bin/pdb)")
-    parser.add_option('-I', '--interpreter', dest='interpreter',
+    parser.add_argument('-I', '--interpreter', dest='interpreter',
         help="path to interpreter to use for this module (e.g. ansible_python_interpreter=/usr/bin/python)",
         metavar='INTERPRETER_TYPE=INTERPRETER_PATH')
-    parser.add_option('-c', '--check', dest='check', action='store_true',
+    parser.add_argument('-c', '--check', dest='check', action='store_true',
         help="run the module in check mode")
-    parser.add_option('-n', '--noexecute', dest='execute', action='store_false',
+    parser.add_argument('-n', '--noexecute', dest='execute', action='store_false',
         default=True, help="do not run the resulting module")
-    parser.add_option('-o', '--output', dest='filename',
+    parser.add_argument('-o', '--output', dest='filename',
         help="Filename for resulting module",
         default="~/.ansible_module_generated")
-    options, args = parser.parse_args()
-    if not options.module_path:
-        parser.print_help()
-        sys.exit(1)
-    else:
-        return options, args
+
+    if argcomplete:
+        argcomplete.autocomplete(parser, always_complete_options=False, validator=lambda i, k: True)
+
+    return parser.parse_args()
 
 
 def write_argsfile(argstring, json=False):
@@ -242,7 +244,7 @@ def rundebug(debugger, modfile, argspath, modname, module_style):
 
 def main():
 
-    options, args = parse()
+    options = parse()
     interpreters = get_interpreters(options.interpreter)
     (modfile, modname, module_style) = boilerplate_module(options.module_path, options.module_args, interpreters, options.check, options.filename)
 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -401,7 +401,7 @@ class CLI(with_metaclass(ABCMeta, object)):
             argcomplete.autocomplete(self.parser, always_complete_options=False, validator=lambda i, k: True)
 
         self.options = self.parser.parse_args(self.args[1:])
-        self.args = getattr(self.options, 'args', [])
+        self.args = getattr(self.options, 'args', []) or []
 
         # process tags
         if hasattr(self.options, 'tags') and not self.options.tags:

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -105,7 +105,7 @@ class CLI(with_metaclass(ABCMeta, object)):
         running an Ansible command.
         """
 
-        display.vv(self.parser.get_version())
+        display.vv(CLI.version(self.parser.prog))
 
         if C.CONFIG_FILE:
             display.v(u"Using %s as config file" % to_text(C.CONFIG_FILE))

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -238,14 +238,14 @@ class CLI(with_metaclass(ABCMeta, object)):
     @staticmethod
     def _vault_opts(parser):
         parser.add_argument('--ask-vault-pass', default=C.DEFAULT_ASK_VAULT_PASS, dest='ask_vault_pass', action='store_true',
-            help='ask for vault password')
+                            help='ask for vault password')
         parser.add_argument('--vault-password-file', default=C.DEFAULT_VAULT_PASSWORD_FILE, dest='vault_password_file',
-            help="vault password file", type=CLI.unfrack_path)
+                            help="vault password file", type=CLI.unfrack_path)
 
     @staticmethod
     def base_parser(output_opts=False, runas_opts=False, meta_opts=False, runtask_opts=False, vault_opts=False, module_opts=False,
-            async_opts=False, connect_opts=False, subset_opts=False, check_opts=False, inventory_opts=False, epilog=None, fork_opts=False,
-            runas_prompt_opts=False, desc=None):
+                    async_opts=False, connect_opts=False, subset_opts=False, check_opts=False, inventory_opts=False, epilog=None, fork_opts=False,
+                    runas_prompt_opts=False, desc=None):
         ''' create an options parser for most ansible scripts '''
 
         # base opts
@@ -256,66 +256,67 @@ class CLI(with_metaclass(ABCMeta, object)):
         )
         parser.add_argument('--version', action='version', version=CLI.version("%(prog)s"))
 
-        parser.add_argument('-v','--verbose', dest='verbosity', default=C.DEFAULT_VERBOSITY, action="count",
-            help="verbose mode (-vvv for more, -vvvv to enable connection debugging)")
+        parser.add_argument('-v', '--verbose', dest='verbosity', default=C.DEFAULT_VERBOSITY, action="count",
+                            help="verbose mode (-vvv for more, -vvvv to enable connection debugging)")
 
         if inventory_opts:
             parser.add_argument('-i', '--inventory-file', dest='inventory',
-                help="specify inventory host path (default=%s) or comma separated host list. --inventory-file is deprecated" % C.DEFAULT_HOST_LIST,
-                default=C.DEFAULT_HOST_LIST, type=CLI.expand_tilde)
+                                help="specify inventory host path (default=%s) or comma separated host list. "
+                                     "--inventory-file is deprecated" % C.DEFAULT_HOST_LIST,
+                                default=C.DEFAULT_HOST_LIST, type=CLI.expand_tilde)
             parser.add_argument('--list-hosts', dest='listhosts', action='store_true',
-                help='outputs a list of matching hosts; does not execute anything else')
+                                help='outputs a list of matching hosts; does not execute anything else')
             parser.add_argument('-l', '--limit', default=C.DEFAULT_SUBSET, dest='subset',
-                help='further limit selected hosts to an additional pattern')
+                                help='further limit selected hosts to an additional pattern')
 
         if module_opts:
             parser.add_argument('-M', '--module-path', dest='module_path', default=None,
-                help="prepend path(s) to module library (default=%s)" % C.DEFAULT_MODULE_PATH,
-                type=CLI.expand_tilde)
+                                help="prepend path(s) to module library (default=%s)" % C.DEFAULT_MODULE_PATH,
+                                type=CLI.expand_tilde)
         if runtask_opts:
             parser.add_argument('-e', '--extra-vars', dest="extra_vars", action="append",
-                help="set additional variables as key=value or YAML/JSON", default=[])
+                                help="set additional variables as key=value or YAML/JSON", default=[])
 
         if fork_opts:
-            parser.add_argument('-f','--forks', dest='forks', default=C.DEFAULT_FORKS, type=int,
-                help="specify number of parallel processes to use (default=%s)" % C.DEFAULT_FORKS)
+            parser.add_argument('-f', '--forks', dest='forks', default=C.DEFAULT_FORKS, type=int,
+                                help="specify number of parallel processes to use (default=%s)" % C.DEFAULT_FORKS)
 
         if vault_opts:
             CLI._vault_opts(parser)
 
         if subset_opts:
             parser.add_argument('-t', '--tags', dest='tags', default=[], action='append',
-                help="only run plays and tasks tagged with these values")
+                                help="only run plays and tasks tagged with these values")
             parser.add_argument('--skip-tags', dest='skip_tags', default=[], action='append',
-                help="only run plays and tasks whose tags do not match these values")
+                                help="only run plays and tasks whose tags do not match these values")
 
         if output_opts:
             parser.add_argument('-o', '--one-line', dest='one_line', action='store_true',
-                help='condense output')
+                                help='condense output')
             parser.add_argument('-t', '--tree', dest='tree', default=None,
-                help='log output to this directory')
+                                help='log output to this directory')
 
         if connect_opts:
             connect_group = parser.add_argument_group('Connection Options', 'control as whom and how to connect to hosts')
             connect_group.add_argument('-k', '--ask-pass', default=C.DEFAULT_ASK_PASS, dest='ask_pass', action='store_true',
-                help='ask for connection password')
-            connect_group.add_argument('--private-key','--key-file', default=C.DEFAULT_PRIVATE_KEY_FILE, dest='private_key_file',
-                help='use this file to authenticate the connection',
-                type=CLI.unfrack_path)
+                                       help='ask for connection password')
+            connect_group.add_argument('--private-key', '--key-file', default=C.DEFAULT_PRIVATE_KEY_FILE, dest='private_key_file',
+                                       help='use this file to authenticate the connection',
+                                       type=CLI.unfrack_path)
             connect_group.add_argument('-u', '--user', default=C.DEFAULT_REMOTE_USER, dest='remote_user',
-                help='connect as this user (default=%s)' % C.DEFAULT_REMOTE_USER)
+                                       help='connect as this user (default=%s)' % C.DEFAULT_REMOTE_USER)
             connect_group.add_argument('-c', '--connection', dest='connection', default=C.DEFAULT_TRANSPORT,
-                help="connection type to use (default=%s)" % C.DEFAULT_TRANSPORT)
+                                       help="connection type to use (default=%s)" % C.DEFAULT_TRANSPORT)
             connect_group.add_argument('-T', '--timeout', default=C.DEFAULT_TIMEOUT, type=int, dest='timeout',
-                help="override the connection timeout in seconds (default=%s)" % C.DEFAULT_TIMEOUT)
+                                       help="override the connection timeout in seconds (default=%s)" % C.DEFAULT_TIMEOUT)
             connect_group.add_argument('--ssh-common-args', default='', dest='ssh_common_args',
-                help="specify common arguments to pass to sftp/scp/ssh (e.g. ProxyCommand)")
+                                       help="specify common arguments to pass to sftp/scp/ssh (e.g. ProxyCommand)")
             connect_group.add_argument('--sftp-extra-args', default='', dest='sftp_extra_args',
-                help="specify extra arguments to pass to sftp only (e.g. -f, -l)")
+                                       help="specify extra arguments to pass to sftp only (e.g. -f, -l)")
             connect_group.add_argument('--scp-extra-args', default='', dest='scp_extra_args',
-                help="specify extra arguments to pass to scp only (e.g. -l)")
+                                       help="specify extra arguments to pass to scp only (e.g. -l)")
             connect_group.add_argument('--ssh-extra-args', default='', dest='ssh_extra_args',
-                help="specify extra arguments to pass to ssh only (e.g. -R)")
+                                       help="specify extra arguments to pass to ssh only (e.g. -R)")
 
             parser.add_argument_group(connect_group)
 
@@ -325,54 +326,55 @@ class CLI(with_metaclass(ABCMeta, object)):
             runas_group = rg
             # priv user defaults to root later on to enable detecting when this option was given here
             runas_group.add_argument("-s", "--sudo", default=C.DEFAULT_SUDO, action="store_true", dest='sudo',
-                help="run operations with sudo (nopasswd) (deprecated, use become)")
+                                     help="run operations with sudo (nopasswd) (deprecated, use become)")
             runas_group.add_argument('-U', '--sudo-user', dest='sudo_user', default=None,
-                help='desired sudo user (default=root) (deprecated, use become)')
+                                     help='desired sudo user (default=root) (deprecated, use become)')
             runas_group.add_argument('-S', '--su', default=C.DEFAULT_SU, action='store_true',
-                help='run operations with su (deprecated, use become)')
+                                     help='run operations with su (deprecated, use become)')
             runas_group.add_argument('-R', '--su-user', default=None,
-                help='run operations with su as this user (default=%s) (deprecated, use become)' % C.DEFAULT_SU_USER)
+                                     help='run operations with su as this user (default=%s) (deprecated, use become)' % C.DEFAULT_SU_USER)
 
             # consolidated privilege escalation (become)
             runas_group.add_argument("-b", "--become", default=C.DEFAULT_BECOME, action="store_true", dest='become',
-                help="run operations with become (does not imply password prompting)")
+                                     help="run operations with become (does not imply password prompting)")
             runas_group.add_argument('--become-method', dest='become_method', default=C.DEFAULT_BECOME_METHOD, choices=C.BECOME_METHODS,
-                help="privilege escalation method to use (default=%s), valid choices: [ %s ]" % (C.DEFAULT_BECOME_METHOD, ' | '.join(C.BECOME_METHODS)))
+                                     help="privilege escalation method to use (default=%s), valid choices: [ %s ]" %
+                                          (C.DEFAULT_BECOME_METHOD, ' | '.join(C.BECOME_METHODS)))
             runas_group.add_argument('--become-user', default=None, dest='become_user', type=str,
-                help='run operations as this user (default=%s)' % C.DEFAULT_BECOME_USER)
+                                     help='run operations as this user (default=%s)' % C.DEFAULT_BECOME_USER)
 
         if runas_opts or runas_prompt_opts:
             if not runas_group:
                 runas_group = rg
             runas_group.add_argument('--ask-sudo-pass', default=C.DEFAULT_ASK_SUDO_PASS, dest='ask_sudo_pass', action='store_true',
-                help='ask for sudo password (deprecated, use become)')
+                                     help='ask for sudo password (deprecated, use become)')
             runas_group.add_argument('--ask-su-pass', default=C.DEFAULT_ASK_SU_PASS, dest='ask_su_pass', action='store_true',
-                help='ask for su password (deprecated, use become)')
+                                     help='ask for su password (deprecated, use become)')
             runas_group.add_argument('-K', '--ask-become-pass', default=False, dest='become_ask_pass', action='store_true',
-                help='ask for privilege escalation password')
+                                     help='ask for privilege escalation password')
 
         if runas_group:
             parser.add_argument_group(runas_group)
 
         if async_opts:
             parser.add_argument('-P', '--poll', default=C.DEFAULT_POLL_INTERVAL, type=int, dest='poll_interval',
-                help="set the poll interval if using -B (default=%s)" % C.DEFAULT_POLL_INTERVAL)
+                                help="set the poll interval if using -B (default=%s)" % C.DEFAULT_POLL_INTERVAL)
             parser.add_argument('-B', '--background', dest='seconds', type=int, default=0,
-                help='run asynchronously, failing after X seconds (default=N/A)')
+                                help='run asynchronously, failing after X seconds (default=N/A)')
 
         if check_opts:
             parser.add_argument("-C", "--check", default=False, dest='check', action='store_true',
-                help="don't make any changes; instead, try to predict some of the changes that may occur")
+                                help="don't make any changes; instead, try to predict some of the changes that may occur")
             parser.add_argument('--syntax-check', dest='syntax', action='store_true',
-                help="perform a syntax check on the playbook, but do not execute it")
+                                help="perform a syntax check on the playbook, but do not execute it")
             parser.add_argument("-D", "--diff", default=False, dest='diff', action='store_true',
-                help="when changing (small) files and templates, show the differences in those files; works great with --check")
+                                help="when changing (small) files and templates, show the differences in those files; works great with --check")
 
         if meta_opts:
             parser.add_argument('--force-handlers', default=C.DEFAULT_FORCE_HANDLERS, dest='force_handlers', action='store_true',
-                help="run handlers even if a task fails")
+                                help="run handlers even if a task fails")
             parser.add_argument('--flush-cache', dest='flush_cache', action='store_true',
-                help="clear the fact cache")
+                                help="clear the fact cache")
 
         return parser
 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -20,9 +20,9 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import argparse
 import getpass
 import operator
-import optparse
 import os
 import subprocess
 import re
@@ -45,54 +45,21 @@ from ansible.utils.vars import load_extra_vars, load_options_vars
 from ansible.vars.manager import VariableManager
 
 try:
+    import argcomplete
+except ImportError:
+    argcomplete = None
+
+try:
     from __main__ import display
 except ImportError:
     from ansible.utils.display import Display
     display = Display()
 
 
-class SortedOptParser(optparse.OptionParser):
-    '''Optparser which sorts the options by opt before outputting --help'''
-
-    def format_help(self, formatter=None, epilog=None):
-        self.option_list.sort(key=operator.methodcaller('get_opt_string'))
-        return optparse.OptionParser.format_help(self, formatter=None)
-
-
-# Note: Inherit from SortedOptParser so that we get our format_help method
-class InvalidOptsParser(SortedOptParser):
-    '''Ignore invalid options.
-
-    Meant for the special case where we need to take care of help and version
-    but may not know the full range of options yet.  (See it in use in set_action)
-    '''
-    def __init__(self, parser):
-        # Since this is special purposed to just handle help and version, we
-        # take a pre-existing option parser here and set our options from
-        # that.  This allows us to give accurate help based on the given
-        # option parser.
-        SortedOptParser.__init__(self, usage=parser.usage,
-                                 option_list=parser.option_list,
-                                 option_class=parser.option_class,
-                                 conflict_handler=parser.conflict_handler,
-                                 description=parser.description,
-                                 formatter=parser.formatter,
-                                 add_help_option=False,
-                                 prog=parser.prog,
-                                 epilog=parser.epilog)
-        self.version = parser.version
-
-    def _process_long_opt(self, rargs, values):
-        try:
-            optparse.OptionParser._process_long_opt(self, rargs, values)
-        except optparse.BadOptionError:
-            pass
-
-    def _process_short_opts(self, rargs, values):
-        try:
-            optparse.OptionParser._process_short_opts(self, rargs, values)
-        except optparse.BadOptionError:
-            pass
+class SortingHelpFormatter(argparse.HelpFormatter):
+    def add_arguments(self, actions):
+        actions = sorted(actions, key=operator.attrgetter('option_strings'))
+        super(SortingHelpFormatter, self).add_arguments(actions)
 
 
 class CLI(with_metaclass(ABCMeta, object)):
@@ -122,28 +89,6 @@ class CLI(with_metaclass(ABCMeta, object)):
         self.parser = None
         self.action = None
         self.callback = callback
-
-    def set_action(self):
-        """
-        Get the action the user wants to execute from the sys argv list.
-        """
-        for i in range(0, len(self.args)):
-            arg = self.args[i]
-            if arg in self.VALID_ACTIONS:
-                self.action = arg
-                del self.args[i]
-                break
-
-        if not self.action:
-            # if we're asked for help or version, we don't need an action.
-            # have to use a special purpose Option Parser to figure that out as
-            # the standard OptionParser throws an error for unknown options and
-            # without knowing action, we only know of a subset of the options
-            # that could be legal for this command
-            tmp_parser = InvalidOptsParser(self.parser)
-            tmp_options, tmp_args = tmp_parser.parse_args(self.args)
-            if not(hasattr(tmp_options, 'help') and tmp_options.help) or (hasattr(tmp_options, 'version') and tmp_options.version):
-                raise AnsibleOptionsError("Missing required action")
 
     def execute(self):
         """
@@ -268,16 +213,19 @@ class CLI(with_metaclass(ABCMeta, object)):
                 self.parser.error("The number of processes (--forks) must be >= 1")
 
     @staticmethod
-    def expand_tilde(option, opt, value, parser):
-        setattr(parser.values, option.dest, os.path.expanduser(value))
+    def expand_tilde(value):
+        try:
+            return os.path.expanduser(value)
+        except AttributeError:
+            raise argparse.ArgumentTypeError('value is not a string')
 
     @staticmethod
-    def unfrack_path(option, opt, value, parser):
-        setattr(parser.values, option.dest, unfrackpath(value))
+    def unfrack_path(value):
+        return unfrackpath(value)
 
     @staticmethod
-    def expand_paths(option, opt, value, parser):
-        """optparse action callback to convert a PATH style string arg to a list of path strings.
+    def expand_paths(value):
+        """argparse type to convert a PATH style string arg to a list of path strings.
 
         For ex, cli arg of '-p /blip/foo:/foo/bar' would be split on the
         default os.pathsep and the option value would be set to
@@ -285,141 +233,146 @@ class CLI(with_metaclass(ABCMeta, object)):
         will also have '~/' values expand via os.path.expanduser()."""
         path_entries = value.split(os.pathsep)
         expanded_path_entries = [os.path.expanduser(path_entry) for path_entry in path_entries]
-        setattr(parser.values, option.dest, expanded_path_entries)
+        return expanded_path_entries
 
     @staticmethod
-    def base_parser(usage="", output_opts=False, runas_opts=False, meta_opts=False, runtask_opts=False, vault_opts=False, module_opts=False,
-                    async_opts=False, connect_opts=False, subset_opts=False, check_opts=False, inventory_opts=False, epilog=None, fork_opts=False,
-                    runas_prompt_opts=False, desc=None):
+    def _vault_opts(parser):
+        parser.add_argument('--ask-vault-pass', default=C.DEFAULT_ASK_VAULT_PASS, dest='ask_vault_pass', action='store_true',
+            help='ask for vault password')
+        parser.add_argument('--vault-password-file', default=C.DEFAULT_VAULT_PASSWORD_FILE, dest='vault_password_file',
+            help="vault password file", type=CLI.unfrack_path)
+
+    @staticmethod
+    def base_parser(output_opts=False, runas_opts=False, meta_opts=False, runtask_opts=False, vault_opts=False, module_opts=False,
+            async_opts=False, connect_opts=False, subset_opts=False, check_opts=False, inventory_opts=False, epilog=None, fork_opts=False,
+            runas_prompt_opts=False, desc=None):
         ''' create an options parser for most ansible scripts '''
 
         # base opts
-        parser = SortedOptParser(usage, version=CLI.version("%prog"), description=desc, epilog=epilog)
-        parser.add_option('-v', '--verbose', dest='verbosity', default=C.DEFAULT_VERBOSITY, action="count",
-                          help="verbose mode (-vvv for more, -vvvv to enable connection debugging)")
+        parser = argparse.ArgumentParser(
+            formatter_class=SortingHelpFormatter,
+            epilog=epilog,
+            description=desc
+        )
+        parser.add_argument('--version', action='version', version=CLI.version("%(prog)s"))
+
+        parser.add_argument('-v','--verbose', dest='verbosity', default=C.DEFAULT_VERBOSITY, action="count",
+            help="verbose mode (-vvv for more, -vvvv to enable connection debugging)")
 
         if inventory_opts:
-            parser.add_option('-i', '--inventory', '--inventory-file', dest='inventory', action="append",
-                              help="specify inventory host path (default=[%s]) or comma separated host list. "
-                                   "--inventory-file is deprecated" % C.DEFAULT_HOST_LIST)
-            parser.add_option('--list-hosts', dest='listhosts', action='store_true',
-                              help='outputs a list of matching hosts; does not execute anything else')
-            parser.add_option('-l', '--limit', default=C.DEFAULT_SUBSET, dest='subset',
-                              help='further limit selected hosts to an additional pattern')
+            parser.add_argument('-i', '--inventory-file', dest='inventory',
+                help="specify inventory host path (default=%s) or comma separated host list. --inventory-file is deprecated" % C.DEFAULT_HOST_LIST,
+                default=C.DEFAULT_HOST_LIST, type=CLI.expand_tilde)
+            parser.add_argument('--list-hosts', dest='listhosts', action='store_true',
+                help='outputs a list of matching hosts; does not execute anything else')
+            parser.add_argument('-l', '--limit', default=C.DEFAULT_SUBSET, dest='subset',
+                help='further limit selected hosts to an additional pattern')
 
         if module_opts:
-            parser.add_option('-M', '--module-path', dest='module_path', default=None,
-                              help="prepend path(s) to module library (default=%s)" % C.DEFAULT_MODULE_PATH,
-                              action="callback", callback=CLI.expand_tilde, type=str)
+            parser.add_argument('-M', '--module-path', dest='module_path', default=None,
+                help="prepend path(s) to module library (default=%s)" % C.DEFAULT_MODULE_PATH,
+                type=CLI.expand_tilde)
         if runtask_opts:
-            parser.add_option('-e', '--extra-vars', dest="extra_vars", action="append",
-                              help="set additional variables as key=value or YAML/JSON", default=[])
+            parser.add_argument('-e', '--extra-vars', dest="extra_vars", action="append",
+                help="set additional variables as key=value or YAML/JSON", default=[])
 
         if fork_opts:
-            parser.add_option('-f', '--forks', dest='forks', default=C.DEFAULT_FORKS, type='int',
-                              help="specify number of parallel processes to use (default=%s)" % C.DEFAULT_FORKS)
+            parser.add_argument('-f','--forks', dest='forks', default=C.DEFAULT_FORKS, type=int,
+                help="specify number of parallel processes to use (default=%s)" % C.DEFAULT_FORKS)
 
         if vault_opts:
-            parser.add_option('--ask-vault-pass', default=C.DEFAULT_ASK_VAULT_PASS, dest='ask_vault_pass', action='store_true',
-                              help='ask for vault password')
-            parser.add_option('--vault-password-file', default=C.DEFAULT_VAULT_PASSWORD_FILE, dest='vault_password_file',
-                              help="vault password file", action="callback", callback=CLI.unfrack_path, type='string')
-            parser.add_option('--new-vault-password-file', dest='new_vault_password_file',
-                              help="new vault password file for rekey", action="callback", callback=CLI.unfrack_path, type='string')
-            parser.add_option('--output', default=None, dest='output_file',
-                              help='output file name for encrypt or decrypt; use - for stdout',
-                              action="callback", callback=CLI.unfrack_path, type='string')
+            CLI._vault_opts(parser)
 
         if subset_opts:
-            parser.add_option('-t', '--tags', dest='tags', default=[], action='append',
-                              help="only run plays and tasks tagged with these values")
-            parser.add_option('--skip-tags', dest='skip_tags', default=[], action='append',
-                              help="only run plays and tasks whose tags do not match these values")
+            parser.add_argument('-t', '--tags', dest='tags', default=['all'], action='append',
+                help="only run plays and tasks tagged with these values")
+            parser.add_argument('--skip-tags', dest='skip_tags', default=[], action='append',
+                help="only run plays and tasks whose tags do not match these values")
 
         if output_opts:
-            parser.add_option('-o', '--one-line', dest='one_line', action='store_true',
-                              help='condense output')
-            parser.add_option('-t', '--tree', dest='tree', default=None,
-                              help='log output to this directory')
+            parser.add_argument('-o', '--one-line', dest='one_line', action='store_true',
+                help='condense output')
+            parser.add_argument('-t', '--tree', dest='tree', default=None,
+                help='log output to this directory')
 
         if connect_opts:
-            connect_group = optparse.OptionGroup(parser, "Connection Options", "control as whom and how to connect to hosts")
-            connect_group.add_option('-k', '--ask-pass', default=C.DEFAULT_ASK_PASS, dest='ask_pass', action='store_true',
-                                     help='ask for connection password')
-            connect_group.add_option('--private-key', '--key-file', default=C.DEFAULT_PRIVATE_KEY_FILE, dest='private_key_file',
-                                     help='use this file to authenticate the connection', action="callback", callback=CLI.unfrack_path, type='string')
-            connect_group.add_option('-u', '--user', default=C.DEFAULT_REMOTE_USER, dest='remote_user',
-                                     help='connect as this user (default=%s)' % C.DEFAULT_REMOTE_USER)
-            connect_group.add_option('-c', '--connection', dest='connection', default=C.DEFAULT_TRANSPORT,
-                                     help="connection type to use (default=%s)" % C.DEFAULT_TRANSPORT)
-            connect_group.add_option('-T', '--timeout', default=C.DEFAULT_TIMEOUT, type='int', dest='timeout',
-                                     help="override the connection timeout in seconds (default=%s)" % C.DEFAULT_TIMEOUT)
-            connect_group.add_option('--ssh-common-args', default='', dest='ssh_common_args',
-                                     help="specify common arguments to pass to sftp/scp/ssh (e.g. ProxyCommand)")
-            connect_group.add_option('--sftp-extra-args', default='', dest='sftp_extra_args',
-                                     help="specify extra arguments to pass to sftp only (e.g. -f, -l)")
-            connect_group.add_option('--scp-extra-args', default='', dest='scp_extra_args',
-                                     help="specify extra arguments to pass to scp only (e.g. -l)")
-            connect_group.add_option('--ssh-extra-args', default='', dest='ssh_extra_args',
-                                     help="specify extra arguments to pass to ssh only (e.g. -R)")
+            connect_group = parser.add_argument_group('Connection Options', 'control as whom and how to connect to hosts')
+            connect_group.add_argument('-k', '--ask-pass', default=C.DEFAULT_ASK_PASS, dest='ask_pass', action='store_true',
+                help='ask for connection password')
+            connect_group.add_argument('--private-key','--key-file', default=C.DEFAULT_PRIVATE_KEY_FILE, dest='private_key_file',
+                help='use this file to authenticate the connection',
+                type=CLI.unfrack_path)
+            connect_group.add_argument('-u', '--user', default=C.DEFAULT_REMOTE_USER, dest='remote_user',
+                help='connect as this user (default=%s)' % C.DEFAULT_REMOTE_USER)
+            connect_group.add_argument('-c', '--connection', dest='connection', default=C.DEFAULT_TRANSPORT,
+                help="connection type to use (default=%s)" % C.DEFAULT_TRANSPORT)
+            connect_group.add_argument('-T', '--timeout', default=C.DEFAULT_TIMEOUT, type=int, dest='timeout',
+                help="override the connection timeout in seconds (default=%s)" % C.DEFAULT_TIMEOUT)
+            connect_group.add_argument('--ssh-common-args', default='', dest='ssh_common_args',
+                help="specify common arguments to pass to sftp/scp/ssh (e.g. ProxyCommand)")
+            connect_group.add_argument('--sftp-extra-args', default='', dest='sftp_extra_args',
+                help="specify extra arguments to pass to sftp only (e.g. -f, -l)")
+            connect_group.add_argument('--scp-extra-args', default='', dest='scp_extra_args',
+                help="specify extra arguments to pass to scp only (e.g. -l)")
+            connect_group.add_argument('--ssh-extra-args', default='', dest='ssh_extra_args',
+                help="specify extra arguments to pass to ssh only (e.g. -R)")
 
-            parser.add_option_group(connect_group)
+            parser.add_argument_group(connect_group)
 
         runas_group = None
-        rg = optparse.OptionGroup(parser, "Privilege Escalation Options", "control how and which user you become as on target hosts")
+        rg = parser.add_argument_group("Privilege Escalation Options", "control how and which user you become as on target hosts")
         if runas_opts:
             runas_group = rg
             # priv user defaults to root later on to enable detecting when this option was given here
-            runas_group.add_option("-s", "--sudo", default=C.DEFAULT_SUDO, action="store_true", dest='sudo',
-                                   help="run operations with sudo (nopasswd) (deprecated, use become)")
-            runas_group.add_option('-U', '--sudo-user', dest='sudo_user', default=None,
-                                   help='desired sudo user (default=root) (deprecated, use become)')
-            runas_group.add_option('-S', '--su', default=C.DEFAULT_SU, action='store_true',
-                                   help='run operations with su (deprecated, use become)')
-            runas_group.add_option('-R', '--su-user', default=None,
-                                   help='run operations with su as this user (default=%s) (deprecated, use become)' % C.DEFAULT_SU_USER)
+            runas_group.add_argument("-s", "--sudo", default=C.DEFAULT_SUDO, action="store_true", dest='sudo',
+                help="run operations with sudo (nopasswd) (deprecated, use become)")
+            runas_group.add_argument('-U', '--sudo-user', dest='sudo_user', default=None,
+                help='desired sudo user (default=root) (deprecated, use become)')
+            runas_group.add_argument('-S', '--su', default=C.DEFAULT_SU, action='store_true',
+                help='run operations with su (deprecated, use become)')
+            runas_group.add_argument('-R', '--su-user', default=None,
+                help='run operations with su as this user (default=%s) (deprecated, use become)' % C.DEFAULT_SU_USER)
 
             # consolidated privilege escalation (become)
-            runas_group.add_option("-b", "--become", default=C.DEFAULT_BECOME, action="store_true", dest='become',
-                                   help="run operations with become (does not imply password prompting)")
-            runas_group.add_option('--become-method', dest='become_method', default=C.DEFAULT_BECOME_METHOD, type='choice', choices=C.BECOME_METHODS,
-                                   help="privilege escalation method to use (default=%s), valid choices: [ %s ]" %
-                                   (C.DEFAULT_BECOME_METHOD, ' | '.join(C.BECOME_METHODS)))
-            runas_group.add_option('--become-user', default=None, dest='become_user', type='string',
-                                   help='run operations as this user (default=%s)' % C.DEFAULT_BECOME_USER)
+            runas_group.add_argument("-b", "--become", default=C.DEFAULT_BECOME, action="store_true", dest='become',
+                help="run operations with become (does not imply password prompting)")
+            runas_group.add_argument('--become-method', dest='become_method', default=C.DEFAULT_BECOME_METHOD, choices=C.BECOME_METHODS,
+                help="privilege escalation method to use (default=%s), valid choices: [ %s ]" % (C.DEFAULT_BECOME_METHOD, ' | '.join(C.BECOME_METHODS)))
+            runas_group.add_argument('--become-user', default=None, dest='become_user', type=str,
+                help='run operations as this user (default=%s)' % C.DEFAULT_BECOME_USER)
 
         if runas_opts or runas_prompt_opts:
             if not runas_group:
                 runas_group = rg
-            runas_group.add_option('--ask-sudo-pass', default=C.DEFAULT_ASK_SUDO_PASS, dest='ask_sudo_pass', action='store_true',
-                                   help='ask for sudo password (deprecated, use become)')
-            runas_group.add_option('--ask-su-pass', default=C.DEFAULT_ASK_SU_PASS, dest='ask_su_pass', action='store_true',
-                                   help='ask for su password (deprecated, use become)')
-            runas_group.add_option('-K', '--ask-become-pass', default=False, dest='become_ask_pass', action='store_true',
-                                   help='ask for privilege escalation password')
+            runas_group.add_argument('--ask-sudo-pass', default=C.DEFAULT_ASK_SUDO_PASS, dest='ask_sudo_pass', action='store_true',
+                help='ask for sudo password (deprecated, use become)')
+            runas_group.add_argument('--ask-su-pass', default=C.DEFAULT_ASK_SU_PASS, dest='ask_su_pass', action='store_true',
+                help='ask for su password (deprecated, use become)')
+            runas_group.add_argument('-K', '--ask-become-pass', default=False, dest='become_ask_pass', action='store_true',
+                help='ask for privilege escalation password')
 
         if runas_group:
-            parser.add_option_group(runas_group)
+            parser.add_argument_group(runas_group)
 
         if async_opts:
-            parser.add_option('-P', '--poll', default=C.DEFAULT_POLL_INTERVAL, type='int', dest='poll_interval',
-                              help="set the poll interval if using -B (default=%s)" % C.DEFAULT_POLL_INTERVAL)
-            parser.add_option('-B', '--background', dest='seconds', type='int', default=0,
-                              help='run asynchronously, failing after X seconds (default=N/A)')
+            parser.add_argument('-P', '--poll', default=C.DEFAULT_POLL_INTERVAL, type=int, dest='poll_interval',
+                help="set the poll interval if using -B (default=%s)" % C.DEFAULT_POLL_INTERVAL)
+            parser.add_argument('-B', '--background', dest='seconds', type=int, default=0,
+                help='run asynchronously, failing after X seconds (default=N/A)')
 
         if check_opts:
-            parser.add_option("-C", "--check", default=False, dest='check', action='store_true',
-                              help="don't make any changes; instead, try to predict some of the changes that may occur")
-            parser.add_option('--syntax-check', dest='syntax', action='store_true',
-                              help="perform a syntax check on the playbook, but do not execute it")
-            parser.add_option("-D", "--diff", default=False, dest='diff', action='store_true',
-                              help="when changing (small) files and templates, show the differences in those files; works great with --check")
+            parser.add_argument("-C", "--check", default=False, dest='check', action='store_true',
+                help="don't make any changes; instead, try to predict some of the changes that may occur")
+            parser.add_argument('--syntax-check', dest='syntax', action='store_true',
+                help="perform a syntax check on the playbook, but do not execute it")
+            parser.add_argument("-D", "--diff", default=False, dest='diff', action='store_true',
+                help="when changing (small) files and templates, show the differences in those files; works great with --check")
 
         if meta_opts:
-            parser.add_option('--force-handlers', default=C.DEFAULT_FORCE_HANDLERS, dest='force_handlers', action='store_true',
-                              help="run handlers even if a task fails")
-            parser.add_option('--flush-cache', dest='flush_cache', action='store_true',
-                              help="clear the fact cache")
+            parser.add_argument('--force-handlers', default=C.DEFAULT_FORCE_HANDLERS, dest='force_handlers', action='store_true',
+                help="run handlers even if a task fails")
+            parser.add_argument('--flush-cache', dest='flush_cache', action='store_true',
+                help="clear the fact cache")
 
         return parser
 
@@ -438,19 +391,17 @@ class CLI(with_metaclass(ABCMeta, object)):
 
             def parse(self):
                 parser = super(MyCLI, self).base_parser(usage="My Ansible CLI", inventory_opts=True)
-                parser.add_option('--my-option', dest='my_option', action='store')
+                parser.add_argument('--my-option', dest='my_option', action='store')
                 self.parser = parser
                 super(MyCLI, self).parse()
                 # If some additional transformations are needed for the
                 # arguments and options, do it here.
         """
+        if argcomplete:
+            argcomplete.autocomplete(self.parser, always_complete_options=False, validator=lambda i, k: True)
 
-        self.options, self.args = self.parser.parse_args(self.args[1:])
-
-        # process tags
-        if hasattr(self.options, 'tags') and not self.options.tags:
-            # optparse defaults does not do what's expected
-            self.options.tags = ['all']
+        self.options = self.parser.parse_args(self.args[1:])
+        self.args = getattr(self.options, 'args', [])
         if hasattr(self.options, 'tags') and self.options.tags:
             if not C.MERGE_MULTIPLE_CLI_TAGS:
                 if len(self.options.tags) > 1:

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -284,7 +284,7 @@ class CLI(with_metaclass(ABCMeta, object)):
             CLI._vault_opts(parser)
 
         if subset_opts:
-            parser.add_argument('-t', '--tags', dest='tags', default=['all'], action='append',
+            parser.add_argument('-t', '--tags', dest='tags', default=[], action='append',
                 help="only run plays and tasks tagged with these values")
             parser.add_argument('--skip-tags', dest='skip_tags', default=[], action='append',
                 help="only run plays and tasks whose tags do not match these values")
@@ -402,6 +402,12 @@ class CLI(with_metaclass(ABCMeta, object)):
 
         self.options = self.parser.parse_args(self.args[1:])
         self.args = getattr(self.options, 'args', [])
+
+        # process tags
+        if hasattr(self.options, 'tags') and not self.options.tags:
+            # parser defaults does not do what's expected
+            self.options.tags = ['all']
+
         if hasattr(self.options, 'tags') and self.options.tags:
             if not C.MERGE_MULTIPLE_CLI_TAGS:
                 if len(self.options.tags) > 1:

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -49,7 +49,6 @@ class AdHocCLI(CLI):
         ''' create an options parser for bin/ansible '''
 
         self.parser = CLI.base_parser(
-            usage='%prog <host-pattern> [options]',
             runas_opts=True,
             inventory_opts=True,
             async_opts=True,
@@ -65,11 +64,12 @@ class AdHocCLI(CLI):
         )
 
         # options unique to ansible ad-hoc
-        self.parser.add_option('-a', '--args', dest='module_args',
-                               help="module arguments", default=C.DEFAULT_MODULE_ARGS)
-        self.parser.add_option('-m', '--module-name', dest='module_name',
-                               help="module name to execute (default=%s)" % C.DEFAULT_MODULE_NAME,
-                               default=C.DEFAULT_MODULE_NAME)
+        self.parser.add_argument('-a', '--args', dest='module_args',
+            help="module arguments", default=C.DEFAULT_MODULE_ARGS)
+        self.parser.add_argument('-m', '--module-name', dest='module_name',
+            help="module name to execute (default=%s)" % C.DEFAULT_MODULE_NAME,
+            default=C.DEFAULT_MODULE_NAME)
+        self.parser.add_argument('args', metavar='pattern', help='host pattern', nargs='*')
 
         super(AdHocCLI, self).parse()
 

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -65,10 +65,10 @@ class AdHocCLI(CLI):
 
         # options unique to ansible ad-hoc
         self.parser.add_argument('-a', '--args', dest='module_args',
-            help="module arguments", default=C.DEFAULT_MODULE_ARGS)
+                                 help="module arguments", default=C.DEFAULT_MODULE_ARGS)
         self.parser.add_argument('-m', '--module-name', dest='module_name',
-            help="module name to execute (default=%s)" % C.DEFAULT_MODULE_NAME,
-            default=C.DEFAULT_MODULE_NAME)
+                                 help="module name to execute (default=%s)" % C.DEFAULT_MODULE_NAME,
+                                 default=C.DEFAULT_MODULE_NAME)
         self.parser.add_argument('args', metavar='pattern', help='host pattern', nargs='*')
 
         super(AdHocCLI, self).parse()

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -79,7 +79,6 @@ class ConsoleCLI(CLI, cmd.Cmd):
 
     def parse(self):
         self.parser = CLI.base_parser(
-            usage='%prog [<host-pattern>] [options]',
             runas_opts=True,
             inventory_opts=True,
             connect_opts=True,
@@ -92,8 +91,9 @@ class ConsoleCLI(CLI, cmd.Cmd):
         )
 
         # options unique to shell
-        self.parser.add_option('--step', dest='step', action='store_true',
-                               help="one-step-at-a-time: confirm each task before running")
+        self.parser.add_argument('--step', dest='step', action='store_true',
+            help="one-step-at-a-time: confirm each task before running")
+        self.parser.add_argument('args', metavar='pattern', help='host pattern', nargs='*')
 
         self.parser.set_defaults(cwd='*')
 

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -92,7 +92,7 @@ class ConsoleCLI(CLI, cmd.Cmd):
 
         # options unique to shell
         self.parser.add_argument('--step', dest='step', action='store_true',
-            help="one-step-at-a-time: confirm each task before running")
+                                 help="one-step-at-a-time: confirm each task before running")
         self.parser.add_argument('args', metavar='pattern', help='host pattern', nargs='*')
 
         self.parser.set_defaults(cwd='*')

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -53,20 +53,20 @@ class DocCLI(CLI):
     def parse(self):
 
         self.parser = CLI.base_parser(
-            usage='usage: %prog [options] [plugin]',
             module_opts=True,
             desc="plugin documentation tool",
             epilog="See man pages for Ansible CLI options or website for tutorials https://docs.ansible.com"
         )
 
-        self.parser.add_option("-l", "--list", action="store_true", default=False, dest='list_dir',
-                               help='List available plugins')
-        self.parser.add_option("-s", "--snippet", action="store_true", default=False, dest='show_snippet',
-                               help='Show playbook snippet for specified plugin(s)')
-        self.parser.add_option("-a", "--all", action="store_true", default=False, dest='all_plugins',
-                               help='Show documentation for all plugins')
-        self.parser.add_option("-t", "--type", action="store", default='module', dest='type', type='choice',
-                               help='Choose which plugin type', choices=['cache', 'callback', 'connection', 'inventory', 'lookup', 'module', 'strategy'])
+        self.parser.add_argument("-l", "--list", action="store_true", default=False, dest='list_dir',
+                help='List available plugins')
+        self.parser.add_argument("-s", "--snippet", action="store_true", default=False, dest='show_snippet',
+                help='Show playbook snippet for specified plugin(s)')
+        self.parser.add_argument("-a", "--all", action="store_true", default=False, dest='all_plugins',
+                help='Show documentation for all plugins')
+        self.parser.add_argument("-t", "--type", action="store", default='module', dest='type',
+                help='Choose which plugin type', choices=['module','cache', 'connection', 'callback', 'lookup', 'strategy', 'inventory'])
+        self.parser.add_argument('args', metavar='plugin', help='plugin', nargs='*')
 
         super(DocCLI, self).parse()
 

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -59,13 +59,13 @@ class DocCLI(CLI):
         )
 
         self.parser.add_argument("-l", "--list", action="store_true", default=False, dest='list_dir',
-                help='List available plugins')
+                                 help='List available plugins')
         self.parser.add_argument("-s", "--snippet", action="store_true", default=False, dest='show_snippet',
-                help='Show playbook snippet for specified plugin(s)')
+                                 help='Show playbook snippet for specified plugin(s)')
         self.parser.add_argument("-a", "--all", action="store_true", default=False, dest='all_plugins',
-                help='Show documentation for all plugins')
+                                 help='Show documentation for all plugins')
         self.parser.add_argument("-t", "--type", action="store", default='module', dest='type',
-                help='Choose which plugin type', choices=['module','cache', 'connection', 'callback', 'lookup', 'strategy', 'inventory'])
+                                 help='Choose which plugin type', choices=['module', 'cache', 'connection', 'callback', 'lookup', 'strategy', 'inventory'])
         self.parser.add_argument('args', metavar='plugin', help='plugin', nargs='*')
 
         super(DocCLI, self).parse()

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -79,6 +79,9 @@ class GalaxyCLI(CLI):
         for name in self.VALID_ACTIONS:
             subparser = subparsers.add_parser(name, parents=[galaxy_parent])
 
+            subparser.add_argument('-v','--verbose', dest='verbosity', default=C.DEFAULT_VERBOSITY, action="count",
+                help="verbose mode (-vvv for more, -vvvv to enable connection debugging)")
+
             if name in ('delete', 'import'):
                 subparser.add_argument('args', metavar='github_user github_repo', nargs='*')
 

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -22,6 +22,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import argparse
 import os.path
 import re
 import shutil
@@ -60,86 +61,96 @@ class GalaxyCLI(CLI):
         self.galaxy = None
         super(GalaxyCLI, self).__init__(args)
 
-    def set_action(self):
-
-        super(GalaxyCLI, self).set_action()
-
-        # specific to actions
-        if self.action == "delete":
-            self.parser.set_usage("usage: %prog delete [options] github_user github_repo")
-        elif self.action == "import":
-            self.parser.set_usage("usage: %prog import [options] github_user github_repo")
-            self.parser.add_option('--no-wait', dest='wait', action='store_false', default=True, help='Don\'t wait for import results.')
-            self.parser.add_option('--branch', dest='reference',
-                                   help='The name of a branch to import. Defaults to the repository\'s default branch (usually master)')
-            self.parser.add_option('--role-name', dest='role_name', help='The name the role should have, if different than the repo name')
-            self.parser.add_option('--status', dest='check_status', action='store_true', default=False,
-                                   help='Check the status of the most recent import request for given github_user/github_repo.')
-        elif self.action == "info":
-            self.parser.set_usage("usage: %prog info [options] role_name[,version]")
-        elif self.action == "init":
-            self.parser.set_usage("usage: %prog init [options] role_name")
-            self.parser.add_option('-p', '--init-path', dest='init_path', default="./",
-                                   help='The path in which the skeleton role will be created. The default is the current working directory.')
-            self.parser.add_option('--container-enabled', dest='container_enabled', action='store_true', default=False,
-                                   help='Initialize the skeleton role with default contents for a Container Enabled role.')
-            self.parser.add_option('--role-skeleton', dest='role_skeleton', default=None,
-                                   help='The path to a role skeleton that the new role should be based upon.')
-        elif self.action == "install":
-            self.parser.set_usage("usage: %prog install [options] [-r FILE | role_name(s)[,version] | scm+role_repo_url[,version] | tar_file(s)]")
-            self.parser.add_option('-i', '--ignore-errors', dest='ignore_errors', action='store_true', default=False,
-                                   help='Ignore errors and continue with the next specified role.')
-            self.parser.add_option('-n', '--no-deps', dest='no_deps', action='store_true', default=False, help='Don\'t download roles listed as dependencies')
-            self.parser.add_option('-r', '--role-file', dest='role_file', help='A file containing a list of roles to be imported')
-        elif self.action == "remove":
-            self.parser.set_usage("usage: %prog remove role1 role2 ...")
-        elif self.action == "list":
-            self.parser.set_usage("usage: %prog list [role_name]")
-        elif self.action == "login":
-            self.parser.set_usage("usage: %prog login [options]")
-            self.parser.add_option('--github-token', dest='token', default=None, help='Identify with github token rather than username and password.')
-        elif self.action == "search":
-            self.parser.set_usage("usage: %prog search [searchterm1 searchterm2] [--galaxy-tags galaxy_tag1,galaxy_tag2] [--platforms platform1,platform2] "
-                                  "[--author username]")
-            self.parser.add_option('--platforms', dest='platforms', help='list of OS platforms to filter by')
-            self.parser.add_option('--galaxy-tags', dest='galaxy_tags', help='list of galaxy tags to filter by')
-            self.parser.add_option('--author', dest='author', help='GitHub username')
-        elif self.action == "setup":
-            self.parser.set_usage("usage: %prog setup [options] source github_user github_repo secret")
-            self.parser.add_option('--remove', dest='remove_id', default=None,
-                                   help='Remove the integration matching the provided ID value. Use --list to see ID values.')
-            self.parser.add_option('--list', dest="setup_list", action='store_true', default=False, help='List all of your integrations.')
-
-        # options that apply to more than one action
-        if self.action in ['init', 'info']:
-            self.parser.add_option('--offline', dest='offline', default=False, action='store_true', help="Don't query the galaxy API when creating roles")
-
-        if self.action not in ("delete", "import", "init", "login", "setup"):
-            # NOTE: while the option type=str, the default is a list, and the
-            # callback will set the value to a list.
-            self.parser.add_option('-p', '--roles-path', dest='roles_path', action="callback", callback=CLI.expand_paths, type=str,
-                                   default=C.DEFAULT_ROLES_PATH,
-                                   help='The path to the directory containing your roles. The default is the roles_path configured in your ansible.cfg '
-                                        'file (/etc/ansible/roles if not configured)')
-
-        if self.action in ("init", "install"):
-            self.parser.add_option('-f', '--force', dest='force', action='store_true', default=False, help='Force overwriting an existing role')
-
     def parse(self):
         ''' create an options parser for bin/ansible '''
 
         self.parser = CLI.base_parser(
-            usage="usage: %%prog [%s] [--help] [options] ..." % "|".join(self.VALID_ACTIONS),
-            epilog="\nSee '%s <command> --help' for more information on a specific command.\n\n" % os.path.basename(sys.argv[0])
+            epilog = "\nSee '%s <command> --help' for more information on a specific command.\n\n" % os.path.basename(sys.argv[0])
         )
 
         # common
-        self.parser.add_option('-s', '--server', dest='api_server', default=C.GALAXY_SERVER, help='The API server destination')
-        self.parser.add_option('-c', '--ignore-certs', action='store_true', dest='ignore_certs', default=C.GALAXY_IGNORE_CERTS,
-                               help='Ignore SSL certificate validation errors.')
-        self.set_action()
+        galaxy_parent = argparse.ArgumentParser(add_help=False)
+        galaxy_parent.add_argument('-s', '--server', dest='api_server', default=C.GALAXY_SERVER, help='The API server destination')
+        galaxy_parent.add_argument('-c', '--ignore-certs', action='store_true', dest='ignore_certs', default=C.GALAXY_IGNORE_CERTS,
+                                   help='Ignore SSL certificate validation errors.')
+
+        subparsers = self.parser.add_subparsers(dest='action')
+
+        for name in self.VALID_ACTIONS:
+            subparser = subparsers.add_parser(name, parents=[galaxy_parent])
+
+            if name in ('delete', 'import'):
+                subparser.add_argument('args', metavar='github_user github_repo', nargs='*')
+
+            if name in ('init', 'list'):
+                subparser.add_argument('args', metavar='role_name')
+
+            if name == "import":
+                subparser.add_argument('--no-wait', dest='wait', action='store_false', default=True, help="Don't wait for import results.")
+                subparser.add_argument('--branch', dest='reference',
+                                       help="The name of a branch to import. Defaults to the repository's default branch (usually master)")
+                subparser.add_argument('--role-name', dest='role_name', help='The name the role should have, if different than the repo name')
+                subparser.add_argument('--status', dest='check_status', action='store_true', default=False,
+                                       help='Check the status of the most recent import request for given github_user/github_repo.')
+
+            elif name == "info":
+                subparser.add_argument('args', metavar='role_name[,version]')
+
+            elif name == "init":
+                subparser.add_argument('-p', '--init-path', dest='init_path', default="./",
+                                       help='The path in which the skeleton role will be created. The default is the current working directory.')
+                subparser.add_argument('--container-enabled', dest='container_enabled', action='store_true', default=False,
+                                       help='Initialize the skeleton role with default contents for a Container Enabled role.')
+                subparser.add_argument('--role-skeleton', dest='role_skeleton', default=None,
+                                       help='The path to a role skeleton that the new role should be based upon.')
+
+            elif name == "install":
+                subparser.add_argument('-i', '--ignore-errors', dest='ignore_errors', action='store_true', default=False,
+                                       help='Ignore errors and continue with the next specified role.')
+                subparser.add_argument('-n', '--no-deps', dest='no_deps', action='store_true', default=False,
+                                       help="Don't download roles listed as dependencies")
+                subparser.add_argument('-r', '--role-file', dest='role_file', help='A file containing a list of roles to be imported')
+                subparser.add_argument('args', metavar='source', nargs='*',
+                                       help='Sources to install, in the format of: role_name(s)[,version] | scm+role_repo_url[,version] | tar_file(s)')
+
+            elif name == "remove":
+                subparser.add_argument('args', metavar='role', nargs='*', help='Roles to remove')
+
+            elif name == "login":
+                subparser.add_argument('--github-token', dest='token', default=None, help='Identify with github token rather than username and password.')
+
+            elif name == "search":
+                subparser.add_argument('--platforms', dest='platforms', help='list of OS platforms to filter by')
+                subparser.add_argument('--galaxy-tags', dest='galaxy_tags', help='list of galaxy tags to filter by')
+                subparser.add_argument('--author', dest='author', help='GitHub username')
+
+            elif name == "setup":
+                subparser.add_argument('args', metavar='source github_user github_repo secret', nargs='*')
+                subparser.add_argument('--remove', dest='remove_id', default=None,
+                                       help='Remove the integration matching the provided ID value. Use --list to see ID values.')
+                subparser.add_argument('--list', dest="setup_list", action='store_true', default=False, help='List all of your integrations.')
+
+            # options that apply to more than one action
+            if name in ('init', 'info'):
+                subparser.add_argument('--offline', dest='offline', default=False, action='store_true', help="Don't query the galaxy API when creating roles")
+
+            if name not in ("delete", "import", "init", "login", "setup"):
+                # NOTE: while the option type=str, the default is a list, and the
+                # callback will set the value to a list.
+                subparser.add_argument('-p', '--roles-path', dest='roles_path', type=CLI.expand_paths,
+                                       default=C.DEFAULT_ROLES_PATH,
+                                       help='The path to the directory containing your roles. The default is the roles_path configured in your ansible.cfg '
+                                            'file (/etc/ansible/roles if not configured)')
+
+            if name in ("init", "install"):
+                subparser.add_argument('-f', '--force', dest='force', action='store_true', default=False, help='Force overwriting an existing role')
 
         super(GalaxyCLI, self).parse()
+
+        self.action = self.options.action
+        if not self.action:
+            self.parser.print_help()
+            self.parser.exit()
 
         display.verbosity = self.options.verbosity
         self.galaxy = Galaxy(self.options)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -131,7 +131,7 @@ class GalaxyCLI(CLI):
                 subparser.add_argument('--list', dest="setup_list", action='store_true', default=False, help='List all of your integrations.')
 
             # options that apply to more than one action
-            if name in ('init', 'info'):
+            if name in ('init', 'info', 'install'):
                 subparser.add_argument('--offline', dest='offline', default=False, action='store_true', help="Don't query the galaxy API when creating roles")
 
             if name not in ("delete", "import", "init", "login", "setup"):
@@ -204,7 +204,7 @@ class GalaxyCLI(CLI):
         force = self.get_opt('force', False)
         role_skeleton = self.get_opt('role_skeleton', C.GALAXY_ROLE_SKELETON)
 
-        role_name = self.args.pop(0).strip() if self.args else None
+        role_name = self.args.strip() if self.args else None
         if not role_name:
             raise AnsibleOptionsError("- no role name specified for init")
         role_path = os.path.join(init_path, role_name)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -65,7 +65,7 @@ class GalaxyCLI(CLI):
         ''' create an options parser for bin/ansible '''
 
         self.parser = CLI.base_parser(
-            epilog = "\nSee '%s <command> --help' for more information on a specific command.\n\n" % os.path.basename(sys.argv[0])
+            epilog="\nSee '%s <command> --help' for more information on a specific command.\n\n" % os.path.basename(sys.argv[0])
         )
 
         # common
@@ -79,8 +79,8 @@ class GalaxyCLI(CLI):
         for name in self.VALID_ACTIONS:
             subparser = subparsers.add_parser(name, parents=[galaxy_parent])
 
-            subparser.add_argument('-v','--verbose', dest='verbosity', default=C.DEFAULT_VERBOSITY, action="count",
-                help="verbose mode (-vvv for more, -vvvv to enable connection debugging)")
+            subparser.add_argument('-v', '--verbose', dest='verbosity', default=C.DEFAULT_VERBOSITY, action="count",
+                                   help="verbose mode (-vvv for more, -vvvv to enable connection debugging)")
 
             if name in ('delete', 'import'):
                 subparser.add_argument('args', metavar='github_user github_repo', nargs='*')

--- a/lib/ansible/cli/playbook.py
+++ b/lib/ansible/cli/playbook.py
@@ -44,7 +44,6 @@ class PlaybookCLI(CLI):
 
         # create parser for CLI options
         parser = CLI.base_parser(
-            usage="%prog [options] playbook.yml [playbook2 ...]",
             connect_opts=True,
             meta_opts=True,
             runas_opts=True,
@@ -59,14 +58,15 @@ class PlaybookCLI(CLI):
         )
 
         # ansible playbook specific opts
-        parser.add_option('--list-tasks', dest='listtasks', action='store_true',
-                          help="list all tasks that would be executed")
-        parser.add_option('--list-tags', dest='listtags', action='store_true',
-                          help="list all available tags")
-        parser.add_option('--step', dest='step', action='store_true',
-                          help="one-step-at-a-time: confirm each task before running")
-        parser.add_option('--start-at-task', dest='start_at_task',
-                          help="start the playbook at the task matching this name")
+        parser.add_argument('--list-tasks', dest='listtasks', action='store_true',
+            help="list all tasks that would be executed")
+        parser.add_argument('--list-tags', dest='listtags', action='store_true',
+            help="list all available tags")
+        parser.add_argument('--step', dest='step', action='store_true',
+            help="one-step-at-a-time: confirm each task before running")
+        parser.add_argument('--start-at-task', dest='start_at_task',
+            help="start the playbook at the task matching this name")
+        parser.add_argument('args', metavar='playbook(s)', help='playbooks', nargs='*')
 
         self.parser = parser
         super(PlaybookCLI, self).parse()

--- a/lib/ansible/cli/playbook.py
+++ b/lib/ansible/cli/playbook.py
@@ -59,13 +59,13 @@ class PlaybookCLI(CLI):
 
         # ansible playbook specific opts
         parser.add_argument('--list-tasks', dest='listtasks', action='store_true',
-            help="list all tasks that would be executed")
+                            help="list all tasks that would be executed")
         parser.add_argument('--list-tags', dest='listtags', action='store_true',
-            help="list all available tags")
+                            help="list all available tags")
         parser.add_argument('--step', dest='step', action='store_true',
-            help="one-step-at-a-time: confirm each task before running")
+                            help="one-step-at-a-time: confirm each task before running")
         parser.add_argument('--start-at-task', dest='start_at_task',
-            help="start the playbook at the task matching this name")
+                            help="start the playbook at the task matching this name")
         parser.add_argument('args', metavar='playbook(s)', help='playbooks', nargs='*')
 
         self.parser = parser

--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -71,7 +71,6 @@ class PullCLI(CLI):
         ''' create an options parser for bin/ansible '''
 
         self.parser = CLI.base_parser(
-            usage='%prog -U <repository> [options] [<playbook.yml>]',
             connect_opts=True,
             vault_opts=True,
             runtask_opts=True,
@@ -83,30 +82,30 @@ class PullCLI(CLI):
         )
 
         # options unique to pull
-        self.parser.add_option('--purge', default=False, action='store_true', help='purge checkout after playbook run')
-        self.parser.add_option('-o', '--only-if-changed', dest='ifchanged', default=False, action='store_true',
-                               help='only run the playbook if the repository has been updated')
-        self.parser.add_option('-s', '--sleep', dest='sleep', default=None,
-                               help='sleep for random interval (between 0 and n number of seconds) before starting. '
-                                    'This is a useful way to disperse git requests')
-        self.parser.add_option('-f', '--force', dest='force', default=False, action='store_true',
-                               help='run the playbook even if the repository could not be updated')
-        self.parser.add_option('-d', '--directory', dest='dest', default=None, help='directory to checkout repository to')
-        self.parser.add_option('-U', '--url', dest='url', default=None, help='URL of the playbook repository')
-        self.parser.add_option('--full', dest='fullclone', action='store_true', help='Do a full clone, instead of a shallow one.')
-        self.parser.add_option('-C', '--checkout', dest='checkout',
-                               help='branch/tag/commit to checkout. Defaults to behavior of repository module.')
-        self.parser.add_option('--accept-host-key', default=False, dest='accept_host_key', action='store_true',
-                               help='adds the hostkey for the repo url if not already added')
-        self.parser.add_option('-m', '--module-name', dest='module_name', default=self.DEFAULT_REPO_TYPE,
-                               help='Repository module name, which ansible will use to check out the repo. Default is %s.' % self.DEFAULT_REPO_TYPE)
-        self.parser.add_option('--verify-commit', dest='verify', default=False, action='store_true',
-                               help='verify GPG signature of checked out commit, if it fails abort running the playbook. '
-                                    'This needs the corresponding VCS module to support such an operation')
-        self.parser.add_option('--clean', dest='clean', default=False, action='store_true',
-                               help='modified files in the working repository will be discarded')
-        self.parser.add_option('--track-subs', dest='tracksubs', default=False, action='store_true',
-                               help='submodules will track the latest changes. This is equivalent to specifying the --remote flag to git submodule update')
+        self.parser.add_argument('--purge', default=False, action='store_true', help='purge checkout after playbook run')
+        self.parser.add_argument('-o', '--only-if-changed', dest='ifchanged', default=False, action='store_true',
+            help='only run the playbook if the repository has been updated')
+        self.parser.add_argument('-s', '--sleep', dest='sleep', default=None,
+            help='sleep for random interval (between 0 and n number of seconds) before starting. This is a useful way to disperse git requests')
+        self.parser.add_argument('-f', '--force', dest='force', default=False, action='store_true',
+            help='run the playbook even if the repository could not be updated')
+        self.parser.add_argument('-d', '--directory', dest='dest', default=None, help='directory to checkout repository to')
+        self.parser.add_argument('-U', '--url', dest='url', default=None, help='URL of the playbook repository')
+        self.parser.add_argument('--full', dest='fullclone', action='store_true', help='Do a full clone, instead of a shallow one.')
+        self.parser.add_argument('-C', '--checkout', dest='checkout',
+            help='branch/tag/commit to checkout. Defaults to behavior of repository module.')
+        self.parser.add_argument('--accept-host-key', default=False, dest='accept_host_key', action='store_true',
+            help='adds the hostkey for the repo url if not already added')
+        self.parser.add_argument('-m', '--module-name', dest='module_name', default=self.DEFAULT_REPO_TYPE,
+            help='Repository module name, which ansible will use to check out the repo. Default is %s.' % self.DEFAULT_REPO_TYPE)
+        self.parser.add_argument('--verify-commit', dest='verify', default=False, action='store_true',
+            help='verify GPG signature of checked out commit, if it fails abort running the playbook.'
+                 ' This needs the corresponding VCS module to support such an operation')
+        self.parser.add_argument('--clean', dest='clean', default=False, action='store_true',
+            help='modified files in the working repository will be discarded')
+        self.parser.add_argument('--track-subs', dest='tracksubs', default=False, action='store_true',
+            help='submodules will track the latest changes. This is equivalent to specifying the --remote flag to git submodule update')
+        self.parser.add_argument('args', metavar='playbook', nargs='*')
 
         # for pull we don't want a default
         self.parser.set_defaults(inventory=None)

--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -84,27 +84,28 @@ class PullCLI(CLI):
         # options unique to pull
         self.parser.add_argument('--purge', default=False, action='store_true', help='purge checkout after playbook run')
         self.parser.add_argument('-o', '--only-if-changed', dest='ifchanged', default=False, action='store_true',
-            help='only run the playbook if the repository has been updated')
+                                 help='only run the playbook if the repository has been updated')
         self.parser.add_argument('-s', '--sleep', dest='sleep', default=None,
-            help='sleep for random interval (between 0 and n number of seconds) before starting. This is a useful way to disperse git requests')
+                                 help='sleep for random interval (between 0 and n number of seconds) before starting. This is a useful way to '
+                                      'disperse git requests')
         self.parser.add_argument('-f', '--force', dest='force', default=False, action='store_true',
-            help='run the playbook even if the repository could not be updated')
+                                 help='run the playbook even if the repository could not be updated')
         self.parser.add_argument('-d', '--directory', dest='dest', default=None, help='directory to checkout repository to')
         self.parser.add_argument('-U', '--url', dest='url', default=None, help='URL of the playbook repository')
         self.parser.add_argument('--full', dest='fullclone', action='store_true', help='Do a full clone, instead of a shallow one.')
         self.parser.add_argument('-C', '--checkout', dest='checkout',
-            help='branch/tag/commit to checkout. Defaults to behavior of repository module.')
+                                 help='branch/tag/commit to checkout. Defaults to behavior of repository module.')
         self.parser.add_argument('--accept-host-key', default=False, dest='accept_host_key', action='store_true',
-            help='adds the hostkey for the repo url if not already added')
+                                 help='adds the hostkey for the repo url if not already added')
         self.parser.add_argument('-m', '--module-name', dest='module_name', default=self.DEFAULT_REPO_TYPE,
-            help='Repository module name, which ansible will use to check out the repo. Default is %s.' % self.DEFAULT_REPO_TYPE)
+                                 help='Repository module name, which ansible will use to check out the repo. Default is %s.' % self.DEFAULT_REPO_TYPE)
         self.parser.add_argument('--verify-commit', dest='verify', default=False, action='store_true',
-            help='verify GPG signature of checked out commit, if it fails abort running the playbook.'
-                 ' This needs the corresponding VCS module to support such an operation')
+                                 help='verify GPG signature of checked out commit, if it fails abort running the playbook. '
+                                      'This needs the corresponding VCS module to support such an operation')
         self.parser.add_argument('--clean', dest='clean', default=False, action='store_true',
-            help='modified files in the working repository will be discarded')
+                                 help='modified files in the working repository will be discarded')
         self.parser.add_argument('--track-subs', dest='tracksubs', default=False, action='store_true',
-            help='submodules will track the latest changes. This is equivalent to specifying the --remote flag to git submodule update')
+                                 help='submodules will track the latest changes. This is equivalent to specifying the --remote flag to git submodule update')
         self.parser.add_argument('args', metavar='playbook', nargs='*')
 
         # for pull we don't want a default

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -82,7 +82,7 @@ class VaultCLI(CLI):
             if name in ('encrypt', 'decrypt', 'encrypt_string'):
                 subparser.add_argument('--output', default=None, dest='output_file',
                     help='output file name for encrypt or decrypt; use - for stdout',
-                    type=CLI.expand_tilde)
+                    type=CLI.unfrack_path)
 
             if name in ('encrypt_string',):
                 subparser.add_argument('-p', '--prompt', dest='encrypt_string_prompt',
@@ -100,7 +100,7 @@ class VaultCLI(CLI):
 
             if name in ('rekey',):
                 subparser.add_argument('--new-vault-password-file', dest='new_vault_password_file',
-                    help="new vault password file for rekey", type=CLI.expand_tilde)
+                    help="new vault password file for rekey", type=CLI.unfrack_path)
 
         super(VaultCLI, self).parse()
 

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -77,12 +77,12 @@ class VaultCLI(CLI):
 
         for name in self.VALID_ACTIONS:
             subparser = subparsers.add_parser(name, parents=[vault_parent])
-            subparser.add_argument('-v','--verbose', dest='verbosity', default=C.DEFAULT_VERBOSITY, action="count",
-                help="verbose mode (-vvv for more, -vvvv to enable connection debugging)")
+            subparser.add_argument('-v', '--verbose', dest='verbosity', default=C.DEFAULT_VERBOSITY, action="count",
+                                   help="verbose mode (-vvv for more, -vvvv to enable connection debugging)")
             if name in ('encrypt', 'decrypt', 'encrypt_string'):
                 subparser.add_argument('--output', default=None, dest='output_file',
-                    help='output file name for encrypt or decrypt; use - for stdout',
-                    type=CLI.unfrack_path)
+                                       help='output file name for encrypt or decrypt; use - for stdout',
+                                       type=CLI.unfrack_path)
 
             if name in ('encrypt_string',):
                 subparser.add_argument('-p', '--prompt', dest='encrypt_string_prompt',
@@ -100,7 +100,7 @@ class VaultCLI(CLI):
 
             if name in ('rekey',):
                 subparser.add_argument('--new-vault-password-file', dest='new_vault_password_file',
-                    help="new vault password file for rekey", type=CLI.unfrack_path)
+                                       help="new vault password file for rekey", type=CLI.unfrack_path)
 
         super(VaultCLI, self).parse()
 
@@ -114,8 +114,8 @@ class VaultCLI(CLI):
         can_output = ['encrypt', 'decrypt', 'encrypt_string']
 
         if self.action not in can_output:
-            #if self.options.output_file:
-            #    raise AnsibleOptionsError("The --output option can be used only with ansible-vault %s" % '/'.join(can_output))
+            # if self.options.output_file:
+            #     raise AnsibleOptionsError("The --output option can be used only with ansible-vault %s" % '/'.join(can_output))
             if len(self.args) == 0:
                 raise AnsibleOptionsError("Vault requires at least one filename as a parameter")
         else:

--- a/test/units/playbook/test_play_context.py
+++ b/test/units/playbook/test_play_context.py
@@ -51,7 +51,7 @@ class TestPlayContext(unittest.TestCase):
         pass
 
     def test_play_context(self):
-        (options, args) = self._parser.parse_args(['-vv', '--check'])
+        options = self._parser.parse_args(['-vv', '--check'])
         play_context = PlayContext(options=options)
         self.assertEqual(play_context._attributes['connection'], C.DEFAULT_TRANSPORT)
         self.assertEqual(play_context.remote_addr, None)
@@ -117,7 +117,7 @@ class TestPlayContext(unittest.TestCase):
         self.assertEqual(play_context.no_log, False)
 
     def test_play_context_make_become_cmd(self):
-        (options, args) = self._parser.parse_args([])
+        options = self._parser.parse_args([])
         play_context = PlayContext(options=options)
 
         default_cmd = "/bin/foo"
@@ -307,7 +307,7 @@ class TestTaskAndVariableOverrride(unittest.TestCase):
             inventory_opts=True,
         )
 
-        (options, args) = parser.parse_args(['-vv', '--check'])
+        options = parser.parse_args(['-vv', '--check'])
 
         mock_play = MagicMock()
         mock_play.connection = 'mock'


### PR DESCRIPTION
##### SUMMARY

Optparse is deprecated, all versions of python we use controller side have argparse support.

Additionally this gives us easy integration with argcomplete which we already use in ansible-test for command and option completion.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
cli

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION

To test argcomplete functionality, follow roughly the same instructions as ansible-test:

```
eval "$(register-python-argcomplete ansible)"
eval "$(register-python-argcomplete ansible-playbook)"
...
```

This change was made as minimally invasive as possible.  We can extend functionality later.  Currently to support only changes to the parser, I've effectively aliased a `args` positional argument to `self.args` so that the existing API still works the same.

In the future, we can rework the assumptions of how optparses `parse_args` worked, where it returned a tuple of `options, args`