### PR TITLE
Add alternative syntax for upgrading all installed packages via apt

### DIFF
--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -148,3 +148,15 @@
   assert:
     that:
         - "dpkg_force.changed"
+
+# NEGATIVE: upgrade all packages while providing additional packages to install
+- name: provide additional packages to install while upgrading all installed packages
+  apt: pkg=*,test state=latest
+  ignore_errors: True
+  register: apt_result
+
+- name: verify failure of upgrade packages and install
+  assert:
+    that:
+        - "not apt_result.changed"
+        - "apt_result.failed"


### PR DESCRIPTION
##### SUMMARY
Added alternative syntax to the apt module for supporting the upgrade of all packages.

#24189
Example:
```
- name: upgrade all installed packages
  apt: pkg=* state=latest
```
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
apt

##### ANSIBLE VERSION
devel