### PR TITLE
Cmp python3 compat

### DIFF
--- a/lib/ansible/modules/cloud/docker/_docker.py
+++ b/lib/ansible/modules/cloud/docker/_docker.py
@@ -1755,7 +1755,8 @@ def present(manager, containers, count, name):
     if delta < 0:
         # If both running and stopped containers exist, remove
         # stopped containers first.
-        containers.deployed.sort(lambda cx, cy: cmp(is_running(cx), is_running(cy)))
+        # Use key param for python 2/3 compatibility.
+        containers.deployed.sort(key=is_running)
 
         to_stop = []
         to_remove = []

--- a/lib/ansible/modules/network/cloudengine/ce_ntp.py
+++ b/lib/ansible/modules/network/cloudengine/ce_ntp.py
@@ -478,7 +478,7 @@ class Ntp(object):
                                    peer_type=ntp_dict['type'], prefer=is_preferred, key_id=key_id)
                 exp_ntp_cfg = dict(vpn_name=self.vpn_name, source_int=self.interface.lower(), address=self.address,
                                    peer_type=self.peer_type, prefer=self.is_preferred, key_id=self.key_id)
-                if cmp(cur_ntp_cfg, exp_ntp_cfg) == 0:
+                if cur_ntp_cfg == exp_ntp_cfg:
                     self.conf_exsit = True
 
             vpn_name = ntp_dict['vpnName']

--- a/lib/ansible/modules/network/cloudengine/ce_rollback.py
+++ b/lib/ansible/modules/network/cloudengine/ce_rollback.py
@@ -402,7 +402,7 @@ class RollBack(object):
                 self.module.fail_json(
                     msg='Error: Commit label which should not start with a number.')
             if len(self.label.replace(' ', '')) == 1:
-                if cmp(self.label, '-') == 0:
+                if self.label == '-':
                     self.module.fail_json(
                         msg='Error: Commit label which should not be "-"')
             if len(self.label.replace(' ', '')) < 1 or len(self.label) > 256:

--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -568,7 +568,7 @@ class ACMEClient(object):
         for index, cur_auth in enumerate(self.authorizations):
             if (cur_auth['uri'] == auth['uri']):
                 # does the auth parameter contain updated data?
-                if cmp(cur_auth, auth) != 0:
+                if cur_auth != auth:
                     # yes, update our current authorization list
                     self.authorizations[index] = auth
                     return True

--- a/test/integration/targets/expect/tasks/main.yml
+++ b/test/integration/targets/expect/tasks/main.yml
@@ -33,7 +33,7 @@
   expect:
     command: "{{ansible_python_interpreter}} {{test_command_file}}"
     responses:
-      foo: bar
+      foo: "bar"
   register: expect_result
 
 - name: assert expect worked
@@ -46,7 +46,7 @@
   expect:
     command: "echo"
     responses:
-      foo: bar
+      foo: "bar"
     creates: "{{output_file}}"
   register: creates_result
 
@@ -60,7 +60,7 @@
     command: "pwd"
     chdir: "{{output_dir}}"
     responses:
-      foo: bar
+      foo: "bar"
   register: chdir_result
 
 - name: assert chdir works
@@ -72,7 +72,7 @@
   expect:
     command: "cat"
     responses:
-      foo: bar
+      foo: "bar"
     timeout: 0
   ignore_errors: true
   register: timeout_result
@@ -86,7 +86,7 @@
   expect:
     command: "{{ansible_python_interpreter}} {{test_command_file}}"
     responses:
-      foo: bar
+      foo: "bar"
     echo: true
   register: echo_result
 

--- a/test/integration/targets/expect/tasks/main.yml
+++ b/test/integration/targets/expect/tasks/main.yml
@@ -33,7 +33,7 @@
   expect:
     command: "{{ansible_python_interpreter}} {{test_command_file}}"
     responses:
-      foo: "bar"
+      foo: bar
   register: expect_result
 
 - name: assert expect worked
@@ -46,7 +46,7 @@
   expect:
     command: "echo"
     responses:
-      foo: "bar"
+      foo: bar
     creates: "{{output_file}}"
   register: creates_result
 
@@ -60,7 +60,7 @@
     command: "pwd"
     chdir: "{{output_dir}}"
     responses:
-      foo: "bar"
+      foo: bar
   register: chdir_result
 
 - name: assert chdir works
@@ -72,7 +72,7 @@
   expect:
     command: "cat"
     responses:
-      foo: "bar"
+      foo: bar
     timeout: 0
   ignore_errors: true
   register: timeout_result
@@ -86,7 +86,7 @@
   expect:
     command: "{{ansible_python_interpreter}} {{test_command_file}}"
     responses:
-      foo: "bar"
+      foo: bar
     echo: true
   register: echo_result
 

--- a/test/sanity/code-smell/no-list-cmp.sh
+++ b/test/sanity/code-smell/no-list-cmp.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 CMP_USERS=$(grep -rI ' cmp[^a-zA-Z0-9_]' . \
+	--exclude-dir .tox \
 	| grep -v \
 	-e lib/ansible/module_utils/six/_six.py \
 	-e test/sanity/code-smell/no-list-cmp.sh

--- a/test/sanity/code-smell/no-list-cmp.sh
+++ b/test/sanity/code-smell/no-list-cmp.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+CMP_USERS=$(grep -rI ' cmp[^a-zA-Z0-9_]' . \
+	| grep -v \
+	-e lib/ansible/module_utils/six/_six.py \
+	-e test/sanity/code-smell/no-list-cmp.sh
+	)
+
+if [ "${CMP_USERS}" ]; then
+	echo 'cmp has been removed in python3.  Alternatives:'
+	echo '    http://python3porting.com/preparing.html#when-sorting-use-key-instead-of-cmp'
+	echo "${CMP_USERS}"
+	exit 1
+fi


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The cmp method has been removed from python3.
The changes remove cmp from several modules and replaces them with equality operators.
A code-smell test has been added to look for usage of cmp.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (cmp_python3_compat 3f79eadc6e) last updated 2017/05/24 14:25:09 (GMT -700)
  config file =
  configured module search path = ['/Users/kevinj/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kevinj/pycon_stash/ansible/lib/ansible
  executable location = /Users/kevinj/pycon_stash/ansible/bin/ansible
  python version = 3.6.1 (default, Apr  4 2017, 09:40:21) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
