### PR TITLE
Expose variable_manager to PlayIterator

### DIFF
--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -150,6 +150,7 @@ class PlayIterator:
     def __init__(self, inventory, play, play_context, variable_manager, all_vars, start_at_done=False):
         self._play = play
         self._blocks = []
+        self._variable_manager = variable_manager
 
         self._task_uuid_cache = dict()
 
@@ -303,7 +304,7 @@ class PlayIterator:
 
                     if (gathering == 'implicit' and implied) or \
                        (gathering == 'explicit' and boolean(self._play.gather_facts)) or \
-                       (gathering == 'smart' and implied and not (variable_manager._fact_cache.get(host.name,{}).get('module_setup', False))):
+                       (gathering == 'smart' and implied and not (self._variable_manager._fact_cache.get(host.name,{}).get('module_setup', False))):
                         # The setup block is always self._blocks[0], as we inject it
                         # during the play compilation in __init__ above.
                         setup_block = self._blocks[0]


### PR DESCRIPTION
##### SUMMARY
`variable_manager` is passed to the constructor of `PlayIterator`,
and then used to access the fact cache when fact gathering.
Make `_variable_manager` an attribute of the `PlayIterator` class

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
play_iterator

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 8e1e896955) last updated 2017/05/25 11:06:42 (GMT +1000)
  config file = ~/ansible.cfg
  configured module search path = [u'./library']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible-playbook
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
```
ERROR! Unexpected Exception: global name 'variable_manager' is not defined
the full traceback was:

Traceback (most recent call last):
  File "/home/will/src/ansible/bin/ansible-playbook", line 106, in <module>
    exit_code = cli.run()
  File "/home/will/src/ansible/lib/ansible/cli/playbook.py", line 134, in run
    results = pbex.run()
  File "/home/will/src/ansible/lib/ansible/executor/playbook_executor.py", line 153, in run
    result = self._tqm.run(play=play)
  File "/home/will/src/ansible/lib/ansible/executor/task_queue_manager.py", line 285, in run
    play_return = strategy.run(iterator, play_context)
  File "/home/will/src/ansible/lib/ansible/plugins/strategy/linear.py", line 192, in run
    host_tasks = self._get_next_task_lockstep(hosts_left, iterator)
  File "/home/will/src/ansible/lib/ansible/plugins/strategy/linear.py", line 70, in _get_next_task_lockstep
    host_tasks[host.name] = iterator.get_next_task_for_host(host, peek=True)
  File "/home/will/src/ansible/lib/ansible/executor/play_iterator.py", line 262, in get_next_task_for_host
    (s, task) = self._get_next_task_from_state(s, host=host, peek=peek)
  File "/home/will/src/ansible/lib/ansible/executor/play_iterator.py", line 306, in _get_next_task_from_state
    (gathering == 'smart' and implied and not (variable_manager._fact_cache.get(host.name,{}).get('module_setup', False))):
NameError: global name 'variable_manager' is not defined
```