### PR TITLE
Improve Camel to Snake conversion

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -47,12 +47,6 @@ try:
 except:
     HAS_BOTO3 = False
 
-try:
-    from distutils.version import LooseVersion
-    HAS_LOOSE_VERSION = True
-except:
-    HAS_LOOSE_VERSION = False
-
 from ansible.module_utils.six import string_types, binary_type, text_type
 
 

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -346,9 +346,12 @@ def _camel_to_snake(name):
 
     import re
     # Cope with pluralized abbreviations such as TargetGroupARNs
-    # that would otherwise be rendered target_group_arns
+    # that would otherwise be rendered target_group_ar_ns
     plural_pattern = r'[A-Z]{3,}s$'
     s1 = re.sub(plural_pattern, prepend_underscore_and_lower, name)
+    # Handle when there was nothing before the plural_pattern
+    if s1.startswith("_") and not name.startswith("_"):
+        s1 = s1[1:]
     # Remainder of solution seems to be https://stackoverflow.com/a/1176023
     first_cap_pattern = r'(.)([A-Z][a-z]+)'
     all_cap_pattern = r'([a-z0-9])([A-Z]+)'

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -345,17 +345,24 @@ def paging(pause=0, marker_property='marker'):
     return wrapper
 
 
+def _camel_to_snake(name):
+
+    def prepend_underscore_and_lower(m):
+        return '_' + m.group(0).lower()
+
+    import re
+    # Cope with pluralized abbreviations such as TargetGroupARNs
+    # that would otherwise be rendered target_group_arns
+    plural_pattern = r'[A-Z]{3,}s$'
+    s1 = re.sub(plural_pattern, prepend_underscore_and_lower, name)
+    # Remainder of solution seems to be https://stackoverflow.com/a/1176023
+    first_cap_pattern = r'(.)([A-Z][a-z]+)'
+    all_cap_pattern = r'([a-z0-9])([A-Z]+)'
+    s2 = re.sub(first_cap_pattern, r'\1_\2', s1)
+    return re.sub(all_cap_pattern, r'\1_\2', s2).lower()
+
+
 def camel_dict_to_snake_dict(camel_dict):
-
-    def camel_to_snake(name):
-
-        import re
-
-        first_cap_re = re.compile('(.)([A-Z][a-z]+)')
-        all_cap_re = re.compile('([a-z0-9])([A-Z])')
-        s1 = first_cap_re.sub(r'\1_\2', name)
-
-        return all_cap_re.sub(r'\1_\2', s1).lower()
 
     def value_is_list(camel_list):
 
@@ -373,11 +380,11 @@ def camel_dict_to_snake_dict(camel_dict):
     snake_dict = {}
     for k, v in camel_dict.items():
         if isinstance(v, dict):
-            snake_dict[camel_to_snake(k)] = camel_dict_to_snake_dict(v)
+            snake_dict[_camel_to_snake(k)] = camel_dict_to_snake_dict(v)
         elif isinstance(v, list):
-            snake_dict[camel_to_snake(k)] = value_is_list(v)
+            snake_dict[_camel_to_snake(k)] = value_is_list(v)
         else:
-            snake_dict[camel_to_snake(k)] = v
+            snake_dict[_camel_to_snake(k)] = v
 
     return snake_dict
 

--- a/test/units/module_utils/ec2/test_camel_to_snake.py
+++ b/test/units/module_utils/ec2/test_camel_to_snake.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# (c) 2017, Will Thames <will.thames@xvt.com.au>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from ansible.compat.tests import unittest
+from ansible.module_utils.ec2 import _camel_to_snake
+
+EXPECTED_CAMELIZATION = {
+    'alllower': 'alllower',
+    'TwoWords': 'two_words',
+    'AllUpperAtEND': 'all_upper_at_end',
+    'AllUpperButPLURALs': 'all_upper_but_plurals',
+    'TargetGroupARNs': 'target_group_arns',
+}
+
+
+class CamelToSnakeTestCase(unittest.TestCase):
+
+    def test_camel_to_snake(self):
+        for (k, v) in EXPECTED_CAMELIZATION.items():
+            self.assertEqual(_camel_to_snake(k), v)

--- a/test/units/module_utils/ec2/test_camel_to_snake.py
+++ b/test/units/module_utils/ec2/test_camel_to_snake.py
@@ -19,17 +19,19 @@
 from ansible.compat.tests import unittest
 from ansible.module_utils.ec2 import _camel_to_snake
 
-EXPECTED_CAMELIZATION = {
+EXPECTED_SNAKIFICATION = {
     'alllower': 'alllower',
     'TwoWords': 'two_words',
     'AllUpperAtEND': 'all_upper_at_end',
     'AllUpperButPLURALs': 'all_upper_but_plurals',
     'TargetGroupARNs': 'target_group_arns',
+    'HTTPEndpoints': 'http_endpoints',
+    'PLURALs': 'plurals'
 }
 
 
 class CamelToSnakeTestCase(unittest.TestCase):
 
     def test_camel_to_snake(self):
-        for (k, v) in EXPECTED_CAMELIZATION.items():
+        for (k, v) in EXPECTED_SNAKIFICATION.items():
             self.assertEqual(_camel_to_snake(k), v)


### PR DESCRIPTION
##### SUMMARY
Fix camelization of pluralized values. 

As a specific example, `TargetGroupARNs` became `target_group_ar_ns`. The fix was very much inspired by [botocore's solution](https://github.com/boto/botocore/blob/develop/botocore/__init__.py#L34-L36), but sufficiently rewritten to avoid licensing conflicts.

Reduce use of `re.compile` which makes no sense when the compilation is not reused.

Add tests in case future changes

PEP8 fixes as a second commit

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils.ec2

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 8e1e896955) last updated 2017/05/25 11:06:42 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```
