### PR TITLE
New AWS module for managing IAM groups fork from @naslanidis

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam_group.py
+++ b/lib/ansible/modules/cloud/amazon/iam_group.py
@@ -200,7 +200,8 @@ def compare_group_members(current_group_members, new_group_members):
 
 
 def convert_friendly_names_to_arns(connection, module, policies):
-    if not any([not policy.startswith('arn:') for policy in policies]):
+    # if not any([not policy.startswith('arn:') for policy in policies if policy is not None]):
+    if not [policy.startswith('arn:') for policy in policies if policy is not None]:
         return policies
     allpolicies = {}
     paginator = connection.get_paginator('list_policies')

--- a/lib/ansible/modules/cloud/amazon/iam_group.py
+++ b/lib/ansible/modules/cloud/amazon/iam_group.py
@@ -128,9 +128,7 @@ group:
             type: string
             sample: testgroup1
         path:
-            description: the path to the group
-            type: string
-            sample: /
+            description: the path def convert_friendly_names_to_arns(connection, module, policies):
 users:
     description: list containing all the group members
     returned: success

--- a/lib/ansible/modules/cloud/amazon/iam_group.py
+++ b/lib/ansible/modules/cloud/amazon/iam_group.py
@@ -14,9 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-ANSIBLE_METADATA = {'status': ['preview'],
-                    'supported_by': 'community',
-                    'version': '1.0'}
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
 
 DOCUMENTATION = '''
 ---
@@ -24,8 +24,8 @@ module: iam_group
 short_description: Manage AWS IAM groups
 description:
   - Manage AWS IAM groups
-version_added: "2.3"
-author: Nick Aslanidis, @naslanidis
+version_added: "2.4"
+author: Nick Aslanidis, @naslanidis, Maksym Postument, @infectsoldier
 options:
   name:
     description:
@@ -44,6 +44,16 @@ options:
       - Create or remove the IAM group
     required: true
     choices: [ 'present', 'absent' ]
+  purge_policy:
+    description:
+      - Deatach policy which not included in managed_policy list
+    required: false
+    default: false
+  purge_users:
+    description:
+      - Deatach users which not included in users list
+    required: false
+    default: false
 requirements: [ botocore, boto3 ]
 extends_documentation_fragment:
   - aws
@@ -77,17 +87,15 @@ EXAMPLES = '''
 # Remove all managed policies from an existing group with an empty list
 - iam_group:
     name: testgroup1
-    managed_policy:
-      -
     state: present
+    purge_policy: true
 
-# Remove all group members from an existing group with an empty list
+# Remove all group members from an existing group
 - iam_group:
     name: testgroup1
     managed_policy:
       - arn:aws:iam::aws:policy/AmazonSNSFullAccess
-    users:
-      -
+    purge_users: true
     state: present
 
 
@@ -101,7 +109,7 @@ RETURN = '''
 group:
     description: dictionary containing all the group information
     returned: success
-    type: dictionary
+    type: complex
     contains:
         arn:
             description: the Amazon Resource Name (ARN) specifying the group
@@ -126,7 +134,7 @@ group:
 users:
     description: list containing all the group members
     returned: success
-    type: list
+    type: complex
     contains:
         arn:
             description: the Amazon Resource Name (ARN) specifying the user
@@ -150,8 +158,10 @@ users:
             sample: /
 '''
 
-
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict, ec2_argument_spec, get_aws_connection_info, boto3_conn
 import json
+import traceback
 
 try:
     import boto3
@@ -195,6 +205,8 @@ def create_or_update_group(connection, module):
     params['GroupName'] = module.params.get('name')
     managed_policies = module.params.get('managed_policy')
     users = module.params.get('users')
+    purge_users = module.params.get('purge_users')
+    purge_policy = module.params.get('purge_policy')
     changed = False
 
     # Get group
@@ -205,39 +217,41 @@ def create_or_update_group(connection, module):
         try:
             group = connection.create_group(**params)
             changed = True
-        except (ClientError, ParamValidationError) as e:
-            module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+        except ClientError as e:
+            module.fail_json(msg=e.message, exception=traceback.format_exc(),
+                             **camel_dict_to_snake_dict(e.response))
+        except ParamValidationError as e:
+            module.fail_json(msg=e.message, exception=traceback.format_exc())
 
     # Manage managed policies
     current_attached_policies = get_attached_policy_list(connection, params['GroupName'])
     if not compare_attached_group_policies(current_attached_policies, managed_policies):
         # If managed_policies has a single empty element we want to remove all attached policies
-        if len(managed_policies) == 1 and managed_policies[0] == "":
+        if purge_policy:
+            # Detach policies not present
+            current_attached_policies_arn_list = []
             for policy in current_attached_policies:
+                current_attached_policies_arn_list.append(policy['PolicyArn'])
+
+            for policy_arn in list(set(current_attached_policies_arn_list) - set(managed_policies)):
                 try:
-                    connection.detach_group_policy(GroupName=params['GroupName'], PolicyArn=policy['PolicyArn'])
-                except (ClientError, ParamValidationError) as e:
-                    module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
-
-        # Detach policies not present
-        current_attached_policies_arn_list = []
-        for policy in current_attached_policies:
-            current_attached_policies_arn_list.append(policy['PolicyArn'])
-
-        for policy_arn in list(set(current_attached_policies_arn_list) - set(managed_policies)):
-            try:
-                connection.detach_group_policy(GroupName=params['GroupName'], PolicyArn=policy_arn)
-            except (ClientError, ParamValidationError) as e:
-                module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
-
+                    connection.detach_group_policy(GroupName=params['GroupName'], PolicyArn=policy_arn)
+                except ClientError as e:
+                    module.fail_json(msg=e.message, exception=traceback.format_exc(),
+                                     **camel_dict_to_snake_dict(e.response))
+                except ParamValidationError as e:
+                    module.fail_json(msg=e.message, exception=traceback.format_exc())
 
         # If there are policies in managed_policies attach each policy
         if managed_policies != [None]:
             for policy_arn in managed_policies:
                 try:
                     connection.attach_group_policy(GroupName=params['GroupName'], PolicyArn=policy_arn)
-                except (ClientError, ParamValidationError) as e:
-                    module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+                except ClientError as e:
+                    module.fail_json(msg=e.message, exception=traceback.format_exc(),
+                                     **camel_dict_to_snake_dict(e.response))
+                except ParamValidationError as e:
+                    module.fail_json(msg=e.message, exception=traceback.format_exc())
 
         changed = True
 
@@ -249,26 +263,25 @@ def create_or_update_group(connection, module):
 
     if not compare_group_members(current_group_members_list, users):
 
-        # If users has a single empty element we want to remove all users that are members of the group
-        if len(users) == 1 and users[0] is None:
-            for user in current_group_members_list:
+        if purge_users:
+            for user in list(set(current_group_members_list) - set(users)):
                 try:
                     connection.remove_user_from_group(GroupName=params['GroupName'], UserName=user)
-                except (ClientError, ParamValidationError) as e:
-                    module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
-
-        for user in list(set(current_group_members_list) - set(users)):
-            try:
-                connection.remove_user_from_group(GroupName=params['GroupName'], UserName=user)
-            except (ClientError, ParamValidationError) as e:
-                module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+                except ClientError as e:
+                    module.fail_json(msg=e.message, exception=traceback.format_exc(),
+                                     **camel_dict_to_snake_dict(e.response))
+                except ParamValidationError as e:
+                    module.fail_json(msg=e.message, exception=traceback.format_exc())
 
         if users != [None]:
             for user in users:
                 try:
                     connection.add_user_to_group(GroupName=params['GroupName'], UserName=user)
-                except (ClientError, ParamValidationError) as e:
-                    module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+                except ClientError as e:
+                    module.fail_json(msg=e.message, exception=traceback.format_exc(),
+                                     **camel_dict_to_snake_dict(e.response))
+                except ParamValidationError as e:
+                    module.fail_json(msg=e.message, exception=traceback.format_exc())
 
         changed = True
 
@@ -289,8 +302,11 @@ def destroy_group(connection, module):
         try:
             for policy in get_attached_policy_list(connection, params['GroupName']):
                 connection.detach_group_policy(GroupName=params['GroupName'], PolicyArn=policy['PolicyArn'])
-        except (ClientError, ParamValidationError) as e:
-            module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+        except ClientError as e:
+            module.fail_json(msg=e.message, exception=traceback.format_exc(),
+                             **camel_dict_to_snake_dict(e.response))
+        except ParamValidationError as e:
+            module.fail_json(msg=e.message, exception=traceback.format_exc())
 
         # Remove any users in the group otherwise deletion fails
         current_group_members_list = []
@@ -300,13 +316,19 @@ def destroy_group(connection, module):
         for user in current_group_members_list:
             try:
                 connection.remove_user_from_group(GroupName=params['GroupName'], UserName=user)
-            except (ClientError, ParamValidationError) as e:
-                module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+            except ClientError as e:
+                module.fail_json(msg=e.message, exception=traceback.format_exc(),
+                                 **camel_dict_to_snake_dict(e.response))
+            except ParamValidationError as e:
+                module.fail_json(msg=e.message, exception=traceback.format_exc())
 
         try:
             connection.delete_group(**params)
         except ClientError as e:
-            module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+            module.fail_json(msg=e.message, exception=traceback.format_exc(),
+                             **camel_dict_to_snake_dict(e.response))
+        except ParamValidationError as e:
+            module.fail_json(msg=e.message, exception=traceback.format_exc())
 
     else:
         module.exit_json(changed=False)
@@ -345,9 +367,11 @@ def main():
     argument_spec.update(
         dict(
             name=dict(required=True, type='str'),
-            managed_policy=dict(default=[], required=False, type='list'),
-            users=dict(default=[], required=False, type='list'),
-            state=dict(default=None, choices=['present', 'absent'], required=True)
+            managed_policy=dict(default=[], type='list'),
+            users=dict(default=[], type='list'),
+            state=dict(choices=['present', 'absent'], required=True),
+            purge_users=dict(default=False, type='bool'),
+            purge_policy=dict(default=False, type='bool')
         )
     )
 
@@ -368,9 +392,6 @@ def main():
         create_or_update_group(connection, module)
     else:
         destroy_group(connection, module)
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ec2 import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/amazon/iam_group.py
+++ b/lib/ansible/modules/cloud/amazon/iam_group.py
@@ -170,6 +170,7 @@ try:
 except ImportError:
     pass  # caught by imported HAS_BOTO3
 
+
 def compare_attached_group_policies(current_attached_policies, new_attached_policies):
 
     # If new_attached_policies is None it means we want to remove all policies
@@ -196,6 +197,7 @@ def compare_group_members(current_group_members, new_group_members):
         return True
     else:
         return False
+
 
 def convert_friendly_names_to_arns(connection, module, policies):
     if not any([not policy.startswith('arn:') for policy in policies]):

--- a/lib/ansible/modules/cloud/amazon/iam_group.py
+++ b/lib/ansible/modules/cloud/amazon/iam_group.py
@@ -128,7 +128,9 @@ group:
             type: string
             sample: testgroup1
         path:
-            description: the path def convert_friendly_names_to_arns(connection, module, policies):
+            description: the path to the group
+            type: string
+            sample: /
 users:
     description: list containing all the group members
     returned: success

--- a/lib/ansible/modules/cloud/amazon/iam_group.py
+++ b/lib/ansible/modules/cloud/amazon/iam_group.py
@@ -33,12 +33,12 @@ options:
     required: true
   managed_policy:
     description:
-      - A list of managed policy ARNs (can't use friendly names due to AWS API limitation) to attach to the group. To embed an inline policy, use M(iam_policy). To remove existing policies, use an empty list item.
+      - A list of managed policy ARNs (can't use friendly names due to AWS API limitation) to attach to the group.
     required: false
   users:
     description:
       - A list of existing users to add as members of the group.
-    required: false    
+    required: false
   state:
     description:
       - Create or remove the IAM group
@@ -208,7 +208,7 @@ def create_or_update_group(connection, module):
         except (ClientError, ParamValidationError) as e:
             module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
 
-    # Manage managed policies      
+    # Manage managed policies
     current_attached_policies = get_attached_policy_list(connection, params['GroupName'])
     if not compare_attached_group_policies(current_attached_policies, managed_policies):
         # If managed_policies has a single empty element we want to remove all attached policies
@@ -240,7 +240,7 @@ def create_or_update_group(connection, module):
                     module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
 
         changed = True
-    
+
     # Manage group memberships
     current_group_members = get_group(connection, params['GroupName'])['Users']
     current_group_members_list = []
@@ -250,7 +250,7 @@ def create_or_update_group(connection, module):
     if not compare_group_members(current_group_members_list, users):
 
         # If users has a single empty element we want to remove all users that are members of the group
-        if len(users) == 1 and users[0] == None:
+        if len(users) == 1 and users[0] is None:
             for user in current_group_members_list:
                 try:
                     connection.remove_user_from_group(GroupName=params['GroupName'], UserName=user)
@@ -261,7 +261,7 @@ def create_or_update_group(connection, module):
             try:
                 connection.remove_user_from_group(GroupName=params['GroupName'], UserName=user)
             except (ClientError, ParamValidationError) as e:
-                module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))                    
+                module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))         
 
         if users != [None]:
             for user in users:
@@ -307,7 +307,7 @@ def destroy_group(connection, module):
             connection.delete_group(**params)
         except ClientError as e:
             module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
-    
+
     else:
         module.exit_json(changed=False)
 

--- a/lib/ansible/modules/cloud/amazon/iam_group.py
+++ b/lib/ansible/modules/cloud/amazon/iam_group.py
@@ -1,0 +1,376 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+
+DOCUMENTATION = '''
+---
+module: iam_group
+short_description: Manage AWS IAM groups
+description:
+  - Manage AWS IAM groups
+version_added: "2.3"
+author: Nick Aslanidis, @naslanidis
+options:
+  name:
+    description:
+      - The name of the group to create.
+    required: true
+  managed_policy:
+    description:
+      - A list of managed policy ARNs (can't use friendly names due to AWS API limitation) to attach to the group. To embed an inline policy, use M(iam_policy). To remove existing policies, use an empty list item.
+    required: false
+  users:
+    description:
+      - A list of existing users to add as members of the group.
+    required: false    
+  state:
+    description:
+      - Create or remove the IAM group
+    required: true
+    choices: [ 'present', 'absent' ]
+requirements: [ botocore, boto3 ]
+extends_documentation_fragment:
+  - aws
+'''
+
+EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+
+# Create a group
+- iam_group:
+    name: testgroup1
+    state: present
+
+# Create a group and attach a managed policy using its ARN
+- iam_group:
+    name: testgroup1
+    managed_policy:
+      - arn:aws:iam::aws:policy/AmazonSNSFullAccess
+    state: present
+
+# Create a group with users as members and attach a managed policy using its ARN
+- iam_group:
+    name: testgroup1
+    managed_policy:
+      - arn:aws:iam::aws:policy/AmazonSNSFullAccess
+    users:
+      - test_user1
+      - test_user2
+    state: present
+
+# Remove all managed policies from an existing group with an empty list
+- iam_group:
+    name: testgroup1
+    managed_policy:
+      -
+    state: present
+
+# Remove all group members from an existing group with an empty list
+- iam_group:
+    name: testgroup1
+    managed_policy:
+      - arn:aws:iam::aws:policy/AmazonSNSFullAccess
+    users:
+      -
+    state: present
+
+
+# Delete the group
+- iam_group:
+    name: testgroup1
+    state: absent
+
+'''
+RETURN = '''
+group:
+    description: dictionary containing all the group information
+    returned: success
+    type: dictionary
+    contains:
+        arn:
+    		description: the Amazon Resource Name (ARN) specifying the group
+    		type: string
+    		sample: "arn:aws:iam::1234567890:group/testgroup1"
+		create_date:
+		    description: the date and time, in ISO 8601 date-time format, when the group was created
+		    type: string
+		    sample: "2017-02-08T04:36:28+00:00"
+	    group_id:
+		    description: the stable and unique string identifying the group
+		    type: string
+		    sample: AGPAIDBWE12NSFINE55TM
+		group_name:
+		    description: the friendly name that identifies the group
+		    type: string
+		    sample: testgroup1
+		path:
+		    description: the path to the group
+		    type: string
+		    sample: /
+users:
+    description: list containing all the group members
+    returned: success
+    type: list
+    contains:
+        arn:
+    		description: the Amazon Resource Name (ARN) specifying the user
+    		type: string
+    		sample: "arn:aws:iam::1234567890:user/test_user1"
+		create_date:
+		    description: the date and time, in ISO 8601 date-time format, when the user was created
+		    type: string
+		    sample: "2017-02-08T04:36:28+00:00"
+	    user_id:
+		    description: the stable and unique string identifying the user
+		    type: string
+		    sample: AIDAIZTPY123YQRS22YU2
+		user_name:
+		    description: the friendly name that identifies the user
+		    type: string
+		    sample: testgroup1
+		path:
+		    description: the path to the user
+		    type: string
+		    sample: /		    
+'''
+
+
+import json
+
+try:
+    import boto3
+    from botocore.exceptions import ClientError, ParamValidationError
+    HAS_BOTO3 = True
+except ImportError:
+    HAS_BOTO3 = False
+
+
+def compare_attached_group_policies(current_attached_policies, new_attached_policies):
+
+    # If new_attached_policies is None it means we want to remove all policies
+    if len(current_attached_policies) > 0 and new_attached_policies is None:
+        return False
+
+    current_attached_policies_arn_list = []
+    for policy in current_attached_policies:
+        current_attached_policies_arn_list.append(policy['PolicyArn'])
+
+    if set(current_attached_policies_arn_list) == set(new_attached_policies):
+        return True
+    else:
+        return False
+
+
+def compare_group_members(current_group_members, new_group_members):
+
+    # If new_attached_policies is None it means we want to remove all policies
+    if len(current_group_members) > 0 and new_group_members is None:
+        return False
+
+    if set(current_group_members) == set(new_group_members):
+        return True
+    else:
+        return False
+
+
+def create_or_update_group(connection, module):
+
+    params = dict()
+    params['GroupName'] = module.params.get('name')
+    managed_policies = module.params.get('managed_policy')
+    users = module.params.get('users')
+    changed = False
+
+    # Get group
+    group = get_group(connection, params['GroupName'])
+
+    # If group is None, create it
+    if group is None:
+        try:
+            group = connection.create_group(**params)
+            changed = True
+        except (ClientError, ParamValidationError) as e:
+            module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+
+    # Manage managed policies      
+    current_attached_policies = get_attached_policy_list(connection, params['GroupName'])
+    if not compare_attached_group_policies(current_attached_policies, managed_policies):
+        # If managed_policies has a single empty element we want to remove all attached policies
+        if len(managed_policies) == 1 and managed_policies[0] == "":
+            for policy in current_attached_policies:
+                try:
+                    connection.detach_group_policy(GroupName=params['GroupName'], PolicyArn=policy['PolicyArn'])
+                except (ClientError, ParamValidationError) as e:
+                    module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+
+        # Detach policies not present
+        current_attached_policies_arn_list = []
+        for policy in current_attached_policies:
+            current_attached_policies_arn_list.append(policy['PolicyArn'])
+
+        for policy_arn in list(set(current_attached_policies_arn_list) - set(managed_policies)):
+            try:
+                connection.detach_group_policy(GroupName=params['GroupName'], PolicyArn=policy_arn)
+            except (ClientError, ParamValidationError) as e:
+                module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+
+
+        # If there are policies in managed_policies attach each policy
+        if managed_policies != [None]:
+	        for policy_arn in managed_policies:
+	            try:
+	                connection.attach_group_policy(GroupName=params['GroupName'], PolicyArn=policy_arn)
+	            except (ClientError, ParamValidationError) as e:
+	                module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+
+        changed = True
+    
+    # Manage group memberships
+    current_group_members = get_group(connection, params['GroupName'])['Users']
+    current_group_members_list = []
+    for member in current_group_members:
+    	current_group_members_list.append(member['UserName'])
+
+    if not compare_group_members(current_group_members_list, users):
+
+        # If users has a single empty element we want to remove all users that are members of the group
+        if len(users) == 1 and users[0] == None:
+            for user in current_group_members_list:
+                try:
+                    connection.remove_user_from_group(GroupName=params['GroupName'], UserName=user)
+                except (ClientError, ParamValidationError) as e:
+                    module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+
+        for user in list(set(current_group_members_list) - set(users)):
+            try:
+                connection.remove_user_from_group(GroupName=params['GroupName'], UserName=user)
+            except (ClientError, ParamValidationError) as e:
+                module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))                    
+
+        if users != [None]:
+	        for user in users:
+	            try:
+	                connection.add_user_to_group(GroupName=params['GroupName'], UserName=user)
+	            except (ClientError, ParamValidationError) as e:
+	                module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+
+        changed = True
+
+    # Get the group again
+    group = get_group(connection, params['GroupName'])
+
+    module.exit_json(changed=changed, iam_group=camel_dict_to_snake_dict(group))
+
+
+def destroy_group(connection, module):
+
+    params = dict()
+    params['GroupName'] = module.params.get('name')
+
+    if get_group(connection, params['GroupName']):
+
+        # Remove any attached policies otherwise deletion fails
+        try:
+            for policy in get_attached_policy_list(connection, params['GroupName']):
+                connection.detach_group_policy(GroupName=params['GroupName'], PolicyArn=policy['PolicyArn'])
+        except (ClientError, ParamValidationError) as e:
+            module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+
+        # Remove any users in the group otherwise deletion fails
+    	current_group_members = get_group(connection, params['GroupName'])['Users']
+    	current_group_members_list = []
+    	for member in current_group_members:
+    		current_group_members_list.append(member['UserName'])
+        for user in current_group_members_list:
+            try:
+                connection.remove_user_from_group(GroupName=params['GroupName'], UserName=user)
+            except (ClientError, ParamValidationError) as e:
+                module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+
+        try:
+            connection.delete_group(**params)
+        except ClientError as e:
+            module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+    
+    else:
+        module.exit_json(changed=False)
+
+    module.exit_json(changed=True)
+
+
+def get_group(connection, name):
+
+    params = dict()
+    params['GroupName'] = name
+
+    try:
+        return connection.get_group(**params)
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'NoSuchEntity':
+            return None
+        else:
+            module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+
+
+def get_attached_policy_list(connection, name):
+
+    try:
+        return connection.list_attached_group_policies(GroupName=name)['AttachedPolicies']
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'NoSuchEntity':
+            return None
+        else:
+            module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+
+
+def main():
+
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(
+        dict(
+            name=dict(required=True, type='str'),
+            managed_policy=dict(default=[], required=False, type='list'),
+            users=dict(default=[], required=False, type='list'),
+            state=dict(default=None, choices=['present', 'absent'], required=True)
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+    )
+
+    if not HAS_BOTO3:
+        module.fail_json(msg='boto3 required for this module')
+
+    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
+
+    connection = boto3_conn(module, conn_type='client', resource='iam', region=region, endpoint=ec2_url, **aws_connect_params)
+
+    state = module.params.get("state")
+
+    if state == 'present':
+        create_or_update_group(connection, module)
+    else:
+        destroy_group(connection, module)
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import *
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/iam_group.py
+++ b/lib/ansible/modules/cloud/amazon/iam_group.py
@@ -261,7 +261,7 @@ def create_or_update_group(connection, module):
             try:
                 connection.remove_user_from_group(GroupName=params['GroupName'], UserName=user)
             except (ClientError, ParamValidationError) as e:
-                module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))         
+                module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
 
         if users != [None]:
             for user in users:

--- a/lib/ansible/modules/cloud/amazon/iam_group.py
+++ b/lib/ansible/modules/cloud/amazon/iam_group.py
@@ -104,50 +104,50 @@ group:
     type: dictionary
     contains:
         arn:
-    		description: the Amazon Resource Name (ARN) specifying the group
-    		type: string
-    		sample: "arn:aws:iam::1234567890:group/testgroup1"
-		create_date:
-		    description: the date and time, in ISO 8601 date-time format, when the group was created
-		    type: string
-		    sample: "2017-02-08T04:36:28+00:00"
-	    group_id:
-		    description: the stable and unique string identifying the group
-		    type: string
-		    sample: AGPAIDBWE12NSFINE55TM
-		group_name:
-		    description: the friendly name that identifies the group
-		    type: string
-		    sample: testgroup1
-		path:
-		    description: the path to the group
-		    type: string
-		    sample: /
+            description: the Amazon Resource Name (ARN) specifying the group
+            type: string
+            sample: "arn:aws:iam::1234567890:group/testgroup1"
+        create_date:
+            description: the date and time, in ISO 8601 date-time format, when the group was created
+            type: string
+            sample: "2017-02-08T04:36:28+00:00"
+        group_id:
+            description: the stable and unique string identifying the group
+            type: string
+            sample: AGPAIDBWE12NSFINE55TM
+        group_name:
+            description: the friendly name that identifies the group
+            type: string
+            sample: testgroup1
+        path:
+            description: the path to the group
+            type: string
+            sample: /
 users:
     description: list containing all the group members
     returned: success
     type: list
     contains:
         arn:
-    		description: the Amazon Resource Name (ARN) specifying the user
-    		type: string
-    		sample: "arn:aws:iam::1234567890:user/test_user1"
-		create_date:
-		    description: the date and time, in ISO 8601 date-time format, when the user was created
-		    type: string
-		    sample: "2017-02-08T04:36:28+00:00"
-	    user_id:
-		    description: the stable and unique string identifying the user
-		    type: string
-		    sample: AIDAIZTPY123YQRS22YU2
-		user_name:
-		    description: the friendly name that identifies the user
-		    type: string
-		    sample: testgroup1
-		path:
-		    description: the path to the user
-		    type: string
-		    sample: /		    
+            description: the Amazon Resource Name (ARN) specifying the user
+            type: string
+            sample: "arn:aws:iam::1234567890:user/test_user1"
+        create_date:
+            description: the date and time, in ISO 8601 date-time format, when the user was created
+            type: string
+            sample: "2017-02-08T04:36:28+00:00"
+        user_id:
+            description: the stable and unique string identifying the user
+            type: string
+            sample: AIDAIZTPY123YQRS22YU2
+        user_name:
+            description: the friendly name that identifies the user
+            type: string
+            sample: testgroup1
+        path:
+            description: the path to the user
+            type: string
+            sample: /
 '''
 
 
@@ -233,11 +233,11 @@ def create_or_update_group(connection, module):
 
         # If there are policies in managed_policies attach each policy
         if managed_policies != [None]:
-	        for policy_arn in managed_policies:
-	            try:
-	                connection.attach_group_policy(GroupName=params['GroupName'], PolicyArn=policy_arn)
-	            except (ClientError, ParamValidationError) as e:
-	                module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+            for policy_arn in managed_policies:
+                try:
+                    connection.attach_group_policy(GroupName=params['GroupName'], PolicyArn=policy_arn)
+                except (ClientError, ParamValidationError) as e:
+                    module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
 
         changed = True
     
@@ -245,7 +245,7 @@ def create_or_update_group(connection, module):
     current_group_members = get_group(connection, params['GroupName'])['Users']
     current_group_members_list = []
     for member in current_group_members:
-    	current_group_members_list.append(member['UserName'])
+        current_group_members_list.append(member['UserName'])
 
     if not compare_group_members(current_group_members_list, users):
 
@@ -264,11 +264,11 @@ def create_or_update_group(connection, module):
                 module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))                    
 
         if users != [None]:
-	        for user in users:
-	            try:
-	                connection.add_user_to_group(GroupName=params['GroupName'], UserName=user)
-	            except (ClientError, ParamValidationError) as e:
-	                module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+            for user in users:
+                try:
+                    connection.add_user_to_group(GroupName=params['GroupName'], UserName=user)
+                except (ClientError, ParamValidationError) as e:
+                    module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
 
         changed = True
 
@@ -293,10 +293,9 @@ def destroy_group(connection, module):
             module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
 
         # Remove any users in the group otherwise deletion fails
-    	current_group_members = get_group(connection, params['GroupName'])['Users']
-    	current_group_members_list = []
-    	for member in current_group_members:
-    		current_group_members_list.append(member['UserName'])
+        current_group_members = get_group(connection, params['GroupName'])['Users'    current_group_members_list = []
+        for member in current_group_members:
+            current_group_members_list.append(member['UserName'])
         for user in current_group_members_list:
             try:
                 connection.remove_user_from_group(GroupName=params['GroupName'], UserName=user)

--- a/lib/ansible/modules/cloud/amazon/iam_group.py
+++ b/lib/ansible/modules/cloud/amazon/iam_group.py
@@ -293,7 +293,8 @@ def destroy_group(connection, module):
             module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
 
         # Remove any users in the group otherwise deletion fails
-        current_group_members = get_group(connection, params['GroupName'])['Users'    current_group_members_list = []
+        current_group_members_list = []
+        current_group_members = get_group(connection, params['GroupName'])['Users']
         for member in current_group_members:
             current_group_members_list.append(member['UserName'])
         for user in current_group_members_list:

--- a/lib/ansible/modules/cloud/amazon/iam_group.py
+++ b/lib/ansible/modules/cloud/amazon/iam_group.py
@@ -162,7 +162,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict, ec2_argument_spec, get_aws_connection_info, boto3_conn
 from ansible.module_utils.ec2 import HAS_BOTO3
 
-import json
 import traceback
 
 try:


### PR DESCRIPTION
##### SUMMARY
The module was forked from https://github.com/ansible/ansible/pull/21236. Because author left this module unfinished 

##### ISSUE TYPE
New Module Pull Request

##### COMPONENT NAME
iam_group

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
Module to allow managing AWS IAM groups.

As per the below PR, it was decided that the iam module should be split in to separate ones i.e. iam_role, iam_user, iam_group. This module completes the iam_group module.

I debated whether to include the user output, however as this is returned by the get_group API action and is useful I decided to keep it.

https://boto3.readthedocs.io/en/latest/reference/services/iam.html#IAM.Client.get_group
```
TASK [debug] *************************************************
ok: [localhost] => {
    "msg": {
        "changed": true, 
        "iam_group": {
            "group": {
                "arn": "arn:aws:iam::1234567890:group/test_group", 
                "create_date": "2017-02-10T09:43:01+00:00", 
                "group_id": "AGPAIDBWE123SFINE55TM", 
                "group_name": "test_group", 
                "path": "/"
            }, 
            "users": [
                {
                    "arn": "arn:aws:iam::1234567890:user/test_user1", 
                    "create_date": "2017-02-10T07:12:32+00:00", 
                    "path": "/", 
                    "user_id": "AIDAIZTPYHR4123S22YU2", 
                    "user_name": "test_user1"
                }
            ]
        }
    }
}

```
