### PR TITLE
ansible-connection refactor

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# (c) 2016, Ansible, Inc. <support@ansible.com>
+# (c) 2017, Ansible, Inc. <support@ansible.com>
 #
 # This file is part of Ansible
 #
@@ -33,18 +33,17 @@ import os
 import shlex
 import signal
 import socket
-import struct
 import sys
 import time
 import traceback
-import syslog
 import datetime
-import logging
+import errno
 
 from ansible import constants as C
 from ansible.module_utils._text import to_bytes, to_native
 from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves import cPickle
+from ansible.module_utils.connection import send_data, recv_data
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins import connection_loader
 from ansible.utils.path import unfrackpath, makedirs_safe
@@ -88,33 +87,11 @@ def do_fork():
     except OSError as e:
         sys.exit(1)
 
-def send_data(s, data):
-    packed_len = struct.pack('!Q', len(data))
-    return s.sendall(packed_len + data)
-
-def recv_data(s):
-    header_len = 8 # size of a packed unsigned long long
-    data = b""
-    while len(data) < header_len:
-        d = s.recv(header_len - len(data))
-        if not d:
-            return None
-        data += d
-    data_len = struct.unpack('!Q', data[:header_len])[0]
-    data = data[header_len:]
-    while len(data) < data_len:
-        d = s.recv(data_len - len(data))
-        if not d:
-            return None
-        data += d
-    return data
-
 
 class Server():
 
-    def __init__(self, path, play_context):
-
-        self.path = path
+    def __init__(self, socket_path, play_context):
+        self.socket_path = socket_path
         self.play_context = play_context
 
         display.display(
@@ -123,64 +100,38 @@ class Server():
             log_only=True
         )
 
-        display.display('control socket path is %s' % path, log_only=True)
+        display.display('control socket path is %s' % socket_path, log_only=True)
         display.display('current working directory is %s' % os.getcwd(), log_only=True)
 
         self._start_time = datetime.datetime.now()
 
         display.display("using connection plugin %s" % self.play_context.connection, log_only=True)
 
-        self.conn = connection_loader.get(play_context.connection, play_context, sys.stdin)
-        self.conn._connect()
-        if not self.conn.connected:
+        self.connection = connection_loader.get(play_context.connection, play_context, sys.stdin)
+        self.connection._connect()
+
+        if not self.connection.connected:
             raise AnsibleConnectionFailure('unable to connect to remote host %s' % self._play_context.remote_addr)
 
         connection_time = datetime.datetime.now() - self._start_time
         display.display('connection established to %s in %s' % (play_context.remote_addr, connection_time), log_only=True)
 
         self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        self.socket.bind(path)
+        self.socket.bind(self.socket_path)
         self.socket.listen(1)
-
-        signal.signal(signal.SIGALRM, self.alarm_handler)
-
-    def dispatch(self, obj, name, *args, **kwargs):
-        meth = getattr(obj, name, None)
-        if meth:
-            return meth(*args, **kwargs)
-
-    def alarm_handler(self, signum, frame):
-        '''
-        Alarm handler
-        '''
-        # FIXME: this should also set internal flags for other
-        #        areas of code to check, so they can terminate
-        #        earlier than the socket going back to the accept
-        #        call and failing there.
-        #
-        # hooks the connection plugin to handle any cleanup
-        self.dispatch(self.conn, 'alarm_handler', signum, frame)
-        self.socket.close()
+        display.display('local socket is set to listening', log_only=True)
 
     def run(self):
         try:
             while True:
-                # set the alarm, if we don't get an accept before it
-                # goes off we exit (via an exception caused by the socket
-                # getting closed while waiting on accept())
-                # FIXME: is this the best way to exit? as noted above in the
-                #        handler we should probably be setting a flag to check
-                #        here and in other parts of the code
+                signal.signal(signal.SIGALRM, self.connect_timeout)
+                signal.signal(signal.SIGTERM, self.shutdown)
                 signal.alarm(C.PERSISTENT_CONNECT_TIMEOUT)
-                try:
-                    (s, addr) = self.socket.accept()
-                    display.display('incoming request accepted on persistent socket', log_only=True)
-                    # clear the alarm
-                    # FIXME: potential race condition here between the accept and
-                    #        time to this call.
-                    signal.alarm(0)
-                except:
-                    break
+
+                (s, addr) = self.socket.accept()
+                display.display('incoming request accepted on persistent socket', log_only=True)
+
+                signal.alarm(0)
 
                 while True:
                     data = recv_data(s)
@@ -189,69 +140,112 @@ class Server():
 
                     signal.alarm(self.play_context.timeout)
 
+                    op = data.split(':')[0]
+                    display.display('socket operation is %s' % op, log_only=True)
+
+                    method = getattr(self, 'do_%s' % op, None)
+
                     rc = 255
-                    try:
-                        if data.startswith(b'EXEC: '):
-                            display.display("socket operation is EXEC", log_only=True)
-                            cmd = data.split(b'EXEC: ')[1]
-                            (rc, stdout, stderr) = self.conn.exec_command(cmd)
-                        elif data.startswith(b'PUT: ') or data.startswith(b'FETCH: '):
-                            (op, src, dst) = shlex.split(to_native(data))
-                            stdout = stderr = ''
-                            try:
-                                if op == 'FETCH:':
-                                    display.display("socket operation is FETCH", log_only=True)
-                                    self.conn.fetch_file(src, dst)
-                                elif op == 'PUT:':
-                                    display.display("socket operation is PUT", log_only=True)
-                                    self.conn.put_file(src, dst)
-                                rc = 0
-                            except:
-                                pass
-                        elif data.startswith(b'CONTEXT: '):
-                            display.display("socket operation is CONTEXT", log_only=True)
-                            pc_data = data.split(b'CONTEXT: ', 1)[1]
+                    stdout = stderr = ''
 
-                            if PY3:
-                                pc_data = cPickle.loads(pc_data, encoding='bytes')
-                            else:
-                                pc_data = cPickle.loads(pc_data)
+                    if not method:
+                        stderr = 'Invalid action specified'
+                    else:
+                        rc, stdout, stderr = method(data)
 
-                            pc = PlayContext()
-                            pc.deserialize(pc_data)
-
-                            self.dispatch(self.conn, 'update_play_context', pc)
-                            continue
-                        else:
-                            display.display("socket operation is UNKNOWN", log_only=True)
-                            stdout = ''
-                            stderr = 'Invalid action specified'
-                    except:
-                        stdout = ''
-                        stderr = traceback.format_exc()
-
-                    signal.alarm(0)
-
-                    display.display("socket operation completed with rc %s" % rc, log_only=True)
+                    display.display('socket operation completed with rc %s' % rc, log_only=True)
 
                     send_data(s, to_bytes(rc))
                     send_data(s, to_bytes(stdout))
                     send_data(s, to_bytes(stderr))
+
                 s.close()
+
         except Exception as e:
-            display.display(traceback.format_exc(), log_only=True)
+            # socket.accept() will raise EINTR if the socket.close() is called
+            if e.errno != errno.EINTR:
+                display.display(traceback.format_exc(), log_only=True)
+
         finally:
             # when done, close the connection properly and cleanup
             # the socket file so it can be recreated
+            self.shutdown()
             end_time = datetime.datetime.now()
             delta = end_time - self._start_time
-            display.display('shutting down control socket, connection was active for %s secs' % delta, log_only=True)
-            try:
-                self.conn.close()
+            display.display('shutdown local socket, connection was active for %s secs' % delta, log_only=True)
+
+    def connect_timeout(self, signum, frame):
+        self.shutdown()
+
+    def shutdown(self):
+        display.display('shutdown persistent connection requested', log_only=True)
+
+        if not os.path.exists(self.socket_path):
+            display.display('persistent connection is not active', log_only=True)
+            return
+
+        try:
+            if self.socket:
+                display.display('closing local listener', log_only=True)
                 self.socket.close()
-            except Exception as e:
-                pass
-            os.remove(self.path)
+            if self.connection:
+                display.display('closing the connection', log_only=True)
+                self.close()
+        except:
+            pass
+        finally:
+            if os.path.exists(self.socket_path):
+                display.display('removing the local control socket', log_only=True)
+                os.remove(self.socket_path)
+
+        display.display('shutdown complete', log_only=True)
+
+    def do_EXEC(self, data):
+        cmd = data.split(b'EXEC: ')[1]
+        return self.connection.exec_command(cmd)
+
+    def do_PUT(self, data):
+        (op, src, dst) = shlex.split(to_native(data))
+        return self.connection.fetch_file(src, dst)
+
+    def do_FETCH(self, data):
+        (op, src, dst) = shlex.split(to_native(data))
+        return self.connection.put_file(src, dst)
+
+    def do_CONTEXT(self, data):
+        pc_data = data.split(b'CONTEXT: ', 1)[1]
+
+        if PY3:
+            pc_data = cPickle.loads(pc_data, encoding='bytes')
+        else:
+            pc_data = cPickle.loads(pc_data)
+
+        pc = PlayContext()
+        pc.deserialize(pc_data)
+
+        try:
+            self.connection.update_play_context(pc)
+        except AttributeError:
+            pass
+
+        return (0, 'ok', '')
+
+    def do_RUN(self, data):
+        timeout = self.play_context.timeout
+        while bool(timeout):
+            if os.path.exists(self.socket_path):
+                break
+            time.sleep(1)
+            timeout -= 1
+        return (0, self.socket_path, '')
+
+
+def communicate(sock, data):
+    send_data(sock, data)
+    rc = int(recv_data(sock), 10)
+    stdout = recv_data(sock)
+    stderr = recv_data(sock)
+    return (rc, stdout, stderr)
 
 def main():
     # Need stdin as a byte stream
@@ -279,30 +273,32 @@ def main():
 
         pc = PlayContext()
         pc.deserialize(pc_data)
+
     except Exception as e:
         # FIXME: better error message/handling/logging
         sys.stderr.write(traceback.format_exc())
         sys.exit("FAIL: %s" % e)
 
     ssh = connection_loader.get('ssh', class_only=True)
-    m = ssh._create_control_path(pc.remote_addr, pc.port, pc.remote_user)
+    cp = ssh._create_control_path(pc.remote_addr, pc.port, pc.remote_user)
 
     # create the persistent connection dir if need be and create the paths
     # which we will be using later
-    tmp_path = unfrackpath("$HOME/.ansible/pc")
+    tmp_path = unfrackpath(C.PERSISTENT_CONTROL_PATH_DIR)
     makedirs_safe(tmp_path)
-    lk_path = unfrackpath("%s/.ansible_pc_lock" % tmp_path)
-    sf_path = unfrackpath(m % dict(directory=tmp_path))
+    lock_path = unfrackpath("%s/.ansible_pc_lock" % tmp_path)
+    socket_path = unfrackpath(cp % dict(directory=tmp_path))
 
     # if the socket file doesn't exist, spin up the daemon process
-    lock_fd = os.open(lk_path, os.O_RDWR|os.O_CREAT, 0o600)
+    lock_fd = os.open(lock_path, os.O_RDWR|os.O_CREAT, 0o600)
     fcntl.lockf(lock_fd, fcntl.LOCK_EX)
-    if not os.path.exists(sf_path):
+
+    if not os.path.exists(socket_path):
         pid = do_fork()
         if pid == 0:
             rc = 0
             try:
-                server = Server(sf_path, pc)
+                server = Server(socket_path, pc)
             except AnsibleConnectionFailure as exc:
                 display.display('connecting to host %s returned an error' % pc.remote_addr, log_only=True)
                 display.display(str(exc), log_only=True)
@@ -318,50 +314,57 @@ def main():
             sys.exit(rc)
     else:
         display.display('re-using existing socket for %s@%s:%s' % (pc.remote_user, pc.remote_addr, pc.port), log_only=True)
+
     fcntl.lockf(lock_fd, fcntl.LOCK_UN)
     os.close(lock_fd)
+
+    timeout = pc.timeout
+    while bool(timeout):
+        if os.path.exists(socket_path):
+            display.vvvv('connected to local socket in %s' % (pc.timeout - timeout), pc.remote_addr)
+            break
+        time.sleep(1)
+        timeout -= 1
+    else:
+        raise AnsibleConnectionFailure('timeout waiting for local socket', pc.remote_addr)
 
     # now connect to the daemon process
     # FIXME: if the socket file existed but the daemonized process was killed,
     #        the connection will timeout here. Need to make this more resilient.
-    rc = 0
-    while rc == 0:
+    while True:
         data = stdin.readline()
         if data == b'':
             break
         if data.strip() == b'':
             continue
-        sf = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        attempts = 1
-        while True:
+
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+
+        attempts = C.PERSISTENT_CONNECT_RETRIES
+        while bool(attempts):
             try:
-                sf.connect(sf_path)
+                sock.connect(socket_path)
                 break
             except socket.error:
-                # FIXME: better error handling/logging/message here
                 time.sleep(C.PERSISTENT_CONNECT_INTERVAL)
-                attempts += 1
-                if attempts > C.PERSISTENT_CONNECT_RETRIES:
-                    display.display('number of connection attempts exceeded, unable to connect to control socket', pc.remote_addr, pc.remote_user, log_only=True)
-                    display.display('persistent_connect_interval=%s, persistent_connect_retries=%s' % (C.PERSISTENT_CONNECT_INTERVAL, C.PERSISTENT_CONNECT_RETRIES), pc.remote_addr, pc.remote_user, log_only=True)
-                    sys.stderr.write('failed to connect to control socket')
-                    sys.exit(255)
+                attempts -= 1
+        else:
+            display.display('number of connection attempts exceeded, unable to connect to control socket', pc.remote_addr, pc.remote_user, log_only=True)
+            display.display('persistent_connect_interval=%s, persistent_connect_retries=%s' % (C.PERSISTENT_CONNECT_INTERVAL, C.PERSISTENT_CONNECT_RETRIES), pc.remote_addr, pc.remote_user, log_only=True)
+            sys.stderr.write('failed to connect to control socket')
+            sys.exit(255)
 
         # send the play_context back into the connection so the connection
         # can handle any privilege escalation activities
         pc_data = b'CONTEXT: %s' % init_data
-        send_data(sf, pc_data)
+        communicate(sock, pc_data)
 
-        send_data(sf, data.strip())
-
-        rc = int(recv_data(sf), 10)
-        stdout = recv_data(sf)
-        stderr = recv_data(sf)
+        rc, stdout, stderr = communicate(sock, data.strip())
 
         sys.stdout.write(to_native(stdout))
         sys.stderr.write(to_native(stderr))
 
-        sf.close()
+        sock.close()
         break
 
     sys.exit(rc)

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -394,7 +394,7 @@ PARAMIKO_LOOK_FOR_KEYS = get_config(p, 'paramiko_connection', 'look_for_keys', '
 PERSISTENT_CONNECT_TIMEOUT = get_config(p, 'persistent_connection', 'connect_timeout', 'ANSIBLE_PERSISTENT_CONNECT_TIMEOUT', 30, value_type='integer')
 PERSISTENT_CONNECT_RETRIES = get_config(p, 'persistent_connection', 'connect_retries', 'ANSIBLE_PERSISTENT_CONNECT_RETRIES', 30, value_type='integer')
 PERSISTENT_CONNECT_INTERVAL = get_config(p, 'persistent_connection', 'connect_interval', 'ANSIBLE_PERSISTENT_CONNECT_INTERVAL', 1, value_type='integer')
-PERSISTENT_CONTROL_PATH_DIR    = get_config(p, 'persistent_connection', 'control_path_dir', 'ANSIBLE_PERSISTENT_CONTROL_PATH_DIR', u'~/.ansible/pc')
+PERSISTENT_CONTROL_PATH_DIR = get_config(p, 'persistent_connection', 'control_path_dir', 'ANSIBLE_PERSISTENT_CONTROL_PATH_DIR', u'~/.ansible/pc')
 
 # obsolete -- will be formally removed
 ACCELERATE_PORT = get_config(p, 'accelerate', 'accelerate_port', 'ACCELERATE_PORT', 5099, value_type='integer')

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -394,6 +394,7 @@ PARAMIKO_LOOK_FOR_KEYS = get_config(p, 'paramiko_connection', 'look_for_keys', '
 PERSISTENT_CONNECT_TIMEOUT = get_config(p, 'persistent_connection', 'connect_timeout', 'ANSIBLE_PERSISTENT_CONNECT_TIMEOUT', 30, value_type='integer')
 PERSISTENT_CONNECT_RETRIES = get_config(p, 'persistent_connection', 'connect_retries', 'ANSIBLE_PERSISTENT_CONNECT_RETRIES', 30, value_type='integer')
 PERSISTENT_CONNECT_INTERVAL = get_config(p, 'persistent_connection', 'connect_interval', 'ANSIBLE_PERSISTENT_CONNECT_INTERVAL', 1, value_type='integer')
+PERSISTENT_CONTROL_PATH_DIR    = get_config(p, 'persistent_connection', 'control_path_dir', 'ANSIBLE_PERSISTENT_CONTROL_PATH_DIR', u'~/.ansible/pc')
 
 # obsolete -- will be formally removed
 ACCELERATE_PORT = get_config(p, 'accelerate', 'accelerate_port', 'ACCELERATE_PORT', 5099, value_type='integer')

--- a/lib/ansible/plugins/action/dellos10.py
+++ b/lib/ansible/plugins/action/dellos10.py
@@ -25,6 +25,7 @@ import os
 import sys
 import copy
 
+from ansible import constants as C
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.utils.path import unfrackpath
 from ansible.plugins import connection_loader
@@ -72,13 +73,13 @@ class ActionModule(_ActionModule):
 
         if not os.path.exists(socket_path):
             # start the connection if it isn't started
-            rc, out, err = connection.exec_command('open_shell()')
-            display.vvvv('open_shell() returned %s %s %s' % (rc, out, err))
-            if not rc == 0:
+            socket_path = connection.run()
+            if not socket_path:
                 return {'failed': True,
                         'msg': 'unable to open shell. Please see: ' +
-                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
-                        'rc': rc}
+                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
+
+                display.vvvv('connected to socket in %s' % socket_path, pc.remote_addr)
         else:
             # make sure we are in the right cli context which should be
             # enable mode and not config module
@@ -100,7 +101,7 @@ class ActionModule(_ActionModule):
     def _get_socket_path(self, play_context):
         ssh = connection_loader.get('ssh', class_only=True)
         cp = ssh._create_control_path(play_context.remote_addr, play_context.port, play_context.remote_user)
-        path = unfrackpath("$HOME/.ansible/pc")
+        path = unfrackpath(C.PERSISTENT_CONTROL_PATH_DIR)
         return cp % dict(directory=path)
 
     def load_provider(self):

--- a/lib/ansible/plugins/action/dellos6.py
+++ b/lib/ansible/plugins/action/dellos6.py
@@ -22,6 +22,7 @@ import os
 import sys
 import copy
 
+from ansible import constants as C
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.utils.path import unfrackpath
 from ansible.plugins import connection_loader
@@ -68,13 +69,13 @@ class ActionModule(_ActionModule):
 
         if not os.path.exists(socket_path):
             # start the connection if it isn't started
-            rc, out, err = connection.exec_command('open_shell()')
-            display.vvvv('open_shell() returned %s %s %s' % (rc, out, err))
-            if not rc == 0:
+            socket_path = connection.run()
+            if not socket_path:
                 return {'failed': True,
                         'msg': 'unable to open shell. Please see: ' +
-                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
-                        'rc': rc}
+                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
+
+                display.vvvv('connected to socket in %s' % socket_path, pc.remote_addr)
         else:
             # make sure we are in the right cli context which should be
             # enable mode and not config module
@@ -96,7 +97,7 @@ class ActionModule(_ActionModule):
     def _get_socket_path(self, play_context):
         ssh = connection_loader.get('ssh', class_only=True)
         cp = ssh._create_control_path(play_context.remote_addr, play_context.port, play_context.remote_user)
-        path = unfrackpath("$HOME/.ansible/pc")
+        path = unfrackpath(C.PERSISTENT_CONTROL_PATH_DIR)
         return cp % dict(directory=path)
 
     def load_provider(self):

--- a/lib/ansible/plugins/action/dellos9.py
+++ b/lib/ansible/plugins/action/dellos9.py
@@ -25,6 +25,7 @@ import os
 import sys
 import copy
 
+from ansible import constants as C
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.utils.path import unfrackpath
 from ansible.plugins import connection_loader
@@ -72,13 +73,13 @@ class ActionModule(_ActionModule):
 
         if not os.path.exists(socket_path):
             # start the connection if it isn't started
-            rc, out, err = connection.exec_command('open_shell()')
-            display.vvvv('open_shell() returned %s %s %s' % (rc, out, err))
-            if not rc == 0:
+            socket_path = connection.run()
+            if not socket_path:
                 return {'failed': True,
                         'msg': 'unable to open shell. Please see: ' +
-                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
-                        'rc': rc}
+                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
+
+                display.vvvv('connected to socket in %s' % socket_path, pc.remote_addr)
         else:
             # make sure we are in the right cli context which should be
             # enable mode and not config module
@@ -100,7 +101,7 @@ class ActionModule(_ActionModule):
     def _get_socket_path(self, play_context):
         ssh = connection_loader.get('ssh', class_only=True)
         cp = ssh._create_control_path(play_context.remote_addr, play_context.port, play_context.remote_user)
-        path = unfrackpath("$HOME/.ansible/pc")
+        path = unfrackpath(C.PERSISTENT_CONTROL_PATH_DIR)
         return cp % dict(directory=path)
 
     def load_provider(self):

--- a/lib/ansible/plugins/action/ios.py
+++ b/lib/ansible/plugins/action/ios.py
@@ -23,6 +23,7 @@ import os
 import sys
 import copy
 
+from ansible import constants as C
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.utils.path import unfrackpath
 from ansible.plugins import connection_loader
@@ -71,13 +72,13 @@ class ActionModule(_ActionModule):
 
         if not os.path.exists(socket_path):
             # start the connection if it isn't started
-            rc, out, err = connection.exec_command('open_shell()')
-            display.vvvv('open_shell() returned %s %s %s' % (rc, out, err))
-            if not rc == 0:
+            socket_path = connection.run()
+            if not socket_path:
                 return {'failed': True,
                         'msg': 'unable to open shell. Please see: ' +
-                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
-                        'rc': rc}
+                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
+
+                display.vvvv('connected to socket in %s' % socket_path, pc.remote_addr)
         else:
             # make sure we are in the right cli context which should be
             # enable mode and not config module
@@ -98,7 +99,7 @@ class ActionModule(_ActionModule):
     def _get_socket_path(self, play_context):
         ssh = connection_loader.get('ssh', class_only=True)
         cp = ssh._create_control_path(play_context.remote_addr, play_context.port, play_context.remote_user)
-        path = unfrackpath("$HOME/.ansible/pc")
+        path = unfrackpath(C.PERSISTENT_CONTROL_PATH_DIR)
         return cp % dict(directory=path)
 
     def load_provider(self):

--- a/lib/ansible/plugins/action/iosxr.py
+++ b/lib/ansible/plugins/action/iosxr.py
@@ -23,10 +23,10 @@ import os
 import sys
 import copy
 
+from ansible import constants as C
 from ansible.module_utils.basic import AnsibleFallbackNotFound
 from ansible.module_utils.iosxr import iosxr_argument_spec
 from ansible.module_utils.six import iteritems
-from ansible.module_utils._text import to_bytes
 from ansible.plugins import connection_loader
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.utils.path import unfrackpath
@@ -68,13 +68,13 @@ class ActionModule(_ActionModule):
 
         if not os.path.exists(socket_path):
             # start the connection if it isn't started
-            rc, out, err = connection.exec_command('open_shell()')
-            display.vvvv('open_shell() returned %s %s %s' % (rc, out, err))
-            if rc != 0:
+            socket_path = connection.run()
+            if not socket_path:
                 return {'failed': True,
                         'msg': 'unable to open shell. Please see: ' +
-                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
-                        'rc': rc}
+                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
+
+                display.vvvv('connected to socket in %s' % socket_path, pc.remote_addr)
         else:
             # make sure we are in the right cli context which should be
             # enable mode and not config module
@@ -92,7 +92,7 @@ class ActionModule(_ActionModule):
     def _get_socket_path(self, play_context):
         ssh = connection_loader.get('ssh', class_only=True)
         cp = ssh._create_control_path(play_context.remote_addr, play_context.port, play_context.remote_user)
-        path = unfrackpath("$HOME/.ansible/pc")
+        path = unfrackpath(C.PERSISTENT_CONTROL_PATH_DIR)
         return cp % dict(directory=path)
 
     def load_provider(self):

--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -81,22 +81,13 @@ class ActionModule(_ActionModule):
 
         if not os.path.exists(socket_path):
             # start the connection if it isn't started
-            if pc.connection == 'netconf':
-                rc, out, err = connection.exec_command('open_session()')
-                display.vvvv('open_session() returned %s %s %s' % (rc, out, err))
-                if rc != 0:
-                    return {'failed': True,
-                            'msg': 'unable to open shell. Please see: ' +
-                                   'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
-                            'rc': rc}
-            else:
-                socket_path = connection.run()
-                if not socket_path:
-                    return {'failed': True,
-                            'msg': 'unable to open shell. Please see: ' +
-                                   'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
+            socket_path = connection.run()
+            if not socket_path:
+                return {'failed': True,
+                        'msg': 'unable to open shell. Please see: ' +
+                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
 
-                    display.vvvv('connected to socket in %s' % socket_path, pc.remote_addr)
+                display.vvvv('connected to socket in %s' % socket_path, pc.remote_addr)
         elif pc.connection == 'network_cli':
             # make sure we are in the right cli context which should be
             # enable mode and not config module

--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -23,6 +23,7 @@ import os
 import sys
 import copy
 
+from ansible import constants as C
 from ansible.module_utils.basic import AnsibleFallbackNotFound
 from ansible.module_utils.junos import junos_argument_spec
 from ansible.module_utils.six import iteritems
@@ -83,16 +84,19 @@ class ActionModule(_ActionModule):
             if pc.connection == 'netconf':
                 rc, out, err = connection.exec_command('open_session()')
                 display.vvvv('open_session() returned %s %s %s' % (rc, out, err))
+                if rc != 0:
+                    return {'failed': True,
+                            'msg': 'unable to open shell. Please see: ' +
+                                   'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
+                            'rc': rc}
             else:
-                rc, out, err = connection.exec_command('open_shell()')
-                display.vvvv('open_shell() returned %s %s %s' % (rc, out, err))
+                socket_path = connection.run()
+                if not socket_path:
+                    return {'failed': True,
+                            'msg': 'unable to open shell. Please see: ' +
+                                   'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
 
-            if rc != 0:
-                return {'failed': True,
-                        'msg': 'unable to open shell. Please see: ' +
-                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
-                        'rc': rc}
-
+                    display.vvvv('connected to socket in %s' % socket_path, pc.remote_addr)
         elif pc.connection == 'network_cli':
             # make sure we are in the right cli context which should be
             # enable mode and not config module
@@ -109,7 +113,7 @@ class ActionModule(_ActionModule):
 
     def _get_socket_path(self, play_context):
         ssh = connection_loader.get('ssh', class_only=True)
-        path = unfrackpath("$HOME/.ansible/pc")
+        path = unfrackpath(C.PERSISTENT_CONTROL_PATH_DIR)
         # use play_context.connection instea of play_context.port to avoid
         # collision if netconf is listening on port 22
         #cp = ssh._create_control_path(play_context.remote_addr, play_context.connection, play_context.remote_user)

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -23,13 +23,13 @@ import os
 import sys
 import copy
 
+from ansible import constants as C
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.utils.path import unfrackpath
 from ansible.plugins import connection_loader
 from ansible.module_utils.basic import AnsibleFallbackNotFound
 from ansible.module_utils.nxos import nxos_argument_spec
 from ansible.module_utils.six import iteritems
-from ansible.module_utils._text import to_bytes
 
 try:
     from __main__ import display
@@ -78,13 +78,13 @@ class ActionModule(_ActionModule):
 
             if not os.path.exists(socket_path):
                 # start the connection if it isn't started
-                rc, out, err = connection.exec_command('open_shell()')
-                display.vvvv('open_shell() returned %s %s %s' % (rc, out, err))
-                if rc != 0:
+                socket_path = connection.run()
+                if not socket_path:
                     return {'failed': True,
                             'msg': 'unable to open shell. Please see: ' +
-                            'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
-                            'rc': rc}
+                                   'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
+
+                    display.vvvv('connected to socket in %s' % socket_path, pc.remote_addr)
             else:
                 # make sure we are in the right cli context which should be
                 # enable mode and not config module
@@ -129,7 +129,7 @@ class ActionModule(_ActionModule):
     def _get_socket_path(self, play_context):
         ssh = connection_loader.get('ssh', class_only=True)
         cp = ssh._create_control_path(play_context.remote_addr, play_context.port, play_context.remote_user)
-        path = unfrackpath("$HOME/.ansible/pc")
+        path = unfrackpath(C.PERSISTENT_CONTROL_PATH_DIR)
         return cp % dict(directory=path)
 
     def load_provider(self):

--- a/lib/ansible/plugins/action/sros.py
+++ b/lib/ansible/plugins/action/sros.py
@@ -23,13 +23,13 @@ import os
 import sys
 import copy
 
+from ansible import constants as C
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.utils.path import unfrackpath
 from ansible.plugins import connection_loader
 from ansible.module_utils.sros import sros_argument_spec
 from ansible.module_utils.basic import AnsibleFallbackNotFound
 from ansible.module_utils.six import iteritems
-from ansible.module_utils._text import to_bytes
 
 try:
     from __main__ import display
@@ -69,13 +69,13 @@ class ActionModule(_ActionModule):
 
         if not os.path.exists(socket_path):
             # start the connection if it isn't started
-            rc, out, err = connection.exec_command('open_shell()')
-            display.vvvv('open_shell() returned %s %s %s' % (rc, out, err))
-            if not rc == 0:
+            socket_path = connection.run()
+            if not socket_path:
                 return {'failed': True,
                         'msg': 'unable to open shell. Please see: ' +
-                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
-                        'rc': rc}
+                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
+
+                display.vvvv('connected to socket in %s' % socket_path, pc.remote_addr)
 
         task_vars['ansible_socket'] = socket_path
 
@@ -85,7 +85,7 @@ class ActionModule(_ActionModule):
     def _get_socket_path(self, play_context):
         ssh = connection_loader.get('ssh', class_only=True)
         cp = ssh._create_control_path(play_context.remote_addr, play_context.port, play_context.remote_user)
-        path = unfrackpath("$HOME/.ansible/pc")
+        path = unfrackpath(C.PERSISTENT_CONTROL_PATH_DIR)
         return cp % dict(directory=path)
 
     def load_provider(self):

--- a/lib/ansible/plugins/action/vyos.py
+++ b/lib/ansible/plugins/action/vyos.py
@@ -23,6 +23,7 @@ import os
 import sys
 import copy
 
+from ansible import constants as C
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.utils.path import unfrackpath
 from ansible.plugins import connection_loader
@@ -68,13 +69,13 @@ class ActionModule(_ActionModule):
 
         if not os.path.exists(socket_path):
             # start the connection if it isn't started
-            rc, out, err = connection.exec_command('open_shell()')
-            display.vvvv('open_shell() returned %s %s %s' % (rc, out, err))
-            if not rc == 0:
+            socket_path = connection.run()
+            if not socket_path:
                 return {'failed': True,
                         'msg': 'unable to open shell. Please see: ' +
-                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell',
-                        'rc': rc}
+                               'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
+
+                display.vvvv('connected to socket in %s' % socket_path, pc.remote_addr)
         else:
             # make sure we are in the right cli context which should be
             # enable mode and not config module
@@ -92,7 +93,7 @@ class ActionModule(_ActionModule):
     def _get_socket_path(self, play_context):
         ssh = connection_loader.get('ssh', class_only=True)
         cp = ssh._create_control_path(play_context.remote_addr, play_context.port, play_context.remote_user)
-        path = unfrackpath("$HOME/.ansible/pc")
+        path = unfrackpath(C.PERSISTENT_CONTROL_PATH_DIR)
         return cp % dict(directory=path)
 
     def load_provider(self):

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -107,9 +107,6 @@ class Connection(ConnectionBase):
     def exec_command(self, request):
         """Sends the request to the node and returns the reply
         """
-        if request == 'open_session()':
-            return (0, 'ok', '')
-
         req = to_ele(request)
         if req is None:
             return (1, '', 'unable to parse request')

--- a/lib/ansible/plugins/connection/persistent.py
+++ b/lib/ansible/plugins/connection/persistent.py
@@ -1,4 +1,4 @@
-# (c) 2016 Red Hat Inc.
+# (c) 2017 Red Hat Inc.
 #
 # This file is part of Ansible
 #
@@ -41,7 +41,6 @@ class Connection(ConnectionBase):
     has_pipelining = False
 
     def _connect(self):
-
         self._connected = True
         return self
 
@@ -83,3 +82,7 @@ class Connection(ConnectionBase):
 
     def close(self):
         self._connected = False
+
+    def run(self):
+        rc, out, err = self._do_it('RUN:')
+        return out

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -919,7 +919,6 @@ test/units/plugins/action/test_raw.py
 test/units/plugins/action/test_synchronize.py
 test/units/plugins/connection/test_connection.py
 test/units/plugins/connection/test_netconf.py
-test/units/plugins/connection/test_network_cli.py
 test/units/plugins/connection/test_ssh.py
 test/units/plugins/lookup/test_ini.py
 test/units/plugins/lookup/test_password.py

--- a/test/units/plugins/connection/test_network_cli.py
+++ b/test/units/plugins/connection/test_network_cli.py
@@ -35,7 +35,8 @@ from ansible.plugins.connection import network_cli
 
 class TestConnectionClass(unittest.TestCase):
 
-    def test_network_cli__connect_error(self):
+    @patch("ansible.plugins.connection.network_cli._Connection._connect")
+    def test_network_cli__connect_error(self, mocked_super):
         pc = PlayContext()
         new_stdin = StringIO()
 
@@ -46,7 +47,8 @@ class TestConnectionClass(unittest.TestCase):
         pc.network_os = None
         self.assertRaises(AnsibleConnectionFailure, conn._connect)
 
-    def test_network_cli__invalid_os(self):
+    @patch("ansible.plugins.connection.network_cli._Connection._connect")
+    def test_network_cli__invalid_os(self, mocked_super):
         pc = PlayContext()
         new_stdin = StringIO()
 
@@ -104,7 +106,8 @@ class TestConnectionClass(unittest.TestCase):
         conn.close()
         self.assertIsNone(conn._shell)
 
-    def test_network_cli_exec_command(self):
+    @patch("ansible.plugins.connection.network_cli._Connection._connect")
+    def test_network_cli_exec_command(self, mocked_super):
         pc = PlayContext()
         new_stdin = StringIO()
         conn = network_cli.Connection(pc, new_stdin)

--- a/test/units/plugins/connection/test_network_cli.py
+++ b/test/units/plugins/connection/test_network_cli.py
@@ -35,6 +35,28 @@ from ansible.plugins.connection import network_cli
 
 class TestConnectionClass(unittest.TestCase):
 
+    def test_network_cli__connect_error(self):
+        pc = PlayContext()
+        new_stdin = StringIO()
+
+        conn = network_cli.Connection(pc, new_stdin)
+        conn.ssh = MagicMock()
+        conn.receive = MagicMock()
+        conn._terminal = MagicMock()
+        pc.network_os = None
+        self.assertRaises(AnsibleConnectionFailure, conn._connect)
+
+    def test_network_cli__invalid_os(self):
+        pc = PlayContext()
+        new_stdin = StringIO()
+
+        conn = network_cli.Connection(pc, new_stdin)
+        conn.ssh = MagicMock()
+        conn.receive = MagicMock()
+        conn._terminal = MagicMock()
+        pc.network_os = None
+        self.assertRaises(AnsibleConnectionFailure, conn._connect)
+
     @patch("ansible.plugins.connection.network_cli.terminal_loader")
     @patch("ansible.plugins.connection.network_cli._Connection._connect")
     def test_network_cli__connect(self, mocked_super, mocked_terminal_loader):
@@ -42,27 +64,7 @@ class TestConnectionClass(unittest.TestCase):
         new_stdin = StringIO()
 
         conn = network_cli.Connection(pc, new_stdin)
-        conn.ssh = None
-
-        self.assertRaises(AnsibleConnectionFailure, conn._connect)
-
-        mocked_terminal_loader.reset_mock()
-        mocked_terminal_loader.get.return_value = None
-
-        pc.network_os = 'invalid'
-        self.assertRaises(AnsibleConnectionFailure, conn._connect)
-        self.assertFalse(mocked_terminal_loader.all.called)
-
-        mocked_terminal_loader.reset_mock()
-        mocked_terminal_loader.get.return_value = 'valid'
-
-        conn._connect()
-        self.assertEqual(conn._terminal, 'valid')
-
-    def test_network_cli_open_shell(self):
-        pc = PlayContext()
-        new_stdin = StringIO()
-        conn = network_cli.Connection(pc, new_stdin)
+        pc.network_os = 'ios'
 
         conn.ssh = MagicMock()
         conn.receive = MagicMock()
@@ -70,26 +72,19 @@ class TestConnectionClass(unittest.TestCase):
         mock_terminal = MagicMock()
         conn._terminal = mock_terminal
 
-        mock__connect = MagicMock()
-        conn._connect = mock__connect
-
-        conn.open_shell()
-
-        self.assertTrue(mock__connect.called)
-        self.assertTrue(mock_terminal.on_open_shell.called)
-        self.assertFalse(mock_terminal.on_authorize.called)
-
-        mock_terminal.reset_mock()
+        conn._connect()
+        self.assertTrue(conn._terminal.on_open_shell.called)
+        self.assertFalse(conn._terminal.on_authorize.called)
 
         conn._play_context.become = True
         conn._play_context.become_pass = 'password'
 
-        conn.open_shell()
+        conn._connect()
 
-        self.assertTrue(mock__connect.called)
-        mock_terminal.on_authorize.assert_called_with(passwd='password')
+        conn._terminal.on_authorize.assert_called_with(passwd='password')
 
-    def test_network_cli_close_shell(self):
+    @patch("ansible.plugins.connection.network_cli._Connection.close")
+    def test_network_cli_close(self, mocked_super):
         pc = PlayContext()
         new_stdin = StringIO()
         conn = network_cli.Connection(pc, new_stdin)
@@ -97,16 +92,16 @@ class TestConnectionClass(unittest.TestCase):
         terminal = MagicMock(supports_multiplexing=False)
         conn._terminal = terminal
 
-        conn.close_shell()
+        conn.close()
 
         conn._shell = MagicMock()
 
-        conn.close_shell()
+        conn.close()
         self.assertTrue(terminal.on_close_shell.called)
 
         terminal.supports_multiplexing = True
 
-        conn.close_shell()
+        conn.close()
         self.assertIsNone(conn._shell)
 
     def test_network_cli_exec_command(self):
@@ -114,35 +109,25 @@ class TestConnectionClass(unittest.TestCase):
         new_stdin = StringIO()
         conn = network_cli.Connection(pc, new_stdin)
 
-        mock_open_shell = MagicMock()
-        conn.open_shell = mock_open_shell
-
         mock_send = MagicMock(return_value=b'command response')
         conn.send = mock_send
 
         # test sending a single command and converting to dict
         rc, out, err = conn.exec_command('command')
         self.assertEqual(out, b'command response')
-        self.assertTrue(mock_open_shell.called)
         mock_send.assert_called_with({'command': b'command'})
-
-        mock_open_shell.reset_mock()
 
         # test sending a json string
         rc, out, err = conn.exec_command(json.dumps({'command': 'command'}))
         self.assertEqual(out, b'command response')
         mock_send.assert_called_with({'command': b'command'})
-        self.assertTrue(mock_open_shell.called)
 
-        mock_open_shell.reset_mock()
         conn._shell = MagicMock()
 
         # test _shell already open
         rc, out, err = conn.exec_command('command')
         self.assertEqual(out, b'command response')
-        self.assertFalse(mock_open_shell.called)
         mock_send.assert_called_with({'command': b'command'})
-
 
     def test_network_cli_send(self):
         pc = PlayContext()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* Refactor `ansible-connection` to remove the dependency, of invoking a dummy command `open_shell` to start `ansible-connection` and other refactor.
* related action plugin changes 
* related network_cli changes

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bin/ansible-connection
plugins/action/dellos10.py
plugins/action/dellos6.py
plugins/action/dellos9.py
plugins/action/eos
plugins/action/ios
plugins/action/iosxr
plugins/action/nxos
plugins/action/junos
plugins/action/sros
plugins/action/vyos
plugins/connection/network_cli
plugins/connection/persistent

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```