### PR TITLE
Add Cloudlinux support for hostname.py

### DIFF
--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -647,6 +647,16 @@ class CentOSLinuxHostname(Hostname):
     distribution = 'Centos linux'
     strategy_class = RedHatStrategy
 
+class CloudlinuxHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Cloudlinux'
+    strategy_class = RedHatStrategy
+
+class CloudlinuxServerHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Cloudlinux server'
+    strategy_class = RedHatStrategy
+
 class ScientificHostname(Hostname):
     platform = 'Linux'
     distribution = 'Scientific'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add Cloudlinux 6 and Cloudlinux 7 support for hostname module
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/system/hostname.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```
