### PR TITLE
TaskQueueManager: cooerce options.module_path list to string where applicable

### DIFF
--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -86,7 +86,10 @@ class TaskQueueManager:
         # make sure the module path (if specified) is parsed and
         # added to the module_loader object
         if options.module_path is not None:
-            for path in options.module_path.split(os.pathsep):
+            module_paths = options.module_path
+            if isinstance(module_paths, list):
+                module_paths = os.pathsep.join(module_paths)
+            for path in module_paths.split(os.pathsep):
                 module_loader.add_directory(path)
 
         # a special flag to help us exit cleanly


### PR DESCRIPTION
##### SUMMARY
W/ recent 2.4 changes when using the TaskQueueManager directly the following AttributeError occurs:

```
        if options.module_path is not None:
>           for path in options.module_path.split(os.pathsep):
E           AttributeError: 'list' object has no attribute 'split'

ansible/lib/ansible/executor/task_queue_manager.py:89: AttributeError
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> entering PDB >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
> ansible/executor/task_queue_manager.py(89)__init__()
-> for path in options.module_path.split(os.pathsep):
(Pdb) l
 84              self._start_at_done    = False
 85
 86              # make sure the module path (if specified) is parsed and
 87              # added to the module_loader object
 88              if options.module_path is not None:
 89  ->                for path in options.module_path.split(os.pathsep):
 90                      module_loader.add_directory(path)
 91
 92              # a special flag to help us exit cleanly
 93              self._terminated = False
 94
(Pdb) options.module_path
[u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
```

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
ansible.executor.task_queue_manager.TaskQueueManager

##### ANSIBLE VERSION
```
# ansible --version
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```
