### PR TITLE
unarchive module to zip archive with exclude option does not work correctly

### DIFF
--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -278,7 +278,7 @@ class ZipArchive(object):
     def is_unarchived(self):
         cmd = [ self.cmd_path, '-ZT', '-s', self.src ]
         if self.excludes:
-            cmd.extend([ ' -x ', ] + self.excludes)
+            cmd.extend([ '-x' ] + self.excludes)
         rc, out, err = self.module.run_command(cmd)
 
         old_out = out


### PR DESCRIPTION
##### SUMMARY
unarchive module to zip archive with exclude option does not work correctly.
For example, task described bellow always reports changed=True.

```
- unarchive:
    src:  apache-tomcat-8.5.15.zip
    dest: /tmp
    exclude:
      - apache-tomcat-8.5.15/webapps/examples
```

and next example report fails.

```
    - unarchive:
        src:   apache-tomcat-8.5.15.zip
        dest:  /tmp
        exclude:
          - apache-tomcat-8.5.15/webapps/ROOT/index.jsp
```

```
fatal: [localhost]: FAILED! => {"changed": false, "check_results": {"cmd": ["/usr/bin/unzip", "-ZT", "-s", "/root/.ansible/tmp/ansible-tmp-1495755207.8-78580815873129/source", " -x ", "apache-tomcat-8.5.15/webapps/ROOT/index.jsp"], "diff": "", "err": "caution: filename not matched:   -x \n", "out": "Path apache-tomcat-8.5.15/webapps/ROOT/index.jsp is excluded on request\n", "rc": 0, "unarchived": true}, "dest": "/tmp", "failed": true, "gid": 0, "group": "root", "handler": "ZipArchive", "mode": "01777", "msg": "Unexpected error when accessing exploded file: [Errno 2] No such file or directory: '/tmp/apache-tomcat-8.5.15/'", "owner": "root", "size": 4096, "src": "/root/.ansible/tmp/ansible-tmp-1495755207.8-78580815873129/source", "state": "directory", "uid": 0}
        to retry, use: --limit @/home/vagrant/test/test.retry
```

The reason is an argument passed to unzip command in ZipArchive.is_unarchived method is incorrect.
This PR fixes argument.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
unarchive

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```

