### PR TITLE
Check sysctl no name

### DIFF
--- a/test/integration/targets/sysctl/tasks/main.yml
+++ b/test/integration/targets/sysctl/tasks/main.yml
@@ -89,3 +89,16 @@
           - 'sysctl_test2.changed is defined'
           - 'sysctl_test2.changed'
           - 'sysctl_check2.stdout_lines == ["net.ipv4.ip_forward = 1"]'
+
+- name: Try sysctl with no name
+  sysctl:
+    name:
+    value: 1
+    sysctl_set: yes
+  ignore_errors: True
+  register: sysctl_no_name
+
+- name: validate nameless results
+  assert:
+    that:
+    - "sysctl_no_name|failed"

--- a/test/integration/targets/sysctl/tasks/main.yml
+++ b/test/integration/targets/sysctl/tasks/main.yml
@@ -102,3 +102,18 @@
   assert:
     that:
     - "sysctl_no_name|failed"
+    - "sysctl_no_name.msg == 'name can not be None'"
+
+- name: Try sysctl with no value
+  sysctl:
+    name: Foo
+    value:
+    sysctl_set: yes
+  ignore_errors: True
+  register: sysctl_no_value
+
+- name: validate nameless results
+  assert:
+    that:
+    - "sysctl_no_value|failed"
+    - "sysctl_no_value.msg == 'value can not be None'"


### PR DESCRIPTION
##### SUMMARY
adds integration test to check for None value for name/value in sysctl module
fixes #25035 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
sysctl
##### ANSIBLE VERSION
93ddfeb98ae97305b5b47a5cc735e6e12e198b58


##### ADDITIONAL INFORMATION
