### PR TITLE
Openssl privatekey tests

### DIFF
--- a/test/integration/targets/openssl_privatekey/aliases
+++ b/test/integration/targets/openssl_privatekey/aliases
@@ -1,0 +1,1 @@
+posix/ci/group2

--- a/test/integration/targets/openssl_privatekey/tasks/main.yaml
+++ b/test/integration/targets/openssl_privatekey/tasks/main.yaml
@@ -23,10 +23,20 @@
     path: "{{output_file}}"
   register: privatekey_result
 
-- name: assert openssl_privatekey works  
+- name: assert openssl_privatekey works
   assert:
     that:
     - "privatekey_result.changed == true"
+
+- name: check privatekey file permissions
+  stat: path={{output_file}}
+  register: privatekey_stat
+
+- name: assert openssl_privatekey permissions
+  assert:
+    that:
+    - "privatekey_stat.stat.exists == true"
+    - "privatekey_stat.stat.mode == '0600'"
 
 - name: test openssl_privatekey already exists
   openssl_privatekey:
@@ -37,3 +47,53 @@
   assert:
     that:
     - "privatekey_exists_result.changed == false"
+
+- name: test openssl_privatekey force
+  openssl_privatekey:
+    path: "{{output_file}}"
+    force: true
+  register: privatekey_force_result
+
+- name: assert openssl_privatekey force overwrites existing keys
+  assert:
+    that:
+    - "privatekey_force_result.changed == true"
+
+- name: test openssl_privatekey state
+  openssl_privatekey:
+    path: "{{output_file}}"
+    state: "absent"
+  register: privatekey_state_result
+
+- name: check that privatekey file is absent
+  stat: path={{output_file}}
+  register: privatekey_absent_stat
+
+- name: assert openssl_privatekey absent state
+  assert:
+    that:
+    - "not privatekey_absent_stat.stat.exists"
+
+- name: test openssl_privatekey size
+  openssl_privatekey:
+    path: "{{output_file}}"
+    state: "absent"
+    size: 8192
+  register: privatekey_size_result
+
+- name: assert openssl_privatekey size
+  assert:
+    that:
+    - "privatekey_size_result.size == 8192"
+
+- name: test openssl_privatekey type
+  openssl_privatekey:
+    path: "{{output_file}}"
+    state: "absent"
+    type: "DSA"
+  register: privatekey_type_result
+
+- name: assert openssl_privatekey type
+  assert:
+    that:
+    - "privatekey_type_result.type == 'DSA'"

--- a/test/integration/targets/openssl_privatekey/tasks/main.yaml
+++ b/test/integration/targets/openssl_privatekey/tasks/main.yaml
@@ -1,0 +1,39 @@
+# test code for the openssl_privatekey
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- name: record the output file
+  set_fact: output_file={{output_dir}}/foo.key
+
+- name: test openssl_privatekey
+  openssl_privatekey:
+    path: "{{output_file}}"
+  register: privatekey_result
+
+- name: assert openssl_privatekey works  
+  assert:
+    that:
+    - "privatekey_result.changed == true"
+
+- name: test openssl_privatekey already exists
+  openssl_privatekey:
+    path: "{{output_file}}"
+  register: privatekey_exists_result
+
+- name: assert openssl_privatekey does not overwrite existing keys
+  assert:
+    that:
+    - "privatekey_exists_result.changed == false"

--- a/test/runner/requirements/integration.txt
+++ b/test/runner/requirements/integration.txt
@@ -6,4 +6,5 @@ paramiko
 passlib
 pexpect
 pycrypto
+pyOpenSSL
 pyyaml


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add integration tests for openssl_privatekey
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
openssl_privatekey
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (openssl_privatekey_tests 59dabd1ee8) last updated 2017/05/25 12:45:48 (GMT -700)
  config file =
  configured module search path = ['/Users/kevinj/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kevinj/pycon_stash/ansible/lib/ansible
  executable location = /Users/kevinj/pycon_stash/ansible/bin/ansible
  python version = 3.6.1 (default, Apr  4 2017, 09:40:21) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
