### PR TITLE
Added autoclean/autoremove for the apt module

### DIFF
--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -160,3 +160,12 @@
     that:
         - "not apt_result.changed"
         - "apt_result.failed"
+
+- name: autoclean during install
+  apt: pkg=hello state=present autoclean=yes
+
+- name: autoclean
+  apt: autoclean=yes
+
+- name: autoremove
+  apt: autoremove=yes


### PR DESCRIPTION
##### SUMMARY
- Removed alias autoclean from autoremove.
- Added independent execution of apt-get autoclean/autoremove
- Continued to support --auto-remove as a flag to install/remove

Fixes #22222 #24718

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
apt

##### ANSIBLE VERSION
devel