### PR TITLE
Fix synchronize setting user variable

### DIFF
--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -311,17 +311,10 @@ class ActionModule(ActionBase):
             return dict(failed=True,
                     msg="synchronize requires both src and dest parameters are set")
 
+        # Determine if we need a user@
+        user = None
         if not dest_is_local:
-            # Private key handling
-            private_key = self._play_context.private_key_file
-
-            if private_key is not None:
-                private_key = os.path.expanduser(private_key)
-                _tmp_args['private_key'] = private_key
-
             # Src and dest rsync "path" handling
-            # Determine if we need a user@
-            user = None
             if boolean(_tmp_args.get('set_remote_user', 'yes')):
                 if use_delegate:
                     user = task_vars.get('ansible_delegated_vars', dict()).get('ansible_ssh_user', None)
@@ -330,6 +323,13 @@ class ActionModule(ActionBase):
 
                 else:
                     user = task_vars.get('ansible_ssh_user') or self._play_context.remote_user
+
+            # Private key handling
+            private_key = self._play_context.private_key_file
+
+            if private_key is not None:
+                private_key = os.path.expanduser(private_key)
+                _tmp_args['private_key'] = private_key
 
             # use the mode to define src and dest's url
             if _tmp_args.get('mode', 'push') == 'pull':


### PR DESCRIPTION
The user variable stores whether we need to set user@ in our connection
string.  It's now being used at the toplevel of the run() method so the
default needs to be calculated further up the stack

Fixes #24910

##### SUMMARY
Set the user default for the synchronize plugin at a level that will be picked up when the docker connection plugin is used.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
synchronize.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.3
```


##### ADDITIONAL INFORMATION
This is a regression in 2.3.0 and should be cerry-picked to stable-2.3