### PR TITLE
Correcting YAML identation

### DIFF
--- a/docs/docsite/rst/guide_azure.rst
+++ b/docs/docsite/rst/guide_azure.rst
@@ -156,7 +156,7 @@ azure_rm_virtualmachine module at the end:
         name: publicip001
 
     - name: Create security group that allows SSH
-        azure_rm_securitygroup:
+      azure_rm_securitygroup:
         resource_group: Testing
         name: secgroup001
         rules:


### PR DESCRIPTION
##### SUMMARY
With the published example for using Azure Resource Manager modules, the indentation appears to throw a YAML syntax error when parsing the network security group section:

```
ERROR! Syntax Error while loading YAML.

The error appears to have been in '/home/azureuser/azure_create_complete_vm.yml': line 22, column 29, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

  - name: Create Network Security Group that allows SSH
      azure_rm_securitygroup:
                            ^ here
```

Adjusting indentation to the proposed allows the YAML parsing to complete successfully and the task to run correctly.

##### ISSUE TYPE
 - Docs Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```
