### PR TITLE
Use wait_timeout as integer in redshift module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/redshift.py
+++ b/lib/ansible/modules/cloud/amazon/redshift.py
@@ -434,7 +434,7 @@ def main():
         elastic_ip                          = dict(required=False),
         new_cluster_identifier              = dict(aliases=['new_identifier']),
         wait                                = dict(type='bool', default=False),
-        wait_timeout                        = dict(default=300),
+        wait_timeout                        = dict(type='int', default=300),
     )
     )
 


### PR DESCRIPTION

##### SUMMARY
Fix stricts datatype of wait_timeout to int as module
is using it as integer.

Fixes #25056

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/redshift.py

##### ANSIBLE VERSION
```
stable-2.3
```