### PR TITLE
win_timezone: Added tests for module and updated sections of docs

### DIFF
--- a/lib/ansible/modules/windows/win_timezone.py
+++ b/lib/ansible/modules/windows/win_timezone.py
@@ -32,21 +32,21 @@ module: win_timezone
 version_added: "2.1"
 short_description: Sets Windows machine timezone
 description:
-    - Sets machine time to the specified timezone, the module will check if the provided timezone is supported on the machine.
+  - Sets machine time to the specified timezone, the module will check if the provided timezone is supported on the machine.
+notes:
+  - If running on Server 2008 the hotfix https://support.microsoft.com/en-us/help/2556308/tzutil-command-line-tool-is-added-to-windows-vista-and-to-windows-server-2008
+    needs to be installed to be able to run this module.
 options:
   timezone:
     description:
-      - Timezone to set to.  Example Central Standard Time
+      - Timezone to set to. Example Central Standard Time.
+      - Run tzutil.exe /g to get a list of supported timezones on your server.
     required: true
-    default: null
-    aliases: []
-
 author: Phil Schwartz
 '''
 
-
 EXAMPLES = r'''
-  # Set machine's timezone to Central Standard Time
+- name: Set machine's timezone to Central Standard Time
   win_timezone:
     timezone: "Central Standard Time"
 '''

--- a/lib/ansible/modules/windows/win_timezone.py
+++ b/lib/ansible/modules/windows/win_timezone.py
@@ -34,7 +34,7 @@ short_description: Sets Windows machine timezone
 description:
   - Sets machine time to the specified timezone, the module will check if the provided timezone is supported on the machine.
 notes:
-  - If running on Server 2008 the hotfix 
+  - If running on Server 2008 the hotfix
     https://support.microsoft.com/en-us/help/2556308/tzutil-command-line-tool-is-added-to-windows-vista-and-to-windows-server-2008
     needs to be installed to be able to run this module.
 options:

--- a/lib/ansible/modules/windows/win_timezone.py
+++ b/lib/ansible/modules/windows/win_timezone.py
@@ -34,7 +34,8 @@ short_description: Sets Windows machine timezone
 description:
   - Sets machine time to the specified timezone, the module will check if the provided timezone is supported on the machine.
 notes:
-  - If running on Server 2008 the hotfix https://support.microsoft.com/en-us/help/2556308/tzutil-command-line-tool-is-added-to-windows-vista-and-to-windows-server-2008
+  - If running on Server 2008 the hotfix 
+    https://support.microsoft.com/en-us/help/2556308/tzutil-command-line-tool-is-added-to-windows-vista-and-to-windows-server-2008
     needs to be installed to be able to run this module.
 options:
   timezone:

--- a/test/integration/targets/win_timezone/aliases
+++ b/test/integration/targets/win_timezone/aliases
@@ -1,0 +1,1 @@
+windows/ci/group1

--- a/test/integration/targets/win_timezone/defaults/main.yml
+++ b/test/integration/targets/win_timezone/defaults/main.yml
@@ -1,0 +1,1 @@
+test_timezone: Eastern Standard Time

--- a/test/integration/targets/win_timezone/tasks/main.yml
+++ b/test/integration/targets/win_timezone/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: determine if server has tzutil.exe installed
+  win_command: tzutil.exe /g
+  register: tzutil_output
+  ignore_errors: True
+
+- include: test.yml
+  when: tzutil_output.rc == 0

--- a/test/integration/targets/win_timezone/tasks/test.yml
+++ b/test/integration/targets/win_timezone/tasks/test.yml
@@ -1,0 +1,54 @@
+---
+- name: set the timezone to a default before the tests are run
+  win_timezone:
+    timezone: E. Australia Standard Time
+
+- name: change the timezone check
+  win_timezone:
+    timezone: "{{test_timezone}}"
+  register: change_timezone_check
+  check_mode: True
+
+- name: get stat on current time zone check
+  win_command: tzutil.exe /g
+  register: actual_timezone_check
+
+- name: assert change the timezone check
+  assert:
+    that:
+    - change_timezone_check|changed
+    - actual_timezone_check.stdout == 'E. Australia Standard Time'
+
+- name: change the timezone
+  win_timezone:
+    timezone: "{{test_timezone}}"
+  register: change_timezone
+
+- name: get stat on current time zone
+  win_command: tzutil.exe /g
+  register: actual_timezone
+
+- name: assert change the timezone check
+  assert:
+    that:
+    - change_timezone|changed
+    - actual_timezone.stdout == test_timezone
+
+- name: change the timezone again
+  win_timezone:
+    timezone: "{{test_timezone}}"
+  register: change_timezone_again
+
+- name: get stat on current time zone again
+  win_command: tzutil.exe /g
+  register: actual_timezone_again
+
+- name: assert change the timezone check again
+  assert:
+    that:
+    - not change_timezone_again|changed
+    - actual_timezone_again.stdout == test_timezone
+
+- name: reset test back to normal
+  win_timezone:
+    timezone: E. Australia Standard Time

--- a/test/integration/test_win_group1.yml
+++ b/test/integration/test_win_group1.yml
@@ -9,3 +9,4 @@
     - { role: win_fetch, tags: test_win_fetch }
     - { role: win_regmerge, tags: test_win_regmerge }
     - { role: win_regedit, tags: test_win_regedit }
+    - { role: win_timezone, tags: test_win_timezone }


### PR DESCRIPTION
##### SUMMARY
Added integration tests for win_timezone and updated docs with some more information.

##### ISSUE TYPE
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
win_timezone

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 6a3ce18e4b) last updated 2017/05/25 20:15:42 (GMT +1000)
  config file = /mnt/c/dev/module-tester/ansible.cfg
  configured module search path = [u'/home/jordan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/c/dev/linux-ansible/lib/ansible
  executable location = /mnt/c/dev/linux-ansible/bin/ansible
  python version = 2.7.13 (default, Apr 13 2017, 08:16:29) [GCC 5.4.0 20160609]
```
