### PR TITLE
cloud: gce: Allow specifying scopes by URI

### DIFF
--- a/lib/ansible/modules/cloud/google/gce.py
+++ b/lib/ansible/modules/cloud/google/gce.py
@@ -233,6 +233,7 @@ EXAMPLES = '''
         - storage-full
         - taskqueue
         - bigquery
+        - https://www.googleapis.com/auth/ndev.clouddns.readwrite
       service_account_email: "your-sa@your-project-name.iam.gserviceaccount.com"
       credentials_file: "/path/to/your-key.json"
       project_id: "your-project-name"
@@ -463,7 +464,7 @@ def create_instances(module, gce, instance_names, number, lc_zone):
     bad_perms = []
     if service_account_permissions:
         for perm in service_account_permissions:
-            if perm not in gce.SA_SCOPES_MAP:
+            if perm not in gce.SA_SCOPES_MAP and not perm.startswith('https://www.googleapis.com/auth'):
                 bad_perms.append(perm)
         if len(bad_perms) > 0:
             module.fail_json(msg='bad permissions: %s' % str(bad_perms))


### PR DESCRIPTION
##### SUMMARY
Previously the gce module would only allow scopes to be specified by
alias, this adds support for specifying scopes by full URI, however
validation is limited to just ensuring the URI begins with:
https://www.googleapis.com/auth

The description for the service_account_permissions argument references https://cloud.google.com/sdk/gcloud/reference/compute/instances/create for valid values, but the module did not previously accept scopes specified by full URI.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
gce

##### ANSIBLE VERSION
```
ansible 2.3.0.0
```


##### ADDITIONAL INFORMATION
Specifically, this enables the ability to set scopes like: `https://www.googleapis.com/auth/ndev.clouddns.readwrite`, which are not available as part of an alias.

