### PR TITLE
rhn_register fixes for #24997 and #22300

### DIFF
--- a/changelogs/fragments/rhn_regiter-user-pass-unregister.yaml
+++ b/changelogs/fragments/rhn_regiter-user-pass-unregister.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - rhn_register - require username/password when unregistering and provide useful error message (https://github.com/ansible/ansible/issues/22300)

--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -344,7 +344,13 @@ def main():
             enable_eus=dict(default=False, type='bool'),
             nopackages=dict(default=False, type='bool'),
             channels=dict(default=[], type='list'),
-        )
+        ),
+        # username/password is required for state=absent, or if channels is not empty
+        # (basically anything that uses self.api requires username/password) but it doesnt
+        # look like we can express that with required_if/required_together/mutually_exclusive
+
+        # only username+password can be used for unregister
+        required_if=[['state', 'absent', ['username', 'password']]]
     )
 
     if not HAS_UP2DATE_CLIENT:
@@ -403,6 +409,9 @@ def main():
     if state == 'absent':
         if not rhn.is_registered:
             module.exit_json(changed=False, msg="System already unregistered.")
+
+        if not (rhn.username and rhn.password):
+            module.fail_json(msg="Missing arguments, the system is currently registered and unregistration requires a username and password")
 
         try:
             rhn.unregister()

--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -295,11 +295,13 @@ class Rhn(redhat.RegistrationBase):
     def subscribe(self, channels):
         if not channels:
             return
+
         if self._is_hosted():
             current_channels = self.api('channel.software.listSystemChannels', self.systemid)
             new_channels = [item['channel_label'] for item in current_channels]
             new_channels.extend(channels)
             return self.api('channel.software.setSystemChannels', self.systemid, list(new_channels))
+
         else:
             current_channels = self.api('channel.software.listSystemChannels', self.systemid)
             current_channels = [item['label'] for item in current_channels]
@@ -315,10 +317,13 @@ class Rhn(redhat.RegistrationBase):
                         new_childs.append(ch)
             out_base = 0
             out_childs = 0
+
             if new_base:
                 out_base = self.api('system.setBaseChannel', self.systemid, new_base)
+
             if new_childs:
                 out_childs = self.api('system.setChildChannels', self.systemid, new_childs)
+
             return out_base and out_childs
 
     def _is_hosted(self):

--- a/test/units/modules/packaging/os/test_rhn_register.py
+++ b/test/units/modules/packaging/os/test_rhn_register.py
@@ -110,7 +110,7 @@ def test_without_required_parameters(capfd, patch_rhn):
 TESTED_MODULE = rhn_register.__name__
 TEST_CASES = [
     [
-        # Registering an unregistered host and subscribing to one channel
+        # Registering an unregistered host with channels
         {
             'channels': 'rhel-x86_64-server-6',
             'username': 'user',
@@ -137,9 +137,11 @@ TEST_CASES = [
         }
     ],
     [
-        # Registering an unregistered host with only an activationkey and without subscribing any channels
+        # Registering an unregistered host without channels
         {
             'activationkey': 'key',
+            'username': 'user',
+            'password': 'pass',
         },
         {
             'calls': [


### PR DESCRIPTION
##### SUMMARY

Require username and password for unregistering and avoid "cannot marshal None unless allow_none is enabled" error when using an activationkey and no channels specified.

Fixes for #24997 and #22300, including the changes from ansible/ansible@4f8dc60 and ansible/ansible@a4b69c1.

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME

    rhn_register.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
    ansible 2.3.0.0
      config file = /home/ansible/ansible.cfg
      configured module search path = Default w/o overrides
      python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```


##### ADDITIONAL INFORMATION
Undoes ansible/ansible@7faef2c.
