### PR TITLE
Get rid of various warnings in test output

### DIFF
--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -4,6 +4,8 @@
 #  on python2 will require python2-dnf)
 - name: check python2-dnf with rpm
   shell: rpm -q python2-dnf
+  args:
+    warn: no
   register: rpm_result
   ignore_errors: true
 
@@ -11,6 +13,8 @@
 # some dnf python files after the package is uninstalled.
 - name: uninstall python2-dnf with shell
   shell: dnf -y remove python2-dnf
+  args:
+    warn: no
   when: rpm_result|success
 
 # UNINSTALL
@@ -24,6 +28,8 @@
 
 - name: check sos with rpm
   shell: rpm -q sos
+  args:
+    warn: no
   failed_when: False
   register: rpm_result
 
@@ -57,6 +63,8 @@
 
 - name: check sos with rpm
   shell: rpm -q sos
+  args:
+    warn: no
   failed_when: False
   register: rpm_result
 
@@ -95,11 +103,15 @@
 
 - name: check sos with rpm
   shell: rpm -q sos
+  args:
+    warn: no
   failed_when: False
   register: rpm_sos_result
 
 - name: check sharutils with rpm
   shell: rpm -q sharutils
+  args:
+    warn: no
   failed_when: False
   register: rpm_sharutils_result
 
@@ -115,11 +127,15 @@
 
 - name: check sos with rpm
   shell: rpm -q sos
+  args:
+    warn: no
   failed_when: False
   register: rpm_sos_result
 
 - name: check sharutils with rpm
   shell: rpm -q sharutils
+  args:
+    warn: no
   failed_when: False
   register: rpm_sharutils_result
 
@@ -145,11 +161,15 @@
 
 - name: check sos with rpm
   shell: rpm -q sos
+  args:
+    warn: no
   failed_when: False
   register: rpm_sos_result
 
 - name: check sharutils with rpm
   shell: rpm -q sharutils
+  args:
+    warn: no
   failed_when: False
   register: rpm_sharutils_result
 
@@ -175,11 +195,15 @@
 
 - name: check sos with rpm
   shell: rpm -q sos
+  args:
+    warn: no
   failed_when: False
   register: rpm_sos_result
 
 - name: check sos with rpm
   shell: rpm -q sharutils
+  args:
+    warn: no
   failed_when: False
   register: rpm_sharutils_result
 
@@ -218,6 +242,8 @@
 
 - name: check sos with rpm in /
   shell: rpm -q sos --root=/
+  args:
+    warn: no
   failed_when: False
   register: rpm_result
 

--- a/test/integration/targets/dnf/tasks/dnfinstallroot.yml
+++ b/test/integration/targets/dnf/tasks/dnfinstallroot.yml
@@ -22,6 +22,8 @@
 
 - name: check sos with rpm in installroot
   shell: rpm -q sos --root="/{{ dnfroot.stdout }}/"
+  args:
+    warn: no
   failed_when: False
   register: rpm_result
 

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -112,8 +112,7 @@
         - "'local' == ['localhost']|map('extract',hostvars,'ansible_connection')|list|first"
         - "'local' == ['localhost']|map('extract',hostvars,['ansible_connection'])|list|first"
   # map was added to jinja2 in version 2.7
-  when: "{{ ( lookup('pipe', '{{ ansible_python[\"executable\"] }} -c \"import jinja2; print(jinja2.__version__)\"') |
-              version_compare('2.7', '>=') ) }}"
+  when: lookup('pipe', ansible_python['executable'] ~ ' -c "import jinja2; print(jinja2.__version__)"') | version_compare('2.7', '>=')
 
 - name: Test json_query filter
   assert:

--- a/test/integration/targets/gem/tasks/main.yml
+++ b/test/integration/targets/gem/tasks/main.yml
@@ -21,6 +21,8 @@
 
 - name: verify gist is not installed
   shell: gem list | egrep '^gist '
+  args:
+    warn: no
   register: uninstall
   failed_when: "uninstall.rc != 1"
 
@@ -37,3 +39,5 @@
 
 - name: verify gist is installed
   shell: gem list | egrep '^gist '
+  args:
+    warn: no

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -143,21 +143,21 @@
 
 - command: "grep '{{ sni_host }}' {{ output_dir}}/sni.html"
   register: data_result
-  when: "{{ python_has_ssl_context }}"
+  when: python_has_ssl_context
 
 - debug: var=get_url_result
 - name: Assert that SNI works with this python version
   assert:
     that:
       - 'data_result.rc == 0'
-  when: "{{ python_has_ssl_context }}"
+  when: python_has_ssl_context
 
 # If the client doesn't support SNI then get_url should have failed with a certificate mismatch
 - name: Assert that hostname verification failed because SNI is not supported on this version of python
   assert:
     that:
       - 'get_url_result|failed'
-  when: "{{ not python_has_ssl_context }}"
+  when: not python_has_ssl_context
 
 # These tests are just side effects of how the site is hosted.  It's not
 # specifically a test site.  So the tests may break due to the hosting changing
@@ -170,7 +170,7 @@
 
 - command: "grep '{{ sni_host }}' {{ output_dir}}/sni.html"
   register: data_result
-  when: "{{ python_has_ssl_context }}"
+  when: python_has_ssl_context
 
 - debug: var=get_url_result
 - name: Assert that SNI works with this python version
@@ -178,7 +178,7 @@
     that:
       - 'data_result.rc == 0'
       - 'not get_url_result|failed'
-  when: "{{ python_has_ssl_context }}"
+  when: python_has_ssl_context
 
 # If the client doesn't support SNI then get_url should have failed with a certificate mismatch
 - name: Assert that hostname verification failed because SNI is not supported on this version of python

--- a/test/integration/targets/git/tasks/ambiguous-ref.yml
+++ b/test/integration/targets/git/tasks/ambiguous-ref.yml
@@ -8,7 +8,10 @@
     dest: '{{ checkout_dir }}'
 
 - name: rename remote to be ambiguous
-  command: git remote rename origin v0.1 chdir="{{ checkout_dir }}"
+  command: git remote rename origin v0.1
+  args:
+    chdir: '{{ checkout_dir }}'
+    warn: no
 
 - name: switch to HEAD
   git:
@@ -17,11 +20,17 @@
     remote: v0.1
 
 - name: rev-parse remote HEAD
-  command: git rev-parse v0.1/HEAD chdir="{{ checkout_dir }}"
+  command: git rev-parse v0.1/HEAD
+  args:
+    chdir: '{{ checkout_dir }}'
+    warn: no
   register: git_remote_head
 
 - name: rev-parse local HEAD
-  command: git rev-parse HEAD chdir="{{ checkout_dir }}"
+  command: git rev-parse HEAD
+  args:
+    chdir: '{{ checkout_dir }}'
+    warn: no
   register: git_local_head
 
 - assert:

--- a/test/integration/targets/git/tasks/change-repo-url.yml
+++ b/test/integration/targets/git/tasks/change-repo-url.yml
@@ -22,11 +22,12 @@
 
 - name: check url updated
   shell: git remote show origin | grep Fetch
-  register: remote_url
   args:
     chdir: '{{ checkout_dir }}'
+    warn: no
   environment:
     LC_ALL: C
+  register: remote_url
 
 - assert:
     that: 
@@ -79,7 +80,7 @@
   assert:
     that:
       - checkout_new_url_check_mode|changed
-  when: git_version.stdout | version_compare("{{git_version_supporting_ls_remote}}", '>=')
+  when: git_version.stdout | version_compare(git_version_supporting_ls_remote, '>=')
 
 - name: clone repo with new url after check mode
   git: repo={{ repo_update_url_1 }} dest={{ checkout_dir }}
@@ -110,6 +111,7 @@
   command: git branch new-branch
   args:
     chdir: '{{ checkout_dir }}/repo'
+    warn: no
 
 - name: Checkout the new branch in the checkout
   git:

--- a/test/integration/targets/git/tasks/checkout-new-tag.yml
+++ b/test/integration/targets/git/tasks/checkout-new-tag.yml
@@ -18,6 +18,7 @@
   command: git tag --contains
   args:
     chdir: "{{ checkout_dir }}"
+    warn: no
   register: listoftags
 
 - name: make sure the tag does not yet exist
@@ -29,6 +30,7 @@
   command: git tag newtag
   args:
     chdir: "{{ repo_dir }}/format1"
+    warn: no
 
 - name: update copy with new tag
   git:
@@ -41,6 +43,7 @@
   command: git tag --contains
   args:
     chdir: "{{ checkout_dir }}"
+    warn: no
   register: listoftags
 
 - name: check new head

--- a/test/integration/targets/git/tasks/depth.yml
+++ b/test/integration/targets/git/tasks/depth.yml
@@ -17,11 +17,12 @@
   failed_when: False
   args:
     chdir: '{{ checkout_dir }}'
+    warn: no
 
 - name: make sure the old commit was not fetched
   assert:
     that: 'checkout_early.rc != 0'
-  when: git_version.stdout | version_compare("{{git_version_supporting_depth}}", '>=')
+  when: git_version.stdout | version_compare(git_version_supporting_depth, '>=')
 
 # tests https://github.com/ansible/ansible/issues/14954
 - name: fetch repo again with depth=1
@@ -33,7 +34,7 @@
 
 - assert:
     that: "not checkout2|changed"
-  when: git_version.stdout | version_compare("{{git_version_supporting_depth}}", '>=')
+  when: git_version.stdout | version_compare(git_version_supporting_depth, '>=')
 
 - name: again try to access earlier commit
   shell: "git checkout {{git_shallow_head_1.stdout}}"
@@ -41,6 +42,7 @@
   failed_when: False
   args:
     chdir: '{{ checkout_dir }}'
+    warn: no
 
 - name: again make sure the old commit was not fetched
   assert:
@@ -63,6 +65,7 @@
   shell: "git checkout {{git_shallow_head_1.stdout}}"
   args:
     chdir: '{{ checkout_dir }}'
+    warn: no
 
 - name: clear checkout_dir
   file:

--- a/test/integration/targets/git/tasks/depth.yml
+++ b/test/integration/targets/git/tasks/depth.yml
@@ -47,7 +47,7 @@
 - name: again make sure the old commit was not fetched
   assert:
     that: 'checkout_early.rc != 0'
-  when: git_version.stdout | version_compare("{{git_version_supporting_depth}}", '>=')
+  when: git_version.stdout | version_compare(git_version_supporting_depth, '>=')
 
 # make sure we are still able to fetch other versions
 - name: Clone same repo with older version

--- a/test/integration/targets/git/tasks/localmods.yml
+++ b/test/integration/targets/git/tasks/localmods.yml
@@ -5,6 +5,7 @@
   shell: rm -rf localmods; mkdir localmods; cd localmods; git init; echo "1" > a; git add a; git commit -m "1"
   args:
     chdir: "{{repo_dir}}"
+    warn: no
 
 - name: checkout old repo
   git:
@@ -55,6 +56,7 @@
   shell: rm -rf localmods; mkdir localmods; cd localmods; git init; echo "1" > a; git add a; git commit -m "1"
   args:
     chdir: "{{repo_dir}}"
+    warn: no
 
 - name: checkout old repo
   git:

--- a/test/integration/targets/git/tasks/reset-origin.yml
+++ b/test/integration/targets/git/tasks/reset-origin.yml
@@ -17,6 +17,7 @@
   shell: git init; echo "PR 22502" > origin; git add origin; git commit -m "PR 22502"
   args:
     chdir: "{{ repo_dir }}/origin"
+    warn: no
 
 - name: Clone a git repo with file named origin
   git:

--- a/test/integration/targets/git/tasks/setup-local-repos.yml
+++ b/test/integration/targets/git/tasks/setup-local-repos.yml
@@ -11,7 +11,8 @@
 - name: prepare minimal git repo
   shell: git init; echo "1" > a; git add a; git commit -m "1"
   args:
-    chdir: "{{repo_dir}}/minimal"
+    chdir: '{{ repo_dir }}/minimal'
+    warn: no
 
 - name: prepare git repo for shallow clone
   shell: |
@@ -19,10 +20,11 @@
     echo "1" > a; git add a; git commit -m "1"; git tag earlytag; git branch earlybranch;
     echo "2" > a; git add a; git commit -m "2";
   args:
-    chdir: "{{repo_dir}}/shallow"
+    chdir: '{{ repo_dir }}/shallow'
 
 - name: set old hash var for shallow test
-  command: 'git rev-parse HEAD~1'
-  register: git_shallow_head_1
+  command: git rev-parse HEAD~1
   args:
-    chdir: "{{repo_dir}}/shallow"
+    chdir: '{{ repo_dir }}/shallow'
+    warn: no
+  register: git_shallow_head_1

--- a/test/integration/targets/git/tasks/setup.yml
+++ b/test/integration/targets/git/tasks/setup.yml
@@ -15,6 +15,8 @@
 
 - name: get git version, only newer than {{git_version_supporting_depth}} has fixed git depth
   shell: git --version | grep 'git version' | sed 's/git version //'
+  args:
+    warn: no
   register: git_version
 
 - name: get gpg version
@@ -23,9 +25,13 @@
 
 - name: set git global user.email if not already set
   shell: git config --global user.email || git config --global user.email "noreply@example.com"
+  args:
+    warn: no
 
 - name: set git global user.name if not already set
   shell: git config --global user.name  || git config --global user.name  "Ansible Test Runner"
+  args:
+    warn: no
 
 - name: create repo_dir
   file: path={{repo_dir}} state=directory

--- a/test/integration/targets/git/tasks/specific-revision.yml
+++ b/test/integration/targets/git/tasks/specific-revision.yml
@@ -16,7 +16,8 @@
 - name: check HEAD after clone to revision
   command: git rev-parse HEAD
   args:
-    chdir: "{{ checkout_dir }}"
+    chdir: '{{ checkout_dir }}'
+    warn: no
   register: git_result
 
 - assert:
@@ -37,7 +38,8 @@
 - name: check HEAD after update to revision
   command: git rev-parse HEAD
   args:
-    chdir: "{{ checkout_dir }}"
+    chdir: '{{ checkout_dir }}'
+    warn: no
   register: git_result
 
 - assert:
@@ -70,7 +72,8 @@
 - name: check HEAD after update with refspec
   command: git rev-parse HEAD
   args:
-    chdir: "{{ checkout_dir }}"
+    chdir: '{{ checkout_dir }}'
+    warn: no
   register: git_result
 
 - assert:
@@ -94,7 +97,8 @@
 - name: check HEAD after update with refspec
   command: git rev-parse HEAD
   args:
-    chdir: "{{ checkout_dir }}"
+    chdir: '{{ checkout_dir }}'
+    warn: no
   register: git_result
 
 - assert:
@@ -103,17 +107,18 @@
 
 - name: try to access other commit
   shell: git checkout 0ce1096
-  register: checkout_shallow
-  failed_when: False
   args:
     chdir: '{{ checkout_dir }}'
+    warn: no
+  register: checkout_shallow
+  failed_when: False
 
 - name: "make sure the old commit was not fetched, task is 'forced success'"
   assert:
     that:
       - 'checkout_shallow.rc != 0'
       - checkout_shallow|success
-  when: git_version.stdout | version_compare("{{git_version_supporting_depth}}", '>=')
+  when: git_version.stdout | version_compare(git_version_supporting_depth, '>=')
 
 - name: clear checkout_dir
   file:
@@ -130,7 +135,8 @@
 - name: check HEAD after update with refspec
   command: git rev-parse HEAD
   args:
-    chdir: "{{ checkout_dir }}"
+    chdir: '{{ checkout_dir }}'
+    warn: no
   register: git_result
 
 - assert:
@@ -151,7 +157,8 @@
 - name: prepare origina repo
   shell: git init; echo "1" > a; git add a; git commit -m "1"
   args:
-    chdir: "{{checkout_dir}}"
+    chdir: '{{ checkout_dir }}'
+    warn: no
 
 - name: clone example repo locally
   git: 
@@ -159,31 +166,44 @@
     dest: "{{checkout_dir}}.copy"
 
 - name: create branch in original
-  command: git checkout -b test/branch chdir="{{checkout_dir}}"
+  command: git checkout -b test/branch
+  args:
+    chdir: '{{ checkout_dir }}'
+    warn: no
 
 - name: get commit for HEAD on new branch
-  command: git rev-parse HEAD chdir="{{checkout_dir}}.copy"
+  command: git rev-parse HEAD
+  args:
+    chdir: '{{ checkout_dir }}.copy'
+    warn: no
   register: originaltip0
 
 - name: shallow force checkout new branch in copy
   git: 
-    repo: "{{checkout_dir}}" 
+    repo: "{{checkout_dir}}"
     dest: "{{checkout_dir}}.copy"
     version: test/branch 
-    depth: 1 
+    depth: 1
     force: yes
 
 - name: create new commit in original
   shell: git init; echo "2" > b; git add b; git commit -m "2"
   args:
-    chdir: "{{checkout_dir}}"
+    chdir: '{{ checkout_dir }}'
+    warn: no
 
 - name: get commit for new HEAD on original branch
-  command: git rev-parse HEAD chdir="{{checkout_dir}}"
+  command: git rev-parse HEAD
+  args:
+    chdir: '{{ checkout_dir }}'
+    warn: no
   register: originaltip1
 
 - name: get commit for HEAD on new branch
-  command: git rev-parse HEAD chdir="{{checkout_dir}}.copy"
+  command: git rev-parse HEAD
+  args:
+    chdir: '{{ checkout_dir }}.copy'
+    warn: no
   register: newtip
 
 - name: assert that copy is still pointing at previous tip
@@ -194,18 +214,22 @@
 - name: create a local modification in the copy
   shell: echo "3" > c
   args:
-    chdir: "{{ checkout_dir }}.copy"
+    chdir: '{{ checkout_dir }}.copy'
+    warn: no
 
 - name: shallow force checkout new branch in copy (again)
   git: 
     repo: "{{checkout_dir}}"
-    dest: "{{checkout_dir}}.copy" 
+    dest: "{{checkout_dir}}.copy"
     version: test/branch
-    depth: 1 
+    depth: 1
     force: yes
 
 - name: get commit for HEAD on new branch
-  command: git rev-parse HEAD chdir="{{checkout_dir}}.copy"
+  command: git rev-parse HEAD
+  args:
+    chdir: '{{ checkout_dir }}.copy'
+    warn: no
   register: newtip
 
 - name: make sure copy tip is not pointing at previous sha and that new tips match

--- a/test/integration/targets/hg/tasks/main.yml
+++ b/test/integration/targets/hg/tasks/main.yml
@@ -24,6 +24,8 @@
 
 - name: clean out the output_dir
   shell: rm -rf {{ output_dir }}/*
+  args:
+    warn: no
 
 - name: verify that mercurial is installed so this test can continue
   shell: which hg

--- a/test/integration/targets/mount/tasks/main.yml
+++ b/test/integration/targets/mount/tasks/main.yml
@@ -117,6 +117,8 @@
 
 - name: Get mount options
   shell: mount | grep mount_dest | grep -E -w '(ro|read-only)' | wc -l
+  args:
+    warn: no
   register: remount_options
 
 - debug: var=remount_options

--- a/test/integration/targets/prepare_http_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_http_tests/tasks/main.yml
@@ -1,7 +1,7 @@
 # The docker --link functionality gives us an ENV var we can key off of to see if we have access to
 # the httptester container
 - set_fact:
-    has_httptester: "{{ lookup('env', 'HTTPTESTER') != '' }}"
+    has_httptester: lookup('env', 'HTTPTESTER') != ''
 
 # If we are running with access to a httptester container, grab it's cacert and install it
 - block:

--- a/test/integration/targets/service/tasks/systemd_cleanup.yml
+++ b/test/integration/targets/service/tasks/systemd_cleanup.yml
@@ -17,6 +17,8 @@
 
 - name: make sure systemd is reloaded
   shell: systemctl daemon-reload
+  args:
+    warn: no
   register: restart_systemd_result
 
 - name: assert that systemd was reloaded

--- a/test/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/test/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -24,6 +24,8 @@
 
 - name: remove old db (RedHat or Suse)
   command: rm -rf "{{ pg_dir }}"
+  args:
+    warn: no
   ignore_errors: True
   when: ansible_os_family == "RedHat" or ansible_os_family == "Suse"
 
@@ -36,11 +38,15 @@
 # Theoretically, pg_dropcluster should work but it doesn't so rm files
 - name: remove old db config (debian)
   command: rm -rf /etc/postgresql
+  args:
+    warn: no
   ignore_errors: True
   when: ansible_os_family == "Debian"
 
 - name: remove old db files (debian)
   command: rm -rf /var/lib/postgresql
+  args:
+    warn: no
   ignore_errors: True
   when: ansible_os_family == "Debian"
 
@@ -60,6 +66,8 @@
 
 - name: Initialize postgres (RedHat sysv)
   command: /sbin/service postgresql initdb
+  args:
+    warn: no
   when: ansible_os_family == "RedHat" and ansible_service_mgr != "systemd"
 
 - name: Initialize postgres (Debian)

--- a/test/integration/targets/setup_sshkey/tasks/main.yml
+++ b/test/integration/targets/setup_sshkey/tasks/main.yml
@@ -17,6 +17,8 @@
 
 - name: create random file
   shell: mktemp /tmp/id_rsa.XXXXXX
+  args:
+    warn: no
   register: sshkey
   tags:
     - prepare

--- a/test/integration/targets/subversion/tasks/main.yml
+++ b/test/integration/targets/subversion/tasks/main.yml
@@ -24,6 +24,8 @@
 
 - name: clean out the output_dir
   shell: rm -rf {{ output_dir }}/*
+  args:
+    warn: no
 
 - name: verify that subversion is installed so this test can continue
   shell: which svn

--- a/test/integration/targets/synchronize/tasks/main.yml
+++ b/test/integration/targets/synchronize/tasks/main.yml
@@ -18,6 +18,8 @@
 
 - name: cleanup old files
   shell: rm -rf {{output_dir}}/*
+  args:
+    warn: no
 
 - name: create test new files
   copy: dest={{output_dir}}/{{item}} mode=0644 content="hello world"

--- a/test/integration/targets/sysctl/tasks/main.yml
+++ b/test/integration/targets/sysctl/tasks/main.yml
@@ -81,6 +81,8 @@
 
 - name: check with sysctl command
   shell: sysctl net.ipv4.ip_forward
+  args:
+    warn: no
   register: sysctl_check2
 
 - name: validate results for test 2

--- a/test/integration/targets/systemd/tasks/main.yml
+++ b/test/integration/targets/systemd/tasks/main.yml
@@ -25,9 +25,14 @@
   failed_when: False
   register: systemctl_check
 
-- block:
+- name: run tests if systemmctl was found on the system
+  when: systemctl_check.rc == 0
+  block:
+
     - name: get a list of running services
-      shell: systemctl | fgrep 'running' | awk '{print $1}' | sed 's/\.service//g' | fgrep -v '.' | egrep ^[a-z]
+      shell: systemctl | awk '/running/ { print $1 }' | sed 's/\.service//g' | fgrep -v '.' | egrep '^[a-z]'
+      args:
+        warn: no
       register: running_names
     - debug: var=running_names
 
@@ -46,5 +51,3 @@
               - 'systemd_test0.status is defined'
               - 'not systemd_test0.changed'
               - 'systemd_test0.state == "started"'
-
-  when: 'systemctl_check.rc == 0'

--- a/test/integration/targets/unarchive/tasks/main.yml
+++ b/test/integration/targets/unarchive/tasks/main.yml
@@ -70,7 +70,10 @@
   copy: src=foo.txt dest={{output_dir}}/unarchive-dir/foo-unarchive.txt
 
 - name: prep a tar.gz file with directory
-  shell: tar czvf test-unarchive-dir.tar.gz unarchive-dir  chdir={{output_dir}}
+  shell: tar czvf test-unarchive-dir.tar.gz unarchive-dir
+  args:
+    chdir: '{{ output_dir }}'
+    warn: no
 
 - name: create our tar unarchive destination
   file: path={{output_dir}}/test-unarchive-tar state=directory

--- a/test/integration/targets/yum/tasks/yuminstallroot.yml
+++ b/test/integration/targets/yum/tasks/yuminstallroot.yml
@@ -37,6 +37,8 @@
 
 - name: check sos with rpm in installroot
   shell: rpm -q zlib --root="{{ yumroot.stdout }}/"
+  args:
+    warn: no
   failed_when: False
   register: rpm_result
 

--- a/test/integration/targets/zypper/tasks/zypper.yml
+++ b/test/integration/targets/zypper/tasks/zypper.yml
@@ -5,6 +5,8 @@
 
 - name: check hello with rpm
   shell: rpm -q hello
+  args:
+    warn: no
   failed_when: False
   register: rpm_result
 
@@ -34,6 +36,8 @@
 
 - name: check hello with rpm
   shell: rpm -q hello
+  args:
+    warn: no
   failed_when: False
   register: rpm_result
 
@@ -68,11 +72,15 @@
 
 - name: check hello with rpm
   shell: rpm -q hello
+  args:
+    warn: no
   failed_when: False
   register: rpm_hello_result
 
 - name: check metamail with rpm
   shell: rpm -q metamail
+  args:
+    warn: no
   failed_when: False
   register: rpm_metamail_result
 
@@ -92,11 +100,15 @@
 
 - name: check hello with rpm
   shell: rpm -q hello
+  args:
+    warn: no
   failed_when: False
   register: rpm_hello_result
 
 - name: check metamail with rpm
   shell: rpm -q metamail
+  args:
+    warn: no
   failed_when: False
   register: rpm_metamail_result
 
@@ -193,6 +205,8 @@
 
 - name: check empty with rpm
   shell: rpm -q empty
+  args:
+    warn: no
   failed_when: False
   register: rpm_result
 


### PR DESCRIPTION
##### SUMMARY
Skimming the test output for issues is easier without the bright purple
warnings. I believe each of these need to be surpressed (by fixing them
or disabling the warning itself).

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
test

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.4