### PR TITLE
win_owner: added tests and fixed up bool handling

### DIFF
--- a/lib/ansible/modules/windows/win_owner.ps1
+++ b/lib/ansible/modules/windows/win_owner.ps1
@@ -90,7 +90,7 @@ $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "b
 
 $path = Get-AnsibleParam -obj $params -name "path" -type "path" -failifempty $true
 $user = Get-AnsibleParam -obj $params -name "user" -type "str" -failifempty $true
-$recurse = Get-AnsibleParam -obj $params -name "recurse" -type "bool" -default "no" -validateset "no","yes" -resultobj $result
+$recurse = Get-AnsibleParam -obj $params -name "recurse" -type "bool" -default $false -resultobj $result
 
 If (-Not (Test-Path -Path $path)) {
     Fail-Json $result "$path file or directory does not exist on the host"
@@ -129,7 +129,7 @@ Try {
     }
 }
 Catch {
-    Fail-Json $result "an error occurred when attempting to change owner on $path for $user"
+    Fail-Json $result "an error occurred when attempting to change owner on $path for $($user): $($_.Exception.Message)"
 }
 
 Exit-Json $result

--- a/lib/ansible/modules/windows/win_owner.py
+++ b/lib/ansible/modules/windows/win_owner.py
@@ -45,10 +45,8 @@ options:
   recurse:
     description:
       - Indicates if the owner should be changed recursively
-    choices:
-      - no
-      - yes
-    default: no
+    type: bool
+    default: 'no'
 author: Hans-Joachim Kliemeck (@h0nIg)
 '''
 

--- a/test/integration/targets/win_owner/aliases
+++ b/test/integration/targets/win_owner/aliases
@@ -1,0 +1,1 @@
+windows/ci/group1

--- a/test/integration/targets/win_owner/defaults/main.yml
+++ b/test/integration/targets/win_owner/defaults/main.yml
@@ -1,0 +1,1 @@
+test_win_owner_path: C:\ansible\win_owner

--- a/test/integration/targets/win_owner/tasks/main.yml
+++ b/test/integration/targets/win_owner/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
 # Setup tests
+- name: gather facts on host for use with later tests
+  setup:
+
 - name: remove test path to ensure baseline
   win_file:
     path: "{{test_win_owner_path}}"

--- a/test/integration/targets/win_owner/tasks/main.yml
+++ b/test/integration/targets/win_owner/tasks/main.yml
@@ -1,0 +1,230 @@
+---
+# Setup tests
+- name: remove test path to ensure baseline
+  win_file:
+    path: "{{test_win_owner_path}}"
+    state: absent
+
+- name: create test paths
+  win_file:
+    path: "{{test_win_owner_path}}\\{{item}}"
+    state: directory
+  with_items:
+  - folder
+  - folder\folder1
+  - folder\folder2
+  - folder with space
+  - folder with space\folder1
+  - folder with space\folder2
+
+- name: create system test files
+  win_copy:
+    dest: "{{test_win_owner_path}}\\{{item}}"
+    content: content
+  with_items:
+  - folder\file.txt
+  - folder\folder1\file.txt
+  - folder\folder2\file.txt
+  - folder with space\file.txt
+  - folder with space\folder1\file.txt
+  - folder with space\folder2\file.txt
+
+# Run win_owner tests
+- name: set owner for invalid path
+  win_owner:
+    path: C:\invalid
+    user: SYSTEM
+  register: invalid_path
+  failed_when: invalid_path.msg != 'C:\invalid file or directory does not exist on the host'
+
+- name: set owner for invalid user
+  win_owner:
+    path: "{{test_win_owner_path}}"
+    user: invalid-user
+  register: invalid_user
+  failed_when: invalid_user.msg != 'invalid-user is not a valid user or group on the host machine or domain'
+
+- name: set owner defaults check
+  win_owner:
+    path: "{{test_win_owner_path}}\\folder"
+    user: SYSTEM
+  register: defaults_check
+  check_mode: True
+
+- name: get owner of folder of set owner defaults check
+  win_command: powershell.exe "(Get-Acl -Path '{{test_win_owner_path}}\\folder').Owner"
+  register: actual_defaults_check
+
+- name: assert set owner defaults check
+  assert:
+    that:
+    - defaults_check|changed
+    - actual_defaults_check.stdout_lines[0] == 'BUILTIN\Administrators'
+
+- name: set owner defaults
+  win_owner:
+    path: "{{test_win_owner_path}}\\folder"
+    user: SYSTEM
+  register: defaults
+
+- name: get owner of folder of set owner defaults
+  win_command: powershell.exe "(Get-Acl -Path '{{test_win_owner_path}}\\folder').Owner"
+  register: actual_defaults
+
+- name: assert set owner defaults
+  assert:
+    that:
+    - defaults|changed
+    - actual_defaults.stdout_lines[0] == 'NT AUTHORITY\SYSTEM'
+
+- name: set owner defaults again
+  win_owner:
+    path: "{{test_win_owner_path}}\\folder"
+    user: SYSTEM
+  register: defaults_again
+
+- name: get owner of folder of set owner defaults again
+  win_command: powershell.exe "(Get-Acl -Path '{{test_win_owner_path}}\\folder').Owner"
+  register: actual_defaults_again
+
+- name: assert set owner defaults again
+  assert:
+    that:
+    - not defaults_again|changed
+    - actual_defaults_again.stdout_lines[0] == 'NT AUTHORITY\SYSTEM'
+
+- name: set owner recurse check
+  win_owner:
+    path: "{{test_win_owner_path}}\\folder"
+    user: SYSTEM
+    recurse: True
+  register: recurse_check
+  check_mode: True
+
+- name: get owner of folder of set owner recurse check
+  win_command: powershell.exe "(Get-Acl -Path '{{test_win_owner_path}}\\{{item.path}}').Owner"
+  register: actual_recurse_check
+  failed_when: actual_recurse_check.stdout_lines[0] != item.owner
+  with_items:
+  - { path: 'folder', owner: 'NT AUTHORITY\SYSTEM' }
+  - { path: 'folder\file.txt', owner: 'BUILTIN\Administrators' }
+  - { path: 'folder\folder1', owner: 'BUILTIN\Administrators' }
+  - { path: 'folder\folder1\file.txt', owner: 'BUILTIN\Administrators' }
+  - { path: 'folder\folder2', owner: 'BUILTIN\Administrators' }
+  - { path: 'folder\folder2\file.txt', owner: 'BUILTIN\Administrators' }
+
+- name: assert set owner recurse check
+  assert:
+    that:
+    - recurse_check|changed
+
+- name: set owner recurse
+  win_owner:
+    path: "{{test_win_owner_path}}\\folder"
+    user: SYSTEM
+    recurse: True
+  register: recurse
+
+- name: get owner of folder of set owner recurse
+  win_command: powershell.exe "(Get-Acl -Path '{{test_win_owner_path}}\\{{item}}').Owner"
+  register: actual_recurse
+  failed_when: actual_recurse.stdout_lines[0] != 'NT AUTHORITY\SYSTEM'
+  with_items:
+  - folder
+  - folder\file.txt
+  - folder\folder1
+  - folder\folder1\file.txt
+  - folder\folder2
+  - folder\folder2\file.txt
+
+- name: assert set owner recurse
+  assert:
+    that:
+    - recurse|changed
+
+- name: set owner recurse again
+  win_owner:
+    path: "{{test_win_owner_path}}\\folder"
+    user: SYSTEM
+    recurse: True
+  register: recurse_again
+
+- name: get owner of folder of set owner recurse again
+  win_command: powershell.exe "(Get-Acl -Path '{{test_win_owner_path}}\\{{item}}').Owner"
+  register: actual_recurse_again
+  failed_when: actual_recurse_again.stdout_lines[0] != 'NT AUTHORITY\SYSTEM'
+  with_items:
+  - folder
+  - folder\file.txt
+  - folder\folder1
+  - folder\folder1\file.txt
+  - folder\folder2
+  - folder\folder2\file.txt
+
+- name: assert set owner recurse again
+  assert:
+    that:
+    - not recurse_again|changed
+
+- name: create test user
+  win_user:
+    name: test win owner
+
+- name: set owner with space recurse
+  win_owner:
+    path: "{{test_win_owner_path}}\\folder with space"
+    user: test win owner
+    recurse: True
+  register: recurse_space
+
+- name: get owner of folder of set owner with space recurse
+  win_command: powershell.exe "(Get-Acl -Path '{{test_win_owner_path}}\\{{item}}').Owner"
+  register: actual_recurse_space
+  failed_when: actual_recurse_space.stdout_lines[0]|upper != ansible_hostname + '\\TEST WIN OWNER'
+  with_items:
+  - folder with space
+  - folder with space\file.txt
+  - folder with space\folder1
+  - folder with space\folder1\file.txt
+  - folder with space\folder2
+  - folder with space\folder2\file.txt
+
+- name: assert set owner with space recurse
+  assert:
+    that:
+    - recurse_space|changed
+
+- name: set owner with space recurse again
+  win_owner:
+    path: "{{test_win_owner_path}}\\folder with space"
+    user: test win owner
+    recurse: True
+  register: recurse_space_again
+
+- name: get owner of folder of set owner with space recurse again
+  win_command: powershell.exe "(Get-Acl -Path '{{test_win_owner_path}}\\{{item}}').Owner"
+  register: actual_recurse_space_again
+  failed_when: actual_recurse_space_again.stdout_lines[0]|upper != ansible_hostname + '\\TEST WIN OWNER'
+  with_items:
+  - folder with space
+  - folder with space\file.txt
+  - folder with space\folder1
+  - folder with space\folder1\file.txt
+  - folder with space\folder2
+  - folder with space\folder2\file.txt
+
+- name: assert set owner with space recurse again
+  assert:
+    that:
+    - not recurse_space_again|changed
+
+# Run cleanup after tests
+- name: delete test path
+  win_file:
+    path: "{{test_win_owner_path}}"
+    state: absent
+
+- name: remove test user
+  win_user:
+    name: test win owner
+    state: absent

--- a/test/integration/test_win_group1.yml
+++ b/test/integration/test_win_group1.yml
@@ -9,3 +9,4 @@
     - { role: win_fetch, tags: test_win_fetch }
     - { role: win_regmerge, tags: test_win_regmerge }
     - { role: win_regedit, tags: test_win_regedit }
+    - { role: win_owner, tags: test_win_owner }

--- a/test/integration/test_win_group1.yml
+++ b/test/integration/test_win_group1.yml
@@ -9,4 +9,3 @@
     - { role: win_fetch, tags: test_win_fetch }
     - { role: win_regmerge, tags: test_win_regmerge }
     - { role: win_regedit, tags: test_win_regedit }
-    - { role: win_owner, tags: test_win_owner }


### PR DESCRIPTION
##### SUMMARY
Added integration tests for win_owner, fixed up docs with recurse parameter and also fixed up the handling of this parameter so it can take in`true/false` as well as `yes/no`.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
win_owner

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 6a3ce18e4b) last updated 2017/05/25 20:15:42 (GMT +1000)
  config file =
  configured module search path = [u'/home/jordan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/c/dev/linux-ansible/lib/ansible
  executable location = /mnt/c/dev/linux-ansible/bin/ansible
  python version = 2.7.13 (default, Apr 13 2017, 08:16:29) [GCC 5.4.0 20160609]
```
