### PR TITLE
Ensure `when` warning is checked before expanding

### DIFF
--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -127,6 +127,11 @@ class Conditional:
         if conditional is None or conditional == '':
             return True
 
+        if templar.is_template(conditional):
+            display.warning('when statements should not include jinja2 '
+                            'templating delimiters such as {{ }} or {%% %%}. '
+                            'Found: %s' % conditional)
+
         # pull the "bare" var out, which allows for nested conditionals
         # and things like:
         # - assert:
@@ -136,11 +141,6 @@ class Conditional:
         #   - 1 == 1
         if conditional in all_vars and VALID_VAR_REGEX.match(conditional):
             conditional = all_vars[conditional]
-
-        if templar.is_template(conditional):
-            display.warning('when statements should not include jinja2 '
-                            'templating delimiters such as {{ }} or {%% %%}. '
-                            'Found: %s' % conditional)
 
         # make sure the templar is using the variables specified with this method
         templar.set_available_variables(variables=all_vars)


### PR DESCRIPTION
##### SUMMARY
The `when` condition templating warning should only happen
if the condition itself contains templating, not if variables
in the condition are themselves composed through templating

Before

```
vars:
  x: hello
  y: "{{ x }}"

tasks:
- debug: msg=hello
  when: y
```

would fire a warning because `y` would get expanded to `{{ x }}`.
This checks whether a warning is required prior to expansion.



Fixes #25053
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
when condition warning
##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 757758cd1a) last updated 2017/05/27 12:51:07 (GMT +1000)
  config file = 
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
With the following playbook:
```
- hosts: localhost
  connection: local
  gather_facts: False

  vars:
    x: hello
    y: world
    a_list:
      - "{{ x }}"
      - "{{ y }}"

  tasks:
    - debug:
        var: a_list
      when: a_list

    - debug:
        var: a_list
      when: "{{ a_list }}"
```


After:
```
$ ansible-playbook playbook.yml -v
No config file found; using defaults
 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [localhost] ****************************************************************************************************************************************************************************

TASK [debug] ********************************************************************************************************************************************************************************
ok: [localhost] => {
    "a_list": [
        "hello", 
        "world"
    ]
}

TASK [debug] ********************************************************************************************************************************************************************************
 [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{ a_list }}

ok: [localhost] => {
    "a_list": [
        "hello", 
        "world"
    ]
}

PLAY RECAP **********************************************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0   
```

We no longer get the undesirable warning but still get the warning when the `when` condition is templated.

Thanks to @sivel for the proposed solution in #25053