### PR TITLE
Import from urllib and not url

### DIFF
--- a/lib/ansible/module_utils/lxd.py
+++ b/lib/ansible/module_utils/lxd.py
@@ -56,7 +56,7 @@ try:
     from urlparse import urlparse
 except ImportError:
     # Python 3
-    from url.parse import urlparse
+    from urllib.parse import urlparse
 
 class LXDClientException(Exception):
     def __init__(self, msg, **kwargs):

--- a/lib/ansible/module_utils/lxd.py
+++ b/lib/ansible/module_utils/lxd.py
@@ -27,7 +27,7 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from ansible.module_utils import six
+from ansible.compat import six
 from ansible.module_utils.urls import generic_urlparse
 from six.moves.urllib.parse import urlparse
 

--- a/lib/ansible/module_utils/lxd.py
+++ b/lib/ansible/module_utils/lxd.py
@@ -29,7 +29,7 @@
 
 from ansible.module_utils import six
 from ansible.module_utils.urls import generic_urlparse
-from six.moves.urllib import parse as urlparse
+from six.moves.urllib.parse import urlparse
 
 try:
     import json

--- a/lib/ansible/module_utils/lxd.py
+++ b/lib/ansible/module_utils/lxd.py
@@ -27,9 +27,8 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from ansible.compat import six
 from ansible.module_utils.urls import generic_urlparse
-from six.moves.urllib.parse import urlparse
+from ansible.module_utils.six.moves.urllib.parse import urlparse
 
 try:
     import json

--- a/lib/ansible/module_utils/lxd.py
+++ b/lib/ansible/module_utils/lxd.py
@@ -27,6 +27,10 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+from ansible.module_utils import six
+from ansible.module_utils.urls import generic_urlparse
+from six.moves.urllib import parse as urlparse
+
 try:
     import json
 except ImportError:
@@ -50,13 +54,6 @@ class UnixHTTPConnection(HTTPConnection):
         sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         sock.connect(self.path)
         self.sock = sock
-
-from ansible.module_utils.urls import generic_urlparse
-try:
-    from urlparse import urlparse
-except ImportError:
-    # Python 3
-    from urllib.parse import urlparse
 
 class LXDClientException(Exception):
     def __init__(self, msg, **kwargs):


### PR DESCRIPTION
In Python 3, the correct way to import
urlparse is through urllib.parse.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Import from urllib and not url, as that is the correct name for the module in Python3.
Currently, an ImportError is being raised by the lxd module when used with Python 3.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
- LXD module with Python 3

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
- The traceback is:
```
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible___idoz8m/ansible_modlib.zip/ansible/module_utils/lxd.py", line 56, in <module>
ImportError: No module named 'urlparse'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/ansible___idoz8m/ansible_module_lxd_container.py", line 254, in <module>
    from ansible.module_utils.lxd import LXDClient, LXDClientException
  File "/tmp/ansible___idoz8m/ansible_modlib.zip/ansible/module_utils/lxd.py", line 59, in <module>
ImportError: No module named 'url'

failed: [10.118.6.204] (item=kinto) => {
    "failed": true,
    "item": "kinto",
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible___idoz8m/ansible_modlib.zip/ansible/module_utils/lxd.py\", line 56, in <module>\nImportError: No module named 'urlparse'\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/tmp/ansible___idoz8m/ansible_module_lxd_container.py\", line 254, in <module>\n    from ansible.module_utils.lxd import LXDClient, LXDClientException\n  File \"/tmp/ansible___idoz8m/ansible_modlib.zip/ansible/module_utils/lxd.py\", line 59, in <module>\nImportError: No module named 'url'\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE",
    "rc": 0
}
```
