### PR TITLE
Fix module name in example

### DIFF
--- a/lib/ansible/modules/system/runit.py
+++ b/lib/ansible/modules/system/runit.py
@@ -67,32 +67,32 @@ options:
 
 EXAMPLES = '''
 # Example action to start sv dnscache, if not running
- - sv:
+ - runit:
     name: dnscache
     state: started
 
 # Example action to stop sv dnscache, if running
- - sv:
+ - runit:
     name: dnscache
     state: stopped
 
 # Example action to kill sv dnscache, in all cases
- - sv:
+ - runit:
     name: dnscache
     state: killed
 
 # Example action to restart sv dnscache, in all cases
- - sv:
+ - runit:
     name: dnscache
     state: restarted
 
 # Example action to reload sv dnscache, in all cases
- - sv:
+ - runit:
     name: dnscache
     state: reloaded
 
 # Example using alt sv directory location
- - sv:
+ - runit:
     name: dnscache
     state: reloaded
     service_dir: /run/service


### PR DESCRIPTION
'sv' module name in example refers to non-existent module.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
[runit](https://docs.ansible.com/ansible/runit_module.html)

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Apr 11 2017, 16:54:36) [GCC 6.3.0]
```

##### ADDITIONAL INFORMATION
playbook will fail due to mispelled module name, or incorrect module path since module sv does not exist. Module name runit should be used instead.