### PR TITLE
Add note to `apt_key` doc about update requirement

### DIFF
--- a/lib/ansible/modules/packaging/os/apt_key.py
+++ b/lib/ansible/modules/packaging/os/apt_key.py
@@ -26,6 +26,7 @@ notes:
     - Doesn't download the key unless it really needs it.
     - As a sanity check, downloaded key id must match the one specified.
     - Best practice is to specify the key id and the URL.
+    - Adding a new key requires an apt cache update (e.g. `apt-get update`)
 options:
     id:
         description:

--- a/lib/ansible/modules/packaging/os/apt_key.py
+++ b/lib/ansible/modules/packaging/os/apt_key.py
@@ -26,7 +26,7 @@ notes:
     - Doesn't download the key unless it really needs it.
     - As a sanity check, downloaded key id must match the one specified.
     - Best practice is to specify the key id and the URL.
-    - Adding a new key requires an apt cache update (e.g. `apt-get update`)
+    - Adding a new key requires an apt cache update (e.g. using the apt module's update_cache option)
 options:
     id:
         description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When a new repo and new key are added, attempts to install packages
signed by that key fail until `apt-get update` is run.  This note
is an attempt to help users avoid getting errors when they miss
this step.

Helps with #25091

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module: `apt_key`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Dec 18 2016, 07:03:34) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Adds one line to the notes section. I'm not sure how to represent that here.
