### PR TITLE
Add new drained state

### DIFF
--- a/lib/ansible/modules/net_tools/haproxy.py
+++ b/lib/ansible/modules/net_tools/haproxy.py
@@ -345,8 +345,8 @@ class HAProxy(object):
 
     def drained(self, host, backend):
         """
-        Drained action, sets the server to DRAIN mode. 
-        In this mode mode, the server will not accept any new connections 
+        Drained action, sets the server to DRAIN mode.
+        In this mode mode, the server will not accept any new connections
         other than those that are accepted via persistence.
         """
         cmd = "set server $pxname/$svname state drain"

--- a/lib/ansible/modules/net_tools/haproxy.py
+++ b/lib/ansible/modules/net_tools/haproxy.py
@@ -30,10 +30,10 @@ version_added: "1.9"
 short_description: Enable, disable, and set weights for HAProxy backend servers using socket commands.
 author: "Ravi Bhure (@ravibhure)"
 description:
-    - Enable, disable, and set weights for HAProxy backend servers using socket
+    - Enable, disable, drain and set weights for HAProxy backend servers using socket
       commands.
 notes:
-    - Enable and disable commands are restricted and can only be issued on
+    - Enable and disable and drained commands are restricted and can only be issued on
       sockets configured for level 'admin'. For example, you can add the line
       'stats socket /var/run/haproxy.sock level admin' to the general section of
       haproxy.cfg. See U(http://haproxy.1wt.eu/download/1.5/doc/configuration.txt).
@@ -67,7 +67,7 @@ options:
       - Desired state of the provided backend host.
     required: true
     default: null
-    choices: [ "enabled", "disabled" ]
+    choices: [ "enabled", "disabled", "drained" ]
   fail_on_not_found:
     description:
       - Fail whenever trying to enable/disable a backend host that does not exist
@@ -76,8 +76,8 @@ options:
     version_added: "2.2"
   wait:
     description:
-      - Wait until the server reports a status of 'UP' when `state=enabled`, or
-        status of 'MAINT' when `state=disabled`.
+      - Wait until the server reports a status of 'UP' when `state=enabled`, 
+        status of 'MAINT' when `state=disabled` or status of 'DRAIN' when `state=drained`
     required: false
     default: false
     version_added: "2.0"
@@ -173,6 +173,13 @@ EXAMPLES = '''
     socket: /var/run/haproxy.sock
     weight: 10
     backend: www
+
+# set the server in 'www' backend pool to drain mode
+- haproxy:
+    state: drained
+    host: '{{ inventory_hostname }}'
+    socket: /var/run/haproxy.sock
+    backend: www
 '''
 
 import socket
@@ -183,7 +190,7 @@ from string import Template
 
 DEFAULT_SOCKET_LOCATION = "/var/run/haproxy.sock"
 RECV_SIZE = 1024
-ACTION_CHOICES = ['enabled', 'disabled']
+ACTION_CHOICES = ['enabled', 'disabled', 'drained']
 WAIT_RETRIES = 25
 WAIT_INTERVAL = 5
 
@@ -336,6 +343,15 @@ class HAProxy(object):
             cmd += "; shutdown sessions server $pxname/$svname"
         self.execute_for_backends(cmd, backend, host, 'MAINT')
 
+    def drained(self, host, backend):
+        """
+        Drained action, sets the server to DRAIN mode. 
+        In this mode mode, the server will not accept any new connections 
+        other than those that are accepted via persistence.
+        """
+        cmd = "set server $pxname/$svname state drain"
+        self.execute_for_backends(cmd, backend, host, 'DRAIN')
+
     def act(self):
         """
         Figure out what you want to do from ansible, and then do it.
@@ -349,6 +365,8 @@ class HAProxy(object):
             self.enabled(self.host, self.backend, self.weight)
         elif self.state == 'disabled':
             self.disabled(self.host, self.backend, self.shutdown_sessions)
+        elif self.state == 'drained':
+            self.drained(self.host, self.backend)
         else:
             self.module.fail_json(msg="unknown state specified: '%s'" % self.state)
 

--- a/lib/ansible/modules/net_tools/haproxy.py
+++ b/lib/ansible/modules/net_tools/haproxy.py
@@ -76,7 +76,7 @@ options:
     version_added: "2.2"
   wait:
     description:
-      - Wait until the server reports a status of 'UP' when `state=enabled`, 
+      - Wait until the server reports a status of 'UP' when `state=enabled`,
         status of 'MAINT' when `state=disabled` or status of 'DRAIN' when `state=drained`
     required: false
     default: false

--- a/lib/ansible/modules/net_tools/haproxy.py
+++ b/lib/ansible/modules/net_tools/haproxy.py
@@ -33,7 +33,7 @@ description:
     - Enable, disable, drain and set weights for HAProxy backend servers using socket
       commands.
 notes:
-    - Enable and disable and drained commands are restricted and can only be issued on
+    - Enable and disable and drain commands are restricted and can only be issued on
       sockets configured for level 'admin'. For example, you can add the line
       'stats socket /var/run/haproxy.sock level admin' to the general section of
       haproxy.cfg. See U(http://haproxy.1wt.eu/download/1.5/doc/configuration.txt).
@@ -67,7 +67,7 @@ options:
       - Desired state of the provided backend host.
     required: true
     default: null
-    choices: [ "enabled", "disabled", "drained" ]
+    choices: [ "enabled", "disabled", "drain" ]
   fail_on_not_found:
     description:
       - Fail whenever trying to enable/disable a backend host that does not exist
@@ -77,7 +77,7 @@ options:
   wait:
     description:
       - Wait until the server reports a status of 'UP' when `state=enabled`,
-        status of 'MAINT' when `state=disabled` or status of 'DRAIN' when `state=drained`
+        status of 'MAINT' when `state=disabled` or status of 'DRAIN' when `state=drain`
     required: false
     default: false
     version_added: "2.0"
@@ -176,7 +176,7 @@ EXAMPLES = '''
 
 # set the server in 'www' backend pool to drain mode
 - haproxy:
-    state: drained
+    state: drain
     host: '{{ inventory_hostname }}'
     socket: /var/run/haproxy.sock
     backend: www
@@ -190,7 +190,7 @@ from string import Template
 
 DEFAULT_SOCKET_LOCATION = "/var/run/haproxy.sock"
 RECV_SIZE = 1024
-ACTION_CHOICES = ['enabled', 'disabled', 'drained']
+ACTION_CHOICES = ['enabled', 'disabled', 'drain']
 WAIT_RETRIES = 25
 WAIT_INTERVAL = 5
 
@@ -343,9 +343,9 @@ class HAProxy(object):
             cmd += "; shutdown sessions server $pxname/$svname"
         self.execute_for_backends(cmd, backend, host, 'MAINT')
 
-    def drained(self, host, backend):
+    def drain(self, host, backend):
         """
-        Drained action, sets the server to DRAIN mode.
+        Drain action, sets the server to DRAIN mode.
         In this mode mode, the server will not accept any new connections
         other than those that are accepted via persistence.
         """
@@ -365,8 +365,8 @@ class HAProxy(object):
             self.enabled(self.host, self.backend, self.weight)
         elif self.state == 'disabled':
             self.disabled(self.host, self.backend, self.shutdown_sessions)
-        elif self.state == 'drained':
-            self.drained(self.host, self.backend)
+        elif self.state == 'drain':
+            self.drain(self.host, self.backend)
         else:
             self.module.fail_json(msg="unknown state specified: '%s'" % self.state)
 

--- a/lib/ansible/modules/net_tools/haproxy.py
+++ b/lib/ansible/modules/net_tools/haproxy.py
@@ -33,7 +33,7 @@ description:
     - Enable, disable, drain and set weights for HAProxy backend servers using socket
       commands.
 notes:
-    - Enable and disable and drain commands are restricted and can only be issued on
+    - Enable, disable and drain commands are restricted and can only be issued on
       sockets configured for level 'admin'. For example, you can add the line
       'stats socket /var/run/haproxy.sock level admin' to the general section of
       haproxy.cfg. See U(http://haproxy.1wt.eu/download/1.5/doc/configuration.txt).

--- a/lib/ansible/modules/net_tools/haproxy.py
+++ b/lib/ansible/modules/net_tools/haproxy.py
@@ -64,9 +64,9 @@ options:
     default: /var/run/haproxy.sock
   state:
     description:
-      - Desired state of the provided backend host. 
-        Note that "drain" state is supported only by HAProxy version 1.5 or later, 
-        if used on versions < 1.5, it will be ignored. 
+      - Desired state of the provided backend host.
+        Note that "drain" state is supported only by HAProxy version 1.5 or later,
+        if used on versions < 1.5, it will be ignored.
     required: true
     default: null
     choices: [ "enabled", "disabled", "drain" ]
@@ -276,7 +276,6 @@ class HAProxy(object):
         data = self.execute('show info', 200, False)
         lines = data.splitlines()
         line = [x for x in lines if 'Version:' in x]
-        
         try:
             version_values = line[0].partition(':')[2].strip().split('.', 3)
             version = (int(version_values[0]), int(version_values[1]))
@@ -371,7 +370,7 @@ class HAProxy(object):
         haproxy_version = self.discover_version()
 
         # check if haproxy version suppots DRAIN state (starting with 1.5)
-        if haproxy_version and (1,5) <= haproxy_version: 
+        if haproxy_version and (1, 5) <= haproxy_version:
             cmd = "set server $pxname/$svname state drain"
             self.execute_for_backends(cmd, backend, host, 'DRAIN')
 


### PR DESCRIPTION
##### SUMMARY
New 'drained' state allows to set haproxy servers to 'DRAIN' mode

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
haproxy module (haproxy.py)
 
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.12+ (default, Sep 17 2016, 12:08:02) [GCC 6.2.0 20160914]

```

##### ADDITIONAL INFORMATION
The haproxy module was missing the ability to set servers in DRAIN mode, only UP (enabled) and MAINT (disabled) were supported.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
