### PR TITLE
Add config_format note in junos_facts docs

### DIFF
--- a/lib/ansible/modules/network/junos/junos_facts.py
+++ b/lib/ansible/modules/network/junos/junos_facts.py
@@ -51,10 +51,15 @@ options:
       - The I(config_format) argument specifies the format of the configuration
          when serializing output from the device. This argument is applicable
          only when C(config) value is present in I(gather_subset).
+         The I(config_format) should be supported by the junos version running on
+         device.
     required: false
     default: text
     choices: ['xml', 'set', 'text', 'json']
     version_added: "2.3"
+notes:
+  - Ensure I(config_format) used to retrieve configuration from device
+    is supported by junos version running on device.
 """
 
 EXAMPLES = """


### PR DESCRIPTION
Fixes #24610

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add note to mention config_format value
dependency.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
junos_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
