### PR TITLE
Allow removal of target groups from ASGs

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -689,10 +689,8 @@ def create_autoscaling_group(connection, module):
                 module.fail_json(msg="Failed to update Autoscaling Group.",
                                  exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.message))
         # Update target groups if they are specified and one or more already exists
-        elif target_group_arns and as_group['TargetGroupARNs']:
+        elif target_group_arns is not None and as_group['TargetGroupARNs']:
             # Get differences
-            if not target_group_arns:
-                target_group_arns = list()
             wanted_tgs = set(target_group_arns)
             has_tgs = set(as_group['TargetGroupARNs'])
             # check if all requested are already existing


### PR DESCRIPTION
##### SUMMARY
An empty `target_group_arns` list represents no target groups.
This is different to not passing a `target_group_arns` list at all
which can signify no change.

Remove unnecessary empty list construction, as it must already be
an empty list to get to that point.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_asg

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 9cbae80c3b) last updated 2017/05/29 11:09:41 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 12 2017, 17:59:37) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
