### PR TITLE
openvswitch_bridge.py: Avoid runtime error with no external_ids

### DIFF
--- a/lib/ansible/modules/network/ovs/openvswitch_bridge.py
+++ b/lib/ansible/modules/network/ovs/openvswitch_bridge.py
@@ -157,11 +157,12 @@ def map_obj_to_commands(want, have, module):
                 templatized_command = ("%(ovs-vsctl)s -t %(timeout)s"
                                        " br-set-external-id %(bridge)s")
                 command = templatized_command % module.params
-                for k, v in iteritems(want['external_ids']):
-                    if (k not in have['external_ids']
-                            or want['external_ids'][k] != have['external_ids'][k]):
-                        command += " " + k + " " + v
-                        commands.append(command)
+                if want['external_ids']:
+                    for k, v in iteritems(want['external_ids']):
+                        if (k not in have['external_ids']
+                                or want['external_ids'][k] != have['external_ids'][k]):
+                            command += " " + k + " " + v
+                            commands.append(command)
         else:
             templatized_command = ("%(ovs-vsctl)s -t %(timeout)s add-br"
                                    " %(bridge)s")


### PR DESCRIPTION

##### SUMMARY

This happens when there is external_ids configured on the existing
OvS bridge, though playbook doesn't.

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME

`modules/network/ovs/openvswitch_bridge.py`

##### ANSIBLE VERSION

```
ocean$ ansible --version
ansible 2.4.0
  config file = /usr/local/git/ovn-on-air/ansible.cfg
  configured module search path = [u'/home/kei/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible-2.4.0-py2.7.egg/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Feb 11 2017, 12:22:40) [GCC 6.3.1 20170109]
ocean$

```

##### ADDITIONAL INFORMATION

Here is the error message without the patch:

```
TASK [create integration bridge] ************************************************
An exception occurred during task execution. To see the full traceback, use -vvv.
 The error was: AttributeError: 'NoneType' object has no attribute 'iteritems'
fatal: [hv13]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Tr
aceback (most recent call last):\n  File \"/tmp/ansible_YUwVz8/ansible_module_ope
nvswitch_bridge.py\", line 286, in <module>\n    main()\n  File \"/tmp/ansible_YU
wVz8/ansible_module_openvswitch_bridge.py\", line 273, in main\n    commands = ma
p_obj_to_commands(want, have, module)\n  File \"/tmp/ansible_YUwVz8/ansible_modul
e_openvswitch_bridge.py\", line 157, in map_obj_to_commands\n    for k, v in iter
items(want['external_ids']):\n  File \"<string>\", line 599, in iteritems\nAttrib
uteError: 'NoneType' object has no attribute 'iteritems'\n", "module_stdout": "",
 "msg": "MODULE FAILURE", "rc": 1}
```
and the actual task:

https://github.com/keinohguchi/ovn-on-air/blob/master/setup.yml#L18-L19