### PR TITLE
python 3 compatibility: import guard around ConfigParser

### DIFF
--- a/contrib/inventory/digital_ocean.py
+++ b/contrib/inventory/digital_ocean.py
@@ -138,8 +138,12 @@ import sys
 import re
 import argparse
 from time import time
-import ConfigParser
 import ast
+
+try:
+    import ConfigParser
+except ImportError:
+    import configparser as ConfigParser
 
 try:
     import json


### PR DESCRIPTION


##### SUMMARY
In python3 `ConfigParser` has become `configparser`. Added an import guard that aliases it back to the old name. I came across this when starting up a new project and my local python happened to be `python36`.

Tried to follow the same style as the other guarded imports in the same file.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
contrib/inventory/digital_ocean

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION

Before:

```
jelford@ ~/s/v/ansible> cp /path/to/digital_ocean.py inventory
jelford@ ~/s/v/ansible> ansible-playbook ./myconfig.yml
ERROR! Attempted to execute "./inventory" as inventory script: Inventory script (./inventory) had an execution error: Traceback (most recent call last):
  File "/home/jelford/s/v/ansible/inventory", line 143, in <module>
    import ConfigParser
ModuleNotFoundError: No module named 'ConfigParser'
```

After:
```
jelford@ ~/s/v/ansible> ansible-playbook ./myconfig.yml
... # expected output

```

