### PR TITLE
Automatically set role name as tag

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1326,6 +1326,14 @@ RETRY_FILES_SAVE_PATH:
   - {key: retry_files_save_path, section: defaults}
   type: path
   yaml: {key: errors.retry.path}
+ROLE_NAME_AS_TAG:
+  default: False
+  description: Automatically tag tasks with the corresponding role name.
+  env: [{name: ANSIBLE_ROLE_NAME_AS_TAG}]
+  ini:
+  - {key: role_name_as_tag, section: defaults}
+  type: boolean
+  yaml: {key: defaults.role_name_as_tag}
 SHOW_CUSTOM_STATS:
   default: False
   description: 'This adds the custom stats set via the set_stats plugin to the default output'

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -33,6 +33,7 @@ from ansible.playbook.role.metadata import RoleMetadata
 from ansible.playbook.taggable import Taggable
 from ansible.plugins.loader import get_all_plugin_loaders
 from ansible.utils.vars import combine_vars
+from ansible import constants as C
 
 
 __all__ = ['Role', 'hash_params']
@@ -188,7 +189,8 @@ class Role(Base, Become, Conditional, Taggable):
 
         current_tags = getattr(self, 'tags')[:]
         current_tags.extend(role_include.tags)
-        current_tags.append(self._role_name)
+        if C.ROLE_NAME_AS_TAG:
+            current_tags.append(self._role_name)
         setattr(self, 'tags', current_tags)
 
         # dynamically load any plugins from the role directory

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -188,6 +188,7 @@ class Role(Base, Become, Conditional, Taggable):
 
         current_tags = getattr(self, 'tags')[:]
         current_tags.extend(role_include.tags)
+        current_tags.append(self._role_name)
         setattr(self, 'tags', current_tags)
 
         # dynamically load any plugins from the role directory


### PR DESCRIPTION
##### SUMMARY
Fixes #17434

A common theme is to use the role name also as a tag, e.g.

    roles:
      - { role: webserver, tags: [ 'webserver' ] }

With this patch one can instead write

    roles:
      - webserver
and have the same result.



##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
playbook/role

##### ANSIBLE VERSION
devel
