### PR TITLE
Fix IndexError when junos_config contains multiple delete lines

### DIFF
--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -169,6 +169,9 @@ def get_diff(module):
 def load_config(module, candidate, warnings, action='merge', commit=False, format='xml',
                 comment=None, confirm=False, confirm_timeout=None):
 
+    if not candidate:
+        return
+
     with locked_config(module):
         if isinstance(candidate, list):
             candidate = '\n'.join(candidate)

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -242,7 +242,7 @@ def filter_delete_statements(module, candidate):
     config = to_native(match.text, encoding='latin1')
 
     modified_candidate = candidate[:]
-    for index, line in enumerate(candidate):
+    for index, line in reversed(list(enumerate(candidate))):
         if line.startswith('delete'):
             newline = re.sub('^delete', 'set', line)
             if newline not in config:


### PR DESCRIPTION
##### SUMMARY
This patch reversed the order in which the lines are deleted in the `filter_delete_statements` function in [modules/network/junos/junos_config.py](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/network/junos/junos_config.py), using a descending list index. This makes sure that the right lines are deleted.

In addition, because JunOS seems to be unable to process empty change-sets, an empty set is not sent to the router at all. It would have been a no-op anyway.

Fixes #25138

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/network/junos/junos_config.py
module_utils/junos.py

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Dec 17 2016, 23:03:43) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```

##### ADDITIONAL INFORMATION
