### PR TITLE
Fix documentation markup

### DIFF
--- a/docs/docsite/rst/intro_inventory.rst
+++ b/docs/docsite/rst/intro_inventory.rst
@@ -20,7 +20,7 @@ Hosts and Groups
 ++++++++++++++++
 
 The inventory file can be in one of many formats, depending on the inventory plugins you have.
-For this example, the format for ``/etc/ansible/hosts`` is an INI-like (one of Ansible's defaults) and looks like this::
+For this example, the format for ``/etc/ansible/hosts`` is an INI-like (one of Ansible's defaults) and looks like this:
 
 .. code-block:: ini
 


### PR DESCRIPTION
##### SUMMARY
The `::` was preventing the proper rendering of the `code-block` directive. The issue can be seen here: http://docs.ansible.com/ansible/intro_inventory.html#hosts-and-groups

##### ISSUE TYPE
 - Docs Pull Request

##### ANSIBLE VERSION

n/a

##### ADDITIONAL INFORMATION

n/a