### PR TITLE
Add 'exists' to win_stat return docs

### DIFF
--- a/lib/ansible/modules/windows/win_stat.py
+++ b/lib/ansible/modules/windows/win_stat.py
@@ -130,6 +130,11 @@ stat:
             returned: success, path exists
             type: float
             sample: 1477984205.15
+        exists:
+            description: if the path exists or not
+            returned: success
+            type: boolean
+            sample: True
         extension:
             description: the extension of the file at path
             returned: success, path exists, path is a file

--- a/lib/ansible/modules/windows/win_stat.py
+++ b/lib/ansible/modules/windows/win_stat.py
@@ -140,6 +140,11 @@ stat:
             returned: success, path exists, path is a file
             type: string
             sample: ".ps1"
+        filename:
+            description: the name of the file (without path)
+            returned: success, path exists, path is a file
+            type: string
+            sammple: foo.ini
         isarchive:
             description: if the path is ready for archiving or not
             returned: success, path exists
@@ -197,9 +202,9 @@ stat:
             sample: BUILTIN\Administrators
         path:
             description: the full absolute path to the file
-            returned: success, path exists
+            returned: success, path exists, file exists
             type: string
-            sample: BUILTIN\Administrators
+            sample: C:\foo.ini
         sharename:
             description: the name of share if folder is shared
             returned: success, path exists, file is a directory and isshared == True


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #25107  by adding documentation for 'exists' return value in win_stat module
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_stat
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (jhawkesworth-win_stat-exists 773d63e6b6) last updated 2017/05/30 06:33:25 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/jon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jon/ansible/ansible/lib/ansible
  executable location = /home/jon/ansible/ansible/bin/ansible
  python version = 2.7.6 (default, Jun 22 2015, 17:58:13) [GCC 4.8.2]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
BEFORE:

ansible-doc win_stat
> WIN_STAT    (/home/jon/ansible/ansible/lib/ansible/modules/windows/win_stat.py

  Returns information about a Windows file

Options (= is mandatory):

- checksum_algorithm
        Algorithm to determine checksum of file. Will throw an error
        if the host is unable to use specified algorithm.
        (Choices: md5, sha1, sha256, sha384, sha512)[Default: sha1]
- get_checksum
        Whether to return a checksum of the file (default sha1)
        [Default: True]
- get_md5
        Whether to return the checksum sum of the file. Between
        Ansible 1.9 and 2.2 this is no longer an MD5, but a SHA1
        instead. As of Ansible 2.3 this is back to an MD5. Will return
        None if host is unable to use specified algorithm.
        This option is deprecated in Ansible 2.3 and is replaced with
        `checksum_algorithm=md5'.
        [Default: True]
= path
        The full path of the file/object to get the facts of; both
        forward and back slashes are accepted.


EXAMPLES:


- name: Obtain information about a file
  win_stat:
    path: C:\foo.ini
  register: file_info

# Obtain information about a folder
- win_stat:
    path: C:\bar
  register: folder_info

# Get MD5 checksum of a file
- win_stat:
    path: C:\foo.ini
    get_checksum: yes
    checksum_algorithm: md5
  register: md5_checksum

- debug:
    var: md5_checksum.stat.checksum

# Get SHA1 checksum of file
- win_stat:
    path: C:\foo.ini
    get_checksum: yes
  register: sha1_checksum

- debug:
    var: sha1_checksum.stat.checksum

# Get SHA256 checksum of file
- win_stat:
    path: C:\foo.ini
    get_checksum: yes
    checksum_algorithm: sha256
  register: sha256_checksum

- debug:
    var: sha256_checksum.stat.checksum

RETURN VALUES:


changed:
    description: Whether anything was changed
    returned: always
    type: boolean
    sample: True
stat:
    description: dictionary containing all the stat data
    returned: success
    type: complex
    contains:
        attributes:
            description: attributes of the file at path in raw form
            returned: success, path exists
            type: string
            sample: "Archive, Hidden"
        checksum:
            description: The checksum of a file based on checksum_algorithm spec
            returned: success, path exist, path is a file, get_checksum == True
              checksum_algorithm specified is supported
            type: string
            sample: 09cb79e8fc7453c84a07f644e441fd81623b7f98
        creationtime:
            description: the create time of the file represented in seconds sinc
            returned: success, path exists
            type: float
            sample: 1477984205.15
        extension:
            description: the extension of the file at path
            returned: success, path exists, path is a file
            type: string
            sample: ".ps1"
        isarchive:
            description: if the path is ready for archiving or not
            returned: success, path exists
            type: boolean
            sample: True
        isdir:
            description: if the path is a directory or not
            returned: success, path exists
            type: boolean
            sample: True
        ishidden:
            description: if the path is hidden or not
            returned: success, path exists
            type: boolean
            sample: True
        islnk:
            description: if the path is a symbolic link or junction or not
            returned: success, path exists
            type: boolean
            sample: True
        isreadonly:
            description: if the path is read only or not
            returned: success, path exists
            type: boolean
            sample: True
        isshared:
            description: if the path is shared or not
            returned: success, path exists
            type: boolean
            sample: True
        lastaccesstime:
            description: the last access time of the file represented in seconds
            returned: success, path exists
            type: float
            sample: 1477984205.15
        lastwritetime:
            description: the last modification time of the file represented in s
            returned: success, path exists
            type: float
            sample: 1477984205.15
        lnk_source:
            description: the target of the symbolic link, will return null if no
            return: success, path exists, file is a symbolic link
            type: string
            sample: C:\temp
        md5:
            description: The MD5 checksum of a file (Between Ansible 1.9 and 2.2
            returned: success, path exist, path is a file, get_md5 == True, md5 
            type: string
            sample: 09cb79e8fc7453c84a07f644e441fd81623b7f98
        owner:
            description: the owner of the file
            returned: success, path exists
            type: string
            sample: BUILTIN\Administrators
        path:
            description: the full absolute path to the file
            returned: success, path exists
            type: string
            sample: BUILTIN\Administrators
        sharename:
            description: the name of share if folder is shared
            returned: success, path exists, file is a directory and isshared == 
            type: string
            sample: file-share
        size:
            description: the size in bytes of a file or folder
            returned: success, path exists, file is not a link
            type: int
            sample: 1024


MAINTAINERS: Chris Church (@cchurch)

METADATA:
        Status: ['stableinterface']
        Supported_by: core



AFTER:

ansible-doc win_stat
> WIN_STAT    (/home/jon/ansible/ansible/lib/ansible/modules/windows/win_stat.py

  Returns information about a Windows file

Options (= is mandatory):

- checksum_algorithm
        Algorithm to determine checksum of file. Will throw an error
        if the host is unable to use specified algorithm.
        (Choices: md5, sha1, sha256, sha384, sha512)[Default: sha1]
- get_checksum
        Whether to return a checksum of the file (default sha1)
        [Default: True]
- get_md5
        Whether to return the checksum sum of the file. Between
        Ansible 1.9 and 2.2 this is no longer an MD5, but a SHA1
        instead. As of Ansible 2.3 this is back to an MD5. Will return
        None if host is unable to use specified algorithm.
        This option is deprecated in Ansible 2.3 and is replaced with
        `checksum_algorithm=md5'.
        [Default: True]
= path
        The full path of the file/object to get the facts of; both
        forward and back slashes are accepted.


EXAMPLES:


- name: Obtain information about a file
  win_stat:
    path: C:\foo.ini
  register: file_info

# Obtain information about a folder
- win_stat:
    path: C:\bar
  register: folder_info

# Get MD5 checksum of a file
- win_stat:
    path: C:\foo.ini
    get_checksum: yes
    checksum_algorithm: md5
  register: md5_checksum

- debug:
    var: md5_checksum.stat.checksum

# Get SHA1 checksum of file
- win_stat:
    path: C:\foo.ini
    get_checksum: yes
  register: sha1_checksum

- debug:
    var: sha1_checksum.stat.checksum

# Get SHA256 checksum of file
- win_stat:
    path: C:\foo.ini
    get_checksum: yes
    checksum_algorithm: sha256
  register: sha256_checksum

- debug:
    var: sha256_checksum.stat.checksum

RETURN VALUES:


changed:
    description: Whether anything was changed
    returned: always
    type: boolean
    sample: True
stat:
    description: dictionary containing all the stat data
    returned: success
    type: complex
    contains:
        attributes:
            description: attributes of the file at path in raw form
            returned: success, path exists
            type: string
            sample: "Archive, Hidden"
        checksum:
            description: The checksum of a file based on checksum_algorithm spec
            returned: success, path exist, path is a file, get_checksum == True
              checksum_algorithm specified is supported
            type: string
            sample: 09cb79e8fc7453c84a07f644e441fd81623b7f98
        creationtime:
            description: the create time of the file represented in seconds sinc
            returned: success, path exists
            type: float
            sample: 1477984205.15
        exists:
            description: if the path exists or not
            returned: success
            type: boolean
            sample: True
        extension:
            description: the extension of the file at path
            returned: success, path exists, path is a file
            type: string
            sample: ".ps1"
        isarchive:
            description: if the path is ready for archiving or not
            returned: success, path exists
            type: boolean
            sample: True
        isdir:
            description: if the path is a directory or not
            returned: success, path exists
            type: boolean
            sample: True
        ishidden:
            description: if the path is hidden or not
            returned: success, path exists
            type: boolean
            sample: True
        islnk:
            description: if the path is a symbolic link or junction or not
            returned: success, path exists
            type: boolean
            sample: True
        isreadonly:
            description: if the path is read only or not
            returned: success, path exists
            type: boolean
            sample: True
        isshared:
            description: if the path is shared or not
            returned: success, path exists
            type: boolean
            sample: True
        lastaccesstime:
            description: the last access time of the file represented in seconds
            returned: success, path exists
            type: float
            sample: 1477984205.15
        lastwritetime:
            description: the last modification time of the file represented in s
            returned: success, path exists
            type: float
            sample: 1477984205.15
        lnk_source:
            description: the target of the symbolic link, will return null if no
            return: success, path exists, file is a symbolic link
            type: string
            sample: C:\temp
        md5:
            description: The MD5 checksum of a file (Between Ansible 1.9 and 2.2
            returned: success, path exist, path is a file, get_md5 == True, md5 
            type: string
            sample: 09cb79e8fc7453c84a07f644e441fd81623b7f98
        owner:
            description: the owner of the file
            returned: success, path exists
            type: string
            sample: BUILTIN\Administrators
        path:
            description: the full absolute path to the file
            returned: success, path exists
            type: string
            sample: BUILTIN\Administrators
        sharename:
            description: the name of share if folder is shared
            returned: success, path exists, file is a directory and isshared == 
            type: string
            sample: file-share
        size:
            description: the size in bytes of a file or folder
            returned: success, path exists, file is not a link
            type: int
            sample: 1024


MAINTAINERS: Chris Church (@cchurch)

METADATA:
        Status: ['stableinterface']
        Supported_by: core

```
