### PR TITLE
Fix IndexError when junos_config contains multiple delete lines (#25139)

### DIFF
--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -168,6 +168,9 @@ def get_diff(module):
 def load_config(module, candidate, warnings, action='merge', commit=False, format='xml',
                 comment=None, confirm=False, confirm_timeout=None):
 
+    if not candidate:
+        return
+
     with locked_config(module):
         if isinstance(candidate, list):
             candidate = '\n'.join(candidate)

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -231,7 +231,7 @@ def filter_delete_statements(module, candidate):
     config = str(match.text)
 
     modified_candidate = candidate[:]
-    for index, line in enumerate(candidate):
+    for index, line in reversed(list(enumerate(candidate))):
         if line.startswith('delete'):
             newline = re.sub('^delete', 'set', line)
             if newline not in config:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* Prevent IndexError when deleting multiple lines

The old code will raise `IndexError: list assignment index out of range` when deleting multiple lines because the indexes of the original and the copy get out of sync. Solved by deleting from the high indexes first so the lower ones remain stable.

* Don't load configuration if nothing to load

Instead of sending an empty candidate config (for example because the candidate only consisted of `delete` lines, and all of them were filtered out by `filter_delete_statements`) just return. JunOS seems to get confused by empty changes, and if the candidate config is empty then it's a no-op anyway.

(cherry picked from commit 06f76a2741eb4216ae1b2a348bbb0f66c05f1e5c)

Merged to devel https://github.com/ansible/ansible/pull/25139
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/network/junos/junos_config.py
module_utils/junos.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Dec 17 2016, 23:03:43) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
