### PR TITLE
hashi_vault module - Add verify param to support ssl Vault

### DIFF
--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -158,6 +158,7 @@ class HashiVault:
         else:
             return arg
 
+
 class LookupModule(LookupBase):
     def run(self, terms, variables, **kwargs):
         if not HAS_HVAC:


### PR DESCRIPTION
##### SUMMARY
Add parameter verify to hashi_vault module. So, it will work with Vault server under ssl.

##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
hashi_vault module

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION

