### PR TITLE
Add provider to prepare_ios_tests role tasks

### DIFF
--- a/test/integration/targets/prepare_ios_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_ios_tests/tasks/main.yml
@@ -3,6 +3,7 @@
 - name: Ensure we have loopback 888 for testing
   ios_config:
     src: config.j2
+    provider: "{{ cli }}"
 
 
 # Some AWS hostnames can be longer than those allowed by the system we are testing


### PR DESCRIPTION
This avoids passing -u <user> -k, as it will just consume
the credentials from group_vars