### PR TITLE
Add provider param to prepare_iosxr_tests role tasks

### DIFF
--- a/test/integration/targets/prepare_iosxr_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_iosxr_tests/tasks/main.yml
@@ -3,6 +3,7 @@
 - name: Ensure we have loopback 888 for testing
   iosxr_config:
     src: config.j2
+    provider: "{{ cli }}"
 
 
 # Some AWS hostnames can be longer than those allowed by the system we are testing


### PR DESCRIPTION
This will avoid passing -u -k to ansible-playbook