### PR TITLE
Amazon Redshift module cluster deletion fix

### DIFF
--- a/lib/ansible/modules/cloud/amazon/redshift.py
+++ b/lib/ansible/modules/cloud/amazon/redshift.py
@@ -448,7 +448,7 @@ def main():
         cluster_type                        = dict(choices=['multi-node', 'single-node', ], default='single-node'),
         cluster_security_groups             = dict(aliases=['security_groups'], type='list'),
         vpc_security_group_ids              = dict(aliases=['vpc_security_groups'], type='list'),
-        skip_final_cluster_snapshot         = dict(aliases=['skip_final_snapshot'], type='bool'),
+        skip_final_cluster_snapshot         = dict(aliases=['skip_final_snapshot'], type='bool', default=False),
         final_cluster_snapshot_identifier   = dict(aliases=['final_snapshot_id'], required=False),
         cluster_subnet_group_name           = dict(aliases=['subnet']),
         availability_zone                   = dict(aliases=['aws_zone', 'zone']),

--- a/lib/ansible/modules/cloud/amazon/redshift.py
+++ b/lib/ansible/modules/cloud/amazon/redshift.py
@@ -83,14 +83,14 @@ options:
   skip_final_cluster_snapshot:
     description:
       - skip a final snapshot before deleting the cluster. Used only when command=delete.
-    aliases: ['skip_snapshot']
+    aliases: ['skip_final_snapshot']
     default: false
     version_added: "2.4"
   final_cluster_snapshot_identifier:
     description:
       - identifier of the final snapshot to be created before deleting the cluster. If this parameter is provided,
         final_cluster_snapshot_identifier must be false. Used only when command=delete.
-    aliases: ['snapshot_identifier']
+    aliases: ['final_snapshot_id']
     default: null
     version_added: "2.4"
   preferred_maintenance_window:

--- a/lib/ansible/modules/cloud/amazon/redshift.py
+++ b/lib/ansible/modules/cloud/amazon/redshift.py
@@ -332,7 +332,7 @@ def delete_cluster(module, redshift):
     wait_timeout = module.params.get('wait_timeout')
 
     try:
-        redshift.delete_custer( identifier )
+        redshift.delete_cluster( identifier )
     except boto.exception.JSONResponseError as e:
         module.fail_json(msg=str(e))
 

--- a/lib/ansible/modules/cloud/amazon/redshift.py
+++ b/lib/ansible/modules/cloud/amazon/redshift.py
@@ -87,10 +87,10 @@ options:
     default: false
   final_cluster_snapshot_identifier:
     description:
-      - identifier of the final snapshot to be created before deleting the cluster. If this parameter is provided, 
+      - identifier of the final snapshot to be created before deleting the cluster. If this parameter is provided,
         final_cluster_snapshot_identifier must be false. Used only when command=delete.
     aliases: ['snapshot_identifier']
-    default: null    
+    default: null
   preferred_maintenance_window:
     description:
       - maintenance window

--- a/lib/ansible/modules/cloud/amazon/redshift.py
+++ b/lib/ansible/modules/cloud/amazon/redshift.py
@@ -85,12 +85,14 @@ options:
       - skip a final snapshot before deleting the cluster. Used only when command=delete.
     aliases: ['skip_snapshot']
     default: false
+    version_added: "2.4"
   final_cluster_snapshot_identifier:
     description:
       - identifier of the final snapshot to be created before deleting the cluster. If this parameter is provided,
         final_cluster_snapshot_identifier must be false. Used only when command=delete.
     aliases: ['snapshot_identifier']
     default: null
+    version_added: "2.4"
   preferred_maintenance_window:
     description:
       - maintenance window

--- a/lib/ansible/modules/cloud/amazon/redshift.py
+++ b/lib/ansible/modules/cloud/amazon/redshift.py
@@ -164,9 +164,9 @@ EXAMPLES = '''
     password=1nsecure
 
 # Cluster delete example
-- redshift: >
-    command: "delete"
-    identifier: "new_cluster"
+- redshift:
+    command: delete
+    identifier: new_cluster
     skip_final_cluster_snapshot: true
     wait: true
 '''
@@ -347,10 +347,10 @@ def delete_cluster(module, redshift):
     redshift: authenticated redshift connection object
     """
 
-    identifier                        = module.params.get('identifier')
-    wait                              = module.params.get('wait')
-    wait_timeout                      = module.params.get('wait_timeout')
-    skip_final_cluster_snapshot       = module.params.get('skip_final_cluster_snapshot')
+    identifier = module.params.get('identifier')
+    wait = module.params.get('wait')
+    wait_timeout = module.params.get('wait_timeout')
+    skip_final_cluster_snapshot = module.params.get('skip_final_cluster_snapshot')
     final_cluster_snapshot_identifier = module.params.get('final_cluster_snapshot_identifier')
 
     try:
@@ -465,8 +465,7 @@ def main():
         new_cluster_identifier              = dict(aliases=['new_identifier']),
         wait                                = dict(type='bool', default=False),
         wait_timeout                        = dict(type='int', default=300),
-    ),
-    )
+    ))
 
     required_if = [
         ('command', 'delete', ['skip_final_cluster_snapshot']),

--- a/lib/ansible/modules/cloud/amazon/redshift.py
+++ b/lib/ansible/modules/cloud/amazon/redshift.py
@@ -448,7 +448,7 @@ def main():
         cluster_type                        = dict(choices=['multi-node', 'single-node', ], default='single-node'),
         cluster_security_groups             = dict(aliases=['security_groups'], type='list'),
         vpc_security_group_ids              = dict(aliases=['vpc_security_groups'], type='list'),
-        skip_final_cluster_snapshot         = dict(aliases=['skip_final_snapshot'], type='bool', default=False),
+        skip_final_cluster_snapshot         = dict(aliases=['skip_final_snapshot'], type='bool'),
         final_cluster_snapshot_identifier   = dict(aliases=['final_snapshot_id'], required=False),
         cluster_subnet_group_name           = dict(aliases=['subnet']),
         availability_zone                   = dict(aliases=['aws_zone', 'zone']),
@@ -469,6 +469,7 @@ def main():
     )
 
     required_if = [
+        ('command', 'delete', ['skip_final_cluster_snapshot']),
         ('skip_final_cluster_snapshot', False, ['final_cluster_snapshot_identifier'])
     ]
 


### PR DESCRIPTION
##### SUMMARY

This pull requests fixes the Redshift cluster deletion operation.

It corrects a typo error in the call to boto.redshift.create_cluster and adds necessary parameters (final snapshot creation options):

* skip_final_cluster_snapshot: skip a final snapshot before deleting the cluster
* final_cluster_snapshot_identifier: identifier of the final snapshot to be created before deleting the cluster

Ref: http://boto.cloudhackers.com/en/latest/ref/redshift.html

Fix #25161 

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

amazon redshift module

##### ANSIBLE VERSION

```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION


