### PR TITLE
ec2_group: document expected source(s) for rules/egress rules - fixes #24741

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -46,11 +46,14 @@ options:
       - List of firewall inbound rules to enforce in this group (see example). If none are supplied,
         no inbound rules will be enabled. Rules list may include its own name in `group_name`.
         This allows idempotent loopback additions (e.g. allow group to acccess itself).
+        Rule sources list support was added in version 2.4. This allows to define multiple sources per
+        source type as well as multiple source types per rule. Prior to 2.4 an individual source is allowed.
     required: false
   rules_egress:
     description:
       - List of firewall outbound rules to enforce in this group (see example). If none are supplied,
         a default all-out rule is assumed. If an empty list is supplied, no outbound rules will be enabled.
+        Rule Egress sources list support was added in version 2.4.
     required: false
     version_added: "1.6"
   state:


### PR DESCRIPTION

##### SUMMARY
Document that group_name/group_id may be a list in 2.4. Also mentioned on [line 156 (now 159)](https://github.com/ansible/ansible/compare/devel...s-hertel:ec2_group_sg_list?expand=1#diff-c699eaa2fb1fe186851a9905e12920e0L156).
Fixes #24741

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_group.py

##### ANSIBLE VERSION
```
2.4.0
```
