### PR TITLE
Fix inventory script for Foreman where group by pattern are not prope…

### DIFF
--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -262,12 +262,9 @@ class ForemanInventory(object):
 
             # Ansible groups by parameters in host groups and Foreman host
             # attributes.
-            groupby = copy.copy(params)
-            for k, v in host.items():
-                if isinstance(v, str):
-                    groupby[k] = self.to_safe(v)
-                elif isinstance(v, int):
-                    groupby[k] = v
+            groupby = dict()
+            for k, v in params.items():
+	        groupby[k] = self.to_safe(str(v))
 
             # The name of the ansible groups is given by group_patterns:
             for pattern in self.group_patterns:

--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -264,7 +264,7 @@ class ForemanInventory(object):
             # attributes.
             groupby = dict()
             for k, v in params.items():
-	        groupby[k] = self.to_safe(str(v))
+                groupby[k] = self.to_safe(str(v))
 
             # The name of the ansible groups is given by group_patterns:
             for pattern in self.group_patterns:


### PR DESCRIPTION
…rly safe-guarded.

##### SUMMARY

When using group_patterns within the inventory script for Foreman, there is a bug that leads to group names being created that are not safe. Actually there were two issues with the code:

1. the parameters were copied from `params` but the loop after was on the items of `host` which didn't make sense IMHO.
2. the isinstance call would fail on UTF-8 strings, which are not strings under Python 2.x.

The new code is now simpler, still takes care of integers and any kind of object, making safe group names out of them.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
contrib/inventory/foreman.py

##### ANSIBLE VERSION

```
ansible 2.3.0.0
  config file = /etc/ansible/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```
The bug is still in the devel branch

##### ADDITIONAL INFORMATION

If I have following extract of foreman.ini:

```ini
[ansible]
group_patterns = ["{MyTest}-{YourTest}",
	          "{MyTest}",
		  "{YourTest}"]
```

and following parameters in Satellite/Foreman:

```json
        "foreman_params": {
          "MyTest": "My-Value?", 
          "YourTest": "Your Value!"
        }
```

Then, before the fix, the resulting groups are:

```json
  "My-Value?": [
    "sat6ewl2.ewl.example.com"
  ], 
  "My-Value?-Your Value!": [
    "sat6ewl2.ewl.example.com"
  ], 
  "Your Value!": [
    "sat6ewl2.ewl.example.com"
  ], 
```

And after they are:

```json
  "My_Value_": [
    "sat6ewl2.ewl.example.com"
  ], 
  "My_Value_-YourValue_": [
    "sat6ewl2.ewl.example.com"
  ], 
  "YourValue_": [
    "sat6ewl2.ewl.example.com"
  ], 
```