### PR TITLE
Fix formatting for rst code block

### DIFF
--- a/docs/docsite/rst/intro_inventory.rst
+++ b/docs/docsite/rst/intro_inventory.rst
@@ -20,7 +20,7 @@ Hosts and Groups
 ++++++++++++++++
 
 The inventory file can be in one of many formats, depending on the inventory plugins you have.
-For this example, the format for ``/etc/ansible/hosts`` is an INI-like (one of Ansible's defaults) and looks like this::
+For this example, the format for ``/etc/ansible/hosts`` is an INI-like (one of Ansible's defaults) and looks like this:
 
 .. code-block:: ini
 


### PR DESCRIPTION
##### SUMMARY
Existing docs at http://docs.ansible.com/ansible/intro_inventory.html#hosts-and-groups have an RST formatting issue:

![screen shot 2017-05-30 at 6 07 32 pm](https://cloud.githubusercontent.com/assets/1408986/26611395/e747b1b6-4562-11e7-98d8-abc63a5801d3.png)


I couldn't find an open ticket for this, but can create one and link it back to this if you like.


##### ISSUE TYPE
 - Docs Pull Request
