### PR TITLE
apache2_module: fix module detection on SLES

### DIFF
--- a/lib/ansible/modules/web_infrastructure/apache2_module.py
+++ b/lib/ansible/modules/web_infrastructure/apache2_module.py
@@ -102,6 +102,7 @@ stderr:
     type: string
 '''
 
+import os
 import re
 
 
@@ -126,11 +127,16 @@ def _get_ctl_binary(module):
 
 
 def _module_is_enabled(module):
-    control_binary = _get_ctl_binary(module)
     name = module.params['name']
     ignore_configcheck = module.params['ignore_configcheck']
 
-    result, stdout, stderr = module.run_command("%s -M" % control_binary)
+    if os.path.exists('/etc/SuSE-release'):
+        result, stdout, stderr = module.run_command(["a2enmod", "-l"])
+        if stdout is not None:
+            stdout = "\n".join([" %s_module" % l for l in stdout.rstrip().split(' ')])
+    else:
+        control_binary = _get_ctl_binary(module)
+        result, stdout, stderr = module.run_command("%s -M" % control_binary)
 
     if result != 0:
         error_msg = "Error executing %s: %s" % (control_binary, stderr)


### PR DESCRIPTION
##### SUMMARY
On at least SLES12 apache2ctl only lists the currently *loaded* apache
modules not the *enabled* ones. "a2enmod -l" lists the enabled ones so
use that instead and format the output so it matches the apache2ctl one.

Without this enabling modules can fail with

      "module already enabled"

since apache2_module misdetects if the module is already enabled.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
apache2_module

##### ANSIBLE VERSION
ansible 2.4.0 (devel d958440bcb) last updated 2017/05/31 08:00:26 (GMT +200)
  config file = /var/scratch/src/ansible/ansible/ansible.cfg
  configured module search path = [u'/home/agx/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /var/scratch/src/ansible/ansible/lib/ansible
  executable location = /var/scratch/src/ansible/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]

##### ADDITIONAL INFORMATION
