### PR TITLE
remove cpuHotAddEnabled, memoryHotAddEnabled defaults from configSpec (fixes #25201)

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -82,6 +82,8 @@ options:
     description:
     - Manage some VM hardware attributes.
     - 'Valid attributes are:'
+    - ' - C(hotadd_cpu) (boolean): Allow cpus to be added while the VM is running.'
+    - ' - C(hotadd_memory) (boolean): Allow memory to be added while the VM is running.'
     - ' - C(memory_mb) (integer): Amount of memory in MB.'
     - ' - C(num_cpus) (integer): Number of CPUs.'
     - ' - C(scsi) (string): Valid values are C(buslogic), C(lsilogic), C(lsilogicsas) and C(paravirtual) (default).'
@@ -604,6 +606,16 @@ class PyVmomiHelper(PyVmomi):
             # memory_mb is mandatory for VM creation
             elif vm_creation and not self.params['template']:
                 self.module.fail_json(msg="hardware.memory_mb attribute is mandatory for VM creation")
+
+            if 'hotadd_memory' in self.params['hardware']:
+                self.configspec.memoryHotAddEnabled = bool(self.params['hardware']['hotadd_memory'])
+                if vm_obj is None or self.configspec.memoryHotAddEnabled != vm_obj.config.memoryHotAddEnabled:
+                    self.change_detected = True
+
+            if 'hotadd_cpu' in self.params['hardware']:
+                self.configspec.cpuHotAddEnabled = bool(self.params['hardware']['hotadd_cpu'])
+                if vm_obj is None or self.configspec.cpuHotAddEnabled != vm_obj.config.cpuHotAddEnabled:
+                    self.change_detected = True
 
     def configure_cdrom(self, vm_obj):
         # Configure the VM CD-ROM
@@ -1267,7 +1279,7 @@ class PyVmomiHelper(PyVmomi):
         # set the destination datastore for VM & disks
         (datastore, datastore_name) = self.select_datastore(vm_obj)
 
-        self.configspec = vim.vm.ConfigSpec(cpuHotAddEnabled=True, memoryHotAddEnabled=True)
+        self.configspec = vim.vm.ConfigSpec()
         self.configspec.deviceChange = []
         self.configure_guestid(vm_obj=vm_obj, vm_creation=True)
         self.configure_cpu_and_memory(vm_obj=vm_obj, vm_creation=True)

--- a/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml
@@ -68,6 +68,8 @@
     hardware:
         num_cpus: 1
         memory_mb: 512
+        hotadd_memory: true
+        hotadd_cpu: false
     disk:
         - size: 0gb
           type: thin


### PR DESCRIPTION
##### SUMMARY
The `vmware_guest` module defaults the vm `ConfigSpec.cpuHotAddEnabled` and `ConfigSpec.memoryHotAddEnabled` attributes to true.
These parameters requires the permissions , as explained in
[](https://www.vmware.com/support/developer/converter-sdk/conv60_apireference/vim.vm.ConfigSpec.html#memoryHotAddEnabled)
and
(https://www.vmware.com/support/developer/converter-sdk/conv60_apireference/vim.vm.ConfigSpec.html#cpuHotAddEnabled)

This PR removes those hardcoded defaults from the deploy_vm method, thus allowing vmware users without `VirtualMachine.Config.Memory` and/or `VirtualMachine.Config.CPUCount` privileges to deploy a VM from a template.

fixes #25201

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vmware_guest module

##### ANSIBLE VERSION
ansible 2.3.0 (devel c3c4ae87dd) last updated 2017/05/31 11:17:49 (GMT +200)
  config file = 
  configured module search path = Default w/o overrides


```
