### PR TITLE
reset_connection fixes: #23621

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -897,6 +897,8 @@ class Connection(ConnectionBase):
             display.vvv(u'sending stop: %s' % cmd)
             p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = p.communicate()
+            status_code = p.wait()
+            if status_code != 0:
 
         self.close()
 

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -897,8 +897,6 @@ class Connection(ConnectionBase):
             display.vvv(u'sending stop: %s' % cmd)
             p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = p.communicate()
-            status_code = p.wait()
-            if status_code != 0:
 
         self.close()
 

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -897,6 +897,9 @@ class Connection(ConnectionBase):
             display.vvv(u'sending stop: %s' % cmd)
             p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = p.communicate()
+            status_code = p.wait()
+            if status_code != 0:
+                raise AnsibleError("Cannot reset connection:\n%s" % stderr)
 
         self.close()
 

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -894,9 +894,9 @@ class Connection(ConnectionBase):
         cmd = map(to_bytes, self._build_command(self._play_context.ssh_executable, '-O', 'stop', self.host))
         controlpersist, controlpath = self._persistence_controls(cmd)
         if controlpersist:
+            display.vvv(u'sending stop: %s' % cmd)
             p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = p.communicate()
-            display.vvv(u'sending stop: %s' % cmd)
 
         self.close()
 


### PR DESCRIPTION
##### SUMMARY

Fixes #23621.
It is supplementary change making sure that the ssh disconnection command failure does not pass unnoticed.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
meta action handler; reset_connection for ssh

##### ANSIBLE VERSION
2.3.x, main branch

##### ADDITIONAL INFORMATION
The current reset_connection action for ssh handler was executed unconditionally. When the handler for connection was resolved properly (i.e. ssh instead of smart), the command was executed, but the result was not checked. This led to the situation that even when the ssh connection was not populated properly and the stop command failed, the failure was not propagated letting the user believe that the disconnection went successfully.



*Edited by gundalow*