### PR TITLE
fix state present nxos_evpn_vni

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_evpn_vni.py
+++ b/lib/ansible/modules/network/nxos/nxos_evpn_vni.py
@@ -220,9 +220,8 @@ def state_present(module, existing, proposed):
             command = '{0} {1}'.format(key, value)
             commands.append(command)
 
-    else:
-        commands = ['vni {0} l2'.format(module.params['vni'])]
-        parents = ['evpn']
+    if commands:
+        parents = ['evpn', 'vni {0} l2'.format(module.params['vni'])]
 
     return commands, parents
 

--- a/test/units/modules/network/nxos/test_nxos_evpn_vni.py
+++ b/test/units/modules/network/nxos/test_nxos_evpn_vni.py
@@ -50,9 +50,13 @@ class TestNxosEvpnVniModule(TestNxosModule):
         self.load_config.return_value = None
 
     def test_nxos_evpn_vni_present(self):
-        set_module_args(dict(vni='6000', state='present'))
+        set_module_args(dict(vni='6000',
+                             route_target_import='5000:10',
+                             state='present'))
         result = self.execute_module(changed=True)
-        self.assertEqual(result['commands'], ['evpn', 'vni 6000 l2'])
+        self.assertEqual(result['commands'], ['evpn',
+                                              'vni 6000 l2',
+                                              'route-target import 5000:10'])
 
     def test_nxos_evpn_vni_absent_not_existing(self):
         set_module_args(dict(vni='12000', state='absent'))


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #24995 
`state=present` fails silently without configuring the device.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/network/nxos/nxos_evpn_vni
test/units/modules/network/test_nxos_evn_vni

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.4
```