### PR TITLE
Apt module: fixed 'only_upgrade' so that the status was not always 'changed'

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -490,7 +490,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
 
         name, version = package_split(package)
         installed, upgradable, has_files = package_status(m, name, version, cache, state='install')
-        if not installed or (upgrade and upgradable):
+        if (not installed and not only_upgrade) or (upgrade and upgradable):
             pkg_list.append("'%s'" % package)
         if installed and upgradable and version:
             # This happens when the package is installed, a newer version is


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Using apt module with state=latest and only_upgrade=yes, the result is always 'changed' if the package is not installed. I've done a very simple fix.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
packaging/os/apt module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.9 (default, Jun 29 2016, 13:08:31) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Without the fix (run on the host without samba installed):
```
ansible -m apt -a 'package=samba state=latest only_upgrade=yes' testhost -v
testhost | SUCCESS => {
    "cache_update_time": 1496216436, 
    "cache_updated": false, 
    "changed": true, 
    "stderr": "", 
    "stderr_lines": [], 
    "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nSkipping samba, it is not installed and only upgrades are requested.\n0 upgraded, 0 newly installed, 0 to remove and 73 not upgraded.\n", 
    "stdout_lines": [
        "Reading package lists...", 
        "Building dependency tree...", 
        "Reading state information...", 
        "Skipping samba, it is not installed and only upgrades are requested.", 
        "0 upgraded, 0 newly installed, 0 to remove and 73 not upgraded."
    ]
}
```
After applying the fix:
```
testhost | SUCCESS => {
    "cache_update_time": 1496216436, 
    "cache_updated": false, 
    "changed": false
}
```
