### PR TITLE
Fix nxos_vpc idempotence issues

### DIFF
--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -472,7 +472,6 @@ lib/ansible/modules/network/nxos/nxos_system.py
 lib/ansible/modules/network/nxos/nxos_udld.py
 lib/ansible/modules/network/nxos/nxos_udld_interface.py
 lib/ansible/modules/network/nxos/nxos_user.py
-lib/ansible/modules/network/nxos/nxos_vpc.py
 lib/ansible/modules/network/nxos/nxos_vpc_interface.py
 lib/ansible/modules/network/nxos/nxos_vrf.py
 lib/ansible/modules/network/nxos/nxos_vrf_interface.py


### PR DESCRIPTION
##### SUMMARY
This update addresses the following issues for the nxos_vpc module
* Idempotence issues around `role_priority` and `peer_gw` which can cause significant network churn.
* Piping to `json` when `execute_show_command` uses `command_type='cli_show'`.  Without this the module was erroring out when `transport = nxapi`
* Removal of `get_config` which is not used by the module.
* Minor Flake8 fixes.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_vpc

##### ANSIBLE VERSION
```
ansible 2.4.0 (fix/nxos_vpc ed41cc650d) last updated 2017/05/30 16:51:53 (GMT -400)
  config file = 
  configured module search path = [u'/Users/mwiebe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible
  executable location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
The following playbook is used for the tests.

```yaml
---
- hosts: nxos
  connection: local
  gather_facts: no

  tasks:
  - name: Configure vpc
    nxos_vpc:
      state: present 
      domain: 100
      #role_priority: 1001
      role_priority: 32667 
      system_priority: 2000
      pkl_dest: 192.168.100.4
      pkl_src: 10.1.100.20
      peer_gw: true 
      auto_recovery: true
      # provider: "{{ cli }}"
      provider: "{{ nxapi }}"
```
The default role priority for nxos is `32667`.  This value does not show up in the running config which causes and idempotence issue.  This update addresses that problem but I am not sure it's the supported ansilble method of handling defaults.

The peer gw logic also results in an idempotence issue when there is no `peer_gw` info in the `vpc` dictionary.  The setting would toggle back and forth from true -> false -> true etc... This update addresses that.

**Ansible Run Before Change using default role_priority and transport = cli:**
```shell
(py2-ansible) mwiebe@MWIEBE-M-D2TB:~/Projects/nxos_ansible/fix_ansible$ansible-playbook -i /etc/ansible/hosts ../ap/test_vpc.yaml

PLAY [nxos] *************************************************************************************************************************************************************************************************************************

TASK [Configure vpc] ****************************************************************************************************************************************************************************************************************
changed: [n9k.example.com]

PLAY RECAP **************************************************************************************************************************************************************************************************************************
n9k.example.com          : ok=1    changed=1    unreachable=0    failed=0   

(py2-ansible) mwiebe@MWIEBE-M-D2TB:~/Projects/nxos_ansible/fix_ansible$ansible-playbook -i /etc/ansible/hosts ../ap/test_vpc.yaml

PLAY [nxos] *************************************************************************************************************************************************************************************************************************

TASK [Configure vpc] ****************************************************************************************************************************************************************************************************************
changed: [n9k.example.com]

PLAY RECAP **************************************************************************************************************************************************************************************************************************
n9k.example.com          : ok=1    changed=1    unreachable=0    failed=0   

(py2-ansible) mwiebe@MWIEBE-M-D2TB:~/Projects/nxos_ansible/fix_ansible$
```

**Ansible Run Before Change transport = nxapi:**
```shell
(py2-ansible) mwiebe@MWIEBE-M-D2TB:~/Projects/nxos_ansible/fix_ansible$ansible-playbook -i /etc/ansible/hosts ../ap/test_vpc.yaml

PLAY [nxos] *************************************************************************************************************************************************************************************************************************

TASK [Configure vpc] ****************************************************************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: string indices must be integers
fatal: [n9k.example.com]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_beuy61ys/ansible_module_nxos_vpc.py\", line 444, in <module>\n    main()\n  File \"/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_beuy61ys/ansible_module_nxos_vpc.py\", line 397, in main\n    if pkl_vrf.lower() not in get_vrf_list(module):\n  File \"/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_beuy61ys/ansible_module_nxos_vpc.py\", line 183, in get_vrf_list\n    vrf_table = body[0]['TABLE_vrf']['ROW_vrf']\nTypeError: string indices must be integers\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 0}
	to retry, use: --limit @/Users/mwiebe/Projects/nxos_ansible/ap/test_vpc.retry

PLAY RECAP **************************************************************************************************************************************************************************************************************************
n9k.example.com          : ok=0    changed=0    unreachable=0    failed=1   

(py2-ansible) mwiebe@MWIEBE-M-D2TB:~/Projects/nxos_ansible/fix_ansible$
```

**Ansible Run After Change using default role_priority and transport = cli:**
```shell
(py2-ansible) mwiebe@MWIEBE-M-D2TB:~/Projects/nxos_ansible/fix_ansible$ansible-playbook -i /etc/ansible/hosts ../ap/test_vpc.yaml

PLAY [nxos] *************************************************************************************************************************************************************************************************************************

TASK [Configure vpc] ****************************************************************************************************************************************************************************************************************
ok: [n9k.example.com]

PLAY RECAP **************************************************************************************************************************************************************************************************************************
n9k.example.com          : ok=1    changed=0    unreachable=0    failed=0   

(py2-ansible) mwiebe@MWIEBE-M-D2TB:~/Projects/nxos_ansible/fix_ansible$
(py2-ansible) mwiebe@MWIEBE-M-D2TB:~/Projects/nxos_ansible/fix_ansible$ansible-playbook -i /etc/ansible/hosts ../ap/test_vpc.yaml

PLAY [nxos] *************************************************************************************************************************************************************************************************************************

TASK [Configure vpc] ****************************************************************************************************************************************************************************************************************
ok: [n9k.example.com]

PLAY RECAP **************************************************************************************************************************************************************************************************************************
n9k.example.com          : ok=1    changed=0    unreachable=0    failed=0   

(py2-ansible) mwiebe@MWIEBE-M-D2TB:~/Projects/nxos_ansible/fix_ansible$
```
**Ansible Run After Change using default role_priority and transport = nxapi:**
```shell
(py2-ansible) mwiebe@MWIEBE-M-D2TB:~/Projects/nxos_ansible/fix_ansible$ansible-playbook -i /etc/ansible/hosts ../ap/test_vpc.yaml

PLAY [nxos] *************************************************************************************************************************************************************************************************************************

TASK [Configure vpc] ****************************************************************************************************************************************************************************************************************
ok: [n9k.example.com]

PLAY RECAP **************************************************************************************************************************************************************************************************************************
n9k.example.com          : ok=1    changed=0    unreachable=0    failed=0   

(py2-ansible) mwiebe@MWIEBE-M-D2TB:~/Projects/nxos_ansible/fix_ansible$ansible-playbook -i /etc/ansible/hosts ../ap/test_vpc.yaml

PLAY [nxos] *************************************************************************************************************************************************************************************************************************

TASK [Configure vpc] ****************************************************************************************************************************************************************************************************************
ok: [n9k.example.com]

PLAY RECAP **************************************************************************************************************************************************************************************************************************
n9k.example.com          : ok=1    changed=0    unreachable=0    failed=0   

(py2-ansible) mwiebe@MWIEBE-M-D2TB:~/Projects/nxos_ansible/fix_ansible$
```