### PR TITLE
Narrowing the match for python 3 cmp check

### DIFF
--- a/test/sanity/code-smell/no-list-cmp.sh
+++ b/test/sanity/code-smell/no-list-cmp.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-CMP_USERS=$(grep -rI ' cmp[^a-zA-Z0-9_]' . \
+CMP_USERS=$(grep -rI ' cmp[^a-zA-Z0-9_:=]' . \
 	--exclude-dir .tox \
 	| grep -v \
 	-e lib/ansible/module_utils/six/_six.py \


### PR DESCRIPTION
Allowing the yaml examples in python documentation.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This change fixes an issue with the listing of the cmp deprecated function to allow for module documentation that contains cmp: or cmp= arguments.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
