### PR TITLE
Added folder and datacenter to the examples

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
@@ -60,7 +60,6 @@ options:
    folder:
         description:
             - Define instance folder location.
-        required: True
    datacenter:
         description:
             - Destination datacenter for the deploy operation

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
@@ -60,6 +60,7 @@ options:
    folder:
         description:
             - Define instance folder location.
+        required: True
    datacenter:
         description:
             - Destination datacenter for the deploy operation
@@ -80,6 +81,8 @@ EXAMPLES = '''
       hostname: 192.168.1.209
       username: administrator@vsphere.local
       password: vmware
+      datacenter: datacenter_name
+      folder: /myfolder
       name: dummy_vm
       state: present
       snapshot_name: snap1
@@ -92,6 +95,8 @@ EXAMPLES = '''
       username: administrator@vsphere.local
       password: vmware
       name: dummy_vm
+      datacenter: datacenter_name
+      folder: /myfolder
       state: remove
       snapshot_name: snap1
     delegate_to: localhost
@@ -101,6 +106,8 @@ EXAMPLES = '''
       hostname: 192.168.1.209
       username: administrator@vsphere.local
       password: vmware
+      datacenter: datacenter_name
+      folder: /myfolder
       name: dummy_vm
       state: revert
       snapshot_name: snap1
@@ -111,6 +118,8 @@ EXAMPLES = '''
       hostname: 192.168.1.209
       username: administrator@vsphere.local
       password: vmware
+      datacenter: datacenter_name
+      folder: /myfolder
       name: dummy_vm
       state: remove_all
     delegate_to: localhost


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
From #22644 it seems that the parameter 'folder' is mandatory. While both are required parameters they should be used in the examples.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vmware_guest_snapshot

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```