### PR TITLE
Fixes for Windows control machine setup

### DIFF
--- a/docs/docsite/rst/intro_windows.rst
+++ b/docs/docsite/rst/intro_windows.rst
@@ -51,7 +51,7 @@ Once WSL is enabled, you can open the Bash terminal. The first time you so this,
 At the prompt you can quickly start using the Ansible devel branch by running the following commands::
 
     sudo apt-get install python-pip
-    pip install pywinrm
+    pip install pywinrm jinja2 pyyaml
     git clone https://github.com/ansible/ansible.git
     source ansible/hacking/env-setup
 


### PR DESCRIPTION
##### SUMMARY
When I just did this, I got exceptions about missing modules until installing these. 

I have Windows 10 Creators Update + WSL.

Onboarding new users should be friction free.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Windows onboarding.

##### ANSIBLE VERSION
```
$ ansible --version
ansible 2.4.0 (devel 75bdcce072) last updated 2017/05/31 16:59:29 (GMT +100)
  config file =
  configured module search path = [u'/home/pete/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/c/Users/Pete/ansible/lib/ansible
  executable location = /mnt/c/Users/Pete/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION

This is more of a trace than a before/after, since I'm fixing two omissions. Essentially, I followed the steps in the docs and ran `ansible --version`, got an error, fixed it, got another, fixed it, success.

```
$ ansible --version
ERROR! Unexpected Exception: No module named yaml
the full traceback was:

Traceback (most recent call last):
  File "/mnt/c/Users/Pete/ansible/bin/ansible", line 85, in <module>
    mycli = getattr(__import__("ansible.cli.%s" % sub, fromlist=[myclass]), myclass)
  File "/mnt/c/Users/Pete/ansible/lib/ansible/cli/__init__.py", line 28, in <module>
    import yaml
ImportError: No module named yaml
pete@petemounce-win-imp:/mnt/c/Users/Pete$ pip install pyyaml
Collecting pyyaml
  Downloading PyYAML-3.12.tar.gz (253kB)
    100% |████████████████████████████████| 256kB 4.2MB/s
Building wheels for collected packages: pyyaml
  Running setup.py bdist_wheel for pyyaml ... done
  Stored in directory: /home/pete/.cache/pip/wheels/2c/f7/79/13f3a12cd723892437c0cfbde1230ab4d82947ff7b3839a4fc
Successfully built pyyaml
Installing collected packages: pyyaml
Successfully installed pyyaml
You are using pip version 8.1.1, however version 9.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.

$ ansible --version
ERROR! Unexpected Exception: No module named jinja2.exceptions
the full traceback was:

Traceback (most recent call last):
  File "/mnt/c/Users/Pete/ansible/bin/ansible", line 85, in <module>
    mycli = getattr(__import__("ansible.cli.%s" % sub, fromlist=[myclass]), myclass)
  File "/mnt/c/Users/Pete/ansible/lib/ansible/cli/__init__.py", line 44, in <module>
    from ansible.vars.manager import VariableManager
  File "/mnt/c/Users/Pete/ansible/lib/ansible/vars/manager.py", line 32, in <module>
    from jinja2.exceptions import UndefinedError
ImportError: No module named jinja2.exceptions

$ pip install jinja2
Collecting jinja2
  Downloading Jinja2-2.9.6-py2.py3-none-any.whl (340kB)
    100% |████████████████████████████████| 348kB 4.2MB/s
Collecting MarkupSafe>=0.23 (from jinja2)
  Downloading MarkupSafe-1.0.tar.gz
Building wheels for collected packages: MarkupSafe
  Running setup.py bdist_wheel for MarkupSafe ... done
  Stored in directory: /home/pete/.cache/pip/wheels/88/a7/30/e39a54a87bcbe25308fa3ca64e8ddc75d9b3e5afa21ee32d57
Successfully built MarkupSafe
Installing collected packages: MarkupSafe, jinja2
Successfully installed MarkupSafe-1.0 jinja2-2.9.6
You are using pip version 8.1.1, however version 9.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.

$ ansible --version
ansible 2.4.0 (devel 75bdcce072) last updated 2017/05/31 16:59:29 (GMT +100)
  config file =
  configured module search path = [u'/home/pete/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/c/Users/Pete/ansible/lib/ansible
  executable location = /mnt/c/Users/Pete/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```
