### PR TITLE
Fix pylint error and .format() err in profile_task

### DIFF
--- a/lib/ansible/plugins/callback/profile_tasks.py
+++ b/lib/ansible/plugins/callback/profile_tasks.py
@@ -138,5 +138,6 @@ class CallbackModule(CallbackBase):
         for uuid, result in results:
             msg=u"{0:-<{2}}{1:->9}".format(result['name'] + u' ',u' {0:.02f}s'.format(result['time']), self.columns - 9)
             if 'path' in result:
-                msg += u"\n{0:-<{1}}".format(result['path'] + u' '.format(self.columns))
+                msg += u"\n{0:-<{1}}".format(result['path'],
+                                             u'{0}'.format(self.columns))
             self._display.display(msg)


### PR DESCRIPTION
introduced by 62a434141e7f96299f820af3ca08fe86231300ed

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/plugins/callback/profile_tasks.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel 05caa3654c) last updated 2017/05/31 12:44:33 (GMT -400)
  config file = 
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]


```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
