### PR TITLE
gce_instance_template: Fix subnetwork not working

### DIFF
--- a/lib/ansible/modules/cloud/google/gce_instance_template.py
+++ b/lib/ansible/modules/cloud/google/gce_instance_template.py
@@ -154,6 +154,7 @@ options:
       - path to the JSON file associated with the service account email
     default: null
   subnetwork_region:
+    version_added: "2.4"
     description:
       - Region that subnetwork resides in. (Required for subnetwork to successfully complete)
     default: null

--- a/lib/ansible/modules/cloud/google/gce_instance_template.py
+++ b/lib/ansible/modules/cloud/google/gce_instance_template.py
@@ -153,6 +153,10 @@ options:
     description:
       - path to the JSON file associated with the service account email
     default: null
+  subnetwork_region:
+    description:
+      - Region that subnetwork resides in. (Required for subnetwork to successfully complete)
+    default: null
 requirements:
     - "python >= 2.6"
     - "apache-libcloud >= 0.13.3, >= 0.17.0 if using JSON credentials,
@@ -254,6 +258,7 @@ def create_instance_template(module, gce):
     disk_auto_delete = module.params.get('disk_auto_delete')
     network = module.params.get('network')
     subnetwork = module.params.get('subnetwork')
+    subnetwork_region = module.params.get('subnetwork_region')
     can_ip_forward = module.params.get('can_ip_forward')
     external_ip = module.params.get('external_ip')
     service_account_email = module.params.get('service_account_email')
@@ -266,7 +271,6 @@ def create_instance_template(module, gce):
     metadata = module.params.get('metadata')
     description = module.params.get('description')
     disks = module.params.get('disks')
-
     changed = False
 
     # args of ex_create_instancetemplate
@@ -314,7 +318,7 @@ def create_instance_template(module, gce):
     gce_args['network'] = gce_network
 
     if subnetwork is not None:
-        gce_args['subnetwork'] = subnetwork
+        gce_args['subnetwork'] = gce.ex_get_subnetwork(subnetwork, region=subnetwork_region)
 
     if can_ip_forward is not None:
         gce_args['can_ip_forward'] = can_ip_forward
@@ -529,6 +533,7 @@ def main():
             project_id=dict(),
             pem_file=dict(type='path'),
             credentials_file=dict(type='path'),
+            subnetwork_region=dict()
         ),
         mutually_exclusive=[['source', 'image']],
         required_one_of=[['image', 'image_family']],


### PR DESCRIPTION


##### SUMMARY
It is broken in the current master branch. This fixes it.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
gce_instance_template

##### ANSIBLE VERSION
ansible 2.3.0.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]


##### ADDITIONAL INFORMATION
To reproduce, try and create a gce_instance_template with subnetwork argument. It will fail because it can never find the region. This adds an attribute that allows the user to specify a region.

example that fails:

```
    - name: create NAT templates for us-central1
      gce_instance_template:
        name: test
        automatic_restart: yes
        can_ip_forward: yes
        disk_type: pd-ssd
        external_ip: ephemeral
        image: centos-7
        metadata: '{"tier":"test" }
        network: "test"
        preemptible: false
        subnetwork: "test-us-central1-subnet"
        size: n1-standard-1
      register: template
```