### PR TITLE
Adds 'deprecated' as an optional field

### DIFF
--- a/test/sanity/validate-modules/schema.py
+++ b/test/sanity/validate-modules/schema.py
@@ -47,6 +47,7 @@ option_schema = Schema(
         'version_added': Any(float, *string_types),
         'default': Any(None, float, int, bool, list, dict, *string_types),
         'suboptions': Any(None, *list_dict_suboption_schema),
+        'deprecated': Any(*string_types),
         # Note: Types are strings, not literal bools, such as True or False
         'type': Any(None, "bool")
     },


### PR DESCRIPTION
##### SUMMARY
The deprecated field for an argument was missing from the schema
and was causing the validate-tests to fail. This patch fixes that

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
test/sanity/validate-modules/schema.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (bugfix.include-optional-deprecated-in-schema 117fde734b) last updated 2017/05/31 12:44:21 (GMT -700)
  config file = 
  configured module search path = [u'/Users/trupp/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/trupp/src/trupp/ansible/lib/ansible
  executable location = /Users/trupp/src/trupp/ansible/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
