### PR TITLE
Fixes: 2256. Replaces expected librato annotation response code with …

### DIFF
--- a/lib/ansible/modules/monitoring/librato_annotation.py
+++ b/lib/ansible/modules/monitoring/librato_annotation.py
@@ -130,8 +130,13 @@ def post_annotation(module):
     module.params['url_username'] = user
     module.params['url_password'] = api_key
     response, info = fetch_url(module, url, data=json_body, headers=headers)
-    if info['status'] != 200:
-        module.fail_json(msg="Request Failed", reason=info.get('msg', ''), status_code=info['status'])
+    response_code = str(info['status'])
+    response_body = info['body']
+    if info['status'] != 201:
+        if info['status'] >= 400:
+            module.fail_json(msg="Request Failed. Response code: " + response_code + " Response body: " + response_body)
+        else:
+            module.fail_json(msg="Request Failed. Response code: " + response_code)
     response = response.read()
     module.exit_json(changed=True, annotation=response)
 


### PR DESCRIPTION
…correct value, fixes error message.

##### SUMMARY
Fixes ansible/ansible-modules-extras#2256
Related: https://github.com/ansible/ansible/pull/23024

Replaces expected librato annotation response code with correct value (201), and changes error messaging to work (as described in fail_json()), with respect to fetch_url() (lib/ansible/module_utils/basic.py). 

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/monitoring/librato_annotation.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


