### PR TITLE
Temporary work-around for setuptools 36.0.0 bug.

### DIFF
--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -83,6 +83,9 @@
 - name: make sure the test env doesn't exist
   file: state=absent name={{ output_dir }}/pipenv
 
+- name: install a working version of setuptools in the virtualenv
+  pip: name=setuptools virtualenv={{ output_dir }}/pipenv state=present version=35.0.2
+
 - name: create a requirement file with an vcs url
   copy: dest={{ output_dir }}/pipreq.txt
     content="-e git+https://github.com/dvarrazzo/pyiso8601#egg=pyiso8601"

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -84,7 +84,7 @@
   file: state=absent name={{ output_dir }}/pipenv
 
 - name: install a working version of setuptools in the virtualenv
-  pip: name=setuptools virtualenv={{ output_dir }}/pipenv state=present version=35.0.2
+  pip: name=setuptools virtualenv={{ output_dir }}/pipenv state=present version=33.1.1
 
 - name: create a requirement file with an vcs url
   copy: dest={{ output_dir }}/pipreq.txt

--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -2,3 +2,4 @@ coverage >= 4.2, != 4.3.2 # features in 4.2+ required, avoid known bug in 4.3.2 
 pywinrm >= 0.2.1 # 0.1.1 required, but 0.2.1 provides better performance
 pylint >= 1.5.3, < 1.7.0 # 1.4.1 adds JSON output, but 1.5.3 fixes bugs related to JSON output
 sphinx < 1.6 ; python_version < '2.7' # sphinx 1.6 and later require python 2.7 or later
+isort < 4.2.8 # 4.2.8 changes import sort order requirements which breaks previously passing pylint tests

--- a/test/runner/tox.ini
+++ b/test/runner/tox.ini
@@ -7,3 +7,4 @@ changedir = {toxinidir}/../../
 commands = {posargs}
 passenv = HOME SHIPPABLE*
 args_are_paths = False
+deps = setuptools == 35.0.2


### PR DESCRIPTION
##### SUMMARY

The [setuptools 36.0.0](http://setuptools.readthedocs.io/en/latest/history.html#v36-0-0) release breaks installations of various packages using pip. This temporary work-around pins the setuptools release to 35.0.2.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Tests

##### ANSIBLE VERSION

```
ansible 2.4.0 (setuptools-fix 63f539373b) last updated 2017/06/01 14:22:36 (GMT +800)
  config file = 
  configured module search path = [u'/home/matt/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/matt/code/mattclay/ansible/lib/ansible
  executable location = /home/matt/code/mattclay/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```
