### PR TITLE
cloud: ovirt: Fix searching of network in datacenter

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_networks.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_networks.py
@@ -229,14 +229,12 @@ def main():
             service=networks_service,
         )
         state = module.params['state']
-        network = networks_module.search_entity(
-            search_params={
-                'name': module.params['name'],
-                'datacenter': module.params['data_center'],
-            },
-        )
+        search_params = {
+            'name': module.params['name'],
+            'datacenter': module.params['data_center'],
+        }
         if state == 'present':
-            ret = networks_module.create(entity=network)
+            ret = networks_module.create(search_params=search_params)
 
             # Update clusters networks:
             if module.params.get('clusters') is not None:
@@ -258,7 +256,7 @@ def main():
                         ret = cluster_networks_module.remove()
 
         elif state == 'absent':
-            ret = networks_module.remove(entity=network)
+            ret = networks_module.remove(search_params=search_params)
 
         module.exit_json(**ret)
     except Exception as e:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR fixes the searching of the network in the data center.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt_networks

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
When running following playbook, the `ovirt_networks` module tried to assign already existing network to cluster, in different datacenter, instead of creating new network in that datacenter.
```yaml
---
- hosts: localhost
  connection: local
  vars_files:
    - ../vars.yml

  tasks:
  - name: Obtain SSO token
    ovirt_auth:
      url: "{{ url }}"
      username: "{{ username }}"
      password: "{{ password }}"
      insecure: "{{ insecure }}"

  - name: Create network
    ovirt_networks:
      auth: "{{ ovirt_auth }}"
      name: test_network
      vlan_tag: 4
      vm_network: yes
      data_center: "{{ item.dc_name }}"
      name: "VlanTEST413"
      vlan_tag: "413"
      vm_network: True
      clusters:
        - name: "{{ item.cl_name }}"
          assigned: True
          required: False
          display: False
          migration: False
          gluster: False
    with_items:
      - { dc_name: 'dc1', cl_name: 'cl1' }
      - { dc_name: 'dc2', cl_name: 'cl2' }
```

After fix, it's properly created:
```bash
omachace ~/workspace/tests/ovirt (master) $ ansible-playbook examples/network/create.yml 

PLAY [localhost] **************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ********************************************************************************************************************************************************************************************
ok: [localhost]

TASK [Obtain SSO token] *******************************************************************************************************************************************************************************************
ok: [localhost]

TASK [Create network] *********************************************************************************************************************************************************************************************
changed: [localhost] => (item={u'dc_name': u'dc1', u'cl_name': u'cl1'})
changed: [localhost] => (item={u'dc_name': u'dc2', u'cl_name': u'cl2'})

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=3    changed=1    unreachable=0    failed=0  
```
