### PR TITLE
Azure_RM_VirtualMachine new functionality

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -222,15 +222,18 @@ options:
               Vault is a string containing the ID of the Vault containing the SSL, key and secret
               and store a string with the name of the Certificate store on the VM, Default: 'My'"
         default: null
+        version_added: "2.4"
     auto_logon:
         description:
             - "A dictionary to set an account that will automatically be logged onto the local machine upon boot, user is a string denoting the username
             and password is a string denoting the password"
         default: null
+        version_added: "2.4"
     security_group:
         description:
             - "the name of a network security group to add the newly created NIC to, must be in the same region as the server and NIC"
         default: null
+        version_added: "2.4"
 
 extends_documentation_fragment:
     - azure
@@ -860,7 +863,13 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                             pass_name="oobesystem",
                             component_name="Microsoft-Windows-Shell-Setup",
                             setting_name="AutoLogon",
-                            content="<AutoLogon><Domain>"+self.name+"</Domain><Username>"+self.auto_logon["user"]+"</Username><Password><Value>"+self.auto_logon["password"]+"</Value></Password><LogonCount>9999</LogonCount><Enabled>true</Enabled></AutoLogon>",
+                            content="<AutoLogon>"
+                                    "<Domain>"+self.name+"</Domain>"
+                                    "<Username>"+self.auto_logon["user"]+"</Username>"
+                                    "<Password><Value>"+self.auto_logon["password"]+"</Value></Password>"
+                                    "<LogonCount>9999</LogonCount>"
+                                    "<Enabled>true</Enabled>"
+                                    "</AutoLogon>",
                         )]
 
                     if self.admin_password:


### PR DESCRIPTION
Pull Request

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Module: azure_rm_virtualmachine


##### ANSIBLE VERSION
```
ansible 2.2.3.0-1
```

##### SUMMARY
######WinRM Configuration:
Add the new option ‘win_rm’ into the azure_rm_virtualmachine module to allow creation of WinRM listeners on the newly created VM, this allows to start configuring with ansible strait away after creation is complete.

I have added four variables,
Boolean: 'SSL' - to enable the HTTPS listener (port 5986), if not set only an HTTP listener will be created (port 5985)
String: 'certificate' - url to a certificate in your ARM Keyvault (required if SSL is true)
String: 'vault' - id of keyvault in ARM (Required if SSL is true)
String: 'store' - store name on windows server (optional, but default is set to 'My' which should work for the most part)

when using this method you must connect to he remote machine using NLTM, so you must set your host transport like so:
ansible_winrm_transport: ntlm

######Auto Logon Configuration
Add the new option ‘auto_logon’ into azure_rm_virtualmachine module to allow the local machine to log directly into a particular user on boot, this allow to run GUI applications etc after boot.

Only two variables are needed for this functionality:
String: ‘user’ - the username you wish to auto login to on boot
String: ‘password’ - the password of the defined user

######Security Group Configuration
Add the new option ‘security_group’ into azure_rm_virtualmachine module to allow new NICs created to be added to a specified security group, this removes an unnecessary step from the deployment, and effectively fixes the issue that Security groups are not removed when removing a server and related items.

This variable accepts a string with just the name of the requested Network Security Group, this security group should be in the same region as the NIC and VM

######Image URI configuration
add the new option 'image.uri' into azure_rm_virtualmachine module to allow the use of custom images that are not searchable etc. Just the URI as a string as returned from the Azure CLI, API or Portal