### PR TITLE
Set attributes if different (fixes #48839)

### DIFF
--- a/lib/ansible/plugins/doc_fragments/files.py
+++ b/lib/ansible/plugins/doc_fragments/files.py
@@ -72,8 +72,7 @@ options:
     description:
     - The attributes the resulting file or directory should have.
     - To get supported flags look at the man page for I(chattr) on the target system.
-    - This string should contain the attributes in the same order as the one displayed by I(lsattr).
-    - The C(=) operator is assumed as default, otherwise C(+) or C(-) operators need to be included in the string.
+    - The C(=) operator is assumed as default, otherwise C(+) or C(-) operators need to be prepended to the string.
     type: str
     aliases: [ attr ]
     version_added: '2.3'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
`chattr` command line tool supports symbolic operators `+`, `-`, and `=`. However, `attributes` in `file` module supports only `=`. This is inconvenient if you do not know what the original attributes are.

This patch adds support for `+` and `-` operator. If you use old syntax (without any operator), the behavior is backwards-compatible.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
file

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /home/wzyboy/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Feb 11 2017, 12:22:40) [GCC 6.3.1 20170109]
```
