### PR TITLE
Update hostname.py

### DIFF
--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -736,6 +736,12 @@ class NetBSDHostname(Hostname):
     strategy_class = FreeBSDStrategy
 
 
+class NeonHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Neon'
+    strategy_class = DebianStrategy
+
+
 # ===========================================
 
 def main():


### PR DESCRIPTION
Added the class "NeonHostname" to add support for KDE Neon. Ansible 2.3 introduced support for this distro - the hostname module still does not recognize Neon. 

# This repository is locked

Please open all new issues and pull requests in https://github.com/ansible/ansible

For more information please see http://docs.ansible.com/ansible/dev_guide/repomerge.html


##### ISSUE TYPE
 - Bugfix Pull Request