### PR TITLE
  Fix issue with get_url not accepting all parameters for file module… Fixes #25263

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -228,7 +228,6 @@ FILE_COMMON_ARGUMENTS=dict(
     directory_mode = dict(), # used by copy
     unsafe_writes  = dict(type='bool'), # should be available to any module using atomic_move
     attributes = dict(aliases=['attr']),
-    state = dict(),         # Useful with get_url
 )
 
 PASSWD_ARG_RE = re.compile(r'^[-]{0,2}pass[-]?(word|wd)?')
@@ -829,12 +828,10 @@ class AnsibleModule(object):
                 secontext[i] = default_secontext[i]
 
         attributes = params.get('attributes', None)
-        state = params.get('state', None)
         return dict(
             path=path, mode=mode, owner=owner, group=group,
             seuser=seuser, serole=serole, setype=setype,
             selevel=selevel, secontext=secontext, attributes=attributes,
-            state=state
         )
 
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -228,6 +228,7 @@ FILE_COMMON_ARGUMENTS=dict(
     directory_mode = dict(), # used by copy
     unsafe_writes  = dict(type='bool'), # should be available to any module using atomic_move
     attributes = dict(aliases=['attr']),
+    state = dict(),         # Useful with get_url
 )
 
 PASSWD_ARG_RE = re.compile(r'^[-]{0,2}pass[-]?(word|wd)?')
@@ -828,10 +829,12 @@ class AnsibleModule(object):
                 secontext[i] = default_secontext[i]
 
         attributes = params.get('attributes', None)
+        state = params.get('state', None)
         return dict(
             path=path, mode=mode, owner=owner, group=group,
             seuser=seuser, serole=serole, setype=setype,
             selevel=selevel, secontext=secontext, attributes=attributes,
+            state=state
         )
 
 

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -570,7 +570,9 @@ def sort_json_policy_dict(policy_dict):
             else:
                 checked_list.append(item)
 
-        checked_list.sort()
+        # Sort list. If it's a list of dictionaries, sort by tuple of key-value
+        # pairs, since Python 3 doesn't allow comparisons such as `<` between dictionaries.
+        checked_list.sort(key=lambda x: sorted(x.items()) if isinstance(x, dict) else x)
         return checked_list
 
     ordered_policy_dict = {}

--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -191,3 +191,6 @@ def load_config(module, candidate, warnings, action='merge', commit=False, forma
                 discard_changes(module)
 
         return diff
+
+def get_param(module, key):
+    return module.params[key] or module.params['provider'].get(key)

--- a/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_parameter_group.py
@@ -28,6 +28,7 @@ description:
   - Returns information about the specified cache cluster.
 version_added: "2.3"
 author: "Sloane Hertel (@s-hertel)"
+requirements: [ boto3, botocore ]
 options:
   group_family:
     description:

--- a/lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
@@ -28,6 +28,7 @@ description:
   - Returns information about the specified snapshot.
 version_added: "2.3"
 author: "Sloane Hertel (@s-hertel)"
+requirements: [ boto3, botocore ]
 options:
   name:
     description:
@@ -135,6 +136,7 @@ try:
 except ImportError:
     HAS_BOTO3 = False
 
+
 def create(module, connection, replication_id, cluster_id, name):
     """ Create an Elasticache backup. """
     try:
@@ -150,6 +152,7 @@ def create(module, connection, replication_id, cluster_id, name):
             module.fail_json(msg="Unable to create the snapshot.", exception=traceback.format_exc())
     return response, changed
 
+
 def copy(module, connection, name, target, bucket):
     """ Copy an Elasticache backup. """
     try:
@@ -160,6 +163,7 @@ def copy(module, connection, name, target, bucket):
     except botocore.exceptions.ClientError as e:
         module.fail_json(msg="Unable to copy the snapshot.", exception=traceback.format_exc())
     return response, changed
+
 
 def delete(module, connection, name):
     """ Delete an Elasticache backup. """
@@ -198,7 +202,7 @@ def main():
 
     name = module.params.get('name')
     state = module.params.get('state')
-    replication_id  = module.params.get('replication_id')
+    replication_id = module.params.get('replication_id')
     cluster_id = module.params.get('cluster_id')
     target = module.params.get('target')
     bucket = module.params.get('bucket')
@@ -206,7 +210,7 @@ def main():
     # Retrieve any AWS settings from the environment.
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
     if not region:
-        module.fail_json(msg = str("Either region or AWS_REGION or EC2_REGION environment variable or boto config aws_region or ec2_region must be set."))
+        module.fail_json(msg=str("Either region or AWS_REGION or EC2_REGION environment variable or boto config aws_region or ec2_region must be set."))
 
     connection = boto3_conn(module, conn_type='client',
                             resource='elasticache', region=region,

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -119,6 +119,7 @@ import traceback
 import xml.etree.ElementTree as ET
 
 import ansible.module_utils.six.moves.urllib.parse as urlparse
+from ansible.module_utils.six import string_types
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import get_aws_connection_info, ec2_argument_spec
 from ansible.module_utils.ec2 import sort_json_policy_dict
@@ -210,7 +211,7 @@ def _create_or_update_bucket(connection, module, location):
         else:
             module.fail_json(msg=e.message)
     if policy is not None:
-        if isinstance(policy, basestring):
+        if isinstance(policy, string_types):
             policy = json.loads(policy)
 
         if not policy:

--- a/lib/ansible/modules/cloud/google/gce_instance_template.py
+++ b/lib/ansible/modules/cloud/google/gce_instance_template.py
@@ -153,6 +153,11 @@ options:
     description:
       - path to the JSON file associated with the service account email
     default: null
+  subnetwork_region:
+    version_added: "2.4"
+    description:
+      - Region that subnetwork resides in. (Required for subnetwork to successfully complete)
+    default: null
 requirements:
     - "python >= 2.6"
     - "apache-libcloud >= 0.13.3, >= 0.17.0 if using JSON credentials,
@@ -254,6 +259,7 @@ def create_instance_template(module, gce):
     disk_auto_delete = module.params.get('disk_auto_delete')
     network = module.params.get('network')
     subnetwork = module.params.get('subnetwork')
+    subnetwork_region = module.params.get('subnetwork_region')
     can_ip_forward = module.params.get('can_ip_forward')
     external_ip = module.params.get('external_ip')
     service_account_email = module.params.get('service_account_email')
@@ -266,7 +272,6 @@ def create_instance_template(module, gce):
     metadata = module.params.get('metadata')
     description = module.params.get('description')
     disks = module.params.get('disks')
-
     changed = False
 
     # args of ex_create_instancetemplate
@@ -314,7 +319,7 @@ def create_instance_template(module, gce):
     gce_args['network'] = gce_network
 
     if subnetwork is not None:
-        gce_args['subnetwork'] = subnetwork
+        gce_args['subnetwork'] = gce.ex_get_subnetwork(subnetwork, region=subnetwork_region)
 
     if can_ip_forward is not None:
         gce_args['can_ip_forward'] = can_ip_forward
@@ -529,6 +534,7 @@ def main():
             project_id=dict(),
             pem_file=dict(type='path'),
             credentials_file=dict(type='path'),
+            subnetwork_region=dict()
         ),
         mutually_exclusive=[['source', 'image']],
         required_one_of=[['image', 'image_family']],

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -23,27 +23,22 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['stableinterface'],
                     'supported_by': 'core'}
 
-
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: find
 author: Brian Coca (based on Ruggero Marchei's Tidy)
 version_added: "2.0"
-short_description: return a list of files based on specific criteria
-requirements: []
+short_description: Return a list of files based on specific criteria
 description:
     - Return a list of files based on specific criteria. Multiple criteria are AND'd together.
 options:
     age:
-        required: false
-        default: null
         description:
             - Select files whose age is equal to or greater than the specified time.
               Use a negative age to find files equal to or less than the specified time.
               You can choose seconds, minutes, hours, days, or weeks by specifying the
               first letter of any of those words (e.g., "1w").
     patterns:
-        required: false
         default: '*'
         description:
             - One or more (shell or regex) patterns, which type is controlled by C(use_regex) option.
@@ -51,31 +46,25 @@ options:
               least one of the patterns specified. Multiple patterns can be specified using a list.
         aliases: ['pattern']
     contains:
-        required: false
-        default: null
         description:
-            - One or more regex patterns which should be matched against the file content
+            - One or more regex patterns which should be matched against the file content.
     paths:
         required: true
-        aliases: [ "name", "path" ]
+        aliases: [ name, path ]
         description:
             - List of paths of directories to search. All paths must be fully qualified.
     file_type:
-        required: false
         description:
-            - Type of file to select
-            - The 'link' and 'any' choices were added in version 2.3
-        choices: [ "file", "directory", "link", "any" ]
-        default: "file"
+            - Type of file to select.
+            - The 'link' and 'any' choices were added in version 2.3.
+        choices: [ any, directory, file, link ]
+        default: file
     recurse:
-        required: false
-        default: "no"
-        choices: [ "yes", "no" ]
+        default: 'no'
+        choices: [ 'no', 'yes' ]
         description:
             - If target is a directory, recursively descend into the directory looking for files.
     size:
-        required: false
-        default: null
         description:
             - Select files whose size is equal to or greater than the specified size.
               Use a negative size to find files equal to or less than the specified size.
@@ -83,76 +72,70 @@ options:
               bytes, kilobytes, megabytes, gigabytes, and terabytes, respectively.
               Size is not evaluated for directories.
     age_stamp:
-        required: false
-        default: "mtime"
-        choices: [ "atime", "mtime", "ctime" ]
+        default: mtime
+        choices: [ atime, ctime, mtime ]
         description:
-            - Choose the file property against which we compare age. Default is mtime.
+            - Choose the file property against which we compare age.
     hidden:
-        required: false
-        default: "False"
-        choices: [ True, False ]
+        default: 'no'
+        choices: [ 'no', 'yes' ]
         description:
             - Set this to true to include hidden files, otherwise they'll be ignored.
     follow:
-        required: false
-        default: "False"
-        choices: [ True, False ]
+        default: 'no'
+        choices: [ 'no', 'yes' ]
         description:
-            - Set this to true to follow symlinks in path for systems with python 2.6+
+            - Set this to true to follow symlinks in path for systems with python 2.6+.
     get_checksum:
-        required: false
-        default: "False"
-        choices: [ True, False ]
+        default: 'no'
+        choices: [ 'no', 'yes' ]
         description:
-            - Set this to true to retrieve a file's sha1 checksum
+            - Set this to true to retrieve a file's sha1 checksum.
     use_regex:
-        required: false
-        default: "False"
-        choices: [ True, False ]
+        default: 'no'
+        choices: [ 'no', 'yes' ]
         description:
-            - If false the patterns are file globs (shell) if true they are python regexes
+            - If false the patterns are file globs (shell) if true they are python regexes.
 '''
 
 
 EXAMPLES = r'''
-# Recursively find /tmp files older than 2 days
-- find:
-    paths: "/tmp"
-    age: "2d"
+- name: Recursively find /tmp files older than 2 days
+  find:
+    paths: /tmp
+    age: 2d
     recurse: yes
 
-# Recursively find /tmp files older than 4 weeks and equal or greater than 1 megabyte
+- name: Recursively find /tmp files older than 4 weeks and equal or greater than 1 megabyte
 - find:
-    paths: "/tmp"
-    age: "4w"
-    size: "1m"
+    paths: /tmp
+    age: 4w
+    size: 1m
     recurse: yes
 
-# Recursively find /var/tmp files with last access time greater than 3600 seconds
+- name: Recursively find /var/tmp files with last access time greater than 3600 seconds
 - find:
-    paths: "/var/tmp"
-    age: "3600"
+    paths: /var/tmp
+    age: 3600
     age_stamp: atime
     recurse: yes
 
-# find /var/log files equal or greater than 10 megabytes ending with .old or .log.gz
+- name: Find /var/log files equal or greater than 10 megabytes ending with .old or .log.gz
 - find:
-    paths: "/var/tmp"
-    patterns: "*.old,*.log.gz"
-    size: "10m"
+    paths: /var/tmp
+    patterns: '*.old,*.log.gz'
+    size: 10m
 
-# find /var/log files equal or greater than 10 megabytes ending with .old or .log.gz via regex
-# Note that yaml double quotes require escaping backslashes but yaml single
-# quotes do not.
+# Note that YAML double quotes require escaping backslashes but yaml single quotes do not.
+- name: Find /var/log files equal or greater than 10 megabytes ending with .old or .log.gz via regex
 - find:
-    paths: "/var/tmp"
+    paths: /var/tmp
     patterns: "^.*?\\.(?:old|log\\.gz)$"
-    size: "10m"
-    use_regex: True
+    size: 10m
+    use_regex: yes
 '''
 
-RETURN = '''
+RETURN = r'''
 files:
     description: all matches found with the specified criteria (see stat module for full output of each dictionary)
     returned: success
@@ -179,11 +162,14 @@ examined:
     sample: 34
 '''
 
-import os
-import stat
 import fnmatch
-import time
+import os
 import re
+import stat
+import sys
+import time
+
+from ansible.module_utils.basic import AnsibleModule
 
 
 def pfilter(f, patterns=None, use_regex=False):
@@ -194,7 +180,7 @@ def pfilter(f, patterns=None, use_regex=False):
 
     if use_regex:
         for p in patterns:
-            r =  re.compile(p)
+            r = re.compile(p)
             if r.match(f):
                 return True
     else:
@@ -208,23 +194,25 @@ def pfilter(f, patterns=None, use_regex=False):
 
 def agefilter(st, now, age, timestamp):
     '''filter files older than age'''
-    if age is None or \
-      (age >= 0 and now - st.__getattribute__("st_%s" % timestamp) >= abs(age)) or \
-      (age < 0 and now - st.__getattribute__("st_%s" % timestamp) <= abs(age)):
-
+    if age is None:
+        return True
+    elif age >= 0 and now - st.__getattribute__("st_%s" % timestamp) >= abs(age):
+        return True
+    elif age < 0 and now - st.__getattribute__("st_%s" % timestamp) <= abs(age):
         return True
     return False
 
 
 def sizefilter(st, size):
     '''filter files greater than size'''
-    if size is None or \
-       (size >= 0 and st.st_size >= abs(size)) or \
-       (size < 0 and st.st_size <= abs(size)):
-
+    if size is None:
         return True
-
+    elif size >= 0 and st.st_size >= abs(size):
+        return True
+    elif size < 0 and st.st_size <= abs(size):
+        return True
     return False
+
 
 def contentfilter(fsname, pattern):
     '''filter files which contain the given expression'''
@@ -235,7 +223,7 @@ def contentfilter(fsname, pattern):
         f = open(fsname)
         prog = re.compile(pattern)
         for line in f:
-            if prog.match (line):
+            if prog.match(line):
                 f.close()
                 return True
 
@@ -245,54 +233,55 @@ def contentfilter(fsname, pattern):
 
     return False
 
+
 def statinfo(st):
     return {
-        'mode'     : "%04o" % stat.S_IMODE(st.st_mode),
-        'isdir'    : stat.S_ISDIR(st.st_mode),
-        'ischr'    : stat.S_ISCHR(st.st_mode),
-        'isblk'    : stat.S_ISBLK(st.st_mode),
-        'isreg'    : stat.S_ISREG(st.st_mode),
-        'isfifo'   : stat.S_ISFIFO(st.st_mode),
-        'islnk'    : stat.S_ISLNK(st.st_mode),
-        'issock'   : stat.S_ISSOCK(st.st_mode),
-        'uid'      : st.st_uid,
-        'gid'      : st.st_gid,
-        'size'     : st.st_size,
-        'inode'    : st.st_ino,
-        'dev'      : st.st_dev,
-        'nlink'    : st.st_nlink,
-        'atime'    : st.st_atime,
-        'mtime'    : st.st_mtime,
-        'ctime'    : st.st_ctime,
-        'wusr'     : bool(st.st_mode & stat.S_IWUSR),
-        'rusr'     : bool(st.st_mode & stat.S_IRUSR),
-        'xusr'     : bool(st.st_mode & stat.S_IXUSR),
-        'wgrp'     : bool(st.st_mode & stat.S_IWGRP),
-        'rgrp'     : bool(st.st_mode & stat.S_IRGRP),
-        'xgrp'     : bool(st.st_mode & stat.S_IXGRP),
-        'woth'     : bool(st.st_mode & stat.S_IWOTH),
-        'roth'     : bool(st.st_mode & stat.S_IROTH),
-        'xoth'     : bool(st.st_mode & stat.S_IXOTH),
-        'isuid'    : bool(st.st_mode & stat.S_ISUID),
-        'isgid'    : bool(st.st_mode & stat.S_ISGID),
+        'mode': "%04o" % stat.S_IMODE(st.st_mode),
+        'isdir': stat.S_ISDIR(st.st_mode),
+        'ischr': stat.S_ISCHR(st.st_mode),
+        'isblk': stat.S_ISBLK(st.st_mode),
+        'isreg': stat.S_ISREG(st.st_mode),
+        'isfifo': stat.S_ISFIFO(st.st_mode),
+        'islnk': stat.S_ISLNK(st.st_mode),
+        'issock': stat.S_ISSOCK(st.st_mode),
+        'uid': st.st_uid,
+        'gid': st.st_gid,
+        'size': st.st_size,
+        'inode': st.st_ino,
+        'dev': st.st_dev,
+        'nlink': st.st_nlink,
+        'atime': st.st_atime,
+        'mtime': st.st_mtime,
+        'ctime': st.st_ctime,
+        'wusr': bool(st.st_mode & stat.S_IWUSR),
+        'rusr': bool(st.st_mode & stat.S_IRUSR),
+        'xusr': bool(st.st_mode & stat.S_IXUSR),
+        'wgrp': bool(st.st_mode & stat.S_IWGRP),
+        'rgrp': bool(st.st_mode & stat.S_IRGRP),
+        'xgrp': bool(st.st_mode & stat.S_IXGRP),
+        'woth': bool(st.st_mode & stat.S_IWOTH),
+        'roth': bool(st.st_mode & stat.S_IROTH),
+        'xoth': bool(st.st_mode & stat.S_IXOTH),
+        'isuid': bool(st.st_mode & stat.S_ISUID),
+        'isgid': bool(st.st_mode & stat.S_ISGID),
     }
 
 
 def main():
     module = AnsibleModule(
-        argument_spec = dict(
-            paths         = dict(required=True, aliases=['name','path'], type='list'),
-            patterns      = dict(default=['*'], type='list', aliases=['pattern']),
-            contains      = dict(default=None, type='str'),
-            file_type     = dict(default="file", choices=['file', 'directory', 'link', 'any'], type='str'),
-            age           = dict(default=None, type='str'),
-            age_stamp     = dict(default="mtime", choices=['atime','mtime','ctime'], type='str'),
-            size          = dict(default=None, type='str'),
-            recurse       = dict(default='no', type='bool'),
-            hidden        = dict(default="False", type='bool'),
-            follow        = dict(default="False", type='bool'),
-            get_checksum  = dict(default="False", type='bool'),
-            use_regex     = dict(default="False", type='bool'),
+        argument_spec=dict(
+            paths=dict(type='list', required=True, aliases=['name', 'path']),
+            patterns=dict(type='list', default=['*'], aliases=['pattern']),
+            contains=dict(type='str'),
+            file_type=dict(type='str', default="file", choices=['any', 'directory', 'file', 'link']),
+            age=dict(type='str'),
+            age_stamp=dict(type='str', default="mtime", choices=['atime', 'mtime', 'ctime']),
+            size=dict(type='str'),
+            recurse=dict(type='bool', default='no'),
+            hidden=dict(type='bool', default='no'),
+            follow=dict(type='bool', default='no'),
+            get_checksum=dict(type='bool', default='no'),
+            use_regex=dict(type='bool', default='no'),
         ),
         supports_check_mode=True,
     )
@@ -329,13 +318,11 @@ def main():
     for npath in params['paths']:
         npath = os.path.expanduser(os.path.expandvars(npath))
         if os.path.isdir(npath):
-
             ''' ignore followlinks for python version < 2.6 '''
-            for root,dirs,files in (sys.version_info < (2,6,0) and os.walk(npath)) or \
-                                    os.walk( npath, followlinks=params['follow']):
+            for root, dirs, files in (sys.version_info < (2, 6, 0) and os.walk(npath)) or os.walk(npath, followlinks=params['follow']):
                 looked = looked + len(files) + len(dirs)
                 for fsobj in (files + dirs):
-                    fsname=os.path.normpath(os.path.join(root, fsobj))
+                    fsname = os.path.normpath(os.path.join(root, fsobj))
 
                     if os.path.basename(fsname).startswith('.') and not params['hidden']:
                         continue
@@ -343,7 +330,7 @@ def main():
                     try:
                         st = os.lstat(fsname)
                     except:
-                        msg+="%s was skipped as it does not seem to be a valid file or it cannot be accessed\n" % fsname
+                        msg += "%s was skipped as it does not seem to be a valid file or it cannot be accessed\n" % fsname
                         continue
 
                     r = {'path': fsname}
@@ -376,13 +363,11 @@ def main():
                 if not params['recurse']:
                     break
         else:
-            msg+="%s was skipped as it does not seem to be a valid directory or it cannot be accessed\n" % npath
+            msg += "%s was skipped as it does not seem to be a valid directory or it cannot be accessed\n" % npath
 
     matched = len(filelist)
     module.exit_json(files=filelist, changed=False, msg=msg, matched=matched, examined=looked)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/files/patch.py
+++ b/lib/ansible/modules/files/patch.py
@@ -23,78 +23,73 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['stableinterface'],
                     'supported_by': 'community'}
 
-
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: patch
 author:
-    - "Jakub Jirutka (@jirutka)"
-    - "Luis Alberto Perez Lazaro (@luisperlaz)"
-version_added: 1.9
+    - Jakub Jirutka (@jirutka)
+    - Luis Alberto Perez Lazaro (@luisperlaz)
+version_added: '1.9'
 description:
     - Apply patch files using the GNU patch tool.
-short_description: Apply patch files using the GNU patch tool.
+short_description: Apply patch files using the GNU patch tool
 options:
   basedir:
     description:
       - Path of a base directory in which the patch file will be applied.
         May be omitted when C(dest) option is specified, otherwise required.
-    required: false
   dest:
     description:
       - Path of the file on the remote machine to be patched.
       - The names of the files to be patched are usually taken from the patch
         file, but if there's just one file to be patched it can specified with
         this option.
-    required: false
-    aliases: [ "originalfile" ]
+    aliases: [ originalfile ]
   src:
     description:
       - Path of the patch file as accepted by the GNU patch tool. If
         C(remote_src) is 'no', the patch source file is looked up from the
-        module's "files" directory.
+        module's I(files) directory.
     required: true
-    aliases: [ "patchfile" ]
+    aliases: [ patchfile ]
   remote_src:
     description:
       - If C(no), it will search for src at originating/master machine, if C(yes) it will
-        go to the remote/target machine for the src. Default is C(no).
-    choices: [ "yes", "no" ]
-    required: false
-    default: "no"
+        go to the remote/target machine for the C(src).
+    choices: [ 'no', 'yes' ]
+    default: 'no'
   strip:
     description:
       - Number that indicates the smallest prefix containing leading slashes
         that will be stripped from each file name found in the patch file.
         For more information see the strip parameter of the GNU patch tool.
-    required: false
-    default: "0"
+    default: 0
   backup:
     version_added: "2.0"
     description:
-      - passes --backup --version-control=numbered to patch,
-        producing numbered backup copies
-    choices: [ 'yes', 'no' ]
+      - Passes C(--backup --version-control=numbered) to patch,
+        producing numbered backup copies.
+    choices: [ 'no', 'yes' ]
     default: 'no'
   binary:
     version_added: "2.0"
     description:
       - Setting to C(yes) will disable patch's heuristic for transforming CRLF
         line endings into LF. Line endings of src and dest must match. If set to
-        C(no), patch will replace CRLF in src files on POSIX.
-    required: false
-    default: "no"
+        C(no), C(patch) will replace CRLF in C(src) files on POSIX.
+    choices: [ 'no', 'yes' ]
+    default: 'no'
 notes:
   - This module requires GNU I(patch) utility to be installed on the remote host.
 '''
 
-EXAMPLES = '''
-- name: apply patch to one file
+EXAMPLES = r'''
+- name: Apply patch to one file
   patch:
     src: /tmp/index.html.patch
     dest: /var/www/index.html
 
-- name: apply patch to multiple files under basedir
+- name: Apply patch to multiple files under basedir
   patch:
     src: /tmp/customize.patch
     basedir: /var/www
@@ -102,7 +97,8 @@ EXAMPLES = '''
 '''
 
 import os
-from os import path, R_OK, W_OK
+
+from ansible.module_utils.basic import AnsibleModule, get_exception
 
 
 class PatchError(Exception):
@@ -143,41 +139,43 @@ def apply_patch(patch_func, patch_file, basedir, dest_file=None, binary=False, s
 
 def main():
     module = AnsibleModule(
-        argument_spec={
-            'src':     {'required': True, 'aliases': ['patchfile']},
-            'dest':    {'aliases': ['originalfile']},
-            'basedir': {},
-            'strip':   {'default': 0, 'type': 'int'},
-            'remote_src': {'default': False, 'type': 'bool'},
+        argument_spec=dict(
+            src=dict(type='path', required=True, aliases=['patchfile']),
+            dest=dict(type='path', aliases=['originalfile']),
+            basedir=dict(type='path'),
+            strip=dict(type='int', default=0),
+            remote_src=dict(type='bool', default=False),
             # NB: for 'backup' parameter, semantics is slightly different from standard
             #     since patch will create numbered copies, not strftime("%Y-%m-%d@%H:%M:%S~")
-            'backup': {'default': False, 'type': 'bool'},
-            'binary': {'default': False, 'type': 'bool'},
-        },
+            backup=dict(type='bool', default=False),
+            binary=dict(type='bool', default=False),
+        ),
         required_one_of=[['dest', 'basedir']],
-        supports_check_mode=True
+        supports_check_mode=True,
     )
 
     # Create type object as namespace for module params
     p = type('Params', (), module.params)
 
     p.src = os.path.expanduser(p.src)
-    if not os.access(p.src, R_OK):
+    if not os.access(p.src, os.R_OK):
         module.fail_json(msg="src %s doesn't exist or not readable" % (p.src))
 
-    if p.dest and not os.access(p.dest, W_OK):
+    if p.dest and not os.access(p.dest, os.W_OK):
         module.fail_json(msg="dest %s doesn't exist or not writable" % (p.dest))
 
-    if p.basedir and not path.exists(p.basedir):
+    if p.basedir and not os.path.exists(p.basedir):
         module.fail_json(msg="basedir %s doesn't exist" % (p.basedir))
 
     if not p.basedir:
-        p.basedir = path.dirname(p.dest)
+        p.basedir = os.path.dirname(p.dest)
 
     patch_bin = module.get_bin_path('patch')
     if patch_bin is None:
         module.fail_json(msg="patch command not found")
-    patch_func = lambda opts: module.run_command("%s %s" % (patch_bin, ' '.join(opts)))
+
+    def patch_func(opts):
+        return module.run_command('%s %s' % (patch_bin, ' '.join(opts)))
 
     # patch need an absolute file name
     p.src = os.path.abspath(p.src)
@@ -185,8 +183,8 @@ def main():
     changed = False
     if not is_already_applied(patch_func, p.src, p.basedir, dest_file=p.dest, binary=p.binary, strip=p.strip):
         try:
-            apply_patch( patch_func, p.src, p.basedir, dest_file=p.dest, binary=p.binary, strip=p.strip,
-                         dry_run=module.check_mode, backup=p.backup )
+            apply_patch(patch_func, p.src, p.basedir, dest_file=p.dest, binary=p.binary, strip=p.strip,
+                        dry_run=module.check_mode, backup=p.backup)
             changed = True
         except PatchError:
             e = get_exception()
@@ -194,8 +192,6 @@ def main():
 
     module.exit_json(changed=changed)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/identity/ipa/ipa_role.py
+++ b/lib/ansible/modules/identity/ipa/ipa_role.py
@@ -66,6 +66,7 @@ options:
     - If option is passed all assigned privileges that are not passed will be removed.
     required: false
     default: None
+    version_added: "2.4"
   service:
     description:
     - List of service names to assign.

--- a/lib/ansible/modules/identity/ipa/ipa_role.py
+++ b/lib/ansible/modules/identity/ipa/ipa_role.py
@@ -58,6 +58,14 @@ options:
     - If option is omitted host groups will not be checked or changed.
     - If option is passed all assigned hostgroups that are not passed will be unassigned from the role.
     required: false
+  privilege:
+    description:
+    - List of privileges granted to the role.
+    - If an empty list is passed all assigned privileges will be removed.
+    - If option is omitted privileges will not be checked or changed.
+    - If option is passed all assigned privileges that are not passed will be removed.
+    required: false
+    default: None
   service:
     description:
     - List of service names to assign.
@@ -129,6 +137,9 @@ EXAMPLES = '''
     - host01.example.com
     hostgroup:
     - hostgroup01
+    privilege:
+    - Group Administrators
+    - User Administrators
     service:
     - service01
 
@@ -205,6 +216,12 @@ class RoleIPAClient(IPAClient):
     def role_remove_user(self, name, item):
         return self.role_remove_member(name=name, item={'user': item})
 
+    def role_add_privilege(self, name, item):
+        return self._post_json(method='role_add_privilege', name=name, item={'privilege': item})
+
+    def role_remove_privilege(self, name, item):
+        return self._post_json(method='role_remove_privilege', name=name, item={'privilege': item})
+
 
 def get_role_dict(description=None):
     data = {}
@@ -223,6 +240,7 @@ def ensure(module, client):
     group = module.params['group']
     host = module.params['host']
     hostgroup = module.params['hostgroup']
+    privilege = module.params['privilege']
     service = module.params['service']
     user = module.params['user']
 
@@ -249,7 +267,6 @@ def ensure(module, client):
             changed = client.modify_if_diff(name, ipa_role.get('member_group', []), group,
                                             client.role_add_group,
                                             client.role_remove_group) or changed
-
         if host is not None:
             changed = client.modify_if_diff(name, ipa_role.get('member_host', []), host,
                                             client.role_add_host,
@@ -260,6 +277,10 @@ def ensure(module, client):
                                             client.role_add_hostgroup,
                                             client.role_remove_hostgroup) or changed
 
+        if privilege is not None:
+            changed = client.modify_if_diff(name, ipa_role.get('memberof_privilege', []), privilege,
+                                            client.role_add_privilege,
+                                            client.role_remove_privilege) or changed
         if service is not None:
             changed = client.modify_if_diff(name, ipa_role.get('member_service', []), service,
                                             client.role_add_service,
@@ -268,6 +289,7 @@ def ensure(module, client):
             changed = client.modify_if_diff(name, ipa_role.get('member_user', []), user,
                                             client.role_add_user,
                                             client.role_remove_user) or changed
+
     else:
         if ipa_role:
             changed = True
@@ -285,6 +307,7 @@ def main():
             group=dict(type='list', required=False),
             host=dict(type='list', required=False),
             hostgroup=dict(type='list', required=False),
+            privilege=dict(type='list', required=False),
             service=dict(type='list', required=False),
             state=dict(type='str', required=False, default='present', choices=['present', 'absent']),
             user=dict(type='list', required=False),

--- a/lib/ansible/modules/monitoring/datadog_event.py
+++ b/lib/ansible/modules/monitoring/datadog_event.py
@@ -68,6 +68,11 @@ options:
         required: false
         default: normal
         choices: [normal, low]
+    host:
+        description: ["Host name to associate with the event."]
+        required: false
+        default: "{{ ansible_hostname }}"
+        version_added: "2.3"
     tags:
         description: ["Comma separated list of tags to apply to the event."]
         required: false
@@ -115,6 +120,9 @@ try:
 except:
     HAS_DATADOG = False
 
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.pycompat24 import get_exception
+
 
 def main():
     module = AnsibleModule(
@@ -127,6 +135,7 @@ def main():
             priority=dict(
                 required=False, default='normal', choices=['normal', 'low']
             ),
+            host=dict(required=False, default=None),
             tags=dict(required=False, default=None, type='list'),
             alert_type=dict(
                 required=False, default='info',
@@ -153,8 +162,11 @@ def main():
 
 def _post_event(module):
     try:
+        if module.params['host'] is None:
+            module.params['host'] = platform.node().split('.')[0]
         msg = api.Event.create(title=module.params['title'],
                                text=module.params['text'],
+                               host=module.params['host'],
                                tags=module.params['tags'],
                                priority=module.params['priority'],
                                alert_type=module.params['alert_type'],

--- a/lib/ansible/modules/monitoring/datadog_event.py
+++ b/lib/ansible/modules/monitoring/datadog_event.py
@@ -72,7 +72,7 @@ options:
         description: ["Host name to associate with the event."]
         required: false
         default: "{{ ansible_hostname }}"
-        version_added: "2.3"
+        version_added: "2.4"
     tags:
         description: ["Comma separated list of tags to apply to the event."]
         required: false

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -156,9 +156,16 @@ options:
         client authentication. If C(client_cert) contains both the certificate
         and key, this option is not required.
     version_added: '2.4'
+  state:
+    description:
+      - When specified as 'directory' specifies a directory for the file to
+        be placed in, creating the parent tree as required. When 'file' 
+        specifies the destination file for the downloaded item. 
   others:
     description:
-      - all arguments accepted by the M(file) module also work here
+      - The src, mode, owner, group, se* and follow argument from the M(file)
+        module are accepted by this module
+        
 # informational: requirements for nodes
 extends_documentation_fragment:
     - files
@@ -306,6 +313,7 @@ def main():
         timeout=dict(type='int', default=10),
         headers=dict(type='str'),
         tmp_dest=dict(type='path'),
+        state=dict(type='path'),
     )
 
     module = AnsibleModule(
@@ -335,12 +343,12 @@ def main():
             module.fail_json(msg="The header parameter requires a key:value,key:value syntax to be properly parsed.")
     else:
         headers = None
-        
+
     if not state:
         state = 'file'
-    elif state in ['link','absent','hard']:
+    elif state in ['link', 'absent', 'hard']:
         module.fail_json(msg="The state parameter can be only one of 'file' and 'directory' if specified.")
-    
+
     dest_is_dir = os.path.isdir(dest) or state == 'directory'
     last_mod_time = None
 
@@ -408,7 +416,7 @@ def main():
             except OSError:
                 e = get_exception()
                 module.fail_json(msg="create a destination directory failure %s: %s" % (dest, e))
-        
+
         filename = extract_filename_from_headers(info)
         if not filename:
             # Fall back to extracting the filename from the URL.

--- a/lib/ansible/modules/network/f5/bigip_command.py
+++ b/lib/ansible/modules/network/f5/bigip_command.py
@@ -83,7 +83,6 @@ options:
 notes:
   - Requires the f5-sdk Python package on the host. This is as easy as pip
     install f5-sdk.
-  - Requires Ansible >= 2.3.
 requirements:
   - f5-sdk >= 2.2.3
 extends_documentation_fragment: f5

--- a/lib/ansible/modules/network/junos/junos_facts.py
+++ b/lib/ansible/modules/network/junos/junos_facts.py
@@ -42,7 +42,9 @@ options:
         all, hardware, config, and interfaces.  Can specify a list of
         values to include a larger subset.  Values can also be used
         with an initial C(M(!)) to specify that a specific subset should
-        not be collected.
+        not be collected. To maintain backward compatbility old style facts
+        can be retrieved using all value, this reqires junos-eznc to be installed
+        as a prerequisite.
     required: false
     default: "!config"
     version_added: "2.3"
@@ -78,17 +80,24 @@ ansible_facts:
   type: dict
 """
 
-import re
 from xml.etree.ElementTree import Element, SubElement, tostring
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.six import iteritems
-from ansible.module_utils.junos import junos_argument_spec, check_args
+from ansible.module_utils.junos import junos_argument_spec, check_args, get_param
 from ansible.module_utils.junos import command, get_configuration
 from ansible.module_utils.netconf import send_request
 
+try:
+    from jnpr.junos import Device
+    from jnpr.junos.exception import ConnectError
+    HAS_PYEZ = True
+except ImportError:
+    HAS_PYEZ = False
 
 USE_PERSISTENT_CONNECTION = True
+
 
 class FactsBase(object):
 
@@ -140,7 +149,7 @@ class Config(FactsBase):
         config_format = self.module.params['config_format']
         reply = get_configuration(self.module, format=config_format)
 
-        if config_format =='xml':
+        if config_format == 'xml':
             config = tostring(reply.find('configuration')).strip()
 
         elif config_format == 'text':
@@ -153,7 +162,6 @@ class Config(FactsBase):
             config = self.get_text(reply, 'configuration-set')
 
         self.facts['config'] = config
-
 
 
 class Hardware(FactsBase):
@@ -202,11 +210,55 @@ class Interfaces(FactsBase):
         self.facts['interfaces'] = interfaces
 
 
+class Facts(FactsBase):
+    def _connect(self, module):
+        host = get_param(module, 'host')
+
+        kwargs = {
+            'port': get_param(module, 'port') or 830,
+            'user': get_param(module, 'username')
+        }
+
+        if get_param(module, 'password'):
+            kwargs['passwd'] = get_param(module, 'password')
+
+        if get_param(module, 'ssh_keyfile'):
+            kwargs['ssh_private_key_file'] = get_param(module, 'ssh_keyfile')
+
+        kwargs['gather_facts'] = False
+
+        try:
+            device = Device(host, **kwargs)
+            device.open()
+            device.timeout = get_param(module, 'timeout') or 10
+        except ConnectError:
+            exc = get_exception()
+            module.fail_json('unable to connect to %s: %s' % (host, str(exc)))
+
+        return device
+
+    def populate(self):
+
+        device = self._connect(self.module)
+        facts = dict(device.facts)
+
+        if '2RE' in facts:
+            facts['has_2RE'] = facts['2RE']
+            del facts['2RE']
+
+        facts['version_info'] = dict(facts['version_info'])
+        if 'junos_info' in facts:
+            for key, value in facts['junos_info'].items():
+                if 'object' in value:
+                    value['object'] = dict(value['object'])
+
+        return facts
+
 FACT_SUBSETS = dict(
     default=Default,
     hardware=Hardware,
     config=Config,
-    interfaces=Interfaces,
+    interfaces=Interfaces
 )
 
 VALID_SUBSETS = frozenset(FACT_SUBSETS.keys())
@@ -229,6 +281,7 @@ def main():
     check_args(module, warnings)
 
     gather_subset = module.params['gather_subset']
+    ofacts = False
 
     runable_subsets = set()
     exclude_subsets = set()
@@ -236,12 +289,14 @@ def main():
     for subset in gather_subset:
         if subset == 'all':
             runable_subsets.update(VALID_SUBSETS)
+            ofacts = True
             continue
 
         if subset.startswith('!'):
             subset = subset[1:]
             if subset == 'all':
                 exclude_subsets.update(VALID_SUBSETS)
+                ofacts = False
                 continue
             exclude = True
         else:
@@ -277,6 +332,13 @@ def main():
     for key, value in iteritems(facts):
         key = 'ansible_net_%s' % key
         ansible_facts[key] = value
+
+    if ofacts:
+        if HAS_PYEZ:
+            ansible_facts.update(Facts(module).populate())
+        else:
+            warnings += ['junos-eznc is required to gather old style facts but does not appear to be installed. '
+                         'It can be installed using `pip  install junos-eznc`']
 
     module.exit_json(ansible_facts=ansible_facts, warnings=warnings)
 

--- a/lib/ansible/modules/network/junos/junos_package.py
+++ b/lib/ansible/modules/network/junos/junos_package.py
@@ -99,7 +99,7 @@ EXAMPLES = """
 """
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
-from ansible.module_utils.junos import junos_argument_spec
+from ansible.module_utils.junos import junos_argument_spec, get_param
 
 try:
     from jnpr.junos import Device
@@ -109,8 +109,6 @@ try:
 except ImportError:
     HAS_PYEZ = False
 
-
-get_param = lambda x, y: x.params[y] or x.params['provider'].get(y)
 
 def connect(module):
     host = get_param(module, 'host')
@@ -137,6 +135,7 @@ def connect(module):
         module.fail_json('unable to connect to %s: %s' % (host, str(exc)))
 
     return device
+
 
 def install_package(module, device):
     junos = SW(device)

--- a/lib/ansible/modules/packaging/os/pkg5.py
+++ b/lib/ansible/modules/packaging/os/pkg5.py
@@ -128,7 +128,9 @@ def ensure(module, state, packages, params):
             'subcommand': 'install',
         },
         'latest': {
-            'filter': lambda p: not is_latest(module, p),
+            'filter': lambda p: (
+                not is_installed(module, p) or not is_latest(module, p)
+            ),
             'subcommand': 'install',
         },
         'absent': {

--- a/lib/ansible/modules/packaging/os/pkg5.py
+++ b/lib/ansible/modules/packaging/os/pkg5.py
@@ -90,7 +90,8 @@ def main():
                 default=False,
                 aliases=['accept_licences', 'accept'],
             ),
-        )
+        ),
+        supports_check_mode=True,
     )
 
     params = module.params
@@ -136,6 +137,11 @@ def ensure(module, state, packages, params):
         },
     }
 
+    if module.check_mode:
+        dry_run = ['-n']
+    else:
+        dry_run = []
+
     if params['accept_licenses']:
         accept_licenses = ['--accept']
     else:
@@ -147,6 +153,7 @@ def ensure(module, state, packages, params):
             [
                 'pkg', behaviour[state]['subcommand']
             ]
+            + dry_run
             + accept_licenses
             + [
                 '-q', '--'

--- a/lib/ansible/modules/system/cron.py
+++ b/lib/ansible/modules/system/cron.py
@@ -656,6 +656,10 @@ def main():
        (True in [(x != '*') for x in [minute, hour, day, month, weekday]]):
         module.fail_json(msg="You must specify time and date fields or special time.")
 
+    # cannot support special_time on solaris
+    if (special_time or reboot) and get_platform() == 'SunOS':
+        module.fail_json(msg="Solaris does not support special_time=... or @reboot")
+
     if cron_file and do_install:
         if not user:
             module.fail_json(msg="To use cron_file=... parameter you must specify user=... as well")

--- a/lib/ansible/modules/system/parted.py
+++ b/lib/ansible/modules/system/parted.py
@@ -590,6 +590,7 @@ def main():
         },
         supports_check_mode=True,
     )
+    module.run_command_environ_update = {'LANG': 'C', 'LC_ALL': 'C', 'LC_MESSAGES': 'C'}
 
     # Data extraction
     device = module.params['device']

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_launch.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_launch.py
@@ -75,7 +75,7 @@ EXAMPLES = '''
 - name: Launch a job
   tower_job_launch:
     job_template: "My Job Template"
-    register: job
+  register: job
 - name: Wait for job max 120s
   tower_job_wait:
     job_id: job.id

--- a/lib/ansible/modules/windows/win_dsc.ps1
+++ b/lib/ansible/modules/windows/win_dsc.ps1
@@ -1,0 +1,241 @@
+#!powershell
+# (c) 2015, Trond Hindenes <trond@hindenes.com>, and others
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# WANT_JSON
+# POWERSHELL_COMMON
+
+#Temporary fix
+#Set-StrictMode -Off
+
+$params = Parse-Args $args -supports_check_mode $true
+$result = @{
+    changed = $false
+}
+
+#Check that we're on at least Powershell version 5
+if ($PSVersionTable.PSVersion.Major -lt 5)
+{
+    Fail-Json -obj $Result -message "This module only runs on Powershell version 5 or higher"
+}
+$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
+$resourcename = Get-AnsibleParam -obj $params -name "resource_name" -type "str" -failifempty $true -resultobj $result
+$module_version = Get-AnsibleParam -obj $params -name "module_version" -type "str" -default "latest"
+
+#From Ansible 2.3 onwards, params is now a Hash Array
+$Attributes = $params.GetEnumerator() | where {$_.key -ne "resource_name"} | where {$_.key -notlike "_ansible_*"}
+
+if (!($Attributes))
+{
+    Fail-Json -obj $result -message "No attributes specified"
+}
+
+#Always return some basic info
+$result["resource_name"] = $resourcename
+$result["attributes"] = $Attributes
+$result["reboot_required"] = $null
+
+
+# Build Attributes Hashtable for DSC Resource Propertys
+$Attrib = @{}
+foreach ($key in $Attributes)
+{
+    $result[$key.name] = $key.value
+    $Attrib.Add($Key.Key,$Key.Value)
+}
+
+$result["dsc_attributes"] = $attrib
+
+$Config = @{
+   Name = ($resourcename)
+   Property = @{
+        }
+    }
+
+#Get the latest version of the module
+if ($module_version -eq "latest")
+{
+    $Resource = Get-DscResource -Name $resourcename -ErrorAction SilentlyContinue | sort Version | select -Last 1
+}
+else 
+{
+    $Resource = Get-DscResource -Name $resourcename -ErrorAction SilentlyContinue | where {$_.Version -eq $module_version}
+}
+
+if (!$Resource)
+{
+    if ($module_version -eq "latest")
+    {
+        Fail-Json -obj $result -message "Resource $resourcename not found"
+    }
+    else 
+    {
+        Fail-Json -obj $result -message "Resource $resourcename with version $module_version not found"
+    }
+    
+}
+
+#Get the Module that provides the resource. Will be used as
+#mandatory argument for Invoke-DscResource
+$Module = $Resource.ModuleName
+$result["module_version"] = $Module.Version.ToString()
+
+#Convert params to correct datatype and inject
+$attrib.Keys | foreach-object {
+    $Key = $_.replace("item_name", "name")
+    $prop = $resource.Properties | where {$_.Name -eq $key}
+    if (!$prop)
+    {
+        #If its a credential specified as "credential", Ansible will support credential_username and credential_password. Need to check for that
+        $prop = $resource.Properties | where {$_.Name -eq $key.Replace("_username","")}
+        if ($prop)
+        {
+            #We need to construct a cred object. At this point keyvalue is the username, so grab the password
+            $PropUserNameValue = $attrib.Item($_)
+            $PropPassword = $key.Replace("_username","_password")
+            $PropPasswordValue = $attrib.$PropPassword
+
+            $cred = New-Object System.Management.Automation.PSCredential ($PropUserNameValue, ($PropPasswordValue | ConvertTo-SecureString -AsPlainText -Force))
+            [System.Management.Automation.PSCredential]$KeyValue = $cred
+            $config.Property.Add($key.Replace("_username",""),$KeyValue)
+        }
+        ElseIf ($key.Contains("_password"))
+        {
+            #Do nothing. We suck in the password in the handler for _username, so we can just skip it.
+        }
+        Else
+        {
+            Fail-Json -obj $result -message "Property $key in resource $resourcename is not a valid property"
+        }
+
+    }
+    ElseIf ($prop.PropertyType -eq "[string]")
+    {
+        [String]$KeyValue = $attrib.Item($_)
+        $config.Property.Add($key,$KeyValue)
+    }
+    ElseIf ($prop.PropertyType -eq "[string[]]")
+    {
+        #KeyValue is an array of strings
+        [String]$TempKeyValue = $attrib.Item($_)
+        [String[]]$KeyValue = $TempKeyValue.Split(",").Trim()
+
+        $config.Property.Add($key,$KeyValue)
+    }
+    ElseIf ($prop.PropertyType -eq "[UInt32[]]")
+    {
+        #KeyValue is an array of integers
+        [String]$TempKeyValue = $attrib.Item($_)
+        [UInt32[]]$KeyValue = $attrib.Item($_.split(",").Trim())
+        $config.Property.Add($key,$KeyValue)
+    }
+    ElseIf ($prop.PropertyType -eq "[bool]")
+    {
+        if ($attrib.Item($_) -like "true")
+        {
+            [bool]$KeyValue = $true
+        }
+        ElseIf ($attrib.Item($_) -like "false")
+        {
+            [bool]$KeyValue = $false
+        }
+        $config.Property.Add($key,$KeyValue)
+    }
+    ElseIf ($prop.PropertyType -eq "[int]")
+    {
+        [int]$KeyValue = $attrib.Item($_)
+        $config.Property.Add($key,$KeyValue)
+    }
+    ElseIf ($prop.PropertyType -eq "[CimInstance[]]")
+    {
+      #KeyValue is an array of CimInstance
+      [CimInstance[]]$KeyVal = @()
+      [String]$TempKeyValue = $attrib.Item($_)
+      #Need to split on the string }, because some property values have commas in them
+      [String[]]$KeyValueStr = $TempKeyValue -split("},")
+      #Go through each string of properties and create a hash of them
+      foreach($str in $KeyValueStr)
+      {
+        [string[]]$properties = $str.Split("{")[1].Replace("}","").Trim().Split([environment]::NewLine).Trim()
+        $prph = @{}
+        foreach($p in $properties)
+        {
+          $pArr = $p -split "="
+          #if the value can be an int we must convert it to an int
+          if([bool]($pArr[1] -as [int] -is [int]))
+          {
+              $prph.Add($pArr[0].Trim(),$pArr[1].Trim() -as [int])
+          }
+          else
+          {
+              $prph.Add($pArr[0].Trim(),$pArr[1].Trim())
+          }
+        }
+        #create the new CimInstance
+        $cim = New-CimInstance -ClassName $str.Split("{")[0].Trim() -Property $prph -ClientOnly
+        #add the new CimInstance to the array
+        $KeyVal += $cim
+      }
+      $config.Property.Add($key,$KeyVal)
+    }
+    ElseIf ($prop.PropertyType -eq "[Int32]")
+    {
+        # Add Supoort for Int32
+        [int]$KeyValue = $attrib.Item($_)
+        $config.Property.Add($key,$KeyValue)
+    }
+    ElseIf ($prop.PropertyType -eq "[UInt32]")
+    {
+        # Add Support for [UInt32]
+        [UInt32]$KeyValue = $attrib.Item($_)
+        $config.Property.Add($key,$KeyValue)
+    }
+
+  }
+
+try
+{
+    #Defined variables in strictmode
+    $TestError, $TestError = $null
+    $TestResult = Invoke-DscResource @Config -Method Test -ModuleName $Module -ErrorVariable TestError -ErrorAction SilentlyContinue
+    if ($TestError)
+    {
+       throw ($TestError[0].Exception.Message)
+    }
+    ElseIf (($TestResult.InDesiredState) -ne $true)
+    {
+        if ($check_mode -eq $False)
+        {
+            $SetResult = Invoke-DscResource -Method Set @Config -ModuleName $Module -ErrorVariable SetError -ErrorAction SilentlyContinue -WarningAction SilentlyContinue
+            $result["reboot_required"] = $SetResult.RebootRequired
+        }
+
+        $result["changed"] = $true
+        if ($SetError)
+        {
+           throw ($SetError[0].Exception.Message)
+        }
+    }
+}
+Catch
+{
+    Fail-Json -obj $result -message $_[0].Exception.Message
+}
+
+
+#set-attr -obj $result -name "property" -value $property
+Exit-Json -obj $result

--- a/lib/ansible/modules/windows/win_dsc.py
+++ b/lib/ansible/modules/windows/win_dsc.py
@@ -1,0 +1,110 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2015, Trond Hindenes <trond@hindenes.com>, and others
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: win_dsc
+version_added: "2.4"
+short_description: Invokes a PowerShell DSC configuration
+description: |
+     Invokes a PowerShell DSC Configuration. Requires PowerShell version 5 (February release or newer).
+     Most of the parameters for this module are dynamic and will vary depending on the DSC Resource.
+     In order to find the required parameters for a given DSC resource, you can use the following on-liner:
+     'Get-DscResource <dsc_resource> | select -ExpandProperty properties'
+     Also note that credentials are handled as follows: If the resource accepts a credential type property called "cred",
+     the ansible parameters would be cred_username and cred_password.
+     These will be used to inject a credential object on the fly for the DSC resource.
+options:
+  resource_name:
+    description:
+      - The DSC Resource to use. Must be accessible to PowerShell using any of the default paths.
+    required: true
+  module_version:
+    description: |
+      Can be used to configure the exact version of the dsc resource to be invoked.
+      Useful if the target node has multiple versions installed of the module containing the DSC resource.
+      If not specified, the module will follow standard Powershell convention and use the highest version available.
+    default: latest
+author: Trond Hindenes
+'''
+
+EXAMPLES = r'''
+# Playbook example
+  - name: Extract zip file
+    win_dsc:
+      resource_name: archive
+      ensure: Present
+      path: "C:\\Temp\\zipfile.zip"
+      destination: "C:\\Temp\\Temp2"
+
+  - name: Invoke DSC with check mode
+    win_dsc:
+      resource_name: windowsfeature
+      name: telnet-client
+'''
+
+RETURN = r'''
+resource_name:
+    description: The name of the invoked resource
+    returned: always
+    type: string
+    sample: windowsfeature
+module_version:
+    description: The version of the dsc resource/module used.
+    returned: success
+    type: string
+    sample: "1.0.1"
+attributes:
+    description: The attributes/parameters passed in to the DSC resource as key/value pairs
+    returned: always
+    type: complex
+    sample:
+    contains:
+      Key:
+          description: Attribute key
+      Value:
+          description: Attribute value
+dsc_attributes:
+    description: The attributes/parameters as returned from the DSC engine in dict format
+    returned: always
+    type: complex
+    contains:
+      Key:
+          description: Attribute key
+      Value:
+          description: Attribute value
+reboot_required:
+    description: flag returned from the DSC engine indicating whether or not the machine requires a reboot for the invoked changes to take effect
+    returned: always
+    type: boolean
+    sample: True
+message:
+    description: any error message from invoking the DSC resource
+    returned: error
+    type: string
+    sample: Multiple DSC modules found with resource name xyz
+'''

--- a/lib/ansible/modules/windows/win_timezone.ps1
+++ b/lib/ansible/modules/windows/win_timezone.ps1
@@ -19,15 +19,14 @@
 # WANT_JSON
 # POWERSHELL_COMMON
 
-$result = @{
-    changed = $false
-    win_timezone = @{}
-}
-
 $params = Parse-Args $args -supports_check_mode $true
 $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
 
-$timezone = Get-AnsibleParam -obj $params -name "timezone" -failifempty $true -resultobj $result
+$timezone = Get-AnsibleParam -obj $params -name "timezone" -type "str" -failifempty $true
+
+$result = @{
+    changed = $false
+}
 
 Try {
     # Get the current timezone set

--- a/lib/ansible/modules/windows/win_timezone.py
+++ b/lib/ansible/modules/windows/win_timezone.py
@@ -38,8 +38,6 @@ options:
     description:
       - Timezone to set to.  Example Central Standard Time
     required: true
-    default: null
-    aliases: []
 
 author: Phil Schwartz
 '''

--- a/test/integration/targets/win_dsc/aliases
+++ b/test/integration/targets/win_dsc/aliases
@@ -1,0 +1,1 @@
+windows/ci/group3

--- a/test/integration/targets/win_dsc/defaults/main.yml
+++ b/test/integration/targets/win_dsc/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+# Feature not normally installed by default.
+test_win_feature_name: Telnet-Client

--- a/test/integration/targets/win_dsc/tasks/main.yml
+++ b/test/integration/targets/win_dsc/tasks/main.yml
@@ -1,0 +1,119 @@
+# test code for the win_feature module
+# (c) 2014, Chris Church <chris@ninemoreminutes.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+- name: check whether servermanager module is available (windows 2008 r2 or later)
+  raw: PowerShell -Command Import-Module ServerManager
+  register: win_feature_has_servermanager
+  ignore_errors: true
+
+
+- name: start with feature absent
+  win_feature:
+    name: "{{ test_win_feature_name }}"
+    state: absent
+  when: (win_feature_has_servermanager|success) and (ansible_powershell_version is defined) and (ansible_powershell_version >= 5)
+
+- name: Invoke DSC with check mode
+  win_dsc:
+    resource_name: windowsfeature
+    name: "{{ test_win_feature_name }}"
+  check_mode: yes
+  register: win_dsc_checkmode_result
+  when: (win_feature_has_servermanager|success) and (ansible_powershell_version is defined) and (ansible_powershell_version >= 5)
+
+- name: check result of Invoke DSC with check mode
+  assert:
+    that:
+      - "win_dsc_checkmode_result|changed"
+      - "win_dsc_checkmode_result|success"
+  when: (win_feature_has_servermanager|success) and (ansible_powershell_version is defined) and (ansible_powershell_version >= 5)
+
+- name: Make sure the feature is still absent
+  win_dsc:
+    resource_name: windowsfeature
+    name: "{{ test_win_feature_name }}"
+    ensure: absent
+  register: win_dsc_1_result
+  when: (win_feature_has_servermanager|success) and (ansible_powershell_version is defined) and (ansible_powershell_version >= 5)
+
+- name: check result of Make sure the feature is still absent
+  assert:
+    that:
+      - "not win_dsc_1_result|changed"
+      - "win_dsc_1_result|success"
+  when: (win_feature_has_servermanager|success) and (ansible_powershell_version is defined) and (ansible_powershell_version >= 5)
+
+- name: Install feature for realz
+  win_dsc:
+    resource_name: windowsfeature
+    name: "{{ test_win_feature_name }}"
+  register: win_dsc_2_result
+  when: (win_feature_has_servermanager|success) and (ansible_powershell_version is defined) and (ansible_powershell_version >= 5)
+
+- name: check result of Install feature for realz
+  assert:
+    that:
+      - "win_dsc_2_result|changed"
+      - "win_dsc_2_result|success"
+  when: (win_feature_has_servermanager|success) and (ansible_powershell_version is defined) and (ansible_powershell_version >= 5)
+
+- name: Ensure clean failure
+  win_dsc:
+    resource_name: some_unknown_resource_that_wont_ever_exist
+    name: "{{ test_win_feature_name }}"
+  register: win_dsc_3_result
+  ignore_errors: true
+  when: (win_feature_has_servermanager|success) and (ansible_powershell_version is defined) and (ansible_powershell_version >= 5)
+
+- name: check result of Ensure clean failure
+  assert:
+    that:
+      - "not win_dsc_3_result|changed"
+      - "not win_dsc_3_result|success"
+  when: (win_feature_has_servermanager|success) and (ansible_powershell_version is defined) and (ansible_powershell_version >= 5)
+
+- name: Make sure the feature is absent
+  win_dsc:
+    resource_name: windowsfeature
+    name: "{{ test_win_feature_name }}"
+    ensure: absent
+  register: win_dsc_4_result
+  when: (win_feature_has_servermanager|success) and (ansible_powershell_version is defined) and (ansible_powershell_version >= 5)
+
+- name: check result of Make sure the feature is absent
+  assert:
+    that:
+      - "win_dsc_4_result|changed"
+      - "win_dsc_4_result|success"
+  when: (win_feature_has_servermanager|success) and (ansible_powershell_version is defined) and (ansible_powershell_version >= 5)
+
+- name: Make sure the feature is still absent with no changes
+  win_dsc:
+    resource_name: windowsfeature
+    name: "{{ test_win_feature_name }}"
+    ensure: absent
+  register: win_dsc_5_result
+  when: (win_feature_has_servermanager|success) and (ansible_powershell_version is defined) and (ansible_powershell_version >= 5)
+
+- name: check result of Make sure the feature is absent
+  assert:
+    that:
+      - "not win_dsc_5_result|changed"
+      - "win_dsc_5_result|success"
+  when: (win_feature_has_servermanager|success) and (ansible_powershell_version is defined) and (ansible_powershell_version >= 5)

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -309,7 +309,6 @@ lib/ansible/modules/files/copy.py
 lib/ansible/modules/files/find.py
 lib/ansible/modules/files/ini_file.py
 lib/ansible/modules/files/iso_extract.py
-lib/ansible/modules/files/patch.py
 lib/ansible/modules/files/replace.py
 lib/ansible/modules/files/synchronize.py
 lib/ansible/modules/files/tempfile.py

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -103,7 +103,6 @@ lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
 lib/ansible/modules/cloud/amazon/efs.py
 lib/ansible/modules/cloud/amazon/efs_facts.py
 lib/ansible/modules/cloud/amazon/elasticache.py
-lib/ansible/modules/cloud/amazon/elasticache_snapshot.py
 lib/ansible/modules/cloud/amazon/elasticache_subnet_group.py
 lib/ansible/modules/cloud/amazon/execute_lambda.py
 lib/ansible/modules/cloud/amazon/iam.py

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -411,7 +411,6 @@ lib/ansible/modules/net_tools/ipinfoio_facts.py
 lib/ansible/modules/network/junos/_junos_template.py
 lib/ansible/modules/network/junos/junos_command.py
 lib/ansible/modules/network/junos/junos_config.py
-lib/ansible/modules/network/junos/junos_facts.py
 lib/ansible/modules/network/junos/junos_netconf.py
 lib/ansible/modules/network/junos/junos_package.py
 lib/ansible/modules/network/lenovo/cnos_conditional_template.py

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -306,7 +306,6 @@ lib/ansible/modules/files/archive.py
 lib/ansible/modules/files/assemble.py
 lib/ansible/modules/files/blockinfile.py
 lib/ansible/modules/files/copy.py
-lib/ansible/modules/files/find.py
 lib/ansible/modules/files/ini_file.py
 lib/ansible/modules/files/iso_extract.py
 lib/ansible/modules/files/replace.py


### PR DESCRIPTION
Fixes (#25263) 
_Appreciate this might not be the best solution but it did what I needed from it! Will be keen to see your feedback when I'm back on Friday, thanks!!!_

##### SUMMARY
Addition to allow get_url to process state='directory' to create directory trees prior to deploying the file downloaded

##### ISSUE TYPE
 - Docs Pull Request (I guess, it fixes the fact that get_url states ALL options from file should be available!!!)

##### COMPONENT NAME
get_url / FILE_COMMON_ARGUMENTS

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 45a9f96774) last updated 2017/06/01 17:08:32 (GMT +100)
```


##### ADDITIONAL INFORMATION
Output after change:
```
TASK [Download] ***************************************************************************************************************************************************************
task path: /home/circadian/code/circadian/scratch/gist.yml:4
Using module_utils file /home/circadian/.virtualenvs/ansible-bas/src/ansible/lib/ansible/module_utils/basic.py
Using module_utils file /home/circadian/.virtualenvs/ansible-bas/src/ansible/lib/ansible/module_utils/urls.py
Using module_utils file /home/circadian/.virtualenvs/ansible-bas/src/ansible/lib/ansible/module_utils/six/__init__.py
Using module_utils file /home/circadian/.virtualenvs/ansible-bas/src/ansible/lib/ansible/module_utils/_text.py
Using module_utils file /home/circadian/.virtualenvs/ansible-bas/src/ansible/lib/ansible/module_utils/pycompat24.py
Using module_utils file /home/circadian/.virtualenvs/ansible-bas/src/ansible/lib/ansible/module_utils/six/_six.py
Using module file /home/circadian/.virtualenvs/ansible-bas/src/ansible/lib/ansible/modules/net_tools/basics/get_url.py
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: circadian
<127.0.0.1> EXEC /bin/sh -c 'echo ~ && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/circadian/.ansible/tmp/ansible-tmp-1496335707.23-144998556057262 `" && echo ansible-tmp-1496335707.23-144998556057262="` echo /home/circadian/.ansible/tmp/ansible-tmp-1496335707.23-144998556057262 `" ) && sleep 0'
<127.0.0.1> PUT /tmp/tmpfepJEy TO /home/circadian/.ansible/tmp/ansible-tmp-1496335707.23-144998556057262/get_url.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/circadian/.ansible/tmp/ansible-tmp-1496335707.23-144998556057262/ /home/circadian/.ansible/tmp/ansible-tmp-1496335707.23-144998556057262/get_url.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/home/circadian/.virtualenvs/ansible-bas/bin/python /home/circadian/.ansible/tmp/ansible-tmp-1496335707.23-144998556057262/get_url.py; rm -rf "/home/circadian/.ansible/tmp/ansible-tmp-1496335707.23-144998556057262/" > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true, 
    "checksum_dest": null, 
    "checksum_src": "c47883762e31eb6d88c17e8f6605efdebebc3be7", 
    "dest": "./newdirectory/plain", 
    "failed": false, 
    "gid": 1000, 
    "group": "circadian", 
    "invocation": {
        "module_args": {
            "attributes": null, 
            "backup": null, 
            "checksum": "", 
            "client_cert": null, 
            "client_key": null, 
            "content": null, 
            "delimiter": null, 
            "dest": "./newdirectory/", 
            "directory_mode": null, 
            "follow": false, 
            "force": false, 
            "force_basic_auth": false, 
            "group": null, 
            "headers": null, 
            "http_agent": "ansible-httpget", 
            "mode": null, 
            "owner": null, 
            "path": "./newdirectory/plain", 
            "regexp": null, 
            "remote_src": null, 
            "selevel": null, 
            "serole": null, 
            "setype": null, 
            "seuser": null, 
            "sha256sum": "", 
            "src": null, 
            "state": "directory", 
            "timeout": 10, 
            "tmp_dest": null, 
            "unsafe_writes": null, 
            "url": "http://ipecho.net/plain", 
            "url_password": null, 
            "url_username": null, 
            "use_proxy": true, 
            "validate_certs": true
        }
    }, 
    "md5sum": "eefa366359837a8d7d91af3c8e8e434a", 
    "mode": "0664", 
    "msg": "OK (unknown bytes)", 
    "owner": "circadian", 
    "size": 12, 
    "src": "/tmp/tmpiaedYM", 
    "state": "file", 
    "status_code": 200, 
    "uid": 1000, 
    "url": "http://ipecho.net/plain"
}
META: ran handlers
META: ran handlers
```
