### PR TITLE
foreman.py: create Ansible groups from Satellite 6 host collections

### DIFF
--- a/contrib/inventory/foreman.ini
+++ b/contrib/inventory/foreman.ini
@@ -68,6 +68,17 @@
 #
 #     foreman_hostgroup_myapp_webtier_datacenter1
 #
+# If the parameter want_hostcollections is set to true, the
+# collections each host is in are created as Ansible groups with a
+# foreman_hostcollection prefix, all lowercase and problematic
+# parameters removed. So e.g. the Foreman host collection
+#
+#     Patch Window Thursday
+#
+# would turn into the Ansible group:
+#
+#     foreman_hostcollection_patchwindowthursday
+#
 # Furthermore Ansible groups can be created on the fly using the
 # *group_patterns* variable in *foreman.ini* so that you can build up
 # hierarchies using parameters on the hostgroup and host variables.
@@ -116,6 +127,8 @@ group_patterns = ["{app}-{tier}-{color}",
 group_prefix = foreman_
 # Whether to fetch facts from Foreman and store them on the host
 want_facts = True
+# Whether to create Ansible groups for host collections
+want_hostcollections = False
 
 [cache]
 path = .

--- a/contrib/inventory/foreman.ini
+++ b/contrib/inventory/foreman.ini
@@ -130,9 +130,9 @@ group_prefix = foreman_
 want_facts = True
 
 # Whether to create Ansible groups for host collections. Only tested
-# with Katello (Red Hat Satellite), may have to be disabled for
-# stand-alone Foreman.
-want_hostcollections = True
+# with Katello (Red Hat Satellite). Disabled by default to not break
+# the script for stand-alone Foreman.
+want_hostcollections = False
 
 [cache]
 path = .

--- a/contrib/inventory/foreman.ini
+++ b/contrib/inventory/foreman.ini
@@ -125,10 +125,14 @@ group_patterns = ["{app}-{tier}-{color}",
 	          "{app}",
 		  "{tier}"]
 group_prefix = foreman_
+
 # Whether to fetch facts from Foreman and store them on the host
 want_facts = True
-# Whether to create Ansible groups for host collections
-want_hostcollections = False
+
+# Whether to create Ansible groups for host collections. Only tested
+# with Katello (Red Hat Satellite), may have to be disabled for
+# stand-alone Foreman.
+want_hostcollections = True
 
 [cache]
 path = .

--- a/contrib/inventory/foreman.ini
+++ b/contrib/inventory/foreman.ini
@@ -79,6 +79,10 @@
 #
 #     foreman_hostcollection_patchwindowthursday
 #
+# If the parameter host_filters is set, it will be used as the
+# "search" parameter for the /api/v2/hosts call. This can be used to
+# restrict the list of returned host, as shown below.
+#
 # Furthermore Ansible groups can be created on the fly using the
 # *group_patterns* variable in *foreman.ini* so that you can build up
 # hierarchies using parameters on the hostgroup and host variables.
@@ -118,6 +122,13 @@ url = http://localhost:3000/
 user = foreman
 password = secret
 ssl_verify = True
+
+# Retrieve only hosts from the organization "Web Engineering".
+# host_filters = organization="Web Engineering"
+
+# Retrieve only hosts from the organization "Web Engineering" that are
+# also in the host collection "Apache Servers".
+# host_filters = organization="Web Engineering" and host_collection="Apache Servers"
 
 [ansible]
 group_patterns = ["{app}-{tier}-{color}",

--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -111,7 +111,7 @@ class ForemanInventory(object):
         try:
             self.want_hostcollections = config.getboolean('ansible', 'want_hostcollections')
         except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
-            self.want_hostcollections = True
+            self.want_hostcollections = False
 
         # Cache related
         try:

--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -160,13 +160,16 @@ class ForemanInventory(object):
             self.session.verify = self.foreman_ssl_verify
         return self.session
 
-    def _get_json(self, url, ignore_errors=None, params={}):
+    def _get_json(self, url, ignore_errors=None, params=None):
+        if params is None:
+            params = {}
+        params['per_page'] = 250
+
         page = 1
-        params.update({'per_page': 250})
         results = []
         s = self._get_session()
         while True:
-            params.update({'page': page})
+            params['page'] = page
             ret = s.get(url, params=params)
             if ignore_errors and ret.status_code in ignore_errors:
                 break

--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -112,7 +112,7 @@ class ForemanInventory(object):
         try:
             self.want_hostcollections = config.getboolean('ansible', 'want_hostcollections')
         except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
-            self.want_hostcollections = False
+            self.want_hostcollections = True
 
         # Cache related
         try:

--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -131,9 +131,9 @@ class ForemanInventory(object):
             self.cache_max_age = 60
 
         # If the FOREMAN_ORGANIZATION environment variable is set to the
-        # label of a Foreman organization, only hosts from that
-        # organization will be listed. This can be used in Ansible Tower
-        # inventories.
+        # label of a Foreman organization, only hosts from that organization
+        # will be listed. This can be used to define inventories with
+        # different host subsets in Ansible Tower.
         foreman_organization_label = os.environ.get('FOREMAN_ORGANIZATION')
         self.foreman_organization_id = None
         if foreman_organization_label:
@@ -141,7 +141,8 @@ class ForemanInventory(object):
 
         # If the FOREMAN_HOSTCOLLECTION environment variable is set to the
         # name of a Foreman host collection, only hosts from that collection
-        # will be listed. This can be used in Ansible Tower inventories.
+        # will be listed. This can be used to define inventories with
+        # different host subsets in Ansible Tower.
         self.foreman_hostcollection_name = os.environ.get('FOREMAN_HOSTCOLLECTION')
 
         return True

--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -131,7 +131,7 @@ class ForemanInventory(object):
             self.cache_max_age = 60
 
         # If the FOREMAN_ORGANIZATION environment variable is set to the
-        # label of a Satellite organization, only hosts from that
+        # label of a Foreman organization, only hosts from that
         # organization will be listed. This can be used in Ansible Tower
         # inventories.
         foreman_organization_label = os.environ.get('FOREMAN_ORGANIZATION')
@@ -140,9 +140,8 @@ class ForemanInventory(object):
             self.foreman_organization_id = self._get_organization_id(foreman_organization_label)
 
         # If the FOREMAN_HOSTCOLLECTION environment variable is set to the
-        # name of a Satellite host collection, only hosts from that
-        # collection will be listed. This can be used in Ansible Tower
-        # inventories.
+        # name of a Foreman host collection, only hosts from that collection
+        # will be listed. This can be used in Ansible Tower inventories.
         self.foreman_hostcollection_name = os.environ.get('FOREMAN_HOSTCOLLECTION')
 
         return True

--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -182,7 +182,7 @@ class ForemanInventory(object):
                 return json['results']
             # List of all hosts is returned paginaged
             results = results + json['results']
-            if len(results) >= json['total']:
+            if len(results) >= json['subtotal']:
                 break
             page += 1
             if len(json['results']) == 0:

--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -347,39 +347,36 @@ class ForemanInventory(object):
     def load_inventory_from_cache(self):
         """Read the index from the cache file sets self.index"""
 
-        cache = open(self.cache_path_inventory, 'r')
-        json_inventory = cache.read()
-        self.inventory = json.loads(json_inventory)
+        with open(self.cache_path_inventory, 'r') as fp:
+            self.inventory = json.load(fp)
 
     def load_params_from_cache(self):
         """Read the index from the cache file sets self.index"""
 
-        cache = open(self.cache_path_params, 'r')
-        json_params = cache.read()
-        self.params = json.loads(json_params)
+        with open(self.cache_path_params, 'r') as fp:
+            self.params = json.load(fp)
 
     def load_facts_from_cache(self):
         """Read the index from the cache file sets self.facts"""
+
         if not self.want_facts:
             return
-        cache = open(self.cache_path_facts, 'r')
-        json_facts = cache.read()
-        self.facts = json.loads(json_facts)
+        with open(self.cache_path_facts, 'r') as fp:
+            self.facts = json.load(fp)
 
     def load_hostcollections_from_cache(self):
         """Read the index from the cache file sets self.hostcollections"""
+
         if not self.want_hostcollections:
             return
-        cache = open(self.cache_path_hostcollections, 'r')
-        json_hostcollections = cache.read()
-        self.hostcollections = json.loads(json_hostcollections)
+        with open(self.cache_path_hostcollections, 'r') as fp:
+            self.hostcollections = json.load(fp)
 
     def load_cache_from_cache(self):
         """Read the cache from the cache file sets self.cache"""
 
-        cache = open(self.cache_path_cache, 'r')
-        json_cache = cache.read()
-        self.cache = json.loads(json_cache)
+        with open(self.cache_path_cache, 'r') as fp:
+            self.cache = json.load(fp)
 
     def get_inventory(self):
         if self.args.refresh_cache or not self.is_cache_valid():


### PR DESCRIPTION
##### SUMMARY
Change the foreman.py inventory script so that it creates Ansible groups for Red Hat Satellite 6 host collections.

We needed this for a project where we wanted to run playbooks against a certain set of managed hosts, which were already grouped in the right way with host collections in Red Hat Satellite 6.

The default behaviour does not change, groups from host collections are only created if the want_hostcollections parameter in foreman.ini is set to True.

Also adds support for the environment variables FOREMAN_ORGANIZATION and FOREMAN_HOSTCOLLECTION. If these are set, only hosts from the given organization and/or host collection are listed. This is useful for inventories defined in Ansible Tower.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
foreman dynamic inventory script

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```


##### ADDITIONAL INFORMATION
