### PR TITLE
[tower_job_template] Fix handling of extra_vars_path parameter.

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -233,7 +233,7 @@ def update_fields(p):
 
     extra_vars = params.get('extra_vars_path')
     if extra_vars is not None:
-        params_update['extra_vars'] = '@' + extra_vars
+        params_update['extra_vars'] = ['@' + extra_vars]
 
     params.update(params_update)
     return params


### PR DESCRIPTION

##### SUMMARY

Fix extra_vars_path parameter of tower_job_template module

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
tower_job_template

##### ANSIBLE VERSION
```
2.3
```

##### ADDITIONAL INFORMATION

tower-cli process_extra_vars takes a list, so make sure we pass one.

Fixes https://github.com/ansible/ansible/issues/25266