### PR TITLE
module_utils/ec2: fix boto3 tags to remove

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -638,17 +638,19 @@ def compare_aws_tags(current_tags_dict, new_tags_dict, purge_tags=True):
     :param new_tags_dict:
     :param purge_tags:
     :return: tag_key_value_pairs_to_set: a dict of key value pairs that need to be set in AWS. If all tags are identical this dict will be empty
-    :return: tag_keys_to_unset: a list of key names that need to be unset in AWS. If no tags need to be unset this list will be empty
+    :return: tag_keys_to_unset: a list of key names (in the boto3 form of [{'Key': key}]) that need to be unset in AWS. If no tags need to be unset this list will be empty
     """
 
     tag_key_value_pairs_to_set = {}
     tag_keys_to_unset = []
+    list_tag_keys_to_unset = []
 
     for key in current_tags_dict.keys():
         if key not in new_tags_dict and purge_tags:
-            tag_keys_to_unset.append(key)
+            list_tag_keys_to_unset.append(key)
+            tag_keys_to_unset.append({'Key': key})
 
-    for key in set(new_tags_dict.keys()) - set(tag_keys_to_unset):
+    for key in set(new_tags_dict.keys()) - set(list_tag_keys_to_unset):
         if new_tags_dict[key] != current_tags_dict.get(key):
             tag_key_value_pairs_to_set[key] = new_tags_dict[key]
 

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -638,7 +638,8 @@ def compare_aws_tags(current_tags_dict, new_tags_dict, purge_tags=True):
     :param new_tags_dict:
     :param purge_tags:
     :return: tag_key_value_pairs_to_set: a dict of key value pairs that need to be set in AWS. If all tags are identical this dict will be empty
-    :return: tag_keys_to_unset: a list of key names (in the boto3 form of [{'Key': key}]) that need to be unset in AWS. If no tags need to be unset this list will be empty
+    :return: tag_keys_to_unset: a list of key names (in the boto3 form of [{'Key': key}]) that need to be unset in AWS.
+             If no tags need to be unset this list will be empty
     """
 
     tag_key_value_pairs_to_set = {}

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -632,26 +632,24 @@ def map_complex_type(complex_type, type_map):
 def compare_aws_tags(current_tags_dict, new_tags_dict, purge_tags=True):
     """
     Compare two dicts of AWS tags. Dicts are expected to of been created using 'boto3_tag_list_to_ansible_dict' helper function.
-    Two dicts are returned - the first is tags to be set, the second is any tags to remove
+    Two dicts are returned - the first is tags to be set, the second is any tags to remove. Since the AWS APIs differ t
+hese may not be able to be used out of the box.
 
     :param current_tags_dict:
     :param new_tags_dict:
     :param purge_tags:
     :return: tag_key_value_pairs_to_set: a dict of key value pairs that need to be set in AWS. If all tags are identical this dict will be empty
-    :return: tag_keys_to_unset: a list of key names (in the boto3 form of [{'Key': key}]) that need to be unset in AWS.
-             If no tags need to be unset this list will be empty
+    :return: tag_keys_to_unset: a list of key names (type str) that need to be unset in AWS. If no tags need to be unset this list will be empty
     """
 
     tag_key_value_pairs_to_set = {}
     tag_keys_to_unset = []
-    list_tag_keys_to_unset = []
 
     for key in current_tags_dict.keys():
         if key not in new_tags_dict and purge_tags:
-            list_tag_keys_to_unset.append(key)
-            tag_keys_to_unset.append({'Key': key})
+            tag_keys_to_unset.append(key)
 
-    for key in set(new_tags_dict.keys()) - set(list_tag_keys_to_unset):
+    for key in set(new_tags_dict.keys()) - set(tag_keys_to_unset):
         if new_tags_dict[key] != current_tags_dict.get(key):
             tag_key_value_pairs_to_set[key] = new_tags_dict[key]
 

--- a/lib/ansible/modules/cloud/amazon/GUIDELINES.md
+++ b/lib/ansible/modules/cloud/amazon/GUIDELINES.md
@@ -314,4 +314,6 @@ to modify and a list of tag key names that you need to remove.  Purge is True by
 existing tags will not be modified.
 
 This function is useful when using boto3 'add_tags' and 'remove_tags' functions. Be sure to use the other helper function
-'boto3_tag_list_to_ansible_dict' to get an appropriate tag dict before calling this function.
+'boto3_tag_list_to_ansible_dict' to get an appropriate tag dict before calling this function. Since the AWS APIs are not
+uniform (e.g. EC2 versus Lambda) this will work without modification for some (Lambda) and others may need modification
+before using these values (such as EC2, with requires the tags to unset to be in the form [{'Key': key1}, {'Key': key2}]).


### PR DESCRIPTION
##### SUMMARY
http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.delete_tags
~It's fine to only have the tag keys for deletion but they need to be in the boto3 form of {'Key': key}. Cannot remove a list of strings as is being returned now. I can hack around the bug in a couple lines for what I'm working on but makes more sense just to fix here.~ Edit: hack around we must. Adding a little documentation instead.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/ec2.py

##### ANSIBLE VERSION
```
2.4.0
```