### PR TITLE
Make setting of metadata for crypto backend settable at buildtime

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,16 @@ with open('requirements.txt') as requirements_file:
               "That indicates this copy of the source code is incomplete.")
         sys.exit(2)
 
+# pycrypto or cryptography.   We choose a default but allow the user to
+# override it.  This translates into pip install of the sdist deciding what
+# package to install and also the runtime dependencies that pkg_resources
+# knows about
+crypto_backend = os.environ.get('ANSIBLE_CRYPTO_BACKEND', None)
+if crypto_backend:
+    install_requirements = [r for r in install_requirements if not (r.lower().startswith('pycrypto') or r.lower().startswith('cryptography'))]
+    install_requirements.append(crypto_backend)
+
+
 SYMLINKS = {'ansible': frozenset(('ansible-console',
                                   'ansible-doc',
                                   'ansible-galaxy',


### PR DESCRIPTION
Working on several separate ideas to make ansible work with both
cryptography or pycrypto.  This particular change will let a user
installing ansible change which crypto backend gets encoded in the
metadata (and hence, which backend is required by pkg_resource).

This works with both setup.py and pip::

  ANSIBLE_CRYPTO_BACKEND=cryptography pip install ansible
  ANSIBLE_CRYPTO_BACKEND=cryptography python2 ./setup.py

Note that the code to use cryptography is not yet merged so using
ANSIBLE_CRYPTO_BACKEND is not yet a good idea (as it can lead to not
installing pycrypto and hence the current vault code will fail).

Related to: #20566


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
setup.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
@reaperhulk, does this help out with your work?