### PR TITLE
win_timezone: Add diff support, integration tests

### DIFF
--- a/lib/ansible/modules/windows/win_timezone.py
+++ b/lib/ansible/modules/windows/win_timezone.py
@@ -25,7 +25,6 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
-
 DOCUMENTATION = r'''
 ---
 module: win_timezone
@@ -40,11 +39,13 @@ options:
     required: true
 notes:
 - The module will check if the provided timezone is supported on the machine.
-- A list of possible timezones is available from
+- A list of possible timezones is available from C(tzutil.exe /l) and from
   U(https://msdn.microsoft.com/en-us/library/ms912391.aspx)
+- If running on Server 2008 the hotfix
+  U(https://support.microsoft.com/en-us/help/2556308/tzutil-command-line-tool-is-added-to-windows-vista-and-to-windows-server-2008)
+  needs to be installed to be able to run this module.
 author: Phil Schwartz
 '''
-
 
 EXAMPLES = r'''
 - name: Set timezone to 'Romance Standard Time' (GMT+01:00)

--- a/lib/ansible/modules/windows/win_timezone.py
+++ b/lib/ansible/modules/windows/win_timezone.py
@@ -29,24 +29,46 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 DOCUMENTATION = r'''
 ---
 module: win_timezone
-version_added: "2.1"
+version_added: '2.1'
 short_description: Sets Windows machine timezone
 description:
-    - Sets machine time to the specified timezone, the module will check if the provided timezone is supported on the machine.
+- Sets machine time to the specified timezone.
 options:
   timezone:
     description:
-      - Timezone to set to.  Example Central Standard Time
+    - Timezone to set to. Example Central Standard Time
     required: true
-
+notes:
+- The module will check if the provided timezone is supported on the machine.
+- A list of possible timezones is available from
+  U(https://msdn.microsoft.com/en-us/library/ms912391.aspx)
 author: Phil Schwartz
 '''
 
 
 EXAMPLES = r'''
-  # Set machine's timezone to Central Standard Time
+- name: Set timezone to 'Romance Standard Time' (GMT+01:00)
   win_timezone:
-    timezone: "Central Standard Time"
+    timezone: Romance Standard Time
+
+- name: Set timezone to 'GMT Standard Time' (GMT)
+  win_timezone:
+    timezone: GMT Standard Time
+
+- name: Set timezone to 'Central Standard Time' (GMT-06:00)
+  win_timezone:
+    timezone: Central Standard Time
 '''
 
-RETURN = r'''# '''
+RETURN = r'''
+previous_timezone:
+    description: The previous timezone if it was changed, otherwise the existing timezone
+    returned: success
+    type: string
+    sample: Central Standard Time
+timezone:
+    description: The current timezone (possibly changed)
+    returned: success
+    type: string
+    sample: Central Standard Time
+'''

--- a/test/integration/targets/win_timezone/aliases
+++ b/test/integration/targets/win_timezone/aliases
@@ -1,0 +1,1 @@
+windows/ci/group3

--- a/test/integration/targets/win_timezone/tasks/main.yml
+++ b/test/integration/targets/win_timezone/tasks/main.yml
@@ -1,0 +1,19 @@
+- name: Determine if server has tzutil.exe installed
+  win_command: tzutil.exe /l
+  register: tzutil
+  ignore_errors: yes
+
+- name: Only run tests if tzutil.exe is installed
+  when: tzutil.rc == 0
+  block:
+
+  - name: Test in normal mode
+    include: tests.yml
+    vars:
+      in_check_mode: no
+
+  - name: Test in check-mode
+    include: tests.yml
+    vars:
+      in_check_mode: yes
+    check_mode: yes

--- a/test/integration/targets/win_timezone/tasks/tests.yml
+++ b/test/integration/targets/win_timezone/tasks/tests.yml
@@ -1,0 +1,89 @@
+# NOTE: Set to a known starting value, store original
+- name: Change starting timezone to GMT
+  win_timezone:
+    timezone: GMT Standard Time
+  register: original
+
+# NOTE: We don't know if it changed, we don't care
+- name: Test GMT timezone
+  assert:
+    that:
+    - original.timezone == 'GMT Standard Time'
+
+- name: Change timezone to GMT+1
+  win_timezone:
+    timezone: Romance Standard Time
+  register: romance
+
+- name: Test GMT+1 timezone
+  assert:
+    that:
+    - romance|changed
+    - romance.previous_timezone == 'GMT Standard Time'
+    - romance.timezone == 'Romance Standard Time'
+  when: not in_check_mode
+
+- name: Test GMT+1 timezone
+  assert:
+    that:
+    - romance|changed
+    - romance.previous_timezone == original.timezone
+    - romance.timezone == 'Romance Standard Time'
+  when: in_check_mode
+
+- name: Change timezone to GMT+1 again
+  win_timezone:
+    timezone: Romance Standard Time
+  register: romance
+
+- name: Test GMT+1 timezone
+  assert:
+    that:
+    - not romance|changed
+    - romance.previous_timezone == 'Romance Standard Time'
+    - romance.timezone == 'Romance Standard Time'
+  when: not in_check_mode
+
+- name: Test GMT+1 timezone
+  assert:
+    that:
+    - romance|changed
+    - romance.previous_timezone == original.timezone
+    - romance.timezone == 'Romance Standard Time'
+  when: in_check_mode
+
+- name: Change timezone to GMT+6
+  win_timezone:
+    timezone: Central Standard Time
+  register: central
+
+- name: Test GMT-6 timezone
+  assert:
+    that:
+    - central|changed
+    - central.previous_timezone == 'Romance Standard Time'
+    - central.timezone == 'Central Standard Time'
+  when: not in_check_mode
+
+- name: Test GMT+1 timezone
+  assert:
+    that:
+    - central|changed
+    - central.previous_timezone == original.timezone
+    - central.timezone == 'Central Standard Time'
+  when: in_check_mode
+
+- name: Change timezone to GMT+666
+  win_timezone:
+    timezone: Dag's Standard Time
+  register: dag
+  ignore_errors: yes
+
+- name: Test GMT+666 timezone
+  assert:
+    that:
+    - dag|failed
+
+- name: Restore original timezone
+  win_timezone:
+    timezone: '{{ original.timezone }}'


### PR DESCRIPTION
##### SUMMARY
This PR includes:

- Diff support
- Returns both previous_timezone and timezone
- Adds integration tests
- More examples
- Improved documentation

This fixes #25071 (not really fixes, but rather includes)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_timezone

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.4