### PR TITLE
add Makefile target for single HTML page

### DIFF
--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -50,4 +50,12 @@ staticmin:
 	cat _themes/srtd/static/css/theme.css | sed -e 's/^[ 	]*//g; s/[ 	]*$$//g; s/\([:{;,]\) /\1/g; s/ {/{/g; s/\/\*.*\*\///g; /^$$/d' | sed -e :a -e '$$!N; s/\n\(.\)/\1/; ta' > _themes/srtd/static/css/theme.min.css
 
 epub:
-	 (CPUS=$(CPUS) make -f Makefile.sphinx epub)
+	(CPUS=$(CPUS) make -f Makefile.sphinx epub)
+
+htmlsingle:
+ifndef rst
+    $(error specify target rst file to build via 'rst=somefile.rst')
+endif
+
+	sphinx-build -j $(CPUS) -b html -d _build/doctrees ./rst _build/html rst/$(rst)
+	@echo "Output is in _build/html/$(rst)"


### PR DESCRIPTION
##### SUMMARY
Make a single HTML doc page via:
```
cd ansible/docs/docsite
make htmlsingle rst=roadmap/ROADMAP_2_4.rst
```
instead of building entire tree.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Makefile

##### ANSIBLE VERSION
2.4.0

