### PR TITLE
Improve consistency of behavior around play-level tags

### DIFF
--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -174,7 +174,7 @@ class PlayIterator:
         setup_task = Task(block=setup_block)
         setup_task.action = 'setup'
         setup_task.name = 'Gathering Facts'
-        setup_task.tags = ['always']
+        setup_task.tags = self._play._get_attr_tags()
         setup_task.args = {
             'gather_subset': gather_subset,
         }

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -134,7 +134,7 @@ class PlaybookExecutor:
                         # we are just doing a listing
                         entry['plays'].append(new_play)
 
-                    else:
+                    elif play.evaluate_tags(self._options.tags, self._options.skip_tags, all_vars):
                         self._tqm._unreachable_hosts.update(self._unreachable_hosts)
 
                         previously_failed = len(self._tqm._failed_hosts)


### PR DESCRIPTION
##### SUMMARY

This pull request aspires to correct two surprising behaviors surrounding play-level tags.

First, it modifies the fact gathering step in a play to inherit its tags from its parent play if any exist. I believe this to be a more accurate solution to the problem originally brought up in #14228. The issue involved gathering not taking place at all when tags were specified (since the gathering step had no tags at that time, it would always be skipped). Tag inheritance corrects the problem by making sure that the fact gathering task will only run if the play it is a part of will run. Originally, facts would be forcibly gathered even if tags were configured in such a way that the play would not execute, slowing down playbook execution and cluttering output.

Second, it considers the tags of each play in a playbook before making the decision to execute. This further minimizes unnecessary output when running a small number of tagged plays in a large playbook.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
play_executor  
playbook_executor

##### ANSIBLE VERSION
```
ansible 2.4.0
```