### PR TITLE
  Fix issue with get_url not accepting state parameter for creating directories…(#25263)

### DIFF
--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -154,7 +154,7 @@ options:
         be placed in, creating the parent tree as required. When 'file'
         specifies the destination file for the downloaded item.
     default: 'no'
-    version_added: '2.7'
+    version_added: '2.8'
     type: bool
   others:
     description:


### PR DESCRIPTION
Fix issue with get_url not accepting all parameters for file module… Fixes #25263

_Apologies for the duplicate pull request, hopefully this time the implementation is a bit more agreeable_

##### SUMMARY
Addition to allow get_url to process state='directory' to create directory trees prior to deploying the file downloaded. The documentation previously stated that it accepts all file parameters (but it doesn't) so I've amended the docs and added what I think is quite a useful behaviour when using the module...

##### ISSUE TYPE
 - Feature request 

##### COMPONENT NAME
get_url / FILE_COMMON_ARGUMENTS

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 172e9f8adb) last updated 2017/06/02 11:41:06 (GMT +100)
```


##### ADDITIONAL INFORMATION
Output after change:
```
TASK [Download] *****************************************************************************************************************************************************
task path: /home/circadian/code/circadian/scratch/gist.yml:4
Using module_utils file /home/circadian/.virtualenvs/ansible-bas/src/ansible/lib/ansible/module_utils/basic.py
Using module_utils file /home/circadian/.virtualenvs/ansible-bas/src/ansible/lib/ansible/module_utils/urls.py
Using module_utils file /home/circadian/.virtualenvs/ansible-bas/src/ansible/lib/ansible/module_utils/six/__init__.py
Using module_utils file /home/circadian/.virtualenvs/ansible-bas/src/ansible/lib/ansible/module_utils/_text.py
Using module_utils file /home/circadian/.virtualenvs/ansible-bas/src/ansible/lib/ansible/module_utils/pycompat24.py
Using module_utils file /home/circadian/.virtualenvs/ansible-bas/src/ansible/lib/ansible/module_utils/six/_six.py
Using module file /home/circadian/.virtualenvs/ansible-bas/src/ansible/lib/ansible/modules/net_tools/basics/get_url.py
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: circadian
<127.0.0.1> EXEC /bin/sh -c 'echo ~ && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/circadian/.ansible/tmp/ansible-tmp-1496400586.24-273191799905950 `" && echo ansible-tmp-1496400586.24-273191799905950="` echo /home/circadian/.ansible/tmp/ansible-tmp-1496400586.24-273191799905950 `" ) && sleep 0'
<127.0.0.1> PUT /tmp/tmpJinr0B TO /home/circadian/.ansible/tmp/ansible-tmp-1496400586.24-273191799905950/get_url.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/circadian/.ansible/tmp/ansible-tmp-1496400586.24-273191799905950/ /home/circadian/.ansible/tmp/ansible-tmp-1496400586.24-273191799905950/get_url.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/home/circadian/.virtualenvs/ansible-bas/bin/python /home/circadian/.ansible/tmp/ansible-tmp-1496400586.24-273191799905950/get_url.py; rm -rf "/home/circadian/.ansible/tmp/ansible-tmp-1496400586.24-273191799905950/" > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "changed": true, 
    "checksum_dest": null, 
    "checksum_src": "c47883762e31eb6d88c17e8f6605efdebebc3be7", 
    "dest": "./newdirectory/plain", 
    "failed": false, 
    "gid": 1000, 
    "group": "circadian", 
    "invocation": {
        "module_args": {
            "attributes": null, 
            "backup": null, 
            "checksum": "", 
            "client_cert": null, 
            "client_key": null, 
            "content": null, 
            "delimiter": null, 
            "dest": "./newdirectory", 
            "directory_mode": null, 
            "follow": false, 
            "force": false, 
            "force_basic_auth": false, 
            "group": null, 
            "headers": null, 
            "http_agent": "ansible-httpget", 
            "mode": null, 
            "owner": null, 
            "path": "./newdirectory/plain", 
            "regexp": null, 
            "remote_src": null, 
            "selevel": null, 
            "serole": null, 
            "setype": null, 
            "seuser": null, 
            "sha256sum": "", 
            "src": null, 
            "state": "directory", 
            "timeout": 10, 
            "tmp_dest": null, 
            "unsafe_writes": null, 
            "url": "http://ipecho.net/plain", 
            "url_password": null, 
            "url_username": null, 
            "use_proxy": true, 
            "validate_certs": true
        }
    }, 
    "md5sum": "eefa366359837a8d7d91af3c8e8e434a", 
    "mode": "0664", 
    "msg": "OK (unknown bytes)", 
    "owner": "circadian", 
    "size": 12, 
    "src": "/tmp/tmpCxtKrd", 
    "state": "file", 
    "status_code": 200, 
    "uid": 1000, 
    "url": "http://ipecho.net/plain"
}

```