### PR TITLE
Python3 compatability for elb_application_lb and elb_target_group

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_application_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb.py
@@ -334,6 +334,7 @@ vpc_id:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import string_types
 from ansible.module_utils.ec2 import boto3_conn, get_aws_connection_info, camel_dict_to_snake_dict, ec2_argument_spec, get_ec2_security_group_ids_from_names, \
     ansible_dict_to_boto3_tag_list, boto3_tag_list_to_ansible_dict, compare_aws_tags, HAS_BOTO3
 import collections
@@ -348,7 +349,7 @@ except ImportError:
 
 
 def convert(data):
-    if isinstance(data, basestring):
+    if isinstance(data, string_types):
         return str(data)
     elif isinstance(data, collections.Mapping):
         return dict(map(convert, data.items()))
@@ -427,11 +428,7 @@ def get_elb_attributes(connection, module, elb_arn):
         module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
 
     # Replace '.' with '_' in attribute key names to make it more Ansibley
-    for k, v in elb_attributes.items():
-        elb_attributes[k.replace('.', '_')] = v
-        del elb_attributes[k]
-
-    return elb_attributes
+    return dict((k.replace('.', '_'), v) for k, v in elb_attributes.items())
 
 
 def get_elb(connection, module):

--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -299,11 +299,7 @@ def get_tg_attributes(connection, module, tg_arn):
         module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
 
     # Replace '.' with '_' in attribute key names to make it more Ansibley
-    for k, v in tg_attributes.items():
-        tg_attributes[k.replace('.', '_')] = v
-        del tg_attributes[k]
-
-    return tg_attributes
+    return dict((k.replace('.', '_'), v) for k, v in tg_attributes.items())
 
 
 def get_target_group_tags(connection, module, target_group_arn):


### PR DESCRIPTION
##### SUMMARY

Python3 compatability for elb_application_lb and elb_target_group


##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

 - elb_application_lb 
 - elb_target_group

##### ANSIBLE VERSION

```
ansible 2.4.0 (devel 2f33c1a1a1) last updated 2017/06/02 11:50:36 (GMT +100)
  config file = 
  configured module search path = REDACTED
  ansible python module location = REDACTED
  executable location = REDACTED
  python version = 3.6.1 (default, Mar 27 2017, 00:27:06) [GCC 6.3.1 20170306]
```


##### ADDITIONAL INFORMATION

This fails with the commit:

- `basestring` not a type in py3
- Modification of dict keys during iteration is an error