### PR TITLE
Consider play-level tags when executing play

### DIFF
--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -123,6 +123,10 @@ class PlaybookExecutor:
                     # Create a temporary copy of the play here, so we can run post_validate
                     # on it without the templating changes affecting the original object.
                     all_vars = self._variable_manager.get_vars(play=play)
+
+                    if not play.evaluate_tags(self._options.tags, self._options.skip_tags, all_vars):
+                        continue
+
                     templar = Templar(loader=self._loader, variables=all_vars)
                     new_play = play.copy()
                     new_play.post_validate(templar)


### PR DESCRIPTION
##### SUMMARY

Play-level tags are evaluated before deciding to run a play. If the play contents would not run in the current tagged context, skip the play.

This change cleans up output and decreases execution time when running a small number of tagged plays in a long playbook.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
playbook_executor

##### ANSIBLE VERSION
```
ansible 2.4.0
```

