### PR TITLE
Add missing provider on basic-motd IOS test

### DIFF
--- a/test/integration/targets/ios_banner/tests/cli/basic-motd.yaml
+++ b/test/integration/targets/ios_banner/tests/cli/basic-motd.yaml
@@ -4,6 +4,7 @@
   ios_banner:
     banner: motd
     state: absent
+    provider: "{{ cli }}"
     authorize: yes
 
 - name: Set motd


### PR DESCRIPTION
Without this it fails, as it needs elevated privs.