### PR TITLE
network tests: Actually check for equality on empty commands array

### DIFF
--- a/test/units/modules/network/eos/eos_module.py
+++ b/test/units/modules/network/eos/eos_module.py
@@ -75,7 +75,7 @@ class TestEosModule(unittest.TestCase):
             result = self.changed(changed)
             self.assertEqual(result['changed'], changed, result)
 
-        if commands:
+        if commands is not None:
             if sort:
                 self.assertEqual(sorted(commands), sorted(result['commands']), result['commands'])
             else:

--- a/test/units/modules/network/eos/test_eos_eapi.py
+++ b/test/units/modules/network/eos/test_eos_eapi.py
@@ -95,8 +95,7 @@ class TestEosEapiModule(TestEosModule):
 
     def test_eos_eapi_http_invalid(self):
         set_module_args(dict(http_port=80000))
-        commands = []
-        self.start_unconfigured(failed=True, commands=commands)
+        self.start_unconfigured(failed=True)
 
     def test_eos_eapi_https_enable(self):
         set_module_args(dict(https=True))
@@ -137,8 +136,7 @@ class TestEosEapiModule(TestEosModule):
 
     def test_eos_eapi_vrf_missing(self):
         set_module_args(dict(vrf='missing'))
-        commands = []
-        self.start_unconfigured(failed=True, commands=commands)
+        self.start_unconfigured(failed=True)
 
     def test_eos_eapi_state_absent(self):
         set_module_args(dict(state='stopped'))

--- a/test/units/modules/network/ios/ios_module.py
+++ b/test/units/modules/network/ios/ios_module.py
@@ -75,7 +75,7 @@ class TestIosModule(unittest.TestCase):
             result = self.changed(changed)
             self.assertEqual(result['changed'], changed, result)
 
-        if commands:
+        if commands is not None:
             if sort:
                 self.assertEqual(sorted(commands), sorted(result['commands']), result['commands'])
             else:

--- a/test/units/modules/network/iosxr/iosxr_module.py
+++ b/test/units/modules/network/iosxr/iosxr_module.py
@@ -75,7 +75,7 @@ class TestIosxrModule(unittest.TestCase):
             result = self.changed(changed)
             self.assertEqual(result['changed'], changed, result)
 
-        if commands:
+        if commands is not None:
             if sort:
                 self.assertEqual(sorted(commands), sorted(result['commands']), result['commands'])
             else:

--- a/test/units/modules/network/nxos/nxos_module.py
+++ b/test/units/modules/network/nxos/nxos_module.py
@@ -75,7 +75,7 @@ class TestNxosModule(unittest.TestCase):
             result = self.changed(changed)
             self.assertEqual(result['changed'], changed, result)
 
-        if commands:
+        if commands is not None:
             if sort:
                 self.assertEqual(sorted(commands), sorted(result['commands']), result['commands'])
             else:

--- a/test/units/modules/network/ovs/ovs_module.py
+++ b/test/units/modules/network/ovs/ovs_module.py
@@ -76,7 +76,7 @@ class TestOpenVSwitchModule(unittest.TestCase):
             result = self.changed(changed)
             self.assertEqual(result['changed'], changed, result)
 
-        if commands:
+        if commands is not None:
             self.assertEqual(commands, result['commands'], result['commands'])
 
         return result

--- a/test/units/modules/network/vyos/vyos_module.py
+++ b/test/units/modules/network/vyos/vyos_module.py
@@ -74,7 +74,7 @@ class TestVyosModule(unittest.TestCase):
             result = self.changed(changed)
             self.assertEqual(result['changed'], changed, result)
 
-        if commands:
+        if commands is not None:
             if sort:
                 self.assertEqual(sorted(commands), sorted(result['commands']), result['commands'])
             else:


### PR DESCRIPTION
##### SUMMARY
By using `if commands:`, tests attempting to assert that no commands are emitted from a module do not actually make that check.

This change breaks two EOS tests which provide empty commands despite failing and not having a `commands` key in the result dictionary, which have been fixed to not provide a commands array.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
test/units/network/*

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```