### PR TITLE
LXD module - Fix unicode errors in json.load method

### DIFF
--- a/lib/ansible/module_utils/lxd.py
+++ b/lib/ansible/module_utils/lxd.py
@@ -27,23 +27,22 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import socket
+import ssl
+
 from ansible.module_utils.urls import generic_urlparse
 from ansible.module_utils.six.moves.urllib.parse import urlparse
+from ansible.module_utils.six.moves import http_client
+from ansible.module_utils.six import PY2
+
+# httplib/http.client connection using unix domain socket
+HTTPConnection = http_client.HTTPConnection
+HTTPSConnection = http_client.HTTPSConnection
 
 try:
     import json
 except ImportError:
     import simplejson as json
-
-# httplib/http.client connection using unix domain socket
-import socket
-import ssl
-
-try:
-    from httplib import HTTPConnection, HTTPSConnection
-except ImportError:
-    # Python 3
-    from http.client import HTTPConnection, HTTPSConnection
 
 
 class UnixHTTPConnection(HTTPConnection):
@@ -110,7 +109,10 @@ class LXDClient(object):
             body = json.dumps(body_json)
             self.connection.request(method, url, body=body)
             resp = self.connection.getresponse()
-            resp_json = json.loads(resp.read())
+            resp_data = resp.read()
+            if not PY2:
+                resp_data = resp_data.decode('utf-8')
+            resp_json = json.loads(resp_data)
             self.logs.append({
                 'type': 'sent request',
                 'request': {'method': method, 'url': url, 'json': body_json, 'timeout': timeout},

--- a/lib/ansible/module_utils/lxd.py
+++ b/lib/ansible/module_utils/lxd.py
@@ -33,7 +33,7 @@ import ssl
 from ansible.module_utils.urls import generic_urlparse
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 from ansible.module_utils.six.moves import http_client
-from ansible.module_utils.six import PY2
+from ansible.module_utils._text import to_text
 
 # httplib/http.client connection using unix domain socket
 HTTPConnection = http_client.HTTPConnection
@@ -110,8 +110,7 @@ class LXDClient(object):
             self.connection.request(method, url, body=body)
             resp = self.connection.getresponse()
             resp_data = resp.read()
-            if not PY2:
-                resp_data = resp_data.decode('utf-8')
+            resp_data = to_text(resp_data, errors='surrogate_or_strict')
             resp_json = json.loads(resp_data)
             self.logs.append({
                 'type': 'sent request',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The six.http_client module is used to ensure Python 3 and 2 compatibility of the LXD
ansible module. If not handled explicitly, errors related to bytes <-> unicode conversions are raised. This pull request handles the required imports as well as the encoding errors, mainly to be in conformance with the json module (That operates with unicode and not bytes in Python 3). With this change I could finally make the LXD module create containers in Python 3.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
LXD module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

The error raised prior to the fix is:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
failed: [10.118.6.204] (item=kinto) => {
    "failed": true,
    "item": "kinto",
    "module_stderr": "Shared connection to 10.118.6.204 closed.\r\n",
    "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_zf0o4bfp/ansible_module_lxd_container.py\", line 614, in <module>\r\n    main()\r\n  File \"/tmp/ansible_zf0o4bfp/ansible_module_lxd_container.py\", line 609, in main\r\n    lxd_manage.run()\r\n  File \"/tmp/ansible_zf0o4bfp/ansible_module_lxd_container.py\", line 517, in run\r\n    self.old_container_json = self._get_container_json()\r\n  File \"/tmp/ansible_zf0o4bfp/ansible_module_lxd_container.py\", line 332, in _get_container_json\r\n    ok_error_codes=[404]\r\n  File \"/tmp/ansible_zf0o4bfp/ansible_modlib.zip/ansible/module_utils/lxd.py\", line 97, in do\r\n  File \"/tmp/ansible_zf0o4bfp/ansible_modlib.zip/ansible/module_utils/lxd.py\", line 119, in _send_request\r\n  File \"/usr/lib/python3.5/json/__init__.py\", line 312, in loads\r\n    s.__class__.__name__))\r
        \nTypeError: the JSON object must be str, not 'bytes'\r\nyeep\r\n",
    "msg": "MODULE FAILURE",
    "rc": 0
}
```
After the fix, the LXD module finally works as expected and containers can be created.