### PR TITLE
rds.py: ensure port is expecting an int - fixes #24802

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds.py
+++ b/lib/ansible/modules/cloud/amazon/rds.py
@@ -1084,7 +1084,7 @@ def main():
         iops=dict(required=False),
         security_groups=dict(required=False),
         vpc_security_groups=dict(type='list', required=False),
-        port=dict(required=False),
+        port=dict(required=False, type='int'),
         upgrade=dict(type='bool', default=False),
         option_group=dict(required=False),
         maint_window=dict(required=False),


### PR DESCRIPTION
##### SUMMARY
If port is passed in as a string it won't be caught. Fixes #24802

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/rds.py

##### ANSIBLE VERSION
```
2.4.0
```