### PR TITLE
Python3 fix for hashing in inventory plugins

### DIFF
--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -61,11 +61,11 @@ class BaseInventoryPlugin(object):
         ''' create predictable unique prefix for plugin/inventory '''
 
         m = hashlib.sha1()
-        m.update(self.NAME)
+        m.update(to_bytes(self.NAME))
         d1 = m.hexdigest()
 
         n = hashlib.sha1()
-        n.update(path)
+        n.update(to_bytes(path))
         d2 = n.hexdigest()
 
         return 's_'.join([d1[:5], d2[:5]])


### PR DESCRIPTION
##### SUMMARY

Fixes the following situation on py3.

```
 [WARNING]:  * Failed to parse /Users/matt/projects/ansibledev/playbooks/localhost.py with script inventory plugin: Unicode-objects must be encoded before hashing

 [WARNING]:  * Failed to parse /Users/matt/projects/ansibledev/playbooks/localhost.py with ini inventory plugin: /Users/matt/projects/ansibledev/playbooks/localhost.py:3:
Expected key=value host variable assignment, got: sys

 [WARNING]: Unable to parse /Users/matt/projects/ansibledev/playbooks/localhost.py as an inventory source

 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: provided hosts list is empty, only localhost is available

 [WARNING]: No hosts matched, nothing to do
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```