### PR TITLE
add Makefile target for single HTML page

### DIFF
--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -8,6 +8,11 @@ else
 CPUS ?= $(shell nproc)
 endif
 
+assertrst:
+ifndef rst
+	$(error specify document or pattern with rst=somefile.rst)
+endif
+
 all: docs
 
 docs: clean htmldocs
@@ -50,4 +55,8 @@ staticmin:
 	cat _themes/srtd/static/css/theme.css | sed -e 's/^[ 	]*//g; s/[ 	]*$$//g; s/\([:{;,]\) /\1/g; s/ {/{/g; s/\/\*.*\*\///g; /^$$/d' | sed -e :a -e '$$!N; s/\n\(.\)/\1/; ta' > _themes/srtd/static/css/theme.min.css
 
 epub:
-	 (CPUS=$(CPUS) make -f Makefile.sphinx epub)
+	(CPUS=$(CPUS) make -f Makefile.sphinx epub)
+
+htmlsingle: assertrst
+	sphinx-build -j $(CPUS) -b html -d _build/doctrees ./rst _build/html rst/$(rst)
+	@echo "Output is in _build/html/$(rst)"


### PR DESCRIPTION
##### SUMMARY
add new docsite makefile target `htmlsingle` to build individual or dir of rst's instead of entire site

`make htmlsingle rst=intro_windows.rst`

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
Makefile

##### ANSIBLE VERSION
2.4.0

