### PR TITLE
Make ServiceMgrFactCollector.is_systemd_managed() a static method

### DIFF
--- a/lib/ansible/module_utils/facts/system/service_mgr.py
+++ b/lib/ansible/module_utils/facts/system/service_mgr.py
@@ -39,7 +39,8 @@ class ServiceMgrFactCollector(BaseFactCollector):
     name = 'service_mgr'
     _fact_ids = set()
 
-    def is_systemd_managed(self, module):
+    @staticmethod
+    def is_systemd_managed(module):
         # tools must be installed
         if module.get_bin_path('systemctl'):
 

--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -53,7 +53,7 @@ from distutils.version import LooseVersion
 
 # import module snippets
 from ansible.module_utils.basic import *
-from ansible.module_utils.facts import *
+from ansible.module_utils.facts.system.service_mgr import ServiceMgrFactCollector
 from ansible.module_utils._text import to_bytes, to_native
 
 
@@ -112,7 +112,7 @@ class Hostname(object):
     def __init__(self, module):
         self.module       = module
         self.name         = module.params['name']
-        if self.platform == 'Linux' and Facts(module).is_systemd_managed():
+        if self.platform == 'Linux' and ServiceMgrFactCollector.is_systemd_managed(module):
             self.strategy = SystemdStrategy(module)
         else:
             self.strategy = self.strategy_class(module)


### PR DESCRIPTION



Make ServiceMgrFactCollector.is_systemd_managed() a static method

Fix 'hostname' module Facts is not defined by updating
'hostname' module to use it.

is_systemd_managed() was previously on the module_utils.facts.Facts
class that no longer exists.

Fixes #25289 

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/module_utils/facts/system/service_mgr.py
lib/ansible/modules/system/hostname.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (hostname_fact_use_25289 4cdd088017) last updated 2017/06/02 15:02:49 (GMT -400)
  config file = 
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]


```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
