### PR TITLE
Fix azure module use of module_utils.facts

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure.py
+++ b/lib/ansible/modules/cloud/azure/azure.py
@@ -192,9 +192,11 @@ EXAMPLES = '''
 import base64
 import datetime
 import os
+import signal
 import time
 from urlparse import urlparse
-from ansible.module_utils.facts import * # TimeoutError
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.facts.timeout import TimeoutError
 
 AZURE_LOCATIONS = ['South Central US',
                    'Central US',
@@ -279,6 +281,7 @@ except ImportError:
 from types import MethodType
 import json
 
+
 def _wait_for_completion(azure, promise, wait_timeout, msg):
     if not promise:
         return
@@ -290,6 +293,7 @@ def _wait_for_completion(azure, promise, wait_timeout, msg):
             return
 
     raise AzureException('Timed out waiting for async operation ' + msg + ' "' + str(promise.request_id) + '" to complete.')
+
 
 def _delete_disks_when_detached(azure, wait_timeout, disk_names):
     def _handle_timeout(signum, frame):
@@ -305,9 +309,10 @@ def _delete_disks_when_detached(azure, wait_timeout, disk_names):
                     azure.delete_disk(disk.name, True)
                     disk_names.remove(disk_name)
     except AzureException as e:
-        module.fail_json(msg="failed to get or delete disk %s, error was: %s" % (disk_name, str(e)))
+        raise AzureException("failed to get or delete disk %s, error was: %s" % (disk_name, str(e)))
     finally:
         signal.alarm(0)
+
 
 def get_ssh_certificate_tokens(module, ssh_cert_path):
     """
@@ -376,7 +381,7 @@ def create_virtual_machine(module, azure):
             disable_ssh_password_authentication = not password
             vm_config = LinuxConfigurationSet(hostname, user, password, disable_ssh_password_authentication)
         else:
-            #Create Windows Config
+            # Create Windows Config
             vm_config = WindowsConfigurationSet(hostname, password, None, module.params.get('auto_updates'), None, user)
             vm_config.domain_join = None
             if module.params.get('enable_winrm'):
@@ -620,6 +625,5 @@ class Wrapper(object):
 
 
 # import module snippets
-from ansible.module_utils.basic import *
 if __name__ == '__main__':
     main()

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -66,7 +66,6 @@ lib/ansible/modules/cloud/amazon/sts_assume_role.py
 lib/ansible/modules/cloud/amazon/sts_session_token.py
 lib/ansible/modules/cloud/atomic/atomic_host.py
 lib/ansible/modules/cloud/atomic/atomic_image.py
-lib/ansible/modules/cloud/azure/azure.py
 lib/ansible/modules/cloud/azure/azure_rm_deployment.py
 lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
 lib/ansible/modules/cloud/azure/azure_rm_networkinterface_facts.py


### PR DESCRIPTION
Module was importing '*' from facts to get to TimeoutError
but that has moved to facts.timeout, so import is updated.

Also rm old style imports to new style imports at the start
of the module.

'signal' py module was used and referenced but never imported,
presumably it was using the 'signal' previously imported into
module_utils.facts. Now imported directly.

'AnsibleModule' was also from a * import, so now imported directly.

A ref to 'module' was in _delete_disks_when_detached(), so now it
is updated to raise an AzureException() with its message, and
let its caller catch it and call module.fail_json()


There are still some oddities and flake8 issues, but those are pre-existing conditions.
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/cloud/azure/azure.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (azure_azure_facts 289a774954) last updated 2017/06/02 15:42:03 (GMT -400)
  config file = 
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
