### PR TITLE
Add python-lxml to docker images (and VMs)

### DIFF
--- a/test/utils/docker/centos6/Dockerfile
+++ b/test/utils/docker/centos6/Dockerfile
@@ -21,6 +21,7 @@ RUN yum clean all && \
     python-httplib2 \
     python-jinja2 \
     python-keyczar \
+    python-lxml \
     python-mock \
     python-nose \
     python-paramiko \

--- a/test/utils/docker/centos7/Dockerfile
+++ b/test/utils/docker/centos7/Dockerfile
@@ -29,6 +29,7 @@ RUN yum clean all && \
     python-httplib2 \
     python-jinja2 \
     python-keyczar \
+    python-lxml \
     python-mock \
     python-nose \
     python-paramiko \

--- a/test/utils/docker/cloudstack-simulator/Dockerfile
+++ b/test/utils/docker/cloudstack-simulator/Dockerfile
@@ -15,9 +15,10 @@ RUN apt-get -y update && apt-get install -y \
     netcat \
     openjdk-8-jdk \
     python-dev \
-    python-setuptools \
-    python-pip \
+    python-lxml \
     python-mysql.connector \
+    python-pip \
+    python-setuptools \
     supervisor \
     wget \
     nginx \

--- a/test/utils/docker/fedora24/Dockerfile
+++ b/test/utils/docker/fedora24/Dockerfile
@@ -36,6 +36,7 @@ RUN dnf clean all && \
     python-httplib2 \
     python-jinja2 \
     python-keyczar \
+    python-lxml \
     python-mock \
     python-nose \
     python-paramiko \

--- a/test/utils/docker/fedora25/Dockerfile
+++ b/test/utils/docker/fedora25/Dockerfile
@@ -32,6 +32,7 @@ RUN dnf clean all && \
     python-httplib2 \
     python-jinja2 \
     python-keyczar \
+    python-lxml \
     python-mock \
     python-nose \
     python-paramiko \

--- a/test/utils/docker/opensuse42.1/Dockerfile
+++ b/test/utils/docker/opensuse42.1/Dockerfile
@@ -24,6 +24,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     python-httplib2 \
     python-jinja2 \
     python-keyczar \
+    python-lxml \
     python-mock \
     python-MySQL-python \
     python-nose \

--- a/test/utils/docker/opensuse42.2/Dockerfile
+++ b/test/utils/docker/opensuse42.2/Dockerfile
@@ -24,6 +24,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     python-httplib2 \
     python-jinja2 \
     python-keyczar \
+    python-lxml \
     python-mock \
     python-MySQL-python \
     python-nose \

--- a/test/utils/docker/ubuntu1204/Dockerfile
+++ b/test/utils/docker/ubuntu1204/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update -y && \
     python-httplib2 \
     python-jinja2 \
     python-keyczar \
+    python-lxml \
     python-mock \
     python-mysqldb \
     python-nose \

--- a/test/utils/docker/ubuntu1404/Dockerfile
+++ b/test/utils/docker/ubuntu1404/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update -y && \
     python-httplib2 \
     python-jinja2 \
     python-keyczar \
+    python-lxml \
     python-mock \
     python-mysqldb \
     python-nose \

--- a/test/utils/docker/ubuntu1604/Dockerfile
+++ b/test/utils/docker/ubuntu1604/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update -y && \
     python-httplib2 \
     python-jinja2 \
     python-keyczar \
+    python-lxml \
     python-mock \
     python-mysqldb \
     python-nose \

--- a/test/utils/docker/ubuntu1604py3/Dockerfile
+++ b/test/utils/docker/ubuntu1604py3/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update -y && \
     python3-dbus \
     python3-httplib2 \
     python3-jinja2 \
+    python3-lxml \
     python3-mock \
     python3-mysqldb \
     python3-nose \


### PR DESCRIPTION
##### SUMMARY
For #25323 we need lxml as part of the docker images.

This relates to cmprescott/ansible-xml#52

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
test docker images

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.4