### PR TITLE
ansible-doc: Fix exception for required filed

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -294,7 +294,7 @@ class DocCLI(CLI):
 
             required = opt.pop('required', False)
             if not isinstance(required, bool):
-                raise("Incorrect value for 'Required', a boolean is needed.: %s" % required)
+                raise AnsibleError("Incorrect value for 'Required', a boolean is needed.: %s" % required)
             if required:
                 opt_leadin = "="
             else:


### PR DESCRIPTION
##### SUMMARY
* fixes the exception if the required field is not a boolean. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cli

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
