### PR TITLE
Remove redundant get_sudorule_diff logic

### DIFF
--- a/lib/ansible/modules/identity/ipa/ipa_sudorule.py
+++ b/lib/ansible/modules/identity/ipa/ipa_sudorule.py
@@ -247,19 +247,8 @@ def get_sudorule_dict(cmdcategory=None, description=None, hostcategory=None, ipa
     return data
 
 
-def get_sudorule_diff(ipa_sudorule, module_sudorule):
-    data = []
-    for key in module_sudorule.keys():
-        module_value = module_sudorule.get(key, None)
-        ipa_value = ipa_sudorule.get(key, None)
-        if isinstance(ipa_value, list) and not isinstance(module_value, list):
-            module_value = [module_value]
-        if isinstance(ipa_value, list) and isinstance(module_value, list):
-            ipa_value = sorted(ipa_value)
-            module_value = sorted(module_value)
-        if ipa_value != module_value:
-            data.append(key)
-    return data
+def get_sudorule_diff(client, ipa_sudorule, module_sudorule):
+    return client.get_diff(ipa_data=ipa_sudorule, module_data=module_sudorule)
 
 
 def category_changed(module, client, category_name, ipa_sudorule):


### PR DESCRIPTION
##### SUMMARY
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/identity/ipa/ipa_sudorule.py

##### ANSIBLE VERSION
```
2.4 devel
```