### PR TITLE
Allow creation of github release tags

### DIFF
--- a/lib/ansible/modules/source_control/github_release.py
+++ b/lib/ansible/modules/source_control/github_release.py
@@ -160,7 +160,7 @@ def main():
         supports_check_mode=True,
         required_one_of=(('password', 'token'),),
         mutually_exclusive=(('password', 'token'),),
-
+        required_if=[('action', 'create_release', ['tag'])],
     )
 
     if not HAS_GITHUB_API:
@@ -207,8 +207,6 @@ def main():
             module.exit_json(tag=None)
 
     if action == 'create_release':
-        if tag is None:
-            module.fail_json(msg="Specify tag in order to create a release.")
         release_exists = repository.release_from_tag(tag)
         if release_exists:
             module.exit_json(

--- a/lib/ansible/modules/source_control/github_release.py
+++ b/lib/ansible/modules/source_control/github_release.py
@@ -53,7 +53,42 @@ options:
         required: true
         description:
             - Action to perform
-        choices: [ 'latest_release' ]
+        choices: [ 'latest_release', 'create_release' ]
+    tag:
+        required: false
+        description:
+            - Tag name when creating a release. Required when using create_release.
+        version_added: 2.4
+    target:
+        required: false
+        description:
+            - Target of release when creating a release
+        version_added: 2.4
+    name:
+        required: false
+        description:
+            - Name of release when creating a release
+        version_added: 2.4
+    body:
+        required: false
+        description:
+            - Description of the release when creating a release
+        version_added: 2.4
+    draft:
+        required: false
+        description:
+            - Sets if the release is a draft or not. (boolean)
+        default: false
+        version_added: 2.4
+        choices: ['True', 'False']
+    prerelease:
+        required: false
+        description:
+            - Sets if the release is a prerelease or not. (boolean)
+        default: false
+        version_added: 2.4
+        choices: ['True', 'False']
+
 
 author:
     - "Adrian Moisey (@adrianmoisey)"
@@ -62,7 +97,7 @@ requirements:
 '''
 
 EXAMPLES = '''
-- name: Get latest release of test/test
+- name: Get latest release of testuseer/testrepo
   github_release:
     token: tokenabc1234567890
     user: testuser
@@ -75,6 +110,18 @@ EXAMPLES = '''
     password: secret123
     repo: testrepo
     action: latest_release
+
+- name: Create a new release
+  github:
+    token: tokenabc1234567890
+    user: testuser
+    repo: testrepo
+    action: create_release
+    tag: test
+    target: master
+    name: My Release
+    body: Some description
+
 '''
 
 RETURN = '''
@@ -101,11 +148,19 @@ def main():
             user=dict(required=True),
             password=dict(no_log=True),
             token=dict(no_log=True),
-            action=dict(required=True, choices=['latest_release']),
+            action=dict(
+                required=True, choices=['latest_release', 'create_release']),
+            tag=dict(type='str'),
+            target=dict(type='str'),
+            name=dict(type='str'),
+            body=dict(type='str'),
+            draft=dict(type='bool', default=False),
+            prerelease=dict(type='bool', default=False),
         ),
         supports_check_mode=True,
         required_one_of=(('password', 'token'),),
         mutually_exclusive=(('password', 'token'),),
+
     )
 
     if not HAS_GITHUB_API:
@@ -117,6 +172,12 @@ def main():
     password = module.params['password']
     login_token = module.params['token']
     action = module.params['action']
+    tag = module.params.get('tag')
+    target = module.params.get('target')
+    name = module.params.get('name')
+    body = module.params.get('body')
+    draft = module.params.get('draft')
+    prerelease = module.params.get('prerelease')
 
     # login to github
     try:
@@ -140,6 +201,21 @@ def main():
 
     if action == 'latest_release':
         release = repository.latest_release()
+        if release:
+            module.exit_json(tag=release.tag_name)
+        else:
+            module.exit_json(tag=None)
+
+    if action == 'create_release':
+        if tag is None:
+            module.fail_json(msg="Specify tag in order to create a release.")
+        release_exists = repository.release_from_tag(tag)
+        if release_exists:
+            module.exit_json(
+                skipped=True, msg="Release for tag %s already exists." % tag)
+
+        release = repository.create_release(
+            tag, target, name, body, draft, prerelease)
         if release:
             module.exit_json(tag=release.tag_name)
         else:

--- a/lib/ansible/modules/source_control/github_release.py
+++ b/lib/ansible/modules/source_control/github_release.py
@@ -57,7 +57,7 @@ options:
     tag:
         required: false
         description:
-            - Tag name when creating a release. Required when using create_release.
+            - Tag name when creating a release. Required when using action is set to C(create_release).
         version_added: 2.4
     target:
         required: false


### PR DESCRIPTION
##### SUMMARY

Allows a user to create a github release from Ansible.
Useful for anyone doing code releases with Ansible and GitHub Releases.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
github_release
##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```

##### ADDITIONAL INFORMATION
A replacement for https://github.com/ansible/ansible/pull/22741 which got stale, and difficult to rebase.