### PR TITLE
Temporarily disable failing git test.

### DIFF
--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -22,7 +22,7 @@
 - include: formats.yml
 - include: missing_hostkey.yml
 - include: no-destination.yml
-- include: specific-revision.yml
+#- include: specific-revision.yml
 - include: submodules.yml
 - include: change-repo-url.yml
 - include: depth.yml


### PR DESCRIPTION
##### SUMMARY

This test appears to be failing due to changes outside the repository. It failed on the most recent daily test run, but passed on the previous daily run.

Passed: https://app.shippable.com/github/ansible/ansible/runs/24283/13/console
Failed: https://app.shippable.com/github/ansible/ansible/runs/24322/13/console

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

git integration test

##### ANSIBLE VERSION

```
ansible 2.4.0 (disable-git-test bc60ef0b1f) last updated 2017/06/04 20:25:49 (GMT +800)
  config file = 
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
