### PR TITLE
VMWare disks dont get resized - Update vsphere_guest.py

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vsphere_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vsphere_guest.py
@@ -793,7 +793,7 @@ def update_disks(vsphere_client, vm, module, vm_disk, changes):
         found = False
         for dev_key in vm._devices:
             if vm._devices[dev_key]['type'] == 'VirtualDisk':
-                hdd_id = vm._devices[dev_key]['label'].split()[2]
+                hdd_id = vm._devices[dev_key]['label'].split()[1]
                 if disk_id == hdd_id:
                     found = True
                     continue


### PR DESCRIPTION
the index should be 1 in order to capture the id (the labels look like "Disk 1" or "Festplatte 1" so index 1 will hit it properly.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
