### PR TITLE
remove hack preventing use of custom venv cmd

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -459,14 +459,6 @@ def main():
 
                 if virtualenv_python:
                     cmd += ' -p%s' % virtualenv_python
-                elif PY3:
-                    # Ubuntu currently has a patch making virtualenv always
-                    # try to use python2.  Since Ubuntu16 works without
-                    # python2 installed, this is a problem.  This code mimics
-                    # the upstream behaviour of using the python which invoked
-                    # virtualenv to determine which python is used inside of
-                    # the virtualenv (when none are specified).
-                    cmd += ' -p%s' % sys.executable
 
                 cmd = "%s %s" % (cmd, env)
                 rc, out_venv, err_venv = module.run_command(cmd, cwd=chdir)

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -459,6 +459,20 @@ def main():
 
                 if virtualenv_python:
                     cmd += ' -p%s' % virtualenv_python
+                elif PY3 and module.params['virtualenv_command'] == 'virtualenv':
+                    # Ubuntu currently has a patch making virtualenv always
+                    # try to use python2.  Since Ubuntu16 works without
+                    # python2 installed, this is a problem.  This code mimics
+                    # the upstream behaviour of using the python which invoked
+                    # virtualenv to determine which python is used inside of
+                    # the virtualenv (when none are specified).
+                    #
+                    # However, if we unconditionally add this flag in
+                    # all cases, it breaks any command to create a
+                    # venv which is not arg-compatible with virtualenv
+                    # (including the officially correct way to make
+                    # venvs in py3)
+                    cmd += ' -p%s' % sys.executable
 
                 cmd = "%s %s" % (cmd, env)
                 rc, out_venv, err_venv = module.run_command(cmd, cwd=chdir)


### PR DESCRIPTION
##### SUMMARY

Somebody introduced this to fix an issue with using the virtualenv exe to create venvs on Ubuntu with py3. Since the new py3 way to create venvs is `python -m venv name-of-venv`,  and since this breaks making venvs the new way, it should be removed.

Also, I don't think the project should accept distro-specific hacks in future (especially where the issue is clearly one where the distro is doing something wrong, like in this case) unless the hack is guarded by some reliable check for the distro type. The key word here is "reliable." For example, the only way to get my Ubuntu machine to say 'Ubuntu' is with platform.linux_distribution(), which is due for deprecation (no doubt for good reason). There's [distro](https://github.com/nir0s/distro), but i don't know anything about it other than that it exists.

Fixes #25151 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
pip

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = 
  configured module search path = ['/home/dmr/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.1 (default, Apr 22 2017, 20:17:23) [GCC 5.4.0 20160609]
```
