### PR TITLE
unbreak password_hash('blowfish')

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -271,13 +271,17 @@ def get_encrypted_password(password, hashtype='sha512', salt=None):
     # TODO: find a way to construct dynamically from system
     cryptmethod = {
         'md5': '1',
-        'blowfish': '2a',
+        'blowfish': '2b',
         'sha256': '5',
         'sha512': '6',
     }
 
     if hashtype in cryptmethod:
-        if salt is None:
+        # For Blowfish, skip generating salt manually because what is generated
+        # below contains incorrectly set padding bits. Also the length used to
+        # be incorrect (16 instead of 22). Besides, Passlib recommends NOT
+        # generating a salt string manually.
+        if salt is None and hashtype is not 'blowfish':
             r = SystemRandom()
             if hashtype in ['md5']:
                 saltsize = 8


### PR DESCRIPTION
##### SUMMARY
The used salt buffer was of incorrect length (16 instead of 22). Also the
passlib documentation recommends against generating your own salt. So unless
the salt was provided, let passlib generate it.

Also set the default bcrypto algorithm to '2b' which is the recommended format.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`password_hash` filter

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /home/jasper/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, May 24 2017, 16:43:59) [GCC 4.2.1 20070719 ]
```

##### ADDITIONAL INFORMATION
The upstream documentation for passlib can be found [here](http://passlib.readthedocs.io/en/stable/lib/passlib.hash.bcrypt.html?highlight=blowfish).

About salt it writes:
```
salt (str) – Optional salt string. If not specified, one will be autogenerated (this is recommended). If specified, it must be 22 characters, drawn from the regexp range [./0-9A-Za-z].
```

and about the algorithm:
```
"2a" - some implementations suffered from rare security flaws, replaced by 2b.
[..]
"2b" - latest revision of the official BCrypt algorithm, current default.
```

Before:
```
fatal: [192.168.2.1]: FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value ([]), and could not be converted to an dict. Error was: salt too small (bcrypt
+requires exactly 22 chars)\n\nThe error appears to have been in '/home/jirib/ansible/test.yml': line 11, column 7, but may\nbe elsewhere in the file depending on the exact syntax
+problem.\n\nThe offending line appears to be:\n\n  tasks:\n    - name: Create users from secret.yml\n      ^ here\n"}
```

After:
```
changed: [192.168.2.1]
```

More informatively I've ran a `debug` task (`debug: msg="{{ 'emiel' | password_hash('blowfish') }}"`)  that used to return:
```
TASK [debug] ************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"failed": true, "msg": "the field 'args' has an invalid value ([]), and could not be converted to an dict. Error was: salt too small (bcrypt requires exactly 22 chars)\n\nThe error appears to have been in '/private/tmp/ansible-blowfish/users.yml': line 8, column 5, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n  tasks:\n  - debug: msg=\"{{ 'emiel' | password_hash('blowfish') }}\"\n    ^ here\nWe could be wrong, but this one looks like it might be an issue with\nmissing quotes.  Always quote template expression brackets when they\nstart a value. For instance:\n\n    with_items:\n      - {{ foo }}\n\nShould be written as:\n\n    with_items:\n      - \"{{ foo }}\"\n"}
```

and now returns:
```
ok: [localhost] => {
    "changed": false,
    "msg": "$2b$12$yhShz4JEDMGWCZO3AFpBq..gn6TIq9ydFcxOtqlFcIxdQFJc4zHk2"
}
```