### PR TITLE
Add Foreman to list of Dynamic inventories

### DIFF
--- a/docs/docsite/rst/intro_dynamic_inventory.rst
+++ b/docs/docsite/rst/intro_dynamic_inventory.rst
@@ -321,7 +321,7 @@ In addition to Cobbler and EC2, inventory scripts are also available for::
    BSD Jails
    DigitalOcean
    Google Compute Engine
-   [Foreman](https://github.com/theforeman/foreman_ansible_inventory) / Satellite 6
+   `Foreman <https://github.com/theforeman/foreman_ansible_inventory>`_/ Satellite 6
    Linode
    OpenShift
    OpenStack Nova

--- a/docs/docsite/rst/intro_dynamic_inventory.rst
+++ b/docs/docsite/rst/intro_dynamic_inventory.rst
@@ -321,6 +321,7 @@ In addition to Cobbler and EC2, inventory scripts are also available for::
    BSD Jails
    DigitalOcean
    Google Compute Engine
+   [Foreman](https://github.com/theforeman/foreman_ansible_inventory) / Satellite 6
    Linode
    OpenShift
    OpenStack Nova


### PR DESCRIPTION
##### SUMMARY
Add Foreman to the list linking to the docs. If necessary, I could move the documentation in https://github.com/theforeman/foreman_ansible_inventory/ to this page. 

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Dynamic inventories

##### ANSIBLE VERSION
2.2 onwards