### PR TITLE
added new type 'psobject' to powershell Param parser

### DIFF
--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -226,9 +226,15 @@ Function Get-AnsibleParam($obj, $name, $default = $null, $resultobj = @{}, $fail
             } else {
                 Fail-Json -obj $resultobj -message "Get-AnsibleParam: Parameter $name is not a YAML list."
             }
+        } elseif ($type -eq "psobject") {
+            $result = New-Object psobject;
+            foreach ($key in $value.keys)
+            {
+                $result | Add-Member -MemberType NoteProperty -Name $key -Value $value[$key]
+            }
+            $value = $result
         }
     }
-
     return $value
 }
 


### PR DESCRIPTION
##### SUMMARY
After the refactoring of how powershell params are injected (hashtable vs the old pscustomobject) we are experiencing some issues with modules that take parameters in "special" ways. This change allows a module to specify that it wants a parameter parsed as a "regular" psobject instead of a hashtable. For instance, this would allow us to fix https://github.com/ansible/ansible/issues/25265 by changing a single line of code instead of rewriting much of the module by simply doing:
`$appParameters = Get-AnsibleParam -obj $params -name "app_parameters" -type "psobject"`

 Also, other modules that need a psobject instead of a hashtable can use this functionality to reduce in-module complexity.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
powershell.ps1

##### ANSIBLE VERSION
```
2.4.0
```
