### PR TITLE
Restore app_parameters type from "str" to "dict"

### DIFF
--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -33,7 +33,7 @@ $name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $tru
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present","absent","started","stopped","restarted" -resultobj $result
 
 $application = Get-AnsibleParam -obj $params -name "application" -type "str"
-$appParameters = Get-AnsibleParam -obj $params -name "app_parameters" -type "str"
+$appParameters = Get-AnsibleParam -obj $params -name "app_parameters" -type "dict"
 $appParametersFree  = Get-AnsibleParam -obj $params -name "app_parameters_free_form" -type "str"
 $startMode = Get-AnsibleParam -obj $params -name "start_mode" -type "str" -default "auto" -validateset "auto","manual","disabled" -resultobj $result
 


### PR DESCRIPTION
##### SUMMARY
The "dict" type is not yet implemented.

This fixes the regression from #25265

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_nssm

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.4