### PR TITLE
Added fact for Antergos, a fork of Arch Linux.

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -396,7 +396,7 @@ class Distribution(object):
                      'Debian': ['Debian', 'Ubuntu', 'Raspbian', 'Neon', 'KDE neon'],
                      'Suse': ['SuSE', 'SLES', 'SLED', 'openSUSE', 'openSUSE Tumbleweed',
                               'SLES_SAP', 'SUSE_LINUX', 'openSUSE Leap'],
-                     'Archlinux': ['Archlinux', 'Manjaro'],
+                     'Archlinux': ['Archlinux', 'Antergos', 'Manjaro'],
                      'Mandrake': ['Mandrake', 'Mandriva'],
                      'Solaris': ['Solaris', 'Nexenta', 'OmniOS', 'OpenIndiana', 'SmartOS'],
                      'Slackware': ['Slackware'],


### PR DESCRIPTION
##### SUMMARY
Antergos is a distribution growing in popularity. It's a fork of Arch Linux, similar to Manjaro (which is already supported here). This edit allows Antergos to be understood as a derivative of Arch LInux.

##### ISSUE TYPE
 - Feature Pull Request