### PR TITLE
Check / Skip cores for AIX5 Series  Issue: 25362

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/aix.py
+++ b/lib/ansible/module_utils/facts/hardware/aix.py
@@ -74,9 +74,9 @@ class AIXHardware(Hardware):
             cpu_facts['processor'] = data[1]
 
             rc, out, err = self.module.run_command("/usr/sbin/lsattr -El " + cpudev + " -a smt_threads")
-
-            data = out.split(' ')
-            cpu_facts['processor_cores'] = int(data[1])
+            if out:
+                data = out.split(' ')
+                cpu_facts['processor_cores'] = int(data[1])
 
         return cpu_facts
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Fixes #25362.  Skip processor cores fact on single core AIX5 series.

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
facts/hardware/aix.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
AIX hardware facts were failing on AIX5 Series that lack the attribute smt_threads.

```
attr -El proc0 -a smt_threads
lsattr: 0514-528 The "smt_threads" attribute does not exist in the predefined
        device configuration database.
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
Unable to post all facts due to sensitive nature.   AIX5 hardware facts now available:
```
        "ansible_memfree_mb": 5126,
        "ansible_memtotal_mb": 8192,

        "ansible_processor": "PowerPC_POWER4",
        "ansible_processor_count": 4,
```
