### PR TITLE
fixes bug on user expiration always changing

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -241,6 +241,7 @@ try:
 except:
     HAVE_SPWD = False
 
+
 class User(object):
     """
     This is a generic User manipulation class that is subclassed
@@ -300,10 +301,10 @@ class User(object):
 
         if module.params['expires']:
             try:
-                self.expires = time.gmtime(module.params['expires']//86400*86400)
+                self.expires = time.gmtime(module.params['expires'] // 86400 * 86400)
             except Exception:
                 e = get_exception()
-                module.fail_json(msg="Invalid expires time %s: %s" %(self.expires, str(e)))
+                module.fail_json(msg="Invalid expires time %s: %s" % (self.expires, str(e)))
 
         if module.params['ssh_key_file'] is not None:
             self.ssh_file = module.params['ssh_key_file']
@@ -521,7 +522,7 @@ class User(object):
             cmd.append(self.shell)
 
         if self.expires is not None and info[7] != self.expires:
-            #cmd.append('--expiredate') # SLES11 usermod does not know --expiredate
+            # cmd.append('--expiredate') # SLES11 usermod does not know --expiredate
             cmd.append('-e')
             cmd.append(time.strftime(self.DATE_FORMAT, self.expires))
 
@@ -603,10 +604,10 @@ class User(object):
         if len(info[1]) == 1 or len(info[1]) == 0:
             info[1] = self.user_password()
         expire = self.user_expire()
-        if expire is not None and len(expire)>0:
-            info.append( time.gmtime(float(expire)*86400) )
+        if expire is not None and len(expire) > 0:
+            info.append(time.gmtime(float(expire) * 86400))
         else:
-            info.append( None )
+            info.append(None)
         return info
 
     def user_password(self):
@@ -779,10 +780,10 @@ class FreeBsdUser(User):
         if len(info[1]) == 1 or len(info[1]) == 0:
             info[1] = self.user_password()
         expire = self.user_expire()
-        if expire is not None and len(expire)>0:
-            info.append( time.gmtime(float(expire)) )
+        if expire is not None and len(expire) > 0:
+            info.append(time.gmtime(float(expire)))
         else:
-            info.append( None )
+            info.append(None)
         return info
 
     def user_expire(self):
@@ -865,11 +866,11 @@ class FreeBsdUser(User):
             cmd.append(self.login_class)
 
         if self.expires:
-            expire=calendar.timegm(self.expires)
-            if expire==0:
-                expire=1 # on FreeBSD 0 means unlock account (not 1.1.1970)
+            expire = calendar.timegm(self.expires)
+            if expire == 0:
+                expire = 1  # on FreeBSD 0 means unlock account (not 1.1.1970)
             cmd.append('-e')
-            cmd.append( str(expire) )
+            cmd.append(str(expire))
 
         # system cannot be handled currently - should we error if its requested?
         # create the user
@@ -965,11 +966,11 @@ class FreeBsdUser(User):
                 cmd.append(','.join(new_groups))
 
         if self.expires is not None and info[7] != self.expires:
-            expire=calendar.timegm(self.expires)
-            if expire==0:
-                expire=1 # on FreeBSD 0 means unlock account (not 1.1.1970)
+            expire = calendar.timegm(self.expires)
+            if expire == 0:
+                expire = 1  # on FreeBSD 0 means unlock account (not 1.1.1970)
             cmd.append('-e')
-            cmd.append( str(expire) )
+            cmd.append(str(expire))
 
         # modify the user if cmd will do anything
         if cmd_len != len(cmd):

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -395,10 +395,6 @@ class User(object):
             cmd.append(self.shell)
 
         if self.expires:
-<<<<<<< HEAD
-=======
-            #cmd.append('--expiredate') # SLES11 useradd does not know --expiredate
->>>>>>> Fixes #13235
             cmd.append('-e')
             cmd.append(time.strftime(self.DATE_FORMAT, self.expires))
 
@@ -971,7 +967,7 @@ class FreeBsdUser(User):
 
         if self.expires is not None and info[7] != self.expires:
             expire=calendar.timegm(self.expires)
-            if expire==0: expire=1 # on FreeBSD 0 means unlock account
+            if expire==0: expire=1 # on FreeBSD 0 means unlock account (not 1.1.1970)
             cmd.append('-e')
             cmd.append( str(expire) )
 

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -636,10 +636,6 @@ class User(object):
             # Read shadow file for user's expiry time
             if os.path.exists(self.SHADOWFILE) and os.access(self.SHADOWFILE, os.R_OK):
                 for line in open(self.SHADOWFILE).readlines():
-                    # HINT - GNU/Linux stores EXPIRE at pos. 7, FreeBSD uses pos. 6,
-                    #      - ansible on FreeBSD does not have spwd (freebsd11, python 2.7.13)
-                    #      - FreeBSD stores EXPIRE as UNIX timestamp in /etc/master.passwd (GNU/Linux uses days)
-                    #      - FreeBSD uses 0 as expire date for unlock
                     if line.startswith('%s:' % self.name):
                         expire = line.split(':')[7]
         return expire

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -871,7 +871,7 @@ class FreeBsdUser(User):
         print("StK BSD create_user() - self.expires %s" % str(self.expires) )
         if self.expires:
             expire=calendar.timegm(self.expires)
-            if expire==0: expire=1 # on FreeBSD 0 means unlock account
+            if expire==0: expire=1 # on FreeBSD 0 means unlock account (not 1.1.1970)
             cmd.append('-e')
             cmd.append( str(expire) )
 
@@ -970,7 +970,7 @@ class FreeBsdUser(User):
 
         if self.expires is not None and info[7] != self.expires:
             expire=calendar.timegm(self.expires)
-            if expire==0: expire=1 # on FreeBSD 0 means unlock account
+            if expire==0: expire=1 # on FreeBSD 0 means unlock account (not 1.1.1970)
             cmd.append('-e')
             cmd.append( str(expire) )
 

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -598,7 +598,7 @@ class User(object):
         info = self.get_pwd_info()
         if len(info[1]) == 1 or len(info[1]) == 0:
             info[1] = self.user_password()
-        info.append( time.gmtime(self.user_expire()*86400) )
+        info.append( time.gmtime(self.user_expire()*86400.0) )
         return info
 
     def user_password(self):

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -238,12 +238,6 @@ try:
 except:
     HAVE_SPWD = False
 
-#try:
-#    from __main__ import display
-#except ImportError:
-#    from ansible.utils.display import Display
-#    display = Display()
-
 class User(object):
     """
     This is a generic User manipulation class that is subclassed
@@ -606,10 +600,7 @@ class User(object):
             info[1] = self.user_password()
         expire = self.user_expire()
         if expire is not None and len(expire)>0:
-            if platform.system() == "FreeBSD":
-                info.append( time.gmtime(float(expire)) )
-            else:
-                info.append( time.gmtime(float(expire)*86400) )
+            info.append( time.gmtime(float(expire)*86400) )
         else:
             info.append( None )
         return info
@@ -648,10 +639,7 @@ class User(object):
                     #      - ansible on FreeBSD does not have spwd (freebsd11, python 2.7.13)
                     #      - FreeBSD stores EXPIRE as UNIX timestamp in /etc/master.passwd (GNU/Linux uses days)
                     if line.startswith('%s:' % self.name):
-                        if platform.system() == "FreeBSD":
-                            expire = line.split(':')[6]
-                        else:
-                            expire = line.split(':')[7]
+                        expire = line.split(':')[7]
         return expire
 
     def get_ssh_key_path(self):
@@ -976,11 +964,9 @@ class FreeBsdUser(User):
                 cmd.append(','.join(new_groups))
 
         if self.expires is not None and info[7] != self.expires:
-            expire=calendar.timegm(self.expires)
-            if expire==0:
-                expire=1 # on FreeBSD 0 means unlock account (not 1.1.1970)
+            days = ( time.mktime(self.expires) - time.time() ) / 86400
             cmd.append('-e')
-            cmd.append( str(expire) )
+            cmd.append( str(int(days)) )
 
         # modify the user if cmd will do anything
         if cmd_len != len(cmd):

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -237,11 +237,11 @@ try:
 except:
     HAVE_SPWD = False
 
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
+#try:
+#    from __main__ import display
+#except ImportError:
+#    from ansible.utils.display import Display
+#    display = Display()
 
 class User(object):
     """
@@ -609,8 +609,11 @@ class User(object):
         if len(info[1]) == 1 or len(info[1]) == 0:
             info[1] = self.user_password()
         expire = self.user_expire()
-        if len(expire)>0:
-            info.append( time.gmtime(float(expire)*86400) )
+        if expire is not None and len(expire)>0:
+            if platform.system() == "FreeBSD":
+                info.append( time.gmtime(float(expire)) )
+            else:
+                info.append( time.gmtime(float(expire)*86400) )
         else:
             info.append( None )
         return info
@@ -645,8 +648,14 @@ class User(object):
             # Read shadow file for user's expiry time
             if os.path.exists(self.SHADOWFILE) and os.access(self.SHADOWFILE, os.R_OK):
                 for line in open(self.SHADOWFILE).readlines():
+                    # HINT - GNU/Linux stores EXPIRE at pos. 7, FreeBSD uses pos. 6,
+                    #      - ansible on FreeBSD does not have spwd (freebsd11, python 2.7.13)
+                    #      - FreeBSD stores EXPIRE as UNIX timestamp in /etc/master.passwd (GNU/Linux uses days)
                     if line.startswith('%s:' % self.name):
-                        expire = line.split(':')[7]
+                        if platform.system() == "FreeBSD":
+                            expire = line.split(':')[6]
+                        else:
+                            expire = line.split(':')[7]
         return expire
 
     def get_ssh_key_path(self):

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -229,6 +229,7 @@ import socket
 import time
 import calendar
 import shutil
+
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import load_platform_subclass, AnsibleModule
 
@@ -639,7 +640,7 @@ class User(object):
                     # HINT - GNU/Linux stores EXPIRE at pos. 7, FreeBSD uses pos. 6,
                     #      - ansible on FreeBSD does not have spwd (freebsd11, python 2.7.13)
                     #      - FreeBSD stores EXPIRE as UNIX timestamp in /etc/master.passwd (GNU/Linux uses days)
-                    #      - FreeBSD uses 0 as expire date for unlock 
+                    #      - FreeBSD uses 0 as expire date for unlock
                     if line.startswith('%s:' % self.name):
                         expire = line.split(':')[7]
         return expire
@@ -967,7 +968,8 @@ class FreeBsdUser(User):
 
         if self.expires is not None and info[7] != self.expires:
             expire=calendar.timegm(self.expires)
-            if expire==0: expire=1 # on FreeBSD 0 means unlock account (not 1.1.1970)
+            if expire==0:
+                expire=1 # on FreeBSD 0 means unlock account (not 1.1.1970)
             cmd.append('-e')
             cmd.append( str(expire) )
 

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -237,6 +237,11 @@ try:
 except:
     HAVE_SPWD = False
 
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
 
 class User(object):
     """
@@ -297,7 +302,7 @@ class User(object):
 
         if module.params['expires']:
             try:
-                self.expires = time.gmtime((module.params['expires']//86400) * 86400.0)
+                self.expires = time.gmtime((module.params['expires']//86400) * 86400)
             except Exception:
                 e = get_exception()
                 module.fail_json(msg="Invalid expires time %s: %s" %(self.expires, str(e)))
@@ -603,7 +608,11 @@ class User(object):
         info = self.get_pwd_info()
         if len(info[1]) == 1 or len(info[1]) == 0:
             info[1] = self.user_password()
-        info.append( time.gmtime(self.user_expire()*86400.0) )
+        expire = self.user_expire()
+        if len(expire)>0:
+            info.append( time.gmtime(float(expire)*86400) )
+        else:
+            info.append( None )
         return info
 
     def user_password(self):
@@ -624,7 +633,7 @@ class User(object):
         return passwd
 
     def user_expire(self):
-        expire = ''
+        expire = None
         if HAVE_SPWD:
             try:
                 expire = spwd.getspnam(self.name)[7]
@@ -637,7 +646,7 @@ class User(object):
             if os.path.exists(self.SHADOWFILE) and os.access(self.SHADOWFILE, os.R_OK):
                 for line in open(self.SHADOWFILE).readlines():
                     if line.startswith('%s:' % self.name):
-                        passwd = line.split(':')[7]
+                        expire = line.split(':')[7]
         return expire
 
     def get_ssh_key_path(self):

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -603,7 +603,7 @@ class User(object):
         info = self.get_pwd_info()
         if len(info[1]) == 1 or len(info[1]) == 0:
             info[1] = self.user_password()
-        info.append( time.gmtime(self.user_expire()*86400) )
+        info.append( time.gmtime(self.user_expire()*86400.0) )
         return info
 
     def user_password(self):

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -171,6 +171,7 @@ options:
     expires:
         description:
             - An expiry time for the user in epoch, it will be ignored on platforms that do not support this.
+<<<<<<< HEAD
               Currently supported on Linux, FreeBSD, and DragonFlyBSD.
         version_added: "1.9"
     local:
@@ -182,6 +183,7 @@ options:
         type: bool
         default: 'no'
         version_added: "2.4"
+              Currently supported on GNU/Linux and FreeBSD.
 '''
 
 EXAMPLES = '''
@@ -637,10 +639,6 @@ class User(object):
             # Read shadow file for user's expiry time
             if os.path.exists(self.SHADOWFILE) and os.access(self.SHADOWFILE, os.R_OK):
                 for line in open(self.SHADOWFILE).readlines():
-                    # HINT - GNU/Linux stores EXPIRE at pos. 7, FreeBSD uses pos. 6,
-                    #      - ansible on FreeBSD does not have spwd (freebsd11, python 2.7.13)
-                    #      - FreeBSD stores EXPIRE as UNIX timestamp in /etc/master.passwd (GNU/Linux uses days)
-                    #      - FreeBSD uses 0 as expire date for unlock
                     if line.startswith('%s:' % self.name):
                         expire = line.split(':')[7]
         return expire

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -395,6 +395,10 @@ class User(object):
             cmd.append(self.shell)
 
         if self.expires:
+<<<<<<< HEAD
+=======
+            #cmd.append('--expiredate') # SLES11 useradd does not know --expiredate
+>>>>>>> Fixes #13235
             cmd.append('-e')
             cmd.append(time.strftime(self.DATE_FORMAT, self.expires))
 
@@ -518,7 +522,8 @@ class User(object):
             cmd.append(self.shell)
 
         if self.expires is not None and info[7] != self.expires:
-            cmd.append('--expiredate')
+            #cmd.append('--expiredate') # SLES11 usermod does not know --expiredate
+            cmd.append('-e')
             cmd.append(time.strftime(self.DATE_FORMAT, self.expires))
 
         if self.update_password == 'always' and self.password is not None and info[1] != self.password:

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -297,7 +297,7 @@ class User(object):
 
         if module.params['expires']:
             try:
-                self.expires = time.gmtime((module.params['expires']//86400) * 86400)
+                self.expires = time.gmtime((module.params['expires']//86400) * 86400.0)
             except Exception:
                 e = get_exception()
                 module.fail_json(msg="Invalid expires time %s: %s" %(self.expires, str(e)))

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -519,7 +519,8 @@ class User(object):
             cmd.append(self.shell)
 
         if self.expires is not None and info[7] != self.expires:
-            cmd.append('--expiredate')
+            #cmd.append('--expiredate') # SLES11 usermod does not know --expiredate
+            cmd.append('-e')
             cmd.append(time.strftime(self.DATE_FORMAT, self.expires))
 
         if self.update_password == 'always' and self.password is not None and info[1] != self.password:

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -298,7 +298,6 @@ class User(object):
         if module.params['expires']:
             try:
                 self.expires = time.gmtime(module.params['expires']//86400*86400)
-                print("StK - __INIT__ self.expires: %s" % str(self.expires) ) 
             except Exception:
                 e = get_exception()
                 module.fail_json(msg="Invalid expires time %s: %s" %(self.expires, str(e)))
@@ -640,7 +639,7 @@ class User(object):
                     # HINT - GNU/Linux stores EXPIRE at pos. 7, FreeBSD uses pos. 6,
                     #      - ansible on FreeBSD does not have spwd (freebsd11, python 2.7.13)
                     #      - FreeBSD stores EXPIRE as UNIX timestamp in /etc/master.passwd (GNU/Linux uses days)
-                    #      - FreeBSD uses 0 as expire date for unlock 
+                    #      - FreeBSD uses 0 as expire date for unlock
                     if line.startswith('%s:' % self.name):
                         expire = line.split(':')[7]
         return expire
@@ -781,7 +780,6 @@ class FreeBsdUser(User):
         if len(info[1]) == 1 or len(info[1]) == 0:
             info[1] = self.user_password()
         expire = self.user_expire()
-        print("StK BSD user_info() - expire: %s" % expire)
         if expire is not None and len(expire)>0:
             info.append( time.gmtime(float(expire)) )
         else:
@@ -804,7 +802,6 @@ class FreeBsdUser(User):
                     if line.startswith('%s:' % self.name):
                         expire = line.split(':')[6]
 
-        print("StK BSD user_expire() - expire: %s" % expire)
         return expire
 
     def remove_user(self):
@@ -868,10 +865,10 @@ class FreeBsdUser(User):
             cmd.append('-L')
             cmd.append(self.login_class)
 
-        print("StK BSD create_user() - self.expires %s" % str(self.expires) )
         if self.expires:
             expire=calendar.timegm(self.expires)
-            if expire==0: expire=1 # on FreeBSD 0 means unlock account (not 1.1.1970)
+            if expire==0:
+                expire=1 # on FreeBSD 0 means unlock account (not 1.1.1970)
             cmd.append('-e')
             cmd.append( str(expire) )
 
@@ -970,7 +967,8 @@ class FreeBsdUser(User):
 
         if self.expires is not None and info[7] != self.expires:
             expire=calendar.timegm(self.expires)
-            if expire==0: expire=1 # on FreeBSD 0 means unlock account (not 1.1.1970)
+            if expire==0:
+                expire=1 # on FreeBSD 0 means unlock account (not 1.1.1970)
             cmd.append('-e')
             cmd.append( str(expire) )
 

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -297,9 +297,10 @@ class User(object):
 
         if module.params['expires']:
             try:
-                self.expires = time.gmtime(module.params['expires'])
-            except Exception as e:
-                module.fail_json(msg="Invalid expires time %s: %s" % (self.expires, to_native(e)))
+                self.expires = time.gmtime((module.params['expires']//86400) * 86400)
+            except Exception:
+                e = get_exception()
+                module.fail_json(msg="Invalid expires time %s: %s" %(self.expires, str(e)))
 
         if module.params['ssh_key_file'] is not None:
             self.ssh_file = module.params['ssh_key_file']
@@ -516,8 +517,13 @@ class User(object):
             cmd.append('-s')
             cmd.append(self.shell)
 
+<<<<<<< HEAD
         if self.expires:
             cmd.append('-e')
+=======
+        if self.expires is not None and info[7] != self.expires:
+            cmd.append('--expiredate')
+>>>>>>> Fix #13235
             cmd.append(time.strftime(self.DATE_FORMAT, self.expires))
 
         if self.update_password == 'always' and self.password is not None and info[1] != self.password:
@@ -597,6 +603,7 @@ class User(object):
         info = self.get_pwd_info()
         if len(info[1]) == 1 or len(info[1]) == 0:
             info[1] = self.user_password()
+        info.append( time.gmtime(self.user_expire()*86400) )
         return info
 
     def user_password(self):
@@ -615,6 +622,23 @@ class User(object):
                     if line.startswith('%s:' % self.name):
                         passwd = line.split(':')[1]
         return passwd
+
+    def user_expire(self):
+        expire = ''
+        if HAVE_SPWD:
+            try:
+                expire = spwd.getspnam(self.name)[7]
+            except KeyError:
+                return expire
+        if not self.user_exists():
+            return expire
+        elif self.SHADOWFILE:
+            # Read shadow file for user's expiry time
+            if os.path.exists(self.SHADOWFILE) and os.access(self.SHADOWFILE, os.R_OK):
+                for line in open(self.SHADOWFILE).readlines():
+                    if line.startswith('%s:' % self.name):
+                        passwd = line.split(':')[7]
+        return expire
 
     def get_ssh_key_path(self):
         info = self.user_info()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
expiry time of user account will now be changed only if its different

fixes #13235
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
user module
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/mnt/ramdisk/ansible/lib/ansible/modules/']
  python version = 2.7.13 (default, Mar 22 2017, 12:31:17) [GCC]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
add expires parameter to user module and run it twice. it always changes the expiry time of user(s) because the expiry time of existing users will not be taken into account. I changed ansible user module to read an existing expiry time and save it as time object (in full days)

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
knoedel@section61:/mnt/ramdisk> cd ansible; git checkout devel; cd -
Already on 'devel'
Your branch is up-to-date with 'origin/devel'.
/mnt/ramdisk
knoedel@section61:/mnt/ramdisk> sudo ansible/hacking/test-module --check -m ansible/lib/ansible/modules/system/user.py -a "name=ansible expires=864000"
* including generated source, if any, saving to: /root/.ansible_module_generated
* ansiballz module detected; extracted module source to: /root/debug_dir
***********************************
RAW OUTPUT

{"comment": "tralala", "shell": "/bin/bash", "group": 100, "name": "ansible", "changed": true, "state": "present", "invocation": {"module_args": {"comment": null, "ssh_key_bits": 0, "update_password": "always", "non_unique": false, "force": false, "skeleton": null, "ssh_key_passphrase": null, "createhome": true, "uid": null, "home": null, "append": false, "ssh_key_type": "rsa", "ssh_key_comment": "ansible-generated on section61", "group": null, "system": false, "state": "present", "shell": null, "expires": 864000.0, "ssh_key_file": null, "groups": null, "move_home": false, "password": null, "name": "ansible", "seuser": null, "remove": false, "login_class": null, "generate_ssh_key": null}}, "home": "/home/ansible", "move_home": false, "append": false, "uid": 1003}


***********************************
PARSED OUTPUT
{
    "append": false, 
    "changed": true, 
    "comment": "tralala", 
    "group": 100, 
    "home": "/home/ansible", 
    "invocation": {
        "module_args": {
            "append": false, 
            "comment": null, 
            "createhome": true, 
            "expires": 864000.0, 
            "force": false, 
            "generate_ssh_key": null, 
            "group": null, 
            "groups": null, 
            "home": null, 
            "login_class": null, 
            "move_home": false, 
            "name": "ansible", 
            "non_unique": false, 
            "password": null, 
            "remove": false, 
            "seuser": null, 
            "shell": null, 
            "skeleton": null, 
            "ssh_key_bits": 0, 
            "ssh_key_comment": "ansible-generated on section61", 
            "ssh_key_file": null, 
            "ssh_key_passphrase": null, 
            "ssh_key_type": "rsa", 
            "state": "present", 
            "system": false, 
            "uid": null, 
            "update_password": "always"
        }
    }, 
    "move_home": false, 
    "name": "ansible", 
    "shell": "/bin/bash", 
    "state": "present", 
    "uid": 1003
}
knoedel@section61:/mnt/ramdisk> sudo ansible/hacking/test-module --check -m ansible/lib/ansible/modules/system/user.py -a "name=ansible expires=864000"
* including generated source, if any, saving to: /root/.ansible_module_generated
* ansiballz module detected; extracted module source to: /root/debug_dir
***********************************
RAW OUTPUT

{"comment": "tralala", "shell": "/bin/bash", "group": 100, "name": "ansible", "changed": true, "state": "present", "invocation": {"module_args": {"comment": null, "ssh_key_bits": 0, "update_password": "always", "non_unique": false, "force": false, "skeleton": null, "ssh_key_passphrase": null, "createhome": true, "uid": null, "home": null, "append": false, "ssh_key_type": "rsa", "ssh_key_comment": "ansible-generated on section61", "group": null, "system": false, "state": "present", "shell": null, "expires": 864000.0, "ssh_key_file": null, "groups": null, "move_home": false, "password": null, "name": "ansible", "seuser": null, "remove": false, "login_class": null, "generate_ssh_key": null}}, "home": "/home/ansible", "move_home": false, "append": false, "uid": 1003}


***********************************
PARSED OUTPUT
{
    "append": false, 
    "changed": true, 
    "comment": "tralala", 
    "group": 100, 
    "home": "/home/ansible", 
    "invocation": {
        "module_args": {
            "append": false, 
            "comment": null, 
            "createhome": true, 
            "expires": 864000.0, 
            "force": false, 
            "generate_ssh_key": null, 
            "group": null, 
            "groups": null, 
            "home": null, 
            "login_class": null, 
            "move_home": false, 
            "name": "ansible", 
            "non_unique": false, 
            "password": null, 
            "remove": false, 
            "seuser": null, 
            "shell": null, 
            "skeleton": null, 
            "ssh_key_bits": 0, 
            "ssh_key_comment": "ansible-generated on section61", 
            "ssh_key_file": null, 
            "ssh_key_passphrase": null, 
            "ssh_key_type": "rsa", 
            "state": "present", 
            "system": false, 
            "uid": null, 
            "update_password": "always"
        }
    }, 
    "move_home": false, 
    "name": "ansible", 
    "shell": "/bin/bash", 
    "state": "present", 
    "uid": 1003
}


knoedel@section61:/mnt/ramdisk> sudo chage -l ansible
Last password change                                    : Jun 02, 2017
Password expires                                        : never
Password inactive                                       : never
Account expires                                         : Jan 11, 1970
Minimum number of days between password change          : 0
Maximum number of days between password change          : 99999
Number of days of warning before password expires       : 7

knoedel@section61:/mnt/ramdisk> cd ansible; git checkout issue_13235; cd -
Switched to branch 'issue_13235'
Your branch is up-to-date with 'origin/issue_13235'.
/mnt/ramdisk
knoedel@section61:/mnt/ramdisk> sudo ansible/hacking/test-module --check -m ansible/lib/ansible/modules/system/user.py -a "name=ansible expires=864000"
* including generated source, if any, saving to: /root/.ansible_module_generated
* ansiballz module detected; extracted module source to: /root/debug_dir
***********************************
RAW OUTPUT

{"comment": "tralala", "shell": "/bin/bash", "group": 100, "name": "ansible", "changed": false, "state": "present", "invocation": {"module_args": {"comment": null, "ssh_key_bits": 0, "update_password": "always", "non_unique": false, "force": false, "skeleton": null, "ssh_key_passphrase": null, "createhome": true, "uid": null, "home": null, "append": false, "ssh_key_type": "rsa", "ssh_key_comment": "ansible-generated on section61", "group": null, "system": false, "state": "present", "shell": null, "expires": 864000.0, "ssh_key_file": null, "groups": null, "move_home": false, "password": null, "name": "ansible", "seuser": null, "remove": false, "login_class": null, "generate_ssh_key": null}}, "home": "/home/ansible", "move_home": false, "append": false, "uid": 1003}


***********************************
PARSED OUTPUT
{
    "append": false, 
    "changed": false, 
    "comment": "tralala", 
    "group": 100, 
    "home": "/home/ansible", 
    "invocation": {
        "module_args": {
            "append": false, 
            "comment": null, 
            "createhome": true, 
            "expires": 864000.0, 
            "force": false, 
            "generate_ssh_key": null, 
            "group": null, 
            "groups": null, 
            "home": null, 
            "login_class": null, 
            "move_home": false, 
            "name": "ansible", 
            "non_unique": false, 
            "password": null, 
            "remove": false, 
            "seuser": null, 
            "shell": null, 
            "skeleton": null, 
            "ssh_key_bits": 0, 
            "ssh_key_comment": "ansible-generated on section61", 
            "ssh_key_file": null, 
            "ssh_key_passphrase": null, 
            "ssh_key_type": "rsa", 
            "state": "present", 
            "system": false, 
            "uid": null, 
            "update_password": "always"
        }
    }, 
    "move_home": false, 
    "name": "ansible", 
    "shell": "/bin/bash", 
    "state": "present", 
    "uid": 1003
}

```
