### PR TITLE
Fix #25368 - HPUX facts

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/hpux.py
+++ b/lib/ansible/module_utils/facts/hardware/hpux.py
@@ -62,9 +62,11 @@ class HPUXHardware(Hardware):
         elif collected_facts.get('ansible_architecture') == 'ia64':
             if collected_facts.get('ansible_distribution_version') == "B.11.23":
                 rc, out, err = self.module.run_command("/usr/contrib/bin/machinfo | grep 'Number of CPUs'", use_unsafe_shell=True)
-                cpu_facts['processor_count'] = int(out.strip().split('=')[1])
+                if out:
+                    cpu_facts['processor_count'] = int(out.strip().split('=')[1])
                 rc, out, err = self.module.run_command("/usr/contrib/bin/machinfo | grep 'processor family'", use_unsafe_shell=True)
-                cpu_facts['processor'] = re.search('.*(Intel.*)', out).groups()[0].strip()
+                if out:
+                    cpu_facts['processor'] = re.search('.*(Intel.*)', out).groups()[0].strip()
                 rc, out, err = self.module.run_command("ioscan -FkCprocessor | wc -l", use_unsafe_shell=True)
                 cpu_facts['processor_cores'] = int(out.strip())
             if collected_facts.get('ansible_distribution_version') == "B.11.31":


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #25368.   Skips cpu facts not returned by machinfo on HP Integrity VM's.
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/facts/hardware/hpux.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
All hardware facts (except cpu specific facts not available on HP ia64 VM's are returned.   
Unable to post facts due to protected internal info.
```
