### PR TITLE
When cleaning up the AnsiBallZ tempdir we need to not fail if the tempdir wasn't created

### DIFF
--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -345,7 +345,7 @@ if __name__ == '__main__':
     finally:
         try:
             shutil.rmtree(temp_path)
-        except OSError:
+        except (NameError, OSError):
             # tempdir creation probably failed
             pass
     sys.exit(exitcode)


### PR DESCRIPTION
If the temp directory creation failed in mkdtemp then temp_path is never
given a value.  This would lead to a NameError exception which would
obfuscate the original error (out of disk space being a common one).  By
catching NameError, python will raise the original exception as we want.

Fixes #17215

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
executor/module_common.py

AnsiBallZ wrapper

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.3
```
