### PR TITLE
fixes(#25299) Don't fail when creating a Foreman organization

### DIFF
--- a/lib/ansible/modules/remote_management/foreman/foreman.py
+++ b/lib/ansible/modules/remote_management/foreman/foreman.py
@@ -93,7 +93,7 @@ class NailGun(object):
         if len(response) == 1:
             return response[0]
         else:
-            self._module.fail_json(msg="No Content View found for %s" % name)
+            return None
 
     def organization(self, params):
         name = params['name']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The module would bail if the organization did not already exist and skip creating it, this should fix it.

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
remote_management/foreman/foreman.py
