### PR TITLE
YAML inventory doc: add info about 'all' group, remove unused option

### DIFF
--- a/lib/ansible/plugins/inventory/yaml.py
+++ b/lib/ansible/plugins/inventory/yaml.py
@@ -9,16 +9,15 @@ DOCUMENTATION = '''
     version_added: "2.4"
     short_description: Uses a specific YAML file as an inventory source.
     description:
-        - "YAML based inventory, SHOULD starts with the C(all) group and has hosts/vars/children entries."
+        - "YAML-based inventory, should start with the C(all) group and contain hosts/vars/children entries."
         - Host entries can have sub-entries defined, which will be treated as variables.
         - Vars entries are normal group vars.
         - "Children are 'child groups', which can also have their own vars/hosts/children and so on."
         - File MUST have a valid extension, defined in configuration
     notes:
-        - It takes the place of the previously hardcoded YAML inventory.
-        - To function it requires being whitelisted in configuration.
-        - Beginning with the C(all) group is the only way to set vars for the
-          C(all) group inside the inventory file.
+        - Replaces the previously hardcoded YAML inventory.
+        - Must be whitelisted in configuration to function.
+        - If you want to set vars for the C(all) group inside the inventory file, the C(all) group must be the first entry in the file.
     options:
       yaml_extensions:
         description: list of 'valid' extensions for files containing YAML

--- a/lib/ansible/plugins/inventory/yaml.py
+++ b/lib/ansible/plugins/inventory/yaml.py
@@ -9,7 +9,7 @@ DOCUMENTATION = '''
     version_added: "2.4"
     short_description: Uses a specific YAML file as an inventory source.
     description:
-        - "YAML based inventory, starts with the 'all' group and has hosts/vars/children entries."
+        - "YAML based inventory, SHOULD starts with the C(all) group and has hosts/vars/children entries."
         - Host entries can have sub-entries defined, which will be treated as variables.
         - Vars entries are normal group vars.
         - "Children are 'child groups', which can also have their own vars/hosts/children and so on."
@@ -17,6 +17,8 @@ DOCUMENTATION = '''
     notes:
         - It takes the place of the previously hardcoded YAML inventory.
         - To function it requires being whitelisted in configuration.
+        - Beginning with the C(all) group is the only way to set vars for the
+          C(all) group inside the inventory file.
     options:
       yaml_extensions:
         description: list of 'valid' extensions for files containing YAML
@@ -39,7 +41,7 @@ all: # keys must be unique, i.e. only one 'hosts' per group
         test2:
             var1: value1
     vars:
-        group_var1: value2
+        group_all_var: value
     children:   # key order does not matter, indentation does
         other_group:
             children:

--- a/lib/ansible/plugins/inventory/yaml.py
+++ b/lib/ansible/plugins/inventory/yaml.py
@@ -13,11 +13,10 @@ DOCUMENTATION = '''
         - Host entries can have sub-entries defined, which will be treated as variables.
         - Vars entries are normal group vars.
         - "Children are 'child groups', which can also have their own vars/hosts/children and so on."
-        - File MUST have a valid extension, defined in configuration
+        - File MUST have a valid extension, defined in configuration.
     notes:
-        - Replaces the previously hardcoded YAML inventory.
-        - Must be whitelisted in configuration to function.
         - If you want to set vars for the C(all) group inside the inventory file, the C(all) group must be the first entry in the file.
+        - Whitelisted in configuration by default.
     options:
       yaml_extensions:
         description: list of 'valid' extensions for files containing YAML
@@ -38,7 +37,7 @@ all: # keys must be unique, i.e. only one 'hosts' per group
     hosts:
         test1:
         test2:
-            var1: value1
+            host_var: value
     vars:
         group_all_var: value
     children:   # key order does not matter, indentation does
@@ -56,7 +55,7 @@ all: # keys must be unique, i.e. only one 'hosts' per group
             hosts:
                 test1 # same host as above, additional group membership
             vars:
-                last_var: MYVALUE
+                group_last_var: value
 '''
 
 import os


### PR DESCRIPTION
##### SUMMARY

- Add information about `all` group
- ~~remove unused option `yaml_extensions`~~

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
YAML inventory plugin

##### ANSIBLE VERSION
```
ansible-playbook 2.4.0 (devel 483df9c5f8) last updated 2017/06/06 23:50:25 (GMT +200)
```