### PR TITLE
Added a `name` to the example block

### DIFF
--- a/docs/docsite/rst/playbooks_blocks.rst
+++ b/docs/docsite/rst/playbooks_blocks.rst
@@ -7,13 +7,13 @@ at the block level, which also makes it much easier to set data or directives co
 to the tasks. This does not mean the directive affects the block itself, but is inherited
 by the tasks enclosed by a block. i.e. a `when` will be applied to the tasks, not the block itself.
 
-
 .. code-block:: YAML
- :emphasize-lines: 2
+ :emphasize-lines: 3
  :caption: Block example
 
     tasks:
-      - block:
+      - name: Install, confugure & start services
+        block:
           - yum: name={{ item }} state=installed
             with_items:
               - httpd
@@ -31,6 +31,8 @@ by the tasks enclosed by a block. i.e. a `when` will be applied to the tasks, no
 In the example above, each of the 3 tasks will be executed after appending the `when` condition from the block
 and evaluating it in the task's context. Also they inherit the privilege escalation directives enabling "become to root"
 for all the enclosed tasks.
+
+Blocks also support a `name` field, as shown above, to aid in playbook readability.
 
 
 .. _block_error_handling:

--- a/docs/docsite/rst/playbooks_blocks.rst
+++ b/docs/docsite/rst/playbooks_blocks.rst
@@ -12,7 +12,7 @@ by the tasks enclosed by a block. i.e. a `when` will be applied to the tasks, no
  :caption: Block example
 
     tasks:
-      - name: Install, confugure & start services
+      - name: Install, configure and start services
         block:
           - yum: name={{ item }} state=installed
             with_items:


### PR DESCRIPTION
##### SUMMARY
Blocks have supported `names` for a while (#18985), but it's not documented anywhere, afaik - so I added here.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
blocks

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = 
  configured module search path = [u'/usr/local/lib/python2.7/dist-packages/ara/plugins/modules']
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]

```
