### PR TITLE
new postgresql_query_module

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -167,7 +167,7 @@ def main():
         "login_user": "user",
         "login_password": "password",
         "port": "port",
-        "db": "database",
+        "db": "dbname",
         "ssl_mode": "sslmode",
         "ssl_rootcert": "sslrootcert"
     }

--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -70,50 +70,48 @@ author:
 '''
 
 EXAMPLES = '''
-# Insert or update a record in a table with positional arguments
+# Simple select query.
 - postgresql_query:
     db: acme
     login_user: django
     login_password: ceec4eif7ya
-    query: SELECT * FROM a_table WHERE a_column=%s AND b_column=%s
+    query: SELECT * FROM my_table
     positional_args:
-      - "positional string value 1"
-      - "positional string value 2"
+      - "first positional arg value"
+      - "second positional arg value"
 
-# Insert or update a record in a table with named arguments.
+# Select query using named args.
 - postgresql_query:
     db: acme
     login_user: django
     login_password: ceec4eif7ya
     query: SELECT * FROM some_table WHERE a_column=%(a_value)s AND b_column=%(b_value)s
-    positional_args:
-      a_value: "positional string value 1"
-      b_value: "positional string value 2"
+    named_args:
+      a_value: "named_arg value"
+      b_value: "named_arg value"
 
-# Run queries from a '.sql' file. This file may contain placeholders as shown
-# here.
+# Run queries from a '.sql' script file. This file's script may contain
+# 'named_args' or 'positional_args' placeholders.
 - postgresql_query:
     db: acme
     login_user: django
     login_password: ceec4eif7ya
     query: "{{playbook_dir}}/scripts/my_sql_query_file.sql"
     named_args:
-      a_value: "positional string value 1"
-      b_value: "positional string value 2"
+      a_value: "named arg value"
+      b_value: "named arg value"
 
-# Run queries from a '.sql' file and assign result in a fact available for the
-# rest of the ansible runtime. Query inside scripts may contain 'named_args'
-# or 'positional_args'.
+# Run query and assign result in a fact named 'my_key' that will be available
+# for the rest of the ansible runtime.
 - postgresql_query:
     db: acme
     login_user: django
     login_password: ceec4eif7ya
-    query: SELECT * FROM some_table WHERE a_column=%(a_value)s AND b_column=%(b_value)s
-    query: /path/to/my/script.sql
-    named_args:
-      a_value: "positional string value 1"
-      b_value: "positional string value 2"
     name: my_key
+    query: SELECT * FROM some_table WHERE a_column=%(a_value)s AND b_column=%(b_value)s
+    named_args:
+      a_value: "named arg value"
+      b_value: "named arg value"
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -22,7 +22,7 @@ description:
    - >
     Query results may be assigned to a variable for later reuse during ansible
     runtime.
-version_added: "2.4"
+version_added: "2.5"
 options:
     db:
         description:

--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -162,9 +162,6 @@ def main():
     query_results = []
     rowcount = 0
 
-    # To use defaults values, keyword arguments must be absent, so
-    # check which values are empty and don't include in the **kw
-    # dictionary
     params_map = {
         "login_host": "host",
         "login_user": "user",
@@ -175,8 +172,14 @@ def main():
         "ssl_rootcert": "sslrootcert"
     }
 
+    # To use defaults values, keyword arguments must be absent, so
+    # check which values are empty and don't include in the **kw
+    # dictionary
     kw = dict((params_map[k], v) for (k, v) in iteritems(module.params)
               if k in params_map and v != '' and v is not None)
+
+    if module.params.get('login_unix_socket'):
+        kw["host"] = module.params.get('login_unix_socket')
 
     try:
         pgutils.ensure_libs(sslrootcert=module.params.get('ssl_rootcert'))

--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -30,6 +30,7 @@ description:
      Number of rows affected are returned as "row_count".
    - Can read queries from a .sql script files.
    - SQL scripts may be templated with ansible variables at execution time.
+   - Run queries in check_mode and then roll them back (autocommit must be disabled).
 version_added: "2.4"
 options:
   db:

--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -25,18 +25,16 @@ DOCUMENTATION = '''
 module: postgresql_query
 short_description: Run arbitrary queries on a postgresql database.
 description:
-   - Run arbitrary queries on postgresql instances from the current host.
-   - The function of this module is primarily to allow running queries which
-     would benefit from bound parameters for SQL escaping.
+   - Run arbitrary SQL queries against a PostgreSQL instance from the current host.
    - Query results are returned as "query_results" as a list of dictionaries.
      Number of rows affected are returned as "row_count".
-   - Can read queries from a .sql script files
-   - SQL scripts may be templated with ansible variables at execution time
+   - Can read queries from a .sql script files.
+   - SQL scripts may be templated with ansible variables at execution time.
 version_added: "2.4"
 options:
   db:
     description:
-      - name of the database to run queries against
+      - name of the database to run queries against.
     required: false
     default: postgres
   port:
@@ -46,12 +44,12 @@ options:
     default: 5432
   login_user:
     description:
-      - User (role) used to authenticate with PostgreSQL
+      - User (role) used to authenticate with PostgreSQL.
     required: false
     default: postgres
   login_password:
     description:
-      - Password used to authenticate with PostgreSQL
+      - Password used to authenticate with PostgreSQL.
     required: false
     default: null
   login_host:
@@ -81,7 +79,7 @@ options:
         - If enabled, This WILL run the query in check_mode.
       required: false
       default: false
-      choices: [true, false]
+      type: bool
   named_args:
     description:
       - A dictionary of key-value arguments to pass to the query.
@@ -126,7 +124,9 @@ notes:
      PUBLIC user is specified.
    - The ssl_rootcert parameter requires at least Postgres version 8.4 and I(psycopg2) version 2.4.3.
 requirements: [ psycopg2 ]
-author: "Felix Archambault (@archf)"
+author:
+    - "Felix Archambault (@archf)"
+    - "Will Rouesnel (@wrouesnel)"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -133,20 +133,20 @@ EXAMPLES = '''
 # Insert or update a record in a table with positional arguments
 - postgresql_query:
     db: acme
-    user: django
-    password: ceec4eif7ya
+    login_user: django
+    login_password: ceec4eif7ya
     query: SELECT * FROM a_table WHERE a_column=%s AND b_column=%s
     positional_args:
-    - "positional string value 1"
-    - "positional string value 2"
+      - "positional string value 1"
+      - "positional string value 2"
 
 # Insert or update a record in a table with named arguments
 - postgresql_query:
     db: acme
-    user: django
-    password: ceec4eif7ya
+    login_user: django
+    login_password: ceec4eif7ya
     query: SELECT * FROM some_table WHERE a_column=%(a_value)s AND b_column=%(b_value)s
-    named_args:
+    positional_args:
       a_value: "positional string value 1"
       b_value: "positional string value 2"
 
@@ -154,20 +154,22 @@ EXAMPLES = '''
 # Run queries from a '.sql' file
 - postgresql_query:
     db: acme
-    user: django
-    password: ceec4eif7ya
+    login_user: django
+    login_password: ceec4eif7ya
     query: "{{playbook_dir}}/scripts/my_sql_query_file.sql"
     named_args:
       a_value: "positional string value 1"
       b_value: "positional string value 2"
 
-# Run queries from a '.sql' file and assign result in a fact available at
-# for the rest of the ansible runtime.
+# Run queries from a '.sql' file and assign result in a fact available for the
+# rest of the ansible runtime. Query inside scripts may contain 'named_args'
+# or 'positional_args'.
 - postgresql_query:
     db: acme
-    user: django
-    password: ceec4eif7ya
+    login_user: django
+    login_password: ceec4eif7ya
     query: SELECT * FROM some_table WHERE a_column=%(a_value)s AND b_column=%(b_value)s
+    query: /path/to/my/script.sql
     named_args:
       a_value: "positional string value 1"
       b_value: "positional string value 2"

--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -193,6 +193,7 @@ else:
 
 import traceback
 from ansible.module_utils.six import iteritems
+from ansible.module_utils.basic import AnsibleModule, get_exception, BOOLEANS
 import ansible.module_utils.postgres as pgutils
 
 # ===========================================
@@ -333,9 +334,6 @@ def main():
                      query_results=query_results,
                      ansible_facts=ansible_facts,
                      rowcount=rowcount)
-
-# import module snippets
-from ansible.module_utils.basic import AnsibleModule, get_exception, BOOLEANS
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -1,0 +1,341 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'status': ['stableinterface'],
+                    'supported_by': 'community',
+                    'version': '1.0'}
+DOCUMENTATION = '''
+---
+module: postgresql_query
+short_description: Run arbitrary queries on a postgresql database.
+description:
+   - Run arbitrary queries on postgresql instances from the current host.
+   - The function of this module is primarily to allow running queries which
+     would benefit from bound parameters for SQL escaping.
+   - Query results are returned as "query_results" as a list of dictionaries.
+     Number of rows affected are returned as "row_count".
+   - Can read queries from a .sql script files
+   - SQL scripts may be templated with ansible variables at execution time
+version_added: "2.3"
+options:
+  db:
+    description:
+      - name of the database to run queries against
+    required: true
+    default: null
+  port:
+    description:
+      - Database port to connect to.
+    required: false
+    default: 5432
+  login_user:
+    description:
+      - User (role) used to authenticate with PostgreSQL
+    required: false
+    default: postgres
+  login_password:
+    description:
+      - Password used to authenticate with PostgreSQL
+    required: false
+    default: null
+  login_host:
+    description:
+      - Host running PostgreSQL.
+    required: false
+    default: localhost
+  login_unix_socket:
+    description:
+      - Path to a Unix domain socket for local connections
+    required: false
+    default: null
+  query:
+    description:
+      - SQL query to run. Variables can be escaped with psycopg2 syntax.
+  positional_args:
+    description:
+      - A list of values to be passed as positional arguments to the query.
+      - Cannot be used with named_args
+  autocommit:
+      description:
+        - Enable transaction autocommit
+        - If enabled, This WILL run the query in check_mode
+      required: false
+      default: false
+      choices: [true, false]
+  named_args:
+    description:
+      - A dictionary of key-value arguments to pass to the query.
+      - Cannot be used with positional_args
+  fact: |
+      Append the query_results to this key value, making this new variable
+      available to subsequent plays during an ansible-playbook run.
+  ssl_mode:
+    description:
+      - Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server.
+      - See https://www.postgresql.org/docs/current/static/libpq-ssl.html for more information on the modes.
+      - Default of C(prefer) matches libpq default.
+    required: false
+    default: prefer
+    choices: [disable, allow, prefer, require, verify-ca, verify-full]
+    version_added: '2.3'
+  ssl_rootcert:
+    description:
+      - Specifies the name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
+    required: false
+    default: null
+notes:
+   - The default authentication assumes that you are either logging in as or
+     sudo'ing to the postgres account on the host.
+   - This module uses psycopg2, a Python PostgreSQL database adapter. You must
+     ensure that psycopg2 is installed on the host before using this module. If
+     the remote host is the PostgreSQL server (which is the default case), then
+     PostgreSQL must also be installed on the remote host. For Ubuntu-based
+     systems, install the postgresql, libpq-dev, and python-psycopg2 packages
+     on the remote host before using this module.
+   - If the passlib library is installed, then passwords that are encrypted
+     in the DB but not encrypted when passed as arguments can be checked for
+     changes. If the passlib library is not installed, unencrypted passwords
+     stored in the DB encrypted will be assumed to have changed.
+   - If you specify PUBLIC as the user, then the privilege changes will apply
+     to all users. You may not specify password or role_attr_flags when the
+     PUBLIC user is specified.
+   - The ssl_rootcert parameter requires at least Postgres version 8.4 and I(psycopg2) version 2.4.3.
+requirements: [ psycopg2 ]
+author: "Felix Archambault (@archf)"
+'''
+
+EXAMPLES = '''
+# Insert or update a record in a table with positional arguments
+- postgresql_query:
+    db: acme
+    user: django
+    password: ceec4eif7ya
+    query: SELECT * FROM a_table WHERE a_column=%s AND b_column=%s
+    positional_args:
+    - "positional string value 1"
+    - "positional string value 2"
+
+# Insert or update a record in a table with named arguments
+- postgresql_query:
+    db: acme
+    user: django
+    password: ceec4eif7ya
+    query: SELECT * FROM some_table WHERE a_column=%(a_value)s AND b_column=%(b_value)s
+    named_args:
+      a_value: "positional string value 1"
+      b_value: "positional string value 2"
+
+
+# Run queries from a '.sql' file
+- postgresql_query:
+    db: acme
+    user: django
+    password: ceec4eif7ya
+    query: "{{playbook_dir}}/scripts/my_sql_query_file.sql"
+    named_args:
+      a_value: "positional string value 1"
+      b_value: "positional string value 2"
+
+# Run queries from a '.sql' file and assign result in a fact available at
+# for the rest of the ansible runtime.
+- postgresql_query:
+    db: acme
+    user: django
+    password: ceec4eif7ya
+    query: SELECT * FROM some_table WHERE a_column=%(a_value)s AND b_column=%(b_value)s
+    named_args:
+      a_value: "positional string value 1"
+      b_value: "positional string value 2"
+    fact: my_key
+'''
+
+RETURN = '''
+query_results:
+    description: list of dictionaries in column:value form
+    returned: changed
+    type: list
+    sample: [{"Column": "Value1"},{"Column": "Value2"}]
+row_count:
+    description: number of affected rows by query, if applicable
+    returned: changed
+    type: int
+    sample: 5
+ansible_facts:
+    "my_key": {
+        "column1": "value",
+        "column2": "value"
+        }
+'''
+
+HAS_PSYCOPG2 = False
+try:
+    import psycopg2
+    import psycopg2.extras
+except ImportError:
+    pass
+else:
+    HAS_PSYCOPG2 = True
+
+import traceback
+from ansible.module_utils.six import iteritems
+import ansible.module_utils.postgres as pgutils
+
+# ===========================================
+# Module execution.
+#
+
+def main():
+    argument_spec = pgutils.postgres_common_argument_spec()
+
+    argument_spec.update(dict(
+        db=dict(default=None),
+        query=dict(type="str"),
+        autocommit=dict(type='bool', default=False, choices=BOOLEANS),
+        positional_args=dict(type="list"),
+        named_args=dict(type="dict"),
+        fact=dict(default=None),
+    ))
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        mutually_exclusive=[
+            ["positional_args", "named_args"]
+        ],
+    )
+
+    if not HAS_PSYCOPG2:
+        module.fail_json(msg="the python psycopg2 module is required")
+
+    changed = False
+
+    # To use defaults values, keyword arguments must be absent, so
+    # check which values are empty and don't include in the **kw
+    # dictionary
+    params_map = {
+        "login_host": "host",
+        "login_user": "user",
+        "login_password": "password",
+        "port": "port",
+        "db": "database",
+        "ssl_mode": "sslmode",
+        "ssl_rootcert": "sslrootcert"
+    }
+
+    kw = dict((params_map[k], v) for (k, v) in iteritems(module.params)
+              if k in params_map and v != '' and v is not None)
+
+    # If a login_unix_socket is specified, incorporate it here.
+    is_localhost = "host" not in kw or kw["host"] == "" or kw["host"] == "localhost"
+
+    if is_localhost and module.params["login_unix_socket"] != "":
+        kw["host"] = module.params["login_unix_socket"]
+
+    try:
+        pgutils.ensure_libs(sslrootcert=module.params.get('ssl_rootcert'))
+        db_connection = psycopg2.connect(**kw)
+
+        # Enable autocommit on demand only so we can create databases
+        if module.params['autocommit']:
+            if psycopg2.__version__ >= '2.4.2':
+                db_connection.autocommit = True
+            else:
+                db_connection.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+
+        # Using RealDictCursor allows access to row results by real column name
+        cursor = db_connection.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
+    except Exception:
+        e = get_exception()
+        module.fail_json(msg="unable to connect to database: {0}".format(str(e)), exception=traceback.format_exc())
+
+    except TypeError:
+        e = get_exception()
+        if 'sslrootcert' in e.args[0]:
+            module.fail_json(msg='Postgresql server must be at least version 8.4 to support sslrootcert. Exception: {0}'.format(e), exception=traceback.format_exc())
+        module.fail_json(msg="unable to connect to database: %s" % e, exception=traceback.format_exc())
+
+    # if query is a file, load the file and run it
+    query = module.params["query"]
+    if query.endswith('.sql'):
+        try:
+            query = open(query, 'r').read().strip('\n')
+        except Exception:
+            e = get_exception()
+            module.fail_json(msg="Unable to find '%s' in given path." % query)
+
+    arguments = None
+
+    # prepare args
+    if module.params["positional_args"] is not None:
+        arguments = module.params["positional_args"]
+
+    elif module.params["named_args"] is not None:
+        arguments = module.params["named_args"]
+
+    try:
+        cursor.execute(query, arguments)
+    except Exception:
+        e = get_exception()
+        module.fail_json(msg="Unable to execute query: %s" % e,
+                         query_arguments=arguments)
+
+    ansible_facts = {}
+    query_results = []
+    if cursor.rowcount > 0:
+        # There's no good way to return results arbitrarily without inspecting
+        # the SQL, so we act consistent and return the empty set when there's
+        # nothing to return.
+        try:
+            query_results = cursor.fetchall()
+        except psycopg2.ProgrammingError:
+            pass
+
+        rowcount = len(query_results)
+        fact = module.params["fact"]
+        if fact is not None:
+            ansible_facts = {fact: query_results}
+    else:
+        rowcount = 0
+
+    statusmessage = cursor.statusmessage
+
+    changed = False
+
+    # set changed flag only on non read-only command
+    if "UPDATDE" in statusmessage or "INSERT" in statusmessage or \
+            "UPSERT" in statusmessage:
+        changed = True
+
+    if changed:
+        if module.check_mode:
+            db_connection.rollback()
+        else:
+            db_connection.commit()
+
+    db_connection.close()
+
+    module.exit_json(changed=changed, stout_lines=statusmessage,
+                     query_results=query_results,
+                     ansible_facts=ansible_facts,
+                     rowcount=rowcount)
+
+# import module snippets
+from ansible.module_utils.basic import AnsibleModule, get_exception, BOOLEANS
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -262,9 +262,6 @@ def main():
 
         # Using RealDictCursor allows access to row results by real column name
         cursor = db_connection.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
-    except Exception:
-        e = get_exception()
-        module.fail_json(msg="unable to connect to database: {0}".format(str(e)), exception=traceback.format_exc())
 
     except TypeError:
         e = get_exception()
@@ -273,6 +270,10 @@ def main():
                              8.4 to support sslrootcert.
                              Exception: {0}'''.format(e), exception=traceback.format_exc())
         module.fail_json(msg="unable to connect to database: %s" % e, exception=traceback.format_exc())
+
+    except Exception:
+        e = get_exception()
+        module.fail_json(msg="unable to connect to database: {0}".format(str(e)), exception=traceback.format_exc())
 
     # if query is a file, load the file and run it
     query = module.params["query"]

--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -16,9 +16,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-ANSIBLE_METADATA = {'status': ['stableinterface'],
-                    'supported_by': 'community',
-                    'version': '1.0'}
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
 DOCUMENTATION = '''
 ---
 module: postgresql_query
@@ -318,8 +319,8 @@ def main():
     changed = False
 
     # set changed flag only on non read-only command
-    if "UPDATE" in statusmessage or "INSERT" in statusmessage or \
-            "UPSERT" in statusmessage:
+    if ("UPDATE" in statusmessage or "INSERT" in statusmessage or \
+            "UPSERT" in statusmessage or "DELETE" in statusmessage):
         changed = True
 
     if changed:

--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -31,7 +31,7 @@ description:
      Number of rows affected are returned as "row_count".
    - Can read queries from a .sql script files
    - SQL scripts may be templated with ansible variables at execution time
-version_added: "2.3"
+version_added: "2.4"
 options:
   db:
     description:
@@ -317,7 +317,7 @@ def main():
     changed = False
 
     # set changed flag only on non read-only command
-    if "UPDATDE" in statusmessage or "INSERT" in statusmessage or \
+    if "UPDATE" in statusmessage or "INSERT" in statusmessage or \
             "UPSERT" in statusmessage:
         changed = True
 

--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -30,7 +30,7 @@ description:
      Number of rows affected are returned as "row_count".
    - Can read queries from a .sql script files.
    - SQL scripts may be templated with ansible variables at execution time.
-   - Run queries in check_mode and then roll them back (autocommit must be disabled).
+   - Run queries in check_mode (will roll them back, autocommit must be disabled). This may affect performance of a busy cluster and it may incur side effects.
 version_added: "2.4"
 options:
   db:

--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -127,6 +127,7 @@ rowcount:
 
 __metaclass__ = type
 import traceback
+import os
 from ansible.module_utils.six import iteritems
 from ansible.module_utils.basic import AnsibleModule
 import ansible.module_utils.postgres as pgutils
@@ -210,6 +211,7 @@ def main():
     # if query is a file, try read it
     query = module.params["query"]
     if query.endswith('.sql'):
+        query = os.path.expanduser(query)
         try:
             query = open(query, 'r').read().strip('\n')
         except Exception as e:

--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -151,7 +151,8 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         mutually_exclusive=[
-            ["positional_args", "named_args"]
+            ["positional_args", "named_args"],
+            ["login_host", "login_unix_socket"]
         ],
         supports_check_mode=False,
     )
@@ -177,12 +178,6 @@ def main():
 
     kw = dict((params_map[k], v) for (k, v) in iteritems(module.params)
               if k in params_map and v != '' and v is not None)
-
-    # If a login_unix_socket is specified, incorporate it here.
-    is_localhost = "host" not in kw or kw["host"] == "" or kw["host"] == "localhost"
-
-    if is_localhost and module.params["login_unix_socket"] != "":
-        kw["host"] = module.params["login_unix_socket"]
 
     try:
         pgutils.ensure_libs(sslrootcert=module.params.get('ssl_rootcert'))

--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -129,10 +129,11 @@ rowcount:
     sample: 5
 '''
 
-import traceback
 import os
+import traceback
 from ansible.module_utils.six import iteritems
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
 import ansible.module_utils.postgres as pgutils
 
 
@@ -193,18 +194,9 @@ def main():
         # Using RealDictCursor allows access to row results by real column name
         cursor = db_connection.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
 
-    except TypeError as e:
-        db_connection.close()
-        if 'sslrootcert' in e.args[0]:
-            module.fail_json(msg='''Postgresql server must be at least version
-                             8.4 to support sslrootcert.
-                             Exception: {0}'''.format(e), exception=traceback.format_exc())
-
-        module.fail_json(msg="unable to connect to database: %s" % e, exception=traceback.format_exc())
-
     except Exception as e:
         db_connection.close()
-        module.fail_json(msg="unable to connect to database: {0}".format(str(e)), exception=traceback.format_exc())
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
 
     # if query is a file, try read it
     query = module.params["query"]

--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -2,6 +2,9 @@
 # Copyright (c) 2017 Felix Archambault
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
     'supported_by': 'community',
@@ -125,7 +128,6 @@ rowcount:
     sample: 5
 '''
 
-__metaclass__ = type
 import traceback
 import os
 from ansible.module_utils.six import iteritems

--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -1,128 +1,65 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
+# Copyright (c) 2017 Felix Archambault
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-
-ANSIBLE_METADATA = {'metadata_version': '1.0',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'supported_by': 'community',
+    'status': ['preview']
+}
 
 DOCUMENTATION = '''
 ---
 module: postgresql_query
-short_description: Run arbitrary queries on a postgresql database.
+short_description: Run arbitrary PostgreSQL queries.
 description:
-   - Run arbitrary SQL queries against a PostgreSQL instance from the current host.
-   - Query results are returned as "query_results" as a list of dictionaries.
-     Number of rows affected are returned as "row_count".
+   - Run arbitrary PostgreSQL queries.
    - Can read queries from a .sql script files.
    - SQL scripts may be templated with ansible variables at execution time.
+   - >
+    Query results may be assigned to a variable for later reuse during ansible
+    runtime.
 version_added: "2.4"
 options:
-  db:
-    description:
-      - name of the database to run queries against.
-    required: false
-    default: None
-  port:
-    description:
-      - Database port to connect to.
-    required: false
-    default: 5432
-  login_user:
-    description:
-      - User (role) used to authenticate with PostgreSQL.
-    required: false
-    default: postgres
-  login_password:
-    description:
-      - Password used to authenticate with PostgreSQL.
-    required: false
-    default: null
-  login_host:
-    description:
-      - Host running PostgreSQL.
-    required: false
-    default: localhost
-  login_unix_socket:
-    description:
-      - Path to a Unix domain socket for local connections.
-    required: false
-    default: null
-  query:
-    description:
-      - SQL query to run. Variables can be escaped with psycopg2 syntax.
-      - Can be a SQL scripts file.
-    required: true
-  positional_args:
-    description:
-      - A list of values to be passed as positional arguments to the query.
-      - Cannot be used with named_args.
-    required: false
-    default: null
-  autocommit:
-      description:
-        - Enable transaction autocommit.
-      required: false
-      default: false
-      type: bool
-  named_args:
-    description:
-      - A dictionary of key-value arguments to pass to the query.
-      - Cannot be used with positional_args.
-    required: false
-    default: null
-  fact:
-    description:
-        - Assign the query_results to a key by the name of this arg.
-        - Will make this new variable available as a fact to subsequent tasks.
-    required: false
-    default: null
-  ssl_mode:
-    description:
-      - Determines whether or with what priority a secure SSL TCP/IP connection will be negotiated with the server.
-      - See https://www.postgresql.org/docs/current/static/libpq-ssl.html for more information on the modes.
-      - Default of C(prefer) matches libpq default.
-    required: false
-    default: prefer
-    choices: [disable, allow, prefer, require, verify-ca, verify-full]
-  ssl_rootcert:
-    description:
-      - Specifies the name of a file containing SSL certificate authority (CA) certificate(s).
-      - If the file exists, the server's certificate will be verified to be signed by one of these authorities.
-    required: false
-    default: null
-notes:
-   - The default authentication assumes that you are either logging in as or
-     sudo'ing to the postgres account on the host.
-   - This module uses psycopg2, a Python PostgreSQL database adapter. You must
-     ensure that psycopg2 is installed on the host before using this module. If
-     the remote host is the PostgreSQL server (which is the default case), then
-     PostgreSQL must also be installed on the remote host. For Ubuntu-based
-     systems, install the postgresql, libpq-dev, and python-psycopg2 packages
-     on the remote host before using this module.
-   - If the passlib library is installed, then passwords that are encrypted
-     in the DB but not encrypted when passed as arguments can be checked for
-     changes. If the passlib library is not installed, unencrypted passwords
-     stored in the DB encrypted will be assumed to have changed.
-   - If you specify PUBLIC as the user, then the privilege changes will apply
-     to all users. You may not specify password or role_attr_flags when the
-     PUBLIC user is specified.
-   - The ssl_rootcert parameter requires at least Postgres version 8.4 and I(psycopg2) version 2.4.3.
-requirements: [ psycopg2 ]
+    db:
+        description:
+            - name of the database to run queries against.
+        required: false
+        default: None
+    query:
+        description:
+            - SQL query to run. Variables can be escaped with psycopg2 syntax.
+            - Can be a SQL scripts file.
+        required: true
+    positional_args:
+        description:
+            - List of values to be passed as positional arguments to the query.
+            - Cannot be used with I(named_args).
+        required: false
+        default: null
+    named_args:
+        description:
+            - Dictionary of key-value arguments to pass to the query.
+            - Cannot be used with I(positional_args).
+        required: false
+        default: null
+    name:
+        description:
+            - The name of a variable into which assign the query_results.
+            - Will make this new variable available as a fact to subsequent tasks.
+        required: false
+        default: null
+    autocommit:
+        description:
+            - Enable transaction autocommit.
+        required: false
+        default: false
+        type: bool
+
+extends_documentation_fragment:
+- postgres
+
+requirements: [psycopg2]
 author:
     - "Felix Archambault (@archf)"
     - "Will Rouesnel (@wrouesnel)"
@@ -139,7 +76,7 @@ EXAMPLES = '''
       - "positional string value 1"
       - "positional string value 2"
 
-# Insert or update a record in a table with named arguments
+# Insert or update a record in a table with named arguments.
 - postgresql_query:
     db: acme
     login_user: django
@@ -149,8 +86,8 @@ EXAMPLES = '''
       a_value: "positional string value 1"
       b_value: "positional string value 2"
 
-
-# Run queries from a '.sql' file
+# Run queries from a '.sql' file. This file may contain placeholders as shown
+# here.
 - postgresql_query:
     db: acme
     login_user: django
@@ -172,7 +109,7 @@ EXAMPLES = '''
     named_args:
       a_value: "positional string value 1"
       b_value: "positional string value 2"
-    fact: my_key
+    name: my_key
 '''
 
 RETURN = '''
@@ -181,16 +118,17 @@ query_results:
     returned: changed
     type: list
     sample: [{"Column": "Value1"},{"Column": "Value2"}]
-row_count:
-    description: number of affected rows by query, if applicable
+rowcount:
+    description: Number of affected rows by query, if applicable.
     returned: changed
     type: int
     sample: 5
 '''
 
+__metaclass__ = type
 import traceback
 from ansible.module_utils.six import iteritems
-from ansible.module_utils.basic import AnsibleModule, BOOLEANS
+from ansible.module_utils.basic import AnsibleModule
 import ansible.module_utils.postgres as pgutils
 
 
@@ -199,11 +137,11 @@ def main():
 
     argument_spec.update(dict(
         db=dict(default=None),
-        query=dict(type="str"),
-        autocommit=dict(type='bool', default=False, choices=BOOLEANS),
+        query=dict(required=True, default=None),
+        autocommit=dict(type="bool", default=False),
         positional_args=dict(type="list"),
         named_args=dict(type="dict"),
-        fact=dict(default=None),
+        name=dict(default=None),
     ))
 
     module = AnsibleModule(
@@ -257,25 +195,26 @@ def main():
         cursor = db_connection.cursor(cursor_factory=psycopg2.extras.RealDictCursor)
 
     except TypeError as e:
+        db_connection.close()
         if 'sslrootcert' in e.args[0]:
             module.fail_json(msg='''Postgresql server must be at least version
                              8.4 to support sslrootcert.
                              Exception: {0}'''.format(e), exception=traceback.format_exc())
+
         module.fail_json(msg="unable to connect to database: %s" % e, exception=traceback.format_exc())
-        db_connection.close()
 
     except Exception as e:
-        module.fail_json(msg="unable to connect to database: {0}".format(str(e)), exception=traceback.format_exc())
         db_connection.close()
+        module.fail_json(msg="unable to connect to database: {0}".format(str(e)), exception=traceback.format_exc())
 
-    # if query is a file, load the file and run it
+    # if query is a file, try read it
     query = module.params["query"]
     if query.endswith('.sql'):
         try:
             query = open(query, 'r').read().strip('\n')
         except Exception as e:
-            module.fail_json(msg="Unable to find '%s' in given path." % query)
             db_connection.close()
+            module.fail_json(msg="Unable to find '%s' in given path." % query)
 
     # prepare args
     if module.params["positional_args"] is not None:
@@ -285,13 +224,15 @@ def main():
     else:
         arguments = None
 
+    # execute query
     try:
         cursor.execute(query, arguments)
     except Exception as e:
+        db_connection.close()
         module.fail_json(msg="Unable to execute query: %s" % e,
                          query_arguments=arguments)
-        db_connection.close()
 
+    # retreive results
     if cursor.rowcount > 0:
         # There's no good way to return results arbitrarily without inspecting
         # the SQL, so we act consistent and return the empty set when there's
@@ -302,7 +243,7 @@ def main():
             pass
 
         rowcount = len(query_results)
-        fact = module.params["fact"]
+        fact = module.params["name"]
         if fact is not None:
             ansible_facts = {fact: query_results}
 

--- a/lib/ansible/modules/database/postgresql/postgresql_query.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_query.py
@@ -32,7 +32,8 @@ options:
     query:
         description:
             - SQL query to run. Variables can be escaped with psycopg2 syntax.
-            - Can be a SQL scripts file.
+            - See U(http://initd.org/psycopg/docs/usage.html) and examples below.
+            - This argument can also be a path to a SQL script file.
         required: true
     positional_args:
         description:


### PR DESCRIPTION
##### SUMMARY
New `postgresql_query` module as a companion to other `postgresql_*` modules. Run queries passed as arg or as sql scripts. See documentation in module.

I know of [PR #20793](https://github.com/ansible/ansible/pull/20793) but it seems stuck. I made this one in a attempt to solve the issues and add the capabilities to execute a .sql script file. If someone can review i will resolve any upcoming issues.

I adapted from the one embedded i use in [this role i made](https://github.com/archf/ansible-sql-runner). If anyone shows interests i can also make a PR for the impala_query module.

##### ISSUE TYPE

 - New Module Pull Request