### PR TITLE
document fail module parameters feeding behavior.

### DIFF
--- a/lib/ansible/modules/utilities/logic/fail.py
+++ b/lib/ansible/modules/utilities/logic/fail.py
@@ -38,6 +38,9 @@ options:
         fail will simply bail out with a generic message.
     required: false
     default: "'Failed as requested from task'"
+notes:
+  - This action module will silently take any number of parameters in addition to C(msg)
+    without warnings, beware of indentation issues if you are using C(when) conditionals. 
 
 author: "Dag Wieers (@dagwieers)"
 '''

--- a/lib/ansible/modules/utilities/logic/fail.py
+++ b/lib/ansible/modules/utilities/logic/fail.py
@@ -40,7 +40,7 @@ options:
     default: "'Failed as requested from task'"
 notes:
   - This action module will silently take any number of parameters in addition to C(msg)
-    without warnings, beware of indentation issues if you are using C(when) conditionals. 
+    without warnings, beware of indentation issues if you are using C(when) conditionals.
 
 author: "Dag Wieers (@dagwieers)"
 '''


### PR DESCRIPTION
##### SUMMARY
The fail module silently feeds on any number of parameters. I thought this was worth documenting.


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/utilities/logic/fail.py

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'../../../../library']
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```