### PR TITLE
Revert the accidental addition of python-lxml

### DIFF
--- a/test/utils/docker/cloudstack-simulator/Dockerfile
+++ b/test/utils/docker/cloudstack-simulator/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get -y update && apt-get install -y \
     netcat \
     openjdk-8-jdk \
     python-dev \
-    python-lxml \
     python-mysql.connector \
     python-pip \
     python-setuptools \


### PR DESCRIPTION
##### SUMMARY
I inadvertedly added python-lxml to the cloudstack-simulator Dockerfile.

This PR reverts this specific change.

This relates to PR #25324

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Docker files

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.4