### PR TITLE
Add tzdata back

### DIFF
--- a/test/utils/docker/ubuntu1204/Dockerfile
+++ b/test/utils/docker/ubuntu1204/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get update -y && \
     rubygems \
     subversion \
     sudo \
+    tzdata \
     unzip \
     xsltproc \
     zip \

--- a/test/utils/docker/ubuntu1404/Dockerfile
+++ b/test/utils/docker/ubuntu1404/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update -y && \
     ruby \
     subversion \
     sudo \
+    tzdata \
     unzip \
     xsltproc \
     zip \

--- a/test/utils/docker/ubuntu1604/Dockerfile
+++ b/test/utils/docker/ubuntu1604/Dockerfile
@@ -46,6 +46,7 @@ RUN apt-get update -y && \
     ruby \
     subversion \
     sudo \
+    tzdata \
     unzip \
     virtualenv \
     xsltproc \

--- a/test/utils/docker/ubuntu1604py3/Dockerfile
+++ b/test/utils/docker/ubuntu1604py3/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update -y && \
     ruby \
     subversion \
     sudo \
+    tzdata \
     unzip \
     virtualenv \
     xsltproc \


### PR DESCRIPTION
##### SUMMARY

It appears that the base Docker images have removed tzdata.
We use tzdata in the debconf tests, so add it back.



##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
debconf

##### ANSIBLE VERSION
```
2.4.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
