### PR TITLE
cloud: ovirt: add localfs option to storage_domains module

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
@@ -61,6 +61,12 @@ options:
     host:
         description:
             - "Host to be used to mount storage."
+    localfs:
+        description:
+            - "Dictionary with values for localfs storage type:"
+            - "C(path) - Path of the mount point. E.g.: /path/to/my/data"
+            - "Note that these parameters are not idempotent."
+        version_added: "2.4"
     nfs:
         description:
             - "Dictionary with values for NFS storage type:"
@@ -125,6 +131,14 @@ EXAMPLES = '''
     nfs:
       address: 10.34.63.199
       path: /path/data
+
+# Add data localfs storage domain
+- ovirt_storage_domains:
+    name: data_localfs
+    host: myhost
+    data_center: mydatacenter
+    localfs:
+      path: /path/to/data
 
 # Add data iSCSI storage domain:
 - ovirt_storage_domains:
@@ -209,12 +223,12 @@ from ansible.module_utils.ovirt import (
 class StorageDomainModule(BaseModule):
 
     def _get_storage_type(self):
-        for sd_type in ['nfs', 'iscsi', 'posixfs', 'glusterfs', 'fcp']:
+        for sd_type in ['nfs', 'iscsi', 'posixfs', 'glusterfs', 'fcp', 'localfs']:
             if self._module.params.get(sd_type) is not None:
                 return sd_type
 
     def _get_storage(self):
-        for sd_type in ['nfs', 'iscsi', 'posixfs', 'glusterfs', 'fcp']:
+        for sd_type in ['nfs', 'iscsi', 'posixfs', 'glusterfs', 'fcp', 'localfs']:
             if self._module.params.get(sd_type) is not None:
                 return self._module.params.get(sd_type)
 
@@ -412,6 +426,7 @@ def main():
         data_center=dict(required=True),
         domain_function=dict(choices=['data', 'iso', 'export'], default='data', aliases=['type']),
         host=dict(default=None),
+        localfs=dict(default=None, type='dict'),
         nfs=dict(default=None, type='dict'),
         iscsi=dict(default=None, type='dict'),
         posixfs=dict(default=None, type='dict'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR add new parameter to `ovirt_storage_domains` module to support localfs storage type.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt_storage_domains

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
```yaml
# Add data localfs storage domain
- ovirt_storage_domains:
    name: data_localfs
    host: myhost
    data_center: mydatacenter
    localfs:
      path: /path/to/data
```