### PR TITLE
Fix manual reference for dmidecode (rebase 24106)

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/netbsd.py
+++ b/lib/ansible/module_utils/facts/hardware/netbsd.py
@@ -138,9 +138,9 @@ class NetBSDHardware(Hardware):
 
     def get_dmi_facts(self):
         dmi_facts = {}
-        # We don't use dmidecode(1) here because:
+        # We don't use dmidecode(8) here because:
         # - it would add dependency on an external package
-        # - dmidecode(1) can only be ran as root
+        # - dmidecode(8) can only be ran as root
         # So instead we rely on sysctl(8) to provide us the information on a
         # best-effort basis. As a bonus we also get facts on non-amd64/i386
         # platforms this way.

--- a/lib/ansible/module_utils/facts/hardware/openbsd.py
+++ b/lib/ansible/module_utils/facts/hardware/openbsd.py
@@ -146,9 +146,9 @@ class OpenBSDHardware(Hardware):
 
     def get_dmi_facts(self):
         dmi_facts = {}
-        # We don't use dmidecode(1) here because:
+        # We don't use dmidecode(8) here because:
         # - it would add dependency on an external package
-        # - dmidecode(1) can only be ran as root
+        # - dmidecode(8) can only be ran as root
         # So instead we rely on sysctl(8) to provide us the information on a
         # best-effort basis. As a bonus we also get facts on non-amd64/i386
         # platforms this way.


### PR DESCRIPTION
dmidecode(1) does not exist, dmidecode(8) does exists.

(rebased from https://github.com/ansible/ansible/pull/24106)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
