### PR TITLE
Add UUID, label and id links to devices when building facts (based on 23477)

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -16,11 +16,15 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import collections
 import errno
+import glob
 import json
 import os
 import re
 import sys
+
+from ansible.module_utils.six import iteritems
 
 from ansible.module_utils.basic import bytes_to_human
 
@@ -450,6 +454,41 @@ class LinuxHardware(Hardware):
 
         return mount_facts
 
+    def get_device_links(self, link_dir):
+        if not os.path.exists(link_dir):
+            return {}
+        try:
+            retval = collections.defaultdict(set)
+            for entry in os.listdir(link_dir):
+                try:
+                    target = os.path.basename(os.readlink(os.path.join(link_dir, entry)))
+                    retval[target].add(entry)
+                except OSError:
+                    continue
+            return dict((k, list(sorted(v))) for (k, v) in iteritems(retval))
+        except OSError:
+            return {}
+
+    def get_all_device_owners(self):
+        try:
+            retval = collections.defaultdict(set)
+            for path in glob.glob('/sys/block/*/slaves/*'):
+                elements = path.split('/')
+                device = elements[3]
+                target = elements[5]
+                retval[target].add(device)
+            return dict((k, list(sorted(v))) for (k, v) in iteritems(retval))
+        except OSError:
+            return {}
+
+    def get_all_device_links(self):
+        return {
+            'ids': self.get_device_links('/dev/disk/by-id'),
+            'uuids': self.get_device_links('/dev/disk/by-uuid'),
+            'labels': self.get_device_links('/dev/disk/by-label'),
+            'masters': self.get_all_device_owners(),
+        }
+
     def get_holders(self, block_dev_dict, sysdir):
         block_dev_dict['holders'] = []
         if os.path.isdir(sysdir + "/holders"):
@@ -491,6 +530,9 @@ class LinuxHardware(Hardware):
                         continue
                     devs_wwn[os.path.basename(wwn_link)] = link_name[4:]
 
+        links = self.get_all_device_links()
+        device_facts['device_links'] = links
+
         for block in block_devs:
             virtual = 1
             sysfs_no_links = 0
@@ -503,17 +545,17 @@ class LinuxHardware(Hardware):
                     sysfs_no_links = 1
                 else:
                     continue
-            if "virtual" in path:
-                continue
             sysdir = os.path.join("/sys/block", path)
             if sysfs_no_links == 1:
                 for folder in os.listdir(sysdir):
                     if "device" in folder:
                         virtual = 0
                         break
-                if virtual:
-                    continue
             d = {}
+            d['virtual'] = virtual
+            d['links'] = {}
+            for (link_type, link_values) in iteritems(links):
+                d['links'][link_type] = link_values.get(block, [])
             diskname = os.path.basename(sysdir)
             for key in ['vendor', 'model', 'sas_address', 'sas_device_handle']:
                 d[key] = get_file_content(sysdir + "/device/" + key)
@@ -547,8 +589,13 @@ class LinuxHardware(Hardware):
                     partname = m.group(1)
                     part_sysdir = sysdir + "/" + partname
 
+                    part['links'] = {}
+                    for (link_type, link_values) in iteritems(links):
+                        part['links'][link_type] = link_values.get(partname, [])
+
                     part['start'] = get_file_content(part_sysdir + "/start", 0)
                     part['sectors'] = get_file_content(part_sysdir + "/size", 0)
+
                     part['sectorsize'] = get_file_content(part_sysdir + "/queue/logical_block_size")
                     if not part['sectorsize']:
                         part['sectorsize'] = get_file_content(part_sysdir + "/queue/hw_sector_size", 512)


### PR DESCRIPTION
Rebase of https://github.com/ansible/ansible/pull/23477. Opened this pull request to get a CI run on it.

At present, the available facts around block devices are not sufficient to be able to find stable names guaranteed to work across reboots, or to identify block devices by label (UUID, etc).

This patch provides a list of observed links for each device. It relies on functionality specific to Linux (as does the existing sysfs-based code which it extends), but should not cause issues on other platforms.

Moreover, it prevents virtual devices from being excluded, and links such devices to the physical devices to which they are attached.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
