### PR TITLE
win_get_url improvements; allow dir for dest and helpful error if dest parent dir doesn't exist

### DIFF
--- a/lib/ansible/modules/windows/win_get_url.ps1
+++ b/lib/ansible/modules/windows/win_get_url.ps1
@@ -44,7 +44,23 @@ if($skip_certificate_validation){
     [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
 }
 
+
 Function Download-File($result, $url, $dest, $username, $password, $proxy_url, $proxy_username, $proxy_password) {
+    # use last part of url for dest file name if a directory is supplied for $dest
+    If ( Test-Path -PathType Container $dest ) {
+       $url_basename = Split-Path -leaf $url
+       If ( $url_basename.Length -gt 0 ) {
+          $dest = Join-Path -Path $dest -ChildPath $url_basename
+          $result.win_get_url.actual_dest = $dest
+       }
+    }
+    # check $dest parent folder exists before attempting download, which avoids unhelpful generic error message.
+    $dest_parent = Split-Path -Path $dest
+    $result.win_get_url.dest_parent = $dest_parent
+    If ( -not (Test-Path -Path $dest_parent -PathType Container)) {
+        $result.changed = $false
+        Fail-Json $result "The path '$dest_parent' does not exist for destination '$dest', or is not visible to the current user.  Ensure download destination folder exists (perhaps using win_file state=directory) before win_get_url runs."
+    }
     $webClient = New-Object System.Net.WebClient
     if($proxy_url) {
         $proxy_server = New-Object System.Net.WebProxy($proxy_url, $true)
@@ -68,11 +84,11 @@ Function Download-File($result, $url, $dest, $username, $password, $proxy_url, $
     Catch {
         Fail-Json $result "Error downloading $url to $dest $($_.Exception.Message)"
     }
-
 }
 
 
 If ($force -or -not (Test-Path -Path $dest)) {
+    
     Download-File -result $result -url $url -dest $dest -username $username -password $password -proxy_url $proxy_url -proxy_username $proxy_username -proxy_password $proxy_password
 }
 Else {
@@ -112,4 +128,4 @@ Else {
 
 }
 
-Exit-Json $result;
+Exit-Json $result

--- a/test/integration/targets/win_get_url/defaults/main.yml
+++ b/test/integration/targets/win_get_url/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 
-test_win_get_url_link: https://www.redhat.com
+test_win_get_url_host: www.redhat.com
+test_win_get_url_link: "https://{{test_win_get_url_host}}"
 test_win_get_url_invalid_link: https://www.redhat.com/skynet_module.html
-test_win_get_url_invalid_path: "Q:\\Filez\\Cyberdyne.html"
-test_win_get_url_path: "{{ test_win_get_url_dir_path }}\\docs_index.html"
+test_win_get_url_invalid_path: 'Q:\Filez\Cyberdyne.html'
+test_win_get_url_invalid_path_dir: 'Q:\Filez\'
+test_win_get_url_path: '{{ test_win_get_url_dir_path }}\docs_index.html'

--- a/test/integration/targets/win_get_url/tasks/main.yml
+++ b/test/integration/targets/win_get_url/tasks/main.yml
@@ -99,7 +99,38 @@
   register: win_get_url_result_dir_path
   ignore_errors: true
 
-- name: check that the download failed if dest is a directory
+- name: check that the download did NOT fail, even though dest was directory
   assert:
     that:
-      - "win_get_url_result_dir_path|failed"
+      - "win_get_url_result_dir_path|changed"
+
+- name: test win_get_url with a valid url path and a dest that is a directory (from 2.4 should use url path as filename)
+  win_get_url:
+    url: "{{test_win_get_url_link}}"
+    dest: "{{test_win_get_url_dir_path}}"
+  register: win_get_url_result_dir_path_urlpath
+  ignore_errors: true
+
+- name: set expected destination path fact
+  set_fact:
+    expected_dest_path: '{{test_win_get_url_dir_path}}\{{test_win_get_url_host}}'
+
+- name: check that the download succeeded (changed) and dest is as expected
+  assert:
+    that:
+      - "win_get_url_result_dir_path_urlpath|changed"
+      - "win_get_url_result_dir_path_urlpath.win_get_url.actual_dest==expected_dest_path"
+
+- name: since 2.4 check you get a helpful message if the parent folder of the dest doesnt exist
+  win_get_url:
+    url: "{{test_win_get_url_link}}"
+    dest: "{{test_win_get_url_invalid_path_dir}}"
+  register: win_get_url_result_invalid_dest
+  ignore_errors: true
+
+- name: check if dest parent dir does not exist, module fails and you get a specific error message
+  assert:
+    that:
+      - "win_get_url_result_invalid_dest|failed"
+      - "win_get_url_result_invalid_dest.msg is search('does not exist')"
+

--- a/test/integration/targets/win_get_url/tasks/main.yml
+++ b/test/integration/targets/win_get_url/tasks/main.yml
@@ -133,4 +133,3 @@
     that:
       - "win_get_url_result_invalid_dest|failed"
       - "win_get_url_result_invalid_dest.msg is search('does not exist')"
-


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Following a long discovery on https://github.com/ansible/ansible/issues/24128 I decided to make these two changes to make win_get_url more like get_url (allow a dir for dest) and to return more helpful error if the destination parent dir doesn't exist.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_get_url
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (win_get_url_parent_dir_check 605cade576) last updated 2017/06/07 21:33:37 (GMT +100)
  config file =
  configured module search path = [u'/home/jon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jon/ansible-dev/lib/ansible
  executable location = /home/jon/ansible-dev/bin/ansible
  python version = 2.7.6 (default, Jun 22 2015, 17:58:13) [GCC 4.8.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Destination file is calculated based on the last part of the supplied url.  So depending on url it could be a hostname or a path.

url: http://www.example.com/
calculated_filename: www.example.com
url: http://www.examples.com/index.html
calculated_filename: index.html 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
See updated integration tests for output differences.


```
