### PR TITLE
Bug/docker service stderr3

### DIFF
--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -108,7 +108,6 @@ lib/ansible/modules/cloud/docker/docker_image.py
 lib/ansible/modules/cloud/docker/docker_image_facts.py
 lib/ansible/modules/cloud/docker/docker_login.py
 lib/ansible/modules/cloud/docker/docker_network.py
-lib/ansible/modules/cloud/docker/docker_service.py
 lib/ansible/modules/cloud/google/gc_storage.py
 lib/ansible/modules/cloud/google/gcdns_record.py
 lib/ansible/modules/cloud/google/gcdns_zone.py


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
`docker_service`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (bug/docker_service_stderr3 8e15fe9f76) last updated 2017/01/19 21:05:29 (GMT +100)
  config file = /Users/shabble/work/mhn-automation/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Extends the output-capturing behaviour to include stderr when calling `docker-compose` as a library, since it typically raises empty exceptions and logs useful diagnostic info to stderr by default.  Without access to this output, it is extremely difficult to determine why a docker-compose task might be failing, especially with inline definitions or templated compose-files.

This PR mostly just replicates ansible/ansible-modules-core#5165 and extends the handling to consider stderr as well.

There's a little bit of logic in trying to guess the appropriate message to include in the `.fail_json` msg parameter, but module stderr and stdout are included unmodified in case it guesses wrongly.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #20480 
<!-- Paste verbatim command output below, e.g. before and after your change -->

Output before (-vvv)
```
[...]
fatal: [ansibledocker.mhn]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_args": {
            "api_version": null,
            "build": false,
            "cacert_path": null,
            "cert_path": null,
            "debug": true,
            "definition": {
                "services": {
                    "testcontainer": {
                        "command": "sleep 100",
                        "image": "busybox",
                        "ports": [
                            "8001:8000"
                        ]
                    },
                    "testcontainer2": {
                        "command": "sleep 100",
                        "image": "busybox",
                        "ports": [
                            "8001:8000"
                        ]
                    }
                },
                "version": "2"
            },
            "dependencies": true,
            "docker_host": null,
            "files": null,
            "filter_logger": false,
            "hostname_check": false,
            "key_path": null,
            "nocache": false,
            "project_name": "foo",
            "project_src": null,
            "pull": false,
            "recreate": "smart",
            "remove_images": null,
            "remove_orphans": false,
            "remove_volumes": false,
            "restarted": false,
            "scale": null,
            "services": null,
            "ssl_version": null,
            "state": "present",
            "stopped": false,
            "timeout": 10,
            "tls": null,
            "tls_hostname": null,
            "tls_verify": null
        },
        "module_name": "docker_service"
    },
    "module_stderr": "",
    "module_stdout": "",
    "msg": "Error starting project "
}

```
Using testcase from bug in #20480 

Output after:
```
fatal: [ansibledocker.mhn]: FAILED! => {
    "changed": false,
    "errors": [
        "ERROR: for testcontainer2  Cannot start service testcontainer2: driver failed programming external connectivity on endpoint foo_testcontainer2_1 (d1b78ff057e5e00b8c2711781292ba76eff9928024e944dc275ecc76b98f9b20): Bind for 0.0.0.0:8001 failed: port is already allocated"
    ],
    "failed": true,
    "invocation": {
        "module_args": {
            "api_version": null,
            "build": false,
            "cacert_path": null,
            "cert_path": null,
            "debug": true,
            "definition": {
                "services": {
                    "testcontainer": {
                        "command": "sleep 100",
                        "image": "busybox",
                        "ports": [
                            "8001:8000"
                        ]
                    },
                    "testcontainer2": {
                        "command": "sleep 100",
                        "image": "busybox",
                        "ports": [
                            "8001:8000"
                        ]
                    }
                },
                "version": "2"
            },
            "dependencies": true,
            "docker_host": null,
            "files": null,
            "filter_logger": false,
            "hostname_check": false,
            "key_path": null,
            "nocache": false,
            "project_name": "foo",
            "project_src": null,
            "pull": false,
            "recreate": "smart",
            "remove_images": null,
            "remove_orphans": false,
            "remove_volumes": false,
            "restarted": false,
            "scale": null,
            "services": null,
            "ssl_version": null,
            "state": "present",
            "stopped": false,
            "timeout": 10,
            "tls": null,
            "tls_hostname": null,
            "tls_verify": null
        },
        "module_name": "docker_service"
    },
    "module_stderr": "\nERROR: for testcontainer2  Cannot start service testcontainer2: driver failed programming external connectivity on endpoint foo_testcontainer2_1 (d1b78ff057e5e00b8c2711781292ba76eff9928024e944dc275ecc76b98f9b20): Bind for 0.0.0.0:8001 failed: port is already allocated\n",
    "module_stdout": "",
    "msg": "Error starting project ERROR: for testcontainer2  Cannot start service testcontainer2: driver failed programming external connectivity on endpoint foo_testcontainer2_1 (d1b78ff057e5e00b8c2711781292ba76eff9928024e944dc275ecc76b98f9b20): Bind for 0.0.0.0:8001 failed: port is already allocated",
    "warnings": []
}
```

###### Review considerations

* Correct use of `.encode()` when processing output? I'm not totally confident this is currently ideal.
* Inclusion of empty dicts in returned json? In the example, `warnings` is empty but still included. I'm not sure if it would make more sense to omit it entirely if so.

Replaces PR #20510