### PR TITLE
Missing Else statement win_acl.ps1 

### DIFF
--- a/lib/ansible/modules/windows/win_acl.ps1
+++ b/lib/ansible/modules/windows/win_acl.ps1
@@ -84,6 +84,7 @@ Function UserSearch
             return $apppoolobj.applicationPoolSid
         }
     }
+    Else
     {
         #Search by samaccountname
         $Searcher = [adsisearcher]""


### PR DESCRIPTION
Missing the final Else statement in the conditional statement

##### SUMMARY
The powershell script is missing the final Else catch in the conditional logic. A co-worker and I ran into this problem (he is the one who actually found it @silverbp) and did not discover it until we debugged the module and inspected the result. Since the Else statement is missing, the return value is the entire block of powershell code, instead of the actual computed value.

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
/lib/ansible/modules/windows/win_acl.ps1

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```