### PR TITLE
Strict Mode fix for IIS versions earlier than IIS8. Check for presence of sslFlags property before using it.

### DIFF
--- a/lib/ansible/modules/windows/win_iis_webbinding.ps1
+++ b/lib/ansible/modules/windows/win_iis_webbinding.ps1
@@ -58,14 +58,19 @@ if ((Get-Module "WebAdministration" -ErrorAction SilentlyContinue) -eq $null){
 }
 
 function Create-Binding-Info {
-  return New-Object psobject @{
+  $binding_info = New-Object psobject @{
     "bindingInformation" = $args[0].bindingInformation
     "certificateHash" = $args[0].certificateHash
     "certificateStoreName" = $args[0].certificateStoreName
     "isDsMapperEnabled" = $args[0].isDsMapperEnabled
     "protocol" = $args[0].protocol
-    "sslFlags" = $args[0].sslFlags
   }
+
+  if(Get-Member -InputObject $args[0] -MemberType Properties -Name sslFlags ) {
+      $binding_info | Add-Member -NotePropertyName sslFlags -NotePropertyValue $args[0].sslFlags
+  }
+
+  return $binding_info
 }
 
 # Result


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

win_iis_webbinding.ps1
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Fixes #25470

Website property 'sslFlags' was only added in IIS8. When using an earlier version of IIS, this property will not exist in the response from Get-WebBinding. This change checks for its presence before adding it to the binding info object.

*Migrated from ansible/ansible-modules-extras#2752 by dagwieers (not original author)*