### PR TITLE
Don't fail when creating a Foreman organization fixes(#25299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Ansible Changes By Release
 * Fix so ansilbe-galaxy install --force with unversioned roles will once again
   overwrite old versions.
 * Fix for RabbitMQ 3.6.7 endpoint return code changing.
+* Fix for Foreman organization creation
 
 ## 2.3.1 "Ramble On" - 2017-06-01
 

--- a/lib/ansible/modules/remote_management/foreman/foreman.py
+++ b/lib/ansible/modules/remote_management/foreman/foreman.py
@@ -93,7 +93,7 @@ class NailGun(object):
         if len(response) == 1:
             return response[0]
         else:
-            self._module.fail_json(msg="No Content View found for %s" % name)
+            return None
 
     def organization(self, params):
         name = params['name']


### PR DESCRIPTION
##### SUMMARY
The module would bail if the organization did not already exist and skip creating it, this should fix it.



##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
