### PR TITLE
ec2 module convert basestring to string_types

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -621,6 +621,7 @@ from ansible.module_utils.six import get_function_code
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import get_aws_connection_info, ec2_argument_spec, ec2_connect, connect_to_aws
 from distutils.version import LooseVersion
+from ansible.module_utils.six import string_types
 
 try:
     import boto.ec2
@@ -1039,7 +1040,7 @@ def create_instances(module, ec2, vpc, override_count=None):
                 grp_details = ec2.get_all_security_groups(filters={'vpc_id': vpc_id})
             else:
                 grp_details = ec2.get_all_security_groups()
-            if isinstance(group_name, basestring):
+            if isinstance(group_name, string_types):
                 group_name = [group_name]
             unmatched = set(group_name).difference(str(grp.name) for grp in grp_details)
             if len(unmatched) > 0:
@@ -1048,7 +1049,7 @@ def create_instances(module, ec2, vpc, override_count=None):
         # Now we try to lookup the group id testing if group exists.
         elif group_id:
             # wrap the group_id in a list if it's not one already
-            if isinstance(group_id, basestring):
+            if isinstance(group_id, string_types):
                 group_id = [group_id]
             grp_details = ec2.get_all_security_groups(group_ids=group_id)
             group_name = [grp_item.name for grp_item in grp_details]
@@ -1122,7 +1123,7 @@ def create_instances(module, ec2, vpc, override_count=None):
                     params['network_interfaces'] = interfaces
             else:
                 if network_interfaces:
-                    if isinstance(network_interfaces, basestring):
+                    if isinstance(network_interfaces, string_types):
                         network_interfaces = [network_interfaces]
                     interfaces = []
                     for i, network_interface_id in enumerate(network_interfaces):
@@ -1217,7 +1218,7 @@ def create_instances(module, ec2, vpc, override_count=None):
                     module.fail_json(
                         msg="instance_initiated_shutdown_behavior=stop is not supported for spot instances.")
 
-                if spot_launch_group and isinstance(spot_launch_group, basestring):
+                if spot_launch_group and isinstance(spot_launch_group, string_types):
                     params['launch_group'] = spot_launch_group
 
                 params.update(dict(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Changing basestring to string_types to make the ec2 module works with python3
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ec2
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = 
  configured module search path = ['/home/willricardo/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.5/site-packages/ansible-2.4.0-py3.5.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.5.3 (default, Apr 23 2017, 22:31:59) [GCC 4.8.5]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
This fix the follow error:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
"module_stderr": "Traceback (most recent call last):
 File \"/tmp/ansible_zvesxxj5/ansible_module_ec2.py\", line 1673, in <module>
   main()
  File \"/tmp/ansible_zvesxxj5/ansible_module_ec2.py\", line 1667, in main
    (tagged_instances, instance_dict_array, new_instance_ids, changed) = enforce_count(module, ec2, vpc)
  File \"/tmp/ansible_zvesxxj5/ansible_module_ec2.py\", line 946, in enforce_count
    = create_instances(module, ec2, vpc, override_count=to_create)
  File \"/tmp/ansible_zvesxxj5/ansible_module_ec2.py\", line 1042, in create_instances
    if isinstance(group_name, basestring):\nNameError: name 'basestring' is not defined",
    "module_stdout": "",
    "msg": "MODULE FAILURE",
    "rc": 0
```
