### PR TITLE
Filesystem: refactor, improvements, add tests

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -627,7 +627,7 @@ files:
   $modules/system/dconf.py: azaghal
   $modules/system/debconf.py: bcoca
   $modules/system/facter.py: $team_ansible
-  $modules/system/filesystem.py: abulimov
+  $modules/system/filesystem.py: abulimov pilou-
   $modules/system/firewalld.py: maxamillion
   $modules/system/gconftool2.py: akasurde kevensen
   $modules/system/getent.py: bcoca

--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -47,8 +47,11 @@ options:
   opts:
     description:
     - List of options to be passed to mkfs command.
+requirements:
+  - Uses tools related to the I(fstype) (C(mkfs)) and C(blkid) command. When I(resizefs) is enabled, C(blockdev) command is required too.
 notes:
-  - Uses mkfs command.
+  - Potential filesystem on I(dev) are checked using C(blkid), in case C(blkid) isn't able to detect an existing filesystem,
+    this filesystem is overwritten even if I(force) is C(no).
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -16,15 +16,15 @@ DOCUMENTATION = '''
 author:
 - Alexander Bulimov (@abulimov)
 module: filesystem
-short_description: Makes file system on block device
+short_description: Makes a filesystem on block device
 description:
-  - This module creates file system.
+  - This module creates a filesystem.
 version_added: "1.2"
 options:
   fstype:
     choices: [ btrfs, ext2, ext3, ext4, ext4dev, lvm, reiserfs, xfs ]
     description:
-    - File System type to be created.
+    - Filesystem type to be created.
     - reiserfs support was added in 2.2.
     - lvm support was added in 2.5.
     required: yes
@@ -39,9 +39,9 @@ options:
     default: 'no'
   resizefs:
     description:
-    - If C(yes), if the block device and filessytem size differ, grow the filesystem into the space.
+    - If C(yes), if the block device and filesytem size differ, grow the filesystem into the space.
     - XFS Will only grow if mounted.
-    - btrfs and reiserfs don't support resizing.
+    - C(btrfs) and C(reiserfs) don't support resizing.
     type: bool
     default: 'no'
     version_added: "2.0"

--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -119,7 +119,7 @@ def _get_fs_size(fssize_cmd, dev, module):
         else:
             module.fail_json(msg="Failed to get block count and block size of %s with %s" % (dev, cmd), rc=rc, err=err)
     else:
-        module.exit_json(changed=False, msg="WARNING: module does not support resizing %s filesystem yet." % module.param['fstype'])
+        module.fail_json(changed=False, msg="module does not support resizing %s filesystem yet." % module.param['fstype'])
 
     return block_size * block_count
 
@@ -215,7 +215,7 @@ def main():
     try:
         _ = fs_cmd_map[fstype]
     except KeyError:
-        module.exit_json(changed=False, msg="WARNING: module does not support this filesystem yet. %s" % fstype)
+        module.fail_json(changed=False, msg="module does not support this filesystem (%s) yet." % fstype)
 
     mkfscmd = fs_cmd_map[fstype]['mkfs']
     force_flag = fs_cmd_map[fstype]['force_flag']

--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -40,8 +40,8 @@ options:
   resizefs:
     description:
     - If C(yes), if the block device and filesytem size differ, grow the filesystem into the space.
+    - Supported for C(ext2), C(ext3), C(ext4), C(ext4dev), C(lvm) and C(xfs) filesystems.
     - XFS Will only grow if mounted.
-    - C(btrfs) and C(reiserfs) don't support resizing.
     type: bool
     default: 'no'
     version_added: "2.0"

--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -204,8 +204,8 @@ def main():
     dev = module.params['dev']
     fstype = module.params['fstype']
     opts = module.params['opts']
-    force = module.boolean(module.params['force'])
-    resizefs = module.boolean(module.params['resizefs'])
+    force = module.params['force']
+    resizefs = module.params['resizefs']
 
     if fstype in friendly_names:
         fstype = friendly_names[fstype]

--- a/test/integration/targets/filesystem/aliases
+++ b/test/integration/targets/filesystem/aliases
@@ -1,0 +1,3 @@
+destructive
+posix/ci/group3
+skip/osx

--- a/test/integration/targets/filesystem/defaults/main.yml
+++ b/test/integration/targets/filesystem/defaults/main.yml
@@ -5,7 +5,7 @@ tested_filesystems:
   # Other minimal sizes:
   # - XFS: 20Mo
   # - Btrfs: 100Mo (50Mo when "--metadata single" is used)
-  ext4: {fssize: 5, grow: True}
+  ext4: {fssize: 10, grow: True}
   ext4dev: {fssize: 10, grow: True}
   ext3: {fssize: 10, grow: True}
   ext2: {fssize: 10, grow: True}

--- a/test/integration/targets/filesystem/defaults/main.yml
+++ b/test/integration/targets/filesystem/defaults/main.yml
@@ -1,0 +1,14 @@
+tested_filesystems:
+  # key: fstype
+  #   fssize: size (Mo)
+  #   grow: True if resizefs is supported
+  # Other minimal sizes:
+  # - XFS: 20Mo
+  # - Btrfs: 100Mo (50Mo when "--metadata single" is used)
+  ext4: {fssize: 5, grow: True}
+  ext4dev: {fssize: 10, grow: True}
+  ext3: {fssize: 10, grow: True}
+  ext2: {fssize: 10, grow: True}
+  xfs: {fssize: 20, grow: False}  # grow requires a mounted filesystem
+  btrfs: {fssize: 100, grow: False}  # grow not implemented
+  # untested: lvm, requires a block device

--- a/test/integration/targets/filesystem/tasks/create_fs.yml
+++ b/test/integration/targets/filesystem/tasks/create_fs.yml
@@ -79,6 +79,9 @@
         that:
           - 'not (fs5_result|changed)'
           - 'fs5_result|success'
+
+  - import_tasks: overwrite_another_fs.yml
+
   always:
     - file:
         name: '{{ dev }}'

--- a/test/integration/targets/filesystem/tasks/create_fs.yml
+++ b/test/integration/targets/filesystem/tasks/create_fs.yml
@@ -1,0 +1,52 @@
+- name: Remove existing test file
+  file:
+    path: '{{ dev }}'
+    state: absent
+
+- name: 'Create a "disk" file'
+  command: 'dd if=/dev/zero of={{ dev }} bs=1M count={{ fssize }}'
+
+- name: filesystem creation
+  filesystem:
+    dev: '{{ dev }}'
+    fstype: '{{ fstype }}'
+  register: fs_result
+
+- assert:
+    that:
+      - 'fs_result|changed'
+      - 'fs_result|success'
+
+- command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
+  register: uuid
+
+- name: "Check that filesystem isn't created if force isn't used"
+  filesystem:
+    dev: '{{ dev }}'
+    fstype: '{{ fstype }}'
+  register: fs2_result
+
+- command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
+  register: uuid2
+
+- assert:
+    that:
+      - 'not (fs2_result|changed)'
+      - 'fs2_result|success'
+      - 'uuid.stdout == uuid2.stdout'
+
+- name: Check that filesystem is recreated if force is used
+  filesystem:
+    dev: '{{ dev }}'
+    fstype: '{{ fstype }}'
+    force: yes
+  register: fs3_result
+
+- command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
+  register: uuid3
+
+- assert:
+    that:
+      - 'fs3_result|changed'
+      - 'fs3_result|success'
+      - 'uuid.stdout != uuid3.stdout'

--- a/test/integration/targets/filesystem/tasks/create_fs.yml
+++ b/test/integration/targets/filesystem/tasks/create_fs.yml
@@ -1,52 +1,85 @@
-- name: Remove existing test file
-  file:
-    path: '{{ dev }}'
-    state: absent
+- block:
+  - name: 'Create a "disk" file'
+    command: 'dd if=/dev/zero of={{ dev }} bs=1M count={{ fssize }}'
 
-- name: 'Create a "disk" file'
-  command: 'dd if=/dev/zero of={{ dev }} bs=1M count={{ fssize }}'
+  - name: filesystem creation
+    filesystem:
+      dev: '{{ dev }}'
+      fstype: '{{ fstype }}'
+    register: fs_result
 
-- name: filesystem creation
-  filesystem:
-    dev: '{{ dev }}'
-    fstype: '{{ fstype }}'
-  register: fs_result
+  - assert:
+      that:
+        - 'fs_result|changed'
+        - 'fs_result|success'
 
-- assert:
-    that:
-      - 'fs_result|changed'
-      - 'fs_result|success'
+  - command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
+    register: uuid
 
-- command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
-  register: uuid
+  - name: "Check that filesystem isn't created if force isn't used"
+    filesystem:
+      dev: '{{ dev }}'
+      fstype: '{{ fstype }}'
+    register: fs2_result
 
-- name: "Check that filesystem isn't created if force isn't used"
-  filesystem:
-    dev: '{{ dev }}'
-    fstype: '{{ fstype }}'
-  register: fs2_result
+  - command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
+    register: uuid2
 
-- command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
-  register: uuid2
+  - assert:
+      that:
+        - 'not (fs2_result|changed)'
+        - 'fs2_result|success'
+        - 'uuid.stdout == uuid2.stdout'
 
-- assert:
-    that:
-      - 'not (fs2_result|changed)'
-      - 'fs2_result|success'
-      - 'uuid.stdout == uuid2.stdout'
+  - name: Check that filesystem is recreated if force is used
+    filesystem:
+      dev: '{{ dev }}'
+      fstype: '{{ fstype }}'
+      force: yes
+    register: fs3_result
 
-- name: Check that filesystem is recreated if force is used
-  filesystem:
-    dev: '{{ dev }}'
-    fstype: '{{ fstype }}'
-    force: yes
-  register: fs3_result
+  - command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
+    register: uuid3
 
-- command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
-  register: uuid3
+  - assert:
+      that:
+        - 'fs3_result|changed'
+        - 'fs3_result|success'
+        - 'uuid.stdout != uuid3.stdout'
 
-- assert:
-    that:
-      - 'fs3_result|changed'
-      - 'fs3_result|success'
-      - 'uuid.stdout != uuid3.stdout'
+  - name: increase fake device
+    shell: 'dd if=/dev/zero bs=1M count=20 >> {{ dev }}'
+
+  - when: 'grow|bool'
+    block:
+    - name: Expand filesystem
+      filesystem:
+        dev: '{{ dev }}'
+        fstype: '{{ fstype }}'
+        resizefs: yes
+      register: fs4_result
+
+    - command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
+      register: uuid4
+
+    - assert:
+        that:
+          - 'fs4_result|changed'
+          - 'fs4_result|success'
+          - 'uuid3.stdout == uuid4.stdout' # unchanged
+
+    - name: Try to expand filesystem again
+      filesystem:
+        dev: '{{ dev }}'
+        fstype: '{{ fstype }}'
+        resizefs: yes
+      register: fs5_result
+
+    - assert:
+        that:
+          - 'not (fs5_result|changed)'
+          - 'fs5_result|success'
+  always:
+    - file:
+        name: '{{ dev }}'
+        state: absent

--- a/test/integration/targets/filesystem/tasks/create_fs.yml
+++ b/test/integration/targets/filesystem/tasks/create_fs.yml
@@ -10,8 +10,8 @@
 
   - assert:
       that:
-        - 'fs_result|changed'
-        - 'fs_result|success'
+        - 'fs_result is changed'
+        - 'fs_result is success'
 
   - command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
     register: uuid
@@ -27,8 +27,8 @@
 
   - assert:
       that:
-        - 'not (fs2_result|changed)'
-        - 'fs2_result|success'
+        - 'not (fs2_result is changed)'
+        - 'fs2_result is success'
         - 'uuid.stdout == uuid2.stdout'
 
   - name: Check that filesystem is recreated if force is used
@@ -43,8 +43,8 @@
 
   - assert:
       that:
-        - 'fs3_result|changed'
-        - 'fs3_result|success'
+        - 'fs3_result is changed'
+        - 'fs3_result is success'
         - 'uuid.stdout != uuid3.stdout'
 
   - name: increase fake device
@@ -64,8 +64,8 @@
 
     - assert:
         that:
-          - 'fs4_result|changed'
-          - 'fs4_result|success'
+          - 'fs4_result is changed'
+          - 'fs4_result is success'
           - 'uuid3.stdout == uuid4.stdout' # unchanged
 
     - name: Try to expand filesystem again
@@ -77,8 +77,8 @@
 
     - assert:
         that:
-          - 'not (fs5_result|changed)'
-          - 'fs5_result|success'
+          - 'not (fs5_result is changed)'
+          - 'fs5_result is successful'
 
   - import_tasks: overwrite_another_fs.yml
 

--- a/test/integration/targets/filesystem/tasks/main.yml
+++ b/test/integration/targets/filesystem/tasks/main.yml
@@ -15,15 +15,5 @@
     # On Ubuntu trusty, blkid is unable to identify filesystem smaller than 256Mo, see:
     # https://www.kernel.org/pub/linux/utils/util-linux/v2.21/v2.21-ChangeLog
     # https://anonscm.debian.org/cgit/collab-maint/pkg-util-linux.git/commit/?id=04f7020eadf31efc731558df92daa0a1c336c46c
-    - 'not (item.key == "btrfs" and (ansible_distribution == "Ubuntu" and ansible_distribution_release  == "trusty"))'
-  with_dict:
-    # key: fstype
-    #   fssize: size (Mo)
-    #   grow: True if resizefs is supported
-    ext4: {fssize: 5, grow: True}
-    ext4dev: {fssize: 10, grow: True}
-    ext3: {fssize: 10, grow: True}
-    ext2: {fssize: 10, grow: True}
-    xfs: {fssize: 20, grow: False}  # grow requires a mounted filesystem
-    btrfs: {fssize: 100, grow: False}  # grow not implemented
-    # untested: lvm, requires a block device
+    - 'not (item.key == "btrfs" and (ansible_distribution == "Ubuntu" and ansible_distribution_release == "trusty"))'
+  loop: "{{ lookup('dict', tested_filesystems) }}"

--- a/test/integration/targets/filesystem/tasks/main.yml
+++ b/test/integration/targets/filesystem/tasks/main.yml
@@ -7,18 +7,23 @@
 - include_tasks: create_fs.yml
   vars:
     dev: '{{ ansible_user_dir }}/ansible_testing/img'
+    fstype: '{{ item.key }}'
+    fssize: '{{ item.value.fssize }}'
+    grow: '{{ item.value.grow }}'
   when:
-    - 'not (item == "btrfs" and ansible_system == "FreeBSD")'
+    - 'not (item.key == "btrfs" and ansible_system == "FreeBSD")'
     # On Ubuntu trusty, blkid is unable to identify filesystem smaller than 256Mo, see:
     # https://www.kernel.org/pub/linux/utils/util-linux/v2.21/v2.21-ChangeLog
     # https://anonscm.debian.org/cgit/collab-maint/pkg-util-linux.git/commit/?id=04f7020eadf31efc731558df92daa0a1c336c46c
-    - 'not (item == "btrfs" and (ansible_distribution == "Ubuntu" and ansible_distribution_release  == "trusty"))'
-  with_items:
-    - ext4
-    - ext4dev
-    - ext3
-    - ext2
-    - xfs
-    - btrfs
-#    - reiserfs
-#    - lvm
+    - 'not (item.key == "btrfs" and (ansible_distribution == "Ubuntu" and ansible_distribution_release  == "trusty"))'
+  with_dict:
+    # key: fstype
+    #   fssize: size (Mo)
+    #   grow: True if resizefs is supported
+    ext4: {fssize: 5, grow: True}
+    ext4dev: {fssize: 10, grow: True}
+    ext3: {fssize: 10, grow: True}
+    ext2: {fssize: 10, grow: True}
+    xfs: {fssize: 20, grow: False}  # grow requires a mounted filesystem
+    btrfs: {fssize: 100, grow: False}  # grow not implemented
+    # untested: lvm, requires a block device

--- a/test/integration/targets/filesystem/tasks/main.yml
+++ b/test/integration/targets/filesystem/tasks/main.yml
@@ -1,0 +1,24 @@
+- debug:
+    msg: '{{ role_name }}'
+- debug:
+    msg: '{{ role_path|basename }}'
+- import_tasks: setup.yml
+
+- include_tasks: create_fs.yml
+  vars:
+    dev: '{{ ansible_user_dir }}/ansible_testing/img'
+  when:
+    - 'not (item == "btrfs" and ansible_system == "FreeBSD")'
+    # On Ubuntu trusty, blkid is unable to identify filesystem smaller than 256Mo, see:
+    # https://www.kernel.org/pub/linux/utils/util-linux/v2.21/v2.21-ChangeLog
+    # https://anonscm.debian.org/cgit/collab-maint/pkg-util-linux.git/commit/?id=04f7020eadf31efc731558df92daa0a1c336c46c
+    - 'not (item == "btrfs" and (ansible_distribution == "Ubuntu" and ansible_distribution_release  == "trusty"))'
+  with_items:
+    - ext4
+    - ext4dev
+    - ext3
+    - ext2
+    - xfs
+    - btrfs
+#    - reiserfs
+#    - lvm

--- a/test/integration/targets/filesystem/tasks/overwrite_another_fs.yml
+++ b/test/integration/targets/filesystem/tasks/overwrite_another_fs.yml
@@ -1,0 +1,44 @@
+- name: 'Recreate "disk" file'
+  command: 'dd if=/dev/zero of={{ dev }} bs=1M count={{ fssize }}'
+
+- name: 'Create a vfat filesystem'
+  command: 'mkfs.vfat {{ dev }}'
+  when: ansible_system != 'FreeBSD'
+
+- name: 'Create a vfat filesystem'
+  command: 'newfs_msdos -F12 {{ dev }}'
+  when: ansible_system == 'FreeBSD'
+
+- command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
+  register: uuid
+
+- name: "Check that an existing filesystem (not handled by this module) isn't overwritten when force isn't used"
+  filesystem:
+    dev: '{{ dev }}'
+    fstype: '{{ fstype }}'
+  register: fs_result
+  ignore_errors: True
+
+- command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
+  register: uuid2
+
+- assert:
+    that:
+      - 'fs_result|failed'
+      - 'uuid.stdout == uuid2.stdout'
+
+- name: "Check that an existing filesystem (not handled by this module) is overwritten when force is used"
+  filesystem:
+    dev: '{{ dev }}'
+    fstype: '{{ fstype }}'
+    force: yes
+  register: fs_result2
+
+- command: 'blkid -c /dev/null -o value -s UUID {{ dev }}'
+  register: uuid3
+
+- assert:
+    that:
+      - 'fs_result2|success'
+      - 'fs_result2|changed'
+      - 'uuid2.stdout != uuid3.stdout'

--- a/test/integration/targets/filesystem/tasks/overwrite_another_fs.yml
+++ b/test/integration/targets/filesystem/tasks/overwrite_another_fs.yml
@@ -24,7 +24,7 @@
 
 - assert:
     that:
-      - 'fs_result|failed'
+      - 'fs_result is failed'
       - 'uuid.stdout == uuid2.stdout'
 
 - name: "Check that an existing filesystem (not handled by this module) is overwritten when force is used"
@@ -39,6 +39,6 @@
 
 - assert:
     that:
-      - 'fs_result2|success'
-      - 'fs_result2|changed'
+      - 'fs_result2 is successful'
+      - 'fs_result2 is changed'
       - 'uuid2.stdout != uuid3.stdout'

--- a/test/integration/targets/filesystem/tasks/setup.yml
+++ b/test/integration/targets/filesystem/tasks/setup.yml
@@ -13,13 +13,13 @@
     package:
       name: btrfs-progs
       state: present
-    when: ansible_os_family != 'Suse' and not (ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare('16.04', '<='))
+    when: ansible_os_family != 'Suse' and not (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('16.04', '<='))
 
   - name: install btrfs progs (Ubuntu <= 16.04)
     package:
       name: btrfs-tools
       state: present
-    when: ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare('16.04', '<=')
+    when: ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('16.04', '<=')
 
   - name: install btrfs progs (OpenSuse)
     package:
@@ -42,4 +42,4 @@
     # http://e2fsprogs.sourceforge.net/e2fsprogs-release.html#1.43
     # Mke2fs no longer complains if the user tries to create a file system
     # using the entire block device.
-    force_creation: "{{ e2fsprogs_version | version_compare('1.43', '<') }}"
+    force_creation: "{{ e2fsprogs_version is version('1.43', '<') }}"

--- a/test/integration/targets/filesystem/tasks/setup.yml
+++ b/test/integration/targets/filesystem/tasks/setup.yml
@@ -1,0 +1,43 @@
+- name: install e2fs and xfs
+  package:
+    name: '{{ item }}'
+    state: present
+  with_items:
+    - e2fsprogs
+    - xfsprogs
+
+- block:
+  - name: install btrfs progs
+    package:
+      name: btrfs-progs
+      state: present
+    when: ansible_os_family != 'Suse' and not (ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare('16.04', '<='))
+
+  - name: install btrfs progs (Ubuntu <= 16.04)
+    package:
+      name: btrfs-tools
+      state: present
+    when: ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare('16.04', '<=')
+
+  - name: install btrfs progs (OpenSuse)
+    package:
+      name: '{{ item }}'
+      state: present
+    when: ansible_os_family == 'Suse'
+    with_items:
+      - python-xml
+      - btrfsprogs
+  when: ansible_system != "FreeBSD"
+
+- command: mke2fs -V
+  register: mke2fs
+
+- set_fact:
+    # mke2fs 1.43.6 (29-Aug-2017)
+    e2fsprogs_version: '{{ mke2fs.stderr_lines[0] | regex_search("[0-9]{1,2}\.[0-9]{1,2}(\.[0-9]{1,2})?") }}'
+
+- set_fact:
+    # http://e2fsprogs.sourceforge.net/e2fsprogs-release.html#1.43
+    # Mke2fs no longer complains if the user tries to create a file system
+    # using the entire block device.
+    force_creation: "{{ e2fsprogs_version | version_compare('1.43', '<') }}"

--- a/test/integration/targets/filesystem/tasks/setup.yml
+++ b/test/integration/targets/filesystem/tasks/setup.yml
@@ -1,10 +1,12 @@
-- name: install e2fs and xfs
+- name: install filesystem tools
   package:
     name: '{{ item }}'
     state: present
+  when: ansible_system == 'Linux' or item != 'dosfstools'
   with_items:
     - e2fsprogs
     - xfsprogs
+    - dosfstools
 
 - block:
   - name: install btrfs progs
@@ -27,7 +29,7 @@
     with_items:
       - python-xml
       - btrfsprogs
-  when: ansible_system != "FreeBSD"
+  when: ansible_system == 'Linux'
 
 - command: mke2fs -V
   register: mke2fs


### PR DESCRIPTION
##### SUMMARY
- add integration tests
    - creation, resizing (not for XFS) and overwriting are tested
    - all filesystem but LVM are tested
- improvements:
  - module documentation (requirements, add a warning)
  - explicitly fails when resizing isn't supported
  - handle btrfs < 0.20-rc1
  - device: allow to use regular file
- Fix PEP8.

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
filesystem

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible-playbook 2.5.0 (devel e3f1198a67) last updated 2017/11/01 22:49:06 (GMT +200)
```

##### ADDITIONAL INFORMATION
Related: #24356 