### PR TITLE
CDP support for ios_facts

### DIFF
--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -283,7 +283,7 @@ class Interfaces(FactsBase):
                 facts_cdp = self.parse_cdp_neighbors(cdp_neighbors[0])
                 if facts_cdp:
                     facts_neighbors = self.parse_cdp_neighbors(cdp_neighbors[0])
-           
+
             if facts_neighbors:
                 self.facts['neighbors'] = facts_neighbors
 

--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -271,21 +271,21 @@ class Interfaces(FactsBase):
         data = self.responses[2]
         if data:
             facts_neighbors = dict()
-            
+
             lldp_neighbors = self.run(['show lldp neighbors detail'])
             if lldp_neighbors:
                 facts_lldp = self.parse_lldp_neighbors(lldp_neighbors[0])
                 if facts_lldp:
-                  facts_neighbors.update(facts_lldp)
-            
+                    facts_neighbors.update(facts_lldp)
+
             cdp_neighbors = self.run(['show cdp neighbors detail'])
             if cdp_neighbors:
                 facts_cdp = self.parse_cdp_neighbors(cdp_neighbors[0])
                 if facts_cdp:
-                  facts_neighbors = self.parse_cdp_neighbors(cdp_neighbors[0])
-                               
+                    facts_neighbors = self.parse_cdp_neighbors(cdp_neighbors[0])
+           
             if facts_neighbors:
-              self.facts['neighbors'] = facts_neighbors
+                self.facts['neighbors'] = facts_neighbors
 
     def populate_interfaces(self, interfaces):
         facts = dict()


### PR DESCRIPTION
CDP support for ios_facts

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
Adds CDP support to ansible_net_neighbors. ios_facts will collect CDP and LLDP neighbors, instead of just LLDP.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ios_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /Users/janderson/git/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.10 (default, Jul 30 2016, 19:40:32) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


