### PR TITLE
Added handling optional GCE_CREDENTIALS_FILE_PATH

### DIFF
--- a/contrib/inventory/gce.py
+++ b/contrib/inventory/gce.py
@@ -306,6 +306,8 @@ class GceInventory(object):
         # other configuration; process those into our args and kwargs.
         args[0] = os.environ.get('GCE_EMAIL', args[0])
         args[1] = os.environ.get('GCE_PEM_FILE_PATH', args[1])
+        args[1] = os.environ.get('GCE_CREDENTIALS_FILE_PATH', args[1])
+
         kwargs['project'] = os.environ.get('GCE_PROJECT', kwargs['project'])
         kwargs['datacenter'] = os.environ.get('GCE_ZONE', kwargs['datacenter'])
 


### PR DESCRIPTION
##### SUMMARY
Ansible documentation states that env variable based authentication bases on variable GCE_CREDENTIALS_FILE_PATH while gce.py reads only GCE_PEM_FILE_PATH (see https://docs.ansible.com/ansible/guide_gce.html). This commit adds GCE_CREDENTIALS_FILE_PATH to the configuration chain; if set it will be used.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
contrib/inventory/gce.py

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /somewhere/ansible.cfg
  configured module search path = [u'library/']
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
When following documentation in order to spawn GCE instances (https://docs.ansible.com/ansible/guide_gce.html) I wanted to keep authentication basing on env variables. So I set variables mentioned in docs (GCE_EMAIL, GCE_PROJECT, GCE_CREDENTIALS_FILE_PATH) and run: ```./inventory/gce.py --list``` and got an error:

```./inventory/gce.py --refresh-cache --list
Traceback (most recent call last):
  File "./inventory/gce.py", line 499, in <module>
    GceInventory()
  File "./inventory/gce.py", line 168, in __init__
    self.driver = self.get_gce_driver()
  File "./inventory/gce.py", line 316, in get_gce_driver
    gce = get_driver(Provider.GCE)(*args, **kwargs)
  File "/somewhere/lib/python2.7/site-packages/libcloud/compute/drivers/gce.py", line 1795, in __init__
    super(GCENodeDriver, self).__init__(user_id, key, **kwargs)
  File "/somewhere/lib/python2.7/site-packages/libcloud/common/base.py", line 952, in __init__
    self.connection = self.connectionCls(*args, **conn_kwargs)
  File "/somewhere/lib/python2.7/site-packages/libcloud/compute/drivers/gce.py", line 99, in __init__
    credential_file=credential_file, **kwargs)
  File "/somewhere/lib/python2.7/site-packages/libcloud/common/google.py", line 765, in __init__
    user_id, key, auth_type, credential_file, scopes, **kwargs)
  File "/somewhere/lib/python2.7/site-packages/libcloud/common/google.py", line 651, in __init__
    self.user_id, self.key, self.scopes, **kwargs)
  File "/somewhere/lib/python2.7/site-packages/libcloud/common/google.py", line 493, in __init__
    "file: '%s'" % key)
ValueError: Missing (or not readable) key file: ''```

So this led me to gce.py from which I deduced that mentioned in docs "GCE_CREDENTIALS_FILE_PATH" is not read at all (instead GCE_PEM_FILE_PATH is used).

After this fix:
```
./inventory/gce.py --refresh-cache --list
{"_meta": {"stats": {"cache_used": true, "inventory_load_time": 0.0004260540008544922}, "hostvars": {}}}
```
