### PR TITLE
win_regedit: Make the string comparison case sensitive when comparing string values

### DIFF
--- a/lib/ansible/modules/windows/win_regedit.ps1
+++ b/lib/ansible/modules/windows/win_regedit.ps1
@@ -83,7 +83,7 @@ Function Compare-Data {
             return $false
         }
     } elseif ($ReferenceData -is [string] -or $ReferenceData -is [int]) {
-        if ($ReferenceData -eq $DifferenceData) {
+        if ($ReferenceData -ceq $DifferenceData) {
             return $true
         } else {
             return $false

--- a/lib/ansible/modules/windows/win_regedit.py
+++ b/lib/ansible/modules/windows/win_regedit.py
@@ -76,6 +76,7 @@ notes:
 - Check-mode C(-C/--check) and diff output C(-D/--diff) are supported, so that you can test every change against the active configuration before
   applying changes.
 - Beware that some registry hives (C(HKEY_USERS) in particular) do not allow to create new registry paths.
+- Since ansible 2.4, when checking if a string registry value has changed, a case-sensitive test is used.  Previously the test was case-insensitive.
 author: "Adam Keech (@smadam813), Josh Ludwig (@joshludwig)"
 '''
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
It transpires powershell's -eq test operator defaults to case-insensitive operation.

This led to unexpected behaviour reported in #25239 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #25239 (already closed).
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_regedit
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (win_regedit_case_sensitive_comparison 384713d69d) last updated 2017/06/09 12:59:35 (GMT +100)
  config file =
  configured module search path = [u'/home/jon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jon/ansible-dev/lib/ansible
  executable location = /home/jon/ansible-dev/bin/ansible
  python version = 2.7.6 (default, Jun 22 2015, 17:58:13) [GCC 4.8.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
When comparing the registry value contents with the module parameters, case insensitive string matching was being used.  This means the strings 'False' and 'false' would be considered equivalent.  This change ensures that only strings with the same casing will match, thereby correctly identifying if the existing registry value is stored.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
See example cases /reproducers on #25239
```
