### PR TITLE
Add log_only to debug messages

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -290,7 +290,7 @@ def main():
         sys.stderr.write(traceback.format_exc())
         sys.exit("FAIL: %s" % e)
 
-    ssh = connection_loader.get('ssh', class_only=True)
+    ssh = connection_loader.get('ssh', class_only=True, log_only=True)
     cp = ssh._create_control_path(pc.remote_addr, pc.connection, pc.remote_user)
 
     # create the persistent connection dir if need be and create the paths

--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -343,6 +343,7 @@ class PluginLoader:
 
         found_in_cache = True
         class_only = kwargs.pop('class_only', False)
+        log_only = kwargs.pop('log_only', False)
         if name in self.aliases:
             name = self.aliases[name]
         path = self.find_plugin(name)
@@ -367,7 +368,7 @@ class PluginLoader:
                 return None
 
         self._display_plugin_load(self.class_name, name, self._searched_paths, path,
-                                  found_in_cache=found_in_cache, class_only=class_only)
+                                  found_in_cache=found_in_cache, class_only=class_only, log_only=log_only)
         if not class_only:
             try:
                 obj = obj(*args, **kwargs)
@@ -383,7 +384,7 @@ class PluginLoader:
         setattr(obj, '_load_name', name)
         return obj
 
-    def _display_plugin_load(self, class_name, name, searched_paths, path, found_in_cache=None, class_only=None):
+    def _display_plugin_load(self, class_name, name, searched_paths, path, found_in_cache=None, class_only=None, log_only=False):
         msg = 'Loading %s \'%s\' from %s' % (class_name, os.path.basename(name), path)
 
         if len(searched_paths) > 1:
@@ -392,7 +393,7 @@ class PluginLoader:
         if found_in_cache or class_only:
             msg = '%s (found_in_cache=%s, class_only=%s)' % (msg, found_in_cache, class_only)
 
-        display.debug(msg)
+        display.debug(msg, log_only)
 
     def all(self, *args, **kwargs):
         ''' instantiates all plugins with the same arguments '''

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -174,9 +174,9 @@ class Display:
     def vvvvvv(self, msg, host=None):
         return self.verbose(msg, host=host, caplevel=5)
 
-    def debug(self, msg):
+    def debug(self, msg, log_only=False):
         if C.DEFAULT_DEBUG:
-            self.display("%6d %0.5f: %s" % (os.getpid(), time.time(), msg), color=C.COLOR_DEBUG)
+            self.display("%6d %0.5f: %s" % (os.getpid(), time.time(), msg), color=C.COLOR_DEBUG, log_only=log_only)
 
     def verbose(self, msg, host=None, caplevel=2):
         if self.verbosity > caplevel:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #25544
When `debug` is enabled the debug messages triggered
from `bin/ansible-connection` should be logged only to file
and not on stdout.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bin/ansible-connection
utils/display
plugins/__init__

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
