### PR TITLE
FEATURE option `comment` in ufw module

### DIFF
--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -111,6 +111,11 @@ options:
       - Use profile located in C(/etc/ufw/applications.d)
     required: false
     aliases: ['app']
+  comment:
+    description:
+      - "This specifies a comment that will be added to the rule"
+    required: false
+    default: null
   delete:
     description:
       - Delete rule.
@@ -250,6 +255,7 @@ def main():
             to_ip     = dict(default='any', aliases=['dest', 'to']),
             to_port   = dict(default=None,  aliases=['port']),
             proto     = dict(default=None,  aliases=['protocol'], choices=['any', 'tcp', 'udp', 'ipv6', 'esp', 'ah']),
+            comment   = dict(default=None,  type='str'),
             app       = dict(default=None,  aliases=['name'])
         ),
         supports_check_mode = True,
@@ -306,7 +312,7 @@ def main():
             #
             # ufw [--dry-run] [delete] [insert NUM] [route] allow|deny|reject|limit [in|out on INTERFACE] [log|log-all] \
             #     [from ADDRESS [port PORT]] [to ADDRESS [port PORT]] \
-            #     [proto protocol] [app application]
+            #     [proto protocol] [app application] [comment COMMENT]
             cmd.append([module.boolean(params['delete']), 'delete'])
             cmd.append([module.boolean(params['route']), 'route'])
             cmd.append([params['insert'], "insert %s" % params['insert']])
@@ -317,7 +323,8 @@ def main():
 
             for (key, template) in [('from_ip',   "from %s" ), ('from_port', "port %s" ),
                                     ('to_ip',     "to %s"   ), ('to_port',   "port %s" ),
-                                    ('proto',     "proto %s"), ('app',       "app '%s'")]:
+                                    ('proto',     "proto %s"), ('app',       "app '%s'"),
+                                    ('comment',   "comment '%s'")]:
 
                 value = params[key]
                 cmd.append([value, template % (value)])

--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -115,7 +115,7 @@ options:
     description:
       - "This specifies a comment that will be added to the rule"
     required: false
-    default: null
+    version_added: 2.4
   delete:
     description:
       - Delete rule.


### PR DESCRIPTION
UFW supports adding comments on rules, so this is good idea to allow ansible ufw module use this feature

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
This commit adds the option comment to ufw ansible module

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ufw module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
