### PR TITLE
Fix import for get_exception

### DIFF
--- a/lib/ansible/modules/utilities/logic/wait_for.py
+++ b/lib/ansible/modules/utilities/logic/wait_for.py
@@ -183,6 +183,7 @@ import time
 
 from ansible.module_utils.basic import AnsibleModule, load_platform_subclass
 from ansible.module_utils._text import to_native
+from ansible.module_utils.pycompat24 import get_exception
 
 
 HAS_PSUTIL = False


### PR DESCRIPTION

##### SUMMARY
Fixes #25549

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/utilities/logic/wait_for.py

##### ANSIBLE VERSION
```
2.4devel
```