### PR TITLE
cloudstack: cs_zone: fix missing type bool for params

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_zone.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_zone.py
@@ -373,8 +373,8 @@ def main():
         network_domain = dict(default=None),
         guest_cidr_address = dict(default=None),
         dhcp_provider = dict(default=None),
-        local_storage_enabled = dict(default=None),
-        securitygroups_enabled = dict(default=None),
+        local_storage_enabled = dict(type='bool', default=None),
+        securitygroups_enabled = dict(type='bool', default=None),
         state = dict(choices=['present', 'enabled', 'disabled', 'absent'], default='present'),
         domain = dict(default=None),
     ))


### PR DESCRIPTION
##### SUMMARY

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
cs_zone

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
