### PR TITLE
Fix pep8 issue in lib/ansible/inventory/manager.py

### DIFF
--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -128,9 +128,9 @@ class InventoryManager(object):
         self._subset = None
 
         # caches
-        self._hosts_patterns_cache = {} # resolved full patterns
-        self._pattern_cache = {}        # resolved individual patterns
-        self._inventory_plugins = []    # for generating inventory
+        self._hosts_patterns_cache = {}  # resolved full patterns
+        self._pattern_cache = {}  # resolved individual patterns
+        self._inventory_plugins = []  # for generating inventory
 
         # the inventory dirs, files, script paths or lists of hosts
         if sources is None:


### PR DESCRIPTION
##### SUMMARY

Fix pep8 issue in lib/ansible/inventory/manager.py introduced in cc66bd4ad08f55189b4d05f4bbb68cad604537d6

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/inventory/manager.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```