### PR TITLE
Fix version_added for tags and wait_for_active_timeout params (#24993)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/dynamodb_table.py
+++ b/lib/ansible/modules/cloud/amazon/dynamodb_table.py
@@ -86,13 +86,13 @@ options:
     default: []
     version_added: "2.1"
   tags:
-    version_added: "2.3"
+    version_added: "2.4"
     description:
       - a hash/dictionary of tags to add to the new instance or for starting/stopping instance by tag; '{"key":"value"}' and '{"key":"value","key":"value"}'
     required: false
     default: null
   wait_for_active_timeout:
-    version_added: "2.3"
+    version_added: "2.4"
     description:
       - how long before wait gives up, in seconds. only used when tags is set
     required: false


### PR DESCRIPTION
##### SUMMARY

Fixes #24993.

Update `version_added` for `tags` and `wait_for_active_timeout` params.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
dynamodb_table

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```
