### PR TITLE
Fix hash_key_name to be optional for delete (#25009)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/dynamodb_table.py
+++ b/lib/ansible/modules/cloud/amazon/dynamodb_table.py
@@ -444,7 +444,7 @@ def main():
     argument_spec.update(dict(
         state=dict(default='present', choices=['present', 'absent']),
         name=dict(required=True, type='str'),
-        hash_key_name=dict(required=True, type='str'),
+        hash_key_name=dict(type='str'),
         hash_key_type=dict(default='STRING', type='str', choices=['STRING', 'NUMBER', 'BINARY']),
         range_key_name=dict(type='str'),
         range_key_type=dict(default='STRING', type='str', choices=['STRING', 'NUMBER', 'BINARY']),


### PR DESCRIPTION
##### SUMMARY

Fixes #25009.

Fix `hash_key_name` param to be optional when deleting a table.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
dynamodb_table

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```
