### PR TITLE
Return exception as string

### DIFF
--- a/lib/ansible/modules/database/vertica/vertica_configuration.py
+++ b/lib/ansible/modules/database/vertica/vertica_configuration.py
@@ -89,6 +89,7 @@ else:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils._text import to_native
 
 
 class NotSupportedError(Exception):
@@ -198,7 +199,7 @@ def main():
         raise
     except Exception:
         e = get_exception()
-        module.fail_json(msg=e)
+        module.fail_json(msg=to_native(e))
 
     module.exit_json(changed=changed, parameter=parameter_name, ansible_facts={'vertica_configuration': configuration_facts})
 

--- a/lib/ansible/modules/database/vertica/vertica_facts.py
+++ b/lib/ansible/modules/database/vertica/vertica_facts.py
@@ -81,6 +81,7 @@ else:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils._text import to_native
 
 
 class NotSupportedError(Exception):
@@ -278,7 +279,7 @@ def main():
         raise
     except Exception:
         e = get_exception()
-        module.fail_json(msg=e)
+        module.fail_json(msg=to_native(e))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/database/vertica/vertica_role.py
+++ b/lib/ansible/modules/database/vertica/vertica_role.py
@@ -100,6 +100,7 @@ else:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils._text import to_native
 
 
 class NotSupportedError(Exception):
@@ -248,7 +249,7 @@ def main():
         raise
     except Exception:
         e = get_exception()
-        module.fail_json(msg=e)
+        module.fail_json(msg=to_native(e))
 
     module.exit_json(changed=changed, role=role, ansible_facts={'vertica_roles': role_facts})
 

--- a/lib/ansible/modules/database/vertica/vertica_schema.py
+++ b/lib/ansible/modules/database/vertica/vertica_schema.py
@@ -124,6 +124,7 @@ else:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils._text import to_native
 
 
 class NotSupportedError(Exception):
@@ -323,7 +324,7 @@ def main():
         raise
     except Exception:
         e = get_exception()
-        module.fail_json(msg=e)
+        module.fail_json(msg=to_native(e))
 
     module.exit_json(changed=changed, schema=schema, ansible_facts={'vertica_schemas': schema_facts})
 

--- a/lib/ansible/modules/database/vertica/vertica_user.py
+++ b/lib/ansible/modules/database/vertica/vertica_user.py
@@ -137,6 +137,7 @@ else:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils._text import to_native
 
 
 class NotSupportedError(Exception):
@@ -393,7 +394,7 @@ def main():
         raise
     except Exception:
         e = get_exception()
-        module.fail_json(msg=e)
+        module.fail_json(msg=to_native(e))
 
     module.exit_json(changed=changed, user=user, ansible_facts={'vertica_users': user_facts})
 


### PR DESCRIPTION

##### SUMMARY
Pyodbc returns exception as Python Exception class,
typecast as string for fail_json.

Partially fixes: #25010

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/database/vertica/vertica_configuration.py lib/ansible/modules/database/vertica/vertica_facts.py
lib/ansible/modules/database/vertica/vertica_role.py
lib/ansible/modules/database/vertica/vertica_schema.py
lib/ansible/modules/database/vertica/vertica_user.py

##### ANSIBLE VERSION
```
2.4devel
```