### PR TITLE
facts: Add linux virtio module detection

### DIFF
--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -215,6 +215,11 @@ class LinuxVirtual(Virtual):
                 virtual_facts['virtualization_role'] = 'host'
                 return virtual_facts
 
+            if 'virtio' in modules:
+                virtual_facts['virtualization_type'] = 'kvm'
+                virtual_facts['virtualization_role'] = 'guest'
+                return virtual_facts
+
         # If none of the above matches, return 'NA' for virtualization_type
         # and virtualization_role. This allows for proper grouping.
         virtual_facts['virtualization_type'] = 'NA'


### PR DESCRIPTION
Detect as kvm guest if virtio linux kernel module is loaded

##### SUMMARY
Improve detection of virtualization role (guest) and type (kvm) when
all implemented methods failed. New detection method is based
on test if virtio linux kernel module was loaded.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Gathering Facts about virtual machine

##### ANSIBLE VERSION
```
ansible 2.4.0 (virtual_facts_virtio_modules 4894c37d50) last updated 2017/06/10 22:59:32 (GMT +200)
  config file = 
  configured module search path = [u'/home/tomas/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/tomas/git/ansible/ansible/lib/ansible
  executable location = /home/tomas/git/ansible/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:36) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```

##### ADDITIONAL INFORMATION
When virtual machine started with custom smbios information, detections failed with ansible_virtualization_role/type NA. This patch add detection based on linux kernel virtio module.

###### Before
```
ansible -m setup localhost
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_all_ipv4_addresses": [
       ..........
        "ansible_system_capabilities_enforced": "True", 
        "ansible_system_vendor": "MSI", 
        "ansible_uptime_seconds": 515342, 
        "ansible_user_dir": "/home/ansible", 
        "ansible_user_gecos": "ansible management account", 
        "ansible_user_gid": 1000, 
        "ansible_user_id": "XXX", 
        "ansible_user_shell": "/bin/bash", 
        "ansible_user_uid": 1000, 
        "ansible_userspace_architecture": "x86_64", 
        "ansible_userspace_bits": "64", 
        "ansible_virtualization_role": "NA", 
        "ansible_virtualization_type": "NA", 
        "gather_subset": [
            "all"
        ], 
        "module_setup": true
    }, 
    "changed": false, 
    "failed": false
}
```
###### After
```
ansible -m setup localhost
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_all_ipv4_addresses": [
       ..........
        "ansible_system_capabilities_enforced": "True", 
        "ansible_system_vendor": "MSI", 
        "ansible_uptime_seconds": 515342, 
        "ansible_user_dir": "/home/ansible", 
        "ansible_user_gecos": "ansible management account", 
        "ansible_user_gid": 1000, 
        "ansible_user_id": "XXX", 
        "ansible_user_shell": "/bin/bash", 
        "ansible_user_uid": 1000, 
        "ansible_userspace_architecture": "x86_64", 
        "ansible_userspace_bits": "64", 
        "ansible_virtualization_role": "guest", 
        "ansible_virtualization_type": "kvm", 
        "gather_subset": [
            "all"
        ], 
        "module_setup": true
    }, 
    "changed": false, 
    "failed": false
}
```
