### PR TITLE
Add deps for cryptography to the Docker images

### DIFF
--- a/test/utils/docker/centos6/Dockerfile
+++ b/test/utils/docker/centos6/Dockerfile
@@ -9,6 +9,8 @@ RUN yum clean all && \
     file \
     gcc \
     git \
+    libffi \
+    libffi-devel \
     make \
     mercurial \
     mysql \
@@ -16,6 +18,7 @@ RUN yum clean all && \
     mysql-server \
     openssh-clients \
     openssh-server \
+    openssl-devel \
     python-coverage \
     python-devel \
     python-httplib2 \
@@ -41,7 +44,7 @@ RUN yum clean all && \
     && \
     yum clean all
 
-RUN rpm -e --nodeps python-crypto && pip install --upgrade pycrypto
+RUN rpm -e --nodeps python-crypto && pip install --upgrade pycrypto cryptography
 
 RUN /bin/sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 RUN mkdir /etc/ansible/

--- a/test/utils/docker/centos7/Dockerfile
+++ b/test/utils/docker/centos7/Dockerfile
@@ -17,15 +17,20 @@ RUN yum clean all && \
     bzip2 \
     dbus-python \
     file \
+    gcc \
     git \
     iproute \
+    libffi \
+    libffi-devel \
     make \
     mariadb-server \
     mercurial \
     MySQL-python \
     openssh-clients \
     openssh-server \
+    openssl-devel \
     python-coverage \
+    python-devel \
     python-httplib2 \
     python-jinja2 \
     python-keyczar \

--- a/test/utils/docker/fedora24/Dockerfile
+++ b/test/utils/docker/fedora24/Dockerfile
@@ -21,18 +21,23 @@ RUN dnf clean all && \
     dbus-python \
     file \
     findutils \
+    gcc \
     git \
     glibc-locale-source \
     iproute \
+    libffi \
+    libffi-devel \
     make \
     mariadb-server \
     mercurial \
     MySQL-python \
     openssh-clients \
     openssh-server \
+    openssl-devel \
     procps \
     python2-dnf \
     python-coverage \
+    python-devel \
     python-httplib2 \
     python-jinja2 \
     python-keyczar \

--- a/test/utils/docker/fedora25/Dockerfile
+++ b/test/utils/docker/fedora25/Dockerfile
@@ -20,12 +20,15 @@ RUN dnf clean all && \
     git \
     glibc-locale-source \
     iproute \
+    libffi \
+    libffi-devel \
     make \
     mariadb-server \
     mercurial \
     MySQL-python \
     openssh-clients \
     openssh-server \
+    openssl-devel \
     procps \
     python2-dnf \
     python-coverage \

--- a/test/utils/docker/opensuse42.1/Dockerfile
+++ b/test/utils/docker/opensuse42.1/Dockerfile
@@ -21,6 +21,8 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     openssh \
     postgresql-server \
     python-coverage \
+    python-cryptography \
+    python-devel \
     python-httplib2 \
     python-jinja2 \
     python-keyczar \

--- a/test/utils/docker/opensuse42.2/Dockerfile
+++ b/test/utils/docker/opensuse42.2/Dockerfile
@@ -21,6 +21,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     openssh \
     postgresql-server \
     python-coverage \
+    python-cryptography \
     python-httplib2 \
     python-jinja2 \
     python-keyczar \

--- a/test/utils/docker/ubuntu1204/Dockerfile
+++ b/test/utils/docker/ubuntu1204/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update -y && \
     gawk \
     gcc \
     git \
+    libffi-dev \
+    libssl-dev \
     libxml2-utils \
     locales \
     make \
@@ -52,8 +54,7 @@ RUN apt-get update -y && \
     && \
     apt-get clean
 
-RUN pip install --upgrade pycrypto
-
+RUN pip install --upgrade pycrypto cryptography
 # helpful things taken from the ubuntu-upstart Dockerfile:
 # https://github.com/tianon/dockerfiles/blob/4d24a12b54b75b3e0904d8a285900d88d3326361/sbin-init/ubuntu/upstart/14.04/Dockerfile
 ADD init-fake.conf /etc/init/fake-container-events.conf

--- a/test/utils/docker/ubuntu1404/Dockerfile
+++ b/test/utils/docker/ubuntu1404/Dockerfile
@@ -16,6 +16,8 @@ RUN apt-get update -y && \
     fakeroot \
     gawk \
     git \
+    libffi-dev \
+    libssl-dev \
     libxml2-utils \
     locales \
     make \

--- a/test/utils/docker/ubuntu1604/Dockerfile
+++ b/test/utils/docker/ubuntu1604/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update -y && \
     gawk \
     git \
     iproute2 \
+    libffi-dev \
+    libssl-dev \
     libxml2-utils \
     locales \
     lsb-release \

--- a/test/utils/docker/ubuntu1604py3/Dockerfile
+++ b/test/utils/docker/ubuntu1604py3/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get update -y && \
     gawk \
     git \
     iproute2 \
+    libffi-dev \
+    libssl-dev \
     libxml2-utils \
     locales \
     lsb-release \


### PR DESCRIPTION
##### SUMMARY
These are just the Dockerfile changes for https://github.com/ansible/ansible/pull/25560

Hopefully these can be merged and the Docker images recreated.  Then we can rebase #25560 and see if it passes tests with the new images.
 
##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
Dockerfiles

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```