### PR TITLE
Better control over rolename in ansible-galaxy when installing from tarball

### DIFF
--- a/docs/docsite/rst/galaxy.rst
+++ b/docs/docsite/rst/galaxy.rst
@@ -82,7 +82,7 @@ Use the following command to install a role included in a .tar.gz:
 
 ::
 
-   $ ansible-galaxy install hello-test.tar.gz
+   $ ansible-galaxy install --role-name=hello-test /tmp/hello-test.tar.gz
 
 
 Installing multiple roles from a file

--- a/docs/docsite/rst/galaxy.rst
+++ b/docs/docsite/rst/galaxy.rst
@@ -73,11 +73,22 @@ install a specific commit:
 
    $ ansible-galaxy install git+https://github.com/geerlingguy/ansible-role-apache.git,0b7cd353c0250e87a26e0499e59e7fd265cc2f25
 
+Installing a single role from a .tar.gz file
+============================================
+
+You can install a .tar.gz of a valid role you've downloaded directly from github.com. This is mainly useful when the system running Ansible does not have access to the Galaxy API, for instance when behind a firewall or proxy.
+
+Use the following command to install a role included in a .tar.gz:
+
+::
+
+   $ ansible-galaxy install hello-test.tar.gz
+
 
 Installing multiple roles from a file
 =====================================
 
-Beginning with Ansible 1.8 it is possible to install multiple roles by including the roles in a *requirements.yml* file. The format of the file is YAML, and the 
+Beginning with Ansible 1.8 it is possible to install one or more roles by including the roles in a *requirements.yml* file. The format of the file is YAML, and the 
 file extension must be either *.yml* or *.yaml*.
 
 Use the following command to install roles included in *requirements.yml*:
@@ -119,6 +130,10 @@ Use the following example as a guide for specifying roles in *requirements.yml*:
     
     # from a webserver, where the role is packaged in a tar.gz
     - src: https://some.webserver.example.com/files/master.tar.gz
+      name: http-role
+
+    # from a local file, where the role is packaged in a tar.gz
+    - src: /home/example/master.tar.gz
       name: http-role
 
     # from Bitbucket

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -91,6 +91,7 @@ class GalaxyCLI(CLI):
                                    help='Ignore errors and continue with the next specified role.')
             self.parser.add_option('-n', '--no-deps', dest='no_deps', action='store_true', default=False, help='Don\'t download roles listed as dependencies')
             self.parser.add_option('-r', '--role-file', dest='role_file', help='A file containing a list of roles to be imported')
+            self.parser.add_option('--role-name', dest='role_name', help='The name the role should have, if different than the repo name or tar filename')
         elif self.action == "remove":
             self.parser.set_usage("usage: %prog remove role1 role2 ...")
         elif self.action == "list":
@@ -309,8 +310,8 @@ class GalaxyCLI(CLI):
         role_file = self.options.role_file
 
         if len(self.args) == 0 and role_file is None:
-            # the user needs to specify one of either --role-file or specify a single user/role name
-            raise AnsibleOptionsError("- you must specify a user/role name or a roles file")
+            # the user needs to specify one of either --role-file, a single user/role name or a .tar.gz file
+            raise AnsibleOptionsError("- you must specify a user/role name, a .tar.gz file or a roles file")
         elif len(self.args) == 1 and role_file is not None:
             # using a role file is mutually exclusive of specifying the role name on the command line
             raise AnsibleOptionsError("- please specify a user/role name, or a roles file, but not both")
@@ -366,6 +367,8 @@ class GalaxyCLI(CLI):
             # (and their dependencies, unless the user doesn't want us to).
             for rname in self.args:
                 role = RoleRequirement.role_yaml_parse(rname.strip())
+                if self.options.role_name is not None:
+                    role['name'] = self.options.role_name
                 roles_left.append(GalaxyRole(self.galaxy, **role))
 
         for role in roles_left:

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -313,7 +313,7 @@ class GalaxyCLI(CLI):
             # the user needs to specify one of either --role-file, a single user/role name or a .tar.gz file
             raise AnsibleOptionsError("- you must specify a user/role name, a .tar.gz file or a roles file")
         elif len(self.args) == 1 and role_file is not None:
-            # using a role file is mutually exclusive of specifying the role name or the .tar.gz file on the command line 
+            # using a role file is mutually exclusive of specifying the role name or the .tar.gz file on the command line
             raise AnsibleOptionsError("- please specify only one: a user/role name, or a roles file, or a .tar.gz file")
 
         no_deps = self.options.no_deps

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -313,8 +313,8 @@ class GalaxyCLI(CLI):
             # the user needs to specify one of either --role-file, a single user/role name or a .tar.gz file
             raise AnsibleOptionsError("- you must specify a user/role name, a .tar.gz file or a roles file")
         elif len(self.args) == 1 and role_file is not None:
-            # using a role file is mutually exclusive of specifying the role name on the command line
-            raise AnsibleOptionsError("- please specify a user/role name, or a roles file, but not both")
+            # using a role file is mutually exclusive of specifying the role name or the .tar.gz file on the command line 
+            raise AnsibleOptionsError("- please specify only one: a user/role name, or a roles file, or a .tar.gz file")
 
         no_deps = self.options.no_deps
         force = self.options.force

--- a/lib/ansible/playbook/role/requirement.py
+++ b/lib/ansible/playbook/role/requirement.py
@@ -61,8 +61,12 @@ class RoleRequirement(RoleDefinition):
     def repo_url_to_role_name(repo_url):
         # gets the role name out of a repo like
         # http://git.example.com/repos/repo.git" => "repo"
+        # "/tmp/hello-test.tar.gz"                => "hello-test"
 
         if '://' not in repo_url and '@' not in repo_url:
+            trailing_path = repo_url.split('/')[-1]
+            if trailing_path.endswith('.tar.gz'):
+              return trailing_path[:-7]
             return repo_url
         trailing_path = repo_url.split('/')[-1]
         if trailing_path.endswith('.git'):

--- a/lib/ansible/playbook/role/requirement.py
+++ b/lib/ansible/playbook/role/requirement.py
@@ -60,15 +60,14 @@ class RoleRequirement(RoleDefinition):
     @staticmethod
     def repo_url_to_role_name(repo_url):
         # gets the role name out of a repo like
-        # http://git.example.com/repos/repo.git" => "repo"
+        # "http://git.example.com/repos/repo.git" => "repo"
         # "/tmp/hello-test.tar.gz"                => "hello-test"
 
+        trailing_path = os.path.basename(repo_url)
         if '://' not in repo_url and '@' not in repo_url:
-            trailing_path = repo_url.split('/')[-1]
             if trailing_path.endswith('.tar.gz'):
                 return trailing_path[:-7]
             return repo_url
-        trailing_path = repo_url.split('/')[-1]
         if trailing_path.endswith('.git'):
             trailing_path = trailing_path[:-4]
         if trailing_path.endswith('.tar.gz'):

--- a/lib/ansible/playbook/role/requirement.py
+++ b/lib/ansible/playbook/role/requirement.py
@@ -66,7 +66,7 @@ class RoleRequirement(RoleDefinition):
         if '://' not in repo_url and '@' not in repo_url:
             trailing_path = repo_url.split('/')[-1]
             if trailing_path.endswith('.tar.gz'):
-              return trailing_path[:-7]
+                return trailing_path[:-7]
             return repo_url
         trailing_path = repo_url.split('/')[-1]
         if trailing_path.endswith('.git'):


### PR DESCRIPTION
##### SUMMARY

Improve the handling of roles installed from a local tar.gz file. 
Fixes #16136.

I also updated the documentation for the 'ansible-galaxy install' subcommand.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = /home/jacco/ansible.cfg
  configured module search path = [u'/home/jacco/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION


You can install a .tar.gz of a valid role you've downloaded directly from github.com. This is mainly useful when the system running Ansible does not have access to the Galaxy API, for instance when behind a firewall or proxy. For example: 

```
$ ansible-galaxy install hello-test.tar.gz
```
But ansible-galaxy will then try to use the filename as the rolename. My fix removes the tar.gz extension. 

Another example is this:   
```
$ ansible-galaxy install /tmp/hello-test.tar.gz
```
This results in an error "the specified roles path exists and is not a directory" because ansible-galaxy gets confused about the path. The fix also removes the path from the rolename.

The fix also adds the --role-name option to the install subcommand. This allows complete control over the rolename:

```
$ ansible-galaxy install --role-name=hello-test /home/example/master.tar.gz
```
The workaround by @willthames https://github.com/ansible/ansible/issues/16136#issuecomment-225755402 also works. But in my opinion this is less intuitive, even if you add documentation fix #18393.