### PR TITLE
Convert docker cmd output to native, early

### DIFF
--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -35,7 +35,7 @@ from distutils.version import LooseVersion
 
 import ansible.constants as C
 from ansible.errors import AnsibleError, AnsibleFileNotFound
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils._text import to_bytes, to_native
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
 
 
@@ -116,7 +116,7 @@ class Connection(ConnectionBase):
         p = subprocess.Popen(old_docker_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         cmd_output, err = p.communicate()
 
-        return old_docker_cmd, cmd_output, err, p.returncode
+        return old_docker_cmd, to_native(cmd_output), err, p.returncode
 
     def _new_docker_version(self):
         # no result yet, must be newer Docker version
@@ -129,7 +129,7 @@ class Connection(ConnectionBase):
         new_docker_cmd = [self.docker_cmd] + cmd_args + new_version_subcommand
         p = subprocess.Popen(new_docker_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         cmd_output, err = p.communicate()
-        return new_docker_cmd, cmd_output, err, p.returncode
+        return new_docker_cmd, to_native(cmd_output), err, p.returncode
 
     def _get_docker_version(self):
 


### PR DESCRIPTION
(cherry picked from commit ccd170cbdd32c0b0896a8bc289ab8583031a2827)

##### SUMMARY

This PR updates the docker connection plugin to support python3

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

plugins/connection/docker.py

##### ANSIBLE VERSION

2.2

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
