### PR TITLE
Fail module instead of returning boolean value

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_stack.py
+++ b/lib/ansible/modules/cloud/openstack/os_stack.py
@@ -182,7 +182,6 @@ def _create_stack(module, stack, cloud):
         if stack.stack_status == 'CREATE_COMPLETE':
             return stack
         else:
-            return False
             module.fail_json(msg="Failure in creating stack: {0}".format(stack))
     except shade.OpenStackCloudException as e:
         module.fail_json(msg=str(e))


### PR DESCRIPTION
##### SUMMARY
Fix added to fail module instead of returning boolean value
which raises AttributeError.

Fixes #21770

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/openstack/os_stack.py

##### ANSIBLE VERSION
```
2.4devel
```