### PR TITLE
Adds win_pagefile module

### DIFF
--- a/lib/ansible/modules/windows/win_pagefile.ps1
+++ b/lib/ansible/modules/windows/win_pagefile.ps1
@@ -45,6 +45,7 @@ $override =  Get-AnsibleParam -obj $params -name "override" -type "bool" -defaul
 $removeAll = Get-AnsibleParam -obj $params -name "remove_all" -type "bool" -default $false
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "query" -validateset "present","absent","query"
 $systemManaged = Get-AnsibleParam -obj $params -name "system_managed" -type "bool" -default $false
+$testPath = Get-AnsibleParam -obj $params -name "test_path" -type "bool" -default $true
 
 $result = @{
     changed = $false
@@ -101,7 +102,7 @@ if ($state -eq "absent") {
     }
 
     # Make sure drive is accessible
-    if (-not (Test-Path "${drive}:")) {
+    if (($test_path) -and (-not (Test-Path "${drive}:"))) {
         Fail-Json $result "Unable to access '${drive}:' drive"
     }
 

--- a/lib/ansible/modules/windows/win_pagefile.ps1
+++ b/lib/ansible/modules/windows/win_pagefile.ps1
@@ -21,9 +21,9 @@
 
 ########
 
-Function Remove-Pagefile($path) 
+Function Remove-Pagefile($path, $whatif) 
 {
-    Get-WmiObject Win32_PageFileSetting | WHERE { $_.Name -eq $path } | Remove-WmiObject
+    Get-WmiObject Win32_PageFileSetting | WHERE { $_.Name -eq $path } | Remove-WmiObject -WhatIf:$whatif
 }
 
 Function Get-Pagefile($path)
@@ -53,9 +53,7 @@ $result = @{
 if ($removeAll) {
     $currentPageFiles = Get-WmiObject Win32_PageFileSetting
     if ($currentPageFiles -ne $null) {
-        if (-not $check_mode) {
-            $currentPageFiles | Remove-WmiObject | Out-Null
-        }
+        $currentPageFiles | Remove-WmiObject -WhatIf:$check_mode | Out-Null
         $result.changed = $true
     }
 }
@@ -82,9 +80,7 @@ if ($state -eq "absent") {
     if ((Get-Pagefile $fullPath) -ne $null)
     {
         try {
-            if (-not $check_mode) {
-                Remove-Pagefile $fullPath
-            }
+            Remove-Pagefile $fullPath -whatif:$check_mode
             $result.changed = $true
         } catch {
             Fail-Json $result "Failed to remove pagefile $_.Exception.Message"
@@ -96,9 +92,7 @@ if ($state -eq "absent") {
         if ((Get-Pagefile $fullPath) -ne $null)
         {
             try {
-                if (-not $check_mode) {
-                    Remove-Pagefile $fullPath
-                }
+                Remove-Pagefile $fullPath -whatif:$check_mode
                 $result.changed = $true
             } catch {
                 Fail-Json $result "Failed to remove current pagefile $_.Exception.Message"
@@ -114,11 +108,11 @@ if ($state -eq "absent") {
     # Set pagefile
     try {
         if ((Get-Pagefile $fullPath) -eq $null) {
-            $pagefile = Set-WmiInstance -Class Win32_PageFileSetting -Arguments @{name = $fullPath; InitialSize = 0; MaximumSize = 0}
-            if (!$systemManaged) {
-                $pagefile.InitialSize = $initialSize
-                $pagefile.MaximumSize = $maximumSize
-                if (-not $check_mode) {
+            if (-not $check_mode) {
+                $pagefile = Set-WmiInstance -Class Win32_PageFileSetting -Arguments @{name = $fullPath; InitialSize = 0; MaximumSize = 0}
+                if (!$systemManaged) {
+                    $pagefile.InitialSize = $initialSize
+                    $pagefile.MaximumSize = $maximumSize
                     $pagefile.Put() | out-null
                 }
             }

--- a/lib/ansible/modules/windows/win_pagefile.ps1
+++ b/lib/ansible/modules/windows/win_pagefile.ps1
@@ -1,0 +1,147 @@
+#!powershell
+# This file is part of Ansible
+#
+# Copyright 2017, Liran Nisanov <lirannis@gmail.com>
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# WANT_JSON
+# POWERSHELL_COMMON
+
+########
+
+Function Remove-Pagefile($path) 
+{
+    Get-WmiObject Win32_PageFileSetting | WHERE { $_.Name -eq $path } | Remove-WmiObject
+}
+
+Function Get-Pagefile($path)
+{
+    Get-WmiObject Win32_PageFileSetting | WHERE { $_.Name -eq $path }
+}
+
+########
+
+$params = Parse-Args $args;
+
+$result = @{ 
+    changed = $false
+}
+
+$automatic = Get-AnsibleParam -obj $params -name "automatic" -type "bool"
+$drive = Get-AnsibleParam -obj $params -name "drive" -type "str"
+$fullPath = $drive + ":\pagefile.sys"
+$initialSize = Get-AnsibleParam -obj $params -name "initial_size" -type "int"
+$maximumSize = Get-AnsibleParam -obj $params -name "maximum_size" -type "int"
+$override =  Get-AnsibleParam -obj $params -name "override" -type "bool" -default $true
+$removeAll = Get-AnsibleParam -obj $params -name "remove_all" -type "bool" -default $false
+$state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "query" -validateset "present","absent","query"
+$systemManaged = Get-AnsibleParam -obj $params -name "system_managed" -type "bool" -default $false
+
+$ErrorActionPreference = "Stop"
+
+if ($removeAll) {
+    Get-WmiObject Win32_PageFileSetting | Remove-WmiObject | Out-Null
+}
+
+if ($automatic -ne $null) {
+    # change autmoatic managed pagefile 
+    try {
+        $computerSystem = Get-WmiObject -Class win32_computersystem -EnableAllPrivileges
+    
+        if ($computerSystem.AutomaticManagedPagefile -ne $automatic) {
+            $computerSystem.AutomaticManagedPagefile = $automatic
+            $computerSystem.Put() | Out-Null
+            $result.changed = $true
+        }
+    } catch {
+        Fail-Json $result "Failed to set AutomaticManagedPagefile $_.Exception.Message"
+    }
+}
+
+if ($state -eq "absent") {
+    # Remove pagefile
+    if ((Get-Pagefile $fullPath) -ne $null)
+    {
+        try {
+            Remove-Pagefile $fullPath
+            $result.changed = $true
+        } catch {
+            Fail-Json $result "Failed to remove pagefile $_.Exception.Message"
+        }
+    }
+} elseif ($state -eq "present") {   
+    # Remove current pagefile
+    if ($override) {
+        if ((Get-Pagefile $fullPath) -ne $null)
+        {
+            try {
+                Remove-Pagefile $fullPath
+                $result.changed = $true
+            } catch {
+                Fail-Json $result "Failed to remove current pagefile $_.Exception.Message"
+            }
+        }
+    }
+
+    # Make sure drive is accessible
+    if (!(Test-Path "${drive}:")) {
+        Fail-Json $result "Unable to access '${drive}:' drive"
+    }
+
+    # Set pagefile
+    try {
+        if ((Get-Pagefile $fullPath) -eq $null) {
+            $pagefile = Set-WmiInstance -Class Win32_PageFileSetting -Arguments @{name = $fullPath; InitialSize = 0; MaximumSize = 0}
+            if (!$systemManaged) {
+                $pagefile.InitialSize = $initialSize
+                $pagefile.MaximumSize = $maximumSize
+                $pagefile.Put() | out-null
+            }
+            $result.changed = $true
+        }
+    } catch {
+        Fail-Json $result "Failed to set pagefile $_.Exception.Message"
+    }
+} elseif ($state -eq "query") {
+    try {
+
+        $result.pagefiles = @()
+
+        if ($drive -eq $null) {
+            $pagefiles = Get-WmiObject Win32_PageFileSetting
+        } else {
+            $pagefiles = Get-Pagefile $fullPath
+        }
+
+        # Get all pagefiles
+        foreach ($currentPagefile in $pagefiles) {
+            $currentPagefileObject = @{
+                name = $currentPagefile.Name
+                initial_size = $currentPagefile.InitialSize
+                maximum_size = $currentPagefile.MaximumSize
+                caption = $currentPagefile.Caption
+                description = $currentPagefile.Description
+            }
+
+            $result.pagefiles += $currentPagefileObject
+        }
+
+        # Get automatic managed pagefile state
+        $result.automatic_managed_pagefiles = (Get-WmiObject -Class win32_computersystem).AutomaticManagedPagefile
+    } catch {
+        Fail-Json $result "Failed to query current pagefiles $_.Exception.Message"
+    }
+}
+Exit-Json $result

--- a/lib/ansible/modules/windows/win_pagefile.ps1
+++ b/lib/ansible/modules/windows/win_pagefile.ps1
@@ -101,20 +101,18 @@ if ($state -eq "absent") {
     }
 
     # Make sure drive is accessible
-    if (!(Test-Path "${drive}:")) {
+    if (-not (Test-Path "${drive}:")) {
         Fail-Json $result "Unable to access '${drive}:' drive"
     }
 
     # Set pagefile
     try {
         if ((Get-Pagefile $fullPath) -eq $null) {
-            if (-not $check_mode) {
-                $pagefile = Set-WmiInstance -Class Win32_PageFileSetting -Arguments @{name = $fullPath; InitialSize = 0; MaximumSize = 0}
-                if (!$systemManaged) {
-                    $pagefile.InitialSize = $initialSize
-                    $pagefile.MaximumSize = $maximumSize
-                    $pagefile.Put() | out-null
-                }
+            $pagefile = Set-WmiInstance -Class Win32_PageFileSetting -Arguments @{name = $fullPath; InitialSize = 0; MaximumSize = 0} -WhatIf:$check_mode
+            if (-not ($systemManaged -or $check_mode)) {
+                $pagefile.InitialSize = $initialSize
+                $pagefile.MaximumSize = $maximumSize
+                $pagefile.Put() | out-null
             }
             $result.changed = $true
         }

--- a/lib/ansible/modules/windows/win_pagefile.ps1
+++ b/lib/ansible/modules/windows/win_pagefile.ps1
@@ -132,13 +132,13 @@ if ($state -eq "absent") {
                 try {
                     $pagingFilesValues = (Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management").PagingFiles
                 } catch {
-                    Fail-Json $result "Failed to get pagefile settings from registry for workaround $($_.Exception.Message) Original exception: $originalExceptionMessage"
+                    Fail-Json $result "Failed to get pagefile settings from the registry for workaround $($_.Exception.Message) Original exception: $originalExceptionMessage"
                 }
                 $pagingFilesValues += "$fullPath $initialSize $maximumSize"
                 try {
                     Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management" "PagingFiles" $pagingFilesValues
                 } catch {
-                    Fail-Json $result "Failed to set pagefile settings to registry for workaround $($_.Exception.Message) Original exception: $originalExceptionMessage"
+                    Fail-Json $result "Failed to set pagefile settings to the registry for workaround $($_.Exception.Message) Original exception: $originalExceptionMessage"
                 }
             }
         }

--- a/lib/ansible/modules/windows/win_pagefile.ps1
+++ b/lib/ansible/modules/windows/win_pagefile.ps1
@@ -33,10 +33,6 @@ Function Get-Pagefile($path)
 
 ########
 
-$result = @{ 
-    changed = $false
-}
-
 $params = Parse-Args $args -supports_check_mode $true
 $check_mode = Get-AnsibleParam -obj $params -name '_ansible_check_mode' -type 'bool' -default $false
 
@@ -50,7 +46,9 @@ $removeAll = Get-AnsibleParam -obj $params -name "remove_all" -type "bool" -defa
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "query" -validateset "present","absent","query"
 $systemManaged = Get-AnsibleParam -obj $params -name "system_managed" -type "bool" -default $false
 
-$ErrorActionPreference = "Stop"
+$result = @{
+    changed = $false
+}
 
 if ($removeAll) {
     $currentPageFiles = Get-WmiObject Win32_PageFileSetting

--- a/lib/ansible/modules/windows/win_pagefile.ps1
+++ b/lib/ansible/modules/windows/win_pagefile.ps1
@@ -72,7 +72,7 @@ if ($automatic -ne $null) {
             $result.changed = $true
         }
     } catch {
-        Fail-Json $result "Failed to set AutomaticManagedPagefile $_.Exception.Message"
+        Fail-Json $result "Failed to set AutomaticManagedPagefile $($_.Exception.Message)"
     }
 }
 
@@ -84,7 +84,7 @@ if ($state -eq "absent") {
             Remove-Pagefile $fullPath -whatif:$check_mode
             $result.changed = $true
         } catch {
-            Fail-Json $result "Failed to remove pagefile $_.Exception.Message"
+            Fail-Json $result "Failed to remove pagefile $($_.Exception.Message)"
         }
     }
 } elseif ($state -eq "present") {   
@@ -96,7 +96,7 @@ if ($state -eq "absent") {
                 Remove-Pagefile $fullPath -whatif:$check_mode
                 $result.changed = $true
             } catch {
-                Fail-Json $result "Failed to remove current pagefile $_.Exception.Message"
+                Fail-Json $result "Failed to remove current pagefile $($_.Exception.Message)"
             }
         }
     }
@@ -118,7 +118,7 @@ if ($state -eq "absent") {
             $result.changed = $true
         }
     } catch {
-        Fail-Json $result "Failed to set pagefile $_.Exception.Message"
+        Fail-Json $result "Failed to set pagefile $($_.Exception.Message)"
     }
 } elseif ($state -eq "query") {
     try {
@@ -147,7 +147,7 @@ if ($state -eq "absent") {
         # Get automatic managed pagefile state
         $result.automatic_managed_pagefiles = (Get-WmiObject -Class win32_computersystem).AutomaticManagedPagefile
     } catch {
-        Fail-Json $result "Failed to query current pagefiles $_.Exception.Message"
+        Fail-Json $result "Failed to query current pagefiles $($_.Exception.Message)"
     }
 }
 Exit-Json $result

--- a/lib/ansible/modules/windows/win_pagefile.ps1
+++ b/lib/ansible/modules/windows/win_pagefile.ps1
@@ -78,7 +78,7 @@ if ($state -eq "absent") {
         }
         $result.changed = $true
     }
-} elseif ($state -eq "present") {   
+} elseif ($state -eq "present") {
     # Remove current pagefile
     if ($override) {
         if ((Get-Pagefile $fullPath) -ne $null)

--- a/lib/ansible/modules/windows/win_pagefile.ps1
+++ b/lib/ansible/modules/windows/win_pagefile.ps1
@@ -2,19 +2,7 @@
 # This file is part of Ansible
 #
 # Copyright 2017, Liran Nisanov <lirannis@gmail.com>
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # WANT_JSON
 # POWERSHELL_COMMON

--- a/lib/ansible/modules/windows/win_pagefile.ps1
+++ b/lib/ansible/modules/windows/win_pagefile.ps1
@@ -9,7 +9,7 @@
 
 ########
 
-Function Remove-Pagefile($path, $whatif) 
+Function Remove-Pagefile($path, $whatif)
 {
     Get-WmiObject Win32_PageFileSetting | WHERE { $_.Name -eq $path } | Remove-WmiObject -WhatIf:$whatif
 }

--- a/lib/ansible/modules/windows/win_pagefile.py
+++ b/lib/ansible/modules/windows/win_pagefile.py
@@ -39,7 +39,6 @@ options:
   drive:
     description:
       - The drive of the pagefile.
-    required: false
   initial_size:
     description:
       - The initial size of the pagefile.
@@ -49,30 +48,22 @@ options:
   override:
     description:
       - Override the current pagefile on the drive.
-    choices:
-      - true
-      - false
-    default: true
+    type: bool
+    default: 'yes'
   system_managed:
     description:
       - Configures current pagefile to be managed by the system.
-    choices:
-      - true
-      - false
-    default: false
+    type: bool
+    default: 'no'
   automatic:
     description:
       - Configures AutomaticManagedPagefile for the entire system.
-    choices:
-      - true
-      - false
+    type: bool
   remove_all:
     description:
       - Remove all pagefiles in the system, not including automatic managed.
-    choices:
-      - true
-      - false
-    default: false
+    type: bool
+    default: 'no'
   state:
     description:
       - State of the pagefile.
@@ -86,7 +77,8 @@ notes:
 - InitialSize 0 and MaximumSize 0 means the pagefile is managed by the system.
 - Value out of range exception may be caused by several different issues, two common problems - No such drive, Pagefile size is too small.
 - Setting a pagefile when AutomaticManagedPagefile is on will disable the AutomaticManagedPagefile.
-author: "Liran Nisanov (@LiranNis)"
+author:
+- Liran Nisanov (@LiranNis)
 '''
 
 EXAMPLES = r'''
@@ -102,7 +94,7 @@ EXAMPLES = r'''
     drive: C
     initial_size: 1024
     maximum_size: 1024
-    override: false
+    override: no
     state: present
 
 - name: Set C pagefile, override if exists
@@ -119,16 +111,16 @@ EXAMPLES = r'''
 
 - name: Remove all current pagefiles, enable AutomaticManagedPagefile and query at the end
   win_pagefile:
-    remove_all: true
-    automatic: true
+    remove_all: yes
+    automatic: yes
 
 - name: Remove all pagefiles disable AutomaticManagedPagefile and set C pagefile
   win_pagefile:
     drive: C
     initial_size: 2048
     maximum_size: 2048
-    remove_all: true
-    automatic: false
+    remove_all: yes
+    automatic: no
     state: present
 
 - name: Set D pagefile, override if exists

--- a/lib/ansible/modules/windows/win_pagefile.py
+++ b/lib/ansible/modules/windows/win_pagefile.py
@@ -64,6 +64,11 @@ options:
       - Remove all pagefiles in the system, not including automatic managed.
     type: bool
     default: 'no'
+  test_path:
+    description:
+      - Use Test-Path on the drive to make sure the drive is accessible before creating the pagefile.
+    type: bool
+    default: 'yes'
   state:
     description:
       - State of the pagefile.

--- a/lib/ansible/modules/windows/win_pagefile.py
+++ b/lib/ansible/modules/windows/win_pagefile.py
@@ -32,9 +32,9 @@ module: win_pagefile
 version_added: "2.4"
 short_description: Query or change pagefile configuration
 description:
-    - Query current pagefile configuration
-    - Enable/Disable AutomaticManagedPagefile
-    - Create new or override pagefile configuration
+    - Query current pagefile configuration.
+    - Enable/Disable AutomaticManagedPagefile.
+    - Create new or override pagefile configuration.
 options:
   drive:
     description:

--- a/lib/ansible/modules/windows/win_pagefile.py
+++ b/lib/ansible/modules/windows/win_pagefile.py
@@ -95,48 +95,48 @@ EXAMPLES = r'''
 
 - name: Query C pagefile
   win_pagefile:
-    drive=c
+    drive: C
 
 - name: Set C pagefile, don't override if exists
   win_pagefile:
-    drive=C
-    initial_size=1024
-    maximum_size=1024
-    override=false
-    state=present
+    drive: C
+    initial_size: 1024
+    maximum_size: 1024
+    override: false
+    state: present
 
 - name: Set C pagefile, override if exists
   win_pagefile:
-    drive=C
-    initial_size=1024
-    maximum_size=1024
-    state=present
+    drive: C
+    initial_size: 1024
+    maximum_size: 1024
+    state: present
 
 - name: Remove C pagefile
   win_pagefile:
-    drive=c
-    state=absent
+    drive: C
+    state: absent
 
 - name: Remove all current pagefiles, enable AutomaticManagedPagefile and query at the end
   win_pagefile:
-    remove_all=true
-    automatic=true
+    remove_all: true
+    automatic: true
 
 - name: Remove all pagefiles disable AutomaticManagedPagefile and set C pagefile
   win_pagefile:
-    drive=c
-    initial_size=2048
-    maximum_size=2048
-    remove_all=true
-    automatic=false
-    state=present
+    drive: C
+    initial_size: 2048
+    maximum_size: 2048
+    remove_all: true
+    automatic: false
+    state: present
 
 - name: Set D pagefile, override if exists
   win_pagefile:
-    drive=d
-    initial_size=1024
-    maximum_size=1024
-    state=present
+    drive: d
+    initial_size: 1024
+    maximum_size: 1024
+    state: present
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/windows/win_pagefile.py
+++ b/lib/ansible/modules/windows/win_pagefile.py
@@ -1,0 +1,154 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Liran Nisanov <lirannis@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = r'''
+---
+module: win_pagefile
+version_added: "2.3.1"
+short_description: Query or change pagefile configuration
+description:
+    - Query current pagefile configuration
+    - Enable/Disable AutomaticManagedPagefile
+    - Create new or override pagefile configuration
+options:
+  drive:
+    description:
+      - The drive of the pagefile.
+    required: false
+  initial_size:
+    description:
+      - The initial size of the pagefile.
+  maximum_size:
+    description:
+      - The maximum size of the pagefile.
+  override:
+    description:
+      - Override the current pagefile on the drive.
+    choices:
+      - true
+      - false
+    default: true
+  system_managed:
+    description:
+      - Configures current pagefile to be managed by the system.
+    choices:
+      - true
+      - false
+    default: false
+  automatic:
+    description:
+      - Configures AutomaticManagedPagefile for the entire system.
+    choices:
+      - true
+      - false
+  remove_all:
+    description:
+      - Remove all pagefiles in the system, not including automatic managed.
+    choices:
+      - true
+      - false
+    default: false
+  state:
+    description:
+      - State of the pagefile.
+    choices:
+      - present
+      - absent
+      - query
+    default: query
+notes:
+- There is difference between automatic managed pagefiles that configured once for the entire system and system managed pagefile that configured per pagefile.
+- InitialSize 0 and MaximumSize 0 means the pagefile is managed by the system.
+- Value out of range exception may be caused by several different issues, two common problems - No such drive, Pagefile size is too small.
+- Setting a pagefile when AutomaticManagedPagefile is on will disable the AutomaticManagedPagefile.
+author: "Liran Nisanov (@LiranNis)"
+'''
+
+EXAMPLES = r'''
+- name: Query pagefiles configuration
+  win_pagefile:
+
+- name: Query C pagefile
+  win_pagefile:
+    drive=c
+
+- name: Set C pagefile, don't override if exists
+  win_pagefile:
+    drive=C
+    initial_size=1024
+    maximum_size=1024
+    override=false
+    state=present
+
+- name: Set C pagefile, override if exists
+  win_pagefile:
+    drive=C
+    initial_size=1024
+    maximum_size=1024
+    state=present
+
+- name: Remove C pagefile
+  win_pagefile:
+    drive=c
+    state=absent
+
+- name: Remove all current pagefiles, enable AutomaticManagedPagefile and query at the end
+  win_pagefile:
+    remove_all=true
+    automatic=true
+
+- name: Remove all pagefiles disable AutomaticManagedPagefile and set C pagefile
+  win_pagefile:
+    drive=c
+    initial_size=2048
+    maximum_size=2048
+    remove_all=true
+    automatic=false
+    state=present
+
+- name: Set D pagefile, override if exists
+  win_pagefile:
+    drive=d
+    initial_size=1024
+    maximum_size=1024
+    state=present
+'''
+
+RETURN = r'''
+automatic_managed_pagefiles:
+    description: Whether the pagefiles is automatically managed
+    returned: When state is query.   
+    type: boolean
+    sample: true
+pagefiles:
+    description: Pagefiles on the system.
+    returned: When state is query.
+    type: JSON that contains caption, description, initial_size, maximum_size and name.
+    sample: [{"caption": "c:\\ 'pagefile.sys'", "description": "'pagefile.sys' @ c:\\", "initial_size": 2048, "maximum_size": 2048, "name": "c:\\pagefile.sys"}, {"caption": "d:\\ 'pagefile.sys'", "description": "'pagefile.sys' @ d:\\", "initial_size": 1024, "maximum_size": 1024, "name": "d:\\pagefile.sys"}]
+
+'''

--- a/lib/ansible/modules/windows/win_pagefile.py
+++ b/lib/ansible/modules/windows/win_pagefile.py
@@ -29,7 +29,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 DOCUMENTATION = r'''
 ---
 module: win_pagefile
-version_added: "2.3.1"
+version_added: "2.4"
 short_description: Query or change pagefile configuration
 description:
     - Query current pagefile configuration
@@ -141,14 +141,16 @@ EXAMPLES = r'''
 
 RETURN = r'''
 automatic_managed_pagefiles:
-    description: Whether the pagefiles is automatically managed
-    returned: When state is query.   
+    description: Whether the pagefiles is automatically managed.
+    returned: When state is query.
     type: boolean
     sample: true
 pagefiles:
-    description: Pagefiles on the system.
+    description: Contains caption, description, initial_size, maximum_size and name for each pagefile in the system.
     returned: When state is query.
-    type: JSON that contains caption, description, initial_size, maximum_size and name.
-    sample: [{"caption": "c:\\ 'pagefile.sys'", "description": "'pagefile.sys' @ c:\\", "initial_size": 2048, "maximum_size": 2048, "name": "c:\\pagefile.sys"}, {"caption": "d:\\ 'pagefile.sys'", "description": "'pagefile.sys' @ d:\\", "initial_size": 1024, "maximum_size": 1024, "name": "d:\\pagefile.sys"}]
+    type: list
+    sample: 
+      [{"caption": "c:\\ 'pagefile.sys'", "description": "'pagefile.sys' @ c:\\", "initial_size": 2048, "maximum_size": 2048, "name": "c:\\pagefile.sys"}, 
+       {"caption": "d:\\ 'pagefile.sys'", "description": "'pagefile.sys' @ d:\\", "initial_size": 1024, "maximum_size": 1024, "name": "d:\\pagefile.sys"}]
 
 '''

--- a/lib/ansible/modules/windows/win_pagefile.py
+++ b/lib/ansible/modules/windows/win_pagefile.py
@@ -41,10 +41,10 @@ options:
       - The drive of the pagefile.
   initial_size:
     description:
-      - The initial size of the pagefile.
+      - The initial size of the pagefile in megabytes.
   maximum_size:
     description:
-      - The maximum size of the pagefile.
+      - The maximum size of the pagefile in megabytes.
   override:
     description:
       - Override the current pagefile on the drive.

--- a/lib/ansible/modules/windows/win_pagefile.py
+++ b/lib/ansible/modules/windows/win_pagefile.py
@@ -149,8 +149,8 @@ pagefiles:
     description: Contains caption, description, initial_size, maximum_size and name for each pagefile in the system.
     returned: When state is query.
     type: list
-    sample: 
-      [{"caption": "c:\\ 'pagefile.sys'", "description": "'pagefile.sys' @ c:\\", "initial_size": 2048, "maximum_size": 2048, "name": "c:\\pagefile.sys"}, 
+    sample:
+      [{"caption": "c:\\ 'pagefile.sys'", "description": "'pagefile.sys' @ c:\\", "initial_size": 2048, "maximum_size": 2048, "name": "c:\\pagefile.sys"},
        {"caption": "d:\\ 'pagefile.sys'", "description": "'pagefile.sys' @ d:\\", "initial_size": 1024, "maximum_size": 1024, "name": "d:\\pagefile.sys"}]
 
 '''

--- a/lib/ansible/modules/windows/win_pagefile.py
+++ b/lib/ansible/modules/windows/win_pagefile.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-
-# (c) 2017, Liran Nisanov <lirannis@gmail.com>
+# Copyright 2017, Liran Nisanov <lirannis@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # this is a windows documentation stub.  actual code lives in the .ps1

--- a/lib/ansible/modules/windows/win_pagefile.py
+++ b/lib/ansible/modules/windows/win_pagefile.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+
 # Copyright 2017, Liran Nisanov <lirannis@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 

--- a/lib/ansible/modules/windows/win_pagefile.py
+++ b/lib/ansible/modules/windows/win_pagefile.py
@@ -1,22 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2017, Liran Nisanov <lirannis@gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright 2017, Liran Nisanov <lirannis@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # this is a windows documentation stub.  actual code lives in the .ps1
 # file of the same name

--- a/lib/ansible/modules/windows/win_pagefile.py
+++ b/lib/ansible/modules/windows/win_pagefile.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright 2017, Liran Nisanov <lirannis@gmail.com>
+# (c) 2017, Liran Nisanov <lirannis@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # this is a windows documentation stub.  actual code lives in the .ps1

--- a/test/integration/targets/win_pagefile/aliases
+++ b/test/integration/targets/win_pagefile/aliases
@@ -1,0 +1,1 @@
+windows/ci/group2

--- a/test/integration/targets/win_pagefile/tasks/main.yml
+++ b/test/integration/targets/win_pagefile/tasks/main.yml
@@ -1,0 +1,136 @@
+---
+# Test 1: Set c pagefile with inital and maximum size
+- name: Set C pagefile as 1024-2048MB
+  win_pagefile:
+    remove_all: yes
+    drive: C
+    initial_size: 1024
+    maximum_size: 2048
+    override: yes
+    state: present
+  register: c_pagefile
+
+- name: Test set c pagefile
+  assert:
+    that:
+    - c_pagefile.changed == true
+  
+- name: Query all pagefiles
+  win_pagefile:
+    state: query
+  register: pagefiles_query
+
+- name: Set fact for pagefile expected result
+  set_fact: 
+    expected:
+      pagefiles: 
+      - { caption: "C:\\ 'pagefile.sys'",
+          description: "'pagefile.sys' @ C:\\",
+          initial_size: 1024,
+          maximum_size: 2048,
+          name: "C:\\pagefile.sys" }
+
+- name: Test query - c pagefile 1024-2048
+  assert:
+    that:
+    - pagefiles_query.changed == false
+    - pagefiles_query.pagefiles == expected.pagefiles
+    - pagefiles_query.automatic_managed_pagefiles == false
+
+
+# Test 2: Remove c pagefile
+- name: Remove C pagefile
+  win_pagefile:
+    drive: C
+    state: absent
+  register: delete_c_pagefile
+
+- name: Test removal of c pagefile
+  assert:
+    that:
+      - delete_c_pagefile.changed == true
+
+- name: Query all pagefiles
+  win_pagefile:
+    state: query
+  register: pagefiles_query
+
+- name: Set fact for pagefile expected result
+  set_fact:
+    expected:
+      pagefiles: []
+
+- name: Test query - no c pagefile
+  assert:
+    that:
+      - pagefiles_query.changed == false
+      - pagefiles_query.pagefiles == expected.pagefiles
+      - pagefiles_query.automatic_managed_pagefiles == false
+
+
+# Test 3: Set automatic managed pagefile as true
+- name: Set automatic managed pagefiles as true
+  win_pagefile:
+    automatic: yes
+  register: set_automatic_true
+
+- name: Test removal of c pagefile
+  assert:
+    that:
+      - set_automatic_true.changed == true
+      - set_automatic_true.automatic_managed_pagefiles == true
+
+
+# Test 4: Set c pagefile as system managed pagefile
+- name: Set c pagefile as system managed pagefile
+  win_pagefile:
+    drive: C
+    system_managed: yes
+    state: present
+  register: c_pagefile_system_managed
+
+- name: Test set c pagefile as system managed
+  assert:
+    that:
+    - c_pagefile_system_managed.changed == true
+
+- name: Query all pagefiles
+  win_pagefile:
+    state: query
+  register: pagefiles_query
+
+- name: Set fact for pagefile expected result
+  set_fact:
+    expected:
+      pagefiles:
+      - { caption: "C:\\ 'pagefile.sys'",
+          description: "'pagefile.sys' @ C:\\",
+          initial_size: 0,
+          maximum_size: 0,
+          name: "C:\\pagefile.sys" }
+
+- name: Test query - c pagefile 0-0 (system managed)
+  assert:
+    that:
+    - pagefiles_query.changed == false
+    - pagefiles_query.pagefiles == expected.pagefiles
+    - pagefiles_query.automatic_managed_pagefiles == false
+
+
+# Test 5: Remove all pagefiles
+- name: Remove all pagefiles
+  win_pagefile:
+    remove_all: true
+  register: remove_all_pagefiles
+
+- name: Set fact for pagefile expected result
+  set_fact:
+    expected:
+      pagefiles: []
+
+- name: Test query - no pagefiles
+  assert:
+    that:
+      - remove_all_pagefiles.changed == true
+      - remove_all_pagefiles.pagefiles == expected.pagefiles
+      - pagefiles_query.automatic_managed_pagefiles == false

--- a/test/integration/targets/win_pagefile/tasks/main.yml
+++ b/test/integration/targets/win_pagefile/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+# Get current pagefiles status
+- name: Get original pagefile settings
+  win_pagefile:
+    state: query
+  register: original_pagefile_settings
+
 # Test 1: Set c pagefile with inital and maximum size
 - name: Set C pagefile as 1024-2048MB
   win_pagefile:
@@ -24,11 +30,11 @@
   set_fact: 
     expected:
       pagefiles: 
-      - { caption: "C:\\ 'pagefile.sys'",
-          description: "'pagefile.sys' @ C:\\",
-          initial_size: 1024,
-          maximum_size: 2048,
-          name: "C:\\pagefile.sys" }
+      - caption: "C:\\ 'pagefile.sys'"
+        description: "'pagefile.sys' @ C:\\"
+        initial_size: 1024
+        maximum_size: 2048
+        name: "C:\\pagefile.sys"
 
 - name: Test query - c pagefile 1024-2048
   assert:
@@ -103,11 +109,11 @@
   set_fact:
     expected:
       pagefiles:
-      - { caption: "C:\\ 'pagefile.sys'",
-          description: "'pagefile.sys' @ C:\\",
-          initial_size: 0,
-          maximum_size: 0,
-          name: "C:\\pagefile.sys" }
+      - caption: "C:\\ 'pagefile.sys'"
+        description: "'pagefile.sys' @ C:\\"
+        initial_size: 0
+        maximum_size: 0
+        name: "C:\\pagefile.sys"
 
 - name: Test query - c pagefile 0-0 (system managed)
   assert:
@@ -116,8 +122,71 @@
     - pagefiles_query.pagefiles == expected.pagefiles
     - pagefiles_query.automatic_managed_pagefiles == false
 
+# Test 5: Test no override
+- name: Set c pagefile 1024-1024, no override
+  win_pagefile:
+    drive: C
+    initial_size: 1024
+    maximum_size: 1024
+    override: no
+    state: present
+  register: c_pagefile_no_override
 
-# Test 5: Remove all pagefiles
+- name: Test set c pagefile no override
+  assert:
+    that:
+    - c_pagefile_no_override.changed == false
+
+- name: Query all pagefiles
+  win_pagefile:
+    state: query
+  register: pagefiles_query
+
+- name: Test query - c pagefile unchanged
+  assert:
+    that:
+    - pagefiles_query.changed == false
+    - pagefiles_query.pagefiles == expected.pagefiles
+    - pagefiles_query.automatic_managed_pagefiles == false
+
+
+# Test 6: Test override
+- name: Set c pagefile 1024-1024, override
+  win_pagefile:
+    drive: C
+    initial_size: 1024
+    maximum_size: 1024
+    state: present
+  register: c_pagefile_override
+
+- name: Test set c pagefile no override
+  assert:
+    that:
+    - c_pagefile_override.changed == true
+
+- name: Query all pagefiles
+  win_pagefile:
+    state: query
+  register: pagefiles_query
+
+- name: Set fact for pagefile expected result
+  set_fact:
+    expected:
+      pagefiles:
+      - caption: "C:\\ 'pagefile.sys'"
+        description: "'pagefile.sys' @ C:\\"
+        initial_size: 1024
+        maximum_size: 1024
+        name: "C:\\pagefile.sys"
+
+- name: Test query - c pagefile 1024-1024
+  assert:
+    that:
+    - pagefiles_query.changed == false
+    - pagefiles_query.pagefiles == expected.pagefiles
+    - pagefiles_query.automatic_managed_pagefiles == false
+
+# Test 7: Remove all pagefiles
 - name: Remove all pagefiles
   win_pagefile:
     remove_all: true
@@ -134,3 +203,18 @@
       - remove_all_pagefiles.changed == true
       - remove_all_pagefiles.pagefiles == expected.pagefiles
       - pagefiles_query.automatic_managed_pagefiles == false
+
+# Return all pagefile settings to its original state
+- name: Remove all pagefiles and return automatic to its original state
+  win_pagefile:
+    remove_all: yes
+    automatic: "{{ original_pagefile_settings.automatic_managed_pagefiles }}"
+
+- name: Return all previous pagefiles settings
+  win_pagefile:
+    drive: "{{ item.name[0] }}"
+    initial_size: "{{ item.initial_size }}"
+    maximum_size: "{{ item.maximum_size }}"
+    state: present
+  with_items: "{{ original_pagefile_settings.pagefiles }}"
+

--- a/test/integration/targets/win_pagefile/tasks/main.yml
+++ b/test/integration/targets/win_pagefile/tasks/main.yml
@@ -215,5 +215,6 @@
     drive: "{{ item.name[0] }}"
     initial_size: "{{ item.initial_size }}"
     maximum_size: "{{ item.maximum_size }}"
+    test_path: no
     state: present
   with_items: "{{ original_pagefile_settings.pagefiles }}"

--- a/test/integration/targets/win_pagefile/tasks/main.yml
+++ b/test/integration/targets/win_pagefile/tasks/main.yml
@@ -217,4 +217,3 @@
     maximum_size: "{{ item.maximum_size }}"
     state: present
   with_items: "{{ original_pagefile_settings.pagefiles }}"
-


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adds module that allows management of **Windows** pagefiles.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module: lib/ansible/modules/windows/win_pagefile.ps1
doc: lib/ansible/modules/windows/win_pagefile.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/etc/ansible/modules/']
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
