### PR TITLE
Fix redis cache for python3

### DIFF
--- a/lib/ansible/plugins/cache/redis.py
+++ b/lib/ansible/plugins/cache/redis.py
@@ -84,7 +84,7 @@ class CacheModule(BaseCacheModule):
 
     def contains(self, key):
         self._expire_keys()
-        return (self._cache.zrank(self._keys_set, key) >= 0)
+        return (self._cache.zrank(self._keys_set, key) is not None)
 
     def delete(self, key):
         self._cache.delete(self._make_key(key))


### PR DESCRIPTION
According to the redis-py docs, zrank will return the 0 based index for
the value in the sorted set.  So the logic here wasn't right to begin
with (It just means that a value at the 0-th position would never show
up as cached).  Need to compare against None to know if the value
exists in the cache.

https://redis-py.readthedocs.io/en/latest/#redis.StrictRedis.zrank

Fixes #25590

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
plugins/cache/redis.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel, 2.3
```


##### ADDITIONAL INFORMATION
Could someone who knows the redis API have a look at this?  I only read the redis docs to determine how this should be fixed so I could be wrong.  Thanks!