### PR TITLE
Correct variable name in vca_nat module

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vca_nat.py
+++ b/lib/ansible/modules/cloud/vmware/vca_nat.py
@@ -126,7 +126,7 @@ def rule_to_string(rule):
     strings = list()
     for key, value in rule.items():
         strings.append('%s=%s' % (key, value))
-    return ', '.join(string)
+    return ', '.join(strings)
 
 def main():
     argument_spec = vca_argument_spec()


### PR DESCRIPTION
##### SUMMARY
Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vca_nat.py

##### ANSIBLE VERSION
```
2.4devel
```