### PR TITLE
Added integration tests for apt: update

### DIFF
--- a/test/integration/targets/apt/defaults/main.yml
+++ b/test/integration/targets/apt/defaults/main.yml
@@ -1,2 +1,2 @@
 apt_foreign_arch: i386
-hello_old_version: 2.9-2
+hello_old_version: 2.6-1

--- a/test/integration/targets/apt/defaults/main.yml
+++ b/test/integration/targets/apt/defaults/main.yml
@@ -1,1 +1,2 @@
 apt_foreign_arch: i386
+hello_old_version: 2.9-2

--- a/test/integration/targets/apt/defaults/main.yml
+++ b/test/integration/targets/apt/defaults/main.yml
@@ -1,3 +1,2 @@
 apt_foreign_arch: i386
 hello_old_version: 2.6-1
-hello_old_version: 2.9-2

--- a/test/integration/targets/apt/defaults/main.yml
+++ b/test/integration/targets/apt/defaults/main.yml
@@ -1,2 +1,3 @@
 apt_foreign_arch: i386
 hello_old_version: 2.6-1
+hello_old_version: 2.9-2

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -116,6 +116,7 @@
 - name: check hello version
   shell: dpkg -s hello | grep Version | awk '{print $2}'
   register: hello_version
+
 - name: check hello architecture
   shell: dpkg -s hello | grep Architecture | awk '{print $2}'
   register: hello_architecture

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -15,11 +15,28 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-- include: 'apt.yml'
-  when: ansible_distribution in ('Ubuntu', 'Debian')
+ - name: Check if aptitude is installed
+   command: dpkg-query -l aptitude
+   register: deb_check
 
-- include: 'apt-multiarch.yml'
-  when: ansible_distribution in ('Ubuntu', 'Debian') and ansible_userspace_architecture != apt_foreign_arch
+ - include: upgrade.yml upgrade_type=dist
+   when: ansible_distribution in ('Ubuntu', 'Debian')
 
-- include: 'apt-builddep.yml'
-  when: ansible_distribution in ('Ubuntu', 'Debian')
+ - include: upgrade.yml upgrade_type=safe
+   when:
+     - deb_check.stdout.find('no packages found') != -1
+     - ansible_distribution in ('Ubuntu', 'Debian')
+
+ - include: upgrade.yml upgrade_type=full
+   when:
+     - deb_check.stdout.find('no packages found') != -1
+     - ansible_distribution in ('Ubuntu', 'Debian')
+
+ - include: 'apt.yml'
+   when: ansible_distribution in ('Ubuntu', 'Debian')
+
+ - include: 'apt-multiarch.yml'
+   when: ansible_distribution in ('Ubuntu', 'Debian') and ansible_userspace_architecture != apt_foreign_arch
+
+ - include: 'apt-builddep.yml'
+   when: ansible_distribution in ('Ubuntu', 'Debian')

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -25,13 +25,13 @@
 
  - include: upgrade.yml upgrade_type=safe
    when:
-     - deb_check.stdout.find('no packages found') != -1
      - ansible_distribution in ('Ubuntu', 'Debian')
+     - deb_check.stdout.find('no packages found') != -1
 
  - include: upgrade.yml upgrade_type=full
    when:
-     - deb_check.stdout.find('no packages found') != -1
      - ansible_distribution in ('Ubuntu', 'Debian')
+     - deb_check.stdout.find('no packages found') != -1
 
  - include: 'apt.yml'
    when: ansible_distribution in ('Ubuntu', 'Debian')

--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -18,6 +18,7 @@
  - name: Check if aptitude is installed
    command: dpkg-query -l aptitude
    register: deb_check
+   when: ansible_distribution in ('Ubuntu', 'Debian')
 
  - include: upgrade.yml upgrade_type=dist
    when: ansible_distribution in ('Ubuntu', 'Debian')

--- a/test/integration/targets/apt/tasks/upgrade.yml
+++ b/test/integration/targets/apt/tasks/upgrade.yml
@@ -1,14 +1,7 @@
 ---
-#### Tests for upgrade ####
-
-# TODO: dynamic architecture
-
-- name: "download deb of older version of hello"
-  get_url: "url=https://launchpad.net/ubuntu/+archive/primary/+files/hello_{{ hello_old_version }}_amd64.deb dest={{ ansible_user_dir }}/hello.deb"
-
-# # Tests for dist-upgrade
-- name: install old version of hello
-  apt: "deb={{ ansible_user_dir }}/hello.deb"
+#### Tests for upgrade/download functions in modules/packaging/os/apt.py ####
+- name: download and install old version of hello
+  apt: "deb=https://launchpad.net/ubuntu/+archive/primary/+files/hello_{{ hello_old_version }}_amd64.deb"
 
 - name: check hello version
   shell: dpkg -s hello | grep Version | awk '{print $2}'

--- a/test/integration/targets/apt/tasks/upgrade.yml
+++ b/test/integration/targets/apt/tasks/upgrade.yml
@@ -1,0 +1,49 @@
+---
+#### Tests for upgrade ####
+
+# TODO: dynamic architecture
+
+- name: "download deb of older version of hello"
+  get_url: "url=https://launchpad.net/ubuntu/+archive/primary/+files/hello_{{ hello_old_version }}_amd64.deb dest={{ ansible_user_dir }}/hello.deb"
+
+# # Tests for dist-upgrade
+- name: install old version of hello
+  apt: "deb={{ ansible_user_dir }}/hello.deb"
+
+- name: check hello version
+  shell: dpkg -s hello | grep Version | awk '{print $2}'
+  register: hello_version
+
+- debug: var=hello_version
+
+- name: ensure the correct version of hello has been installed
+  assert:
+    that:
+      - "{{ hello_version.stdout }}=={{ hello_old_version }}"
+
+- name: "(upgrade type: {{upgrade_type}}) upgrade packages to latest version"
+  apt:
+    upgrade: "{{ upgrade_type }}"
+
+- name: check hello version
+  shell: dpkg -s hello | grep Version | awk '{print $2}'
+  register: hello_version
+
+- name: check that old version upgraded correctly
+  assert:
+    that:
+      - "{{ hello_version.stdout }}!={{ hello_old_version }}"
+      - "{{ hello_version.changed }}"
+
+- name: "(upgrade type: {{upgrade_type}}) upgrade packages to latest version (Idempotant)"
+  apt:
+    upgrade: "{{ upgrade_type }}"
+  register: result
+
+- name: check that nothing has changed (Idempotant)
+  assert:
+    that:
+      - "result.changed == false"
+
+- name: remove hello
+  apt: pkg=hello state=absent autoclean=yes


### PR DESCRIPTION
##### SUMMARY
Integration tests for apt module. Test coverage for update() and download() functions are missing according to codecov: https://codecov.io/gh/ansible/ansible/src/devel/lib/ansible/modules/packaging/os/apt.py

##### COMPONENT NAME
-module: apt

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel a784840fcd) last updated 2017/06/12 16:21:37 (GMT -400)
  config file =
  configured module search path = [u'/Users/dnewswan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dnewswan/code/ansible/lib/ansible
  executable location = /Users/dnewswan/code/ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Expands integration test coverage for the apt module.