### PR TITLE
Support one to many A records in nsupdate module

### DIFF
--- a/lib/ansible/modules/net_tools/nsupdate.py
+++ b/lib/ansible/modules/net_tools/nsupdate.py
@@ -273,7 +273,7 @@ class RecordManager(object):
                 self.module.fail_json(msg='value needed when state=present')
             except dns.exception.SyntaxError:
                 self.module.fail_json(msg='Invalid/malformed value')
-            response = self.__do_update(update)
+        response = self.__do_update(update)
 
         return dns.message.Message.rcode(response)
 

--- a/lib/ansible/modules/net_tools/nsupdate.py
+++ b/lib/ansible/modules/net_tools/nsupdate.py
@@ -321,8 +321,8 @@ class RecordManager(object):
                     self.module.fail_json(msg='value needed when state=present')
                 except dns.exception.SyntaxError:
                     self.module.fail_json(msg='Invalid/malformed value')
-                response = self.__do_update(update)
-                self.dns_rc = dns.message.Message.rcode(response)
+            response = self.__do_update(update)
+            self.dns_rc = dns.message.Message.rcode(response)
             if self.dns_rc == 0:
                 return 1
             else:

--- a/lib/ansible/modules/net_tools/nsupdate.py
+++ b/lib/ansible/modules/net_tools/nsupdate.py
@@ -127,9 +127,9 @@ type:
     type: string
     sample: 'CNAME'
 value:
-    description: DNS record value
+    description: DNS record value(s)
     returned: success
-    type: string
+    type: list
     sample: '192.168.1.1'
 zone:
     description: DNS record zone
@@ -237,27 +237,35 @@ class RecordManager(object):
 
     def create_record(self):
         update = dns.update.Update(self.zone, keyring=self.keyring, keyalgorithm=self.algorithm)
-        try:
-            update.add(self.module.params['record'],
-                       self.module.params['ttl'],
-                       self.module.params['type'],
-                       self.module.params['value'])
-        except AttributeError:
-            self.module.fail_json(msg='value needed when state=present')
-        except dns.exception.SyntaxError:
-            self.module.fail_json(msg='Invalid/malformed value')
+        for entry in self.module.params['value']:
+            try:
+                update.add(self.module.params['record'],
+                           self.module.params['ttl'],
+                           self.module.params['type'],
+                           entry)
+            except AttributeError:
+                self.module.fail_json(msg='value needed when state=present')
+            except dns.exception.SyntaxError:
+                self.module.fail_json(msg='Invalid/malformed value')
 
         response = self.__do_update(update)
         return dns.message.Message.rcode(response)
 
     def modify_record(self):
         update = dns.update.Update(self.zone, keyring=self.keyring, keyalgorithm=self.algorithm)
-        update.replace(self.module.params['record'],
-                       self.module.params['ttl'],
-                       self.module.params['type'],
-                       self.module.params['value'])
+        update.delete(self.module.params['record'], self.module.params['type'])
+        for entry in self.module.params['value']:
+            try:
+                update.add(self.module.params['record'],
+                           self.module.params['ttl'],
+                           self.module.params['type'],
+                           entry)
+            except AttributeError:
+                self.module.fail_json(msg='value needed when state=present')
+            except dns.exception.SyntaxError:
+                self.module.fail_json(msg='Invalid/malformed value')
+            response = self.__do_update(update)
 
-        response = self.__do_update(update)
         return dns.message.Message.rcode(response)
 
     def remove_record(self):
@@ -297,14 +305,15 @@ class RecordManager(object):
         if self.dns_rc == 0:
             if self.module.params['state'] == 'absent':
                 return 1
-            try:
-                update.present(self.module.params['record'], self.module.params['type'], self.module.params['value'])
-            except AttributeError:
-                self.module.fail_json(msg='value needed when state=present')
-            except dns.exception.SyntaxError:
-                self.module.fail_json(msg='Invalid/malformed value')
-            response = self.__do_update(update)
-            self.dns_rc = dns.message.Message.rcode(response)
+            for entry in self.module.params['value']:
+                try:
+                    update.present(self.module.params['record'], self.module.params['type'], entry)
+                except AttributeError:
+                    self.module.fail_json(msg='value needed when state=present')
+                except dns.exception.SyntaxError:
+                    self.module.fail_json(msg='Invalid/malformed value')
+                response = self.__do_update(update)
+                self.dns_rc = dns.message.Message.rcode(response)
             if self.dns_rc == 0:
                 return 1
             else:
@@ -328,7 +337,7 @@ def main():
             record=dict(required=True, type='str'),
             type=dict(required=False, default='A', type='str'),
             ttl=dict(required=False, default=3600, type='int'),
-            value=dict(required=False, default=None, type='str')
+            value=dict(required=False, default=None, type='list')
         ),
         supports_check_mode=True
     )

--- a/lib/ansible/modules/net_tools/nsupdate.py
+++ b/lib/ansible/modules/net_tools/nsupdate.py
@@ -95,6 +95,15 @@ EXAMPLES = '''
     record: "ansible"
     value: "192.168.1.1"
 
+- name: Add or modify ansible.example.org A to 192.168.1.1, 192.168.1.2 and 192.168.1.3"
+  nsupdate:
+    key_name: "nsupdate"
+    key_secret: "+bFQtBCta7j2vWkjPkAFtgA=="
+    server: "10.1.1.1"
+    zone: "example.org"
+    record: "ansible"
+    value: ["192.168.1.1", "192.168.1.2", "192.168.1.3"]
+
 - name: Remove puppet.example.org CNAME
   nsupdate:
     key_name: "nsupdate"


### PR DESCRIPTION
Updating the nsupdate module to accept a list for 'value' instead
of a string. This is to allow manipulating 1:many DNS records.

A string can still be supplied so it should be backwards compatible.

Addresses issue #25554

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
There are certain use cases where one would want a one to many mapping of A records. For instance, in a kubernetes or OpenShift environment with a load balanced router, a wildcard DNS entry is required.

```
# host foo.paas.ocp.example.com 192.168.1.211
Using domain server:
Name: 192.168.1.211
Address: 192.168.1.211#53
Aliases: 

foo.paas.ocp.example.com has address 192.168.1.172
foo.paas.ocp.example.com has address 192.168.1.171
foo.paas.ocp.example.com has address 192.168.1.171
```
The current version of the module will overwrite entries rather than manage this type of record.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #25554 
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
nsupdate
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
I've tested the module successfully. An example play would be:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
---
- hosts: localhost
  gather_facts: false
  tasks:
  - name: update wildcard DNS entry
    nsupdate:
      state: present
      key_name: "rndc-key"
      key_secret: "r/SECRETKEEEEEEYYYY"
      server: "192.168.1.211"
      zone: "ocp.example.com"
      record: "*.paas"
      value: ["192.168.1.171", "192.168.1.172"]
    delegate_to: localhost
    run_once: true
```
