### PR TITLE
If there are no DOCs provided at all, don't traceback in validate-modules

### DIFF
--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -542,9 +542,14 @@ class ModuleValidator(Validator):
                 )
 
     def _ensure_imports_below_docs(self, doc_info, first_callable):
-        min_doc_line = min(
-            [doc_info[key]['lineno'] for key in doc_info if doc_info[key]['lineno']]
-        )
+        try:
+            min_doc_line = min(
+                [doc_info[key]['lineno'] for key in doc_info if doc_info[key]['lineno']]
+            )
+        except ValueError:
+            # We can't perform this validation, as there are no DOCs provided at all
+            return
+
         max_doc_line = max(
             [doc_info[key]['end_lineno'] for key in doc_info if doc_info[key]['end_lineno']]
         )


### PR DESCRIPTION
##### SUMMARY

A module without `DOCUMENTATION`, `EXAMPLES`, `RETURN` or `ANSIBLE_METADATA` would cause `validate-modules` to traceback, when it tried determining the min doc line number.

Catch the `ValueError` and return, skipping that test.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
validate-modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```