### PR TITLE
win_say: documentation: Small improvement to the way the powershell code lines render on docsite

### DIFF
--- a/lib/ansible/modules/windows/win_say.py
+++ b/lib/ansible/modules/windows/win_say.py
@@ -72,11 +72,17 @@ options:
 author: "Jon Hawkesworth (@jhawkesworth)"
 notes:
    - Needs speakers or headphones to do anything useful.
-   - To find which voices are installed, run the following powershell
-     Add-Type -AssemblyName System.Speech
-     $speech = New-Object -TypeName System.Speech.Synthesis.SpeechSynthesizer
-     $speech.GetInstalledVoices() | ForEach-Object { $_.VoiceInfo }
-     $speech.Dispose()
+   - |
+     To find which voices are installed, run the following powershell commands.
+
+                 Add-Type -AssemblyName System.Speech
+
+                 $speech = New-Object -TypeName System.Speech.Synthesis.SpeechSynthesizer
+
+                 $speech.GetInstalledVoices() | ForEach-Object { $_.VoiceInfo }
+
+                 $speech.Dispose()
+
    - Speech can be surprisingly slow, so its best to keep message text short.
 '''
 


### PR DESCRIPTION
 (html rendering only, still does not break lines properly in ansible-doc)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Makes the 4 lines of powershell in the Notes section appear with suitable line breaks.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_say

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (win_say_docfix 3bb846f34e) last updated 2017/06/12 22:25:39 (GMT +100)
  config file =
  configured module search path = [u'/home/jon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jon/ansible-dev/lib/ansible
  executable location = /home/jon/ansible-dev/bin/ansible
  python version = 2.7.6 (default, Jun 22 2015, 17:58:13) [GCC 4.8.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
No bug report, just spotted that it didn't look right and meant that you couldn't copy and paste straight from the documentation page into powershell

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
currently renders like this:

To find which voices are installed, run the following powershell Add-Type -AssemblyName System.Speech $speech = New-Object -TypeName System.Speech.Synthesis.SpeechSynthesizer $speech.GetInstalledVoices() | ForEach-Object { $_.VoiceInfo } $speech.Dispose()

afterwards renders like this:

To find which voices are installed, run the following powershell commands.

    Add-Type -AssemblyName System.Speech

    $speech = New-Object -TypeName System.Speech.Synthesis.SpeechSynthesizer

    $speech.GetInstalledVoices() | ForEach-Object { $_.VoiceInfo }

    $speech.Dispose()


```
