### PR TITLE
F5: Adds a reconnect method

### DIFF
--- a/lib/ansible/module_utils/f5_utils.py
+++ b/lib/ansible/module_utils/f5_utils.py
@@ -203,6 +203,8 @@ class AnsibleF5Client(object):
                  required_if=None, required_one_of=None,
                  f5_product_name='bigip'):
 
+        self.f5_product_name = f5_product_name
+
         merged_arg_spec = dict()
         merged_arg_spec.update(F5_COMMON_ARGS)
         if argument_spec:
@@ -274,6 +276,25 @@ class AnsibleF5Client(object):
                 port=kwargs['server_port'],
                 token='local'
             )
+
+    def reconnect(self):
+        """Attempts to reconnect to a device
+
+        The existing token from a ManagementRoot can become invalid if you,
+        for example, upgrade the device (such as is done in the *_software
+        module.
+
+        This method can be used to reconnect to a remote device without
+        having to re-instantiate the ArgumentSpec and AnsibleF5Client classes
+        it will use the same values that were initially provided to those
+        classes
+
+        :return:
+        :raises iControlUnexpectedHTTPError
+        """
+        self.client.api = self._get_mgmt_root(
+            self.f5_product_name, **self._connect_params
+        )
 
 
 class AnsibleF5Parameters(object):


### PR DESCRIPTION
##### SUMMARY
This is being made available so that module developers do not
need to use the gnarly long-form version to get a similar
result

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/module_utils/f5_utils.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = 
  configured module search path = [u'/Users/trupp/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/trupp/src/envs/ansible-2.0/lib/python2.7/site-packages/ansible
  executable location = /Users/trupp/src/envs/ansible-2.0/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
