### PR TITLE
Have cs_host search both name and ipaddress fields when fetching the …

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_host.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_host.py
@@ -36,7 +36,7 @@ options:
     description:
       - Name of the host.
     required: true
-    aliases: [ 'url' ]
+    aliases: [ 'url', 'ip_address' ]
   username:
     description:
       - Username for the host.
@@ -428,13 +428,15 @@ class AnsibleCloudStackHost(AnsibleCloudStack):
 
     def get_host(self):
         host = None
+        name = self.module.params.get('name')
         args = {
             'zoneid': self.get_zone(key='id'),
-            'name': self.module.params.get('name'),
         }
-        hosts = self.cs.listHosts(**args)
-        if hosts:
-            host = hosts['host'][0]
+        res = self.cs.listHosts(**args)
+        if res:
+            for h in res['host']:
+                if name in [h['ipaddress'], h['name']]:
+                    host = h
         return host
 
     def present_host(self):
@@ -506,7 +508,7 @@ class AnsibleCloudStackHost(AnsibleCloudStack):
 def main():
     argument_spec = cs_argument_spec()
     argument_spec.update(dict(
-        name=dict(required=True, aliases=['url']),
+        name=dict(required=True, aliases=['url', 'ip_address']),
         password=dict(default=None, no_log=True),
         username=dict(default=None),
         hypervisor=dict(choices=CS_HYPERVISORS, default=None),


### PR DESCRIPTION
…host from listHosts.

Make ip_address an alias of name to allow playbooks to more clearly make use of IP addresses.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The change makes cs_host work as expected when IP addresses are passed as names.
Fixes #25627 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/cloud/cloudstack/cs_host.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = /home/john/.ansible.cfg
  configured module search path = [u'/home/john/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible-2.4.0-py2.7.egg/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
