### PR TITLE
Add http:// prefix when adding new host.

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_host.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_host.py
@@ -458,7 +458,7 @@ class AnsibleCloudStackHost(AnsibleCloudStack):
         self.result['changed'] = True
         args = {
             'hypervisor': self.module.params.get('hypervisor'),
-            'url': self.module.params.get('name'),
+            'url': 'http://' + self.module.params.get('name'),
             'username': self.module.params.get('username'),
             'password': self.module.params.get('password'),
             'podid': self.get_pod(key='id'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add http:// prefix to host/url when adding a new host.
Fixes #25641 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/cloud/cloudstack/cs_host.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = /home/john/.ansible.cfg
  configured module search path = [u'/home/john/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible-2.4.0-py2.7.egg/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before change:
```
$ ansible-playbook test_cs_host.yml

PLAY [Setup Cloudstack] ***********************************************************************************************************************

TASK [Gathering Facts] ************************************************************************************************************************
ok: [ceph-the1]

TASK [cs_host] ********************************************************************************************************************************
fatal: [ceph-the1 -> localhost]: FAILED! => {"changed": false, "failed": true, "msg": "CloudStackException: ('HTTP 431 response from CloudStack', <Response [431]>, {u'errorcode': 431, u'uuidList': [], u'cserrorcode': 4350, u'errortext': u'uri.scheme is null server12.example.com, add nfs:// (or cifs://) as a prefix'})"}
        to retry, use: --limit @/home/john/ansible/theceph/test_cs_host.retry

PLAY RECAP ************************************************************************************************************************************
ceph-the1                  : ok=1    changed=0    unreachable=0    failed=1   

```
After change:
```
$ ansible-playbook test_cs_host.yml

PLAY [Setup Cloudstack] ****************************************************************************************************************************

TASK [Gathering Facts] *****************************************************************************************************************************
ok: [ceph-the1]

TASK [cs_host] *************************************************************************************************************************************
changed: [ceph-the1 -> localhost]

PLAY RECAP *****************************************************************************************************************************************
ceph-the1                  : ok=2    changed=1    unreachable=0    failed=0   

```
