### PR TITLE
Fix pep8 extra lines error

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -253,7 +253,6 @@ class CLI(with_metaclass(ABCMeta, object)):
         if self.options.ask_su_pass or self.options.su_user:
             _dep('su')
 
-
     def validate_conflicts(self, vault_opts=False, runas_opts=False, fork_opts=False):
         ''' check for conflicting options '''
 


### PR DESCRIPTION
##### SUMMARY
Fixes PEP8 error introduced by https://github.com/ansible/ansible/commit/37acb7423b4ad085af0b3922fa1ab76ddd18bab1#diff-bdd6c847fae8976ab8a7259d0b583f34R255

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/cli/__init__.py

##### ANSIBLE VERSION

```
devel
```
