### PR TITLE
Added requires WMF5 note to win_firewall module documentation

### DIFF
--- a/lib/ansible/modules/windows/win_firewall.py
+++ b/lib/ansible/modules/windows/win_firewall.py
@@ -47,6 +47,8 @@ options:
     choices:
     - enabled
     - disabled
+requirements:
+  - This module requires Windows Management Framework 5 or later.
 author: Michael Eaton (@MichaelEaton83)
 '''
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Document that win_firewall needs WMF 5 later to work.

Why? because Its better to document such limitations rather than have users discover them at runtime.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_firewall
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (win_firewall_requires_wmf5 eba1e2abef) last updated 2017/06/14 06:39:03 (GMT +100)
  config file =
  configured module search path = [u'/home/jon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jon/ansible-dev/lib/ansible
  executable location = /home/jon/ansible-dev/bin/ansible
  python version = 2.7.6 (default, Jun 22 2015, 17:58:13) [GCC 4.8.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Small documentation change only.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
