### PR TITLE
Workaround python-libselinux API change

### DIFF
--- a/lib/ansible/modules/system/seboolean.py
+++ b/lib/ansible/modules/system/seboolean.py
@@ -79,7 +79,12 @@ def has_boolean_value(module, name):
         rc, bools = selinux.security_get_boolean_names()
     except OSError:
         module.fail_json(msg="Failed to get list of boolean names")
-    if to_bytes(name) in bools:
+    # work around for selinux who changed its API, see
+    # https://github.com/ansible/ansible/issues/25651
+    if len(bools) > 0:
+        if isinstance(bools[0], binary_type):
+            name = to_bytes(name)
+    if name in bools:
         return True
     else:
         return False
@@ -224,6 +229,7 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 from ansible.module_utils._text import to_bytes
+from ansible.module_utils.six import binary_type
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION

##### SUMMARY

In the past, selinux.security_get_boolean_names did return 'bytes'
on python 3, but this was changed to return string later, cf:
https://github.com/SELinuxProject/selinux/commit/b8711e2eaf4f83bf943ac8ad28c35cb1db9c001f

So we have to convert to bytes only if the API return us bytes.

Fix #25651

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
seboolean
