### PR TITLE
win_share: Add integration tests and various fixes

### DIFF
--- a/lib/ansible/modules/windows/win_share.ps1
+++ b/lib/ansible/modules/windows/win_share.ps1
@@ -111,26 +111,34 @@ Function NormalizeAccounts
 
 $result = @{
     changed = $false
+    actions = @() # More for debug purposes
 }
 
-$params = Parse-Args $args
+$params = Parse-Args $args -supports_check_mode $true
+$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
 
 $name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present","absent"
 
+if (-not (Get-Command -Name Get-SmbShare -ErrorAction SilentlyContinue)) {
+    Fail-Json $result "The current host does not support the -SmbShare cmdlets required by this module. Please run on Server 2012 or Windows 8 and later"
+}
+
 Try {
-    $share = Get-SmbShare $name -ErrorAction SilentlyContinue
+    $share = Get-SmbShare -Name $name -ErrorAction SilentlyContinue
     If ($state -eq "absent") {
         If ($share) {
-            Remove-SmbShare -Force -Name $name
+            if (-not $check_mode) {
+                Remove-SmbShare -Force -Name $name
+            }
+            $result.actions += "Remove-SmbShare -Force -Name $name"
             $result.changed = $true
         }
-    }
-    Else {
+    } Else {
         $path = Get-AnsibleParam -obj $params -name "path" -type "path" -failifempty $true
         $description = Get-AnsibleParam -obj $params -name "description" -type "str" -default ""
 
-        $permissionList = Get-AnsibleParam -obj $params -name "list" -type "bool" -default "no" -validateset "no","yes" -resultobj $result
+        $permissionList = Get-AnsibleParam -obj $params -name "list" -type "bool" -default $false
         $folderEnum = if ($permissionList) { "Unrestricted" } else { "AccessBased" }
 
         $permissionRead = Get-AnsibleParam -obj $params -name "read" -type "str" -default "" | NormalizeAccounts
@@ -139,6 +147,7 @@ Try {
         $permissionDeny = Get-AnsibleParam -obj $params -name "deny" -type "str" -default "" | NormalizeAccounts
 
         $cachingMode = Get-AnsibleParam -obj $params -name "caching_mode" -type "str" -default "Manual" -validateSet "BranchCache","Documents","Manual","None","Programs","Unknown"
+        $encrypt = Get-AnsibleParam -obj $params -name "encrypt" -type "bool" -default $false
 
         If (-Not (Test-Path -Path $path)) {
             Fail-Json $result "$path directory does not exist on the host"
@@ -149,32 +158,53 @@ Try {
 
         # need to (re-)create share
         If (-not $share) {
-            New-SmbShare -Name $name -Path $path
-            $share = Get-SmbShare $name -ErrorAction SilentlyContinue
+            if (-not $check_mode) {
+                New-SmbShare -Name $name -Path $path
+            }
+            $share = Get-SmbShare -Name $name -ErrorAction SilentlyContinue
 
             $result.changed = $true
+            $result.actions += "New-SmbShare -Name $name -Path $path"
         }
         If ($share.Path -ne $path) {
-            Remove-SmbShare -Force -Name $name
-
-            New-SmbShare -Name $name -Path $path
-            $share = Get-SmbShare $name -ErrorAction SilentlyContinue
-
+            if (-not $check_mode) {
+                Remove-SmbShare -Force -Name $name
+                New-SmbShare -Name $name -Path $path
+            }
+            $share = Get-SmbShare -Name $name -ErrorAction SilentlyContinue
             $result.changed = $true
+            $result.actions += "Remove-SmbShare -Force -Name $name"
+            $result.actions += "New-SmbShare -Name $name -Path $path"
         }
 
         # updates
         If ($share.Description -ne $description) {
-            Set-SmbShare -Force -Name $name -Description $description
+            if (-not $check_mode) {
+                Set-SmbShare -Force -Name $name -Description $description
+            }
             $result.changed = $true
+            $result.actions += "Set-SmbShare -Force -Name $name -Description $description"
         }
         If ($share.FolderEnumerationMode -ne $folderEnum) {
-            Set-SmbShare -Force -Name $name -FolderEnumerationMode $folderEnum
+            if (-not $check_mode) {
+                Set-SmbShare -Force -Name $name -FolderEnumerationMode $folderEnum
+            }
             $result.changed = $true
+            $result.actions += "Set-SmbShare -Force -Name $name -FolderEnumerationMode $folderEnum"
         }
         if ($share.CachingMode -ne $cachingMode) {
-            Set-SmbShare -Force -Name $name -CachingMode $cachingMode
+            if (-not $check_mode) {
+                Set-SmbShare -Force -Name $name -CachingMode $cachingMode
+            }
             $result.changed = $true
+            $result.actions += "Set-SmbShare -Force -Name $name -CachingMode $cachingMode"
+        }
+        if ($share.EncryptData -ne $encrypt) {
+            if (-not $check_mode) {
+                Set-SmbShare -Force -Name $name -EncryptData $encrypt
+            }
+            $result.changed = $true
+            $result.actions += "Set-SmbShare -Force -Name $name -EncryptData $encrypt"
         }
 
         # clean permissions that imply others
@@ -190,38 +220,57 @@ Try {
         $permissions = Get-SmbShareAccess -Name $name
         ForEach ($permission in $permissions) {
             If ($permission.AccessControlType -eq "Deny") {
-                If (!$permissionDeny.Contains($permission.AccountName)) {
-                    Unblock-SmbShareAccess -Force -Name $name -AccountName $permission.AccountName
-                    $result.changed = $true
+                $cim_count = 0
+                foreach ($count in $permissions) {
+                    $cim_count++
                 }
-            }
-            ElseIf ($permission.AccessControlType -eq "Allow") {
-                If ($permission.AccessRight -eq "Full") {
-                    If (!$permissionFull.Contains($permission.AccountName)) {
-                        Revoke-SmbShareAccess -Force -Name $name -AccountName $permission.AccountName
+                # Don't remove the Deny entry for Everyone if there are no other permissions set (cim_count == 1)
+                if (-not ($permission.AccountName -eq 'Everyone' -and $cim_count -eq 1)) {
+                    If (-not ($permissionDeny.Contains($permission.AccountName))) {
+                        if (-not $check_mode) {
+                            Unblock-SmbShareAccess -Force -Name $name -AccountName $permission.AccountName
+                        }
                         $result.changed = $true
+                        $result.actions += "Unblock-SmbShareAccess -Force -Name $name -AccountName $($permission.AccountName)"
+                    } else {
+                        # Remove from the deny list as it already has the permissions
+                        $permissionDeny.remove($permission.AccountName)
+                    }
+                }
+            } ElseIf ($permission.AccessControlType -eq "Allow") {
+                If ($permission.AccessRight -eq "Full") {
+                    If (-not ($permissionFull.Contains($permission.AccountName))) {
+                        if (-not $check_mode) {
+                            Revoke-SmbShareAccess -Force -Name $name -AccountName $permission.AccountName
+                        }
+                        $result.changed = $true
+                        $result.actions += "Revoke-SmbShareAccess -Force -Name $name -AccountName $($permission.AccountName)"
 
                         Continue
                     }
 
                     # user got requested permissions
                     $permissionFull.remove($permission.AccountName)
-                }
-                ElseIf ($permission.AccessRight -eq "Change") {
-                    If (!$permissionChange.Contains($permission.AccountName)) {
-                        Revoke-SmbShareAccess -Force -Name $name -AccountName $permission.AccountName
+                } ElseIf ($permission.AccessRight -eq "Change") {
+                    If (-not ($permissionChange.Contains($permission.AccountName))) {
+                        if (-not $check_mode) {
+                            Revoke-SmbShareAccess -Force -Name $name -AccountName $permission.AccountName
+                        }
                         $result.changed = $true
+                        $result.actions += "Revoke-SmbShareAccess -Force -Name $name -AccountName $($permission.AccountName)"
 
                         Continue
                     }
 
                     # user got requested permissions
                     $permissionChange.remove($permission.AccountName)
-                }
-                ElseIf ($permission.AccessRight -eq "Read") {
-                    If (!$permissionRead.Contains($permission.AccountName)) {
-                        Revoke-SmbShareAccess -Force -Name $name -AccountName $permission.AccountName
+                } ElseIf ($permission.AccessRight -eq "Read") {
+                    If (-not ($permissionRead.Contains($permission.AccountName))) {
+                        if (-not $check_mode) {
+                            Revoke-SmbShareAccess -Force -Name $name -AccountName $permission.AccountName
+                        }
                         $result.changed = $true
+                        $result.actions += "Revoke-SmbShareAccess -Force -Name $name -AccountName $($permission.AccountName)"
 
                         Continue
                     }
@@ -234,24 +283,35 @@ Try {
 
         # add missing permissions
         ForEach ($user in $permissionRead) {
-            Grant-SmbShareAccess -Force -Name $name -AccountName $user -AccessRight "Read"
+            if (-not $check_mode) {
+                Grant-SmbShareAccess -Force -Name $name -AccountName $user -AccessRight "Read"
+            }
             $result.changed = $true
+            $result.actions += "Grant-SmbShareAccess -Force -Name $name -AccountName $user -AccessRight Read"
         }
         ForEach ($user in $permissionChange) {
-            Grant-SmbShareAccess -Force -Name $name -AccountName $user -AccessRight "Change"
+            if (-not $check_mode) {
+                Grant-SmbShareAccess -Force -Name $name -AccountName $user -AccessRight "Change"
+            }
             $result.changed = $true
+            $result.actions += "Grant-SmbShareAccess -Force -Name $name -AccountName $user -AccessRight Change"
         }
         ForEach ($user in $permissionFull) {
-            Grant-SmbShareAccess -Force -Name $name -AccountName $user -AccessRight "Full"
+            if (-not $check_mode) {
+                Grant-SmbShareAccess -Force -Name $name -AccountName $user -AccessRight "Full"
+            }
             $result.changed = $true
+            $result.actions += "Grant-SmbShareAccess -Force -Name $name -AccountName $user -AccessRight Full"
         }
         ForEach ($user in $permissionDeny) {
-            Block-SmbShareAccess -Force -Name $name -AccountName $user
+            if (-not $check_mode) {
+                Block-SmbShareAccess -Force -Name $name -AccountName $user
+            }
             $result.changed = $true
+            $result.actions += "Block-SmbShareAccess -Force -Name $name -AccountName $user"
         }
     }
-}
-Catch {
+} Catch {
     Fail-Json $result "an error occurred when attempting to create share $($name): $($_.Exception.Message)"
 }
 

--- a/lib/ansible/modules/windows/win_share.ps1
+++ b/lib/ansible/modules/windows/win_share.ps1
@@ -115,6 +115,8 @@ $result = @{
 }
 
 $params = Parse-Args $args -supports_check_mode $true
+
+# While the -SmbShare cmdlets have a -WhatIf parameter, they don't honor it, need to skip the cmdlet if in check mode
 $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
 
 $name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true
@@ -128,6 +130,7 @@ Try {
     $share = Get-SmbShare -Name $name -ErrorAction SilentlyContinue
     If ($state -eq "absent") {
         If ($share) {
+            # See message around -WhatIf where $check_mode is defined
             if (-not $check_mode) {
                 Remove-SmbShare -Force -Name $name
             }

--- a/lib/ansible/modules/windows/win_share.py
+++ b/lib/ansible/modules/windows/win_share.py
@@ -57,9 +57,8 @@ options:
   list:
     description:
       - Specify whether to allow or deny file listing, in case user got no permission on share
-    choices:
-      - yes
-      - no
+    type: bool
+    default: 'no'
   read:
     description:
       - Specify user list that should get read access on share, separated by comma.
@@ -84,6 +83,11 @@ options:
       - Unknown
     default: "Manual"
     version_added: "2.3"
+  encrypt:
+    description: Sets whether to encrypt the traffic to the share or not.
+    type: bool
+    default: 'no'
+    version_added: "2.4"
 author: Hans-Joachim Kliemeck (@h0nIg), David Baumann (@daBONDi)
 '''
 
@@ -96,7 +100,7 @@ EXAMPLES = r'''
     name: internal
     description: top secret share
     path: C:\shares\internal
-    list: 'no'
+    list: no
     full: Administrators,CEO
     read: HR-Global
     deny: HR-External
@@ -106,16 +110,20 @@ EXAMPLES = r'''
     name: company
     description: top secret share
     path: C:\shares\company
-    list: 'yes'
+    list: yes
     full: Administrators,CEO
     read: Global
 
-# Remove previously added share
+- name: Remove previously added share
   win_share:
     name: internal
     state: absent
 '''
 
 RETURN = r'''
-
+actions:
+    description: A list of action cmdlets that were run by the module.
+    returned: success
+    type: list
+    sample: ['New-SmbShare -Name share -Path C:\temp']
 '''

--- a/lib/ansible/modules/windows/win_share.py
+++ b/lib/ansible/modules/windows/win_share.py
@@ -32,21 +32,25 @@ module: win_share
 version_added: "2.1"
 short_description: Manage Windows shares
 description:
-     - Add, modify or remove Windows share and set share permissions.
+  - Add, modify or remove Windows share and set share permissions.
 requirements:
-    - Windows 8.1 / Windows 2012 or newer
+  - As this module used newer cmdlets like New-SmbShare this can only run on
+    Windows 8 / Windows 2012 or newer.
+  - This is due to the reliance on the WMI provider MSFT_SmbShare
+    U(https://msdn.microsoft.com/en-us/library/hh830471(v=vs.85).aspx) which
+    was only added with these Windows releases.
 options:
   name:
     description:
-      - Share name
+      - Share name.
     required: True
   path:
     description:
-      - Share directory
+      - Share directory.
     required: True
   state:
     description:
-      - Specify whether to add C(present) or remove C(absent) the specified share
+      - Specify whether to add C(present) or remove C(absent) the specified share.
     choices:
       - present
       - absent
@@ -56,7 +60,7 @@ options:
       - Share description
   list:
     description:
-      - Specify whether to allow or deny file listing, in case user got no permission on share
+      - Specify whether to allow or deny file listing, in case user got no permission on share.
     type: bool
     default: 'no'
   read:
@@ -88,7 +92,9 @@ options:
     type: bool
     default: 'no'
     version_added: "2.4"
-author: Hans-Joachim Kliemeck (@h0nIg), David Baumann (@daBONDi)
+author:
+  - Hans-Joachim Kliemeck (@h0nIg)
+  - David Baumann (@daBONDi)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_share.py
+++ b/lib/ansible/modules/windows/win_share.py
@@ -37,8 +37,8 @@ requirements:
   - As this module used newer cmdlets like New-SmbShare this can only run on
     Windows 8 / Windows 2012 or newer.
   - This is due to the reliance on the WMI provider MSFT_SmbShare
-    U(https://msdn.microsoft.com/en-us/library/hh830471(v=vs.85).aspx) which
-    was only added with these Windows releases.
+    U(https://msdn.microsoft.com/en-us/library/hh830471) which was only added
+    with these Windows releases.
 options:
   name:
     description:

--- a/test/integration/targets/win_share/aliases
+++ b/test/integration/targets/win_share/aliases
@@ -1,0 +1,1 @@
+windows/ci/group1

--- a/test/integration/targets/win_share/defaults/main.yml
+++ b/test/integration/targets/win_share/defaults/main.yml
@@ -1,0 +1,2 @@
+test_win_share_path: C:\ansible\win_share
+test_win_share_name: test share

--- a/test/integration/targets/win_share/tasks/main.yml
+++ b/test/integration/targets/win_share/tasks/main.yml
@@ -1,0 +1,43 @@
+---
+- name: check if -SmbShare cmdlets are available
+  win_command: powershell.exe "Get-Command -Name Get-SmbShare"
+  register: module_available
+  failed_when: False
+
+- name: check that module fails with helpful message on older hosts
+  win_share:
+    name: test
+  register: module_not_supported
+  when: module_available.rc == 1
+  failed_when: module_not_supported.msg != 'The current host does not support the -SmbShare cmdlets required by this module. Please run on Server 2012 or Windows 8 and later'
+  check_mode: yes
+
+# Run the actual tests
+- block:
+  # setup for tests
+  - name: create testing folder
+    win_file:
+      path: "{{test_win_share_path}}"
+      state: directory
+
+  - name: ensure testing folder isn't shared as a baseline
+    win_share:
+      name: "{{test_win_share_name}}"
+      state: absent
+
+  - name: run tests on hosts that support it
+    include_tasks: tests.yml
+    when: module_available.rc == 0
+
+  always:
+  # cleanup
+  - name: ensure testing folder isn't shared anymore
+    win_share:
+      name: "{{test_win_share_name}}"
+      state: absent
+
+  - name: remove testing folder
+    win_file:
+      path: "{{test_win_share_path}}"
+      state: absent
+  when: module_available.rc == 0

--- a/test/integration/targets/win_share/tasks/tests.yml
+++ b/test/integration/targets/win_share/tasks/tests.yml
@@ -1,0 +1,448 @@
+---
+- name: create share check
+  win_share:
+    name: "{{test_win_share_name}}"
+    path: "{{test_win_share_path}}"
+    state: present
+  register: create_share_check
+  check_mode: yes
+
+- name: check if share exists check
+  win_shell: Get-SmbShare | Where-Object { $_.Name -eq  '{{test_win_share_name}}' }
+  register: create_share_actual_check
+
+- name: assert create share check
+  assert:
+    that:
+    - create_share_check|changed
+    - create_share_actual_check.stdout_lines == []
+
+- name: create share
+  win_share:
+    name: "{{test_win_share_name}}"
+    path: "{{test_win_share_path}}"
+    state: present
+  register: create_share
+
+- name: check if share exists
+  win_shell: Get-SmbShare | Where-Object { $_.Name -eq  '{{test_win_share_name}}' }
+  register: create_share_actual
+
+- name: assert create share
+  assert:
+    that:
+    - create_share|changed
+    - create_share_actual.stdout_lines != []
+
+- name: create share again
+  win_share:
+    name: "{{test_win_share_name}}"
+    path: "{{test_win_share_path}}"
+    state: present
+  register: create_share_again
+
+- name: check if share exists again
+  win_shell: Get-SmbShare | Where-Object { $_.Name -eq  '{{test_win_share_name}}' }
+  register: create_share_actual_again
+
+- name: assert create share again
+  assert:
+    that:
+    - not create_share_again|changed
+    - create_share_actual_again.stdout_lines == create_share_actual.stdout_lines
+
+- name: set caching mode to Programs check
+  win_share:
+    name: "{{test_win_share_name}}"
+    state: present
+    path: "{{test_win_share_path}}"
+    caching_mode: Programs
+  register: caching_mode_programs_check
+  check_mode: yes
+
+- name: get actual caching mode check
+  win_command: powershell.exe "(Get-SmbShare -Name '{{test_win_share_name}}').CachingMode"
+  register: caching_mode_programs_actual_check
+
+- name: assert caching mode to Programs check
+  assert:
+    that:
+    - caching_mode_programs_check|changed
+    - caching_mode_programs_actual_check.stdout == "Manual\r\n"
+
+- name: set caching mode to Programs
+  win_share:
+    name: "{{test_win_share_name}}"
+    state: present
+    path: "{{test_win_share_path}}"
+    caching_mode: Programs
+  register: caching_mode_programs
+
+- name: get actual caching mode
+  win_command: powershell.exe "(Get-SmbShare -Name '{{test_win_share_name}}').CachingMode"
+  register: caching_mode_programs_actual
+
+- name: assert caching mode to Programs
+  assert:
+    that:
+    - caching_mode_programs|changed
+    - caching_mode_programs_actual.stdout == "Programs\r\n"
+
+- name: set caching mode to Programs again
+  win_share:
+    name: "{{test_win_share_name}}"
+    state: present
+    path: "{{test_win_share_path}}"
+    caching_mode: Programs
+  register: caching_mode_programs_again
+
+- name: get actual caching mode again
+  win_command: powershell.exe "(Get-SmbShare -Name '{{test_win_share_name}}').CachingMode"
+  register: caching_mode_programs_actual_again
+
+- name: assert caching mode to Programs again
+  assert:
+    that:
+    - not caching_mode_programs_again|changed
+    - caching_mode_programs_actual_again.stdout == "Programs\r\n"
+
+- name: set encryption on share check
+  win_share:
+    name: "{{test_win_share_name}}"
+    state: present
+    path: "{{test_win_share_path}}"
+    encrypt: True
+  register: encrypt_on_check
+  check_mode: yes
+
+- name: get actual encrypt mode check
+  win_command: powershell.exe "(Get-SmbShare -Name '{{test_win_share_name}}').EncryptData"
+  register: encrypt_on_actual_check
+
+- name: assert set encryption on check
+  assert:
+    that:
+    - encrypt_on_check|changed
+    - encrypt_on_actual_check.stdout == "False\r\n"
+
+- name: set encryption on share
+  win_share:
+    name: "{{test_win_share_name}}"
+    state: present
+    path: "{{test_win_share_path}}"
+    encrypt: True
+  register: encrypt_on
+
+- name: get actual encrypt mode
+  win_command: powershell.exe "(Get-SmbShare -Name '{{test_win_share_name}}').EncryptData"
+  register: encrypt_on_actual
+
+- name: assert set encryption on
+  assert:
+    that:
+    - encrypt_on|changed
+    - encrypt_on_actual.stdout == "True\r\n"
+
+- name: set encryption on share again
+  win_share:
+    name: "{{test_win_share_name}}"
+    state: present
+    path: "{{test_win_share_path}}"
+    encrypt: True
+  register: encrypt_on_again
+
+- name: get actual encrypt mode again
+  win_command: powershell.exe "(Get-SmbShare -Name '{{test_win_share_name}}').EncryptData"
+  register: encrypt_on_actual
+
+- name: assert set encryption on again
+  assert:
+    that:
+    - not encrypt_on_again|changed
+    - encrypt_on_actual.stdout == "True\r\n"
+
+- name: set description check
+  win_share:
+    name: "{{test_win_share_name}}"
+    state: present
+    path: "{{test_win_share_path}}"
+    description: description
+  register: change_decription_check
+  check_mode: yes
+
+- name: get actual description check
+  win_command: powershell.exe "(Get-SmbShare -Name '{{test_win_share_name}}').Description"
+  register: change_description_actual_check
+
+- name: assert change description check
+  assert:
+    that:
+    - change_decription_check|changed
+    - change_description_actual_check.stdout == "\r\n"
+
+- name: set description
+  win_share:
+    name: "{{test_win_share_name}}"
+    state: present
+    path: "{{test_win_share_path}}"
+    description: description
+  register: change_decription
+
+- name: get actual description
+  win_command: powershell.exe "(Get-SmbShare -Name '{{test_win_share_name}}').Description"
+  register: change_description_actual
+
+- name: assert change description
+  assert:
+    that:
+    - change_decription|changed
+    - change_description_actual.stdout == "description\r\n"
+
+- name: set description again
+  win_share:
+    name: "{{test_win_share_name}}"
+    state: present
+    path: "{{test_win_share_path}}"
+    description: description
+  register: change_decription_again
+
+- name: get actual description again
+  win_command: powershell.exe "(Get-SmbShare -Name '{{test_win_share_name}}').Description"
+  register: change_description_actual_again
+
+- name: assert change description again
+  assert:
+    that:
+    - not change_decription_again|changed
+    - change_description_actual_again.stdout == "description\r\n"
+
+- name: set allow list check
+  win_share:
+    name: "{{test_win_share_name}}"
+    state: present
+    path: "{{test_win_share_path}}"
+    list: True
+  register: allow_list_check
+  check_mode: yes
+
+- name: get actual allow listing check
+  win_command: powershell.exe "(Get-SmbShare -Name '{{test_win_share_name}}').FolderEnumerationMode"
+  register: allow_list_actual_check
+
+- name: assert allow list check
+  assert:
+    that:
+    - allow_list_check|changed
+    - allow_list_actual_check.stdout == "AccessBased\r\n"
+
+- name: set allow list
+  win_share:
+    name: "{{test_win_share_name}}"
+    state: present
+    path: "{{test_win_share_path}}"
+    list: True
+  register: allow_list
+
+- name: get actual allow listing
+  win_command: powershell.exe "(Get-SmbShare -Name '{{test_win_share_name}}').FolderEnumerationMode"
+  register: allow_list_actual
+
+- name: assert allow list
+  assert:
+    that:
+    - allow_list|changed
+    - allow_list_actual.stdout == "Unrestricted\r\n"
+
+- name: set allow list again
+  win_share:
+    name: "{{test_win_share_name}}"
+    state: present
+    path: "{{test_win_share_path}}"
+    list: True
+  register: allow_list_again
+
+- name: get actual allow listing again
+  win_command: powershell.exe "(Get-SmbShare -Name '{{test_win_share_name}}').FolderEnumerationMode"
+  register: allow_list_actual_again
+
+- name: assert allow list check again
+  assert:
+    that:
+    - not allow_list_again|changed
+    - allow_list_actual_again.stdout == "Unrestricted\r\n"
+
+- name: set deny list check
+  win_share:
+    name: "{{test_win_share_name}}"
+    state: present
+    path: "{{test_win_share_path}}"
+    list: False
+  register: deny_list_check
+  check_mode: yes
+
+- name: get actual deny listing check
+  win_command: powershell.exe "(Get-SmbShare -Name '{{test_win_share_name}}').FolderEnumerationMode"
+  register: deny_list_actual_check
+
+- name: assert deny list check
+  assert:
+    that:
+    - deny_list_check|changed
+    - deny_list_actual_check.stdout == "Unrestricted\r\n"
+
+- name: set deny list
+  win_share:
+    name: "{{test_win_share_name}}"
+    state: present
+    path: "{{test_win_share_path}}"
+    list: False
+  register: deny_list
+
+- name: get actual deny listing
+  win_command: powershell.exe "(Get-SmbShare -Name '{{test_win_share_name}}').FolderEnumerationMode"
+  register: deny_list_actual
+
+- name: assert deny list
+  assert:
+    that:
+    - deny_list|changed
+    - deny_list_actual.stdout == "AccessBased\r\n"
+
+- name: set deny list again
+  win_share:
+    name: "{{test_win_share_name}}"
+    state: present
+    path: "{{test_win_share_path}}"
+    list: False
+  register: deny_list_again
+
+- name: get actual deny listing again
+  win_command: powershell.exe "(Get-SmbShare -Name '{{test_win_share_name}}').FolderEnumerationMode"
+  register: deny_list_actual_again
+
+- name: assert deny list again
+  assert:
+    that:
+    - not deny_list_again|changed
+    - deny_list_actual_again.stdout == "AccessBased\r\n"
+
+- name: set ACLs on share check
+  win_share:
+    name: "{{test_win_share_name}}"
+    state: present
+    path: "{{test_win_share_path}}"
+    full: Administrators
+    change: Users
+    read: Guests
+    deny: Remote Desktop Users
+  register: set_acl_check
+  check_mode: yes
+
+- name: get actual share ACLs check
+  win_shell: foreach ($acl in Get-SmbShareAccess -Name '{{test_win_share_name}}') { Write-Host "$($acl.AccessRight)|$($acl.AccessControlType)|$($acl.AccountName)" }
+  register: set_acl_actual_check
+
+- name: assert set ACLs on share check
+  assert:
+    that:
+    - set_acl_check|changed
+    - set_acl_actual_check.stdout == "Full|Deny|Everyone\n"
+
+- name: set ACLs on share
+  win_share:
+    name: "{{test_win_share_name}}"
+    state: present
+    path: "{{test_win_share_path}}"
+    full: Administrators
+    change: Users
+    read: Guests
+    deny: Remote Desktop Users
+  register: set_acl
+
+- name: get actual share ACLs
+  win_shell: foreach ($acl in Get-SmbShareAccess -Name '{{test_win_share_name}}') { Write-Host "$($acl.AccessRight)|$($acl.AccessControlType)|$($acl.AccountName)" }
+  register: set_acl_actual
+
+- name: assert set ACLs on share
+  assert:
+    that:
+    - set_acl|changed
+    - set_acl_actual.stdout_lines|length == 4
+    - set_acl_actual.stdout_lines[0] == 'Full|Deny|BUILTIN\\Remote Desktop Users'
+    - set_acl_actual.stdout_lines[1] == 'Read|Allow|BUILTIN\\Guests'
+    - set_acl_actual.stdout_lines[2] == 'Change|Allow|BUILTIN\\Users'
+    - set_acl_actual.stdout_lines[3] == 'Full|Allow|BUILTIN\\Administrators'
+
+- name: set ACLs on share again
+  win_share:
+    name: "{{test_win_share_name}}"
+    state: present
+    path: "{{test_win_share_path}}"
+    full: Administrators
+    change: Users
+    read: Guests
+    deny: Remote Desktop Users
+  register: set_acl_again
+
+- name: get actual share ACLs again
+  win_shell: foreach ($acl in Get-SmbShareAccess -Name '{{test_win_share_name}}') { Write-Host "$($acl.AccessRight)|$($acl.AccessControlType)|$($acl.AccountName)" }
+  register: set_acl_actual_again
+
+- name: assert set ACLs on share again
+  assert:
+    that:
+    - not set_acl_again|changed
+    - set_acl_actual_again.stdout_lines|length == 4
+    - set_acl_actual_again.stdout_lines[0] == 'Full|Deny|BUILTIN\\Remote Desktop Users'
+    - set_acl_actual_again.stdout_lines[1] == 'Read|Allow|BUILTIN\\Guests'
+    - set_acl_actual_again.stdout_lines[2] == 'Change|Allow|BUILTIN\\Users'
+    - set_acl_actual_again.stdout_lines[3] == 'Full|Allow|BUILTIN\\Administrators'
+
+- name: remove share check
+  win_share:
+    name: "{{test_win_share_name}}"
+    state: absent
+  register: remove_share_check
+  check_mode: yes
+
+- name: check if share is removed check
+  win_shell: Get-SmbShare | Where-Object { $_.Name -eq '{{test_win_share_name}}' }
+  register: remove_share_actual_check
+
+- name: assert remove share check
+  assert:
+    that:
+    - remove_share_check|changed
+    - remove_share_actual_check.stdout_lines != []
+
+- name: remove share
+  win_share:
+    name: "{{test_win_share_name}}"
+    state: absent
+  register: remove_share
+
+- name: check if share is removed
+  win_shell: Get-SmbShare | Where-Object { $_.Name -eq '{{test_win_share_name}}' }
+  register: remove_share_actual
+
+- name: assert remove share
+  assert:
+    that:
+    - remove_share|changed
+    - remove_share_actual.stdout_lines == []
+
+- name: remove share again
+  win_share:
+    name: "{{test_win_share_name}}"
+    state: absent
+  register: remove_share_again
+
+- name: check if share is removed again
+  win_shell: Get-SmbShare | Where-Object { $_.Name -eq '{{test_win_share_name}}' }
+  register: remove_share_actual_again
+
+- name: assert remove share again
+  assert:
+    that:
+    - not remove_share_again|changed
+    - remove_share_actual_again.stdout_lines == []


### PR DESCRIPTION
##### SUMMARY
Includes the following  changes to win_share

* Add integration tests
* Add check mode
* Add actions return value
* Add check to see if the host will support the module
* Add encrypt option
* Fix for idempotency when not setting share ACLs

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
win_share

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 91e995d691) last updated 2017/06/14 17:34:57 (GMT +1000)
  config file = /mnt/c/dev/module-tester/ansible.cfg
  configured module search path = [u'/home/jordan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/c/dev/linux-ansible/lib/ansible
  executable location = /mnt/c/dev/linux-ansible/bin/ansible
  python version = 2.7.13 (default, May 28 2017, 21:25:12) [GCC 5.4.0 20160609]
```
