### PR TITLE
Add Jenkins's pipeline job type to those that don't have a property that makes them enabled/disabled

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_job.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job.py
@@ -192,7 +192,10 @@ class JenkinsJob:
         }
 
         # This kind of jobs do not have a property that makes them enabled/disabled
-        self.job_classes_exceptions = ["jenkins.branch.OrganizationFolder"]
+        self.job_classes_exceptions = [
+            "jenkins.branch.OrganizationFolder",
+            "org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject"
+        ]
 
         self.EXCL_STATE = "excluded state"
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The jenkins_job module cannot handle creating jobs of type org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
web_infrastructure/jenkins_job.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

See https://github.com/ansible/ansible/issues/18995#issuecomment-308138228