### PR TITLE
filesystem: workaround bug in xfs_info, use xfs_growfs instead

### DIFF
--- a/lib/ansible/modules/system/filesystem.py
+++ b/lib/ansible/modules/system/filesystem.py
@@ -96,17 +96,17 @@ def _get_fs_size(fssize_cmd, dev, module):
                     break
         else:
             module.fail_json(msg="Failed to get block count and block size of %s with %s" % (dev, cmd), rc=rc, err=err )
-    elif 'xfs_info' == fssize_cmd:
+    elif 'xfs_growfs' == fssize_cmd:
         # Get Block count and Block size
-        rc, size, err = module.run_command("%s %s" % (cmd, dev))
+        rc, size, err = module.run_command([cmd, '-n', dev])
         if rc == 0:
             for line in size.splitlines():
                 col = line.split('=')
                 if col[0].strip() == 'data':
                     if col[1].strip() != 'bsize':
-                        module.fail_json(msg='Unexpected output format from xfs_info (could not locate "bsize")')
+                        module.fail_json(msg='Unexpected output format from xfs_growfs (could not locate "bsize")')
                     if col[2].split()[1] != 'blocks':
-                        module.fail_json(msg='Unexpected output format from xfs_info (could not locate "blocks")')
+                        module.fail_json(msg='Unexpected output format from xfs_growfs (could not locate "blocks")')
                     block_size = int(col[2].split()[0])
                     block_count = int(col[3].split(',')[0])
                     break
@@ -176,7 +176,7 @@ def main():
             'grow' : 'xfs_growfs',
             'grow_flag' : None,
             'force_flag' : '-f',
-            'fsinfo': 'xfs_info',
+            'fsinfo': 'xfs_growfs',
         },
         'btrfs' : {
             'mkfs' : 'mkfs.btrfs',


### PR DESCRIPTION
##### SUMMARY
Fixes #24823.

`xfs_info` is a [bash script](https://git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/tree/growfs/xfs_info.sh) located in `/usr/sbin/` (`/sbin` is a symlink to `/usr/sbin/`) which calls `xfs_growfs` command. It seems ansible is able to find `xfs_info` because `/sbin` path is [hardcoded](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/basic.py#L2024) in `get_bin_path`, then `xfs_growfs` isn't found because neither `/sbin` nor `/usr/sbin` are in the `PATH` environment variable.

`xfs_growfs -n` could be used directly instead of `xfs_info`, (the [man page](https://linux.die.net/man/8/xfs_info) states that: _xfs_info is equivalent to invoking xfs_growfs with the -n option_) but I am not sure if it would be an improvement.

##### ISSUE TYPE
 - Bugfix/Workaround Pull Request

##### COMPONENT NAME
filesystem

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible-playbook 2.4.0 (devel 4344132a7d) last updated 2017/06/14 17:06:57 (GMT +200)
```