### PR TITLE
Fix logical flaw (update when diff), use string ports everywhere

### DIFF
--- a/lib/ansible/modules/cloud/amazon/route53_health_check.py
+++ b/lib/ansible/modules/cloud/amazon/route53_health_check.py
@@ -314,9 +314,9 @@ def main():
     # Default port
     if port_in is None:
         if type_in in ['HTTP', 'HTTP_STR_MATCH']:
-            port_in = 80
+            port_in = '80'
         elif type_in in ['HTTPS', 'HTTPS_STR_MATCH']:
-            port_in = 443
+            port_in = '443'
         else:
             module.fail_json(msg="parameter 'port' is required for 'type' TCP")
 
@@ -352,7 +352,7 @@ def main():
             changed = True
         else:
             diff = health_check_diff(existing_config, wanted_config)
-            if not diff:
+            if diff:
                 action = "update"
                 update_health_check(conn, existing_check.Id, int(existing_check.HealthCheckVersion), wanted_config)
                 changed = True

--- a/lib/ansible/modules/cloud/amazon/route53_health_check.py
+++ b/lib/ansible/modules/cloud/amazon/route53_health_check.py
@@ -169,7 +169,7 @@ def find_health_check(conn, wanted):
 def to_health_check(config):
     return HealthCheck(
         config.get('IPAddress'),
-        config.get('Port'),
+        int(config.get('Port')),
         config.get('Type'),
         config.get('ResourcePath'),
         fqdn=config.get('FullyQualifiedDomainName'),
@@ -314,9 +314,9 @@ def main():
     # Default port
     if port_in is None:
         if type_in in ['HTTP', 'HTTP_STR_MATCH']:
-            port_in = '80'
+            port_in = 80
         elif type_in in ['HTTPS', 'HTTPS_STR_MATCH']:
-            port_in = '443'
+            port_in = 443
         else:
             module.fail_json(msg="parameter 'port' is required for 'type' TCP")
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
There is presently a logical flaw that states (in pseudocode):

```
diff=[Difference between what we want and what is in place, empty dict if no differences]
if there are no differences:
  Execute the update code
```

This is clearly not what was intended.
As a part of this, I also discovered that the API returns the string format of port numbers, and when given a port number this code references it as a string, but when not given one it sets it to the integer value, thus the comparison shows a false positive difference. By changing the default to the string representation, this false positive goes away, and the module behaves as one would expect.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
route53_health_check

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Oct 11 2016, 05:16:02) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Create a `route53_health_check` using Ansible, then change any parameter in it (port/path/etc...), run your playbook again, there will be no changes.

Apply this patch and there will be.

