### PR TITLE
Report fact exceptions 25365

### DIFF
--- a/lib/ansible/modules/system/setup.py
+++ b/lib/ansible/modules/system/setup.py
@@ -126,7 +126,6 @@ EXAMPLES = """
 # ansible windows -m setup -a "fact_path='c:\\custom_facts'"
 """
 import fnmatch
-import sys
 import traceback
 
 # import module snippets
@@ -174,7 +173,6 @@ class AnsibleFactCollector(collector.BaseFactCollector):
 
         for collector_obj in self.collectors:
             info_dict = {}
-            error_dict = {}
 
             # shallow copy of the accumulated collected facts to pass to each collector
             # for reference.
@@ -288,7 +286,8 @@ def main():
     if fail_on_error:
         facts_exceptions = facts_dict.get('ansible_facts_exceptions', None)
         if facts_exceptions:
-            module.fail_json(msg='There was one or more exceptions while collecting facts and fail_on_error is True. The first exception is provided as the \'exception\' return value.',
+            module.fail_json(msg='There was one or more exceptions while collecting facts and fail_on_error is True. '
+                             'The first exception is provided as the \'exception\' return value.',
                              facts_exceptions=facts_exceptions,
                              exception=facts_exceptions[0]['traceback'])
 

--- a/test/integration/targets/gathering_facts/test_gathering_facts.yml
+++ b/test/integration/targets/gathering_facts/test_gathering_facts.yml
@@ -16,6 +16,24 @@
       debug:
         var: not_hardware_facts
 
+- hosts: facthost14
+  tags: [ 'fact_error_on_fail' ]
+  connection: local
+  gather_subset: "all"
+  gather_facts: no
+  tasks:
+    - name: setup with all and error_on_fail true but no errors
+      setup:
+       gather_subset:
+           - "all"
+       fail_on_error: true
+      register: error_on_fail_no_error
+
+    - name: debug setup with error_on_fail no error
+      debug:
+        var: error_on_fail_no_error
+
+
 - hosts: facthost0
   tags: [ 'fact_min' ]
   connection: local


### PR DESCRIPTION
##### SUMMARY
    Add a 'fail_on_error' option to setup.py and set a 'ansible_facts_exceptions' with any fact collector exceptions.
   
    If setup.py encounters an exception while running a fact
    collector, the default (fail_on_error=False) is to not consider
    that a fatal error. In that case, all collectors will run,
    and any exceptions found will be collected in 'ansible_facts_exceptions'
    and returned in the 'facts_exceptions' return value.
    
    If 'fail_on_error=True', the module will return a failure (fail_json()).
    The 'ansible_facts_exceptions' and 'facts_exceptions' return value will
    still have the list of exceptions encounterd. The first exception in
    the list will be returned as the 'exception' return value so callback
    plugins can display it.
    
    This is provided to aid in debugging fact collection errors.
    
    Fixes #25365


<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules_utils/facts/system/setup.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (report_fact_exceptions_25365 2960a510a6) last updated 2017/06/14 12:45:40 (GMT -400)
  config file = None
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]


```


##### ADDITIONAL INFORMATION

Example output when running 'ansible -vvv localhost -m setup.py -a fail_on_error=True' where the 'local' facts collector hits a divide-by-zero

```
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_chVxqA/ansible_module_setup.py", line 180, in collect
    collected_facts=collected_facts)
  File "/tmp/ansible_chVxqA/ansible_modlib.zip/ansible/module_utils/facts/collector.py", line 68, in collect_with_namespace
    facts_dict = self.collect(module=module, collected_facts=collected_facts)
  File "/tmp/ansible_chVxqA/ansible_modlib.zip/ansible/module_utils/facts/system/env.py", line 34, in collect
    raise Exception("Just a test exception from env fact collector")
Exception: Just a test exception from env fact collector

localhost | FAILED! => {
    "changed": false, 
    "facts_exceptions": [
        {
            "collector_name": "env", 
            "error_message": "Just a test exception from env fact collector", 
            "traceback": "Traceback (most recent call last):\n  File \"/tmp/ansible_chVxqA/ansible_module_setup.py\", line 180, in collect\n    collected_facts=collected_facts)\n  File \"/tmp/ansible_chVxqA/ansible_modlib.zip/ansible/module_utils/facts/collector.py\", line 68, in collect_with_namespace\n    facts_dict = self.collect(module=module, collected_facts=collected_facts)\n  File \"/tmp/ansible_chVxqA/ansible_modlib.zip/ansible/module_utils/facts/system/env.py\", line 34, in collect\n    raise Exception(\"Just a test exception from env fact collector\")\nException: Just a test exception from env fact collector\n"
        }, 
        {
            "collector_name": "local", 
            "error_message": "division by zero", 
            "traceback": "Traceback (most recent call last):\n  File \"/tmp/ansible_chVxqA/ansible_module_setup.py\", line 180, in collect\n    collected_facts=collected_facts)\n  File \"/tmp/ansible_chVxqA/ansible_modlib.zip/ansible/module_utils/facts/collector.py\", line 68, in collect_with_namespace\n    facts_dict = self.collect(module=module, collected_facts=collected_facts)\n  File \"/tmp/ansible_chVxqA/ansible_modlib.zip/ansible/module_utils/facts/system/local.py\", line 40, in collect\n    37/0\nZeroDivisionError: division by zero\n"
        }
    ], 
    "failed": true, 
    "invocation": {
        "module_args": {
            "fact_path": "/etc/ansible/facts.d", 
            "fail_on_error": true, 
            "filter": "*", 
            "gather_subset": [
                "all"
            ], 
            "gather_timeout": 10
        }
    }, 
    "msg": "There was one or more exceptions while collecting facts and fail_on_error is True. The first exception is provided as the 'exception' return value."
}
```