### PR TITLE
s3_bucket: policy comparison - fixes #25428

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -161,36 +161,18 @@ def hashable_policy(policy, policy_list):
         Takes a policy and returns a list, the contents of which are all hashable and sorted.
         Example input policy:
         {'Version': '2012-10-17',
-         'Statement': [{'Action': ['s3:PutObject', 's3:PutObjectAcl'],
-                        'Sid': 'AddCannedAcl',
-                        'Resource': 'arn:aws:s3:::test_policy/*',
-                        'Effect': 'Allow',
-                        'Principal': {'AWS': 'arn:aws:iam::XXXXXXXXXXXX:user/username'}},
-                       {'Action': 's3:PutObjectAcl',
+         'Statement': [{'Action': 's3:PutObjectAcl',
                         'Sid': 'AddCannedAcl2',
                         'Resource': 'arn:aws:s3:::test_policy/*',
                         'Effect': 'Allow',
                         'Principal': {'AWS': ['arn:aws:iam::XXXXXXXXXXXX:user/username1', 'arn:aws:iam::XXXXXXXXXXXX:user/username2']}
-                       }]
-        }
+                       }]}
         Returned value:
-        [('Statement',  (
-                            (
-                                ('Action', ((u's3:PutObject',), (u's3:PutObjectAcl',))),
-                                ('Effect', (u'Allow',)),
-                                ('Principal', ('AWS', (u'arn:aws:iam::XXXXXXXXXXXX:user/username',))),
-                                ('Resource', (u'arn:aws:s3:::test_policy/*',)),
-                                ('Sid', (u'AddCannedAcl',))
-                            ),
-                            (
-                                ('Action', (u's3:PutObjectAcl',)),
-                                ('Effect', (u'Allow',)),
-                                ('Principal', ('AWS', ((u'arn:aws:iam::XXXXXXXXXXXX:user/username1',), (u'arn:aws:iam::XXXXXXXXXXXX:user/username2',)))),
-                                ('Resource', (u'arn:aws:s3:::test_policy/*',)), ('Sid', (u'AddCannedAcl2',))
-                            )
-                        )),
-         ('Version', (u'2012-10-17',))
-        ]
+        [('Statement',  ((('Action', (u's3:PutObjectAcl',)),
+                          ('Effect', (u'Allow',)),
+                          ('Principal', ('AWS', ((u'arn:aws:iam::XXXXXXXXXXXX:user/username1',), (u'arn:aws:iam::XXXXXXXXXXXX:user/username2',)))),
+                          ('Resource', (u'arn:aws:s3:::test_policy/*',)), ('Sid', (u'AddCannedAcl2',)))),
+         ('Version', (u'2012-10-17',)))]
 
     """
     if isinstance(policy, list):
@@ -222,16 +204,9 @@ def compare_policies(current_policy, new_policy):
     """ Compares the existing policy and the updated policy
         Returns True if there is a difference between policies.
     """
-    # sort policies while making them hashable
-    fixed_new = hashable_policy(new_policy, [])
-    fixed_old = hashable_policy(current_policy, [])
-
-    if len(fixed_new) != len(fixed_old):
+    if set(hashable_policy(new_policy, [])) != set(hashable_policy(current_policy, [])):
         return True
 
-    for each in range (0, len(fixed_new)):
-        if fixed_new[each] != fixed_old[each]:
-            return True
     return False
 
 

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -288,9 +288,9 @@ def _create_or_update_bucket(connection, module, location):
     requester_pays_status = get_request_payment_status(bucket)
     if requester_pays_status != requester_pays:
         if requester_pays:
-            payer='Requester'
+            payer = 'Requester'
         else:
-            payer='BucketOwner'
+            payer = 'BucketOwner'
         bucket.set_request_payment(payer=payer)
         changed = True
         requester_pays_status = get_request_payment_status(bucket)
@@ -386,7 +386,7 @@ def _destroy_bucket(connection, module):
 
 
 def _create_or_update_bucket_ceph(connection, module, location):
-    #TODO: add update
+    # TODO: add update
 
     name = module.params.get("name")
 
@@ -443,6 +443,7 @@ def is_walrus(s3_url):
         return not o.hostname.endswith('amazonaws.com')
     else:
         return False
+
 
 def main():
 
@@ -529,8 +530,8 @@ def main():
     except Exception as e:
         module.fail_json(msg='Failed to connect to S3: %s' % str(e))
 
-    if connection is None: # this should never happen
-        module.fail_json(msg ='Unknown error, failed to create s3 connection, no information from boto.')
+    if connection is None:  # this should never happen
+        module.fail_json(msg='Unknown error, failed to create s3 connection, no information from boto.')
 
     state = module.params.get("state")
 

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -204,7 +204,7 @@ def compare_policies(current_policy, new_policy):
     """ Compares the existing policy and the updated policy
         Returns True if there is a difference between policies.
     """
-    return set(hashable_policy(new_policy, [])) != set(hashable_policy(current_policy, [])):
+    return set(hashable_policy(new_policy, [])) != set(hashable_policy(current_policy, []))
 
 
 def _create_or_update_bucket(connection, module, location):

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -157,12 +157,12 @@ def create_tags_container(tags):
 
 
 def compare_policy_statement_part(current, new):
-    ''' Takes a matching part of a current policy statement and the
+    """ Takes a matching part of a current policy statement and the
         new policy statement and compares them. Ensures lists are
         compared to other lists and calls itself recursively for dicts
         so nesting structures are as expected.
         Returns True if the policy has changed.
-    '''
+    """
     if current != new:
         if isinstance(current, dict):
             if set(current.keys()) != set(new.keys()):
@@ -173,10 +173,12 @@ def compare_policy_statement_part(current, new):
                 # recursively checking each value in the dicts
                 if compare_policy_statement_part(current_inner, new_inner):
                     return True
+        # The S3 API will automatically turn single-item lists into strings
+        # To account for this we have to ensure we compare lists to lists
         if isinstance(current, list) and isinstance(new, string_types):
             current = [to_text(each) for each in current]
             new = [to_text(new)]
-        elif isinstance(new, list) and isinstance(current, string_types):
+        elif isinstance(current, string_types) and isinstance(new, list):
             new = [to_text(each) for each in new]
             current = [to_text(current)]
         if not isinstance(current, dict) and current != new:
@@ -186,10 +188,11 @@ def compare_policy_statement_part(current, new):
 
 
 def sort_policy_statement(current_policy, new_policy):
-    ''' Takes two policies and looks for matching statement parts (since it is a list of dicts
+    """ Takes two policies and looks for matching statement parts (since it is a list of dicts
         and cannot be easily ordered).
         Returns a list of tuple pairs that can then be given to
-        compare_policy_statement_part()
+        compare_policy_statement_part(); the return value is not a valid policy, it is only intended
+        for comparison purposes to determine if a change has been made to the existing policy.
         Return sample:
           [({
              "Sid":"AddCannedAcl",
@@ -209,7 +212,7 @@ def sort_policy_statement(current_policy, new_policy):
              "Action": "s3:PutObjectAcl",
              "Resource": ["arn:aws:s3:::XXXXXXXX/*"]
            })]
-    '''
+    """
     policy_pairs = []
     for policy_chunk in range(0, len(current_policy.get(u'Statement'))):
         old_chunk = current_policy[u'Statement'][policy_chunk]
@@ -224,9 +227,9 @@ def sort_policy_statement(current_policy, new_policy):
 
 
 def compare_policies(current_policy, new_policy):
-    ''' Compares the existing policy and the updated policy
+    """ Compares the existing policy and the updated policy
         Returns True if there is a difference between policies.
-    '''
+    """
     # check the easily spotted things
     if set(current_policy.keys()) != set(new_policy.keys()):
         return True

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -204,10 +204,7 @@ def compare_policies(current_policy, new_policy):
     """ Compares the existing policy and the updated policy
         Returns True if there is a difference between policies.
     """
-    if set(hashable_policy(new_policy, [])) != set(hashable_policy(current_policy, [])):
-        return True
-
-    return False
+    return set(hashable_policy(new_policy, [])) != set(hashable_policy(current_policy, [])):
 
 
 def _create_or_update_bucket(connection, module, location):

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -59,7 +59,6 @@ lib/ansible/modules/cloud/amazon/rds_subnet_group.py
 lib/ansible/modules/cloud/amazon/redshift.py
 lib/ansible/modules/cloud/amazon/route53_health_check.py
 lib/ansible/modules/cloud/amazon/s3.py
-lib/ansible/modules/cloud/amazon/s3_bucket.py
 lib/ansible/modules/cloud/amazon/s3_lifecycle.py
 lib/ansible/modules/cloud/amazon/s3_logging.py
 lib/ansible/modules/cloud/amazon/s3_website.py


### PR DESCRIPTION
##### SUMMARY
fixes #25428
Since policy statements are a list of dicts and values of said dicts may be identical except different types, comparison is faulty. Before this fix listing a single resource as a list in a policy always results in changed == True (because boto or the S3 API "fixes" this and removes unnecessary [] leaving only the list content). Before this fix reordering the statements of a policy while keeping the contents identical also resulted in changed == True. Another reproducer for this bug can be specifying the Principal like `"Principal": {"AWS": ["arn:aws:iam::XXXXXXXXXXXX:user/name"]}` (as opposed to `"Principal": {"AWS": "arn:aws:iam::XXXXXXXXXXXX:user/name"}`), which will always show changed as being True before this fix.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/s3_bucket.py

##### ANSIBLE VERSION
```
2.4.0
```
