### PR TITLE
Set shell variable first in run_command

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2423,6 +2423,7 @@ class AnsibleModule(object):
             strings on python3, use encoding=None to turn decoding to text off.
         '''
 
+        shell = False
         if isinstance(args, list):
             if use_unsafe_shell:
                 args = " ".join([shlex_quote(x) for x in args])
@@ -2442,7 +2443,6 @@ class AnsibleModule(object):
             msg = "Argument 'args' to run_command must be list or string"
             self.fail_json(rc=257, cmd=args, msg=msg)
 
-        shell = False
         if use_unsafe_shell:
             if executable is None:
                 executable = os.environ.get('SHELL')


### PR DESCRIPTION
##### SUMMARY
In 55135c08 the shell=False initializer was moved from above the first
block to beneath. This means that the variable will be reset and ignore
where it is set in the first block.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py

##### ANSIBLE VERSION
devel

##### ADDITIONAL INFORMATION
So I haven't hit a problem associated with this. I was going through the code for something else and saw it was off and think it's just a simple mistake.