### PR TITLE
host_group_vars: skip files having blacklisted ext

### DIFF
--- a/lib/ansible/plugins/vars/host_group_vars.py
+++ b/lib/ansible/plugins/vars/host_group_vars.py
@@ -23,6 +23,7 @@ DOCUMENTATION:
     description:
         - Loads YAML vars into corresponding groups/hosts in group_vars/ and host_vars/ directories.
         - Files are restricted by extension to one of .yaml, .json, .yml or no extension.
+        - Hidden (starting with '.') and backup (ending with '~') files and directories are ignored.
         - Only applies to inventory sources that are existing paths.
     notes:
         - It takes the place of the previously hardcoded group_vars/host_vars loading.

--- a/lib/ansible/plugins/vars/host_group_vars.py
+++ b/lib/ansible/plugins/vars/host_group_vars.py
@@ -121,7 +121,7 @@ class VarsModule(BaseVarsPlugin):
 
         found = []
         for spath in os.listdir(path):
-            if not spath.startswith('.'):  # skip hidden
+            if not spath.startswith('.') and not spath.endswith('~'):  # skip hidden and backups
 
                 ext = os.path.splitext(spath)[-1]
                 full_spath = os.path.join(path, spath)


### PR DESCRIPTION
##### SUMMARY
* Skipping var files (in var dirs) having a blacklisted extension. Intension is to skip files having a ~ extension. ~Reused  C.BLACKLIST_EXTS since it contains the '~'.~
* ~Validate files in var dirs having yaml extension~



##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
host_group_vars

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
fixes #17968

~~~
 [WARNING]: Skipping var file main~ in /home/resmo/tmp/ansible-bug-repo/bl-ext/host_vars/two having blacklisted extension

ok: [one] => {
    "failed": false, 
    "foo": "one"
}
ok: [two] => {
    "failed": false, 
    "foo": "all"
}
ok: [three] => {
    "failed": false, 
    "foo": "all"
}
~~~