### PR TITLE
Add secondary_storage management to cs_zone module.

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_zone.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_zone.py
@@ -421,15 +421,15 @@ class AnsibleCloudStackZone(AnsibleCloudStack):
         zoneid = zone['id']
         for secstore in self.module.params.get('secondary_storage'):
             url = secstore['url']
-            store = self.get_secondary_storage(url)
+            existing = self.get_secondary_storage(url)
             state = secstore['state'].lower() if 'state' in secstore else 'present'
             if state not in ['present', 'absent']:
                 self.module.fail_json(msg="Secondary Storage state must be either 'present' or 'absent'")
 
-            if store and state == 'absent':
-                self.secondary_storage_absent(store)
+            if existing and state == 'absent':
+                self.secondary_storage_absent(existing)
 
-            if state == 'absent':
+            if state == 'absent' or existing:
                 continue
 
             name = secstore['name'] if 'name' in secstore else url

--- a/lib/ansible/modules/cloud/cloudstack/cs_zone.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_zone.py
@@ -406,14 +406,12 @@ class AnsibleCloudStackZone(AnsibleCloudStack):
 
         return self.secondary_storage
 
-
     def secondary_storage_absent(self, store=None):
         self.result['changed'] = True
         args = {'id': store['id']}
         res = self.cs.deleteImageStore(**args)
         if 'errortext' in res:
             self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
-
 
     def secondary_storage_apply(self):
         zone = self.get_zone()
@@ -433,7 +431,7 @@ class AnsibleCloudStackZone(AnsibleCloudStack):
 
             name = secstore['name'] if 'name' in secstore else url
             if 'provider' not in secstore:
-                self.module.fail_json(msg="Failed: Provider must be specified for secondary storage '%s'" % name)
+                self.module.fail_json(msg="Failed: Provider required for sec-storage '%s'" % name)
             provider = secstore['provider']
 
             self.result['changed'] = True
@@ -451,6 +449,7 @@ class AnsibleCloudStackZone(AnsibleCloudStack):
             self.secondary_storage[store['url']] = store
 
         return self.secondary_storage
+
 
 def main():
     argument_spec = cs_argument_spec()

--- a/lib/ansible/modules/cloud/cloudstack/cs_zone.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_zone.py
@@ -112,6 +112,9 @@ options:
       - Only additions and deletions are possible. No modification are allowed.
       - Stores are keyed on the URL rather than the name.
       - Set 'state' to absent to remove a storage URL (defaults to present).
+    required: false
+    default: null
+    version_added: "2.4"
 extends_documentation_fragment: cloudstack
 '''
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Rather than write a new module to control Secondary Storage pools, this change adds that functionality to the existing cs_zone module.

Secondary Storage pools are bound directly to Zones, and not to any other object such as Pods or Clusters. The API allows additions and deletions, so in the absence of much complexity it seemed appropriate to work with the existing module.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/cloud/cloudstack/cs_zone.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = /home/john/.ansible.cfg
  configured module search path = [u'/home/john/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible-2.4.0-py2.7.egg/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Sample playbook:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
---
- name: Setup Cloudstack
  hosts: host1
  tasks:
  - local_action:
      module: cs_zone
      name: Zone01
      dns1: 8.8.8.8
      internal_dns1: 8.8.8.8
      network_type: advanced
      secondary_storage:
      - name: My NFS
        provider: NFS
        url: nfs://172.30.1.50/exports/cs_secondary
```
