### PR TITLE
plugin,action: print stderr on error

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -274,7 +274,9 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                           'Consider changing the remote temp path in ansible.cfg to a path rooted in "/tmp". '
                           'Failed command was: %s, exited with result %d' % (cmd, result['rc']))
             if 'stdout' in result and result['stdout'] != u'':
-                output = output + u": %s" % result['stdout']
+                output = output + u", stdout output: %s" % result['stdout']
+            if self._play_context.verbosity > 3 and 'stderr' in result and result['stderr'] != u'':
+                output += u", stderr output: %s" % result['stderr']
             raise AnsibleConnectionFailure(output)
         else:
             self._cleanup_remote_tmp = True


### PR DESCRIPTION
##### SUMMARY
This is coming from ansible-container: https://github.com/ansible/ansible-container/issues/99#issuecomment-308428291

The issue is that, if the container doesn't have present `/usr/bin/python` (or more generically, there is some issue executing commands inside a container), `ansible-playbook` fails with

```
fatal: [rust]: UNREACHABLE! => {
    "changed": false,
    "msg": "Authentication or permission failure. In some cases, you may have been able to authenticate and did not have permissions on the target directory. Consider changing the remote temp path in ansible.cfg to a path rooted in \"/tmp\". Failed command was: ( umask 77 && mkdir -p \"` echo ~/.ansible/tmp/ansible-tmp-1497446099.06-166938217066280 `\" && echo ansible-tmp-1497446099.06-166938217066280=\"` echo ~/.ansible/tmp/ansible-tmp-1497446099.06-166938217066280 `\" ), exited with result 1",
    "unreachable": true
}
```

instead it would be super-helpful if ansible-playbook printed output from the commands which are exec'd inside the container -- and that's exactly what this PR addresses.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`plugin/connection/docker`

##### ANSIBLE VERSION
```
[root@8c142963150b /]# ansible-playbook --version
ansible-playbook 2.4.0
  config file =
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/.local/lib/python2.7/site-packages/ansible
  executable location = /root/.local/bin/ansible-playbook
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```

Sample output with the patch applied:

```
<283b83ca13b9> ESTABLISH DOCKER CONNECTION FOR USER: root
<283b83ca13b9> EXEC ['/bin/docker', 'exec', '-i', u'283b83ca13b9', u'/bin/sh', '-c', u"/bin/sh -c 'echo ~ && sleep 0'"]
<283b83ca13b9> STDOUT '/root\n', STDERR ''
<283b83ca13b9> EXEC ['/bin/docker', 'exec', '-i', u'283b83ca13b9', u'/bin/sh', '-c', u'/bin/sh -c \'( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1497515787.09-97492615214755 `" && echo ansible-tmp-1497515787.09-97492615214755="` echo /root/.ansible/tmp/ansible-tmp-1497515787.09-97492615214755 `" ) && sleep 0\'']
<283b83ca13b9> STDOUT 'ansible-tmp-1497515787.09-97492615214755=/root/.ansible/tmp/ansible-tmp-1497515787.09-97492615214755\n', STDERR ''
<283b83ca13b9> PUT /tmp/tmpsxFNur TO /root/.ansible/tmp/ansible-tmp-1497515787.09-97492615214755/setup.py
<283b83ca13b9> EXEC ['/bin/docker', 'exec', '-i', u'283b83ca13b9', u'/bin/sh', '-c', u"/bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1497515787.09-97492615214755/ /root/.ansible/tmp/ansible-tmp-1497515787.09-97492615214755/setup.py && sleep 0'"]
<283b83ca13b9> STDOUT '', STDERR ''
<283b83ca13b9> EXEC ['/bin/docker', 'exec', '-i', u'283b83ca13b9', u'/bin/sh', '-c', u'/bin/sh -c \'/usr/bin/python /root/.ansible/tmp/ansible-tmp-1497515787.09-97492615214755/setup.py; rm -rf "/root/.ansible/tmp/ansible-tmp-1497515787.09-97492615214755/" > /dev/null 2>&1 && sleep 0\'']
<283b83ca13b9> STDOUT '', STDERR '/bin/sh: /usr/bin/python: No such file or directory\n'
```

CC @j00bar @chouseknecht