### PR TITLE
Add persistent connection control path dir constant

### DIFF
--- a/lib/ansible/config/data/config.yml
+++ b/lib/ansible/config/data/config.yml
@@ -1272,6 +1272,14 @@ PERSISTENT_CONNECT_INTERVAL:
   value_type: integer
   vars: []
   yaml: {key: persistent_connection.connect_interval}
+PERSISTENT_CONTROL_PATH_DIR:
+  default: ~/.ansible/pc
+  desc: 'TODO: write it'
+  env: [{name: ANSIBLE_PERSISTENT_CONTROL_PATH_DIR}]
+  ini:
+  - {key: control_path_dir, section: persistent_connection}
+  vars: []
+  yaml: {key: persistent_connection.control_path_dir}
 PERSISTENT_CONNECT_RETRIES:
   default: 30
   desc: 'TODO: write it'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add persistent connection control path dir constant, required to run
`ansible-connection`.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
data/config.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
