### PR TITLE
Rename classic elb modules to match new names applied to application …

### DIFF
--- a/lib/ansible/modules/cloud/amazon/_ec2_elb.py
+++ b/lib/ansible/modules/cloud/amazon/_ec2_elb.py
@@ -1,0 +1,1 @@
+elb_instance.py

--- a/lib/ansible/modules/cloud/amazon/_ec2_elb_facts.py
+++ b/lib/ansible/modules/cloud/amazon/_ec2_elb_facts.py
@@ -1,0 +1,1 @@
+elb_classic_lb_facts.py

--- a/lib/ansible/modules/cloud/amazon/_ec2_elb_lb.py
+++ b/lib/ansible/modules/cloud/amazon/_ec2_elb_lb.py
@@ -1,0 +1,1 @@
+elb_classic_lb.py

--- a/lib/ansible/modules/cloud/amazon/elb_classic_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_classic_lb.py
@@ -21,7 +21,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 
 DOCUMENTATION = """
 ---
-module: ec2_elb_lb
+module: elb_classic_lb
 description:
   - Returns information about the load balancer.
   - Will be marked changed when called only if state is changed.

--- a/lib/ansible/modules/cloud/amazon/elb_classic_lb_facts.py
+++ b/lib/ansible/modules/cloud/amazon/elb_classic_lb_facts.py
@@ -20,7 +20,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 
 DOCUMENTATION = '''
 ---
-module: ec2_elb_facts
+module: elb_classic_lb_facts
 short_description: Gather facts about EC2 Elastic Load Balancers in AWS
 description:
     - Gather facts about EC2 Elastic Load Balancers in AWS

--- a/lib/ansible/modules/cloud/amazon/elb_instance.py
+++ b/lib/ansible/modules/cloud/amazon/elb_instance.py
@@ -21,7 +21,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 
 DOCUMENTATION = """
 ---
-module: ec2_elb
+module: elb_instance
 short_description: De-registers or registers instances from EC2 ELBs
 description:
   - This module de-registers or registers an AWS EC2 instance from the ELBs

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -4,6 +4,9 @@ lib/ansible/config/data.py
 lib/ansible/config/manager.py
 lib/ansible/modules/cloud/amazon/_ec2_ami_search.py
 lib/ansible/modules/cloud/amazon/_ec2_remote_facts.py
+lib/ansible/modules/cloud/amazon/_ec2_elb.py
+lib/ansible/modules/cloud/amazon/_ec2_elb_facts.py
+lib/ansible/modules/cloud/amazon/_ec2_elb_lb.py
 lib/ansible/modules/cloud/amazon/_ec2_vpc.py
 lib/ansible/modules/cloud/amazon/aws_kms.py
 lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -16,9 +19,6 @@ lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
 lib/ansible/modules/cloud/amazon/ec2_ami_find.py
 lib/ansible/modules/cloud/amazon/ec2_customer_gateway.py
 lib/ansible/modules/cloud/amazon/ec2_eip.py
-lib/ansible/modules/cloud/amazon/ec2_elb.py
-lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
-lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
 lib/ansible/modules/cloud/amazon/ec2_eni_facts.py
 lib/ansible/modules/cloud/amazon/ec2_key.py
 lib/ansible/modules/cloud/amazon/ec2_lc.py
@@ -46,6 +46,9 @@ lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
 lib/ansible/modules/cloud/amazon/efs.py
 lib/ansible/modules/cloud/amazon/elasticache.py
 lib/ansible/modules/cloud/amazon/elasticache_subnet_group.py
+lib/ansible/modules/cloud/amazon/elb_instance.py
+lib/ansible/modules/cloud/amazon/elb_classic_lb_facts.py
+lib/ansible/modules/cloud/amazon/elb_classic_lb.py
 lib/ansible/modules/cloud/amazon/execute_lambda.py
 lib/ansible/modules/cloud/amazon/iam.py
 lib/ansible/modules/cloud/amazon/iam_policy.py


### PR DESCRIPTION
…LB modules

##### SUMMARY
While creating the new elb_application_lb module we decided on a new naming convention for the LB modules.

This PR updates the names of the older modules.  Hoping to make 2.4 so they go out with the new application LB module

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ec2_elb, ec2_elb_lb, ec2_elb_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION

