### PR TITLE
use standard service commands on freebsd

### DIFF
--- a/lib/ansible/modules/system/service.py
+++ b/lib/ansible/modules/system/service.py
@@ -1002,7 +1002,7 @@ class FreeBsdService(Service):
         self.sysrc_cmd = self.module.get_bin_path('sysrc')
 
     def get_service_status(self):
-        rc, stdout, stderr = self.execute_command("%s %s %s %s" % (self.svc_cmd, self.name, 'onestatus', self.arguments))
+        rc, stdout, stderr = self.execute_command("%s %s %s %s" % (self.svc_cmd, self.name, 'status', self.arguments))
         if self.name == "pf":
             self.running = "Enabled" in stdout
         else:
@@ -1080,14 +1080,6 @@ class FreeBsdService(Service):
 
 
     def service_control(self):
-
-        if self.action == "start":
-            self.action = "onestart"
-        if self.action == "stop":
-            self.action = "onestop"
-        if self.action == "reload":
-            self.action = "onereload"
-
         ret = self.execute_command("%s %s %s %s" % (self.svc_cmd, self.name, self.action, self.arguments))
 
         if self.sleep:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Uses standard service commands instead of the commands prefixed with `one`. The commands prefixed with `one` are not functionally equivalent, and not what you would expect as the default mode of operation for a service module.

Fixes #25743 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
`module/system/service`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /path/playbooks/ansible.cfg
  configured module search path = [u'../library/']
  python version = 2.7.13 (default, Apr 29 2017, 01:15:48) [GCC 4.2.1 Compatible FreeBSD Clang 3.8.0 (tags/RELEASE_380/final 262564)]
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

