### PR TITLE
optionally show failure on changes with junit report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ Ansible Changes By Release
     * https://github.com/ansible/ansible/blob/2fff690caab6a1c6a81973f704be3fbd0bde2c2f/lib/ansible/module_utils/six/__init__.py
 * Update ipaddr Jinja filters to replace existing non RFC compliant ones. Added additional filters for easier use
   of handling IP addresses. (PR# 26566)
+* The junit plugin now has an option to report a junit test failure on changes for idempotent testing.
 
 #### New Callbacks:
 - full_skip

--- a/lib/ansible/plugins/callback/junit.py
+++ b/lib/ansible/plugins/callback/junit.py
@@ -58,6 +58,8 @@ class CallbackModule(CallbackBase):
                                      Default: ~/.ansible.log
         JUNIT_TASK_CLASS (optional): Configure the output to be one class per yaml file
                                      Default: False
+        JUNIT_FAIL_ON_CHANGE (optional): Consider any tasks reporting "changed" as a junit test failure
+                                     Default: False
 
     Requires:
         junit_xml
@@ -74,6 +76,7 @@ class CallbackModule(CallbackBase):
 
         self._output_dir = os.getenv('JUNIT_OUTPUT_DIR', os.path.expanduser('~/.ansible.log'))
         self._task_class = os.getenv('JUNIT_TASK_CLASS', 'False').lower()
+        self._fail_on_change = os.getenv('JUNIT_FAIL_ON_CHANGE', 'False').lower()
         self._playbook_path = None
         self._playbook_name = None
         self._play_name = None
@@ -128,6 +131,9 @@ class CallbackModule(CallbackBase):
             host_name = 'include'
 
         task_data = self._task_data[task_uuid]
+
+        if self._fail_on_change == 'true' and status == 'changed':
+            status = 'failed'
 
         if status == 'failed' and 'EXPECTED FAILURE' in task_data.name:
             status = 'ok'
@@ -224,7 +230,10 @@ class CallbackModule(CallbackBase):
             self._finish_task('failed', result)
 
     def v2_runner_on_ok(self, result):
-        self._finish_task('ok', result)
+        if result._result.get('changed', False):
+            self._finish_task('changed', result)
+        else:
+            self._finish_task('ok', result)
 
     def v2_runner_on_skipped(self, result):
         self._finish_task('skipped', result)

--- a/lib/ansible/plugins/callback/junit.py
+++ b/lib/ansible/plugins/callback/junit.py
@@ -132,7 +132,7 @@ class CallbackModule(CallbackBase):
 
         task_data = self._task_data[task_uuid]
 
-        if self._fail_on_change == 'true' and status == 'changed':
+        if self._fail_on_change == 'true' and status == 'ok' and result._result.get('changed', False):
             status = 'failed'
 
         if status == 'failed' and 'EXPECTED FAILURE' in task_data.name:
@@ -230,10 +230,7 @@ class CallbackModule(CallbackBase):
             self._finish_task('failed', result)
 
     def v2_runner_on_ok(self, result):
-        if result._result.get('changed', False):
-            self._finish_task('changed', result)
-        else:
-            self._finish_task('ok', result)
+        self._finish_task('ok', result)
 
     def v2_runner_on_skipped(self, result):
         self._finish_task('skipped', result)


### PR DESCRIPTION
##### SUMMARY
This commit provides an environment option to change the behaviour so
that it's possible to declare any changes shoudl be considered a junit
failure.

This is useful when carrying out idempotent testing to ensure that
multiple runs are safe and any changes should be considered a test
failure.

In a CI test of an ansible role the practice would be to run the role
once without this to configure the test system, and tehn to run a second
time including this environment vairable so that the CI engine
processing the junit report recognise any changes to be a test fail.

Fixes #25740 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
junit

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, May 31 2017, 17:58:17) [GCC 7.1.1 20170503 (Red Hat 7.1.1-1)]
```



##### ADDITIONAL INFORMATION
This worked with a test in our environment.

The idempotent test that we only consider valid if there are no changes or failures reported showed a junit test failure when I force a task to always report changed and the junit report screen pinpointed precisely which task was reporting changed.

![screenshot from 2017-06-15 15-55-07](https://user-images.githubusercontent.com/3037132/27187567-7d17a070-51e3-11e7-9573-aa3e450b4ea7.png)